### PR TITLE
Add VZ helper launchd validation drill

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -468,13 +468,13 @@ helper daemon for real `vz_linux` E2E, verifies ephemeral execution, verifies
 same-session VM reuse, verifies recovery diagnostics plus dry-run
 reconciliation repair planning, and stops the helper on exit.
 
-`restart-drill` is a narrower local helper lifecycle check. Use it after
-starting the helper through `vz-helperctl.py start` when you need to prove that
-the managed pid-file/socket workflow can stop the helper, start a replacement
-on the same paths, and reach healthy status again. It refuses absent or
-unmanaged helpers, preserves existing helper logs under the configured log
-directory, and does not run guest commands, mutate reconciliation state, manage
-launchd, or validate host reboot behavior.
+`restart-drill` validates the direct `vz-helperctl.py`-managed lifecycle. Use it
+after starting the helper through `vz-helperctl.py start` when you need to prove
+that the managed pid-file/socket workflow can stop the helper, start a
+replacement on the same paths, and reach healthy status again. It refuses
+absent or unmanaged helpers, preserves existing helper logs under the
+configured log directory, and does not run guest commands, mutate
+reconciliation state, manage launchd, or validate host reboot behavior.
 
 ```bash
 tools/macos-vz-helper/scripts/vz-helperctl.py start
@@ -499,16 +499,38 @@ tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootstrap \
 tools/macos-vz-helper/scripts/vz-helperctl.py launchd kickstart
 tools/macos-vz-helper/scripts/vz-helperctl.py launchd status
 tools/macos-vz-helper/scripts/vz-helperctl.py status
-tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
-  --bundle /path/to/canonical/bundle \
-  --entitlements /path/to/helper.entitlements
 tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootout
 ```
 
