### PR TITLE
Add Persona Visual custom state runtime triggers

### DIFF
--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -373,6 +373,7 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     renderContext.visual_state ??
     resolvePersonaVisualState({
       liveVoiceState: renderContext.live_voice_state,
+      activeToolName: renderContext.active_tool_name,
       activeToolStatus: renderContext.active_tool_status,
       wakeArmed: renderContext.wake_armed,
       recovering:

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellRenderContext.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellRenderContext.tsx
@@ -49,6 +49,7 @@ const areRenderContextsEqual = (
     areBuddySummariesEqual(left.buddy_summary, right.buddy_summary) &&
     left.live_session_id === right.live_session_id &&
     left.live_voice_state === right.live_voice_state &&
+    left.active_tool_name === right.active_tool_name &&
     left.active_tool_status === right.active_tool_status &&
     left.wake_armed === right.wake_armed &&
     left.recovery_mode === right.recovery_mode &&

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/store/persona-buddy-shell"
 import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
 import type { PersonaBuddyRenderContext } from "@/types/persona-buddy"
+import { asPersonaVisualCustomStateId } from "@/types/persona-visuals"
 import { BuddyShellHost } from "../BuddyShellHost"
 
 const mocks = vi.hoisted(() => ({
@@ -713,19 +714,20 @@ describe("BuddyShellHost", () => {
 
   it("renders custom visual states from exact active tool names", async () => {
     const basePack = buildVisualPack("persona-1")
+    const customState = asPersonaVisualCustomStateId("tool.notes_search")
     const visualPack = {
       ...basePack,
       manifest: {
         ...basePack.manifest,
         state_catalog: {
-          "tool.notes_search": {
+          [customState]: {
             label: "Searching notes",
             kind: "tool_variant"
           }
         },
         states: {
           ...basePack.manifest.states,
-          "tool.notes_search": { animation_id: "tool-notes-search" }
+          [customState]: { animation_id: "tool-notes-search" }
         },
         animations: {
           ...basePack.manifest.animations,
@@ -738,7 +740,7 @@ describe("BuddyShellHost", () => {
             id: "notes-search",
             source: "tool_name",
             match: "notes.search",
-            state: "tool.notes_search",
+            state: customState,
             duration_ms: 500,
             priority: 90
           }

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -711,6 +711,84 @@ describe("BuddyShellHost", () => {
     )
   })
 
+  it("renders custom visual states from exact active tool names", async () => {
+    const basePack = buildVisualPack("persona-1")
+    const visualPack = {
+      ...basePack,
+      manifest: {
+        ...basePack.manifest,
+        state_catalog: {
+          "tool.notes_search": {
+            label: "Searching notes",
+            kind: "tool_variant"
+          }
+        },
+        states: {
+          ...basePack.manifest.states,
+          "tool.notes_search": { animation_id: "tool-notes-search" }
+        },
+        animations: {
+          ...basePack.manifest.animations,
+          "tool-notes-search": {
+            frames: [{ asset_id: "tool-notes-search-asset", duration_ms: 100 }]
+          }
+        },
+        authored_triggers: [
+          {
+            id: "notes-search",
+            source: "tool_name",
+            match: "notes.search",
+            state: "tool.notes_search",
+            duration_ms: 500,
+            priority: 90
+          }
+        ]
+      },
+      assets_by_id: {
+        ...basePack.assets_by_id,
+        "tool-notes-search-asset": {
+          id: "tool-notes-search-asset",
+          url: "/assets/tool-notes-search.png",
+          mime_type: "image/png",
+          asset_role: "frame",
+          width: 24,
+          height: 24
+        }
+      }
+    }
+    visualMocks.listPersonaVisualPacks.mockResolvedValue({
+      packs: [visualPack],
+      active_pack: visualPack
+    })
+    const context = {
+      surface_id: "persona-garden",
+      surface_active: true,
+      active_persona_id: "persona-1",
+      position_bucket: "sidepanel-desktop",
+      persona_source: "route-local",
+      buddy_summary: buildBuddySummary("persona-1"),
+      live_voice_state: "thinking",
+      active_tool_name: "notes.search",
+      active_tool_status: "Searching notes"
+    } as PersonaBuddyRenderContext
+
+    renderHost({
+      context,
+      root: "sidepanel"
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-visual-frame")).toHaveAttribute(
+        "data-visual-state",
+        "tool.notes_search"
+      )
+    })
+    expect(screen.getByTestId("persona-visual-frame")).toHaveAttribute(
+      "src",
+      expect.stringContaining("/assets/tool-notes-search.png")
+    )
+  })
+
   it("keeps derived buddy text when active visual pack loading fails", async () => {
     visualMocks.listPersonaVisualPacks.mockRejectedValue(new Error("offline"))
 

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { asPersonaVisualCustomStateId } from "@/types/persona-visuals"
 import { resolvePersonaVisualState } from "../personaVisualState"
 
 describe("resolvePersonaVisualState", () => {
@@ -79,6 +80,7 @@ describe("resolvePersonaVisualState", () => {
   })
 
   it("uses exact tool_name triggers from structured tool context", () => {
+    const customState = asPersonaVisualCustomStateId("tool.notes_search")
     expect(
       resolvePersonaVisualState({
         liveVoiceState: "thinking",
@@ -89,7 +91,7 @@ describe("resolvePersonaVisualState", () => {
             id: "notes-search",
             source: "tool_name",
             match: "notes.search",
-            state: "tool.notes_search",
+            state: customState,
             duration_ms: 500,
             priority: 90
           }
@@ -99,6 +101,7 @@ describe("resolvePersonaVisualState", () => {
   })
 
   it("does not infer exact tool_name triggers from status display text", () => {
+    const customState = asPersonaVisualCustomStateId("tool.notes_search")
     expect(
       resolvePersonaVisualState({
         liveVoiceState: "thinking",
@@ -108,7 +111,7 @@ describe("resolvePersonaVisualState", () => {
             id: "notes-search",
             source: "tool_name",
             match: "notes.search",
-            state: "tool.notes_search",
+            state: customState,
             duration_ms: 500,
             priority: 90
           }

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts
@@ -78,6 +78,45 @@ describe("resolvePersonaVisualState", () => {
     ).toBe("approval_needed")
   })
 
+  it("uses exact tool_name triggers from structured tool context", () => {
+    expect(
+      resolvePersonaVisualState({
+        liveVoiceState: "thinking",
+        activeToolName: "notes.search",
+        activeToolStatus: "Searching notes",
+        authoredTriggers: [
+          {
+            id: "notes-search",
+            source: "tool_name",
+            match: "notes.search",
+            state: "tool.notes_search",
+            duration_ms: 500,
+            priority: 90
+          }
+        ]
+      })
+    ).toBe("tool.notes_search")
+  })
+
+  it("does not infer exact tool_name triggers from status display text", () => {
+    expect(
+      resolvePersonaVisualState({
+        liveVoiceState: "thinking",
+        activeToolStatus: "Running notes.search",
+        authoredTriggers: [
+          {
+            id: "notes-search",
+            source: "tool_name",
+            match: "notes.search",
+            state: "tool.notes_search",
+            duration_ms: 500,
+            priority: 90
+          }
+        ]
+      })
+    ).toBe("tool_running")
+  })
+
   it("maps active tool status to tool_running", () => {
     expect(
       resolvePersonaVisualState({

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
@@ -16,6 +16,7 @@ export type ResolvePersonaVisualStateInput = {
   approvalNeeded?: boolean
   runtimeOverride?: PersonaVisualRuntimeOverride | null
   authoredTriggers?: PersonaVisualAuthoredTrigger[] | null
+  activeToolName?: string | null
   activeToolStatus?: string | null
   wakeArmed?: boolean
   isOffline?: boolean
@@ -23,7 +24,7 @@ export type ResolvePersonaVisualStateInput = {
   now?: number
 }
 
-const VISUAL_STATES = new Set<PersonaVisualStateId>([
+const BUILTIN_VISUAL_STATES = new Set<PersonaVisualStateId>([
   "idle",
   "wake_armed",
   "listening",
@@ -45,7 +46,7 @@ const normalizeLiveVoiceState = (
 ): PersonaVisualStateId | null => {
   const normalized = toNormalizedToken(value).replace(/[\s-]+/g, "_")
   if (!normalized) return null
-  if (VISUAL_STATES.has(normalized as PersonaVisualStateId)) {
+  if (BUILTIN_VISUAL_STATES.has(normalized as PersonaVisualStateId)) {
     return normalized as PersonaVisualStateId
   }
   if (
@@ -89,6 +90,9 @@ const triggerMatches = (
     const category = parseToolCategory(input.activeToolStatus)
     return match === category || toolStatus.startsWith(match)
   }
+  if (trigger.source === "tool_name") {
+    return match === toNormalizedToken(input.activeToolName)
+  }
   if (trigger.source === "mcp_runtime") {
     const runtimeReason =
       toNormalizedToken(input.mcpRuntimeReason) ||
@@ -119,7 +123,7 @@ export const resolvePersonaVisualState = (
   if (
     input.runtimeOverride &&
     input.runtimeOverride.expiresAt > now &&
-    VISUAL_STATES.has(input.runtimeOverride.state)
+    BUILTIN_VISUAL_STATES.has(input.runtimeOverride.state)
   ) {
     return input.runtimeOverride.state
   }

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
@@ -1,10 +1,15 @@
 import type {
   PersonaVisualAuthoredTrigger,
+  PersonaVisualBuiltinStateId,
   PersonaVisualStateId
+} from "@/types/persona-visuals"
+import {
+  isPersonaVisualBuiltinStateId,
+  PERSONA_VISUAL_BUILTIN_STATES
 } from "@/types/persona-visuals"
 
 export type PersonaVisualRuntimeOverride = {
-  state: PersonaVisualStateId
+  state: PersonaVisualBuiltinStateId
   reason?: string | null
   expiresAt: number
 }
@@ -24,17 +29,9 @@ export type ResolvePersonaVisualStateInput = {
   now?: number
 }
 
-const BUILTIN_VISUAL_STATES = new Set<PersonaVisualStateId>([
-  "idle",
-  "wake_armed",
-  "listening",
-  "thinking",
-  "speaking",
-  "tool_running",
-  "approval_needed",
-  "error",
-  "offline"
-])
+const BUILTIN_VISUAL_STATES = new Set<PersonaVisualBuiltinStateId>(
+  PERSONA_VISUAL_BUILTIN_STATES
+)
 
 const toNormalizedToken = (value: string | null | undefined): string =>
   String(value || "")
@@ -43,11 +40,11 @@ const toNormalizedToken = (value: string | null | undefined): string =>
 
 const normalizeLiveVoiceState = (
   value: string | null | undefined
-): PersonaVisualStateId | null => {
+): PersonaVisualBuiltinStateId | null => {
   const normalized = toNormalizedToken(value).replace(/[\s-]+/g, "_")
   if (!normalized) return null
-  if (BUILTIN_VISUAL_STATES.has(normalized as PersonaVisualStateId)) {
-    return normalized as PersonaVisualStateId
+  if (isPersonaVisualBuiltinStateId(normalized)) {
+    return normalized
   }
   if (
     normalized === "recording" ||
@@ -78,7 +75,7 @@ const parseToolCategory = (activeToolStatus: string | null | undefined): string 
 const triggerMatches = (
   trigger: PersonaVisualAuthoredTrigger,
   input: ResolvePersonaVisualStateInput,
-  liveState: PersonaVisualStateId | null
+  liveState: PersonaVisualBuiltinStateId | null
 ): boolean => {
   const match = toNormalizedToken(trigger.match)
   if (!match) return false
@@ -91,7 +88,8 @@ const triggerMatches = (
     return match === category || toolStatus.startsWith(match)
   }
   if (trigger.source === "tool_name") {
-    return match === toNormalizedToken(input.activeToolName)
+    const activeToolName = toNormalizedToken(input.activeToolName)
+    return Boolean(activeToolName) && match === activeToolName
   }
   if (trigger.source === "mcp_runtime") {
     const runtimeReason =
@@ -104,7 +102,7 @@ const triggerMatches = (
 
 const resolveAuthoredTriggerState = (
   input: ResolvePersonaVisualStateInput,
-  liveState: PersonaVisualStateId | null
+  liveState: PersonaVisualBuiltinStateId | null
 ): PersonaVisualStateId | null => {
   const triggers = [...(input.authoredTriggers || [])]
     .filter((trigger) => triggerMatches(trigger, input, liveState))

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -247,6 +247,7 @@ const ASSET_ROLES: PersonaVisualAssetRole[] = [
 const TRIGGER_SOURCES: PersonaVisualAuthoredTrigger["source"][] = [
   "live_state",
   "tool_category",
+  "tool_name",
   "mcp_runtime"
 ]
 
@@ -415,6 +416,7 @@ const DEFAULT_MANIFEST: PersonaVisualManifest = {
   states: {},
   animations: {},
   fallbacks: {},
+  state_catalog: {},
   authored_triggers: []
 }
 
@@ -446,6 +448,9 @@ const normalizeManifest = (
     },
     fallbacks: {
       ...(source.fallbacks || {})
+    },
+    state_catalog: {
+      ...(source.state_catalog || {})
     },
     authored_triggers: Array.isArray(source.authored_triggers)
       ? source.authored_triggers
@@ -873,6 +878,21 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const animationIds = React.useMemo(
     () => getAnimationIds(draftManifest),
     [draftManifest]
+  )
+  const customVisualStates = React.useMemo(
+    () =>
+      Object.keys(draftManifest.state_catalog || {}).sort((a, b) =>
+        a.localeCompare(b)
+      ) as PersonaVisualStateId[],
+    [draftManifest.state_catalog]
+  )
+  const activeVisualStates = React.useMemo(
+    () => [...VISUAL_STATES, ...customVisualStates],
+    [customVisualStates]
+  )
+  const editableFallbackStates = React.useMemo(
+    () => [...OPTIONAL_VISUAL_STATES, ...customVisualStates],
+    [customVisualStates]
   )
   const selectedAnimation =
     selectedAnimationId && draftManifest.animations[selectedAnimationId]
@@ -1817,7 +1837,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       const nextValues = value
         .split(",")
         .map((item) => item.trim() as PersonaVisualStateId)
-        .filter((item) => VISUAL_STATES.includes(item))
+        .filter((item) => activeVisualStates.includes(item))
       if (nextValues.length) {
         fallbacks[state] = nextValues
       } else {
@@ -2919,8 +2939,37 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 </label>
               ))}
             </div>
+            {customVisualStates.length ? (
+              <>
+                <div className="mt-4 text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+                  Custom States
+                </div>
+                <div className="mt-2 grid gap-2 md:grid-cols-2">
+                  {customVisualStates.map((state) => (
+                    <label key={state} className="text-xs text-text-muted">
+                      <span className="mb-1 flex items-center gap-1">
+                        <span>{formatStateLabel(state)}</span>
+                        <Tag color="blue">
+                          {draftManifest.state_catalog?.[state]?.kind || "custom"}
+                        </Tag>
+                      </span>
+                      <select
+                        data-testid={`persona-visual-state-${state}-select`}
+                        className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                        value={draftManifest.states?.[state]?.animation_id || ""}
+                        onChange={(event) =>
+                          handleStateMappingChange(state, event.target.value)
+                        }
+                      >
+                        {renderAnimationOptions()}
+                      </select>
+                    </label>
+                  ))}
+                </div>
+              </>
+            ) : null}
             <div className="mt-3 grid gap-2 md:grid-cols-2">
-              {OPTIONAL_VISUAL_STATES.map((state) => (
+              {editableFallbackStates.map((state) => (
                 <label key={state} className="text-xs text-text-muted">
                   <span className="mb-1 block">{`${formatStateLabel(state)} fallbacks`}</span>
                   <input
@@ -3209,7 +3258,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                   }))
                 }
               >
-                {VISUAL_STATES.map((state) => (
+                {activeVisualStates.map((state) => (
                   <option key={state} value={state}>
                     {state}
                   </option>
@@ -3354,7 +3403,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                     setGenerationTargetState(event.target.value as PersonaVisualStateId)
                   }
                 >
-                  {VISUAL_STATES.map((state) => (
+                  {activeVisualStates.map((state) => (
                     <option key={state} value={state}>
                       {state}
                     </option>

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -50,6 +50,7 @@ import type {
   PersonaVisualAsset,
   PersonaVisualAssetRole,
   PersonaVisualAuthoredTrigger,
+  PersonaVisualBuiltinStateId,
   PersonaVisualCandidate,
   PersonaVisualDuplicateTarget,
   PersonaVisualLibraryItem,
@@ -67,6 +68,10 @@ import type {
   PersonaVisualPortabilityJobResponse,
   PersonaVisualRendererImportPreview,
   PersonaVisualStateId
+} from "@/types/persona-visuals"
+import {
+  asPersonaVisualCustomStateId,
+  asPersonaVisualStateId
 } from "@/types/persona-visuals"
 import { getDesignSystemState } from "@/design-system"
 import {
@@ -216,7 +221,7 @@ const getGenerationReadinessCopy = (
   }
 }
 
-const REQUIRED_VISUAL_STATES: PersonaVisualStateId[] = [
+const REQUIRED_VISUAL_STATES: PersonaVisualBuiltinStateId[] = [
   "idle",
   "listening",
   "thinking",
@@ -224,7 +229,7 @@ const REQUIRED_VISUAL_STATES: PersonaVisualStateId[] = [
   "error"
 ]
 
-const OPTIONAL_VISUAL_STATES: PersonaVisualStateId[] = [
+const OPTIONAL_VISUAL_STATES: PersonaVisualBuiltinStateId[] = [
   "wake_armed",
   "tool_running",
   "approval_needed",
@@ -472,6 +477,16 @@ const normalizeFrames = (
 
 const formatStateLabel = (state: PersonaVisualStateId): string =>
   state.replace(/_/g, " ")
+
+const resolveGenerationTargetState = (
+  current: PersonaVisualStateId,
+  availableStates: PersonaVisualStateId[]
+): PersonaVisualStateId => {
+  if (availableStates.includes(current)) return current
+  return availableStates.includes("thinking")
+    ? "thinking"
+    : availableStates[0] ?? "thinking"
+}
 
 const stringifyPreviewValue = (value: unknown): string => {
   if (value == null) return ""
@@ -786,6 +801,8 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   >(null)
   const [importTargetMode, setImportTargetMode] =
     React.useState<PersonaVisualImportTargetMode | "">("create_new")
+  const [importTargetChoicePreviewId, setImportTargetChoicePreviewId] =
+    React.useState("")
   const [importReplacePackId, setImportReplacePackId] = React.useState("")
   const [importDraftTitle, setImportDraftTitle] = React.useState("")
   const [importCommitJob, setImportCommitJob] = React.useState<
@@ -883,16 +900,20 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     () =>
       Object.keys(draftManifest.state_catalog || {}).sort((a, b) =>
         a.localeCompare(b)
-      ) as PersonaVisualStateId[],
+      ).map(asPersonaVisualCustomStateId),
     [draftManifest.state_catalog]
   )
-  const activeVisualStates = React.useMemo(
+  const activeVisualStates: PersonaVisualStateId[] = React.useMemo(
     () => [...VISUAL_STATES, ...customVisualStates],
     [customVisualStates]
   )
-  const editableFallbackStates = React.useMemo(
+  const editableFallbackStates: PersonaVisualStateId[] = React.useMemo(
     () => [...OPTIONAL_VISUAL_STATES, ...customVisualStates],
     [customVisualStates]
+  )
+  const normalizedGenerationTargetState = React.useMemo(
+    () => resolveGenerationTargetState(generationTargetState, activeVisualStates),
+    [activeVisualStates, generationTargetState]
   )
   const selectedAnimation =
     selectedAnimationId && draftManifest.animations[selectedAnimationId]
@@ -1161,6 +1182,12 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       setSelectedAnimationId(animationIds[0] || "")
     }
   }, [animationIds, selectedAnimationId])
+
+  React.useEffect(() => {
+    if (generationTargetState !== normalizedGenerationTargetState) {
+      setGenerationTargetState(normalizedGenerationTargetState)
+    }
+  }, [generationTargetState, normalizedGenerationTargetState])
 
   React.useEffect(() => {
     setExportJob(null)
@@ -1511,6 +1538,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       setImportPreview(preview)
       setImportCommitJob(null)
       setImportTargetMode("create_new")
+      setImportTargetChoicePreviewId("")
       setImportReplacePackId("")
       setImportDraftTitle("")
       setSelectedImportPreviewFile(null)
@@ -1557,7 +1585,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     if (!selectedPersonaId || !fullImportPreview?.preview_id) return
     if (fullImportPreview.status !== "completed") return
     if (!importPreviewCommitEligible) return
-    if (importConflictChoiceRequired && !importTargetMode) return
+    if (importConflictChoiceRequired && !importConflictChoiceValid) return
     importCommitInFlightRef.current = true
     setCommittingImport(true)
     setError(null)
@@ -1741,12 +1769,19 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     setEnqueueingGeneration(true)
     setError(null)
     try {
+      const targetState = resolveGenerationTargetState(
+        generationTargetState,
+        activeVisualStates
+      )
+      if (targetState !== generationTargetState) {
+        setGenerationTargetState(targetState)
+      }
       const job = await createPersonaVisualGenerationJob(
         selectedPersonaId,
         selectedPack.id,
         {
           prompt: generationPrompt.trim(),
-          target_state: generationTargetState || null,
+          target_state: targetState || null,
           backend: generationBackend.trim() || null
         }
       )
@@ -1836,7 +1871,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       const fallbacks = { ...(manifest.fallbacks || {}) }
       const nextValues = value
         .split(",")
-        .map((item) => item.trim() as PersonaVisualStateId)
+        .map((item) => asPersonaVisualStateId(item.trim()))
         .filter((item) => activeVisualStates.includes(item))
       if (nextValues.length) {
         fallbacks[state] = nextValues
@@ -2165,10 +2200,17 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const importAllowedTargetModes = getAllowedImportTargetModes(importTargetChoice)
   const replaceableImportConflicts = getReplaceableImportConflicts(importPreviewConflicts)
   const importConflictChoiceRequired = Boolean(importTargetChoice)
+  const importConflictChoiceSelected =
+    !importConflictChoiceRequired ||
+    (Boolean(importTargetMode) &&
+      importTargetChoicePreviewId === fullImportPreview?.preview_id)
   const importConflictChoiceValid =
     !importConflictChoiceRequired ||
-    importTargetMode === "create_new" ||
-    Boolean(importReplacePackId)
+    (importConflictChoiceSelected &&
+      importAllowedTargetModes.includes(
+        importTargetMode as PersonaVisualImportTargetMode
+      ) &&
+      (importTargetMode !== "replace_draft" || Boolean(importReplacePackId)))
   const canCommitImportPreview = fullImportPreview?.status === "completed"
   const importPreviewCommitEligible = isImportPreviewCommitEligible(
     fullImportPreview,
@@ -2188,12 +2230,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   React.useEffect(() => {
     if (!fullImportPreview) {
       setImportTargetMode("create_new")
+      setImportTargetChoicePreviewId("")
       setImportReplacePackId("")
       setImportDraftTitle("")
       return
     }
     const choice = getImportTargetChoice(fullImportPreview)
     setImportTargetMode(choice ? "" : "create_new")
+    setImportTargetChoicePreviewId(choice ? "" : fullImportPreview.preview_id)
     setImportReplacePackId("")
     setImportDraftTitle(getDefaultImportDraftTitle(fullImportPreview))
   }, [fullImportPreview?.preview_id])
@@ -2802,6 +2846,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                                   const nextMode = event.target
                                     .value as PersonaVisualImportTargetMode | ""
                                   setImportTargetMode(nextMode)
+                                  setImportTargetChoicePreviewId(
+                                    nextMode ? fullImportPreview?.preview_id || "" : ""
+                                  )
                                   if (nextMode !== "replace_draft") {
                                     setImportReplacePackId("")
                                   } else if (!importReplacePackId) {
@@ -3254,7 +3301,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 onChange={(event) =>
                   setTriggerDraft((current) => ({
                     ...current,
-                    state: event.target.value as PersonaVisualStateId
+                    state: asPersonaVisualStateId(event.target.value)
                   }))
                 }
               >
@@ -3398,9 +3445,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 <select
                   data-testid="persona-visual-generation-target-state-select"
                   className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
-                  value={generationTargetState}
+                  value={normalizedGenerationTargetState}
                   onChange={(event) =>
-                    setGenerationTargetState(event.target.value as PersonaVisualStateId)
+                    setGenerationTargetState(asPersonaVisualStateId(event.target.value))
                   }
                 >
                   {activeVisualStates.map((state) => (

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -131,6 +131,20 @@ const readyGenerationReadiness = {
   reasons: []
 }
 
+const mockVisualPackBackgroundGet = (path: string, method: string) => {
+  if (method !== "GET") return null
+  if (path.endsWith("/generation-readiness")) {
+    return okResponse(readyGenerationReadiness)
+  }
+  if (path === "/api/v1/persona/catalog") {
+    return okResponse([])
+  }
+  if (path === "/api/v1/persona/visual-library") {
+    return okResponse({ items: [] })
+  }
+  return null
+}
+
 describe("VisualPackEditor", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -186,6 +200,8 @@ describe("VisualPackEditor", () => {
       if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
         return okResponse([pack])
       }
+      const backgroundResponse = mockVisualPackBackgroundGet(path, method)
+      if (backgroundResponse) return backgroundResponse
       if (
         path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
         method === "GET"
@@ -312,6 +328,8 @@ describe("VisualPackEditor", () => {
       if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
         return okResponse([pack])
       }
+      const backgroundResponse = mockVisualPackBackgroundGet(path, method)
+      if (backgroundResponse) return backgroundResponse
       if (
         path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
         method === "GET"

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { asPersonaVisualCustomStateId } from "@/types/persona-visuals"
+
 const mocks = vi.hoisted(() => ({
   fetchWithAuth: vi.fn(),
   translate: vi.fn(
@@ -1023,6 +1025,111 @@ describe("VisualPackEditor", () => {
         )
       ).toHaveLength(2)
     )
+  })
+
+  it("clamps stale generation target states after switching packs", async () => {
+    const queuedPayloads: any[] = []
+    const customState = asPersonaVisualCustomStateId("tool.notes_search")
+    const customManifest = {
+      ...structuredClone(baseManifest),
+      state_catalog: {
+        [customState]: {
+          label: "Searching notes",
+          kind: "tool_variant"
+        }
+      },
+      states: {
+        ...structuredClone(baseManifest).states,
+        [customState]: { animation_id: "thinking" }
+      }
+    }
+    const customPack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Custom pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: customManifest,
+      assets: visualAssets,
+      version: 3
+    }
+    const plainPack = {
+      id: "pack-2",
+      persona_id: "persona-1",
+      title: "Plain pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 1
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([customPack, plainPack])
+      }
+      if (path.endsWith("/generated-candidates") && method === "GET") {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-2/generation-jobs" &&
+        method === "POST"
+      ) {
+        queuedPayloads.push(parseJsonBody(init?.body))
+        return okResponse({ job_id: "job-created", status: "queued" })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue("pack-1")
+    )
+    fireEvent.change(screen.getByTestId("persona-visual-generation-target-state-select"), {
+      target: { value: "tool.notes_search" }
+    })
+    expect(screen.getByTestId("persona-visual-generation-target-state-select")).toHaveValue(
+      "tool.notes_search"
+    )
+
+    fireEvent.change(screen.getByTestId("persona-visual-pack-select"), {
+      target: { value: "pack-2" }
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue("pack-2")
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-generation-target-state-select")).toHaveValue(
+        "thinking"
+      )
+    )
+
+    fireEvent.change(screen.getByTestId("persona-visual-generation-prompt-input"), {
+      target: { value: "make a thinking pose" }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-generation-enqueue-button"))
+
+    await waitFor(() => expect(queuedPayloads).toHaveLength(1))
+    expect(queuedPayloads[0]).toMatchObject({
+      target_state: "thinking"
+    })
   })
 
   it("disables visual generation when the Jobs worker is unavailable", async () => {

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -2086,6 +2086,40 @@ describe("usePersonaLiveVoiceController", () => {
     expect((result.current as any).recoveryMode).toBe("thinking_stuck")
   })
 
+  it("extracts activeToolName from object-shaped tool payloads", () => {
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-voice",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true
+      })
+    )
+
+    act(() => {
+      result.current.handlePayload({
+        event: "tool_call",
+        tool: {
+          name: "notes.search",
+          arguments: { query: "migu" }
+        },
+        why: "Looking through notes"
+      })
+    })
+
+    expect((result.current as any).activeToolName).toBe("notes.search")
+    expect((result.current as any).activeToolStatus).toBe(
+      "Running notes.search: Looking through notes"
+    )
+  })
+
   it("clears activeToolStatus and recovery on approval tool_result", async () => {
     vi.useFakeTimers()
 

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -2065,6 +2065,7 @@ describe("usePersonaLiveVoiceController", () => {
     })
 
     expect((result.current as any).activeToolStatus).toBeTruthy()
+    expect((result.current as any).activeToolName).toBe("search_notes")
 
     act(() => {
       result.current.handlePayload({
@@ -2136,6 +2137,7 @@ describe("usePersonaLiveVoiceController", () => {
     })
 
     expect((result.current as any).activeToolStatus).toBe("")
+    expect((result.current as any).activeToolName).toBe("")
     expect((result.current as any).recoveryMode).toBe("none")
   })
 

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -126,9 +126,32 @@ const formatActiveToolStatus = (tool: unknown, why: unknown): string => {
   return `Running ${toolName}: ${whyText}`
 }
 
+const getRecordValue = (value: unknown, key: string): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return (value as Record<string, unknown>)[key]
+}
+
+const normalizeToolNameCandidate = (value: unknown): string => {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value).trim()
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return ""
+  }
+  return (
+    normalizeToolNameCandidate(getRecordValue(value, "tool_name")) ||
+    normalizeToolNameCandidate(getRecordValue(value, "name")) ||
+    normalizeToolNameCandidate(getRecordValue(getRecordValue(value, "function"), "name"))
+  )
+}
+
 const getPayloadToolName = (payload: PersonaLiveVoicePayload): string => {
   if (!payload || typeof payload !== "object") return ""
-  return String(payload.tool_name || payload.tool || payload.name || "").trim()
+  return (
+    normalizeToolNameCandidate(payload.tool_name) ||
+    normalizeToolNameCandidate(payload.tool) ||
+    normalizeToolNameCandidate(payload.name)
+  )
 }
 
 const WAKE_REJECTION_MESSAGES: Record<string, string> = {

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -126,6 +126,11 @@ const formatActiveToolStatus = (tool: unknown, why: unknown): string => {
   return `Running ${toolName}: ${whyText}`
 }
 
+const getPayloadToolName = (payload: PersonaLiveVoicePayload): string => {
+  if (!payload || typeof payload !== "object") return ""
+  return String(payload.tool_name || payload.tool || payload.name || "").trim()
+}
+
 const WAKE_REJECTION_MESSAGES: Record<string, string> = {
   not_saved_in_profile:
     "Wake phrase was heard, but it is not a saved trigger phrase for this " +
@@ -185,6 +190,7 @@ export const usePersonaLiveVoiceController = ({
   const [state, setState] = React.useState<PersonaLiveVoiceState>("idle")
   const [heardText, setHeardText] = React.useState("")
   const [lastCommittedText, setLastCommittedText] = React.useState("")
+  const [activeToolName, setActiveToolName] = React.useState("")
   const [activeToolStatus, setActiveToolStatus] = React.useState("")
   const [warning, setWarning] = React.useState<string | null>(null)
   const [warningReasonCode, setWarningReasonCode] =
@@ -554,6 +560,7 @@ export const usePersonaLiveVoiceController = ({
     clearTransientWarning()
     setHeardText("")
     heardTranscriptRef.current = ""
+    setActiveToolName("")
     setActiveToolStatus("")
     setRecoveryMode("none")
     clearThinkingRecovery()
@@ -667,6 +674,7 @@ export const usePersonaLiveVoiceController = ({
     setHeardText("")
     heardTranscriptRef.current = ""
     setLastCommittedText("")
+    setActiveToolName("")
     setActiveToolStatus("")
     if (!manualModeRequiredRef.current && !textOnlyDueToTtsFailureRef.current) {
       setVoiceWarning(null)
@@ -782,6 +790,7 @@ export const usePersonaLiveVoiceController = ({
       clearTransientWarning()
       setHeardText("")
       heardTranscriptRef.current = ""
+      setActiveToolName("")
       setActiveToolStatus("")
       setRecoveryMode("none")
       clearThinkingRecovery()
@@ -1043,6 +1052,7 @@ export const usePersonaLiveVoiceController = ({
     setHeardText("")
     heardTranscriptRef.current = ""
     setLastCommittedText("")
+    setActiveToolName("")
     setActiveToolStatus("")
     setRecoveryMode("none")
     setListeningRecoveryCount(0)
@@ -1095,6 +1105,7 @@ export const usePersonaLiveVoiceController = ({
       setRecoveryMode("none")
       setListeningRecoveryCount(0)
       setThinkingRecoveryCount(0)
+      setActiveToolName("")
       setActiveToolStatus("")
       setWakeRecoveryWarning(null)
       setListeningRecoveryRestartKey(0)
@@ -1246,6 +1257,7 @@ export const usePersonaLiveVoiceController = ({
         const text = String(payload?.text_delta || "").trim()
         if (!text) return
         clearAwaitingTtsTimeout()
+        setActiveToolName("")
         setActiveToolStatus("")
         clearThinkingRecovery()
         if (textOnlyDueToTtsFailure) {
@@ -1282,7 +1294,9 @@ export const usePersonaLiveVoiceController = ({
       }
 
       if (eventType === "tool_call") {
-        setActiveToolStatus(formatActiveToolStatus(payload?.tool, payload?.why))
+        const toolName = getPayloadToolName(payload)
+        setActiveToolName(toolName)
+        setActiveToolStatus(formatActiveToolStatus(toolName, payload?.why))
         if (state === "thinking") {
           armThinkingRecovery()
         }
@@ -1290,6 +1304,7 @@ export const usePersonaLiveVoiceController = ({
       }
 
       if (eventType === "tool_result") {
+        setActiveToolName("")
         setActiveToolStatus("")
         if (payload?.approval && typeof payload.approval === "object") {
           clearThinkingRecovery()
@@ -1305,6 +1320,7 @@ export const usePersonaLiveVoiceController = ({
 
       if (eventType === "tts_audio") {
         clearAwaitingTtsTimeout()
+        setActiveToolName("")
         setActiveToolStatus("")
         clearThinkingRecovery()
         const chunkIndex =
@@ -1359,6 +1375,7 @@ export const usePersonaLiveVoiceController = ({
         }
         if (reasonCode === "TTS_UNAVAILABLE_TEXT_ONLY") {
           clearAwaitingTtsTimeout()
+          setActiveToolName("")
           setActiveToolStatus("")
           clearThinkingRecovery()
           textOnlyDueToTtsFailureRef.current = true
@@ -1392,6 +1409,7 @@ export const usePersonaLiveVoiceController = ({
           if (committedTranscript) {
             setLastCommittedText(committedTranscript)
           }
+          setActiveToolName("")
           setActiveToolStatus("")
           if (!manualModeRequiredRef.current && !textOnlyDueToTtsFailureRef.current) {
             setVoiceWarning(null)
@@ -1402,6 +1420,7 @@ export const usePersonaLiveVoiceController = ({
           return
         }
         if (reasonCode === "VOICE_COMMIT_IGNORED_ALREADY_COMMITTED") {
+          setActiveToolName("")
           setActiveToolStatus("")
           setVoiceWarning(
             String(payload?.message || "This utterance was already committed."),
@@ -1411,6 +1430,7 @@ export const usePersonaLiveVoiceController = ({
           return
         }
         if (reasonCode === "VOICE_TRIGGER_NOT_HEARD") {
+          setActiveToolName("")
           setActiveToolStatus("")
           setHeardText("")
           heardTranscriptRef.current = ""
@@ -1426,6 +1446,7 @@ export const usePersonaLiveVoiceController = ({
           return
         }
         if (reasonCode === "VOICE_EMPTY_COMMAND_AFTER_TRIGGER") {
+          setActiveToolName("")
           setActiveToolStatus("")
           setHeardText("")
           heardTranscriptRef.current = ""
@@ -1444,6 +1465,7 @@ export const usePersonaLiveVoiceController = ({
           return
         }
         if (reasonCode === "TRANSCRIPT_REQUIRED") {
+          setActiveToolName("")
           setActiveToolStatus("")
           setVoiceWarning(
             "No speech transcript was captured for that live turn.",
@@ -1493,6 +1515,7 @@ export const usePersonaLiveVoiceController = ({
     thinkingRecoveryCount,
     heardText,
     lastCommittedText,
+    activeToolName,
     activeToolStatus,
     warning,
     warningReasonCode,

--- a/apps/packages/ui/src/routes/hooks/usePersonaIncomingPayload.ts
+++ b/apps/packages/ui/src/routes/hooks/usePersonaIncomingPayload.ts
@@ -2,7 +2,11 @@ import React from "react"
 import type { PersonaSetupStep } from "@/hooks/usePersonaSetupWizard"
 import type { SetupTestOutcome } from "@/components/PersonaGarden/SetupTestAndFinishStep"
 import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
-import type { PersonaVisualStateId } from "@/types/persona-visuals"
+import type { PersonaVisualBuiltinStateId } from "@/types/persona-visuals"
+import {
+  isPersonaVisualBuiltinStateId,
+  PERSONA_VISUAL_BUILTIN_STATES
+} from "@/types/persona-visuals"
 import {
   coerceGovernanceContext as _coerceGovernanceContext,
   formatGovernanceDenyMessage as _formatGovernanceDenyMessage,
@@ -87,18 +91,10 @@ export const usePersonaIncomingPayload = ({
 
       if (eventType === "visual_state_override") {
         const state = String(payload?.state || payload?.visual_state || "").trim()
-        const allowedStates = new Set<PersonaVisualStateId>([
-          "idle",
-          "wake_armed",
-          "listening",
-          "thinking",
-          "speaking",
-          "tool_running",
-          "approval_needed",
-          "error",
-          "offline"
-        ])
-        if (!allowedStates.has(state as PersonaVisualStateId)) return
+        const allowedStates = new Set<PersonaVisualBuiltinStateId>(
+          PERSONA_VISUAL_BUILTIN_STATES
+        )
+        if (!isPersonaVisualBuiltinStateId(state) || !allowedStates.has(state)) return
         const durationMsRaw =
           typeof payload?.duration_ms === "number"
             ? payload.duration_ms
@@ -113,7 +109,7 @@ export const usePersonaIncomingPayload = ({
             : sessionId
               ? String(sessionId)
               : null,
-          state: state as PersonaVisualStateId,
+          state,
           reason: payload?.reason ? String(payload.reason) : null,
           expiresAt: Date.now() + durationMs
         })

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -234,6 +234,7 @@ const SidepanelPersona = ({
   )
   const [buddyShellLiveContext, setBuddyShellLiveContext] = React.useState({
     live_voice_state: "idle",
+    active_tool_name: "",
     active_tool_status: "",
     wake_armed: false,
     recovery_mode: "none"
@@ -275,6 +276,7 @@ const SidepanelPersona = ({
           null,
         live_session_id: sessionId,
         live_voice_state: buddyShellLiveContext.live_voice_state,
+        active_tool_name: buddyShellLiveContext.active_tool_name,
         active_tool_status: buddyShellLiveContext.active_tool_status,
         wake_armed: buddyShellLiveContext.wake_armed,
         recovery_mode: buddyShellLiveContext.recovery_mode,
@@ -599,11 +601,13 @@ const SidepanelPersona = ({
   React.useEffect(() => {
     setBuddyShellLiveContext({
       live_voice_state: liveVoiceController.state,
+      active_tool_name: liveVoiceController.activeToolName,
       active_tool_status: liveVoiceController.activeToolStatus,
       wake_armed: liveVoiceController.wakeArmed,
       recovery_mode: liveVoiceController.recoveryMode
     })
   }, [
+    liveVoiceController.activeToolName,
     liveVoiceController.activeToolStatus,
     liveVoiceController.recoveryMode,
     liveVoiceController.state,

--- a/apps/packages/ui/src/store/persona-visual-runtime.ts
+++ b/apps/packages/ui/src/store/persona-visual-runtime.ts
@@ -1,12 +1,15 @@
 import { create } from "zustand"
 
 import type { PersonaVisualDiagnostic } from "@/components/Common/PersonaBuddy/personaVisualDiagnostics"
-import type { PersonaVisualStateId } from "@/types/persona-visuals"
+import type {
+  PersonaVisualBuiltinStateId,
+  PersonaVisualStateId
+} from "@/types/persona-visuals"
 
 export interface PersonaVisualRuntimeOverride {
   personaId: string
   sessionId: string | null
-  state: PersonaVisualStateId
+  state: PersonaVisualBuiltinStateId
   reason: string | null
   expiresAt: number
 }

--- a/apps/packages/ui/src/types/persona-buddy.ts
+++ b/apps/packages/ui/src/types/persona-buddy.ts
@@ -29,6 +29,7 @@ export interface PersonaBuddyRenderContext {
   buddy_summary?: PersonaBuddySummary | null
   live_session_id?: string | null
   live_voice_state?: string | null
+  active_tool_name?: string | null
   active_tool_status?: string | null
   wake_armed?: boolean
   recovery_mode?: string | null

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -1,4 +1,4 @@
-export type PersonaVisualStateId =
+export type PersonaVisualBuiltinStateId =
   | "idle"
   | "wake_armed"
   | "listening"
@@ -8,6 +8,11 @@ export type PersonaVisualStateId =
   | "approval_needed"
   | "error"
   | "offline"
+
+export type PersonaVisualCustomStateId = string & {}
+export type PersonaVisualStateId =
+  | PersonaVisualBuiltinStateId
+  | PersonaVisualCustomStateId
 
 export type PersonaVisualRendererType =
   | "sprite_frames"
@@ -101,9 +106,30 @@ export interface PersonaVisualAnimation {
   preview_asset_id?: string
 }
 
+export type PersonaVisualStateCatalogKind =
+  | "tool_variant"
+  | "reaction"
+  | "live_variant"
+  | "mcp_runtime"
+  | "mood"
+  | "pack_private"
+
+export interface PersonaVisualStateCatalogEntry {
+  label: string
+  kind: PersonaVisualStateCatalogKind
+  description?: string | null
+  tags?: string[]
+}
+
+export type PersonaVisualAuthoredTriggerSource =
+  | "live_state"
+  | "tool_category"
+  | "mcp_runtime"
+  | "tool_name"
+
 export interface PersonaVisualAuthoredTrigger {
   id: string
-  source: "live_state" | "tool_category" | "mcp_runtime"
+  source: PersonaVisualAuthoredTriggerSource
   match: string
   state: PersonaVisualStateId
   duration_ms: number
@@ -116,6 +142,7 @@ export interface PersonaVisualManifest {
   states: Partial<Record<PersonaVisualStateId, { animation_id: string }>>
   animations: Record<string, PersonaVisualAnimation>
   fallbacks?: Partial<Record<PersonaVisualStateId, PersonaVisualStateId[]>>
+  state_catalog?: Record<PersonaVisualCustomStateId, PersonaVisualStateCatalogEntry>
   authored_triggers?: PersonaVisualAuthoredTrigger[]
 }
 

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -1,18 +1,39 @@
-export type PersonaVisualBuiltinStateId =
-  | "idle"
-  | "wake_armed"
-  | "listening"
-  | "thinking"
-  | "speaking"
-  | "tool_running"
-  | "approval_needed"
-  | "error"
-  | "offline"
+export const PERSONA_VISUAL_BUILTIN_STATES = [
+  "idle",
+  "wake_armed",
+  "listening",
+  "thinking",
+  "speaking",
+  "tool_running",
+  "approval_needed",
+  "error",
+  "offline"
+] as const
 
-export type PersonaVisualCustomStateId = string & {}
+export type PersonaVisualBuiltinStateId =
+  (typeof PERSONA_VISUAL_BUILTIN_STATES)[number]
+
+declare const personaVisualCustomStateIdBrand: unique symbol
+export type PersonaVisualCustomStateId = string & {
+  readonly [personaVisualCustomStateIdBrand]: "PersonaVisualCustomStateId"
+}
 export type PersonaVisualStateId =
   | PersonaVisualBuiltinStateId
   | PersonaVisualCustomStateId
+
+export const isPersonaVisualBuiltinStateId = (
+  value: string
+): value is PersonaVisualBuiltinStateId =>
+  (PERSONA_VISUAL_BUILTIN_STATES as readonly string[]).includes(value)
+
+export const asPersonaVisualCustomStateId = (
+  value: string
+): PersonaVisualCustomStateId => value as PersonaVisualCustomStateId
+
+export const asPersonaVisualStateId = (value: string): PersonaVisualStateId =>
+  isPersonaVisualBuiltinStateId(value)
+    ? value
+    : asPersonaVisualCustomStateId(value)
 
 export type PersonaVisualRendererType =
   | "sprite_frames"

--- a/backlog/tasks/task-347.1 - Implement-Persona-Visual-custom-state-runtime-triggers.md
+++ b/backlog/tasks/task-347.1 - Implement-Persona-Visual-custom-state-runtime-triggers.md
@@ -4,7 +4,7 @@ title: Implement Persona Visual custom-state runtime triggers
 status: Done
 assignee: []
 created_date: '2026-05-15 03:17'
-updated_date: '2026-05-15 05:19'
+updated_date: '2026-05-15 05:32'
 labels:
   - persona
   - buddy
@@ -45,6 +45,8 @@ Review follow-up started for PR #1717. Actionable comments found: branded custom
 PR #1717 review follow-up addressed: branded PersonaVisualCustomStateId no longer widens PersonaVisualStateId to plain string; runtime visual_state_override is built-in-only in store, resolver, and incoming payload handling; tool_name triggers now require a present structured activeToolName; live voice tool payloads extract object-shaped tool.name/function.name safely; VisualPackEditor clamps stale generation target states after pack switches and guards submit payloads; import conflict commit eligibility now waits for an explicit target-mode choice for the active preview.
 
 Review follow-up verification: bun run test src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx -t "extracts activeToolName" passed; bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "clamps stale generation" --testTimeout=20000 passed; bun run test src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx src/store/__tests__/persona-visual-runtime.test.ts passed with 86 tests; bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testTimeout=30000 passed with 25 tests; git diff --check passed. ./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false still exits nonzero on existing repo-wide type drift outside this slice; no changed persona visual files were reported in the emitted errors. Bandit remains not applicable for this frontend-only TypeScript/task-file slice.
+
+Follow-up after PR comment: hardened VisualPackEditor localization test background fetch stubs so the candidate-loading assertion no longer waits on unrelated background requests. Verification after this follow-up: bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "localizes loading and refresh labels while candidates are loading" --testTimeout=20000 passed; bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testTimeout=30000 passed with 25 tests; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-347.1 - Implement-Persona-Visual-custom-state-runtime-triggers.md
+++ b/backlog/tasks/task-347.1 - Implement-Persona-Visual-custom-state-runtime-triggers.md
@@ -4,7 +4,7 @@ title: Implement Persona Visual custom-state runtime triggers
 status: Done
 assignee: []
 created_date: '2026-05-15 03:17'
-updated_date: '2026-05-15 03:42'
+updated_date: '2026-05-15 05:19'
 labels:
   - persona
   - buddy
@@ -39,12 +39,20 @@ Implement the frontend Stage 3 runtime/type slice for Persona Visual state catal
 Implemented frontend Persona Visual custom-state runtime support. Added custom visual state typing and state_catalog metadata, exact tool_name authored-trigger matching from structured activeToolName, active_tool_name render-context propagation from live voice, and custom state display/preservation in VisualPackEditor.
 
 Verification: bun run test src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx passed with 81 tests. VisualPackEditor default timeout run exposed two slow existing tests; rerun with --testTimeout=20000 passed all 24 editor tests. git diff --check passed. Package tsc was attempted and exited nonzero due existing repo-wide test type errors outside this slice, so it is recorded as a known non-clean baseline gate rather than a pass. Bandit is not applicable because this slice touched frontend TypeScript and Backlog task files only.
+
+Review follow-up started for PR #1717. Actionable comments found: branded custom-state ID typing, built-in-only runtime override type contract, stale generationTargetState clamp/submit guard, object-safe getPayloadToolName extraction, and explicit structured activeToolName guard for tool_name trigger matching.
+
+PR #1717 review follow-up addressed: branded PersonaVisualCustomStateId no longer widens PersonaVisualStateId to plain string; runtime visual_state_override is built-in-only in store, resolver, and incoming payload handling; tool_name triggers now require a present structured activeToolName; live voice tool payloads extract object-shaped tool.name/function.name safely; VisualPackEditor clamps stale generation target states after pack switches and guards submit payloads; import conflict commit eligibility now waits for an explicit target-mode choice for the active preview.
+
+Review follow-up verification: bun run test src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx -t "extracts activeToolName" passed; bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "clamps stale generation" --testTimeout=20000 passed; bun run test src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx src/store/__tests__/persona-visual-runtime.test.ts passed with 86 tests; bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testTimeout=30000 passed with 25 tests; git diff --check passed. ./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false still exits nonzero on existing repo-wide type drift outside this slice; no changed persona visual files were reported in the emitted errors. Bandit remains not applicable for this frontend-only TypeScript/task-file slice.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented Persona Visual custom-state runtime triggers for the WebUI. The buddy shell now carries structured active tool identity, resolves exact tool_name authored triggers from active visual packs, and can render custom state animations through the existing sprite-frame path. Frontend manifest types now include state_catalog/custom states and tool_name trigger sources, and the visual pack editor preserves/displays custom state mappings for imported or backend-validated packs.
+
+PR #1717 review follow-up tightened the runtime visual trigger contract: custom state ids are truly branded, incoming runtime overrides are built-in-only for this V1 path, tool_name matching uses structured active tool identity, generation jobs cannot submit stale custom target_state values after pack switches, and import conflict commits require an explicit target-mode choice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-347.1 - Implement-Persona-Visual-custom-state-runtime-triggers.md
+++ b/backlog/tasks/task-347.1 - Implement-Persona-Visual-custom-state-runtime-triggers.md
@@ -1,0 +1,58 @@
+---
+id: TASK-347.1
+title: Implement Persona Visual custom-state runtime triggers
+status: Done
+assignee: []
+created_date: '2026-05-15 03:17'
+updated_date: '2026-05-15 03:42'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - frontend
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md
+parent_task_id: TASK-347
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the frontend Stage 3 runtime/type slice for Persona Visual state catalogs. The buddy shell should consume active-pack authored exact tool_name triggers from structured live tool context and render declared custom visual states through the existing Persona Visual pack runtime, while preserving current built-in live-state and tool-category fallback behavior. This is scoped to the WebUI runtime/type path, not MCP direct trigger-state handling, generation jobs, or default starter-pack art production.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Frontend Persona Visual types represent built-in and custom state IDs plus tool_name authored trigger sources without dropping the known built-in state set.
+- [x] #2 Buddy visual runtime resolves exact tool_name authored triggers from structured active tool context before falling back to tool_running.
+- [x] #3 Buddy shell render context carries structured active tool identity separately from human-readable tool status.
+- [x] #4 Custom state animations render through the existing SpriteFrameRenderer path for active visual packs.
+- [x] #5 Focused tests cover exact tool_name matching, no text-only inference, BuddyShell rendering of a custom tool state, and existing category fallback behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented frontend Persona Visual custom-state runtime support. Added custom visual state typing and state_catalog metadata, exact tool_name authored-trigger matching from structured activeToolName, active_tool_name render-context propagation from live voice, and custom state display/preservation in VisualPackEditor.
+
+Verification: bun run test src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx passed with 81 tests. VisualPackEditor default timeout run exposed two slow existing tests; rerun with --testTimeout=20000 passed all 24 editor tests. git diff --check passed. Package tsc was attempted and exited nonzero due existing repo-wide test type errors outside this slice, so it is recorded as a known non-clean baseline gate rather than a pass. Bandit is not applicable because this slice touched frontend TypeScript and Backlog task files only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Persona Visual custom-state runtime triggers for the WebUI. The buddy shell now carries structured active tool identity, resolves exact tool_name authored triggers from active visual packs, and can render custom state animations through the existing sprite-frame path. Frontend manifest types now include state_catalog/custom states and tool_name trigger sources, and the visual pack editor preserves/displays custom state mappings for imported or backend-validated packs.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Pending human-authored summary per the AI-generated PR merge gate.

## Summary

- Adds frontend Persona Visual types for custom state IDs, state_catalog metadata, and tool_name authored triggers.
- Propagates structured active tool identity from live voice into the Buddy shell and resolves exact tool_name triggers before the generic tool_running fallback.
- Preserves and displays custom state mappings in the VisualPackEditor for backend-validated/imported packs.

## Test plan

- bun run test src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
- bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testTimeout=20000
- git diff --check

## Notes

- Package-wide tsc was attempted but exits nonzero on existing repo-wide test type errors outside this slice, so it is not claimed as a clean gate.
- Bandit is not applicable; this slice only changes frontend TypeScript and Backlog task metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime support for custom Persona Visual states triggered by exact `tool_name`, using structured `active_tool_name` from live voice so Buddy Shell can render tool-specific animations. Tightens types (branded custom IDs, built‑in‑only overrides) and updates the Visual Pack Editor to preserve `state_catalog`, show/edit custom states, and clamp generation targets; meets TASK-347.1.

- **New Features**
  - Branded custom state IDs and `state_catalog`; added `tool_name` triggers and separated built‑in vs custom IDs (overrides are built‑in only).
  - Structured `active_tool_name` extracted from tool payloads and passed into Buddy Shell; resolver matches exact `tool_name` before `tool_running` and never from status text.
  - Visual Pack Editor preserves/edits custom states (shown in mapping and fallbacks), normalizes generation target state, and supports `tool_name` triggers.

- **Bug Fixes**
  - Clamp generation target after pack switches and when enqueuing jobs; require an explicit import target choice for the active preview before commit.
  - Stabilized Visual Pack Editor tests by stubbing background fetches to avoid flaky localization assertions.

<sup>Written for commit 45a84eca10a2dd5062536c32b670e5ff98f61c50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

