### PR TITLE
Promote ACP deliverables into traceable artifacts

### DIFF
--- a/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
+++ b/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-369
 title: Implement ACP deliverable promotion into traceable artifacts
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-15 03:51'
-updated_date: '2026-05-15 04:16'
+updated_date: '2026-05-15 04:45'
 labels:
   - acp
   - artifacts
@@ -53,12 +53,24 @@ Implement GitHub issue #1706: promote one golden-path ACP run deliverable, such 
 Implemented ACP artifact promotion backend slice for issue #1706. Added a focused promotion service at tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py and dispatch wiring in tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py. Added regression coverage in tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py plus a dispatch-level golden path in test_orchestration_api.py. Verification: pytest tldw_Server_API/tests/Agent_Orchestration -q => 176 passed, 5 warnings. Ruff check on touched files => all checks passed. Bandit production touched files => exit 0; touched files with pytest B101/B105 excluded => exit 0.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented issue #1706 in draft PR #1718: https://github.com/rmusser01/tldw_server/pull/1718
+
+Added ACP deliverable promotion into traceable workspace artifacts through a focused backend service and ACP dispatch wiring. The implementation promotes only structured work-product artifacts with source lineage, preserves ACP producer/session/run/review metadata, stores redaction/version/source-lineage contract fields, updates existing artifacts by version, and leaves retry/rejected/malformed payloads out of accepted artifact state.
+
+Verification recorded: Agent Orchestration pytest suite passed (176 passed, 5 warnings); Ruff passed on touched files; Bandit passed on production touched files and on the touched set with pytest-only B101/B105 excluded.
+
+Known merge gate: PR remains draft until the requester adds the required human-authored Change summary.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
+++ b/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
@@ -4,7 +4,7 @@ title: Implement ACP deliverable promotion into traceable artifacts
 status: Done
 assignee: []
 created_date: '2026-05-15 03:51'
-updated_date: '2026-05-15 04:45'
+updated_date: '2026-05-15 21:58'
 labels:
   - acp
   - artifacts
@@ -45,24 +45,27 @@ Implement GitHub issue #1706: promote one golden-path ACP run deliverable, such 
 3. Implement the minimal backend promotion service/API seam that creates or updates traceable workspace artifacts while preserving ACP producer/session/run/review references. - Complete
 4. Wire the golden-path ACP completion caller only where the existing architecture already exposes deliverable metadata. - Complete
 5. Verify with focused pytest/Bandit and update #1706/TASK-369 evidence. - Complete
+6. Address PR #1718 review feedback: avoid converting post-commit artifact promotion failures into failed dispatch responses, preserve promotion failure metadata in the response/audit path, and replace repeated preview truncation literals with a named module constant. - Complete
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented ACP artifact promotion backend slice for issue #1706. Added a focused promotion service at tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py and dispatch wiring in tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py. Added regression coverage in tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py plus a dispatch-level golden path in test_orchestration_api.py. Verification: pytest tldw_Server_API/tests/Agent_Orchestration -q => 176 passed, 5 warnings. Ruff check on touched files => all checks passed. Bandit production touched files => exit 0; touched files with pytest B101/B105 excluded => exit 0.
+
+PR #1718 review follow-up reopened this task for Gemini feedback on post-commit promotion error handling and preview truncation maintainability.
+
+Review follow-up verification: `python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -k promotion_failure_without_rolling_back_task -q` failed before the endpoint fix and passed after it; `python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -q` passed with 43 tests and 5 warnings; `python -m ruff check tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py` passed; `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py -f json -o /tmp/bandit_acp_artifact_promotion_1718.json` passed with 0 results/errors; `git diff --check` passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented issue #1706 in draft PR #1718: https://github.com/rmusser01/tldw_server/pull/1718
+Implemented issue #1706 in PR #1718: https://github.com/rmusser01/tldw_server/pull/1718
 
 Added ACP deliverable promotion into traceable workspace artifacts through a focused backend service and ACP dispatch wiring. The implementation promotes only structured work-product artifacts with source lineage, preserves ACP producer/session/run/review metadata, stores redaction/version/source-lineage contract fields, updates existing artifacts by version, and leaves retry/rejected/malformed payloads out of accepted artifact state.
 
-Verification recorded: Agent Orchestration pytest suite passed (176 passed, 5 warnings); Ruff passed on touched files; Bandit passed on production touched files and on the touched set with pytest-only B101/B105 excluded.
-
-Known merge gate: PR remains draft until the requester adds the required human-authored Change summary.
+Verification recorded: Agent Orchestration pytest suite passed (176 passed, 5 warnings); Ruff passed on touched files; Bandit passed on production touched files and on the touched set with pytest-only B101/B105 excluded. PR review follow-up also keeps dispatch responses successful when post-commit artifact promotion fails, includes a structured promotion failure result for audit/response metadata, and replaces repeated preview truncation literals with a named module constant.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
+++ b/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
@@ -4,7 +4,7 @@ title: Implement ACP deliverable promotion into traceable artifacts
 status: Done
 assignee: []
 created_date: '2026-05-15 03:51'
-updated_date: '2026-05-15 21:58'
+updated_date: '2026-05-15 22:11'
 labels:
   - acp
   - artifacts
@@ -45,7 +45,7 @@ Implement GitHub issue #1706: promote one golden-path ACP run deliverable, such 
 3. Implement the minimal backend promotion service/API seam that creates or updates traceable workspace artifacts while preserving ACP producer/session/run/review references. - Complete
 4. Wire the golden-path ACP completion caller only where the existing architecture already exposes deliverable metadata. - Complete
 5. Verify with focused pytest/Bandit and update #1706/TASK-369 evidence. - Complete
-6. Address PR #1718 review feedback: avoid converting post-commit artifact promotion failures into failed dispatch responses, preserve promotion failure metadata in the response/audit path, and replace repeated preview truncation literals with a named module constant. - Complete
+6. Address PR #1718 review feedback: avoid converting post-commit artifact promotion failures into failed dispatch responses, preserve promotion failure metadata in the response/audit path, replace repeated preview truncation literals with a named module constant, offload sync promotion I/O from the async endpoint, and harden malformed artifact metadata handling. - Complete
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -56,6 +56,8 @@ Implemented ACP artifact promotion backend slice for issue #1706. Added a focuse
 PR #1718 review follow-up reopened this task for Gemini feedback on post-commit promotion error handling and preview truncation maintainability.
 
 Review follow-up verification: `python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -k promotion_failure_without_rolling_back_task -q` failed before the endpoint fix and passed after it; `python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -q` passed with 43 tests and 5 warnings; `python -m ruff check tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py` passed; `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py -f json -o /tmp/bandit_acp_artifact_promotion_1718.json` passed with 0 results/errors; `git diff --check` passed.