+`launchd-drill` is the opt-in validation path for LaunchAgent bootstrap,
+kickstart, helper readiness, bootout, and optional real `vz_linux` smoke through
+the launchd-managed helper. Use isolated labels and private plist/runtime paths
+so the drill cannot take ownership of a user's existing service.
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-launchd-drill.XXXXXX")"
+chmod 700 "$runtime_dir"
+label="org.tldw.macos-vz-helper.drill.$$"
+
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
+  --socket "$runtime_dir/helper.sock" \
+  --log-dir "$runtime_dir/logs" \
+  --plist-output "$runtime_dir/${label}.plist" \
+  --label "$label" \
+  --write-plist \
+  --create-dirs \
+  --skip-smoke
+```
+
+Omit `--skip-smoke` and add `--bundle /path/to/canonical/bundle` when the
+prepared host should also run the real `vz_linux` smoke against the
+launchd-managed helper. The default direct-helper smoke path remains unchanged.
+
 The launchd path does not run from diagnostics, server startup, `status`,
 `plist`, or `smoke`. It also does not validate host reboot behavior; reboot
-testing remains a manual operator drill until a prepared runner can preserve
-logs and tolerate disruptive host lifecycle changes.
+testing remains a manual operator drill and must stay out of scheduled CI until
+a prepared runner can tolerate disruptive host lifecycle changes and preserve
+logs.
 
 Manual failure drills are opt-in and remain disabled for default smoke and
 scheduled host-gated runs. To include them, pass:

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -511,6 +511,7 @@ so the drill cannot take ownership of a user's existing service.
 runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-launchd-drill.XXXXXX")"
 chmod 700 "$runtime_dir"
 label="org.tldw.macos-vz-helper.drill.$$"
+trap 'tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootout --label "$label" --plist-output "$runtime_dir/${label}.plist" >/dev/null 2>&1 || true; rm -rf "$runtime_dir"' EXIT
 
 tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
   --socket "$runtime_dir/helper.sock" \

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -124,7 +124,7 @@ disruptive reboot testing and preserve helper/stdout/serial logs reliably.
 
 `tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill` is the explicit
 LaunchAgent validation path. It may be run manually on a prepared runner, but
-this PR must not enable it in the scheduled workflow by default. A
+the scheduled workflow must not enable it by default. A
 `launchd-drill` skip is expected unless a maintainer deliberately requested
 LaunchAgent validation for that runner.
 

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -122,6 +122,12 @@ mode before any mutation, and then run the real host smoke. A host reboot drill
 must not be added to scheduled CI until a dedicated prepared runner can tolerate
 disruptive reboot testing and preserve helper/stdout/serial logs reliably.
 
+`tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill` is the explicit
+LaunchAgent validation path. It may be run manually on a prepared runner, but
+this PR must not enable it in the scheduled workflow by default. A
+`launchd-drill` skip is expected unless a maintainer deliberately requested
+LaunchAgent validation for that runner.
+
 For a non-launchd helper lifecycle check, maintainers can run
 `tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill` against a helper
 that was started through `vz-helperctl.py start`. That drill is local and
@@ -144,6 +150,8 @@ These are expected and should not block ordinary PRs:
   `include_failure_drills=true`
 - managed helper `restart-drill` skipped because no helper was started through
   the local `vz-helperctl.py start` workflow
+- launchd drill skipped because no maintainer requested it on a prepared
+  LaunchAgent validation runner
 - launchd operator validation skipped because the helper is managed through
   direct `vz-helperctl.py start` or no LaunchAgent plist has been prepared
 - host reboot validation handled through a manual operator procedure rather
@@ -172,6 +180,9 @@ prepared host and fails one of the accepted runtime guarantees:
 - a manually requested helper restart drill cannot replace stale session-control
   VM state after the helper process is stopped and restarted through the smoke
   harness restart lease
+- a manually requested launchd drill fails after the runner was explicitly
+  configured for LaunchAgent validation and helper/template readiness already
+  passed
 - cleanup leaves the helper process or accepted socket path behind
 - helper protocol mismatch is introduced without a matching compatibility plan
 - artifacts/logs are not uploaded when the job fails

--- a/Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md
+++ b/Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md
@@ -1,0 +1,679 @@
+# VZ Helper Launchd Validation Drill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an explicit operator-owned `vz-helperctl.py launchd-drill` command that validates launchd helper supervision without changing the default direct-helper smoke path.
+
+**Architecture:** Keep the drill inside `tools/macos-vz-helper/scripts/vz-helperctl.py` so it reuses the existing launchd argv, plist, path-safety, status, and output conventions. Add portable tests with injected runners for launchctl/status/smoke behavior, then document the local operator flow and host-gated boundaries. Do not add workflow integration in this first implementation.
+
+**Tech Stack:** Python 3 CLI, `argparse`, existing helperctl `CheckResult` output, pytest, macOS `launchctl` command construction, existing VZ Linux host-gated pytest smoke contract.
+
+---
+
+## Source Inputs
+
+- Spec: `Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md`
+- Existing launchd plan: `Docs/superpowers/plans/2026-05-13-vz-helper-launchd-operator.md`
+- Helper CLI: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Helper CLI tests: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+- Operator docs: `tools/macos-vz-helper/README.md`
+- macOS operator notes: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Host-gated policy: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Tracker: `https://github.com/rmusser01/tldw_server/issues/1442`
+
+## File Map
+
+- Modify `tools/macos-vz-helper/scripts/vz-helperctl.py`
+  - Add launchd drill defaults, launchd loaded-state check, external-helper smoke runner, drill orchestration, CLI parser, and JSON/human output.
+- Modify `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+  - Add portable unit tests for dry-run, sequencing, cleanup, loaded-label guard, missing pid-file launchd mode, JSON shape, and external-helper smoke command construction.
+- Modify `tools/macos-vz-helper/README.md`
+  - Document local launchd drill usage, isolated labels, and cleanup expectations.
+- Modify `Docs/Sandbox/macos-runtime-operator-notes.md`
+  - Add operator guidance for the launchd validation drill and clarify that it is distinct from `restart-drill`.
+- Modify `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+  - Document expected skip/blocking semantics for manual launchd validation without enabling it in scheduled CI.
+- Modify `backlog/tasks/task-364 - Plan-VZ-helper-launchd-validation-drill-implementation.md`
+  - Track planning completion.
+
+## Implementation Constraints
+
+- Default drill label must be isolated, for example `org.tldw.macos-vz-helper.drill.<pid>`.
+- Default drill plist path must live under a private runtime directory, not `~/Library/LaunchAgents`.
+- If the selected launchd target is already loaded before bootstrap, fail with `launchd_service_already_loaded` and do not bootout it.
+- Only bootout a service target that this drill successfully bootstrapped.
+- Missing helperctl pid file is acceptable in launchd mode when launchd status plus helper ping/protocol are healthy.
+- Do not start a second helper during VM smoke. Use the host-gated pytest smoke contract against the launchd-managed socket.
+- Do not add `run-host-e2e-smoke.sh --use-launchd` or workflow integration in this first PR.
+- Do not hide build/sign inside the drill. Require a prepared helper and report clear preflight failures.
+
+---
+
+### Task 1: Drill Defaults And Launchd Loaded Guard
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Write failing tests for drill defaults**
+
+Add tests near existing launchd tests:
+
+```python
+def test_launchd_drill_defaults_use_private_runtime_label_and_plist(monkeypatch, tmp_path):
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    paths = helperctl.default_paths()
+    label = helperctl.default_launchd_drill_label(pid=12345)
+    plist_path = helperctl.default_launchd_drill_plist_path(paths, label)
+
+    CASE.assertEqual(label, "org.tldw.macos-vz-helper.drill.12345")
+    CASE.assertEqual(
+        plist_path,
+        paths.socket_path.parent / "launchd-drill" / "org.tldw.macos-vz-helper.drill.12345.plist",
+    )
+```
+
+- [ ] **Step 2: Write failing tests for loaded-service guard**
+
+```python
+def test_launchd_service_loaded_returns_true_for_launchctl_print_zero():
+    helperctl = load_helperctl()
+
+    result = helperctl.launchd_service_loaded(
+        "org.tldw.test",
+        uid=501,
+        command_runner=lambda argv, **kwargs: 0,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True, reason="launchd_service_loaded"))
+
+
+def test_launchd_service_loaded_returns_false_for_launchctl_print_nonzero():
+    helperctl = load_helperctl()
+
+    result = helperctl.launchd_service_loaded(
+        "org.tldw.test",
+        uid=501,
+        command_runner=lambda argv, **kwargs: 3,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True, reason="launchd_service_absent"))
+```
+
+- [ ] **Step 3: Run focused tests and verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd_drill_defaults or launchd_service_loaded' -q
+```
+
+Expected: FAIL because the new helper functions do not exist.
+
+- [ ] **Step 4: Implement defaults and loaded guard**
+
+Add near the existing launchd helpers:
+
+```python
+def default_launchd_drill_label(*, pid: int | None = None) -> str:
+    suffix = os.getpid() if pid is None else pid
+    return f"{DEFAULT_LAUNCHD_LABEL}.drill.{suffix}"
+
+
+def default_launchd_drill_plist_path(paths: HelperPaths, label: str) -> Path:
+    return paths.socket_path.parent / "launchd-drill" / f"{label}.plist"
+
+
+def launchd_service_loaded(
+    label: str,
+    *,
+    uid: int | None = None,
+    dry_run: bool = False,
+    command_runner: Callable[..., int] | None = None,
+) -> CheckResult:
+    runner = command_runner or run_command
+    argv = launchd_argv("status", label=label, uid=uid)
+    if dry_run:
+        code = runner(argv, dry_run=True)
+        return CheckResult(ok=True, reason="dry_run" if code == 0 else "launchd_service_absent")
+    if _is_default_run_command(runner) and shutil.which("launchctl") is None:
+        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
+    code = runner(argv, dry_run=False)
+    if code == 0:
+        return CheckResult(ok=True, reason="launchd_service_loaded", message=launchd_service_target(label, uid=uid))
+    if code == 127:
+        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
+    return CheckResult(ok=True, reason="launchd_service_absent", message=launchd_service_target(label, uid=uid))
+```
+
+- [ ] **Step 5: Run focused tests and verify pass**
+
+Run the same focused pytest command.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "test(sandbox): add launchd drill defaults"
+```
+
+---
+
+### Task 2: Launchd Drill Orchestration And Cleanup
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Write failing tests for drill sequencing**
+
+Add tests that inject launchd and ping runners:
+
+```python
+def test_launchd_drill_runs_bootstrap_status_kickstart_ping_bootout(tmp_path):
+    helperctl = load_helperctl()
+    private_root = tmp_path / "private"
+    private_root.mkdir(mode=0o700)
+    private_root.chmod(0o700)
+    helper = private_root / "macos-vz-helper"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    socket_path = private_root / "runtime" / "helper.sock"
+    log_dir = private_root / "logs"
+    plist_path = private_root / "launchd-drill" / "org.tldw.test.plist"
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        return 3 if argv[:2] == ["launchctl", "print"] and len(calls) == 1 else 0
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=lambda path: helperctl.PingState(helperctl.CheckResult(ok=True), "1", "test"),
+        smoke_runner=None,
+    )
+
+    by_name = dict(results)
+    CASE.assertTrue(all(result.ok for _, result in results))
+    CASE.assertEqual(by_name["launchd_bootstrap"].reason, "ok")
+    CASE.assertEqual(by_name["launchd_bootout"].reason, "ok")
+    CASE.assertIn(["launchctl", "bootstrap", "gui/501", str(plist_path)], calls)
+    CASE.assertIn(["launchctl", "kickstart", "-k", "gui/501/org.tldw.test"], calls)
+    CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
+```
+
+- [ ] **Step 2: Write failing tests for cleanup and loaded-label protection**
+
+Cover:
+
+```python
+def test_launchd_drill_refuses_already_loaded_service_without_bootout(...):
+    # First launchctl print returns 0.
+    # Assert result contains launchd_preflight with launchd_service_already_loaded.
+    # Assert no bootstrap or bootout call was made.
+
+def test_launchd_drill_bootouts_after_kickstart_success_and_ping_failure(...):
+    # Preflight print returns nonzero, bootstrap and kickstart return 0,
+    # ping returns helper_ping_failed.
+    # Assert bootout is still attempted and primary failure is preserved.
+
+def test_launchd_drill_preserves_primary_failure_when_bootout_fails(...):
+    # Ping fails and bootout returns nonzero.
+    # Assert primary result reason is helper_ping_failed and cleanup result records launchd_bootout_failed.
+```
+
+- [ ] **Step 3: Run focused tests and verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd_drill' -q
+```
+
+Expected: FAIL because `run_launchd_drill` does not exist.
+
+- [ ] **Step 4: Implement `run_launchd_drill`**
+
+Add a function returning `list[tuple[str, CheckResult]]`. Keep it small and procedural:
+
+```python
+def run_launchd_drill(
+    *,
+    helper_path: Path,
+    socket_path: Path,
+    log_dir: Path,
+    plist_path: Path,
+    label: str,
+    uid: int | None = None,
+    write_plist: bool = False,
+    create_dirs: bool = False,
+    dry_run: bool = False,
+    ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
+    launchd_runner: Callable[..., int] | None = None,
+    smoke_runner: Callable[[], CheckResult] | None = None,
+) -> list[tuple[str, CheckResult]]:
+    results: list[tuple[str, CheckResult]] = []
+    bootstrapped = False
+
+    preflight = launchd_service_loaded(label, uid=uid, dry_run=dry_run, command_runner=launchd_runner)
+    if preflight.reason == "launchd_service_loaded":
+        results.append(("launchd_preflight", CheckResult(False, "launchd_service_already_loaded", preflight.message)))
+        return results
+    results.append(("launchd_preflight", preflight))
+    if not preflight.ok:
+        return results
+
+    bootstrap = run_launchd_action(
+        "bootstrap",
+        label=label,
+        plist_path=plist_path,
+        helper_path=helper_path,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        uid=uid,
+        dry_run=dry_run,
+        write_plist=write_plist,
+        create_dirs=create_dirs,
+        command_runner=launchd_runner,
+    )
+    results.append(("launchd_bootstrap", bootstrap))
+    if not bootstrap.ok:
+        return results
+    bootstrapped = not dry_run
+
+    try:
+        # status, kickstart, wait_for_ping, optional smoke
+        ...
+    finally:
+        if bootstrapped:
+            bootout = run_launchd_action(...)
+            results.append(("launchd_bootout", bootout))
+```
+
+Use `wait_for_ping(socket_path, ping_checker=ping_checker)` after kickstart. Do not require a helperctl pid file.
+
+- [ ] **Step 5: Run focused tests and verify pass**
+
+Run the focused launchd-drill pytest selection.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "feat(sandbox): add launchd drill orchestration"
+```
+
+---
+
+### Task 3: External-Helper VZ Smoke Runner
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Write failing tests for external smoke command construction**
+
+```python
+def test_run_vz_linux_host_smoke_uses_existing_helper_socket(tmp_path):
+    helperctl = load_helperctl()
+    calls: list[tuple[list[str], dict[str, str] | None]] = []
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    socket_path = tmp_path / "helper.sock"
+
+    result = helperctl.run_vz_linux_host_smoke(
+        bundle_path=bundle,
+        socket_path=socket_path,
+        python_path=Path("/usr/bin/python3"),
+        command_runner=lambda argv, **kwargs: calls.append((argv, kwargs.get("env"))) or 0,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True))
+    argv, env = calls[0]
+    CASE.assertEqual(argv[:3], ["/usr/bin/python3", "-m", "pytest"])
+    CASE.assertEqual(env["TLDW_SANDBOX_MACOS_HELPER_SOCKET"], str(socket_path))
+    CASE.assertEqual(env["TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE"], str(bundle))
+    CASE.assertEqual(env["SANDBOX_BACKGROUND_EXECUTION"], "0")
+```
+
+- [ ] **Step 2: Write failing test for smoke failure reason**
+
+```python
+def test_run_vz_linux_host_smoke_reports_failure(tmp_path):
+    helperctl = load_helperctl()
+
+    result = helperctl.run_vz_linux_host_smoke(
+        bundle_path=tmp_path / "bundle",
+        socket_path=tmp_path / "helper.sock",
+        python_path=Path("/usr/bin/python3"),
+        command_runner=lambda argv, **kwargs: 2,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=False, reason="vz_linux_smoke_failed", message="2"))
+```
+
+- [ ] **Step 3: Run focused tests and verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'vz_linux_host_smoke' -q
+```
+
+Expected: FAIL because `run_vz_linux_host_smoke` does not exist.
+
+- [ ] **Step 4: Implement smoke runner**
+
+Add:
+
+```python
+def run_vz_linux_host_smoke(
+    *,
+    bundle_path: Path,
+    socket_path: Path,
+    python_path: Path | None = None,
+    dry_run: bool = False,
+    command_runner: Callable[..., int] | None = None,
+) -> CheckResult:
+    runner = command_runner or run_command
+    python_bin = python_path or Path(sys.executable)
+    env = os.environ.copy()
+    env.update(
+        {
+            "TEST_MODE": "0",
+            "TLDW_SANDBOX_VZ_LINUX_E2E": "1",
+            "TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE": str(bundle_path),
+            "TLDW_SANDBOX_MACOS_HELPER_SOCKET": str(socket_path),
+            "SANDBOX_ENABLE_EXECUTION": "1",
+            "SANDBOX_BACKGROUND_EXECUTION": "0",
+        }
+    )
+    argv = [
+        str(python_bin),
+        "-m",
+        "pytest",
+        str(REPO_ROOT / "tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py"),
+        "-m",
+        "vz_linux_host_smoke",
+        "-q",
+        "-rs",
+    ]
+    code = runner(argv, dry_run=dry_run, env=env)
+    if code == 0:
+        return CheckResult(ok=True, reason="dry_run" if dry_run else "ok")
+    return CheckResult(ok=False, reason="vz_linux_smoke_failed", message=str(code))
+```
+
+- [ ] **Step 5: Wire optional smoke into `run_launchd_drill`**
+
+If `bundle_path` is supplied, call `run_vz_linux_host_smoke(...)` after helper ping succeeds. If no bundle is supplied or `--skip-smoke` is set, append a `vz_linux_smoke` result with `ok=True, reason="skipped"` or omit the step consistently; tests should assert the chosen behavior.
+
+- [ ] **Step 6: Run focused tests and verify pass**
+
+Run the `vz_linux_host_smoke or launchd_drill` focused selection.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "feat(sandbox): run VZ smoke through launchd helper"
+```
+
+---
+
+### Task 4: CLI Parser And Output
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Cover:
+
+```python
+def test_launchd_drill_cli_dry_run_uses_isolated_label(monkeypatch, tmp_path, capsys):
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    code = helperctl.main(["launchd-drill", "--dry-run", "--skip-smoke"])
+
+    output = capsys.readouterr().out
+    CASE.assertEqual(code, 0)
+    CASE.assertIn("org.tldw.macos-vz-helper.drill.", output)
+    CASE.assertIn("launchd_preflight", output)
+
+
+def test_launchd_drill_cli_json_outputs_steps(monkeypatch, tmp_path, capsys):
+    # Monkeypatch run_launchd_drill to return deterministic CheckResult steps.
+    # Assert JSON includes launchd_preflight, launchd_bootstrap, launchd_bootout.
+```
+
+Also test `--bundle` with `--skip-smoke` conflict if you decide to reject that combination. If accepted, document and test that `--skip-smoke` wins.
+
+- [ ] **Step 2: Run CLI tests and verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd_drill_cli' -q
+```
+
+Expected: FAIL because the parser lacks `launchd-drill`.
+
+- [ ] **Step 3: Implement `_launchd_drill_command` and parser**
+
+Add parser:
+
+```python
+launchd_drill = subparsers.add_parser("launchd-drill", help="validate launchd-managed helper lifecycle")
+launchd_drill.add_argument("--bundle")
+launchd_drill.add_argument("--helper", "--helper-path", dest="helper_path")
+launchd_drill.add_argument("--socket", "--socket-path", dest="socket_path")
+launchd_drill.add_argument("--log-dir")
+launchd_drill.add_argument("--plist-output")
+launchd_drill.add_argument("--label")
+launchd_drill.add_argument("--uid", type=int)
+launchd_drill.add_argument("--python")
+launchd_drill.add_argument("--write-plist", action="store_true")
+launchd_drill.add_argument("--create-dirs", action="store_true")
+launchd_drill.add_argument("--skip-smoke", action="store_true")
+launchd_drill.add_argument("--dry-run", action="store_true")
+launchd_drill.add_argument("--json", action="store_true")
+launchd_drill.set_defaults(func=_launchd_drill_command)
+```
+
+In `_launchd_drill_command`, resolve defaults as:
+
+```python
+paths = default_paths()
+label = args.label or default_launchd_drill_label()
+plist_path = Path(args.plist_output) if args.plist_output else default_launchd_drill_plist_path(paths, label)
+```
+
+Use `_print_results(results, as_json=args.json)` and return `0` only when every result is ok.
+
+- [ ] **Step 4: Run focused and full helperctl tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k 'launchd_drill' -q
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q
+```
+
+Expected: focused and full helperctl tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "feat(sandbox): expose launchd drill CLI"
+```
+
+---
+
+### Task 5: Operator Docs And Acceptance Policy
+
+**Files:**
+- Modify: `tools/macos-vz-helper/README.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Modify: `backlog/tasks/task-364 - Plan-VZ-helper-launchd-validation-drill-implementation.md` only if completing this planning PR before implementation
+
+- [ ] **Step 1: Update helper README**
+
+Add a section after the existing `launchd` command examples:
+
+````markdown
+### Launchd Validation Drill
+
+Use `launchd-drill` when you want to validate the launchd-managed helper path
+without making launchd the default smoke lifecycle:
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-launchd-drill.XXXXXX")"
+chmod 700 "$runtime_dir"
+trap 'tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootout --label "$label" --plist-output "$runtime_dir/${label}.plist" >/dev/null 2>&1 || true; rm -rf "$runtime_dir"' EXIT
+
+label="org.tldw.macos-vz-helper.drill.$$"
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
+  --socket "$runtime_dir/helper.sock" \
+  --log-dir "$runtime_dir/logs" \
+  --plist-output "$runtime_dir/${label}.plist" \
+  --label "$label" \
+  --write-plist \
+  --create-dirs \
+  --skip-smoke
+```
+
+Pass `--bundle /path/to/canonical/bundle` to run the real VZ Linux host smoke
+through the launchd-managed helper. The drill uses an isolated label by default
+and refuses to take over a service that was loaded before the drill started.
+````
+
+Adjust the trap snippet if the final CLI can do a safer cleanup command.
+
+- [ ] **Step 2: Update macOS operator notes**
+
+Clarify:
+
+- `restart-drill` validates direct helperctl-managed helper lifecycle.
+- `launchd-drill` validates LaunchAgent bootstrap/kickstart/bootout and optional real `vz_linux` smoke.
+- Host reboot remains manual and out of scheduled CI.
+- The drill is opt-in and should use isolated labels/private plist paths.
+
+- [ ] **Step 3: Update host-gated policy**
+
+Add:
+
+- launchd drill is an expected skip unless manually requested on a prepared runner.
+- launchd drill failure is blocking only when the runner is explicitly configured for LaunchAgent validation and helper/template readiness passes.
+- scheduled workflow should not enable it by default in this PR.
+
+- [ ] **Step 4: Run docs checks**
+
+Run:
+
+```bash
+git diff --check
+rg -n "launchd-drill|Launchd Validation Drill|external-helper" tools/macos-vz-helper/README.md Docs/Sandbox/macos-runtime-operator-notes.md Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+```
+
+Expected: no whitespace errors; all docs include the new drill references.
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add tools/macos-vz-helper/README.md Docs/Sandbox/macos-runtime-operator-notes.md Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+git commit -m "docs(sandbox): document launchd validation drill"
+```
+
+---
+
+### Task 6: Final Verification And PR Prep
+
+**Files:**
+- Modify: `backlog/tasks/task-364 - Plan-VZ-helper-launchd-validation-drill-implementation.md` if this planning branch is being finalized.
+- Otherwise, for the implementation PR, update the implementation Backlog task created for that PR.
+
+- [ ] **Step 1: Run full helperctl tests**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q
+```
+
+Expected: all helperctl tests pass. At the time this plan was written, the current baseline around helperctl was `101 passed, 1 skipped`; update the expected count if the baseline has changed.
+
+- [ ] **Step 2: Run docs whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run Bandit on touched Python script**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_launchd_drill.json
+```
+
+Expected: no new findings in `vz-helperctl.py`. If Bandit reports existing subprocess warnings, verify they match the existing direct-argv/no-shell pattern and document them in the task notes.
+
+- [ ] **Step 4: Optional real-host manual smoke**
+
+Only on a prepared Apple silicon host with a signed helper and canonical bundle:
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-launchd-drill.XXXXXX")"
+chmod 700 "$runtime_dir"
+label="org.tldw.macos-vz-helper.drill.$$"
+
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
+  --bundle /path/to/canonical/bundle \
+  --socket "$runtime_dir/helper.sock" \
+  --log-dir "$runtime_dir/logs" \
+  --plist-output "$runtime_dir/${label}.plist" \
+  --label "$label" \
+  --write-plist \
+  --create-dirs
+```
+
+Expected: launchd bootstrap/status/kickstart/ping/smoke/bootout all report ok. If this is not run, document it as a host-gated skip.
+
+- [ ] **Step 5: Update Backlog task final summary**
+
+Record:
+
+- tests run and result
+- Bandit result
+- whether real launchd host smoke was run or skipped
+- any known limitations
+
+- [ ] **Step 6: Create PR against `dev`**
+
+```bash
+git status --short --branch
+git push -u origin codex/vz-launchd-validation-drill
+gh pr create --base dev --head codex/vz-launchd-validation-drill --title "Add VZ helper launchd validation drill" --draft
+```
+
+The PR body should explain that the default direct-helper smoke path remains unchanged and launchd validation is opt-in/operator-owned.

--- a/Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
+++ b/Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
@@ -1,0 +1,269 @@
+# VZ Helper Launchd Validation Drill Design
+
+**Date:** 2026-05-15
+**Status:** Proposed design for implementation planning
+**Backlog:** TASK-360
+**GitHub:** https://github.com/rmusser01/tldw_server/issues/1442
+**Scope:** `tools/macos-vz-helper/`, `tools/vz-linux-image/scripts/`,
+host-gated VZ Linux smoke policy, and macOS operator documentation.
+
+## Summary
+
+The repo now has explicit `vz-helperctl.py launchd` operator commands for
+`bootstrap`, `bootout`, `kickstart`, and `status`. The remaining gap is proving
+that those commands form a repeatable operator drill without changing the
+default direct-helper smoke path.
+
+This design adds a dedicated launchd validation drill. The drill should validate
+the LaunchAgent plist and private runtime paths, bootstrap the helper through
+`launchd`, inspect launchd status, kickstart the helper, verify helper
+readiness through the existing socket/protocol checks, optionally run the
+existing host-gated `vz_linux` pytest smoke contract against that helper, then
+bootout the service and verify cleanup. It stays explicit and operator-owned:
+no server startup automation, no implicit install, no scheduled host reboot,
+and no hidden repair.
+
+## Source Documents
+
+- `Docs/Sandbox/sandbox-architecture-doctrine.md`
+- `Docs/Sandbox/macos-runtime-operator-notes.md`
+- `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- `Docs/superpowers/specs/2026-04-29-vz-helper-lifecycle-hardening-design.md`
+- `Docs/superpowers/specs/2026-05-09-vz-linux-helper-crash-host-reboot-recovery-posture-design.md`
+- `Docs/superpowers/plans/2026-05-13-vz-helper-launchd-operator.md`
+- `tools/macos-vz-helper/PROTOCOL.md`
+- `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+
+## Current Baseline
+
+Already implemented behavior:
+
+- `vz-helperctl.py launchd` can construct and execute explicit `launchctl`
+  `bootstrap`, `bootout`, `kickstart`, and `print` actions.
+- Bootstrap can validate or explicitly write a LaunchAgent plist with
+  operator-supplied `--write-plist` and `--create-dirs`.
+- Launchd plist rendering reuses the helper socket, serial log directory,
+  protocol version, stdout/stderr log paths, and label contract.
+- `vz-helperctl.py status` can validate helper binary, socket/pid/log paths,
+  serial log directory, launchd plist match, entitlements, ping, helper version,
+  and protocol version.
+- `run-host-e2e-smoke.sh` directly starts the helper, runs helper daemon smoke,
+  runs real `vz_linux` ephemeral execution, verifies same-session reuse, runs
+  read-only recovery/dry-run repair checks, and optionally runs failure drills.
+  That shell script is useful prior art for the test contract, but it cannot be
+  invoked unchanged by a launchd-managed drill because it owns helper startup.
+- Host-gated CI keeps real VZ execution opt-in to prepared Apple silicon hosts.
+
+Remaining gap:
+
+- There is no single drill that proves the launchd command path can supervise
+  the helper and hand off to the same real `vz_linux` smoke guarantees.
+- The default smoke intentionally bypasses launchd, so launchd regressions can
+  be missed even when direct-helper smoke passes.
+- Operator docs describe launchd commands, but do not give a single repeatable
+  evidence-producing validation flow.
+
+## Goals
+
+1. Add a dedicated launchd validation drill for prepared macOS hosts.
+2. Keep the drill explicit, operator-owned, and separate from default direct
+   helper smoke behavior.
+3. Reuse the existing `vz-helperctl.py launchd` and `status` primitives instead
+   of inventing a workflow-only launchctl path.
+4. Preserve strict socket, runtime-directory, log-directory, serial-directory,
+   and plist safety checks before any launchd mutation.
+5. Preserve logs and report enough launchd/helper evidence to debug partial
+   bootstrap, kickstart, readiness, smoke, or bootout failures.
+6. Define portable tests for command sequencing and dry-run behavior, plus
+   host-gated/manual expectations for real launchd execution.
+
+## Non-Goals
+
+1. No automatic LaunchAgent installation from server startup, diagnostics,
+   `status`, `check`, or ordinary smoke.
+2. No change to the default `run-host-e2e-smoke.sh` direct-helper lifecycle.
+3. No scheduled host reboot drill.
+4. No destructive repair behavior tied to launchd status.
+5. No cross-runtime launchd abstraction.
+6. No replacement of the Swift helper, Python helper client, or guest agent.
+7. No vmnet/networking changes.
+
+## Recommended Shape
+
+Add one explicit operator drill entrypoint. The implementation can choose one of
+two equivalent surfaces, but the preferred user-facing shape is a helperctl
+subcommand:
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
+  --bundle /path/to/canonical/bundle \
+  --helper tools/macos-vz-helper/.build/debug/macos-vz-helper \
+  --socket "$runtime_dir/helper.sock" \
+  --log-dir "$runtime_dir/logs" \
+  --plist-output "$runtime_dir/org.tldw.macos-vz-helper.plist" \
+  --write-plist \
+  --create-dirs
+```
+
+The command should support `--dry-run` and `--json`. Real `launchctl` mutation
+must require a prepared macOS host and explicit non-dry-run execution. The drill
+may optionally expose `--skip-smoke` for launchd-only validation when an operator
+wants to prove process supervision without booting a VM.
+
+Do not add launchd as the default path inside `run-host-e2e-smoke.sh`. If shell
+integration is useful later, add an opt-in wrapper flag such as `--use-launchd`
+that delegates to `vz-helperctl.py launchd-drill`, or add an explicit
+`--external-helper-socket` mode that only runs the existing pytest smoke against
+an already-managed helper. Do not duplicate launchctl sequencing in the shell
+script.
+
+## Drill Lifecycle
+
+The drill should run this sequence:
+
+1. Resolve helper, socket, log directory, serial log directory, plist path,
+   launchd label, UID/domain, and optional bundle path.
+2. Validate or create private parent directories with the existing helperctl
+   path-safety helpers.
+3. Validate helper binary and entitlements state using the existing lifecycle
+   checks.
+4. Render or validate the launchd plist only when explicitly requested.
+5. Run `launchd bootstrap`.
+6. Run `launchd status` and record the launchctl target.
+7. Run `launchd kickstart -k`.
+8. Wait for helper socket readiness and protocol-compatible ping through the
+   existing helper status path.
+9. If bundle smoke is enabled, run the existing host-gated pytest smoke contract
+   against the launchd-managed socket without starting a second helper.
+10. Run `launchd bootout`.
+11. Verify launchd no longer reports a loaded service, helper ping fails or
+   helper is absent, and only safe stale sockets are removed.
+12. Preserve stdout, stderr, serial logs, plist, and JSON/human drill output.
+
+`bootout` should be attempted during cleanup after any failure that happens
+after bootstrap succeeds. Cleanup must not hide the primary failure, but a
+cleanup failure should be reported as secondary evidence.
+
+## Safety Contract
+
+The drill should inherit existing helperctl safety behavior:
+
+- refuse symlink socket paths
+- refuse existing non-socket files at the socket path
+- remove an existing socket only when it is actually a Unix socket and the
+  operator-owned parent directory is private
+- require owner-only runtime, log, serial, and plist parent directories
+- refuse plist writes unless `--write-plist` is present
+- refuse creating missing directories unless `--create-dirs` is present
+- keep `status` and dry-run checks read-only
+- use the explicit launchd label and GUI domain when reporting service targets
+
+The launchd path is a process-supervision drill only. It must not imply VM reuse
+or session repair. Python should continue to trust helper protocol and live VM
+truth, not launchd state, when deciding whether a session VM can be reused.
+
+## Output And Diagnostics
+
+Human output should be step-oriented and terse:
+
+```text
+launchd_plist: ok launchd_plist_written
+launchd_bootstrap: ok
+launchd_status: ok gui/501/org.tldw.macos-vz-helper
+launchd_kickstart: ok
+helper_status: ok protocol_version=1 helper_version=...
+vz_linux_smoke: ok
+launchd_bootout: ok
+cleanup: ok
+```
+
+JSON output should preserve the existing `CheckResult` style so operator
+automation can distinguish setup failures from runtime failures. Include at
+least:
+
+- step name
+- `ok`
+- reason
+- message
+- launchd label
+- launchd service target
+- socket path
+- plist path
+- log directory
+
+Do not include secrets or raw guest command output in drill metadata.
+
+## Failure Handling
+
+Expected failure classes:
+
+- `launchd_launchctl_unavailable`: host is not prepared for launchd execution.
+- `launchd_plist_missing` or `launchd_plist_mismatch`: operator plist setup is
+  incomplete or stale.
+- `helper_directory_not_private` or related path failures: runtime paths are not
+  safe enough for a local helper socket.
+- `launchd_bootstrap_failed`, `launchd_kickstart_failed`, or
+  `launchd_bootout_failed`: launchctl action failed; preserve launchctl target
+  and exit code.
+- `helper_not_running`, `helper_protocol_mismatch`, or ping failure: launchd may
+  have loaded a job but the helper is not usable by Python.
+- `vz_linux_smoke_failed`: launchd worked enough to start the helper, but real
+  VM execution failed.
+
+If bootstrap succeeds and a later step fails, the drill should still attempt
+bootout. If bootout fails, the final result should clearly say that operator
+cleanup is required and print the exact `launchctl bootout <target>` command.
+
+## Test Strategy
+
+Portable tests should cover:
+
+- drill command sequencing with injected launchd/status/smoke runners
+- dry-run output without filesystem mutation
+- no launchctl execution when plist validation fails
+- bootout attempted after bootstrap-plus-later-failure
+- primary failure preserved when cleanup also fails
+- `--skip-smoke` avoids VM smoke while still validating launchd/helper readiness
+- JSON result shape and step names
+- custom launchd labels and UIDs
+
+Host-gated/manual validation should cover:
+
+- real bootstrap/status/kickstart/bootout on Apple silicon
+- helper ping/protocol readiness through the launchd-managed socket
+- real `vz_linux` ephemeral execution through the launchd-managed helper
+- same-session reuse through the launchd-managed helper
+- logs preserved after failure
+
+Scheduled host-gated CI should not enable the launchd drill by default. A manual
+workflow input can enable it later once the drill has proven stable on prepared
+hosts and the runner is explicitly configured for LaunchAgent validation.
+
+## Documentation Updates
+
+The implementation PR should update:
+
+- `tools/macos-vz-helper/README.md` with local drill commands and cleanup notes
+- `Docs/Sandbox/macos-runtime-operator-notes.md` with the launchd validation
+  flow and troubleshooting guidance
+- `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md` with the drill's
+  expected skips and blocking criteria if/when manual workflow support is added
+- GitHub tracker #1442 to record that launchd scaffolding exists and the next
+  gap is drill validation
+
+## Open Questions For Implementation Planning
+
+1. Should the first implementation expose only `vz-helperctl.py launchd-drill`,
+   or also add a thin `run-host-e2e-smoke.sh --external-helper-socket` wrapper
+   that runs the existing pytest smoke without owning helper startup?
+2. Should the initial drill require a bundle path, or should launchd-only
+   validation be the default with `--bundle` enabling VM smoke?
+3. Should real launchd host-gated workflow support land in the same PR as the
+   local operator command, or in a follow-up after local validation?
+
+Recommended answers for the first implementation:
+
+- implement `launchd-drill` first
+- make VM smoke optional through `--bundle`
+- defer workflow integration until the local command has portable coverage and
+  at least one manual real-host run

