### PR TITLE
Harden prototype workspace persistence

### DIFF
--- a/Docs/API-related/Prototype_Workspaces_API.md
+++ b/Docs/API-related/Prototype_Workspaces_API.md
@@ -210,6 +210,44 @@ The short version:
 
 Frontend/backend state names, HTTP status expectations, retryability, and Risk Gate 4 open questions live in `Docs/API-related/Prototype_Workspaces_Contract_Matrix.md`.
 
+## Risk Gate 2 Persistence Contract
+
+Prototype workspace persistence is owned by the AuthNZ repository boundary in `PrototypeWorkspacesRepo`.
+
+Transaction rules:
+
+- workspace creation and seed snapshot creation run in one AuthNZ transaction
+- session snapshot save and session pointer update run in one AuthNZ transaction
+- publish promotion still compensates around preview-broker side effects because preview grants include in-memory broker state plus persisted handles
+- repository transaction adapters preserve the existing `?` placeholder style and convert to PostgreSQL `$N` placeholders when the underlying `DatabasePool` is PostgreSQL-backed
+
+Cleanup and retention rules:
+
+- archived workspaces are soft-archived first and can be deleted after the configured archive-retention cutoff; cascading foreign keys remove related prototype rows
+- expired shared actors are soft-revoked by setting `revoked_at`; they are retained for audit until their workspace is deleted
+- expired sessions are soft-revoked by setting `revoked_at`, `runtime_status = "revoked"`, and `preview_status = "revoked"`
+- active preview handles attached to archived workspaces or revoked/expired sessions are deactivated and receive `revoked_at`
+- inactive preview handles can be deleted after their inactive-preview cutoff
+- old pending promotion requests can be marked `stale`; approved, rejected, promoted, or already stale requests are not rewritten by cleanup
+
+SQLite/PostgreSQL behavior:
+
+- migration 086 is the SQLite migration source for the prototype tables
+- PostgreSQL compatibility is through the AuthNZ `DatabasePool` execution contract and repository table discovery via `information_schema`
+- all repository SQL remains parameterized; no user input is interpolated into SQL strings
+- cleanup accepts explicit cutoff timestamps so callers own retention policy and scheduling
+
+Query/index review:
+
+| Path | Query shape | Index coverage |
+| --- | --- | --- |
+| owner workspace detail | `prototype_workspaces.id`, workspace snapshots by `prototype_workspace_id` | primary key plus `idx_prototype_snapshots_workspace_created` |
+| branch-session inventory | sessions by `prototype_workspace_id`, active first, ordered by update time | `idx_prototype_sessions_workspace_active_updated` |
+| active session reuse | workspace, base snapshot, actor type, actor identity, share link, revoked/expiry/runtime filters | `idx_prototype_sessions_active_lookup` |
+| active shared actor check | workspace-scoped actor activity and expiry checks | primary key plus `idx_prototype_shared_actors_active_lookup` |
+| promotion listings/review | workspace and status with update-time cleanup | `idx_prototype_promotion_requests_workspace_status_updated` |
+| preview handle lookup | handle id, active scope replacement, workspace/session cleanup scans | primary key plus preview handle workspace/session/scope indexes |
+
 ## Preview Broker Guarantees
 
 Preview access is brokered through `preview_handle` records and signed preview grants.

--- a/Docs/API-related/Prototype_Workspaces_API.md
+++ b/Docs/API-related/Prototype_Workspaces_API.md
@@ -246,6 +246,7 @@ Query/index review:
 | active session reuse | workspace, base snapshot, actor type, actor identity, share link, revoked/expiry/runtime filters | `idx_prototype_sessions_active_lookup` |
 | active shared actor check | workspace-scoped actor activity and expiry checks | primary key plus `idx_prototype_shared_actors_active_lookup` |
 | promotion listings/review | workspace and status with update-time cleanup | `idx_prototype_promotion_requests_workspace_status_updated` |
+| cleanup retention sweep | global archived, revoked, expired, and inactive-preview cutoffs | `idx_prototype_workspaces_archived_at_cleanup`, `idx_prototype_sessions_revoked_at_cleanup`, `idx_prototype_sessions_expires_at_cleanup`, `idx_prototype_shared_actors_expires_revoked_cleanup`, `idx_prototype_preview_handles_inactive_revoked_cleanup` |
 | preview handle lookup | handle id, active scope replacement, workspace/session cleanup scans | primary key plus preview handle workspace/session/scope indexes |
 
 ## Preview Broker Guarantees

--- a/Docs/superpowers/plans/2026-05-15-prototype-workspace-risk-gate-2-persistence-hardening.md
+++ b/Docs/superpowers/plans/2026-05-15-prototype-workspace-risk-gate-2-persistence-hardening.md
@@ -74,9 +74,9 @@
 
 **Tests:** `python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q`; focused migration/repo tests as added; Bandit on touched backend files.
 
-**Status:** In Progress
+**Status:** Complete
 
 - [x] Run the focused prototype workspace suite.
 - [x] Run Bandit on touched backend paths.
-- [ ] Update TASK-363 acceptance criteria and final summary.
-- [ ] Prepare a PR summary that explains what changed and why, leaving the required human `Change summary` for merge readiness.
+- [x] Update TASK-363 acceptance criteria and final summary.
+- [x] Prepare a PR summary that explains what changed and why, leaving the required human `Change summary` for merge readiness.