+
+Second review follow-up added `_run_sync` offloading for promotion DB I/O, response-contract assertions, promotable artifact type validation with `promote_as` fallback, optional metadata/schema/export validation, and per-artifact promotion failure isolation. The CodeRabbit suggestion to skip redacted artifacts was evaluated and not implemented because TASK-369's accepted behavior is to preserve the redaction contract for promoted artifacts; the UI layer suppresses sensitive provenance/lineage when the redaction posture requires it. Verification after this patch: `python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py -k 'promote_as or promote_flag_without_allowed_artifact_type or malformed_optional_metadata' -q` passed with 7 tests and 5 warnings; `python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -q` passed with 50 tests and 5 warnings; Ruff passed on the touched endpoint/service/test files; Bandit passed with 0 results/errors; `git diff --check` passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -65,7 +67,7 @@ Implemented issue #1706 in PR #1718: https://github.com/rmusser01/tldw_server/pu
 
 Added ACP deliverable promotion into traceable workspace artifacts through a focused backend service and ACP dispatch wiring. The implementation promotes only structured work-product artifacts with source lineage, preserves ACP producer/session/run/review metadata, stores redaction/version/source-lineage contract fields, updates existing artifacts by version, and leaves retry/rejected/malformed payloads out of accepted artifact state.
 
-Verification recorded: Agent Orchestration pytest suite passed (176 passed, 5 warnings); Ruff passed on touched files; Bandit passed on production touched files and on the touched set with pytest-only B101/B105 excluded. PR review follow-up also keeps dispatch responses successful when post-commit artifact promotion fails, includes a structured promotion failure result for audit/response metadata, and replaces repeated preview truncation literals with a named module constant.
+Verification recorded: Agent Orchestration pytest suite passed (176 passed, 5 warnings); Ruff passed on touched files; Bandit passed on production touched files and on the touched set with pytest-only B101/B105 excluded. PR review follow-up also keeps dispatch responses successful when post-commit artifact promotion fails, includes a structured promotion failure result for audit/response metadata, replaces repeated preview truncation literals with a named module constant, offloads promotion DB work from the async endpoint, and validates malformed optional artifact metadata without aborting the whole promotion pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
+++ b/backlog/tasks/task-369 - Implement-ACP-deliverable-promotion-into-traceable-artifacts.md
@@ -1,0 +1,64 @@
+---
+id: TASK-369
+title: Implement ACP deliverable promotion into traceable artifacts
+status: In Progress
+assignee: []
+created_date: '2026-05-15 03:51'
+updated_date: '2026-05-15 04:16'
+labels:
+  - acp
+  - artifacts
+  - backend
+dependencies:
+  - TASK-357
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1706'
+  - 'https://github.com/rmusser01/tldw_server/issues/1703'
+  - 'https://github.com/rmusser01/tldw_server/issues/1707'
+  - 'https://github.com/rmusser01/tldw_server/pull/1714'
+documentation:
+  - Docs/Product/Traceable_Work_Product_Artifact_Contract.md
+  - Docs/Product/ACP_Agent_Orchestration_PRD.md
+  - Docs/Development/Agent_Client_Protocol.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1706: promote one golden-path ACP run deliverable, such as a source-grounded workspace brief, into the traceable work-product artifact backend contract while preserving ACP execution evidence. This follows the merged storage/API foundation from #1703 and the Workspace UI detail surface from #1707/#1714. Keep raw low-level ACP session artifacts as execution evidence unless explicitly promoted into structured work products, and enforce redaction/review-state semantics from the traceable artifact contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ACP task completion can create or update a traceable work-product artifact through the backend contract.
+- [x] #2 Promotion preserves ACP producer/session/run/review references.
+- [x] #3 Rejected or needs_revision outputs do not masquerade as accepted artifacts.
+- [x] #4 Tests cover accepted, retry, rejected, redacted, and malformed promotion paths.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Map the merged traceable artifact storage/API contract and current ACP execution surfaces. - Complete
+2. Add focused failing backend tests for accepted, retry/needs_revision, rejected, redacted, and malformed ACP promotion payloads. - Complete
+3. Implement the minimal backend promotion service/API seam that creates or updates traceable workspace artifacts while preserving ACP producer/session/run/review references. - Complete
+4. Wire the golden-path ACP completion caller only where the existing architecture already exposes deliverable metadata. - Complete
+5. Verify with focused pytest/Bandit and update #1706/TASK-369 evidence. - Complete
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented ACP artifact promotion backend slice for issue #1706. Added a focused promotion service at tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py and dispatch wiring in tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py. Added regression coverage in tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py plus a dispatch-level golden path in test_orchestration_api.py. Verification: pytest tldw_Server_API/tests/Agent_Orchestration -q => 176 passed, 5 warnings. Ruff check on touched files => all checks passed. Bandit production touched files => exit 0; touched files with pytest B101/B105 excluded => exit 0.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -1827,12 +1827,11 @@ async def dispatch_run(
                     review_decision=review_decision_for_promotion,
                     review_run=review_run_for_promotion,
                 )