--- a/Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
+++ b/Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
@@ -95,12 +95,15 @@ two equivalent surfaces, but the preferred user-facing shape is a helperctl
 subcommand:
 
 ```bash
+label="org.tldw.macos-vz-helper.drill.$$"
+
 tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
   --bundle /path/to/canonical/bundle \
   --helper tools/macos-vz-helper/.build/debug/macos-vz-helper \
   --socket "$runtime_dir/helper.sock" \
   --log-dir "$runtime_dir/logs" \
-  --plist-output "$runtime_dir/org.tldw.macos-vz-helper.plist" \
+  --plist-output "$runtime_dir/${label}.plist" \
+  --label "$label" \
   --write-plist \
   --create-dirs
 ```
@@ -109,6 +112,14 @@ The command should support `--dry-run` and `--json`. Real `launchctl` mutation
 must require a prepared macOS host and explicit non-dry-run execution. The drill
 may optionally expose `--skip-smoke` for launchd-only validation when an operator
 wants to prove process supervision without booting a VM.
+
+The drill should use an isolated validation label by default, for example
+`org.tldw.macos-vz-helper.drill.<pid>`, and a private runtime plist path unless
+the operator explicitly supplies `--label` and `--plist-output`. This avoids
+accidentally booting out a real user LaunchAgent that happens to use the
+production default label. If the selected launchd target is already loaded
+before bootstrap, the drill should fail closed unless a future explicit
+replace-existing option is designed.
 
 Do not add launchd as the default path inside `run-host-e2e-smoke.sh`. If shell
 integration is useful later, add an opt-in wrapper flag such as `--use-launchd`
@@ -127,18 +138,45 @@ The drill should run this sequence:
    path-safety helpers.
 3. Validate helper binary and entitlements state using the existing lifecycle
    checks.
-4. Render or validate the launchd plist only when explicitly requested.
-5. Run `launchd bootstrap`.
-6. Run `launchd status` and record the launchctl target.
-7. Run `launchd kickstart -k`.
-8. Wait for helper socket readiness and protocol-compatible ping through the
+4. Verify the selected launchd service target is not already loaded.
+5. Render or validate the launchd plist only when explicitly requested.
+6. Run `launchd bootstrap`.
+7. Run `launchd status` and record the launchctl target.
+8. Run `launchd kickstart -k`.
+9. Wait for helper socket readiness and protocol-compatible ping through the
    existing helper status path.