--- a/Docs/superpowers/plans/2026-05-15-prototype-workspace-risk-gate-2-persistence-hardening.md
+++ b/Docs/superpowers/plans/2026-05-15-prototype-workspace-risk-gate-2-persistence-hardening.md
@@ -1,0 +1,82 @@
+# Prototype Workspace Risk Gate 2 Persistence Hardening Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for implementation. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden prototype workspace persistence so multi-step backend operations, cleanup rules, and query/index assumptions are explicit, tested, and documented for Risk Gate 2.
+
+**Architecture:** Keep the existing AuthNZ repository/service split. Add transaction-bound repository execution for multi-step prototype operations instead of introducing a new DB_Management subsystem. Keep runtime job durability out of scope for Risk Gate 3.
+
+**Tech Stack:** FastAPI backend, AuthNZ `DatabasePool`, SQLite migrations, async repository/service tests with pytest.
+
+---
+
+## Stage 1: Transaction-Bound Repository Execution
+
+**Goal:** Make prototype repository methods usable inside one AuthNZ transaction for both SQLite and PostgreSQL-backed pools.
+
+**Success Criteria:** Service code can create a transaction-bound `PrototypeWorkspacesRepo` and run existing repo methods without per-statement commits. Placeholder conversion remains compatible with the current `DatabasePool` behavior.
+
+**Tests:** Add repo unit tests proving transaction-bound execution does not call top-level pool `execute`/`fetchone`/`fetchall`, and that PostgreSQL-style transaction adapters receive converted placeholders.
+
+**Status:** Complete
+
+- [x] Add failing tests in `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py`.
+- [x] Add a narrow transaction helper/adapter in `tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py`.
+- [x] Run the new focused repo tests and keep the existing prototype repo tests green.
+
+## Stage 2: Multi-Step Service Compensation And Atomicity
+
+**Goal:** Remove partial-write windows from workspace creation and session snapshot saving, while preserving existing compensation behavior where an external preview broker operation is involved.
+
+**Success Criteria:** Failed seed snapshot creation rolls back the workspace row. Failed session-state persistence rolls back the candidate snapshot row. Promotion failure after preview grant still revokes the preview and restores workspace state.
+
+**Tests:** Add service tests in `tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py` or a new focused persistence test file for failed intermediate writes.
+
+**Status:** Complete
+
+- [x] Write failing tests for create-workspace seed failure and session snapshot state failure.
+- [x] Update `PrototypeWorkspaceService.create_workspace` and `save_session_snapshot` to use the transaction-bound repo.
+- [x] Add or extend promotion compensation tests around persisted preview handle rollback.
+
+## Stage 3: Cleanup And Retention Rules
+
+**Goal:** Define and implement backend cleanup semantics for expired/revoked prototype collaboration state without changing runtime job durability.
+
+**Success Criteria:** Cleanup behavior is explicit for archived workspaces, revoked actors, expired sessions, stale pending promotion requests, and inactive preview handles.
+
+**Tests:** Add repository tests for cleanup cutoffs and non-destructive behavior for active records.
+
+**Status:** Complete
+
+- [x] Add failing cleanup/retention tests against the in-memory SQLite fixture.
+- [x] Add repository cleanup helpers that only touch prototype tables and return count summaries.
+- [x] Document the retention rules in `Docs/API-related/Prototype_Workspaces_API.md`.
+
+## Stage 4: Migration, Index, And Query-Plan Evidence
+
+**Goal:** Record and test the index/query-plan coverage needed by workspace detail, session lookup, active actor lookup, promotion listing, and preview-handle lookup paths.
+
+**Success Criteria:** Migration tests assert required prototype indexes exist. Query-plan evidence is recorded in docs. Any missing index is added to migration 086 with idempotent `CREATE INDEX IF NOT EXISTS` statements.
+
+**Tests:** Add SQLite migration/index tests and fake PostgreSQL/table-discovery compatibility tests where practical.
+
+**Status:** Complete
+
+- [x] Add failing migration tests for the required prototype indexes.
+- [x] Add missing idempotent indexes in `tldw_Server_API/app/core/AuthNZ/migrations.py`.
+- [x] Document SQLite/PostgreSQL behavior, placeholder conversion, and query-plan review in `Docs/API-related/Prototype_Workspaces_API.md`.
+
+## Stage 5: Verification And PR Closeout
+
+**Goal:** Finish Risk Gate 2 with focused automated evidence and the security gate required by the repo.
+
+**Success Criteria:** Focused tests pass, Bandit has been run on touched backend files, TASK-363 has verification notes and a final summary, and GitHub issue #1454 can be linked from the PR.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q`; focused migration/repo tests as added; Bandit on touched backend files.
+
+**Status:** In Progress
+
+- [x] Run the focused prototype workspace suite.
+- [x] Run Bandit on touched backend paths.
+- [ ] Update TASK-363 acceptance criteria and final summary.
+- [ ] Prepare a PR summary that explains what changed and why, leaving the required human `Change summary` for merge readiness.

--- a/backlog/tasks/task-376 - Address-PR-1719-cleanup_retained_state-review-comment.md
+++ b/backlog/tasks/task-376 - Address-PR-1719-cleanup_retained_state-review-comment.md
@@ -1,0 +1,54 @@
+---
+id: TASK-376
+title: Address PR 1719 cleanup_retained_state review comment
+status: Done
+assignee: []
+created_date: '2026-05-15 06:01'
+updated_date: '2026-05-15 06:05'
+labels:
+  - prototype-workspaces
+  - review-fix
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the live PR #1719 review finding that cleanup_retained_state fails when invoked on a transaction-bound PrototypeWorkspacesRepo. Scope is limited to the repository cleanup transaction handling and focused regression tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 cleanup_retained_state can run on a transaction-bound repository without opening a nested transaction
+- [x] #2 Focused prototype workspace repo tests cover the transaction-bound cleanup path
+- [x] #3 Focused pytest, git diff --check, and Bandit on touched backend code are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing regression that calls cleanup_retained_state from inside repo.transaction(). 2. Extract or route the cleanup SQL so transaction-bound repos reuse the existing bound connection instead of opening a nested transaction. 3. Run focused prototype repo tests, git diff --check, and Bandit on the touched repository file. 4. Commit and resolve the PR review thread.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red-green verification: added test_cleanup_retained_state_runs_inside_existing_transaction, confirmed it failed before implementation with RuntimeError from _TransactionBoundPool lacking transaction(), then added _cleanup_transaction() so transaction-bound repos reuse self while top-level repos still open an atomic transaction. Verification passed: focused red/green regression, full test_prototype_repo.py 21 passed, git diff --check passed, Bandit JSON at /tmp/bandit_prototype_repo_1719_review_fix.json reported errors=0 and results=0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1719 review feedback for cleanup_retained_state on transaction-bound PrototypeWorkspacesRepo instances. The cleanup path now uses an internal async context manager that yields the already-bound repo when no transaction factory is present, and otherwise opens the normal transaction. Added regression coverage for calling cleanup_retained_state inside repo.transaction(). Verification: full prototype repo tests passed, git diff --check passed, and Bandit on prototype_workspaces_repo.py reported zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-388 - Address-PR-1719-Qodo-persistence-hardening-review-comments.md
+++ b/backlog/tasks/task-388 - Address-PR-1719-Qodo-persistence-hardening-review-comments.md
@@ -1,0 +1,55 @@
+---
+id: TASK-388
+title: Address PR 1719 Qodo persistence hardening review comments
+status: Done
+assignee: []
+created_date: '2026-05-15 19:27'
+updated_date: '2026-05-15 19:27'
+labels:
+  - prototype-workspaces
+  - review-fix
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the live Qodo follow-up review comments on PR #1719. Scope: add missing type annotations/docstrings, add cleanup-supporting migration indexes and tests, evaluate the raw-SQL comment against existing AuthNZ repository patterns, run focused verification, and resolve review threads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Transaction context managers and helper functions have return type annotations/docstrings where requested
+- [x] #2 Cleanup retention predicates have supporting indexes covered by migration tests
+- [x] #3 Raw-SQL review comment is either fixed or answered with codebase-pattern evidence
+- [x] #4 Focused pytest, git diff --check, and Bandit on touched backend code are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect live Qodo comments and current dirty worktree edits. 2. Preserve existing local edits for annotations, docstring, and cleanup indexes; patch gaps if verification shows any. 3. Verify the raw-SQL finding against existing AuthNZ repository conventions and avoid a broad architecture move if inconsistent. 4. Run focused PrototypeWorkspaces tests, git diff --check, and Bandit on touched backend files. 5. Commit, push, and resolve/reply to review threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed valid Qodo follow-ups by adding AsyncIterator return annotations for transaction context managers, adding a _result_row_count docstring, and adding cleanup-supporting migration indexes for archived workspaces, expired/revoked actors and sessions, and inactive revoked preview handles. Verified raw-SQL comment against AuthNZ repo patterns: AuthNZ repos are the persistence abstraction for this database and existing repo modules use db_pool.execute/fetch* throughout; cleanup SQL remains parameterized and transaction-bound, so moving it to DB_Management would be inconsistent and broader than the PR.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1719 Qodo follow-up review comments. Implemented type/docstring fixes and cleanup indexes with migration test coverage. The raw-SQL comment is handled with codebase-pattern evidence rather than a broad architecture move: AuthNZ repos already centralize AuthNZ DB persistence with parameterized db_pool calls. Verification passed: test_prototype_repo.py 21 passed, git diff --check passed, and Bandit on migrations.py plus prototype_workspaces_repo.py reported zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -686,6 +686,10 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
         "CREATE INDEX IF NOT EXISTS idx_prototype_workspaces_owner_updated "
         "ON prototype_workspaces(owner_user_id, updated_at)"
     )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_workspaces_archived_at_cleanup "
