### PR TITLE
Migrate Persona Buddy diagnostics labels to design-system registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -5267,49 +5267,5 @@
     "reason": "Existing Alert product-state UI in src/components/Option/Evaluations/tabs/RecipesTab.tsx after the embeddings recipe flow merge; baseline refresh captures current dev debt.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Ready#label-ready-personabuddydiagnostics-line-116-v09kqm",
-    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Ready#label-ready-personabuddydiagnostics-line-127-1qda4me",
-    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Ready\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Loading#label-loading-personabuddydiagnostics-line-173-gk5tgm",
-    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
-    "rule": "canonical-state-label",
-    "subject": "Loading",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Loading\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/PersonaGarden/personaBuddyDiagnostics.ts:Loading#label-loading-personabuddydiagnostics-line-612-1pmf966",
-    "path": "src/components/PersonaGarden/personaBuddyDiagnostics.ts",
-    "rule": "canonical-state-label",
-    "subject": "Loading",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing hardcoded \"Loading\" state label in src/components/PersonaGarden/personaBuddyDiagnostics.ts on current dev; baseline refresh captures current shared-product-state debt.",
-    "replacement": "getDesignSystemState(...)",
-    "migrationQueue": "shared-product-state"
   }
 ]

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts
@@ -1,8 +1,49 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+
+const registryLabels = vi.hoisted(() => ({
+  loading: "Registry Loading",
+  ready: "Registry Ready"
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+  return {
+    ...actual,
+    LOADING_STATE_LABEL: registryLabels.loading,
+    READY_STATE_LABEL: registryLabels.ready
+  }
+})
 
 import { buildPersonaBuddyDiagnostics } from "../personaBuddyDiagnostics"
 
 describe("buildPersonaBuddyDiagnostics", () => {
+  it("uses design-system registry labels for canonical ready and loading diagnostics", () => {
+    const diagnostics = buildPersonaBuddyDiagnostics({
+      selectedPersona: { id: "persona-1", name: "Ada" },
+      profileState: "loading",
+      buddySummary: "Uses the active persona profile.",
+      capabilities: { hasPersona: true, hasMcp: true },
+      liveSession: { connected: true, connecting: false, sessionId: "session-1" },
+      liveVoice: { state: "idle", recoveryMode: "none" },
+      wake: { armed: true, detectorState: "ready" },
+      visual: {
+        packId: "pack-1",
+        packTitle: "Animated Pack",
+        packLoadStatus: "loading",
+        visualState: "idle",
+        diagnostic: null
+      }
+    })
+
+    expect(diagnostics.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Buddy", value: registryLabels.ready }),
+        expect.objectContaining({ label: "Profile", value: registryLabels.loading }),
+        expect.objectContaining({ label: "Visual pack", value: registryLabels.loading })
+      ])
+    )
+  })
+
   it("returns healthy diagnostics for connected persona live state", () => {
     const diagnostics = buildPersonaBuddyDiagnostics({
       selectedPersona: { id: "persona-1", name: "Ada" },

--- a/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
@@ -1,4 +1,5 @@
 import type { PersonaVisualDiagnostic } from "@/components/Common/PersonaBuddy/personaVisualDiagnostics"
+import { LOADING_STATE_LABEL, READY_STATE_LABEL } from "@/design-system"
 import type {
   PersonaLiveVoiceWarningReasonCode,
   PersonaWakeWarningReasonCode
@@ -113,7 +114,7 @@ const summarizeBuddy = (
   if (typeof buddySummary === "string" && buddySummary.trim()) {
     return {
       label: "Buddy",
-      value: "Ready",
+      value: READY_STATE_LABEL,
       state: "healthy",
       detail: buddySummary.trim()
     }
@@ -124,7 +125,7 @@ const summarizeBuddy = (
     if (buddySummary.has_buddy || roleSummary) {
       return {
         label: "Buddy",
-        value: "Ready",
+        value: READY_STATE_LABEL,
         state: "healthy",
         detail: roleSummary || "Buddy summary is attached to this persona."
       }
@@ -170,7 +171,7 @@ const summarizeVisual = (
   if (visual?.packLoadStatus === "loading") {
     return {
       label: "Visual pack",
-      value: "Loading",
+      value: LOADING_STATE_LABEL,
       state: "recovering",
       detail: joinDetails([packIdDetail, renderState])
     }
@@ -609,7 +610,7 @@ export const buildPersonaBuddyDiagnostics = ({
     profileState === "loading"
       ? {
           label: "Profile",
-          value: "Loading",
+          value: LOADING_STATE_LABEL,
           state: "recovering"
         }
       : profileState === "error"

--- a/apps/packages/ui/src/design-system/__tests__/states.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/states.test.ts
@@ -3,6 +3,7 @@ import {
   BLOCKED_STATE_LABEL,
   DESIGN_SYSTEM_STATES,
   EMPTY_STATE_LABEL,
+  LOADING_STATE_LABEL,
   READY_STATE_LABEL,
   getDesignSystemState,
   isDesignSystemStateKey
@@ -183,6 +184,7 @@ describe("design-system state registry", () => {
   it("exports canonical state labels through defensive fallbacks", () => {
     expect(READY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.ready.label)
     expect(EMPTY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.empty.label)
+    expect(LOADING_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.loading.label)
     expect(BLOCKED_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.blocked.label)
   })
 })

--- a/apps/packages/ui/src/design-system/states.ts
+++ b/apps/packages/ui/src/design-system/states.ts
@@ -213,6 +213,7 @@ export function getDesignSystemStateLabel(
 
 export const READY_STATE_LABEL = getDesignSystemStateLabel("ready", "Ready")
 export const EMPTY_STATE_LABEL = getDesignSystemStateLabel("empty", "Empty")
+export const LOADING_STATE_LABEL = getDesignSystemStateLabel("loading", "Loading")
 export const DEGRADED_STATE_LABEL = getDesignSystemStateLabel("degraded", "Degraded")
 export const ERROR_STATE_LABEL = getDesignSystemStateLabel("error", "Error")
 export const BLOCKED_STATE_LABEL = getDesignSystemStateLabel("blocked", "Blocked")

--- a/backlog/tasks/task-45.46 - Migrate-Persona-Buddy-diagnostics-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-45.46 - Migrate-Persona-Buddy-diagnostics-labels-to-design-system-registry.md
@@ -4,7 +4,7 @@ title: Migrate Persona Buddy diagnostics labels to design-system registry
 status: Done
 assignee: []
 created_date: '2026-05-15 06:41'
-updated_date: '2026-05-15 07:01'
+updated_date: '2026-05-15 19:14'
 labels:
   - design-system
   - webui
@@ -38,7 +38,7 @@ Continue the tldw_server WebUI design-system migration by routing the remaining 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implementation completed in /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/design-system-next-slice-6 on branch codex/design-system-next-slice-6.
+Implementation completed on branch codex/design-system-next-slice-6 in the dedicated design-system worktree.
 
 Persona Buddy diagnostics now consume READY_STATE_LABEL and LOADING_STATE_LABEL from the design-system registry exports, preserving the existing diagnostic ordering and state logic.
 

--- a/backlog/tasks/task-45.46 - Migrate-Persona-Buddy-diagnostics-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-45.46 - Migrate-Persona-Buddy-diagnostics-labels-to-design-system-registry.md
@@ -1,0 +1,66 @@
+---
+id: TASK-45.46
+title: Migrate Persona Buddy diagnostics labels to design-system registry
+status: Done
+assignee: []
+created_date: '2026-05-15 06:41'
+updated_date: '2026-05-15 07:01'
+labels:
+  - design-system
+  - webui
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts
+  - apps/packages/ui/src/design-system/states.ts
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - https://github.com/rmusser01/tldw_server/pull/1722
+documentation:
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by routing the remaining Persona Buddy diagnostics canonical Ready and Loading row labels through the shared design-system state registry instead of local string literals. This is a narrow baseline-reduction slice for apps/packages/ui/src/components/PersonaGarden/personaBuddyDiagnostics.ts and the design-system state label exports.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Buddy diagnostics use design-system registry label exports for Ready and Loading diagnostics values without changing diagnostic state ranking or copy.
+- [x] #2 Focused Persona Buddy diagnostics coverage proves the labels come from the registry contract rather than local literals.
+- [x] #3 The design-system product-state baseline no longer contains Persona Buddy diagnostics canonical-state-label exceptions.
+- [x] #4 Focused tests and design-system verifier results are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation completed in /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/design-system-next-slice-6 on branch codex/design-system-next-slice-6.
+
+Persona Buddy diagnostics now consume READY_STATE_LABEL and LOADING_STATE_LABEL from the design-system registry exports, preserving the existing diagnostic ordering and state logic.
+
+Focused coverage mocks the design-system registry labels to prove Persona Buddy diagnostics read canonical labels instead of local literals.
+
+Removed Persona Buddy diagnostics canonical-state-label exceptions from apps/packages/ui/scripts/design-system-product-state-baseline.json.
+
+PR opened against dev: https://github.com/rmusser01/tldw_server/pull/1722.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated Persona Buddy diagnostics Ready and Loading labels to design-system registry exports, added focused registry-label coverage, exported LOADING_STATE_LABEL from the state registry helper, and removed the Persona Buddy canonical-state-label baseline exceptions. Verification recorded: focused Persona Buddy/design-system tests passed, product-state verifier passed, combined guard suite passed, baseline JSON parse passed, git diff --check passed, and package TypeScript still has existing unrelated diagnostics with no touched-file matches. Bandit is not applicable because this slice touched TypeScript, test, and JSON frontend files only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- route Persona Buddy Ready/Loading diagnostic labels through design-system registry exports
- add a LOADING_STATE_LABEL export and focused registry-label coverage
- remove the Persona Buddy canonical-state-label baseline exceptions and close TASK-45.46

## Test plan
- bunx vitest run src/components/PersonaGarden/__tests__/personaBuddyDiagnostics.test.ts src/design-system/__tests__/states.test.ts src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"
- git diff --check
- bunx tsc --noEmit --pretty false (known existing package-wide failures; touched-path filter returned no diagnostics)

## Change summary
TODO: human-authored summary required before merge per AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Persona Buddy diagnostics to use canonical Ready/Loading labels from the design-system state registry, removing local literals and baseline exceptions. Added `LOADING_STATE_LABEL`, tests that mock registry labels, and a sanitized TASK-45.46 backlog note.

- **Refactors**
  - Diagnostics now read `READY_STATE_LABEL` and `LOADING_STATE_LABEL` from `@/design-system`.
  - Exported `LOADING_STATE_LABEL` with a defensive fallback in the design-system.
  - Removed Persona Buddy canonical-state-label exceptions from the product-state baseline.
  - Added focused tests that mock registry labels and updated design-system state tests to cover `LOADING_STATE_LABEL`.

<sup>Written for commit 84882f42651afe5689eaf1cf13a4d3d1ac0560ab. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1722?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