-9. If bundle smoke is enabled, run the existing host-gated pytest smoke contract
-   against the launchd-managed socket without starting a second helper.
-10. Run `launchd bootout`.
-11. Verify launchd no longer reports a loaded service, helper ping fails or
-   helper is absent, and only safe stale sockets are removed.
-12. Preserve stdout, stderr, serial logs, plist, and JSON/human drill output.
+10. If bundle smoke is enabled, run the existing host-gated pytest smoke
+    contract against the launchd-managed socket without starting a second
+    helper.
+11. Run `launchd bootout`.
+12. Verify launchd no longer reports a loaded service, helper ping fails or
+    helper is absent, and only safe stale sockets are removed.
+13. Preserve stdout, stderr, serial logs, plist, and JSON/human drill output.
+
+The smoke step should use the same environment contract as the existing
+host-gated tests rather than invoking `run-host-e2e-smoke.sh` unchanged:
+
+```bash
+TEST_MODE=0 \
+TLDW_SANDBOX_VZ_LINUX_E2E=1 \
+TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE="$bundle" \
+TLDW_SANDBOX_MACOS_HELPER_SOCKET="$socket" \
+SANDBOX_ENABLE_EXECUTION=1 \
+SANDBOX_BACKGROUND_EXECUTION=0 \
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py \
+  -m vz_linux_host_smoke -q -rs
+```
+
+The helper daemon smoke currently starts or validates the helper binary through
+its own test contract. The launchd drill should either skip that helper-daemon
+smoke or add a separate external-helper mode before reusing it, so the drill
+does not start a second helper on the same socket.
+
+The drill should not silently build or sign the helper. It may fail with clear
+preflight reasons, or a future implementation may add explicit `--build` and
+`--sign` flags that delegate to the existing helperctl `build` and `sign`
+subcommands before launchd mutation.
 
 `bootout` should be attempted during cleanup after any failure that happens
 after bootstrap succeeds. Cleanup must not hide the primary failure, but a
@@ -157,10 +195,20 @@ The drill should inherit existing helperctl safety behavior:
 - refuse creating missing directories unless `--create-dirs` is present
 - keep `status` and dry-run checks read-only
 - use the explicit launchd label and GUI domain when reporting service targets
+- only bootout the service target that this drill bootstrapped, unless a future
+  explicit replace-existing mode is designed
+- avoid `~/Library/LaunchAgents` as the default drill plist location; use a
+  private runtime path unless the operator deliberately points elsewhere
 
 The launchd path is a process-supervision drill only. It must not imply VM reuse
 or session repair. Python should continue to trust helper protocol and live VM
 truth, not launchd state, when deciding whether a session VM can be reused.
+
+Launchd-managed helpers will not necessarily have a `vz-helperctl.py start`
+pid file. The drill should treat a missing helperctl pid file as expected for
+launchd mode and use launchd status plus helper socket/ping/protocol readiness
+as the proof of usable helper state. A missing pid file should not make the
+drill fail when the helper is otherwise reachable and protocol-compatible.
 
 ## Output And Diagnostics
 
@@ -169,7 +217,7 @@ Human output should be step-oriented and terse:
 ```text
 launchd_plist: ok launchd_plist_written
 launchd_bootstrap: ok
-launchd_status: ok gui/501/org.tldw.macos-vz-helper
+launchd_status: ok gui/501/org.tldw.macos-vz-helper.drill.12345
 launchd_kickstart: ok
 helper_status: ok protocol_version=1 helper_version=...
 vz_linux_smoke: ok
@@ -198,6 +246,8 @@ Do not include secrets or raw guest command output in drill metadata.
 Expected failure classes:
 
 - `launchd_launchctl_unavailable`: host is not prepared for launchd execution.
+- `launchd_service_already_loaded`: the chosen label was loaded before the
+  drill, so cleanup ownership is ambiguous.
 - `launchd_plist_missing` or `launchd_plist_mismatch`: operator plist setup is
   incomplete or stale.
 - `helper_directory_not_private` or related path failures: runtime paths are not
@@ -211,8 +261,11 @@ Expected failure classes:
   VM execution failed.
 
 If bootstrap succeeds and a later step fails, the drill should still attempt
-bootout. If bootout fails, the final result should clearly say that operator
-cleanup is required and print the exact `launchctl bootout <target>` command.
+bootout for the service target it bootstrapped. If bootout fails because the
+target is already absent, the drill may treat cleanup as effectively complete
+while preserving the bootout reason. If bootout fails for any other reason, the
+final result should clearly say that operator cleanup is required and print the
+exact `launchctl bootout <target>` command.
 
 ## Test Strategy
 
@@ -226,6 +279,11 @@ Portable tests should cover:
 - `--skip-smoke` avoids VM smoke while still validating launchd/helper readiness
 - JSON result shape and step names
 - custom launchd labels and UIDs
+- selected label already loaded before bootstrap fails without bootout
+- missing helperctl pid file is accepted when launchd status and helper ping are
+  healthy
+- launchd drill smoke uses an externally managed helper socket and does not
+  start a second helper
 
 Host-gated/manual validation should cover:
 
@@ -260,6 +318,8 @@ The implementation PR should update:
    validation be the default with `--bundle` enabling VM smoke?
 3. Should real launchd host-gated workflow support land in the same PR as the
    local operator command, or in a follow-up after local validation?
+4. Should helper build/sign remain strict preconditions, or should the drill
+   grow explicit `--build` and `--sign` convenience flags?
 
 Recommended answers for the first implementation:
 
@@ -267,3 +327,5 @@ Recommended answers for the first implementation:
 - make VM smoke optional through `--bundle`
 - defer workflow integration until the local command has portable coverage and
   at least one manual real-host run
+- require prebuilt/signed helper in the first implementation instead of hiding
+  build/sign inside the drill

--- a/backlog/tasks/task-360 - Design-VZ-helper-launchd-validation-drill.md
+++ b/backlog/tasks/task-360 - Design-VZ-helper-launchd-validation-drill.md
@@ -46,6 +46,7 @@ Create the design/spec for an explicit operator-owned launchd validation drill f
 <!-- SECTION:NOTES:BEGIN -->
 - Design scope approved by the user before writing the spec.
 - This is a docs-only brainstorming/spec slice. No runtime code changes are included.
+- Design review tightened the spec around launchd label collisions, drill-owned bootout cleanup, helperctl pid-file absence under launchd, and the external-helper smoke seam.
 - Verification: `git diff --check` passed.
 - Bandit: skipped because the slice only adds docs and a Backlog task record.
 <!-- SECTION:NOTES:END -->
@@ -53,5 +54,5 @@ Create the design/spec for an explicit operator-owned launchd validation drill f
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added the approved launchd validation drill design in `Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md`. The spec defines an explicit operator-owned drill on top of the existing `vz-helperctl.py launchd` commands, keeps the default direct-helper smoke path unchanged, calls out the existing shell smoke ownership boundary, and captures safety, cleanup, logging, portable tests, and host-gated/manual validation expectations for the future implementation slice.
+Added and reviewed the approved launchd validation drill design in `Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md`. The spec defines an explicit operator-owned drill on top of the existing `vz-helperctl.py launchd` commands, keeps the default direct-helper smoke path unchanged, calls out the existing shell smoke ownership boundary, avoids collisions with real LaunchAgent labels, and captures safety, cleanup, logging, portable tests, and host-gated/manual validation expectations for the future implementation slice.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-360 - Design-VZ-helper-launchd-validation-drill.md
+++ b/backlog/tasks/task-360 - Design-VZ-helper-launchd-validation-drill.md
@@ -1,0 +1,57 @@
+---
+id: TASK-360
+title: Design VZ helper launchd validation drill
+status: Done
+assignee: []
+created_date: '2026-05-15 03:15'
+labels:
+  - Sandbox
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1442'
+documentation:
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - Docs/superpowers/plans/2026-05-13-vz-helper-launchd-operator.md
+  - Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the design/spec for an explicit operator-owned launchd validation drill for the macOS VZ helper. The design must build on the existing `vz-helperctl.py launchd` commands already merged on dev, keep the default direct-helper smoke path unchanged, preserve explicit opt-in/no hidden install semantics, and define safety, cleanup, logging, and host-gated validation boundaries for a future implementation PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec documents the drill scope, lifecycle sequence, safety boundaries, cleanup behavior, and non-goals.
+- [x] #2 Spec explains why the drill is separate from the default direct-helper smoke path and how it reuses existing launchd commands.
+- [x] #3 Spec defines portable validation expectations and host-gated/manual validation expectations without requiring scheduled CI reboot or automatic launchd installation.
+- [x] #4 Spec references the sandbox tracker and relevant operator docs so future implementers can find the broader roadmap context.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Design scope approved by the user before writing the spec.
+- This is a docs-only brainstorming/spec slice. No runtime code changes are included.
+- Verification: `git diff --check` passed.
+- Bandit: skipped because the slice only adds docs and a Backlog task record.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the approved launchd validation drill design in `Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md`. The spec defines an explicit operator-owned drill on top of the existing `vz-helperctl.py launchd` commands, keeps the default direct-helper smoke path unchanged, calls out the existing shell smoke ownership boundary, and captures safety, cleanup, logging, portable tests, and host-gated/manual validation expectations for the future implementation slice.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-364 - Plan-VZ-helper-launchd-validation-drill-implementation.md
+++ b/backlog/tasks/task-364 - Plan-VZ-helper-launchd-validation-drill-implementation.md
@@ -1,0 +1,53 @@
+---
+id: TASK-364
+title: Plan VZ helper launchd validation drill implementation
+status: Done
+assignee: []
+created_date: '2026-05-15 03:29'
+labels:
+  - Sandbox
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1442'
+documentation:
+  - Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
+  - Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the implementation plan for the reviewed VZ helper launchd validation drill design. The plan should be execution-ready for a future PR, scoped to a single focused slice that adds an explicit operator-owned `vz-helperctl.py launchd-drill`, portable tests, and docs while preserving direct-helper smoke defaults and avoiding automatic launchd installation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan starts from the reviewed launchd validation drill spec and maps exact files to modify or create.
+- [x] #2 Plan decomposes implementation into TDD-sized tasks with concrete tests, commands, and expected outcomes.
+- [x] #3 Plan preserves the design constraints: isolated drill label by default, pre-bootstrap loaded-service guard, drill-owned bootout cleanup only, launchd-mode PID-file expectations, and external-helper smoke semantics.
+- [x] #4 Plan includes verification, docs updates, Bandit guidance, and PR handoff expectations.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Verification: `git diff --check` passed for the docs-only planning slice.
+- Bandit: skipped for this planning slice because it only adds a plan document and Backlog task record. The implementation plan requires Bandit for the future Python changes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added `Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md`, an execution-ready implementation plan for the reviewed launchd validation drill design. The plan breaks the future implementation into TDD-sized tasks for helperctl defaults, loaded-service guards, drill orchestration, external-helper VZ smoke, CLI output, docs, verification, Bandit, optional real-host validation, and PR handoff.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
+++ b/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
@@ -66,4 +66,5 @@ PR #1720 review follow-up: JSON mode now injects a captured launchd command runn
 - Verification: `git diff --check` passed.
 - Verification: `python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_launchd_drill.json` completed with 0 errors and 0 findings.
 - Host-gated real launchd/VM smoke: not run in this final portable verification pass; documented as an explicit prepared-host/manual validation path.
+- PR review fix: addressed Qodo findings by adding a docstring for `run_vz_linux_host_smoke()` and capturing the bundle-smoke pytest subprocess when `launchd-drill --json` is used. Verification: focused helperctl review-fix tests passed with 19 passed; full helperctl tests passed with 125 passed and 1 skipped; `git diff --check` passed; Bandit completed with 0 errors and 0 findings.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
+++ b/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
@@ -1,0 +1,48 @@
+---
+id: TASK-367
+title: Implement VZ helper launchd validation drill
+status: In Progress
+assignee: []
+created_date: '2026-05-15 03:37'
+labels:
+  - Sandbox
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1442'
+documentation:
+  - Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
+  - Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the reviewed and planned VZ helper launchd validation drill. Add an explicit operator-owned `vz-helperctl.py launchd-drill` command with isolated default labels, pre-bootstrap loaded-service guard, drill-owned bootout cleanup, launchd-mode helper readiness without requiring a helperctl pid file, optional external-helper VZ Linux smoke, portable tests, operator docs, and verification. Preserve the default direct-helper smoke path and do not add automatic launchd installation or scheduled workflow integration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `vz-helperctl.py launchd-drill` exists and uses isolated drill labels/private plist paths by default while supporting explicit label/path overrides.
+- [ ] #2 The drill refuses pre-existing loaded launchd services, only bootouts targets it bootstrapped, preserves primary failures when cleanup also fails, and treats missing helperctl pid files as valid in launchd mode when helper ping/protocol are healthy.
+- [ ] #3 Optional VZ Linux smoke runs against the launchd-managed socket without starting a second helper; default direct-helper smoke behavior remains unchanged.
+- [ ] #4 Portable helperctl tests cover defaults, loaded-service guard, sequencing, cleanup, CLI output, JSON shape, and external-helper smoke command construction.
+- [ ] #5 Operator docs and host-gated policy document the drill, expected skips, cleanup behavior, and manual/host-gated validation boundaries.
+- [ ] #6 Focused helperctl tests, `git diff --check`, and Bandit on touched Python code are run or documented with explicit host-gated skips.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Implementation follows `Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
+++ b/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-367
 title: Implement VZ helper launchd validation drill
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-15 03:37'
 labels:
@@ -23,26 +23,37 @@ Implement the reviewed and planned VZ helper launchd validation drill. Add an ex
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `vz-helperctl.py launchd-drill` exists and uses isolated drill labels/private plist paths by default while supporting explicit label/path overrides.
-- [ ] #2 The drill refuses pre-existing loaded launchd services, only bootouts targets it bootstrapped, preserves primary failures when cleanup also fails, and treats missing helperctl pid files as valid in launchd mode when helper ping/protocol are healthy.
-- [ ] #3 Optional VZ Linux smoke runs against the launchd-managed socket without starting a second helper; default direct-helper smoke behavior remains unchanged.
-- [ ] #4 Portable helperctl tests cover defaults, loaded-service guard, sequencing, cleanup, CLI output, JSON shape, and external-helper smoke command construction.
-- [ ] #5 Operator docs and host-gated policy document the drill, expected skips, cleanup behavior, and manual/host-gated validation boundaries.
-- [ ] #6 Focused helperctl tests, `git diff --check`, and Bandit on touched Python code are run or documented with explicit host-gated skips.
+- [x] #1 `vz-helperctl.py launchd-drill` exists and uses isolated drill labels/private plist paths by default while supporting explicit label/path overrides.
+- [x] #2 The drill refuses pre-existing loaded launchd services, only bootouts targets it bootstrapped, preserves primary failures when cleanup also fails, and treats missing helperctl pid files as valid in launchd mode when helper ping/protocol are healthy.
+- [x] #3 Optional VZ Linux smoke runs against the launchd-managed socket without starting a second helper; default direct-helper smoke behavior remains unchanged.
+- [x] #4 Portable helperctl tests cover defaults, loaded-service guard, sequencing, cleanup, CLI output, JSON shape, and external-helper smoke command construction.
+- [x] #5 Operator docs and host-gated policy document the drill, expected skips, cleanup behavior, and manual/host-gated validation boundaries.
+- [x] #6 Focused helperctl tests, `git diff --check`, and Bandit on touched Python code are run or documented with explicit host-gated skips.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
 
 ## Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 - Implementation follows `Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md`.