+        "ON prototype_workspaces(archived_at) WHERE archived_at IS NOT NULL"
+    )
 
     conn.execute(
         """
@@ -742,6 +746,11 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_prototype_shared_actors_active_lookup "
         "ON prototype_shared_actors(prototype_workspace_id, revoked_at, expires_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_shared_actors_expires_revoked_cleanup "
+        "ON prototype_shared_actors(expires_at, revoked_at) "
+        "WHERE expires_at IS NOT NULL AND revoked_at IS NULL"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_prototype_shared_actors_share_link_revoked "
@@ -806,6 +815,14 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
         "actor_shared_actor_id, share_link_id, revoked_at, expires_at, updated_at"
         ")"
     )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_sessions_revoked_at_cleanup "
+        "ON prototype_sessions(revoked_at) WHERE revoked_at IS NOT NULL"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_sessions_expires_at_cleanup "
+        "ON prototype_sessions(expires_at) WHERE expires_at IS NOT NULL"
+    )
 
     conn.execute(
         """
@@ -844,6 +861,11 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
     conn.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_prototype_preview_handles_active_scope "
         "ON prototype_preview_handles(scope_id) WHERE is_active = 1"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_preview_handles_inactive_revoked_cleanup "
+        "ON prototype_preview_handles(is_active, revoked_at) "
+        "WHERE is_active = 0 AND revoked_at IS NOT NULL"
     )
 
     conn.execute(

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -581,6 +581,11 @@ def migration_085_remove_api_keys_scope_default(conn: sqlite3.Connection) -> Non
     pragma_by_name = {row[1]: row for row in pragma_rows}
     current_columns = [row[1] for row in pragma_rows]
 
+    def _quote_sqlite_identifier(identifier: str) -> str:
+        """Quote a SQLite identifier derived from trusted schema metadata."""
+        escaped_identifier = identifier.replace('"', '""')
+        return f'"{escaped_identifier}"'
+
     def _fallback_definition(column_name: str) -> str:
         row = pragma_by_name[column_name]
         column_type = row[2] or "TEXT"
@@ -588,7 +593,7 @@ def migration_085_remove_api_keys_scope_default(conn: sqlite3.Connection) -> Non
         default = row[4]
         primary_key = bool(row[5])
 
-        parts = [column_name, column_type]
+        parts = [_quote_sqlite_identifier(column_name), column_type]
         if primary_key:
             parts.append("PRIMARY KEY")
         elif not_null:
@@ -598,6 +603,7 @@ def migration_085_remove_api_keys_scope_default(conn: sqlite3.Connection) -> Non
         return " ".join(parts)
 
     column_defs = [desired_defs.get(name, _fallback_definition(name)) for name in current_columns]
+    quoted_current_columns = ", ".join(_quote_sqlite_identifier(name) for name in current_columns)
 
     # Use the foreign-key-off rebuild pattern to avoid FK cascade
     # actions (e.g. ON DELETE CASCADE on api_key_audit_log, ON DELETE
@@ -612,13 +618,18 @@ def migration_085_remove_api_keys_scope_default(conn: sqlite3.Connection) -> Non
             )
             """
         )
-        conn.execute(
-            f"""
-            INSERT INTO api_keys_new ({', '.join(current_columns)})
-            SELECT {', '.join(current_columns)}
-            FROM api_keys
-            """
+        # SECURITY: SQL identifiers cannot be bound parameters; the column
+        # names here come from trusted PRAGMA metadata and are SQLite-quoted.
+        insert_api_keys_rebuild_sql = " ".join(
+            (
+                "INSERT INTO api_keys_new",
+                f"({quoted_current_columns})",
+                "SELECT",
+                quoted_current_columns,
+                "FROM api_keys",
+            )
         )
+        conn.execute(insert_api_keys_rebuild_sql)
         conn.execute("DROP TABLE IF EXISTS api_keys")
         conn.execute("ALTER TABLE api_keys_new RENAME TO api_keys")
 
@@ -729,6 +740,10 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
         "ON prototype_shared_actors(prototype_workspace_id)"
     )
     conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_shared_actors_active_lookup "
+        "ON prototype_shared_actors(prototype_workspace_id, revoked_at, expires_at)"
+    )
+    conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_prototype_shared_actors_share_link_revoked "
         "ON prototype_shared_actors(share_link_id, revoked_at)"
     )
@@ -779,6 +794,17 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_prototype_sessions_workspace_updated "
         "ON prototype_sessions(prototype_workspace_id, updated_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_sessions_workspace_active_updated "
+        "ON prototype_sessions(prototype_workspace_id, revoked_at, updated_at, created_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_sessions_active_lookup "
+        "ON prototype_sessions("
+        "prototype_workspace_id, base_snapshot_id, actor_type, actor_user_id, "
+        "actor_shared_actor_id, share_link_id, revoked_at, expires_at, updated_at"
+        ")"
     )
 
     conn.execute(
@@ -851,6 +877,10 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_prototype_promotion_requests_workspace_status "
         "ON prototype_promotion_requests(prototype_workspace_id, status)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_promotion_requests_workspace_status_updated "
+        "ON prototype_promotion_requests(prototype_workspace_id, status, updated_at)"
     )
 
     conn.commit()

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -176,6 +176,15 @@ class PrototypeWorkspacesRepo:
                 raise cause from exc
             raise
 
+    @asynccontextmanager
+    async def _cleanup_transaction(self):
+        """Yield the active transaction-bound repo or open a cleanup transaction."""
+        if getattr(self.db_pool, "transaction", None) is None:
+            yield self
+            return
+        async with self.transaction() as repo:
+            yield repo
+
     @staticmethod
     def _row_to_dict(row: Any) -> dict[str, Any]:
         if row is None:
@@ -1161,7 +1170,7 @@ class PrototypeWorkspacesRepo:
             "archived_workspaces_deleted": 0,
         }
 
-        async with self.transaction() as repo:
+        async with self._cleanup_transaction() as repo:
             if expired_before is not None:
                 counts["expired_shared_actors_revoked"] = _result_row_count(
                     await repo.db_pool.execute(

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import json
 import uuid
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
 from loguru import logger
 
-from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.database import (
+    DatabasePool,
+    _convert_question_mark_to_dollar,
+    _flatten_params,
+)
+from tldw_Server_API.app.core.AuthNZ.exceptions import TransactionError
 
 _VALID_CREATION_SOURCES = {"prompt", "template", "existing_workspace"}
 _VALID_ACTOR_TYPES = {"owner", "internal_collaborator", "external_collaborator"}
@@ -19,6 +25,39 @@ _ROW_CONVERSION_EXCEPTIONS = (AttributeError, KeyError, TypeError, ValueError)
 
 class InactivePrototypeSharedActorError(ValueError):
     """Raised when a shared actor is missing, revoked, or outside its allowed scope."""
+
+
+class _TransactionBoundPool:
+    """Small DatabasePool-compatible adapter bound to one transaction connection."""
+
+    def __init__(self, conn: Any, *, is_postgres_backend: bool) -> None:
+        self._conn = conn
+        self.pool = object() if is_postgres_backend else None
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        params = _flatten_params(args)
+        if self.pool is not None:
+            return await self._conn.execute(_convert_question_mark_to_dollar(query, params), *params)
+        return await self._conn.execute(query, params)
+
+    async def fetchone(self, query: str, *args: Any) -> Any:
+        params = _flatten_params(args)
+        if self.pool is not None:
+            return await self._conn.fetchrow(_convert_question_mark_to_dollar(query, params), *params)
+        if hasattr(self._conn, "fetchone"):
+            return await self._conn.fetchone(query, params)
+        cursor = await self._conn.execute(query, params)
+        return await cursor.fetchone()
+
+    async def fetchall(self, query: str, *args: Any) -> list[Any]:
+        params = _flatten_params(args)
+        if self.pool is not None:
+            rows = await self._conn.fetch(_convert_question_mark_to_dollar(query, params), *params)
+            return list(rows)
+        if hasattr(self._conn, "fetchall"):
+            return await self._conn.fetchall(query, params)
+        cursor = await self._conn.execute(query, params)
+        return list(await cursor.fetchall())
 
 
 def _to_bool(value: Any) -> bool:
@@ -58,6 +97,18 @@ def _load_json_list(raw: Any) -> list[Any]:
             return []
         return list(parsed) if isinstance(parsed, list) else []
     return []
+
+
+def _result_row_count(result: Any) -> int:
+    rowcount = getattr(result, "rowcount", None)
+    if isinstance(rowcount, int):
+        return max(rowcount, 0)
+    if isinstance(result, str):
+        try:
+            return max(int(result.rsplit(" ", 1)[-1]), 0)
+        except (TypeError, ValueError):
+            return 0
+    return 0
 
 
 def _normalize_creation_source(creation_source: str | None) -> str:
@@ -104,6 +155,26 @@ class PrototypeWorkspacesRepo:
     def _ts(self) -> datetime | str:
         now = datetime.now(timezone.utc)
         return now if self._is_postgres_backend() else now.isoformat()
+
+    @asynccontextmanager
+    async def transaction(self):
+        """Yield a repository bound to one AuthNZ database transaction."""
+        transaction_factory = getattr(self.db_pool, "transaction", None)
+        if transaction_factory is None:
+            raise RuntimeError("Prototype workspace repository requires transaction-capable db_pool")
+        try:
+            async with transaction_factory() as conn:
+                yield PrototypeWorkspacesRepo(
+                    db_pool=_TransactionBoundPool(
+                        conn,
+                        is_postgres_backend=self._is_postgres_backend(),
+                    )
+                )
+        except TransactionError as exc:
+            cause = exc.__cause__
+            if isinstance(cause, (RuntimeError, ValueError)):
+                raise cause from exc
+            raise
 
     @staticmethod
     def _row_to_dict(row: Any) -> dict[str, Any]:
@@ -1069,3 +1140,116 @@ class PrototypeWorkspacesRepo:
             ),
         )
         return await self.get_promotion_request(promotion_request_id)
+
+    async def cleanup_retained_state(
+        self,
+        *,
+        now: str | datetime | None = None,
+        expired_before: str | datetime | None = None,
+        stale_promotion_before: str | datetime | None = None,
+        inactive_preview_before: str | datetime | None = None,
+        archived_workspace_before: str | datetime | None = None,
+    ) -> dict[str, int]:
+        """Apply prototype workspace cleanup and retention rules atomically."""
+        ts = now if now is not None else self._ts()
+        counts = {
+            "expired_shared_actors_revoked": 0,
+            "expired_sessions_revoked": 0,
+            "preview_handles_revoked": 0,
+            "stale_promotion_requests_marked": 0,
+            "inactive_preview_handles_deleted": 0,
+            "archived_workspaces_deleted": 0,
+        }
+
+        async with self.transaction() as repo:
+            if expired_before is not None:
+                counts["expired_shared_actors_revoked"] = _result_row_count(
+                    await repo.db_pool.execute(
+                        """
+                        UPDATE prototype_shared_actors
+                        SET revoked_at = ?, updated_at = ?
+                        WHERE expires_at IS NOT NULL
+                          AND expires_at <= ?
+                          AND revoked_at IS NULL
+                        """,
+                        (ts, ts, expired_before),
+                    )
+                )
+                counts["expired_sessions_revoked"] = _result_row_count(
+                    await repo.db_pool.execute(
+                        """
+                        UPDATE prototype_sessions
+                        SET revoked_at = ?,
+                            runtime_status = ?,
+                            preview_status = ?,
+                            updated_at = ?
+                        WHERE expires_at IS NOT NULL
+                          AND expires_at <= ?
+                          AND revoked_at IS NULL
+                        """,
+                        (ts, "revoked", "revoked", ts, expired_before),
+                    )
+                )
+                counts["preview_handles_revoked"] = _result_row_count(
+                    await repo.db_pool.execute(
+                        """
+                        UPDATE prototype_preview_handles
+                        SET is_active = ?, revoked_at = ?
+                        WHERE is_active = ?
+                          AND (
+                            prototype_workspace_id IN (
+                                SELECT id
+                                FROM prototype_workspaces
+                                WHERE archived_at IS NOT NULL
+                            )
+                            OR prototype_session_id IN (
+                                SELECT id
+                                FROM prototype_sessions
+                                WHERE revoked_at IS NOT NULL
+                                   OR (expires_at IS NOT NULL AND expires_at <= ?)
+                            )
+                          )
+                        """,
+                        (False, ts, True, expired_before),
+                    )
+                )
+
+            if stale_promotion_before is not None:
+                counts["stale_promotion_requests_marked"] = _result_row_count(
+                    await repo.db_pool.execute(
+                        """
+                        UPDATE prototype_promotion_requests
+                        SET status = ?, updated_at = ?
+                        WHERE status = ?
+                          AND updated_at <= ?
+                        """,
+                        ("stale", ts, "pending", stale_promotion_before),
+                    )
+                )
+
+            if inactive_preview_before is not None:
+                counts["inactive_preview_handles_deleted"] = _result_row_count(
+                    await repo.db_pool.execute(
+                        """
+                        DELETE FROM prototype_preview_handles
+                        WHERE is_active = ?
+                          AND revoked_at IS NOT NULL
+                          AND revoked_at <= ?
+                        """,
+                        (False, inactive_preview_before),
+                    )
+                )
+
+            if archived_workspace_before is not None:
+                counts["archived_workspaces_deleted"] = _result_row_count(
+                    await repo.db_pool.execute(
+                        """
+                        DELETE FROM prototype_workspaces
+                        WHERE archived_at IS NOT NULL
+                          AND archived_at <= ?
+                        """,
+                        (archived_workspace_before,),
+                    )
+                )
+
+        return counts

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -100,6 +101,7 @@ def _load_json_list(raw: Any) -> list[Any]:
 
 
 def _result_row_count(result: Any) -> int:
+    """Extract affected-row counts from SQLite cursors or asyncpg status strings."""
     rowcount = getattr(result, "rowcount", None)
     if isinstance(rowcount, int):
         return max(rowcount, 0)
@@ -157,7 +159,7 @@ class PrototypeWorkspacesRepo:
         return now if self._is_postgres_backend() else now.isoformat()
 
     @asynccontextmanager
-    async def transaction(self):
+    async def transaction(self) -> AsyncIterator[PrototypeWorkspacesRepo]:
         """Yield a repository bound to one AuthNZ database transaction."""
         transaction_factory = getattr(self.db_pool, "transaction", None)
         if transaction_factory is None:
@@ -177,7 +179,7 @@ class PrototypeWorkspacesRepo:
             raise
 
     @asynccontextmanager
-    async def _cleanup_transaction(self):
+    async def _cleanup_transaction(self) -> AsyncIterator[PrototypeWorkspacesRepo]:
         """Yield the active transaction-bound repo or open a cleanup transaction."""
         if getattr(self.db_pool, "transaction", None) is None:
             yield self

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -72,18 +72,18 @@ class PrototypeWorkspaceService:
         runtime_policy: dict[str, Any] | None = None,
         designated_promoter_ids: list[int] | None = None,
     ) -> dict[str, Any]:
-        workspace = await self._repo.create_workspace(
-            owner_user_id=int(owner_user_id),
-            title=title,
-            description=description,
-            creation_source=creation_source,
-            preview_policy=preview_policy,
-            share_policy=share_policy,
-            runtime_policy=runtime_policy,
-            designated_promoter_ids=designated_promoter_ids,
-        )
-        try:
-            seed_snapshot = await self._repo.create_snapshot(
+        async with self._repo.transaction() as repo:
+            workspace = await repo.create_workspace(
+                owner_user_id=int(owner_user_id),
+                title=title,
+                description=description,
+                creation_source=creation_source,
+                preview_policy=preview_policy,
+                share_policy=share_policy,
+                runtime_policy=runtime_policy,
+                designated_promoter_ids=designated_promoter_ids,
+            )
+            seed_snapshot = await repo.create_snapshot(
                 prototype_workspace_id=workspace["id"],
                 snapshot_id=f"psnap_{uuid.uuid4().hex}",
                 created_by_user_id=int(owner_user_id),
@@ -91,7 +91,7 @@ class PrototypeWorkspaceService:
                 prompt_summary=prompt,
                 diff_summary={"creation_source": creation_source},
             )
-            updated = await self._repo.update_workspace_state(
+            updated = await repo.update_workspace_state(
                 workspace["id"],
                 canonical_snapshot_id=seed_snapshot["snapshot_id"],
                 last_known_good_snapshot_id=seed_snapshot["snapshot_id"],
@@ -101,9 +101,6 @@ class PrototypeWorkspaceService:
             if not updated or updated.get("canonical_snapshot_id") != seed_snapshot["snapshot_id"]:
                 raise RuntimeError("failed to persist prototype workspace seed snapshot")
             return updated
-        except Exception:
-            await self._repo.archive_workspace(workspace["id"])
-            raise
 
     async def create_or_reuse_branch_session(
         self,
@@ -203,46 +200,43 @@ class PrototypeWorkspaceService:
         prompt_summary: str | None = None,
         preview_health: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        session = await self._repo.get_session(prototype_session_id)
-        if not session:
-            raise ValueError("prototype session not found")
-        workspace = await self._repo.get_workspace(str(session["prototype_workspace_id"]))
-        if not workspace:
-            raise ValueError("prototype workspace not found")
-        if workspace.get("is_archived"):
-            raise RuntimeError("archived workspaces cannot save snapshots")
-        await self._assert_session_is_active(session)
+        async with self._repo.transaction() as repo:
+            session = await repo.get_session(prototype_session_id)
+            if not session:
+                raise ValueError("prototype session not found")
+            workspace = await repo.get_workspace(str(session["prototype_workspace_id"]))
+            if not workspace:
+                raise ValueError("prototype workspace not found")
+            if workspace.get("is_archived"):
+                raise RuntimeError("archived workspaces cannot save snapshots")
+            await self._assert_session_is_active(session, repo=repo)
 
-        new_snapshot_id = str(snapshot_id or f"psnap_{uuid.uuid4().hex}")
-        snapshot = await self._repo.create_snapshot(
-            prototype_workspace_id=str(session["prototype_workspace_id"]),
-            snapshot_id=new_snapshot_id,
-            created_by_user_id=session.get("actor_user_id"),
-            created_by_shared_actor_id=session.get("actor_shared_actor_id"),
-            parent_snapshot_id=str(
-                session.get("last_saved_snapshot_id")
-                or session.get("base_snapshot_id")
-                or ""
-            ).strip()
-            or None,
-            created_from_session_id=prototype_session_id,
-            storage_ref=storage_ref,
-            diff_summary=diff_summary,
-            prompt_summary=prompt_summary,
-            preview_health=preview_health,
-        )
-        try:
-            updated_session = await self._repo.update_session_state(
+            new_snapshot_id = str(snapshot_id or f"psnap_{uuid.uuid4().hex}")
+            snapshot = await repo.create_snapshot(
+                prototype_workspace_id=str(session["prototype_workspace_id"]),
+                snapshot_id=new_snapshot_id,
+                created_by_user_id=session.get("actor_user_id"),
+                created_by_shared_actor_id=session.get("actor_shared_actor_id"),
+                parent_snapshot_id=str(
+                    session.get("last_saved_snapshot_id")
+                    or session.get("base_snapshot_id")
+                    or ""
+                ).strip()
+                or None,
+                created_from_session_id=prototype_session_id,
+                storage_ref=storage_ref,
+                diff_summary=diff_summary,
+                prompt_summary=prompt_summary,
+                preview_health=preview_health,
+            )
+            updated_session = await repo.update_session_state(
                 prototype_session_id,
                 last_saved_snapshot_id=snapshot["snapshot_id"],
                 last_activity_at=_utc_now(),
             )
             if not updated_session or updated_session.get("last_saved_snapshot_id") != snapshot["snapshot_id"]:
                 raise RuntimeError("failed to persist session snapshot state")
-        except Exception:
-            await self._repo.delete_snapshot(snapshot["snapshot_id"])
-            raise
-        return snapshot
+            return snapshot
 
     async def promote_candidate(
         self,
@@ -463,7 +457,12 @@ class PrototypeWorkspaceService:
         if expires_at and expires_at <= datetime.now(timezone.utc):
             raise RuntimeError("expired shared actor cannot create or reuse branch sessions")
 
-    async def _assert_session_is_active(self, session: dict[str, Any]) -> None:
+    async def _assert_session_is_active(
+        self,
+        session: dict[str, Any],
+        *,
+        repo: PrototypeWorkspacesRepo | None = None,
+    ) -> None:
         if session.get("is_revoked") or session.get("revoked_at"):
             raise RuntimeError("revoked session cannot save snapshots")
         expires_at = _normalize_datetime(session.get("expires_at"))
@@ -472,7 +471,8 @@ class PrototypeWorkspaceService:
         actor_type = str(session.get("actor_type") or "").strip().lower()
         if actor_type != "external_collaborator":
             return
-        actor = await self._repo.get_shared_actor(str(session.get("actor_shared_actor_id") or ""))
+        actor_repo = repo or self._repo
+        actor = await actor_repo.get_shared_actor(str(session.get("actor_shared_actor_id") or ""))
         if not actor or actor.get("is_revoked") or actor.get("revoked_at"):
             raise RuntimeError("revoked shared actor cannot save snapshots")
         actor_expires_at = _normalize_datetime(actor.get("expires_at"))

--- a/tldw_Server_API/tests/PrototypeWorkspaces/conftest.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/conftest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -34,6 +35,40 @@ class _FakePool:
         rows = cur.fetchall()
         cols = [d[0] for d in cur.description]
         return [dict(zip(cols, row, strict=True)) for row in rows]
+
+    @asynccontextmanager
+    async def transaction(self):
+        """Yield a no-autocommit adapter over the in-memory SQLite connection."""
+
+        class _TxConn:
+            def __init__(self, conn: sqlite3.Connection) -> None:
+                self._conn = conn
+
+            async def execute(self, sql: str, params: tuple = ()):
+                return self._conn.execute(sql, params)
+
+            async def fetchone(self, sql: str, params: tuple = ()) -> dict | None:
+                cur = self._conn.execute(sql, params)
+                row = cur.fetchone()
+                if row is None:
+                    return None
+                cols = [d[0] for d in cur.description]
+                return dict(zip(cols, row, strict=True))
+
+            async def fetchall(self, sql: str, params: tuple = ()) -> list[dict]:
+                cur = self._conn.execute(sql, params)
+                rows = cur.fetchall()
+                cols = [d[0] for d in cur.description]
+                return [dict(zip(cols, row, strict=True)) for row in rows]
+
+        self._conn.execute("BEGIN")
+        try:
+            yield _TxConn(self._conn)
+        except Exception:
+            self._conn.rollback()
+            raise
+        else:
+            self._conn.commit()
 
 
 @pytest.fixture

--- a/tldw_Server_API/tests/PrototypeWorkspaces/conftest.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/conftest.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 import pytest
 
@@ -37,14 +39,14 @@ class _FakePool:
         return [dict(zip(cols, row, strict=True)) for row in rows]
 
     @asynccontextmanager
-    async def transaction(self):
+    async def transaction(self) -> AsyncIterator[Any]:
         """Yield a no-autocommit adapter over the in-memory SQLite connection."""
 
         class _TxConn:
             def __init__(self, conn: sqlite3.Connection) -> None:
                 self._conn = conn
 
-            async def execute(self, sql: str, params: tuple = ()):
+            async def execute(self, sql: str, params: tuple = ()) -> sqlite3.Cursor:
                 return self._conn.execute(sql, params)
 
             async def fetchone(self, sql: str, params: tuple = ()) -> dict | None:

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py
@@ -99,19 +99,22 @@ def test_build_promote_idempotency_key_uses_workspace_candidate_and_canonical_sn
 
 
 @pytest.mark.asyncio
-async def test_create_workspace_archives_partial_workspace_when_seed_snapshot_fails(
+async def test_create_workspace_rolls_back_partial_workspace_when_seed_snapshot_fails(
     repo,
     prototype_db,
     monkeypatch,
 ):
     module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    repo_module = importlib.import_module(
+        "tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo"
+    )
     service_cls = _load_attr(module, "PrototypeWorkspaceService")
     service = service_cls(repo=repo)
 
-    async def fail_create_snapshot(**_kwargs: Any) -> dict[str, Any]:
+    async def fail_create_snapshot(self: Any, **_kwargs: Any) -> dict[str, Any]:
         raise RuntimeError("seed snapshot failed")
 
-    monkeypatch.setattr(repo, "create_snapshot", fail_create_snapshot)
+    monkeypatch.setattr(repo_module.PrototypeWorkspacesRepo, "create_snapshot", fail_create_snapshot)
 
     with pytest.raises(RuntimeError, match="seed snapshot failed"):
         await service.create_workspace(
@@ -124,8 +127,7 @@ async def test_create_workspace_archives_partial_workspace_when_seed_snapshot_fa
         "SELECT archived_at FROM prototype_workspaces WHERE title = ?",
         ("Partial seed failure",),
     ).fetchone()
-    assert row is not None
-    assert row[0] is not None
+    assert row is None
 
 
 @pytest.mark.asyncio
@@ -135,6 +137,9 @@ async def test_save_session_snapshot_deletes_snapshot_when_session_state_update_
     monkeypatch,
 ):
     module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    repo_module = importlib.import_module(
+        "tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo"
+    )
     service_cls = _load_attr(module, "PrototypeWorkspaceService")
     service = service_cls(repo=repo)
     workspace, base_snapshot, session, _candidate = await _seed_promotable_workspace(repo, prototype_db)
@@ -142,7 +147,11 @@ async def test_save_session_snapshot_deletes_snapshot_when_session_state_update_
     async def fail_update_session_state(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
         raise RuntimeError("session state update failed")
 
-    monkeypatch.setattr(repo, "update_session_state", fail_update_session_state)
+    async def fail_delete_snapshot(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("snapshot delete compensation should not be needed")
+
+    monkeypatch.setattr(repo_module.PrototypeWorkspacesRepo, "update_session_state", fail_update_session_state)
+    monkeypatch.setattr(repo_module.PrototypeWorkspacesRepo, "delete_snapshot", fail_delete_snapshot)
 
     with pytest.raises(RuntimeError, match="session state update failed"):
         await service.save_session_snapshot(

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any
 
@@ -80,6 +81,145 @@ def test_migration_086_creates_prototype_workspace_tables() -> None:
         }.issubset(table_names)
     finally:
         conn.close()
+
+
+def test_migration_086_creates_risk_gate_2_query_indexes() -> None:
+    from tldw_Server_API.app.core.AuthNZ.migrations import (
+        migration_001_create_users_table,
+        migration_086_create_prototype_workspace_tables,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        migration_001_create_users_table(conn)
+        migration_086_create_prototype_workspace_tables(conn)
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_prototype_%'"
+        ).fetchall()
+        index_names = {str(row[0]) for row in rows}
+        assert {
+            "idx_prototype_workspaces_owner_updated",
+            "idx_prototype_sessions_workspace_active_updated",
+            "idx_prototype_sessions_active_lookup",
+            "idx_prototype_shared_actors_active_lookup",
+            "idx_prototype_promotion_requests_workspace_status_updated",
+            "idx_prototype_preview_handles_workspace",
+            "idx_prototype_preview_handles_session",
+            "idx_prototype_preview_handles_scope_active",
+            "idx_prototype_preview_handles_active_scope",
+        }.issubset(index_names)
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_transaction_yields_repo_bound_to_transaction_connection() -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    class TxConn:
+        def __init__(self) -> None:
+            self.fetchall_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+        async def fetchall(self, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, str]]:
+            self.fetchall_calls.append((sql, params))
+            return [
+                {"name": "prototype_workspaces"},
+                {"name": "prototype_snapshots"},
+                {"name": "prototype_sessions"},
+                {"name": "prototype_shared_actors"},
+                {"name": "prototype_promotion_requests"},
+                {"name": "prototype_preview_handles"},
+            ]
+
+    class TxPool:
+        pool = None
+
+        def __init__(self) -> None:
+            self.conn = TxConn()
+            self.transaction_opened = False
+
+        @asynccontextmanager
+        async def transaction(self):
+            self.transaction_opened = True
+            yield self.conn
+
+        async def fetchall(self, _sql: str, _params: tuple[Any, ...] = ()) -> list[dict[str, str]]:
+            pytest.fail("transaction-bound repo should not use the top-level pool fetchall")
+
+    pool = TxPool()
+    repo = PrototypeWorkspacesRepo(db_pool=pool)  # type: ignore[arg-type]
+
+    async with repo.transaction() as tx_repo:
+        await tx_repo.ensure_tables()
+
+    assert pool.transaction_opened is True
+    assert pool.conn.fetchall_calls
+
+
+@pytest.mark.asyncio
+async def test_transaction_bound_postgres_repo_converts_question_mark_placeholders() -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    class PgConn:
+        def __init__(self) -> None:
+            self.fetchrow_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+        async def fetchrow(self, sql: str, *params: Any) -> dict[str, Any]:
+            self.fetchrow_calls.append((sql, tuple(params)))
+            return _workspace_row(id=params[0])
+
+    class PgPool:
+        pool = object()
+
+        def __init__(self) -> None:
+            self.conn = PgConn()
+
+        @asynccontextmanager
+        async def transaction(self):
+            yield self.conn
+
+        async def fetchone(self, _sql: str, _params: tuple[Any, ...] = ()) -> dict[str, Any]:
+            pytest.fail("transaction-bound repo should not use the top-level pool fetchone")
+
+    pool = PgPool()
+    repo = PrototypeWorkspacesRepo(db_pool=pool)  # type: ignore[arg-type]
+
+    async with repo.transaction() as tx_repo:
+        workspace = await tx_repo.get_workspace("pws_sql_review")
+
+    assert workspace is not None
+    query, params = pool.conn.fetchrow_calls[0]
+    assert "$1" in query
+    assert "?" not in query
+    assert params == ("pws_sql_review",)
+
+
+@pytest.mark.asyncio
+async def test_transaction_preserves_wrapped_domain_exception() -> None:
+    from tldw_Server_API.app.core.AuthNZ.exceptions import TransactionError
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    class TxPool:
+        pool = None
+
+        @asynccontextmanager
+        async def transaction(self):
+            try:
+                yield object()
+            except RuntimeError as exc:
+                raise TransactionError("SQLite transaction", str(exc)) from exc
+
+    repo = PrototypeWorkspacesRepo(db_pool=TxPool())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="domain failure"):
+        async with repo.transaction():
+            raise RuntimeError("domain failure")
 
 
 @pytest.mark.asyncio
@@ -414,6 +554,183 @@ async def test_find_active_session_filters_candidate_in_sql() -> None:
     assert "expires_at" in query
     assert "LIMIT 1" in query
     assert params[:3] == ("pws_sql_review", "snap_existing", "external_collaborator")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_retained_state_revokes_expired_records_and_stales_pending_promotions(
+    repo,
+    prototype_db,
+) -> None:
+    old = "2026-01-01T00:00:00+00:00"
+    cutoff = "2026-01-15T00:00:00+00:00"
+    now = "2026-02-01T00:00:00+00:00"
+
+    workspace = await repo.create_workspace(owner_user_id=1, title="cleanup", creation_source="prompt")
+    base_snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_cleanup_base",
+        created_by_user_id=1,
+    )
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=71,
+        display_name="Expired collaborator",
+        runtime_policy_profile="locked_collab",
+        expires_at=old,
+    )
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=base_snapshot["snapshot_id"],
+        actor_type="external_collaborator",
+        actor_shared_actor_id=actor["id"],
+        share_link_id=71,
+        expires_at=old,
+    )
+    preview = await repo.replace_active_preview_handle_record(
+        preview_handle="pph_cleanup_expired",
+        preview_scope="session",
+        scope_id=f"session:{session['id']}",
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        actor_key=f"shared_actor:{actor['id']}",
+        target_ref="runtime://expired",
+        runtime_policy_profile="locked_collab",
+        created_at=old,
+    )
+    candidate = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_cleanup_candidate",
+        created_by_shared_actor_id=actor["id"],
+        parent_snapshot_id=base_snapshot["snapshot_id"],
+        created_from_session_id=session["id"],
+    )
+    promotion = await repo.create_promotion_request(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        candidate_snapshot_id=candidate["snapshot_id"],
+        requested_by_shared_actor_id=actor["id"],
+    )
+    prototype_db.execute(
+        "UPDATE prototype_promotion_requests SET updated_at = ? WHERE id = ?",
+        (old, promotion["id"]),
+    )
+    prototype_db.commit()
+
+    result = await repo.cleanup_retained_state(
+        now=now,
+        expired_before=cutoff,
+        stale_promotion_before=cutoff,
+        inactive_preview_before=old,
+    )
+
+    assert result["expired_shared_actors_revoked"] == 1
+    assert result["expired_sessions_revoked"] == 1
+    assert result["preview_handles_revoked"] == 1
+    assert result["stale_promotion_requests_marked"] == 1
+    assert result["inactive_preview_handles_deleted"] == 0
+
+    updated_actor = await repo.get_shared_actor(actor["id"])
+    updated_session = await repo.get_session(session["id"])
+    updated_preview = await repo.get_preview_handle_record(preview["preview_handle"])
+    updated_promotion = await repo.get_promotion_request(promotion["id"])
+
+    assert updated_actor["is_revoked"] is True
+    assert updated_session["is_revoked"] is True
+    assert updated_session["runtime_status"] == "revoked"
+    assert updated_session["preview_status"] == "revoked"
+    assert updated_preview["is_active"] is False
+    assert updated_preview["revoked_at"] == now
+    assert updated_promotion["status"] == "stale"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_retained_state_deletes_archived_workspaces_after_cutoff(repo) -> None:
+    workspace = await repo.create_workspace(owner_user_id=1, title="archived", creation_source="prompt")
+    snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_archived_cleanup",
+        created_by_user_id=1,
+    )
+    await repo.update_workspace_state(
+        workspace["id"],
+        canonical_snapshot_id=snapshot["snapshot_id"],
+    )
+    await repo.archive_workspace(
+        workspace["id"],
+        archived_at="2026-01-01T00:00:00+00:00",
+    )
+
+    result = await repo.cleanup_retained_state(
+        now="2026-02-01T00:00:00+00:00",
+        archived_workspace_before="2026-01-15T00:00:00+00:00",
+    )
+
+    assert result["archived_workspaces_deleted"] == 1
+    assert await repo.get_workspace(workspace["id"]) is None
+    assert await repo.get_snapshot(snapshot["snapshot_id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_retained_state_preserves_active_recent_records(repo) -> None:
+    workspace = await repo.create_workspace(owner_user_id=1, title="active cleanup", creation_source="prompt")
+    base_snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_active_cleanup_base",
+        created_by_user_id=1,
+    )
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=72,
+        display_name="Active collaborator",
+        runtime_policy_profile="locked_collab",
+        expires_at="2026-03-01T00:00:00+00:00",
+    )
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=base_snapshot["snapshot_id"],
+        actor_type="external_collaborator",
+        actor_shared_actor_id=actor["id"],
+        share_link_id=72,
+        expires_at="2026-03-01T00:00:00+00:00",
+    )
+    preview = await repo.replace_active_preview_handle_record(
+        preview_handle="pph_cleanup_active",
+        preview_scope="session",
+        scope_id=f"session:{session['id']}",
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        actor_key=f"shared_actor:{actor['id']}",
+        target_ref="runtime://active",
+        runtime_policy_profile="locked_collab",
+        created_at="2026-02-01T00:00:00+00:00",
+    )
+    candidate = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_active_cleanup_candidate",
+        created_by_shared_actor_id=actor["id"],
+        parent_snapshot_id=base_snapshot["snapshot_id"],
+        created_from_session_id=session["id"],
+    )
+    promotion = await repo.create_promotion_request(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        candidate_snapshot_id=candidate["snapshot_id"],
+        requested_by_shared_actor_id=actor["id"],
+    )
+
+    result = await repo.cleanup_retained_state(
+        now="2026-02-01T00:00:00+00:00",
+        expired_before="2026-01-15T00:00:00+00:00",
+        stale_promotion_before="2026-01-15T00:00:00+00:00",
+        inactive_preview_before="2026-01-15T00:00:00+00:00",
+        archived_workspace_before="2026-01-15T00:00:00+00:00",
+    )
+
+    assert all(count == 0 for count in result.values())
+    assert (await repo.get_shared_actor(actor["id"]))["is_revoked"] is False
+    assert (await repo.get_session(session["id"]))["is_revoked"] is False
+    assert (await repo.get_preview_handle_record(preview["preview_handle"]))["is_active"] is True
+    assert (await repo.get_promotion_request(promotion["id"]))["status"] == "pending"
 
 
 def test_apply_authnz_migrations_from_v85_includes_prototype_tables(tmp_path) -> None:

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -644,6 +644,19 @@ async def test_cleanup_retained_state_revokes_expired_records_and_stales_pending
 
 
 @pytest.mark.asyncio
+async def test_cleanup_retained_state_runs_inside_existing_transaction(repo) -> None:
+    async with repo.transaction() as tx_repo:
+        result = await tx_repo.cleanup_retained_state(
+            now="2026-02-01T00:00:00+00:00",
+            expired_before="2026-01-15T00:00:00+00:00",
+        )
+
+    assert result["expired_shared_actors_revoked"] == 0
+    assert result["expired_sessions_revoked"] == 0
+    assert result["preview_handles_revoked"] == 0
+
+
+@pytest.mark.asyncio
 async def test_cleanup_retained_state_deletes_archived_workspaces_after_cutoff(repo) -> None:
     workspace = await repo.create_workspace(owner_user_id=1, title="archived", creation_source="prompt")
     snapshot = await repo.create_snapshot(

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -99,14 +99,19 @@ def test_migration_086_creates_risk_gate_2_query_indexes() -> None:
         index_names = {str(row[0]) for row in rows}
         assert {
             "idx_prototype_workspaces_owner_updated",
+            "idx_prototype_workspaces_archived_at_cleanup",
             "idx_prototype_sessions_workspace_active_updated",
             "idx_prototype_sessions_active_lookup",
+            "idx_prototype_sessions_revoked_at_cleanup",
+            "idx_prototype_sessions_expires_at_cleanup",
             "idx_prototype_shared_actors_active_lookup",
+            "idx_prototype_shared_actors_expires_revoked_cleanup",
             "idx_prototype_promotion_requests_workspace_status_updated",
             "idx_prototype_preview_handles_workspace",
             "idx_prototype_preview_handles_session",
             "idx_prototype_preview_handles_scope_active",
             "idx_prototype_preview_handles_active_scope",
+            "idx_prototype_preview_handles_inactive_revoked_cleanup",
         }.issubset(index_names)
     finally:
         conn.close()

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_service_authorization.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_service_authorization.py
@@ -46,67 +46,45 @@ async def test_create_or_reuse_branch_session_rejects_revoked_at_only_shared_act
 
 
 @pytest.mark.asyncio
-async def test_save_session_snapshot_rejects_revoked_at_only_session(repo, monkeypatch):
+async def test_save_session_snapshot_rejects_revoked_at_only_session(repo):
     service = PrototypeWorkspaceService(repo=repo)
     workspace = await _seed_workspace(service)
-
-    async def revoked_session(_prototype_session_id: str) -> dict[str, Any]:
-        return {
-            "id": "pss_revoked",
-            "prototype_workspace_id": workspace["id"],
-            "base_snapshot_id": workspace["canonical_snapshot_id"],
-            "actor_type": "internal_collaborator",
-            "actor_user_id": 2,
-            "revoked_at": _revoked_at(),
-        }
-
-    async def create_snapshot(**_kwargs: Any) -> dict[str, Any]:
-        return {"snapshot_id": "psnap_should_not_be_created"}
-
-    async def update_session_state(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
-        return {}
-
-    monkeypatch.setattr(repo, "get_session", revoked_session)
-    monkeypatch.setattr(repo, "create_snapshot", create_snapshot)
-    monkeypatch.setattr(repo, "update_session_state", update_session_state)
+    session_result = await service.create_or_reuse_branch_session(
+        prototype_workspace_id=workspace["id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+    )
+    session = session_result["session"]
+    await repo.update_session_state(session["id"], revoked_at=_revoked_at())
 
     with pytest.raises(RuntimeError, match="revoked session"):
         await service.save_session_snapshot(
-            prototype_session_id="pss_revoked",
+            prototype_session_id=session["id"],
             snapshot_id="psnap_blocked",
         )
 
 
 @pytest.mark.asyncio
-async def test_save_session_snapshot_rejects_revoked_at_only_shared_actor(repo, monkeypatch):
+async def test_save_session_snapshot_rejects_revoked_at_only_shared_actor(repo):
     service = PrototypeWorkspaceService(repo=repo)
     workspace = await _seed_workspace(service)
-
-    async def external_session(_prototype_session_id: str) -> dict[str, Any]:
-        return {
-            "id": "pss_external",
-            "prototype_workspace_id": workspace["id"],
-            "base_snapshot_id": workspace["canonical_snapshot_id"],
-            "actor_type": "external_collaborator",
-            "actor_shared_actor_id": "pactor_revoked",
-        }
-
-    async def revoked_actor(_shared_actor_id: str) -> dict[str, Any]:
-        return {"id": "pactor_revoked", "revoked_at": _revoked_at()}
-
-    async def create_snapshot(**_kwargs: Any) -> dict[str, Any]:
-        return {"snapshot_id": "psnap_should_not_be_created"}
-
-    async def update_session_state(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
-        return {}
-
-    monkeypatch.setattr(repo, "get_session", external_session)
-    monkeypatch.setattr(repo, "get_shared_actor", revoked_actor)
-    monkeypatch.setattr(repo, "create_snapshot", create_snapshot)
-    monkeypatch.setattr(repo, "update_session_state", update_session_state)
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=91,
+        display_name="Revoked stakeholder",
+        runtime_policy_profile="locked_collab",
+    )
+    session_result = await service.create_or_reuse_branch_session(
+        prototype_workspace_id=workspace["id"],
+        actor_type="external_collaborator",
+        actor_shared_actor_id=actor["id"],
+        share_link_id=91,
+    )
+    session = session_result["session"]
+    await repo.revoke_shared_actor(actor["id"], revoked_at=_revoked_at())
 
     with pytest.raises(RuntimeError, match="revoked shared actor"):
         await service.save_session_snapshot(
-            prototype_session_id="pss_external",
+            prototype_session_id=session["id"],
             snapshot_id="psnap_blocked",
         )


### PR DESCRIPTION
## Summary

- Adds a transaction-bound prototype workspace repository adapter and moves workspace creation plus session snapshot saves into atomic transaction scopes.
- Adds cleanup/retention handling for expired actors and sessions, stale promotion requests, inactive preview handles, and archived workspace deletion.
- Adds Risk Gate 2 indexes and documents the persistence, cleanup, and query/index contract.
- Extends tests for rollback behavior, PostgreSQL placeholder conversion, cleanup retention behavior, index coverage, and revoked session/actor authorization inside transactional reads.

## Human Change Summary Required

This PR is materially AI-authored. Before merge, a human maintainer needs to replace this section with their own Change summary explaining what changed and why these implementation choices were made.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py::test_migration_085_removes_api_keys_scope_default tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py::test_migration_085_preserves_rows_indexes_and_audit_refs -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py tldw_Server_API/app/core/Prototype_Workspaces/service.py tldw_Server_API/app/core/AuthNZ/migrations.py -f json -o /tmp/bandit_prototype_risk_gate_2.json`
- `git diff --check`

Closes #1454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes prototype workspace persistence atomic end-to-end and adds retention cleanup that runs atomically and inside existing transactions. Expands Risk Gate 2 indexes and docs; adds tests for rollback, PostgreSQL placeholder conversion, cleanup-in-transaction, and migration coverage.

- **New Features**
  - Transaction-scoped repo via `db_pool.transaction` with `?` → `$N` conversion for PostgreSQL; single-transaction reads/writes.
  - `create_workspace` and `save_session_snapshot` now run in one transaction; failures roll back; promotion still compensates around the preview broker.
  - Cleanup helper runs atomically (and inside an active transaction without nesting), revokes expired actors/sessions, deactivates affected previews, marks stale pending promotions, deletes inactive previews, and deletes archived workspaces after cutoff; returns per-action counts.
  - Docs add “Risk Gate 2 Persistence Contract” with a query/index matrix; tests cover rollback, transactional auth checks, placeholder conversion, cleanup-in-transaction, and required index coverage.

- **Migration**
  - Adds RG2 indexes for sessions active lookup, sessions workspace+active+updated, sessions revoked-at cleanup, sessions expires-at cleanup, shared actors active lookup, shared actors expires+revoked cleanup, preview handles inactive+revoked cleanup, promotion requests workspace+status+updated, and workspaces archived-at cleanup.
  - Quotes SQLite identifiers during migration 085 table rebuild to harden the change.

<sup>Written for commit e9b263f233fae08217140b9590392314ccc9ffd5. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1719?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