-            except Exception as exc:
+            except Exception:
                 logger.exception("ACP artifact promotion failed for task {}", task_id)
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="ACP artifact promotion failed",
-                ) from exc
+                artifact_promotion_result = ACPArtifactPromotionResult(
+                    errors=[{"artifact_id": "all", "reason": "promotion_failed"}]
+                )
             if any(
                 (
                     artifact_promotion_result.created_artifact_ids,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -16,6 +16,10 @@ from pydantic import BaseModel, Field, field_validator
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard, User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.core.Agent_Orchestration.artifact_promotion import (
+    ACPArtifactPromotionResult,
+    promote_acp_completion_artifacts,
+)
 from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
     CompletionSignalValidationError,
     ReviewDecisionValidationError,
@@ -1448,6 +1452,7 @@ async def dispatch_run(
     task_id: int,
     payload: RunDispatchRequest,
     user: User = Depends(get_request_user),
+    canonical_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> dict[str, Any]:
     """Dispatch a task run to an ACP agent.
 
@@ -1640,6 +1645,9 @@ async def dispatch_run(
             "artifact_count": len(completion_signal.artifacts),
         },
     )
+    artifact_promotion_result: ACPArtifactPromotionResult | None = None
+    review_decision_for_promotion = None
+    review_run_for_promotion = None
     if task.reviewer_agent_type:
         review_session_id: str | None = None
         review_run = None
@@ -1745,6 +1753,8 @@ async def dispatch_run(
                 result_summary=review_decision.feedback,
                 token_usage=review_result.get("usage", {}),
             ))
+            review_decision_for_promotion = review_decision
+            review_run_for_promotion = review_run
             task = await _run_sync(lambda: db.submit_review(
                 task_id,
                 review_decision.approved,
@@ -1798,6 +1808,48 @@ async def dispatch_run(
             metadata={"reason_code": "no_reviewer"},
         )
 
+    if completion_signal.artifacts:
+        if not isinstance(canonical_db, CharactersRAGDB):
+            logger.warning(
+                "Skipping ACP artifact promotion for task {} because the workspace artifact DB is unavailable",
+                task_id,
+            )
+        else:
+            try:
+                artifact_promotion_result = promote_acp_completion_artifacts(
+                    canonical_db,
+                    task=task,
+                    project=project,
+                    workspace=workspace,
+                    run=run,
+                    completion_signal=completion_signal,
+                    final_status=task.status,
+                    review_decision=review_decision_for_promotion,
+                    review_run=review_run_for_promotion,
+                )
+            except Exception as exc:
+                logger.exception("ACP artifact promotion failed for task {}", task_id)
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="ACP artifact promotion failed",
+                ) from exc
+            if any(
+                (
+                    artifact_promotion_result.created_artifact_ids,
+                    artifact_promotion_result.updated_artifact_ids,
+                    artifact_promotion_result.skipped,
+                    artifact_promotion_result.errors,
+                )
+            ):
+                _record_orchestration_audit_event(
+                    action="orchestration_artifact_promotion",
+                    user=user,
+                    task=task,
+                    session_id=session_id,
+                    run_id=run.id,
+                    metadata=artifact_promotion_result.to_dict(),
+                )
+
     # Refetch task to get post-transition status
     updated_task = await _run_sync(lambda: db.get_task(task_id))
     return {
@@ -1806,6 +1858,7 @@ async def dispatch_run(
         "session_id": session_id,
         "status": updated_task.status.value if updated_task else "unknown",
         "effective_cwd": effective_cwd,
+        "artifact_promotion": artifact_promotion_result.to_dict() if artifact_promotion_result else None,
     }
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -1816,16 +1816,18 @@ async def dispatch_run(
             )
         else:
             try:
-                artifact_promotion_result = promote_acp_completion_artifacts(
-                    canonical_db,
-                    task=task,
-                    project=project,
-                    workspace=workspace,
-                    run=run,
-                    completion_signal=completion_signal,
-                    final_status=task.status,
-                    review_decision=review_decision_for_promotion,
-                    review_run=review_run_for_promotion,
+                artifact_promotion_result = await _run_sync(
+                    lambda: promote_acp_completion_artifacts(
+                        canonical_db,
+                        task=task,
+                        project=project,
+                        workspace=workspace,
+                        run=run,
+                        completion_signal=completion_signal,
+                        final_status=task.status,
+                        review_decision=review_decision_for_promotion,
+                        review_run=review_run_for_promotion,
+                    )
                 )
             except Exception:
                 logger.exception("ACP artifact promotion failed for task {}", task_id)

--- a/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
@@ -1,6 +1,7 @@
 """Promotion helpers for ACP deliverables that become workspace artifacts."""
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from enum import Enum
@@ -37,6 +38,11 @@ _PROMOTABLE_ARTIFACT_TYPES = frozenset(
 )
 _DEFAULT_REDACTION = {"support_safe": True, "redacted": False}
 _PREVIEW_TEXT_MAX_CHARS = 500
+_OPTIONAL_MAPPING_FIELDS = {
+    "producer_metadata": "invalid_producer_metadata",
+    "review_metadata": "invalid_review_metadata",
+    "version_metadata": "invalid_version_metadata",
+}
 
 
 @dataclass(frozen=True)
@@ -95,6 +101,11 @@ def promote_acp_completion_artifacts(
             continue
         artifact = dict(raw_artifact)
 
+        artifact_type = _artifact_type(artifact)
+        if not artifact_type:
+            _record_error(result, artifact_id, "missing_artifact_type")
+            continue
+
         if not _is_promotable_artifact(artifact):
             result.skipped.append({"artifact_id": artifact_id, "reason": "not_promotable"})
             continue
@@ -104,33 +115,37 @@ def promote_acp_completion_artifacts(
             _record_error(result, artifact_id, error_reason)
             continue
 
-        payload = _workspace_artifact_payload(
-            artifact,
-            artifact_id=artifact_id,
-            workspace_id=str(target_workspace_id),
-            task=task,
-            project=project,
-            workspace=workspace,
-            run=run,
-            completion_signal=completion_signal,
-            review_decision=review_decision,
-            review_run=review_run,
-        )
-
-        existing = existing_by_id.get(artifact_id)
-        if existing:
-            updated = note_db.update_workspace_artifact(
-                str(target_workspace_id),
-                artifact_id,
-                _update_payload(payload),
-                expected_version=int(existing.get("version") or 1),
+        try:
+            payload = _workspace_artifact_payload(
+                artifact,
+                artifact_id=artifact_id,
+                workspace_id=str(target_workspace_id),
+                task=task,
+                project=project,
+                workspace=workspace,
+                run=run,
+                completion_signal=completion_signal,
+                review_decision=review_decision,
+                review_run=review_run,
             )
-            existing_by_id[artifact_id] = updated
-            result.updated_artifact_ids.append(artifact_id)
-        else:
-            created = note_db.add_workspace_artifact(str(target_workspace_id), payload)
-            existing_by_id[artifact_id] = created
-            result.created_artifact_ids.append(artifact_id)
+
+            existing = existing_by_id.get(artifact_id)
+            if existing:
+                updated = note_db.update_workspace_artifact(
+                    str(target_workspace_id),
+                    artifact_id,
+                    _update_payload(payload),
+                    expected_version=int(existing.get("version") or 1),
+                )
+                existing_by_id[artifact_id] = updated
+                result.updated_artifact_ids.append(artifact_id)
+            else:
+                created = note_db.add_workspace_artifact(str(target_workspace_id), payload)
+                existing_by_id[artifact_id] = created
+                result.created_artifact_ids.append(artifact_id)
+        except (RuntimeError, TypeError, ValueError, sqlite3.Error):
+            logger.exception("ACP artifact promotion failed for artifact {}", artifact_id)
+            _record_error(result, artifact_id, "promotion_failed")
 
     return result
 
@@ -190,15 +205,13 @@ def _artifact_type(artifact: Mapping[str, Any]) -> str:
         artifact.get("artifact_type")
         or artifact.get("type")
         or artifact.get("kind")
+        or artifact.get("promote_as")
         or ""
     ).strip().lower()
 
 
 def _is_promotable_artifact(artifact: Mapping[str, Any]) -> bool:
-    if artifact.get("promote") is True or artifact.get("work_product") is True:
-        return True
-    promote_as = str(artifact.get("promote_as") or "").strip().lower()
-    return promote_as in _PROMOTABLE_ARTIFACT_TYPES or _artifact_type(artifact) in _PROMOTABLE_ARTIFACT_TYPES
+    return _artifact_type(artifact) in _PROMOTABLE_ARTIFACT_TYPES
 
 
 def _validate_artifact_payload(
@@ -217,6 +230,18 @@ def _validate_artifact_payload(
     source_lineage = artifact.get("source_lineage")
     if not isinstance(source_lineage, Mapping) or not source_lineage:
         return "missing_source_lineage"
+    for field_name, reason in _OPTIONAL_MAPPING_FIELDS.items():
+        if field_name in artifact and artifact[field_name] is not None:
+            if not isinstance(artifact[field_name], Mapping):
+                return reason
+    export_refs = artifact.get("export_refs")
+    if export_refs is not None and not isinstance(export_refs, (list, tuple)):
+        return "invalid_export_refs"
+    if "schema_version" in artifact:
+        try:
+            _schema_version(artifact.get("schema_version"))
+        except (TypeError, ValueError):
+            return "invalid_schema_version"
     return _validate_redaction(artifact.get("redaction"))
 
 
@@ -242,6 +267,26 @@ def _preview_text(artifact: Mapping[str, Any]) -> str | None:
     return content[:_PREVIEW_TEXT_MAX_CHARS] if content else None
 
 
+def _coerce_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _coerce_list(value: Any) -> list[Any]:
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return []
+
+
+def _schema_version(value: Any) -> int:
+    if value is None or value == "":
+        return 1
+    if isinstance(value, bool):
+        raise ValueError("schema_version must be an integer")
+    return int(value)
+
+
 def _workspace_artifact_payload(
     artifact: Mapping[str, Any],
     *,
@@ -255,7 +300,7 @@ def _workspace_artifact_payload(
     review_decision: TaskReviewDecision | None,
     review_run: AgentRun | None,
 ) -> dict[str, Any]:
-    producer_metadata = dict(artifact.get("producer_metadata") or {})
+    producer_metadata = _coerce_mapping(artifact.get("producer_metadata"))
     producer_metadata.update(
         {
             "producer_type": "acp",
@@ -276,7 +321,7 @@ def _workspace_artifact_payload(
         producer_metadata["review_session_id"] = review_run.session_id
         producer_metadata["reviewer_agent_type"] = review_run.agent_type or task.reviewer_agent_type
 
-    review_metadata = dict(artifact.get("review_metadata") or {})
+    review_metadata = _coerce_mapping(artifact.get("review_metadata"))
     review_metadata.update(
         {
             "decision": "accepted",
@@ -290,7 +335,7 @@ def _workspace_artifact_payload(
         review_metadata["review_run_id"] = str(review_run.id)
         review_metadata["review_session_id"] = review_run.session_id
 
-    version_metadata = dict(artifact.get("version_metadata") or {})
+    version_metadata = _coerce_mapping(artifact.get("version_metadata"))
     version_metadata.update(
         {
             "source": "acp_completion_signal",
@@ -302,7 +347,7 @@ def _workspace_artifact_payload(
 
     return {
         "id": artifact_id,
-        "artifact_type": str(artifact.get("artifact_type") or _artifact_type(artifact)),
+        "artifact_type": _artifact_type(artifact),
         "title": str(artifact.get("title") or "").strip(),
         "status": str(artifact.get("status") or "completed"),
         "content": artifact.get("content"),
@@ -316,12 +361,12 @@ def _workspace_artifact_payload(
         "task_id": str(task.id),
         "source_collection_id": artifact.get("source_collection_id"),
         "producer_metadata": producer_metadata,
-        "source_lineage": dict(artifact.get("source_lineage") or {}),
+        "source_lineage": _coerce_mapping(artifact.get("source_lineage")),
         "review_metadata": review_metadata,
         "version_metadata": version_metadata,
-        "export_refs": list(artifact.get("export_refs") or []),
-        "redaction": dict(artifact.get("redaction") or _DEFAULT_REDACTION),
-        "schema_version": int(artifact.get("schema_version") or 1),
+        "export_refs": _coerce_list(artifact.get("export_refs")),
+        "redaction": _coerce_mapping(artifact.get("redaction")) or dict(_DEFAULT_REDACTION),
+        "schema_version": _schema_version(artifact.get("schema_version")),
     }
 
 

--- a/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
@@ -1,0 +1,330 @@
+"""Promotion helpers for ACP deliverables that become workspace artifacts."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
+    TaskCompletionSignal,
+    TaskReviewDecision,
+)
+from tldw_Server_API.app.core.Agent_Orchestration.models import (
+    ACPWorkspace,
+    AgentProject,
+    AgentRun,
+    AgentTask,
+    TaskStatus,
+)
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
+    CANONICAL_WORKSPACE_ID_METADATA_KEY,
+)
+
+_PROMOTABLE_ARTIFACT_TYPES = frozenset(
+    {
+        "workspace_brief",
+        "source_grounded_workspace_brief",
+        "source_grounded_brief",
+        "workspace_report",
+        "workspace_spec",
+        "workspace_action_plan",
+        "workspace_table",
+    }
+)
+_DEFAULT_REDACTION = {"support_safe": True, "redacted": False}
+
+
+@dataclass(frozen=True)
+class ACPArtifactPromotionResult:
+    """Outcome summary for a single ACP completion promotion pass."""
+
+    created_artifact_ids: list[str] = field(default_factory=list)
+    updated_artifact_ids: list[str] = field(default_factory=list)
+    skipped: list[dict[str, str]] = field(default_factory=list)
+    errors: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe representation for API responses and audit metadata."""
+        return asdict(self)
+
+
+def promote_acp_completion_artifacts(
+    note_db: CharactersRAGDB,
+    *,
+    task: AgentTask,
+    project: AgentProject | None,
+    workspace: ACPWorkspace | None,
+    run: AgentRun,
+    completion_signal: TaskCompletionSignal,
+    final_status: TaskStatus | str,
+    review_decision: TaskReviewDecision | None = None,
+    review_run: AgentRun | None = None,
+) -> ACPArtifactPromotionResult:
+    """Create or update traceable workspace artifacts from accepted ACP output.
+
+    Raw session artifacts remain ACP execution evidence. Only structured
+    work-product candidates with source lineage are promoted.
+    """
+    result = ACPArtifactPromotionResult()
+    if not completion_signal.artifacts:
+        return result
+
+    decision = _promotion_decision(final_status, review_decision)
+    target_workspace_id = _target_workspace_id(workspace)
+    existing_by_id: dict[str, dict[str, Any]] = {}
+    if target_workspace_id and note_db.get_workspace(target_workspace_id):
+        existing_by_id = {
+            str(item["id"]): item
+            for item in note_db.list_workspace_artifacts(target_workspace_id)
+            if item.get("id")
+        }
+
+    for index, raw_artifact in enumerate(completion_signal.artifacts):
+        artifact_id = _artifact_identifier(raw_artifact, task=task, run=run, index=index)
+        if decision != "accepted":
+            result.skipped.append({"artifact_id": artifact_id, "reason": decision})
+            continue
+
+        if not isinstance(raw_artifact, Mapping):
+            _record_error(result, artifact_id, "malformed_artifact")
+            continue
+        artifact = dict(raw_artifact)
+
+        if not _is_promotable_artifact(artifact):
+            result.skipped.append({"artifact_id": artifact_id, "reason": "not_promotable"})
+            continue
+
+        error_reason = _validate_artifact_payload(artifact, target_workspace_id, note_db)
+        if error_reason:
+            _record_error(result, artifact_id, error_reason)
+            continue
+
+        payload = _workspace_artifact_payload(
+            artifact,
+            artifact_id=artifact_id,
+            workspace_id=str(target_workspace_id),
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=completion_signal,
+            review_decision=review_decision,
+            review_run=review_run,
+        )
+
+        existing = existing_by_id.get(artifact_id)
+        if existing:
+            updated = note_db.update_workspace_artifact(
+                str(target_workspace_id),
+                artifact_id,
+                _update_payload(payload),
+                expected_version=int(existing.get("version") or 1),
+            )
+            existing_by_id[artifact_id] = updated
+            result.updated_artifact_ids.append(artifact_id)
+        else:
+            created = note_db.add_workspace_artifact(str(target_workspace_id), payload)
+            existing_by_id[artifact_id] = created
+            result.created_artifact_ids.append(artifact_id)
+
+    return result
+
+
+def _record_error(result: ACPArtifactPromotionResult, artifact_id: str, reason: str) -> None:
+    logger.warning(
+        "ACP artifact promotion skipped malformed artifact {}: {}",
+        artifact_id,
+        reason,
+    )
+    result.errors.append({"artifact_id": artifact_id, "reason": reason})
+
+
+def _status_value(value: TaskStatus | str) -> str:
+    if isinstance(value, Enum):
+        return str(value.value)
+    return str(value)
+
+
+def _promotion_decision(
+    final_status: TaskStatus | str,
+    review_decision: TaskReviewDecision | None,
+) -> str:
+    status_value = _status_value(final_status)
+    if review_decision is not None and review_decision.approved is False:
+        return "needs_revision" if status_value == TaskStatus.IN_PROGRESS.value else "rejected"
+    if status_value == TaskStatus.COMPLETE.value:
+        return "accepted"
+    if status_value == TaskStatus.IN_PROGRESS.value:
+        return "needs_revision"
+    if status_value == TaskStatus.TRIAGE.value:
+        return "rejected"
+    return "not_accepted"
+
+
+def _target_workspace_id(workspace: ACPWorkspace | None) -> str | None:
+    if workspace is None or not isinstance(workspace.metadata, dict):
+        return None
+    canonical_id = str(workspace.metadata.get(CANONICAL_WORKSPACE_ID_METADATA_KEY) or "").strip()
+    return canonical_id or None
+
+
+def _artifact_identifier(raw_artifact: Any, *, task: AgentTask, run: AgentRun, index: int) -> str:
+    if isinstance(raw_artifact, Mapping):
+        artifact_id = (
+            raw_artifact.get("id")
+            or raw_artifact.get("artifact_id")
+            or raw_artifact.get("root_artifact_id")
+        )
+        if artifact_id:
+            return str(artifact_id)
+    return f"acp-task-{task.id}-run-{run.id}-{index + 1}"
+
+
+def _artifact_type(artifact: Mapping[str, Any]) -> str:
+    return str(
+        artifact.get("artifact_type")
+        or artifact.get("type")
+        or artifact.get("kind")
+        or ""
+    ).strip().lower()
+
+
+def _is_promotable_artifact(artifact: Mapping[str, Any]) -> bool:
+    if artifact.get("promote") is True or artifact.get("work_product") is True:
+        return True
+    promote_as = str(artifact.get("promote_as") or "").strip().lower()
+    return promote_as in _PROMOTABLE_ARTIFACT_TYPES or _artifact_type(artifact) in _PROMOTABLE_ARTIFACT_TYPES
+
+
+def _validate_artifact_payload(
+    artifact: Mapping[str, Any],
+    target_workspace_id: str | None,
+    note_db: CharactersRAGDB,
+) -> str | None:
+    if not target_workspace_id:
+        return "missing_workspace"
+    if note_db.get_workspace(target_workspace_id) is None:
+        return "workspace_not_found"
+    if not str(artifact.get("title") or "").strip():
+        return "missing_title"
+    if not str(artifact.get("content") or "").strip():
+        return "missing_content"
+    source_lineage = artifact.get("source_lineage")
+    if not isinstance(source_lineage, Mapping) or not source_lineage:
+        return "missing_source_lineage"
+    return _validate_redaction(artifact.get("redaction"))
+
+
+def _validate_redaction(redaction: Any) -> str | None:
+    if redaction is None:
+        return None
+    if not isinstance(redaction, Mapping):
+        return "invalid_redaction"
+    for field_name in ("support_safe", "redacted"):
+        if field_name in redaction and not isinstance(redaction[field_name], bool):
+            return "invalid_redaction"
+    return None
+
+
+def _preview_text(artifact: Mapping[str, Any]) -> str | None:
+    preview = str(artifact.get("preview_text") or "").strip()
+    if preview:
+        return preview
+    summary = str(artifact.get("summary") or "").strip()
+    if summary:
+        return summary[:500]
+    content = str(artifact.get("content") or "").strip()
+    return content[:500] if content else None
+
+
+def _workspace_artifact_payload(
+    artifact: Mapping[str, Any],
+    *,
+    artifact_id: str,
+    workspace_id: str,
+    task: AgentTask,
+    project: AgentProject | None,
+    workspace: ACPWorkspace | None,
+    run: AgentRun,
+    completion_signal: TaskCompletionSignal,
+    review_decision: TaskReviewDecision | None,
+    review_run: AgentRun | None,
+) -> dict[str, Any]:
+    producer_metadata = dict(artifact.get("producer_metadata") or {})
+    producer_metadata.update(
+        {
+            "producer_type": "acp",
+            "producer_id": str(task.id),
+            "task_id": str(task.id),
+            "task_ref": f"acp-task:{task.id}",
+            "project_id": str(project.id) if project else None,
+            "acp_workspace_id": str(workspace.id) if workspace else None,
+            "canonical_workspace_id": workspace_id,
+            "run_id": str(run.id),
+            "session_id": run.session_id,
+            "agent_type": run.agent_type or task.agent_type,
+            "completion_status": completion_signal.status,
+        }
+    )
+    if review_run is not None:
+        producer_metadata["review_run_id"] = str(review_run.id)
+        producer_metadata["review_session_id"] = review_run.session_id
+        producer_metadata["reviewer_agent_type"] = review_run.agent_type or task.reviewer_agent_type
+
+    review_metadata = dict(artifact.get("review_metadata") or {})
+    review_metadata.update(
+        {
+            "decision": "accepted",
+            "reviewer": task.reviewer_agent_type,
+            "feedback_present": bool(review_decision and review_decision.feedback),
+            "review_count": int(task.review_count or 0),
+            "max_review_attempts": int(task.max_review_attempts or 0),
+        }
+    )
+    if review_run is not None:
+        review_metadata["review_run_id"] = str(review_run.id)
+        review_metadata["review_session_id"] = review_run.session_id
+
+    version_metadata = dict(artifact.get("version_metadata") or {})
+    version_metadata.update(
+        {
+            "source": "acp_completion_signal",
+            "completion_summary": completion_signal.summary,
+            "completion_status": completion_signal.status,
+            "created_from_run_id": str(run.id),
+        }
+    )
+
+    return {
+        "id": artifact_id,
+        "artifact_type": str(artifact.get("artifact_type") or _artifact_type(artifact)),
+        "title": str(artifact.get("title") or "").strip(),
+        "status": str(artifact.get("status") or "completed"),
+        "content": artifact.get("content"),
+        "content_type": str(artifact.get("content_type") or "text/markdown"),
+        "preview_text": _preview_text(artifact),
+        "summary": artifact.get("summary") or completion_signal.summary,
+        "review_state": "accepted",
+        "owner_scope": "workspace",
+        "owner_id": workspace_id,
+        "project_id": str(project.id) if project else None,
+        "task_id": str(task.id),
+        "source_collection_id": artifact.get("source_collection_id"),
+        "producer_metadata": producer_metadata,
+        "source_lineage": dict(artifact.get("source_lineage") or {}),
+        "review_metadata": review_metadata,
+        "version_metadata": version_metadata,
+        "export_refs": list(artifact.get("export_refs") or []),
+        "redaction": dict(artifact.get("redaction") or _DEFAULT_REDACTION),
+        "schema_version": int(artifact.get("schema_version") or 1),
+    }
+
+
+def _update_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    update = dict(payload)
+    update.pop("id", None)
+    return update

--- a/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
@@ -36,6 +36,7 @@ _PROMOTABLE_ARTIFACT_TYPES = frozenset(
     }
 )
 _DEFAULT_REDACTION = {"support_safe": True, "redacted": False}
+_PREVIEW_TEXT_MAX_CHARS = 500
 
 
 @dataclass(frozen=True)
@@ -236,9 +237,9 @@ def _preview_text(artifact: Mapping[str, Any]) -> str | None:
         return preview
     summary = str(artifact.get("summary") or "").strip()
     if summary:
-        return summary[:500]
+        return summary[:_PREVIEW_TEXT_MAX_CHARS]
     content = str(artifact.get("content") or "").strip()
-    return content[:500] if content else None
+    return content[:_PREVIEW_TEXT_MAX_CHARS] if content else None
 
 
 def _workspace_artifact_payload(

--- a/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
@@ -175,6 +175,82 @@ def test_updates_existing_promoted_artifact_version(tmp_path):
         orch_db.close()
 
 
+def test_promote_as_is_used_as_persisted_artifact_type(tmp_path):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Promote-as brief",
+        artifacts=[
+            _brief_payload(
+                id="brief-promote-as",
+                artifact_type=None,
+                promote_as="workspace_spec",
+            )
+        ],
+        raw_payload={},
+    )
+
+    try:
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=TaskReviewDecision(approved=True, feedback="Accepted"),
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == ["brief-promote-as"]
+        [artifact] = note_db.list_workspace_artifacts("workspace-alpha")
+        assert artifact["artifact_type"] == "workspace_spec"
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
+def test_promote_flag_without_allowed_artifact_type_is_not_promoted(tmp_path):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Missing type",
+        artifacts=[
+            _brief_payload(
+                id="brief-missing-type",
+                artifact_type=None,
+                promote=True,
+            )
+        ],
+        raw_payload={},
+    )
+
+    try:
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=TaskReviewDecision(approved=True, feedback="Accepted"),
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == []
+        assert result.updated_artifact_ids == []
+        assert result.skipped == []
+        assert result.errors == [
+            {"artifact_id": "brief-missing-type", "reason": "missing_artifact_type"}
+        ]
+        assert note_db.list_workspace_artifacts("workspace-alpha") == []
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
 @pytest.mark.parametrize(
     ("final_status", "expected_reason"),
     [
@@ -289,6 +365,57 @@ def test_malformed_promotion_payload_is_not_promoted(tmp_path):
         assert result.skipped == []
         assert result.errors == [{"artifact_id": "brief-1", "reason": "missing_source_lineage"}]
         assert note_db.list_workspace_artifacts("workspace-alpha") == []
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value", "expected_reason"),
+    [
+        ("producer_metadata", "not-a-mapping", "invalid_producer_metadata"),
+        ("review_metadata", "not-a-mapping", "invalid_review_metadata"),
+        ("version_metadata", "not-a-mapping", "invalid_version_metadata"),
+        ("export_refs", {"format": "markdown"}, "invalid_export_refs"),
+        ("schema_version", "not-an-int", "invalid_schema_version"),
+    ],
+)
+def test_malformed_optional_metadata_isolated_to_artifact_error(
+    tmp_path,
+    field_name,
+    bad_value,
+    expected_reason,
+):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Mixed artifacts",
+        artifacts=[
+            _brief_payload(id="bad-brief", **{field_name: bad_value}),
+            _brief_payload(id="good-brief", title="Good Brief"),
+        ],
+        raw_payload={},
+    )
+
+    try:
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=TaskReviewDecision(approved=True, feedback="Accepted"),
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == ["good-brief"]
+        assert result.updated_artifact_ids == []
+        assert result.skipped == []
+        assert result.errors == [{"artifact_id": "bad-brief", "reason": expected_reason}]
+        [artifact] = note_db.list_workspace_artifacts("workspace-alpha")
+        assert artifact["id"] == "good-brief"
     finally:
         note_db.close_all_connections()
         orch_db.close()

--- a/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
@@ -1,0 +1,294 @@
+"""Tests for promoting accepted ACP deliverables into workspace artifacts."""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Orchestration.artifact_promotion import (
+    promote_acp_completion_artifacts,
+)
+from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
+    TaskCompletionSignal,
+    TaskReviewDecision,
+)
+from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
+    CANONICAL_WORKSPACE_ID_METADATA_KEY,
+    CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY,
+    CANONICAL_WORKSPACE_LINKED_STATUS,
+    CANONICAL_WORKSPACE_SOURCE_METADATA_KEY,
+    OrchestrationDB,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _build_context(tmp_path):
+    orch_db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    note_db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    note_db.upsert_workspace("workspace-alpha", "Alpha Workspace")
+    workspace = orch_db.create_workspace(
+        name="ACP Linked Workspace",
+        root_path=str(tmp_path / "workspace"),
+        metadata={
+            CANONICAL_WORKSPACE_ID_METADATA_KEY: "workspace-alpha",
+            CANONICAL_WORKSPACE_SOURCE_METADATA_KEY: "workspace_playground",
+            CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY: CANONICAL_WORKSPACE_LINKED_STATUS,
+        },
+    )
+    project = orch_db.create_project(name="ACP Project", workspace_id=workspace.id)
+    task = orch_db.create_task(
+        project.id,
+        title="Create a grounded brief",
+        description="Summarize the selected sources.",
+        agent_type="codex",
+        reviewer_agent_type="reviewer",
+    )
+    run = orch_db.create_run(task.id, agent_type="codex", session_id="session-run-1")
+    review_run = orch_db.create_run(task.id, agent_type="reviewer", session_id="session-review-1")
+    return orch_db, note_db, project, workspace, task, run, review_run
+
+
+def _brief_payload(**overrides):
+    payload = {
+        "id": "brief-1",
+        "artifact_type": "workspace_brief",
+        "title": "ACP Research Brief",
+        "content": "# Brief\nGrounded finding.",
+        "summary": "Grounded finding.",
+        "source_lineage": {
+            "sources": [
+                {"source_id": "src-1", "source_type": "media", "label": "Transcript"}
+            ]
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_promotes_accepted_acp_brief_with_traceable_metadata(tmp_path):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Brief ready",
+        artifacts=[_brief_payload()],
+        raw_payload={},
+    )
+    review = TaskReviewDecision(approved=True, feedback="Meets criteria")
+
+    try:
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=review,
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == ["brief-1"]
+        assert result.updated_artifact_ids == []
+        assert result.skipped == []
+        assert result.errors == []
+
+        [artifact] = note_db.list_workspace_artifacts("workspace-alpha")
+        assert artifact["id"] == "brief-1"
+        assert artifact["artifact_type"] == "workspace_brief"
+        assert artifact["status"] == "completed"
+        assert artifact["review_state"] == "accepted"
+        assert artifact["owner_scope"] == "workspace"
+        assert artifact["owner_id"] == "workspace-alpha"
+        assert artifact["project_id"] == str(project.id)
+        assert artifact["task_id"] == str(task.id)
+        assert artifact["producer_metadata"]["producer_type"] == "acp"
+        assert artifact["producer_metadata"]["producer_id"] == str(task.id)
+        assert artifact["producer_metadata"]["run_id"] == str(run.id)
+        assert artifact["producer_metadata"]["session_id"] == "session-run-1"
+        assert artifact["producer_metadata"]["review_run_id"] == str(review_run.id)
+        assert artifact["producer_metadata"]["review_session_id"] == "session-review-1"
+        assert artifact["source_lineage"]["sources"][0]["source_id"] == "src-1"
+        assert artifact["review_metadata"]["decision"] == "accepted"
+        assert artifact["review_metadata"]["reviewer"] == "reviewer"
+        assert artifact["version_metadata"]["source"] == "acp_completion_signal"
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
+def test_updates_existing_promoted_artifact_version(tmp_path):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    first_signal = TaskCompletionSignal(
+        status="completed",
+        summary="Initial brief",
+        artifacts=[_brief_payload(content="# Brief\nInitial.")],
+        raw_payload={},
+    )
+    second_signal = TaskCompletionSignal(
+        status="completed",
+        summary="Updated brief",
+        artifacts=[_brief_payload(content="# Brief\nUpdated.", summary="Updated finding.")],
+        raw_payload={},
+    )
+    review = TaskReviewDecision(approved=True, feedback="Accepted")
+
+    try:
+        promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=first_signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=review,
+            review_run=review_run,
+        )
+
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=second_signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=review,
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == []
+        assert result.updated_artifact_ids == ["brief-1"]
+        [artifact] = note_db.list_workspace_artifacts("workspace-alpha")
+        assert artifact["version"] == 2
+        assert artifact["content"] == "# Brief\nUpdated."
+        versions = note_db.list_workspace_artifact_versions("workspace-alpha", "brief-1")
+        assert [version["artifact_version_id"] for version in versions] == [
+            "brief-1:v1",
+            "brief-1:v2",
+        ]
+        assert versions[1]["previous_version_id"] == "brief-1:v1"
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
+@pytest.mark.parametrize(
+    ("final_status", "expected_reason"),
+    [
+        (TaskStatus.IN_PROGRESS, "needs_revision"),
+        (TaskStatus.TRIAGE, "rejected"),
+    ],
+)
+def test_rejected_or_retry_outputs_do_not_create_accepted_artifacts(
+    tmp_path,
+    final_status,
+    expected_reason,
+):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Brief ready",
+        artifacts=[_brief_payload()],
+        raw_payload={},
+    )
+    review = TaskReviewDecision(approved=False, feedback="Missing required evidence")
+
+    try:
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=final_status,
+            review_decision=review,
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == []
+        assert result.updated_artifact_ids == []
+        assert result.errors == []
+        assert result.skipped == [{"artifact_id": "brief-1", "reason": expected_reason}]
+        assert note_db.list_workspace_artifacts("workspace-alpha") == []
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
+def test_preserves_redaction_contract_for_promoted_artifact(tmp_path):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Redacted brief ready",
+        artifacts=[
+            _brief_payload(
+                redaction={
+                    "support_safe": False,
+                    "redacted": True,
+                    "retention_class": "restricted",
+                    "redacted_fields": ["content"],
+                },
+            )
+        ],
+        raw_payload={},
+    )
+
+    try:
+        promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=TaskReviewDecision(approved=True, feedback="Accepted"),
+            review_run=review_run,
+        )
+
+        [artifact] = note_db.list_workspace_artifacts("workspace-alpha")
+        assert artifact["redaction"] == {
+            "support_safe": False,
+            "redacted": True,
+            "retention_class": "restricted",
+            "redacted_fields": ["content"],
+        }
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
+def test_malformed_promotion_payload_is_not_promoted(tmp_path):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Malformed artifact",
+        artifacts=[_brief_payload(source_lineage={})],
+        raw_payload={},
+    )
+
+    try:
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=TaskReviewDecision(approved=True, feedback="Accepted"),
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == []
+        assert result.updated_artifact_ids == []
+        assert result.skipped == []
+        assert result.errors == [{"artifact_id": "brief-1", "reason": "missing_source_lineage"}]
+        assert note_db.list_workspace_artifacts("workspace-alpha") == []
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -323,6 +323,39 @@ class _SuccessfulClient:
         }
 
 
+class _ArtifactPromotionClient:
+    async def create_session(self, *_args, **_kwargs):
+        return "session-promotion-1"
+
+    async def prompt(self, *_args, **_kwargs):
+        return {
+            "stopReason": "end",
+            "taskCompletion": {
+                "status": "completed",
+                "summary": "Brief ready",
+                "artifacts": [
+                    {
+                        "id": "brief-1",
+                        "artifact_type": "workspace_brief",
+                        "title": "ACP Research Brief",
+                        "content": "# Brief\nGrounded answer.",
+                        "summary": "Grounded answer.",
+                        "source_lineage": {
+                            "sources": [
+                                {
+                                    "source_id": "src-1",
+                                    "source_type": "media",
+                                    "label": "Transcript",
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+            "usage": {},
+        }
+
+
 class _MissingCompletionClient:
     async def create_session(self, *_args, **_kwargs):
         return "session-1"
@@ -1083,6 +1116,66 @@ async def test_dispatch_run_valid_completion_without_reviewer_completes_task(mon
         assert runs[0].status.value == "completed"
         assert runs[0].result_summary == "Implemented dispatch work"
     finally:
+        db.close()
+
+
+async def test_dispatch_run_promotes_completion_artifact_to_canonical_workspace(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    note_db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    note_db.upsert_workspace("workspace-alpha", "Alpha Workspace")
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    workspace = db.create_workspace(
+        name="Linked",
+        root_path=str(workspace_root),
+        metadata={
+            "canonical_workspace_id": "workspace-alpha",
+            "canonical_workspace_source": "workspace_playground",
+            "link_status": "linked",
+        },
+    )
+    project = db.create_project(name="P1", workspace_id=workspace.id)
+    task = db.create_task(project.id, title="T1", description="Create a brief", agent_type="codex")
+    client = _ArtifactPromotionClient()
+
+    async def fake_store():
+        return _NoopSessionStore()
+
+    async def fake_client():
+        return client
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_acp_sessions_service.get_acp_session_store",
+        fake_store,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.runner_client.get_runner_client",
+        fake_client,
+    )
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+
+    try:
+        result = await orch_mod.dispatch_run(
+            task.id,
+            orch_mod.RunDispatchRequest(),
+            user=_TestUser(),
+            canonical_db=note_db,
+        )
+
+        assert result["status"] == TaskStatus.COMPLETE
+        [artifact] = note_db.list_workspace_artifacts("workspace-alpha")
+        assert artifact["id"] == "brief-1"
+        assert artifact["review_state"] == "accepted"
+        assert artifact["producer_metadata"]["producer_type"] == "acp"
+        assert artifact["producer_metadata"]["run_id"] == str(result["run_id"])
+        assert artifact["producer_metadata"]["session_id"] == "session-promotion-1"
+        assert artifact["source_lineage"]["sources"][0]["source_id"] == "src-1"
+    finally:
+        note_db.close_all_connections()
         db.close()
 
 

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -1167,6 +1167,12 @@ async def test_dispatch_run_promotes_completion_artifact_to_canonical_workspace(
         )
 
         assert result["status"] == TaskStatus.COMPLETE
+        assert result["artifact_promotion"] == {
+            "created_artifact_ids": ["brief-1"],
+            "updated_artifact_ids": [],
+            "skipped": [],
+            "errors": [],
+        }
         [artifact] = note_db.list_workspace_artifacts("workspace-alpha")
         assert artifact["id"] == "brief-1"
         assert artifact["review_state"] == "accepted"

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -1179,6 +1179,75 @@ async def test_dispatch_run_promotes_completion_artifact_to_canonical_workspace(
         db.close()
 
 
+async def test_dispatch_run_reports_artifact_promotion_failure_without_rolling_back_task(
+    monkeypatch,
+    tmp_path,
+):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    note_db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    note_db.upsert_workspace("workspace-alpha", "Alpha Workspace")
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    workspace = db.create_workspace(
+        name="Linked",
+        root_path=str(workspace_root),
+        metadata={
+            "canonical_workspace_id": "workspace-alpha",
+            "canonical_workspace_source": "workspace_playground",
+            "link_status": "linked",
+        },
+    )
+    project = db.create_project(name="P1", workspace_id=workspace.id)
+    task = db.create_task(project.id, title="T1", description="Create a brief", agent_type="codex")
+    client = _ArtifactPromotionClient()
+
+    async def fake_store():
+        return _NoopSessionStore()
+
+    async def fake_client():
+        return client
+
+    def failing_promotion(*_args, **_kwargs):
+        raise RuntimeError("promotion backend unavailable")
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_acp_sessions_service.get_acp_session_store",
+        fake_store,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.runner_client.get_runner_client",
+        fake_client,
+    )
+    monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
+    monkeypatch.setattr(orch_mod, "promote_acp_completion_artifacts", failing_promotion)
+
+    try:
+        result = await orch_mod.dispatch_run(
+            task.id,
+            orch_mod.RunDispatchRequest(),
+            user=_TestUser(),
+            canonical_db=note_db,
+        )
+
+        assert result["status"] == TaskStatus.COMPLETE
+        assert result["artifact_promotion"] == {
+            "created_artifact_ids": [],
+            "updated_artifact_ids": [],
+            "skipped": [],
+            "errors": [{"artifact_id": "all", "reason": "promotion_failed"}],
+        }
+        updated_task = db.get_task(task.id)
+        assert updated_task.status == TaskStatus.COMPLETE
+        assert note_db.list_workspace_artifacts("workspace-alpha") == []
+    finally:
+        note_db.close_all_connections()
+        db.close()
+
+
 async def test_dispatch_run_injects_workspace_env_and_mcp_servers(monkeypatch, tmp_path):
     from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
 


### PR DESCRIPTION
## Summary
- Adds an ACP artifact promotion service that creates or updates traceable workspace artifacts only for structured work-product deliverables with source lineage.
- Wires ACP dispatch finalization to promote accepted deliverables while preserving producer, session, run, review, redaction, source-lineage, and version metadata.
- Adds regression coverage for accepted, update, retry/needs_revision, rejected, redacted, malformed, and dispatch-level golden-path promotion flows.

## Change summary
Pending human-authored change summary before merge. This PR is draft until the requester adds the required human-written rationale.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Agent_Orchestration -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py -f json -o /tmp/bandit_acp_artifact_promotion_1706_prod.json
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py -s B101,B105 -f json -o /tmp/bandit_acp_artifact_promotion_1706_skip_test_noise.json

Closes #1706.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes ACP deliverables into traceable workspace artifacts so accepted, structured outputs with source lineage are created or updated in the canonical workspace and surfaced in audit and API responses. Implements #1706 and keeps dispatch success even when post-commit promotion fails.

- **New Features**
  - Added `promote_acp_completion_artifacts` and `ACPArtifactPromotionResult` to create/update versioned workspace artifacts for promotable deliverables.
  - Integrated with `dispatch_run` using `CharactersRAGDB`; emits `orchestration_artifact_promotion` and returns `artifact_promotion` (created/updated/skipped/errors); DB I/O is offloaded via `_run_sync`.
  - Only accepted outputs are promoted; `needs_revision`/`rejected` are skipped; failures don’t roll back task completion and are reported (including an `"all"` failure case).
  - Hardened validation: allowed artifact types gated with `promote_as` fallback; validates optional metadata (`producer_metadata`, `review_metadata`, `version_metadata`), `export_refs`, `schema_version`, and redaction; errors are isolated per artifact.
  - Preserves producer/session/run and review-run metadata, redaction, source lineage, and version history; preview truncation uses `_PREVIEW_TEXT_MAX_CHARS`. Added tests for create/update, promote_as, validation errors, canonical workspace promotion, and failure handling.

<sup>Written for commit 05d38a4a48154cd0b4f693f0b08830f9d9d14053. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