+- Review process: each implementation/docs task received spec-compliance and code-quality/doc-quality review; Task 4 and Task 5 review findings were fixed and re-approved.
+- Verification: `python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed with 123 passed and 1 skipped.
+- Verification: `git diff --check` passed.
+- Verification: `python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_launchd_drill.json` completed with 0 errors and 0 findings.
+- Host-gated real launchd/VM smoke: not run in this final portable verification pass; documented as an explicit prepared-host/manual validation path.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the opt-in VZ helper `launchd-drill` workflow. The helperctl CLI now has isolated launchd drill defaults, pre-bootstrap loaded-service protection, drill-owned cleanup, launchd-managed helper readiness checks, optional external-helper `vz_linux` host smoke through the launchd-managed socket, JSON/human output, and portable unit coverage. Operator docs and host-gated policy now describe cleanup, expected skips, manual LaunchAgent validation boundaries, and that the default direct-helper smoke path remains unchanged.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
+++ b/backlog/tasks/task-367 - Implement-VZ-helper-launchd-validation-drill.md
@@ -4,13 +4,15 @@ title: Implement VZ helper launchd validation drill
 status: Done
 assignee: []
 created_date: '2026-05-15 03:37'
+updated_date: '2026-05-15 05:52'
 labels:
   - Sandbox
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1442'
 documentation:
-  - Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-15-vz-helper-launchd-validation-drill-design.md
   - Docs/superpowers/plans/2026-05-15-vz-helper-launchd-validation-drill.md
 priority: medium
 ---
@@ -30,6 +32,20 @@ Implement the reviewed and planned VZ helper launchd validation drill. Add an ex
 - [x] #5 Operator docs and host-gated policy document the drill, expected skips, cleanup behavior, and manual/host-gated validation boundaries.
 - [x] #6 Focused helperctl tests, `git diff --check`, and Bandit on touched Python code are run or documented with explicit host-gated skips.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-15 PR #1720 review fix: verified the JSON-mode subprocess-output finding. Added a failing regression for launchd-drill --json wiring a captured launchd runner through the CLI path, then added a captured command runner for JSON mode only so child stdout/stderr cannot reach the JSON stream while human dry-run output stays unchanged. Verification so far: regression failed before implementation; focused JSON pytest passed; full helperctl pytest passed 124 passed, 1 skipped; git diff --check passed; Bandit JSON at /tmp/bandit_vz_launchd_drill_1720_review_fix.json reported errors=0 and results=0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the opt-in VZ helper `launchd-drill` workflow. The helperctl CLI now has isolated launchd drill defaults, pre-bootstrap loaded-service protection, drill-owned cleanup, launchd-managed helper readiness checks, optional external-helper `vz_linux` host smoke through the launchd-managed socket, JSON/human output, and portable unit coverage. Operator docs and host-gated policy now describe cleanup, expected skips, manual LaunchAgent validation boundaries, and that the default direct-helper smoke path remains unchanged.
+
+PR #1720 review follow-up: JSON mode now injects a captured launchd command runner, so launchctl child stdout/stderr are piped instead of inheriting the CLI streams. Added regression coverage that exercises the CLI JSON path and asserts the runner uses subprocess.PIPE for both stdout and stderr. Verification: red test failed before implementation; focused JSON pytest passed; full helperctl pytest passed 124 passed, 1 skipped; git diff --check passed; Bandit reported errors=0 and results=0 at /tmp/bandit_vz_launchd_drill_1720_review_fix.json.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
@@ -51,9 +67,3 @@ Implement the reviewed and planned VZ helper launchd validation drill. Add an ex
 - Verification: `python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_launchd_drill.json` completed with 0 errors and 0 findings.
 - Host-gated real launchd/VM smoke: not run in this final portable verification pass; documented as an explicit prepared-host/manual validation path.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the opt-in VZ helper `launchd-drill` workflow. The helperctl CLI now has isolated launchd drill defaults, pre-bootstrap loaded-service protection, drill-owned cleanup, launchd-managed helper readiness checks, optional external-helper `vz_linux` host smoke through the launchd-managed socket, JSON/human output, and portable unit coverage. Operator docs and host-gated policy now describe cleanup, expected skips, manual LaunchAgent validation boundaries, and that the default direct-helper smoke path remains unchanged.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -94,10 +94,11 @@ tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
   --skip-smoke
 ```
 
-Add `--bundle /path/to/canonical/bundle` to run the real `vz_linux` host smoke
-through the launchd-managed helper. Keep drill labels isolated and plist paths
-private; the drill refuses to take over a service that is already loaded before
-bootstrap because cleanup ownership would be ambiguous.
+Omit `--skip-smoke` and add `--bundle /path/to/canonical/bundle` to run the
+real `vz_linux` host smoke through the launchd-managed helper. Keep drill labels
+isolated and plist paths private; the drill refuses to take over a service that
+is already loaded before bootstrap because cleanup ownership would be
+ambiguous.
 
 These commands never run automatically from `plist`, `status`, `smoke`, or
 server startup. They are operator-owned scaffolding and do not validate host

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -71,6 +71,34 @@ tools/macos-vz-helper/scripts/vz-helperctl.py launchd kickstart
 tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootout
 ```
 
+### Launchd Validation Drill
+
+`launchd-drill` validates the launchd-managed helper path without making
+launchd the default smoke lifecycle. Use it when an operator wants proof of
+LaunchAgent bootstrap, kickstart, helper readiness, and bootout on isolated
+runtime paths.
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-launchd-drill.XXXXXX")"
+chmod 700 "$runtime_dir"
+label="org.tldw.macos-vz-helper.drill.$$"
+trap 'tools/macos-vz-helper/scripts/vz-helperctl.py launchd bootout --label "$label" --plist-output "$runtime_dir/${label}.plist" >/dev/null 2>&1 || true; rm -rf "$runtime_dir"' EXIT
+
+tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
+  --socket "$runtime_dir/helper.sock" \
+  --log-dir "$runtime_dir/logs" \
+  --plist-output "$runtime_dir/${label}.plist" \
+  --label "$label" \
+  --write-plist \
+  --create-dirs \
+  --skip-smoke
+```
+
+Add `--bundle /path/to/canonical/bundle` to run the real `vz_linux` host smoke
+through the launchd-managed helper. Keep drill labels isolated and plist paths
+private; the drill refuses to take over a service that is already loaded before
+bootstrap because cleanup ownership would be ambiguous.
+
 These commands never run automatically from `plist`, `status`, `smoke`, or
 server startup. They are operator-owned scaffolding and do not validate host
 reboot behavior.

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -1206,6 +1206,71 @@ def test_launchd_drill_preserves_primary_failure_when_bootout_fails(
     CASE.assertFalse((socket_path.parent / "helper.pid").exists())
 
 
+def test_launchd_drill_cli_dry_run_skip_smoke_uses_isolated_label(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    code = helperctl.main(["launchd-drill", "--dry-run", "--skip-smoke"])
+
+    output = capsys.readouterr().out
+    CASE.assertEqual(code, 0)
+    CASE.assertIn("org.tldw.macos-vz-helper.drill.", output)
+    CASE.assertIn("launchd_preflight", output)
+
+
+def test_launchd_drill_cli_json_outputs_deterministic_steps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def fake_run_launchd_drill(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        return [
+            ("launchd_preflight", helperctl.CheckResult(ok=True, reason="launchd_service_absent")),
+            ("launchd_bootstrap", helperctl.CheckResult(ok=True)),
+            ("launchd_bootout", helperctl.CheckResult(ok=True)),
+        ]
+
+    monkeypatch.setattr(helperctl, "run_launchd_drill", fake_run_launchd_drill)
+
+    code = helperctl.main(["launchd-drill", "--dry-run", "--skip-smoke", "--json"])
+
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(
+        [step["name"] for step in output],
+        ["launchd_preflight", "launchd_bootstrap", "launchd_bootout"],
+    )
+    CASE.assertEqual(output[0]["reason"], "launchd_service_absent")
+
+
+def test_launchd_drill_cli_bundle_with_skip_smoke_passes_no_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    bundle = tmp_path / "bundle"
+    captured: dict[str, Any] = {}
+
+    def fake_run_launchd_drill(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        captured.update(kwargs)
+        return [("launchd_preflight", helperctl.CheckResult(ok=True))]
+
+    monkeypatch.setattr(helperctl, "run_launchd_drill", fake_run_launchd_drill)
+
+    code = helperctl.main(["launchd-drill", "--bundle", str(bundle), "--skip-smoke"])
+
+    CASE.assertEqual(code, 0)
+    CASE.assertIsNone(captured["bundle_path"])
+
+
 def test_launchd_bootstrap_requires_existing_plist_without_write(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     commands: list[list[str]] = []

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -695,6 +695,177 @@ def test_launchd_service_loaded_dry_run_reports_absent_for_nonzero_runner() -> N
     CASE.assertEqual(result, helperctl.CheckResult(ok=True, reason="launchd_service_absent"))
 
 
+def _make_launchd_drill_inputs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    private_root = tmp_path / "private"
+    private_root.mkdir(mode=0o700)
+    private_root.chmod(0o700)
+    helper = private_root / "macos-vz-helper"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    socket_path = private_root / "runtime" / "helper.sock"
+    log_dir = private_root / "logs"
+    plist_path = private_root / "launchd-drill" / "org.tldw.test.plist"
+    return helper, socket_path, log_dir, plist_path
+
+
+def test_launchd_drill_runs_bootstrap_status_kickstart_ping_bootout(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[list[str]] = []
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        calls.append(argv)
+        if argv == ["launchctl", "print", "gui/501/org.tldw.test"] and calls.count(argv) == 1:
+            return 3
+        return 0
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=lambda path: helperctl.PingState(helperctl.CheckResult(ok=True), "1", "test"),
+        smoke_runner=None,
+    )
+
+    by_name = dict(results)
+    for name in (
+        "launchd_preflight",
+        "launchd_bootstrap",
+        "launchd_status",
+        "launchd_kickstart",
+        "helper_status",
+        "launchd_bootout",
+    ):
+        CASE.assertIn(name, by_name)
+        CASE.assertTrue(by_name[name].ok, name)
+    CASE.assertEqual(by_name["launchd_bootstrap"].reason, "ok")
+    CASE.assertEqual(by_name["launchd_bootout"].reason, "ok")
+    CASE.assertEqual(by_name["protocol_version"].message, "1")
+    CASE.assertEqual(by_name["helper_version"].message, "test")
+    CASE.assertFalse((socket_path.parent / "helper.pid").exists())
+    CASE.assertIn(["launchctl", "bootstrap", "gui/501", str(plist_path)], calls)
+    CASE.assertGreaterEqual(calls.count(["launchctl", "print", "gui/501/org.tldw.test"]), 2)
+    CASE.assertIn(["launchctl", "kickstart", "-k", "gui/501/org.tldw.test"], calls)
+    CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
+
+
+def test_launchd_drill_refuses_already_loaded_service_without_bootout(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[list[str]] = []
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=lambda argv, **kwargs: calls.append(argv) or 0,
+        ping_checker=lambda path: helperctl.PingState(helperctl.CheckResult(ok=True), "1", "test"),
+    )
+
+    CASE.assertEqual(
+        results,
+        [
+            (
+                "launchd_preflight",
+                helperctl.CheckResult(
+                    ok=False,
+                    reason="launchd_service_already_loaded",
+                    message="gui/501/org.tldw.test",
+                ),
+            )
+        ],
+    )
+    CASE.assertEqual(calls, [["launchctl", "print", "gui/501/org.tldw.test"]])
+
+
+def test_launchd_drill_bootouts_after_kickstart_success_and_ping_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[list[str]] = []
+    monotonic_values = iter([100.0, 111.0])
+    monkeypatch.setattr(helperctl.time, "monotonic", lambda: next(monotonic_values))
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        calls.append(argv)
+        if argv == ["launchctl", "print", "gui/501/org.tldw.test"] and calls.count(argv) == 1:
+            return 3
+        return 0
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=lambda path: helperctl.CheckResult(ok=False, reason="helper_ping_failed"),
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["helper_status"], helperctl.CheckResult(ok=False, reason="helper_ping_failed"))
+    CASE.assertEqual(by_name["launchd_bootout"], helperctl.CheckResult(ok=True))
+    CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
+    CASE.assertFalse((socket_path.parent / "helper.pid").exists())
+
+
+def test_launchd_drill_preserves_primary_failure_when_bootout_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[list[str]] = []
+    monotonic_values = iter([100.0, 111.0])
+    monkeypatch.setattr(helperctl.time, "monotonic", lambda: next(monotonic_values))
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        calls.append(argv)
+        if argv == ["launchctl", "print", "gui/501/org.tldw.test"] and calls.count(argv) == 1:
+            return 3
+        if argv == ["launchctl", "bootout", "gui/501/org.tldw.test"]:
+            return 5
+        return 0
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=lambda path: helperctl.CheckResult(ok=False, reason="helper_ping_failed"),
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["helper_status"], helperctl.CheckResult(ok=False, reason="helper_ping_failed"))
+    CASE.assertEqual(
+        by_name["launchd_bootout"],
+        helperctl.CheckResult(ok=False, reason="launchd_bootout_failed", message="5"),
+    )
+    CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
+    CASE.assertFalse((socket_path.parent / "helper.pid").exists())
+
+
 def test_launchd_bootstrap_requires_existing_plist_without_write(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     commands: list[list[str]] = []

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -695,6 +695,81 @@ def test_launchd_service_loaded_dry_run_reports_absent_for_nonzero_runner() -> N
     CASE.assertEqual(result, helperctl.CheckResult(ok=True, reason="launchd_service_absent"))
 
 
+def test_run_vz_linux_host_smoke_constructs_pytest_command_and_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    bundle = tmp_path / "bundle"
+    socket_path = tmp_path / "helper.sock"
+    python_path = Path("/usr/bin/python3")
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+    monkeypatch.setenv("TLDW_TEST_EXISTING_ENV", "preserved")
+
+    result = helperctl.run_vz_linux_host_smoke(
+        bundle_path=bundle,
+        socket_path=socket_path,
+        python_path=python_path,
+        command_runner=lambda argv, **kwargs: calls.append((argv, kwargs)) or 0,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True))
+    CASE.assertEqual(len(calls), 1)
+    argv, kwargs = calls[0]
+    CASE.assertEqual(
+        argv,
+        [
+            str(python_path),
+            "-m",
+            "pytest",
+            str(helperctl.REPO_ROOT / "tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py"),
+            "-m",
+            "vz_linux_host_smoke",
+            "-q",
+            "-rs",
+        ],
+    )
+    CASE.assertFalse(kwargs["dry_run"])
+    env = kwargs["env"]
+    CASE.assertEqual(env["TEST_MODE"], "0")
+    CASE.assertEqual(env["TLDW_SANDBOX_VZ_LINUX_E2E"], "1")
+    CASE.assertEqual(env["TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE"], str(bundle))
+    CASE.assertEqual(env["TLDW_SANDBOX_MACOS_HELPER_SOCKET"], str(socket_path))
+    CASE.assertEqual(env["SANDBOX_ENABLE_EXECUTION"], "1")
+    CASE.assertEqual(env["SANDBOX_BACKGROUND_EXECUTION"], "0")
+    CASE.assertEqual(env["TLDW_TEST_EXISTING_ENV"], "preserved")
+
+
+def test_run_vz_linux_host_smoke_reports_failure(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+
+    result = helperctl.run_vz_linux_host_smoke(
+        bundle_path=tmp_path / "bundle",
+        socket_path=tmp_path / "helper.sock",
+        python_path=Path("/usr/bin/python3"),
+        command_runner=lambda argv, **kwargs: 2,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=False, reason="vz_linux_smoke_failed", message="2"))
+
+
+def test_run_vz_linux_host_smoke_dry_run_forwards_flag_and_reports_dry_run(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    calls: list[dict[str, Any]] = []
+
+    result = helperctl.run_vz_linux_host_smoke(
+        bundle_path=tmp_path / "bundle",
+        socket_path=tmp_path / "helper.sock",
+        python_path=Path("/usr/bin/python3"),
+        dry_run=True,
+        command_runner=lambda argv, **kwargs: calls.append(kwargs) or 0,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True, reason="dry_run"))
+    CASE.assertEqual(len(calls), 1)
+    CASE.assertTrue(calls[0]["dry_run"])
+
+
 def _make_launchd_drill_inputs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
     private_root = tmp_path / "private"
     private_root.mkdir(mode=0o700)
@@ -748,6 +823,7 @@ def test_launchd_drill_runs_bootstrap_status_kickstart_ping_bootout(tmp_path: Pa
     CASE.assertEqual(by_name["launchd_bootout"].reason, "ok")
     CASE.assertEqual(by_name["protocol_version"].message, "1")
     CASE.assertEqual(by_name["helper_version"].message, "test")
+    CASE.assertNotIn("vz_linux_smoke", by_name)
     CASE.assertFalse((socket_path.parent / "helper.pid").exists())
     CASE.assertIn(["launchctl", "bootstrap", "gui/501", str(plist_path)], calls)
     CASE.assertGreaterEqual(calls.count(["launchctl", "print", "gui/501/org.tldw.test"]), 2)
@@ -959,6 +1035,129 @@ def test_launchd_drill_preserves_smoke_failure_through_bootout(tmp_path: Path) -
             ("launchd_drill", smoke_failure),
         ],
     )
+    CASE.assertIn("launchctl bootout gui/501/org.tldw.test", calls)
+
+
+def test_launchd_drill_runs_bundle_smoke_after_ping_before_bootout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    bundle = tmp_path / "bundle"
+    python_path = Path("/usr/bin/python3")
+    calls: list[str] = []
+    smoke_kwargs: list[dict[str, Any]] = []
+    status_command = "launchctl print gui/501/org.tldw.test"
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        command = " ".join(argv)
+        calls.append(command)
+        if command == status_command and calls.count(status_command) == 1:
+            return 3
+        return 0
+
+    def ping_checker(path: Path) -> helperctl.CheckResult:
+        calls.append("ping")
+        return helperctl.CheckResult(ok=True)
+
+    def smoke_runner(**kwargs: Any) -> helperctl.CheckResult:
+        smoke_kwargs.append(kwargs)
+        calls.append("bundle-smoke")
+        return helperctl.CheckResult(ok=True)
+
+    monkeypatch.setattr(helperctl, "run_vz_linux_host_smoke", smoke_runner)
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=ping_checker,
+        bundle_path=bundle,
+        python_path=python_path,
+    )
+
+    result_names = [name for name, _ in results]
+    CASE.assertLess(result_names.index("helper_status"), result_names.index("vz_linux_smoke"))
+    CASE.assertLess(result_names.index("vz_linux_smoke"), result_names.index("launchd_bootout"))
+    CASE.assertEqual(
+        smoke_kwargs,
+        [
+            {
+                "bundle_path": bundle,
+                "socket_path": socket_path,
+                "python_path": python_path,
+                "dry_run": False,
+            }
+        ],
+    )
+    CASE.assertEqual(
+        calls,
+        [
+            status_command,
+            f"launchctl bootstrap gui/501 {plist_path}",
+            status_command,
+            "launchctl kickstart -k gui/501/org.tldw.test",
+            "ping",
+            "bundle-smoke",
+            "launchctl bootout gui/501/org.tldw.test",
+        ],
+    )
+
+
+def test_launchd_drill_preserves_bundle_smoke_failure_through_bootout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[str] = []
+    status_command = "launchctl print gui/501/org.tldw.test"
+    smoke_failure = helperctl.CheckResult(ok=False, reason="vz_linux_smoke_failed", message="2")
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        command = " ".join(argv)
+        calls.append(command)
+        if command == status_command and calls.count(status_command) == 1:
+            return 3
+        return 0
+
+    def smoke_runner(**kwargs: Any) -> helperctl.CheckResult:
+        calls.append("bundle-smoke")
+        return smoke_failure
+
+    monkeypatch.setattr(helperctl, "run_vz_linux_host_smoke", smoke_runner)
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=lambda path: helperctl.CheckResult(ok=True),
+        bundle_path=tmp_path / "bundle",
+    )
+
+    CASE.assertIn(("vz_linux_smoke", smoke_failure), results)
+    CASE.assertEqual(
+        results[-3:],
+        [
+            ("vz_linux_smoke", smoke_failure),
+            ("launchd_bootout", helperctl.CheckResult(ok=True)),
+            ("launchd_drill", smoke_failure),
+        ],
+    )
+    CASE.assertIn("bundle-smoke", calls)
     CASE.assertIn("launchctl bootout gui/501/org.tldw.test", calls)
 
 

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -755,6 +755,58 @@ def test_launchd_drill_runs_bootstrap_status_kickstart_ping_bootout(tmp_path: Pa
     CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
 
 
+def test_launchd_drill_runs_smoke_after_ping_before_bootout(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[str] = []
+    status_command = "launchctl print gui/501/org.tldw.test"
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        command = " ".join(argv)
+        calls.append(command)
+        if command == status_command and calls.count(status_command) == 1:
+            return 3
+        return 0
+
+    def ping_checker(path: Path) -> helperctl.CheckResult:
+        calls.append("ping")
+        return helperctl.CheckResult(ok=True)
+
+    def smoke_runner() -> helperctl.CheckResult:
+        calls.append("smoke")
+        return helperctl.CheckResult(ok=True)
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=ping_checker,
+        smoke_runner=smoke_runner,
+    )
+
+    result_names = [name for name, _ in results]
+    CASE.assertLess(result_names.index("helper_status"), result_names.index("vz_linux_smoke"))
+    CASE.assertLess(result_names.index("vz_linux_smoke"), result_names.index("launchd_bootout"))
+    CASE.assertEqual(
+        calls,
+        [
+            status_command,
+            f"launchctl bootstrap gui/501 {plist_path}",
+            status_command,
+            "launchctl kickstart -k gui/501/org.tldw.test",
+            "ping",
+            "smoke",
+            "launchctl bootout gui/501/org.tldw.test",
+        ],
+    )
+
+
 def test_launchd_drill_refuses_already_loaded_service_without_bootout(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
@@ -864,6 +916,50 @@ def test_launchd_drill_bootouts_after_kickstart_success_and_ping_failure(
     )
     CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
     CASE.assertFalse((socket_path.parent / "helper.pid").exists())
+
+
+def test_launchd_drill_preserves_smoke_failure_through_bootout(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[str] = []
+    status_command = "launchctl print gui/501/org.tldw.test"
+    smoke_failure = helperctl.CheckResult(ok=False, reason="vz_linux_smoke_failed", message="2")
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        command = " ".join(argv)
+        calls.append(command)
+        if command == status_command and calls.count(status_command) == 1:
+            return 3
+        return 0
+
+    def smoke_runner() -> helperctl.CheckResult:
+        calls.append("smoke")
+        return smoke_failure
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=runner,
+        ping_checker=lambda path: helperctl.CheckResult(ok=True),
+        smoke_runner=smoke_runner,
+    )
+
+    CASE.assertIn(("vz_linux_smoke", smoke_failure), results)
+    CASE.assertEqual(
+        results[-3:],
+        [
+            ("vz_linux_smoke", smoke_failure),
+            ("launchd_bootout", helperctl.CheckResult(ok=True)),
+            ("launchd_drill", smoke_failure),
+        ],
+    )
+    CASE.assertIn("launchctl bootout gui/501/org.tldw.test", calls)
 
 
 def test_launchd_drill_preserves_primary_failure_when_bootout_fails(

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -1274,6 +1274,35 @@ def test_launchd_drill_cli_json_dry_run_stdout_is_parseable(
     )
 
 
+def test_launchd_drill_cli_json_captures_launchd_subprocess_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    subprocess_kwargs: list[dict[str, Any]] = []
+
+    def fake_subprocess_run(argv: list[str], **kwargs: Any) -> CompletedProcess[str]:
+        subprocess_kwargs.append(kwargs)
+        return CompletedProcess(argv, 0, stdout="child stdout", stderr="child stderr")
+
+    def fake_run_launchd_drill(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        code = kwargs["launchd_runner"](["launchctl", "print", "gui/501/org.tldw.test"], dry_run=False)
+        return [("launchd_preflight", helperctl.CheckResult(ok=code == 0))]
+
+    monkeypatch.setattr(helperctl.subprocess, "run", fake_subprocess_run)
+    monkeypatch.setattr(helperctl, "run_launchd_drill", fake_run_launchd_drill)
+
+    code = helperctl.main(["launchd-drill", "--skip-smoke", "--json"])
+
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(output[0]["name"], "launchd_preflight")
+    CASE.assertEqual(subprocess_kwargs[0]["stdout"], helperctl.subprocess.PIPE)
+    CASE.assertEqual(subprocess_kwargs[0]["stderr"], helperctl.subprocess.PIPE)
+
+
 def test_launchd_drill_cli_bundle_with_skip_smoke_passes_no_bundle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -1250,6 +1250,30 @@ def test_launchd_drill_cli_json_outputs_deterministic_steps(
     CASE.assertEqual(output[0]["reason"], "launchd_service_absent")
 
 
+def test_launchd_drill_cli_json_dry_run_stdout_is_parseable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    code = helperctl.main(["launchd-drill", "--dry-run", "--skip-smoke", "--json"])
+
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(
+        [step["name"] for step in output],
+        [
+            "launchd_preflight",
+            "launchd_bootstrap",
+            "launchd_status",
+            "launchd_kickstart",
+            "helper_status",
+        ],
+    )
+
+
 def test_launchd_drill_cli_bundle_with_skip_smoke_passes_no_bundle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -789,6 +789,41 @@ def test_launchd_drill_refuses_already_loaded_service_without_bootout(tmp_path: 
     CASE.assertEqual(calls, [["launchctl", "print", "gui/501/org.tldw.test"]])
 
 
+def test_launchd_drill_dry_run_skips_ping_checker_and_reports_dry_run_helper_status(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    calls: list[list[str]] = []
+
+    def ping_checker(path: Path) -> helperctl.CheckResult:
+        raise AssertionError("dry-run drill must not ping the helper")
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        dry_run=True,
+        launchd_runner=lambda argv, **kwargs: calls.append(argv) or 0,
+        ping_checker=ping_checker,
+    )
+
+    CASE.assertEqual(
+        results,
+        [
+            ("launchd_preflight", helperctl.CheckResult(ok=True, reason="dry_run")),
+            ("launchd_bootstrap", helperctl.CheckResult(ok=True, reason="dry_run")),
+            ("launchd_status", helperctl.CheckResult(ok=True, reason="dry_run")),
+            ("launchd_kickstart", helperctl.CheckResult(ok=True, reason="dry_run")),
+            ("helper_status", helperctl.CheckResult(ok=True, reason="dry_run")),
+        ],
+    )
+    CASE.assertNotIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
+
+
 def test_launchd_drill_bootouts_after_kickstart_success_and_ping_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -818,9 +853,15 @@ def test_launchd_drill_bootouts_after_kickstart_success_and_ping_failure(
         ping_checker=lambda path: helperctl.CheckResult(ok=False, reason="helper_ping_failed"),
     )
 
-    by_name = dict(results)
-    CASE.assertEqual(by_name["helper_status"], helperctl.CheckResult(ok=False, reason="helper_ping_failed"))
-    CASE.assertEqual(by_name["launchd_bootout"], helperctl.CheckResult(ok=True))
+    primary_failure = helperctl.CheckResult(ok=False, reason="helper_ping_failed")
+    CASE.assertEqual(
+        results[-3:],
+        [
+            ("helper_status", primary_failure),
+            ("launchd_bootout", helperctl.CheckResult(ok=True)),
+            ("launchd_drill", primary_failure),
+        ],
+    )
     CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
     CASE.assertFalse((socket_path.parent / "helper.pid").exists())
 
@@ -856,11 +897,15 @@ def test_launchd_drill_preserves_primary_failure_when_bootout_fails(
         ping_checker=lambda path: helperctl.CheckResult(ok=False, reason="helper_ping_failed"),
     )
 
-    by_name = dict(results)
-    CASE.assertEqual(by_name["helper_status"], helperctl.CheckResult(ok=False, reason="helper_ping_failed"))
+    primary_failure = helperctl.CheckResult(ok=False, reason="helper_ping_failed")
+    CASE.assertEqual(results[-1], ("launchd_drill", primary_failure))
+    CASE.assertIn(("helper_status", primary_failure), results)
     CASE.assertEqual(
-        by_name["launchd_bootout"],
-        helperctl.CheckResult(ok=False, reason="launchd_bootout_failed", message="5"),
+        results[-2],
+        (
+            "launchd_bootout",
+            helperctl.CheckResult(ok=False, reason="launchd_bootout_failed", message="5"),
+        ),
     )
     CASE.assertIn(["launchctl", "bootout", "gui/501/org.tldw.test"], calls)
     CASE.assertFalse((socket_path.parent / "helper.pid").exists())

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -1303,6 +1303,61 @@ def test_launchd_drill_cli_json_captures_launchd_subprocess_output(
     CASE.assertEqual(subprocess_kwargs[0]["stderr"], helperctl.subprocess.PIPE)
 
 
+def test_launchd_drill_cli_json_captures_bundle_smoke_subprocess_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    bundle = tmp_path / "bundle"
+    subprocess_calls: list[tuple[list[str], dict[str, Any]]] = []
+    status_calls = 0
+
+    def fake_subprocess_run(argv: list[str], **kwargs: Any) -> CompletedProcess[str]:
+        nonlocal status_calls
+        subprocess_calls.append((argv, kwargs))
+        return_code = 0
+        if argv[:2] == ["launchctl", "print"]:
+            status_calls += 1
+            return_code = 3 if status_calls == 1 else 0
+        return CompletedProcess(argv, return_code, stdout="child stdout", stderr="child stderr")
+
+    def fake_wait_for_ping(socket: Path, **kwargs: Any) -> helperctl.PingState:
+        return helperctl.PingState(helperctl.CheckResult(ok=True))
+
+    monkeypatch.setattr(helperctl.subprocess, "run", fake_subprocess_run)
+    monkeypatch.setattr(helperctl, "wait_for_ping", fake_wait_for_ping)
+
+    code = helperctl.main(
+        [
+            "launchd-drill",
+            "--json",
+            "--bundle",
+            str(bundle),
+            "--helper",
+            str(helper),
+            "--socket",
+            str(socket_path),
+            "--log-dir",
+            str(log_dir),
+            "--plist-output",
+            str(plist_path),
+            "--label",
+            "org.tldw.test",
+            "--write-plist",
+            "--create-dirs",
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(code, 0)
+    CASE.assertIn("vz_linux_smoke", [step["name"] for step in output])
+    smoke_call = next(call for call in subprocess_calls if "pytest" in call[0])
+    CASE.assertEqual(smoke_call[1]["stdout"], helperctl.subprocess.PIPE)
+    CASE.assertEqual(smoke_call[1]["stderr"], helperctl.subprocess.PIPE)
+
+
 def test_launchd_drill_cli_bundle_with_skip_smoke_passes_no_bundle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -595,6 +595,106 @@ def test_launchd_argv_shapes(tmp_path: Path) -> None:
     )
 
 
+def test_launchd_drill_defaults_use_private_runtime_label_and_plist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    paths = helperctl.default_paths()
+    label = helperctl.default_launchd_drill_label(pid=12345)
+    plist_path = helperctl.default_launchd_drill_plist_path(paths, label)
+
+    CASE.assertEqual(label, "org.tldw.macos-vz-helper.drill.12345")
+    CASE.assertEqual(
+        plist_path,
+        paths.socket_path.parent / "launchd-drill" / "org.tldw.macos-vz-helper.drill.12345.plist",
+    )
+
+
+def test_launchd_service_loaded_returns_loaded_for_launchctl_print_zero() -> None:
+    helperctl = load_helperctl()
+
+    result = helperctl.launchd_service_loaded(
+        "org.tldw.test",
+        uid=501,
+        command_runner=lambda argv, **kwargs: 0,
+    )
+
+    CASE.assertEqual(
+        result,
+        helperctl.CheckResult(
+            ok=True,
+            reason="launchd_service_loaded",
+            message="gui/501/org.tldw.test",
+        ),
+    )
+
+
+def test_launchd_service_loaded_returns_absent_for_launchctl_print_nonzero() -> None:
+    helperctl = load_helperctl()
+
+    result = helperctl.launchd_service_loaded(
+        "org.tldw.test",
+        uid=501,
+        command_runner=lambda argv, **kwargs: 3,
+    )
+
+    CASE.assertEqual(
+        result,
+        helperctl.CheckResult(
+            ok=True,
+            reason="launchd_service_absent",
+            message="gui/501/org.tldw.test",
+        ),
+    )
+
+
+def test_launchd_service_loaded_returns_unavailable_for_launchctl_127() -> None:
+    helperctl = load_helperctl()
+
+    result = helperctl.launchd_service_loaded(
+        "org.tldw.test",
+        uid=501,
+        command_runner=lambda argv, **kwargs: 127,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=False, reason="launchd_launchctl_unavailable"))
+
+
+def test_launchd_service_loaded_dry_run_invokes_runner_with_dry_run_true() -> None:
+    helperctl = load_helperctl()
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def runner(argv: list[str], **kwargs: Any) -> int:
+        calls.append((argv, kwargs))
+        return 0
+
+    result = helperctl.launchd_service_loaded(
+        "org.tldw.test",
+        uid=501,
+        dry_run=True,
+        command_runner=runner,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True, reason="dry_run"))
+    CASE.assertEqual(calls, [(["launchctl", "print", "gui/501/org.tldw.test"], {"dry_run": True})])
+
+
+def test_launchd_service_loaded_dry_run_reports_absent_for_nonzero_runner() -> None:
+    helperctl = load_helperctl()
+
+    result = helperctl.launchd_service_loaded(
+        "org.tldw.test",
+        uid=501,
+        dry_run=True,
+        command_runner=lambda argv, **kwargs: 3,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(ok=True, reason="launchd_service_absent"))
+
+
 def test_launchd_bootstrap_requires_existing_plist_without_write(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     commands: list[list[str]] = []

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -445,6 +445,24 @@ def run_command(argv: list[str], *, dry_run: bool = False, env: dict[str, str] |
     return int(completed.returncode)
 
 
+def run_command_captured(argv: list[str], *, dry_run: bool = False, env: dict[str, str] | None = None) -> int:
+    """Run a command without letting child stdout/stderr reach the CLI stream."""
+    if dry_run:
+        return 0
+    # argv is executed directly without a shell.
+    try:
+        completed = subprocess.run(  # nosec B603
+            argv,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return 127
+    return int(completed.returncode)
+
+
 def _is_default_run_command(runner: Callable[..., int]) -> bool:
     return getattr(runner, "__module__", None) == __name__ and getattr(runner, "__name__", None) == "run_command"
 
@@ -1875,6 +1893,7 @@ def _launchd_drill_command(args: argparse.Namespace) -> int:
         "python_path": Path(args.python) if args.python else None,
     }
     if args.json:
+        drill_kwargs["launchd_runner"] = run_command_captured
         with contextlib.redirect_stdout(io.StringIO()):
             results = run_launchd_drill(**drill_kwargs)
     else:

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -553,6 +553,11 @@ def run_vz_linux_host_smoke(
     dry_run: bool = False,
     command_runner: Callable[..., int] | None = None,
 ) -> CheckResult:
+    """Run host-gated `vz_linux` smoke against an already-managed helper.
+
+    The smoke uses the existing pytest contract, points it at the provided
+    helper socket, and reports nonzero exits as `vz_linux_smoke_failed`.
+    """
     runner = command_runner or run_command
     python_bin = python_path if python_path is not None else Path(sys.executable)
     env = os.environ.copy()
@@ -801,6 +806,7 @@ def run_launchd_drill(
     launchd_runner: Callable[..., int] | None = None,
     bundle_path: Path | None = None,
     python_path: Path | None = None,
+    smoke_command_runner: Callable[..., int] | None = None,
     smoke_runner: Callable[[], CheckResult] | None = None,
 ) -> list[tuple[str, CheckResult]]:
     """Run an isolated launchd helper lifecycle validation drill."""
@@ -875,12 +881,15 @@ def run_launchd_drill(
         if dry_run:
             results.append(("helper_status", CheckResult(ok=True, reason="dry_run")))
             if smoke_runner is None and bundle_path is not None:
-                smoke_result = run_vz_linux_host_smoke(
-                    bundle_path=bundle_path,
-                    socket_path=socket_path,
-                    python_path=python_path,
-                    dry_run=True,
-                )
+                smoke_kwargs = {
+                    "bundle_path": bundle_path,
+                    "socket_path": socket_path,
+                    "python_path": python_path,
+                    "dry_run": True,
+                }
+                if smoke_command_runner is not None:
+                    smoke_kwargs["command_runner"] = smoke_command_runner
+                smoke_result = run_vz_linux_host_smoke(**smoke_kwargs)
                 results.append(("vz_linux_smoke", smoke_result))
                 if not smoke_result.ok:
                     primary_failure = smoke_result
@@ -902,12 +911,15 @@ def run_launchd_drill(
             if not smoke_result.ok:
                 primary_failure = smoke_result
         elif bundle_path is not None:
-            smoke_result = run_vz_linux_host_smoke(
-                bundle_path=bundle_path,
-                socket_path=socket_path,
-                python_path=python_path,
-                dry_run=dry_run,
-            )
+            smoke_kwargs = {
+                "bundle_path": bundle_path,
+                "socket_path": socket_path,
+                "python_path": python_path,
+                "dry_run": dry_run,
+            }
+            if smoke_command_runner is not None:
+                smoke_kwargs["command_runner"] = smoke_command_runner
+            smoke_result = run_vz_linux_host_smoke(**smoke_kwargs)
             results.append(("vz_linux_smoke", smoke_result))
             if not smoke_result.ok:
                 primary_failure = smoke_result
@@ -1894,6 +1906,7 @@ def _launchd_drill_command(args: argparse.Namespace) -> int:
     }
     if args.json:
         drill_kwargs["launchd_runner"] = run_command_captured
+        drill_kwargs["smoke_command_runner"] = run_command_captured
         with contextlib.redirect_stdout(io.StringIO()):
             results = run_launchd_drill(**drill_kwargs)
     else:

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -1849,6 +1849,34 @@ def _launchd_command(args: argparse.Namespace) -> int:
     return 0 if result.ok else 1
 
 
+def _launchd_drill_command(args: argparse.Namespace) -> int:
+    paths = default_paths()
+    label = args.label or default_launchd_drill_label()
+    plist_path = (
+        Path(args.plist_output)
+        if args.plist_output
+        else default_launchd_drill_plist_path(paths, label)
+    )
+    bundle_path = None
+    if not args.skip_smoke and args.bundle:
+        bundle_path = Path(args.bundle)
+    results = run_launchd_drill(
+        helper_path=Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
+        socket_path=Path(args.socket_path) if args.socket_path else paths.socket_path,
+        log_dir=Path(args.log_dir) if args.log_dir else paths.log_dir,
+        plist_path=plist_path,
+        label=label,
+        uid=args.uid,
+        write_plist=args.write_plist,
+        create_dirs=args.create_dirs,
+        dry_run=args.dry_run,
+        bundle_path=bundle_path,
+        python_path=Path(args.python) if args.python else None,
+    )
+    _print_results(results, as_json=args.json)
+    return 0 if all(result.ok for _, result in results) else 1
+
+
 def _start_command(args: argparse.Namespace) -> int:
     paths = default_paths()
     result = start_helper(
@@ -1966,6 +1994,25 @@ def build_parser() -> argparse.ArgumentParser:
     launchd.add_argument("--dry-run", action="store_true")
     launchd.add_argument("--json", action="store_true")
     launchd.set_defaults(func=_launchd_command)
+
+    launchd_drill = subparsers.add_parser(
+        "launchd-drill",
+        help="validate launchd-managed helper lifecycle",
+    )
+    launchd_drill.add_argument("--bundle")
+    launchd_drill.add_argument("--helper", "--helper-path", dest="helper_path")
+    launchd_drill.add_argument("--socket", "--socket-path", dest="socket_path")
+    launchd_drill.add_argument("--log-dir")
+    launchd_drill.add_argument("--plist-output")
+    launchd_drill.add_argument("--label")
+    launchd_drill.add_argument("--uid", type=int)
+    launchd_drill.add_argument("--python")
+    launchd_drill.add_argument("--write-plist", action="store_true")
+    launchd_drill.add_argument("--create-dirs", action="store_true")
+    launchd_drill.add_argument("--skip-smoke", action="store_true")
+    launchd_drill.add_argument("--dry-run", action="store_true")
+    launchd_drill.add_argument("--json", action="store_true")
+    launchd_drill.set_defaults(func=_launchd_drill_command)
 
     start = subparsers.add_parser("start", help="start the helper")
     start.add_argument("--helper", "--helper-path", dest="helper_path")

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -748,6 +748,7 @@ def run_launchd_drill(
     """Run an isolated launchd helper lifecycle validation drill."""
     results: list[tuple[str, CheckResult]] = []
     bootstrapped = False
+    primary_failure: CheckResult | None = None
 
     preflight = launchd_service_loaded(label, uid=uid, dry_run=dry_run, command_runner=launchd_runner)
     if preflight.reason == "launchd_service_loaded":
@@ -794,6 +795,7 @@ def run_launchd_drill(
         )
         results.append(("launchd_status", status))
         if not status.ok:
+            primary_failure = status
             return results
 
         kickstart = run_launchd_action(
@@ -809,6 +811,11 @@ def run_launchd_drill(
         )
         results.append(("launchd_kickstart", kickstart))
         if not kickstart.ok:
+            primary_failure = kickstart
+            return results
+
+        if dry_run:
+            results.append(("helper_status", CheckResult(ok=True, reason="dry_run")))
             return results
 
         ping_state = wait_for_ping(socket_path, ping_checker=ping_checker)
@@ -818,10 +825,14 @@ def run_launchd_drill(
         if ping_state.helper_version:
             results.append(("helper_version", CheckResult(ok=True, message=ping_state.helper_version)))
         if not ping_state.result.ok:
+            primary_failure = ping_state.result
             return results
 
         if smoke_runner is not None:
-            results.append(("vz_linux_smoke", smoke_runner()))
+            smoke_result = smoke_runner()
+            results.append(("vz_linux_smoke", smoke_result))
+            if not smoke_result.ok:
+                primary_failure = smoke_result
 
         return results
     finally:
@@ -838,6 +849,8 @@ def run_launchd_drill(
                 command_runner=launchd_runner,
             )
             results.append(("launchd_bootout", bootout))
+            if primary_failure is not None:
+                results.append(("launchd_drill", primary_failure))
 
 
 def wait_for_socket(

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import io
 import json
 import os
 import plistlib
@@ -1860,19 +1861,24 @@ def _launchd_drill_command(args: argparse.Namespace) -> int:
     bundle_path = None
     if not args.skip_smoke and args.bundle:
         bundle_path = Path(args.bundle)
-    results = run_launchd_drill(
-        helper_path=Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
-        socket_path=Path(args.socket_path) if args.socket_path else paths.socket_path,
-        log_dir=Path(args.log_dir) if args.log_dir else paths.log_dir,
-        plist_path=plist_path,
-        label=label,
-        uid=args.uid,
-        write_plist=args.write_plist,
-        create_dirs=args.create_dirs,
-        dry_run=args.dry_run,
-        bundle_path=bundle_path,
-        python_path=Path(args.python) if args.python else None,
-    )
+    drill_kwargs = {
+        "helper_path": Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
+        "socket_path": Path(args.socket_path) if args.socket_path else paths.socket_path,
+        "log_dir": Path(args.log_dir) if args.log_dir else paths.log_dir,
+        "plist_path": plist_path,
+        "label": label,
+        "uid": args.uid,
+        "write_plist": args.write_plist,
+        "create_dirs": args.create_dirs,
+        "dry_run": args.dry_run,
+        "bundle_path": bundle_path,
+        "python_path": Path(args.python) if args.python else None,
+    }
+    if args.json:
+        with contextlib.redirect_stdout(io.StringIO()):
+            results = run_launchd_drill(**drill_kwargs)
+    else:
+        results = run_launchd_drill(**drill_kwargs)
     _print_results(results, as_json=args.json)
     return 0 if all(result.ok for _, result in results) else 1
 

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -730,6 +730,116 @@ def wait_for_ping(
         time.sleep(interval_sec)
 
 
+def run_launchd_drill(
+    *,
+    helper_path: Path,
+    socket_path: Path,
+    log_dir: Path,
+    plist_path: Path,
+    label: str,
+    uid: int | None = None,
+    write_plist: bool = False,
+    create_dirs: bool = False,
+    dry_run: bool = False,
+    ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
+    launchd_runner: Callable[..., int] | None = None,
+    smoke_runner: Callable[[], CheckResult] | None = None,
+) -> list[tuple[str, CheckResult]]:
+    """Run an isolated launchd helper lifecycle validation drill."""
+    results: list[tuple[str, CheckResult]] = []
+    bootstrapped = False
+
+    preflight = launchd_service_loaded(label, uid=uid, dry_run=dry_run, command_runner=launchd_runner)
+    if preflight.reason == "launchd_service_loaded":
+        results.append(
+            (
+                "launchd_preflight",
+                CheckResult(False, "launchd_service_already_loaded", preflight.message),
+            )
+        )
+        return results
+    results.append(("launchd_preflight", preflight))
+    if not preflight.ok:
+        return results
+
+    bootstrap = run_launchd_action(
+        "bootstrap",
+        label=label,
+        plist_path=plist_path,
+        helper_path=helper_path,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        uid=uid,
+        dry_run=dry_run,
+        write_plist=write_plist,
+        create_dirs=create_dirs,
+        command_runner=launchd_runner,
+    )
+    results.append(("launchd_bootstrap", bootstrap))
+    if not bootstrap.ok:
+        return results
+    bootstrapped = not dry_run
+
+    try:
+        status = run_launchd_action(
+            "status",
+            label=label,
+            plist_path=plist_path,
+            helper_path=helper_path,
+            socket_path=socket_path,
+            log_dir=log_dir,
+            uid=uid,
+            dry_run=dry_run,
+            command_runner=launchd_runner,
+        )
+        results.append(("launchd_status", status))
+        if not status.ok:
+            return results
+
+        kickstart = run_launchd_action(
+            "kickstart",
+            label=label,
+            plist_path=plist_path,
+            helper_path=helper_path,
+            socket_path=socket_path,
+            log_dir=log_dir,
+            uid=uid,
+            dry_run=dry_run,
+            command_runner=launchd_runner,
+        )
+        results.append(("launchd_kickstart", kickstart))
+        if not kickstart.ok:
+            return results
+
+        ping_state = wait_for_ping(socket_path, ping_checker=ping_checker)
+        results.append(("helper_status", ping_state.result))
+        if ping_state.protocol_version:
+            results.append(("protocol_version", CheckResult(ok=True, message=ping_state.protocol_version)))
+        if ping_state.helper_version:
+            results.append(("helper_version", CheckResult(ok=True, message=ping_state.helper_version)))
+        if not ping_state.result.ok:
+            return results
+
+        if smoke_runner is not None:
+            results.append(("vz_linux_smoke", smoke_runner()))
+
+        return results
+    finally:
+        if bootstrapped:
+            bootout = run_launchd_action(
+                "bootout",
+                label=label,
+                plist_path=plist_path,
+                helper_path=helper_path,
+                socket_path=socket_path,
+                log_dir=log_dir,
+                uid=uid,
+                dry_run=dry_run,
+                command_runner=launchd_runner,
+            )
+            results.append(("launchd_bootout", bootout))
+
+
 def wait_for_socket(
     socket_path: Path,
     *,

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -526,6 +526,43 @@ def smoke_helper(
     return CheckResult(ok=True)
 
 
+def run_vz_linux_host_smoke(
+    *,
+    bundle_path: Path,
+    socket_path: Path,
+    python_path: Path | None = None,
+    dry_run: bool = False,
+    command_runner: Callable[..., int] | None = None,
+) -> CheckResult:
+    runner = command_runner or run_command
+    python_bin = python_path if python_path is not None else Path(sys.executable)
+    env = os.environ.copy()
+    env.update(
+        {
+            "TEST_MODE": "0",
+            "TLDW_SANDBOX_VZ_LINUX_E2E": "1",
+            "TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE": str(bundle_path),
+            "TLDW_SANDBOX_MACOS_HELPER_SOCKET": str(socket_path),
+            "SANDBOX_ENABLE_EXECUTION": "1",
+            "SANDBOX_BACKGROUND_EXECUTION": "0",
+        }
+    )
+    argv = [
+        str(python_bin),
+        "-m",
+        "pytest",
+        str(REPO_ROOT / "tldw_Server_API/tests/sandbox/test_vz_linux_real_host_e2e.py"),
+        "-m",
+        "vz_linux_host_smoke",
+        "-q",
+        "-rs",
+    ]
+    code = runner(argv, dry_run=dry_run, env=env)
+    if code == 0:
+        return CheckResult(ok=True, reason="dry_run" if dry_run else "ok")
+    return CheckResult(ok=False, reason="vz_linux_smoke_failed", message=str(code))
+
+
 def read_codesign_entitlements(helper_path: Path) -> CheckResult:
     try:
         # macOS operator command, fixed executable name, no shell expansion.
@@ -743,6 +780,8 @@ def run_launchd_drill(
     dry_run: bool = False,
     ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
     launchd_runner: Callable[..., int] | None = None,
+    bundle_path: Path | None = None,
+    python_path: Path | None = None,
     smoke_runner: Callable[[], CheckResult] | None = None,
 ) -> list[tuple[str, CheckResult]]:
     """Run an isolated launchd helper lifecycle validation drill."""
@@ -816,6 +855,16 @@ def run_launchd_drill(
 
         if dry_run:
             results.append(("helper_status", CheckResult(ok=True, reason="dry_run")))
+            if smoke_runner is None and bundle_path is not None:
+                smoke_result = run_vz_linux_host_smoke(
+                    bundle_path=bundle_path,
+                    socket_path=socket_path,
+                    python_path=python_path,
+                    dry_run=True,
+                )
+                results.append(("vz_linux_smoke", smoke_result))
+                if not smoke_result.ok:
+                    primary_failure = smoke_result
             return results
 
         ping_state = wait_for_ping(socket_path, ping_checker=ping_checker)
@@ -830,6 +879,16 @@ def run_launchd_drill(
 
         if smoke_runner is not None:
             smoke_result = smoke_runner()
+            results.append(("vz_linux_smoke", smoke_result))
+            if not smoke_result.ok:
+                primary_failure = smoke_result
+        elif bundle_path is not None:
+            smoke_result = run_vz_linux_host_smoke(
+                bundle_path=bundle_path,
+                socket_path=socket_path,
+                python_path=python_path,
+                dry_run=dry_run,
+            )
             results.append(("vz_linux_smoke", smoke_result))
             if not smoke_result.ok:
                 primary_failure = smoke_result

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -270,6 +270,17 @@ def launchd_service_target(label: str, *, uid: int | None = None) -> str:
     return f"{launchd_domain(uid)}/{label}"
 
 
+def default_launchd_drill_label(*, pid: int | None = None) -> str:
+    """Return the isolated launchd label used by the validation drill."""
+    suffix = os.getpid() if pid is None else pid
+    return f"{DEFAULT_LAUNCHD_LABEL}.drill.{suffix}"
+
+
+def default_launchd_drill_plist_path(paths: HelperPaths, label: str) -> Path:
+    """Return the private runtime plist path used by the validation drill."""
+    return paths.socket_path.parent / "launchd-drill" / f"{label}.plist"
+
+
 def launchd_argv(
     action: str,
     *,
@@ -289,6 +300,35 @@ def launchd_argv(
     if action == "kickstart":
         return ["launchctl", "kickstart", "-k", launchd_service_target(label, uid=uid)]
     return ["launchctl", "bootout", launchd_service_target(label, uid=uid)]
+
+
+def launchd_service_loaded(
+    label: str,
+    *,
+    uid: int | None = None,
+    dry_run: bool = False,
+    command_runner: Callable[..., int] | None = None,
+) -> CheckResult:
+    """Check whether launchd currently has the helper service loaded."""
+    runner = command_runner or run_command
+    target = launchd_service_target(label, uid=uid)
+    argv = launchd_argv("status", label=label, uid=uid)
+
+    if dry_run:
+        code = runner(argv, dry_run=True)
+        if code == 0:
+            return CheckResult(ok=True, reason="dry_run")
+        return CheckResult(ok=True, reason="launchd_service_absent")
+
+    if _is_default_run_command(runner) and shutil.which("launchctl") is None:
+        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
+
+    code = runner(argv, dry_run=False)
+    if code == 0:
+        return CheckResult(ok=True, reason="launchd_service_loaded", message=target)
+    if code == 127:
+        return CheckResult(ok=False, reason="launchd_launchctl_unavailable")
+    return CheckResult(ok=True, reason="launchd_service_absent", message=target)
 
 
 def _prepare_launchd_plist(


### PR DESCRIPTION
## Summary

Adds an explicit operator-owned `vz-helperctl.py launchd-drill` workflow for validating the macOS VZ helper under LaunchAgent supervision without changing the default direct-helper smoke path.

## What Changed

- Added launchd drill defaults, loaded-service guard, drill orchestration, bootout cleanup, external-helper `vz_linux` smoke execution, and CLI output.
- Added portable helperctl tests for defaults, loaded guard, sequencing, cleanup, smoke invocation, skip-smoke/no-smoke behavior, and JSON output.
- Documented the operator workflow, cleanup trap, expected host-gated skips, and manual LaunchAgent validation boundaries.
- Completed Backlog task tracking for the implementation slice.

## Verification

- `python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q`
  - `123 passed, 1 skipped`
- `git diff --check`
  - passed
- `python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_launchd_drill_post_rebase.json`
  - `0` errors, `0` findings
- Final subagent review
  - approved

## Host-Gated Note

Real LaunchAgent plus VM smoke was not run in this portable pass. The PR documents it as a prepared-host manual validation path.

## Human Change Summary

TODO: Human maintainer must add the required human-written change summary before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operator-owned `launchd-drill` command to `vz-helperctl.py` to validate the macOS VZ helper under LaunchAgent supervision without changing the default direct-helper smoke path. Supports optional real `vz_linux` host smoke through the launchd-managed socket.

- **New Features**
  - Orchestrates `launchctl bootstrap/status/kickstart` → helper ping/version → optional `vz_linux` smoke → `bootout`.
  - Safety: refuses pre-loaded services, only bootouts targets it bootstrapped, accepts missing helperctl pid file in launchd mode.
  - CLI: `--write-plist`, `--create-dirs`, `--skip-smoke`, `--bundle`, `--python`, `--uid`, `--json`, `--dry-run`; uses isolated default label and private plist path.
  - Tests and docs: adds portable tests for defaults/guard/sequencing/cleanup/JSON/smoke; updates `tools/macos-vz-helper/README.md`, macOS operator notes, and host-gated policy with usage and expected skips.

- **Bug Fixes**
  - In `--json` mode, capture stdout/stderr from both `launchctl` and drill `vz_linux` smoke subprocesses to keep JSON output clean; the CLI uses a captured runner in JSON paths and tests cover both.

<sup>Written for commit 09e1926f7060b625e926dec3f487f958f94ca9af. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1720?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

