### PR TITLE
Add Persona Visual setup E2E coverage

### DIFF
--- a/Docs/superpowers/plans/2026-05-15-persona-visual-happy-path-e2e-plan.md
+++ b/Docs/superpowers/plans/2026-05-15-persona-visual-happy-path-e2e-plan.md
@@ -1,0 +1,89 @@
+# Persona Visual Happy Path E2E Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic Persona Visual fixtures and coverage proving default-pack and uploaded-pack setup can activate a sprite-frame visual that BuddyShell renders.
+
+**Architecture:** Keep V1 scoped to the existing Persona Visual pack editor, service contract, and BuddyShell sprite-frame runtime. Reuse the backend starter-pack endpoints already added by the starter catalog and mock those same API shapes in E2E rather than adding a separate setup system. Import/upload remains review-gated: preview, commit to draft, explicit activation, then BuddyShell render.
+
+**Tech Stack:** React, TypeScript, Vitest, Playwright, mocked Persona REST/WebSocket fixtures.
+
+---
+
+### Task 1: Starter-Pack Copy Service And Editor Affordance
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/persona-visuals.ts`
+- Modify: `apps/packages/ui/src/services/persona-visuals.ts`
+- Modify: `apps/packages/ui/src/services/__tests__/persona-visuals.test.ts`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [x] **Step 1: Write failing service and editor tests**
+
+Add tests showing starter packs are listed from `/api/v1/persona/visual-starter-packs`, copied through `/copy`, and selected as a draft without activating.
+
+- [x] **Step 2: Run tests to verify they fail**
+
+Run: `bunx vitest run apps/packages/ui/src/services/__tests__/persona-visuals.test.ts apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [x] **Step 3: Implement minimal service/types/UI**
+
+Add starter-pack response types, service helpers, and a compact "Default starter pack" panel inside `VisualPackEditor`.
+
+- [x] **Step 4: Run tests to verify they pass**
+
+Run the same focused Vitest command.
+
+### Task 2: Deterministic Persona Visual E2E Fixtures
+
+**Files:**
+- Create: `apps/tldw-frontend/e2e/fixtures/persona-visual-packs.ts`
+- Modify: `apps/tldw-frontend/e2e/workflows/persona-live.spec.ts`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
+
+- [x] **Step 1: Write failing E2E fixture consumers**
+
+Update the Persona Live workflow to consume shared default and portable upload fixtures rather than inline ad hoc pack data.
+
+- [x] **Step 2: Run the focused E2E to verify failure**
+
+Run: `bunx playwright test e2e/workflows/persona-live.spec.ts --grep "visual pack" --reporter=line --workers=1`
+
+- [x] **Step 3: Add deterministic fixture helpers**
+
+Expose a sprite-frame starter summary, active/draft pack builders, and a `.tldw-persona-vpack` upload `File` helper with stable bytes, name, and MIME type.
+
+- [x] **Step 4: Run the focused E2E to verify pass**
+
+Run the same Playwright command.
+
+### Task 3: Default And Upload Happy-Path E2E Coverage
+
+**Files:**
+- Modify: `apps/tldw-frontend/e2e/workflows/persona-live.spec.ts`
+
+- [x] **Step 1: Write failing happy-path tests**
+
+Add tests for default starter copy -> activation -> BuddyShell render and upload preview -> commit -> activation -> BuddyShell render.
+
+- [x] **Step 2: Run focused E2E and confirm failures**
+
+Run: `bunx playwright test e2e/workflows/persona-live.spec.ts --grep "setup path" --reporter=line --workers=1`
+
+- [x] **Step 3: Implement mocks and assertions**
+
+Mock starter-pack list/copy, import preview/commit, activation, refreshed pack lists, and assert `persona-visual-frame` renders with the activated pack state.
+
+- [x] **Step 4: Run focused validation**
+
+Run focused Vitest and Playwright checks, plus `git diff --check`. Bandit is not applicable unless Python code changes.
+
+## Validation
+
+- `bun run test:run ../packages/ui/src/services/__tests__/persona-visuals.test.ts ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx ../packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx` passed: 55 tests.
+- `bun -e "import { buildPortablePersonaVisualPackUpload } from './e2e/fixtures/persona-visual-packs.ts'; ..."` passed: repeated fixture builds produced identical bytes (`uploaded-visual-pack.tldw-persona-vpack`, 2055 bytes).
+- `TLDW_WEB_URL=http://localhost:18099 TLDW_WEB_CMD='bun run dev -- -p 18099' bunx playwright test e2e/workflows/persona-live.spec.ts --grep "setup path" --reporter=line --workers=1` passed: 2 tests.
+- `TLDW_WEB_URL=http://localhost:18100 TLDW_WEB_CMD='bun run dev -- -p 18100' bunx playwright test e2e/workflows/persona-live.spec.ts --reporter=line --workers=1` ran the full file; the 4 visual-pack tests passed and the live-backend WebSocket proof timed out waiting for Disconnect.
+- `git diff --check` passed.
+- Bandit not run because this slice changed TypeScript, JSON, Markdown, and Playwright fixture code only.

--- a/apps/packages/ui/src/assets/locale/en/sidepanel.json
+++ b/apps/packages/ui/src/assets/locale/en/sidepanel.json
@@ -534,7 +534,12 @@
       "starterHeading": "Default starter pack",
       "starterDescription": "Copy a bundled sprite-frame pack as a draft, then review and activate it.",
       "starterCopiedDraft": "Starter pack copied as a draft. Review and activate it when ready.",
-      "starterCopyError": "Failed to copy bundled starter pack."
+      "starterCopyError": "Failed to copy bundled starter pack.",
+      "starterSelectLabel": "Starter",
+      "starterDraftTitleLabel": "Draft title",
+      "starterCopyAsDraft": "Copy as draft",
+      "starterAssetUnit": "assets",
+      "starterBytesUnit": "bytes"
     }
   },
   "persona": {

--- a/apps/packages/ui/src/assets/locale/en/sidepanel.json
+++ b/apps/packages/ui/src/assets/locale/en/sidepanel.json
@@ -530,7 +530,11 @@
       "importCommitQueued": "Import commit queued. Refresh to check draft creation status.",
       "importCommitProcessing": "Import commit is processing{{stageSuffix}}",
       "importCommitStatus": "Import commit {{status}}: {{stage}}",
-      "importCommitQueuedStatus": "Import commit queued. Imported packs remain drafts until activated."
+      "importCommitQueuedStatus": "Import commit queued. Imported packs remain drafts until activated.",
+      "starterHeading": "Default starter pack",
+      "starterDescription": "Copy a bundled sprite-frame pack as a draft, then review and activate it.",
+      "starterCopiedDraft": "Starter pack copied as a draft. Review and activate it when ready.",
+      "starterCopyError": "Failed to copy bundled starter pack."
     }
   },
   "persona": {

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -20,6 +20,7 @@ import type {
   PersonaBuddyRenderContext,
   PersonaBuddySummary
 } from "@/types/persona-buddy"
+import { PERSONA_VISUAL_PACK_ACTIVATED_EVENT } from "@/types/persona-visuals"
 import type { PersonaVisualPack } from "@/types/persona-visuals"
 
 import { useBuddyShellRenderContext } from "./BuddyShellRenderContext"
@@ -295,6 +296,7 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     React.useState<PersonaVisualPackLoadStatus>("idle")
   const [visualPackLoadError, setVisualPackLoadError] =
     React.useState<unknown>(null)
+  const [visualPackRefreshNonce, setVisualPackRefreshNonce] = React.useState(0)
   const [visualRenderError, setVisualRenderError] =
     React.useState<PersonaVisualRenderErrorState | null>(null)
   const runtimeOverride = usePersonaVisualRuntimeStore((state) => state.override)
@@ -317,6 +319,25 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     const timer = window.setInterval(() => clearExpiredVisualOverride(), 1000)
     return () => window.clearInterval(timer)
   }, [clearExpiredVisualOverride])
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined
+    const handlePackActivated = (event: Event) => {
+      const detail = (event as CustomEvent<{ personaId?: unknown }>).detail
+      const eventPersonaId = String(detail?.personaId ?? "").trim()
+      const activePersonaId = String(resolvedPersona.activePersonaId ?? "").trim()
+      if (eventPersonaId && eventPersonaId === activePersonaId) {
+        setVisualPackRefreshNonce((current) => current + 1)
+      }
+    }
+    window.addEventListener(PERSONA_VISUAL_PACK_ACTIVATED_EVENT, handlePackActivated)
+    return () => {
+      window.removeEventListener(
+        PERSONA_VISUAL_PACK_ACTIVATED_EVENT,
+        handlePackActivated
+      )
+    }
+  }, [resolvedPersona.activePersonaId])
 
   React.useEffect(() => {
     const activePersonaId = String(resolvedPersona.activePersonaId || "").trim()
@@ -357,7 +378,11 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     return () => {
       cancelled = true
     }
-  }, [resolvedPersona.activePersonaId, resolvedPersona.hasTargetPersona])
+  }, [
+    resolvedPersona.activePersonaId,
+    resolvedPersona.hasTargetPersona,
+    visualPackRefreshNonce
+  ])
 
   const buddySummary = resolvedPersona.buddySummary
   const isDormant = resolvedPersona.hasTargetPersona && !buddySummary?.has_buddy

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -13,7 +13,10 @@ import {
 } from "@/store/persona-buddy-shell"
 import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
 import type { PersonaBuddyRenderContext } from "@/types/persona-buddy"
-import { asPersonaVisualCustomStateId } from "@/types/persona-visuals"
+import {
+  asPersonaVisualCustomStateId,
+  PERSONA_VISUAL_PACK_ACTIVATED_EVENT
+} from "@/types/persona-visuals"
 import { BuddyShellHost } from "../BuddyShellHost"
 
 const mocks = vi.hoisted(() => ({
@@ -504,6 +507,57 @@ describe("BuddyShellHost", () => {
 
     await waitFor(() => {
       expect(visualMocks.listPersonaVisualPacks).toHaveBeenCalledWith("persona-1")
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-visual-frame")).toHaveAttribute(
+        "src",
+        expect.stringContaining("/assets/idle.png")
+      )
+    })
+  })
+
+  it("reloads the active visual pack when the persona editor activates one", async () => {
+    const visualPack = buildVisualPack("persona-1")
+    visualMocks.listPersonaVisualPacks
+      .mockResolvedValue({
+        packs: [visualPack],
+        active_pack: visualPack
+      })
+      .mockResolvedValueOnce({
+        packs: [],
+        active_pack: null
+      })
+
+    renderHost({
+      context: {
+        surface_id: "persona-garden",
+        surface_active: true,
+        active_persona_id: "persona-1",
+        position_bucket: "sidepanel-desktop",
+        persona_source: "route-local",
+        buddy_summary: buildBuddySummary("persona-1"),
+        live_voice_state: "idle"
+      },
+      root: "sidepanel"
+    })
+
+    await waitFor(() => {
+      expect(visualMocks.listPersonaVisualPacks).toHaveBeenCalledWith("persona-1")
+    })
+    expect(screen.queryByTestId("persona-visual-frame")).not.toBeInTheDocument()
+
+    fireEvent(
+      window,
+      new CustomEvent(PERSONA_VISUAL_PACK_ACTIVATED_EVENT, {
+        detail: {
+          personaId: "persona-1",
+          packId: visualPack.id
+        }
+      })
+    )
+
+    await waitFor(() => {
+      expect(visualMocks.listPersonaVisualPacks.mock.calls.length).toBeGreaterThanOrEqual(2)
     })
     await waitFor(() => {
       expect(screen.getByTestId("persona-visual-frame")).toHaveAttribute(

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -770,6 +770,7 @@ const sourceBadgeClass =
   "inline-flex min-h-[22px] items-center rounded border px-1.5 py-0.5 text-xs font-medium"
 const sourceAvailableBadgeClass = `${sourceBadgeClass} border-state-ready/30 bg-state-ready/10 text-state-ready`
 const sourceUnavailableBadgeClass = `${sourceBadgeClass} border-state-unavailable/30 bg-state-unavailable/10 text-state-unavailable`
+const LOADING_STATE_LABEL = getDesignSystemState("loading").label
 
 export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   selectedPersonaId,
@@ -779,7 +780,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
   const loadingLabel = t("common:loading.title", {
-    defaultValue: getDesignSystemState("loading").label
+    defaultValue: LOADING_STATE_LABEL
   })
   const refreshLabel = t("common:refresh", "Refresh")
   const unknownLabel = t("common:unknown", { defaultValue: "unknown" })
@@ -877,6 +878,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const libraryPanelRef = React.useRef<HTMLDivElement | null>(null)
   const generationReadinessRequestIdRef = React.useRef(0)
   const duplicateTargetsRequestIdRef = React.useRef(0)
+  const starterPacksRequestIdRef = React.useRef(0)
   const libraryRequestIdRef = React.useRef(0)
   const importCommitInFlightRef = React.useRef(false)
 
@@ -1115,15 +1117,20 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
   const loadStarterPacks = React.useCallback(async () => {
     if (!isActive || !selectedPersonaId) {
+      starterPacksRequestIdRef.current += 1
       setStarterPacks([])
       setSelectedStarterPackId("")
       setStarterDraftTitle("")
       setStarterPacksLoading(false)
       return
     }
+    const requestId = starterPacksRequestIdRef.current + 1
+    starterPacksRequestIdRef.current = requestId
+    const isLatestRequest = () => starterPacksRequestIdRef.current === requestId
     setStarterPacksLoading(true)
     try {
       const response = await listPersonaVisualStarterPacks()
+      if (!isLatestRequest()) return
       const nextStarterPacks = response.starter_packs || []
       setStarterPacks(nextStarterPacks)
       setSelectedStarterPackId((current) => {
@@ -1134,18 +1141,20 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       })
       setStarterDraftTitle((current) => current || nextStarterPacks[0]?.title || "")
     } catch (loadError) {
-      setStarterPacks([])
-      setSelectedStarterPackId("")
-      setStarterDraftTitle("")
-      if (!(loadError instanceof PersonaVisualApiError && loadError.status === 404)) {
-        setError(
-          loadError instanceof Error
-            ? loadError.message
-            : "Failed to load bundled starter packs."
-        )
+      if (isLatestRequest()) {
+        setStarterPacks([])
+        setSelectedStarterPackId("")
+        setStarterDraftTitle("")
+        if (!(loadError instanceof PersonaVisualApiError && loadError.status === 404)) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Failed to load bundled starter packs."
+          )
+        }
       }
     } finally {
-      setStarterPacksLoading(false)
+      if (isLatestRequest()) setStarterPacksLoading(false)
     }
   }, [isActive, selectedPersonaId])
 
@@ -1195,6 +1204,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   }, [loadDuplicateTargets])
 
   React.useEffect(() => {
+    setStarterDraftTitle("")
     void loadStarterPacks()
   }, [loadStarterPacks])
 
@@ -2487,7 +2497,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       <VisualPackReusePanel
         selectedPersonaName={selectedPersonaName || selectedPersonaId}
         hasSelectedPack={Boolean(selectedPack)}
-        canImport={Boolean(selectedPack)}
+        canImport
         libraryItemCount={libraryItems.length}
         hasDuplicateTargets={availableDuplicateTargets.length > 0}
         duplicateTargetsLoading={duplicateTargetsLoading}
@@ -2520,7 +2530,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           </div>
           <div className="mt-3 grid gap-2 md:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)_auto]">
             <label className="text-xs text-text-muted">
-              <span className="mb-1 block">Starter</span>
+              <span className="mb-1 block">
+                {t("sidepanel:personaGarden.visuals.starterSelectLabel", {
+                  defaultValue: "Starter"
+                })}
+              </span>
               <select
                 data-testid="persona-visual-starter-pack-select"
                 className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
@@ -2543,7 +2557,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               </select>
             </label>
             <label className="text-xs text-text-muted">
-              <span className="mb-1 block">Draft title</span>
+              <span className="mb-1 block">
+                {t("sidepanel:personaGarden.visuals.starterDraftTitleLabel", {
+                  defaultValue: "Draft title"
+                })}
+              </span>
               <input
                 data-testid="persona-visual-starter-title-input"
                 className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
@@ -2561,16 +2579,168 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               disabled={!selectedStarterPack || copyingStarterPack}
               onClick={() => void handleCopyStarterPack()}
             >
-              Copy as draft
+              {t("sidepanel:personaGarden.visuals.starterCopyAsDraft", {
+                defaultValue: "Copy as draft"
+              })}
             </Button>
           </div>
           {selectedStarterPack ? (
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-text-muted">
-              <span>{selectedStarterPack.asset_count} asset</span>
-              <span>{selectedStarterPack.total_bytes} bytes</span>
+              <span>
+                {selectedStarterPack.asset_count}{" "}
+                {t("sidepanel:personaGarden.visuals.starterAssetUnit", {
+                  defaultValue: "assets"
+                })}
+              </span>
+              <span>
+                {selectedStarterPack.total_bytes}{" "}
+                {t("sidepanel:personaGarden.visuals.starterBytesUnit", {
+                  defaultValue: "bytes"
+                })}
+              </span>
               <span>{selectedStarterPack.states_offered.join(", ")}</span>
             </div>
           ) : null}
+        </div>
+      ) : null}
+
+      {!selectedPack ? (
+        <div className="rounded-lg border border-border bg-surface p-3">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+            Portability
+          </div>
+          <div
+            data-testid="persona-visual-portability-copy"
+            className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
+          >
+            <div>
+              {t("sidepanel:personaGarden.visuals.importPreviewHelp", {
+                defaultValue:
+                  "Import preview validates a portable pack archive before it changes this persona."
+              })}
+            </div>
+            <div>
+              {t("sidepanel:personaGarden.visuals.importCommitHelp", {
+                defaultValue:
+                  "Commit import creates a reviewed draft pack for this persona."
+              })}
+            </div>
+          </div>
+          <div className="mt-3 rounded border border-border bg-bg p-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <Typography.Text strong>Import preview</Typography.Text>
+              <Tag>review only</Tag>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <input
+                ref={importPreviewInputRef}
+                data-testid="persona-visual-import-preview-input"
+                type="file"
+                accept={`${PORTABLE_VISUAL_PACK_EXTENSION},application/zip,application/octet-stream`}
+                className="text-xs text-text"
+                onChange={(event) =>
+                  setSelectedImportPreviewFile(event.target.files?.[0] ?? null)
+                }
+              />
+              <Button
+                data-testid="persona-visual-import-preview-button"
+                size="small"
+                icon={<FileSearch className="h-3.5 w-3.5" />}
+                loading={previewingImport}
+                disabled={!selectedImportPreviewFile || Boolean(importPreviewFileError)}
+                onClick={() => void handleStartImportPreview()}
+              >
+                Preview
+              </Button>
+              <Button
+                data-testid="persona-visual-import-preview-refresh-button"
+                size="small"
+                icon={<RefreshCw className="h-3.5 w-3.5" />}
+                loading={refreshingImportPreview}
+                disabled={!importPreview?.preview_id}
+                onClick={() => void handleRefreshImportPreview()}
+              >
+                Refresh
+              </Button>
+            </div>
+            {importPreviewFileError ? (
+              <div
+                data-testid="persona-visual-import-preview-file-error"
+                className="mt-2 text-xs text-state-error"
+              >
+                {importPreviewFileError}
+              </div>
+            ) : null}
+            {importPreview ? (
+              <div className="mt-2 space-y-2 text-xs text-text-muted">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Tag data-testid="persona-visual-import-preview-status">
+                    {importPreview.status}
+                  </Tag>
+                  <span>{importPreview.stage}</span>
+                  <span>{importPreview.preview_id}</span>
+                </div>
+                <div data-testid="persona-visual-import-preview-summary">
+                  {formatImportPreviewSummary(importPreview)}
+                </div>
+                {canCommitImportPreview ? (
+                  <div className="border-t border-border pt-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="font-medium text-text">
+                        Commit reviewed import
+                      </div>
+                      <Tag>creates draft</Tag>
+                    </div>
+                    {!importPreviewCommitEligible ? (
+                      <div
+                        data-testid="persona-visual-import-commit-blocked"
+                        className="mt-2 rounded border border-border bg-bg p-2 text-text-muted"
+                      >
+                        {t(
+                          "sidepanel:personaGarden.visuals.importCommitBlocked",
+                          {
+                            defaultValue:
+                              "Commit unavailable until preview blockers are resolved"
+                          }
+                        )}
+                      </div>
+                    ) : null}
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <Button
+                        data-testid="persona-visual-import-commit-button"
+                        size="small"
+                        icon={<CheckCircle2 className="h-3.5 w-3.5" />}
+                        loading={committingImport}
+                        disabled={!canStartImportCommit}
+                        onClick={() => void handleStartImportCommit()}
+                      >
+                        Commit import
+                      </Button>
+                      <Button
+                        data-testid="persona-visual-import-commit-refresh-button"
+                        size="small"
+                        icon={<RefreshCw className="h-3.5 w-3.5" />}
+                        loading={refreshingImportCommit}
+                        disabled={!importCommitJob?.job_id}
+                        onClick={() => void handleRefreshImportCommit()}
+                      >
+                        Refresh commit
+                      </Button>
+                    </div>
+                    {importCommitJob ? (
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <Tag data-testid="persona-visual-import-commit-status">
+                          {importCommitJob.status}
+                        </Tag>
+                        <span>{importCommitJob.stage}</span>
+                        <span>{importCommitJob.job_id}</span>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
         </div>
       ) : null}
 

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -23,6 +23,7 @@ import {
   createPersonaVisualGenerationJob,
   createPersonaVisualImportPreview,
   createPersonaVisualPack,
+  copyPersonaVisualStarterPack,
   deletePersonaVisualLibraryItem,
   deactivatePersonaVisualPack,
   downloadPersonaVisualPackExportArchive,
@@ -31,6 +32,7 @@ import {
   getPersonaVisualImportCommitStatus,
   getPersonaVisualImportPreview,
   getPersonaVisualPackExportJob,
+  listPersonaVisualStarterPacks,
   listPersonaVisualLibraryItems,
   listPersonaVisualCandidates,
   listPersonaVisualDuplicateTargets,
@@ -45,6 +47,7 @@ import {
   uploadPersonaVisualAsset,
   usePersonaVisualLibraryItem
 } from "@/services/persona-visuals"
+import { PERSONA_VISUAL_PACK_ACTIVATED_EVENT } from "@/types/persona-visuals"
 import type {
   PersonaVisualAnimation,
   PersonaVisualAsset,
@@ -67,6 +70,7 @@ import type {
   PersonaVisualPackExportResponse,
   PersonaVisualPortabilityJobResponse,
   PersonaVisualRendererImportPreview,
+  PersonaVisualStarterPackSummary,
   PersonaVisualStateId
 } from "@/types/persona-visuals"
 import {
@@ -774,7 +778,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   onOpenPersonaVisuals
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
-  const loadingLabel = t("common:loading", getDesignSystemState("loading").label)
+  const loadingLabel = t("common:loading.title", {
+    defaultValue: getDesignSystemState("loading").label
+  })
   const refreshLabel = t("common:refresh", "Refresh")
   const unknownLabel = t("common:unknown", { defaultValue: "unknown" })
   const [packs, setPacks] = React.useState<PersonaVisualPack[]>([])
@@ -816,6 +822,13 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const [duplicateTitle, setDuplicateTitle] = React.useState("")
   const [duplicatingPack, setDuplicatingPack] = React.useState(false)
   const [lastDuplicatedPersonaId, setLastDuplicatedPersonaId] = React.useState("")
+  const [starterPacks, setStarterPacks] = React.useState<
+    PersonaVisualStarterPackSummary[]
+  >([])
+  const [starterPacksLoading, setStarterPacksLoading] = React.useState(false)
+  const [selectedStarterPackId, setSelectedStarterPackId] = React.useState("")
+  const [starterDraftTitle, setStarterDraftTitle] = React.useState("")
+  const [copyingStarterPack, setCopyingStarterPack] = React.useState(false)
   const [libraryItems, setLibraryItems] = React.useState<PersonaVisualLibraryItem[]>([])
   const [libraryLoading, setLibraryLoading] = React.useState(false)
   const [savingToLibrary, setSavingToLibrary] = React.useState(false)
@@ -875,6 +888,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   )
   const selectedDuplicateTarget =
     availableDuplicateTargets.find((target) => target.id === duplicateTargetId) ?? null
+  const selectedStarterPack =
+    starterPacks.find((starter) => starter.id === selectedStarterPackId) ??
+    starterPacks[0] ??
+    null
   const selectedPackLibraryItem = React.useMemo(
     () =>
       selectedPack
@@ -1096,6 +1113,42 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     }
   }, [isActive, selectedPersonaId])
 
+  const loadStarterPacks = React.useCallback(async () => {
+    if (!isActive || !selectedPersonaId) {
+      setStarterPacks([])
+      setSelectedStarterPackId("")
+      setStarterDraftTitle("")
+      setStarterPacksLoading(false)
+      return
+    }
+    setStarterPacksLoading(true)
+    try {
+      const response = await listPersonaVisualStarterPacks()
+      const nextStarterPacks = response.starter_packs || []
+      setStarterPacks(nextStarterPacks)
+      setSelectedStarterPackId((current) => {
+        if (current && nextStarterPacks.some((starter) => starter.id === current)) {
+          return current
+        }
+        return nextStarterPacks[0]?.id ?? ""
+      })
+      setStarterDraftTitle((current) => current || nextStarterPacks[0]?.title || "")
+    } catch (loadError) {
+      setStarterPacks([])
+      setSelectedStarterPackId("")
+      setStarterDraftTitle("")
+      if (!(loadError instanceof PersonaVisualApiError && loadError.status === 404)) {
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Failed to load bundled starter packs."
+        )
+      }
+    } finally {
+      setStarterPacksLoading(false)
+    }
+  }, [isActive, selectedPersonaId])
+
   const loadLibrary = React.useCallback(async () => {
     if (!isActive || !selectedPersonaId) {
       libraryRequestIdRef.current += 1
@@ -1140,6 +1193,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   React.useEffect(() => {
     void loadDuplicateTargets()
   }, [loadDuplicateTargets])
+
+  React.useEffect(() => {
+    void loadStarterPacks()
+  }, [loadStarterPacks])
 
   React.useEffect(() => {
     void loadLibrary()
@@ -1397,6 +1454,35 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       )
     } finally {
       setDuplicatingPack(false)
+    }
+  }
+
+  const handleCopyStarterPack = async () => {
+    if (!selectedPersonaId || !selectedStarterPack) return
+    setCopyingStarterPack(true)
+    setError(null)
+    try {
+      const copied = await copyPersonaVisualStarterPack(selectedStarterPack.id, {
+        target_persona_id: selectedPersonaId,
+        title: starterDraftTitle.trim() || selectedStarterPack.title
+      })
+      await loadPacks(copied.id)
+      setStatusMessage(
+        t("sidepanel:personaGarden.visuals.starterCopiedDraft", {
+          defaultValue:
+            "Starter pack copied as a draft. Review and activate it when ready."
+        })
+      )
+    } catch (copyError) {
+      setError(
+        copyError instanceof Error
+          ? copyError.message
+          : t("sidepanel:personaGarden.visuals.starterCopyError", {
+              defaultValue: "Failed to copy bundled starter pack."
+            })
+      )
+    } finally {
+      setCopyingStarterPack(false)
     }
   }
 
@@ -1715,6 +1801,16 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           defaultValue: "Visual pack activated."
         })
       )
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(
+          new CustomEvent(PERSONA_VISUAL_PACK_ACTIVATED_EVENT, {
+            detail: {
+              personaId: selectedPersonaId,
+              packId: active.id
+            }
+          })
+        )
+      }
     } catch (activateError) {
       setError(
         activateError instanceof Error
@@ -2400,6 +2496,83 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         onOpenImport={openImportArchivePicker}
         onOpenDuplicate={focusDuplicateControls}
       />
+
+      {starterPacksLoading || starterPacks.length ? (
+        <div
+          data-testid="persona-visual-starter-pack-panel"
+          className="rounded-lg border border-border bg-surface p-3"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+                {t("sidepanel:personaGarden.visuals.starterHeading", {
+                  defaultValue: "Default starter pack"
+                })}
+              </div>
+              <div className="mt-1 text-xs leading-5 text-text-muted">
+                {t("sidepanel:personaGarden.visuals.starterDescription", {
+                  defaultValue:
+                    "Copy a bundled sprite-frame pack as a draft, then review and activate it."
+                })}
+              </div>
+            </div>
+            <Tag>sprite_frames</Tag>
+          </div>
+          <div className="mt-3 grid gap-2 md:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)_auto]">
+            <label className="text-xs text-text-muted">
+              <span className="mb-1 block">Starter</span>
+              <select
+                data-testid="persona-visual-starter-pack-select"
+                className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                value={selectedStarterPack?.id || ""}
+                disabled={starterPacksLoading || !starterPacks.length}
+                onChange={(event) => {
+                  const nextId = event.target.value
+                  const nextStarter = starterPacks.find(
+                    (starter) => starter.id === nextId
+                  )
+                  setSelectedStarterPackId(nextId)
+                  setStarterDraftTitle(nextStarter?.title || "")
+                }}
+              >
+                {starterPacks.map((starter) => (
+                  <option key={starter.id} value={starter.id}>
+                    {starter.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs text-text-muted">
+              <span className="mb-1 block">Draft title</span>
+              <input
+                data-testid="persona-visual-starter-title-input"
+                className="w-full rounded border border-border bg-bg px-2 py-1 text-sm text-text"
+                value={starterDraftTitle}
+                disabled={!selectedStarterPack}
+                onChange={(event) => setStarterDraftTitle(event.target.value)}
+              />
+            </label>
+            <Button
+              data-testid="persona-visual-starter-copy-button"
+              className="self-end"
+              size="small"
+              icon={<Copy className="h-3.5 w-3.5" />}
+              loading={copyingStarterPack}
+              disabled={!selectedStarterPack || copyingStarterPack}
+              onClick={() => void handleCopyStarterPack()}
+            >
+              Copy as draft
+            </Button>
+          </div>
+          {selectedStarterPack ? (
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+              <span>{selectedStarterPack.asset_count} asset</span>
+              <span>{selectedStarterPack.total_bytes} bytes</span>
+              <span>{selectedStarterPack.states_offered.join(", ")}</span>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       {error ? (
         <div className="rounded-md border border-danger/30 bg-danger/10 p-2 text-xs text-danger">

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -460,6 +460,9 @@ describe("VisualPackEditor", () => {
       />
     )
 
+    expect(await screen.findByTestId("persona-visual-pack-status")).toHaveTextContent(
+      "draft"
+    )
     const portability = await screen.findByTestId("persona-visual-portability-copy")
     expect(portability).toHaveTextContent(
       "Import preview validates a portable pack archive before it changes this persona"
@@ -578,6 +581,118 @@ describe("VisualPackEditor", () => {
     expect(
       calls.some((call) => call.includes("/starter-copy-1/activate"))
     ).toBe(false)
+  })
+
+  it("ignores stale starter pack responses after switching personas", async () => {
+    const firstStarterResponse = deferredResponse<{
+      ok: boolean
+      json: () => Promise<unknown>
+    }>()
+    let starterRequests = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs" &&
+        method === "GET"
+      ) {
+        return okResponse([])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-2/visual-packs" &&
+        method === "GET"
+      ) {
+        return okResponse([])
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        starterRequests += 1
+        if (starterRequests === 1) return firstStarterResponse.promise
+        return okResponse({
+          starter_packs: [
+            {
+              id: "persona-2-starter",
+              title: "Persona 2 Starter",
+              renderer_type: "sprite_frames",
+              manifest_version: 1,
+              states_offered: ["idle"],
+              asset_count: 1,
+              total_bytes: 96,
+              tags: []
+            }
+          ]
+        })
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([
+          { id: "persona-1", name: "First Persona" },
+          { id: "persona-2", name: "Second Persona" }
+        ])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    const { rerender } = render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="First Persona"
+        isActive
+      />
+    )
+
+    await waitFor(() => expect(starterRequests).toBe(1))
+
+    rerender(
+      <VisualPackEditor
+        selectedPersonaId="persona-2"
+        selectedPersonaName="Second Persona"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-starter-pack-select")).toHaveValue(
+        "persona-2-starter"
+      )
+    )
+    expect(screen.getByTestId("persona-visual-starter-title-input")).toHaveValue(
+      "Persona 2 Starter"
+    )
+
+    await act(async () => {
+      firstStarterResponse.resolve({
+        ok: true,
+        json: async () => ({
+          starter_packs: [
+            {
+              id: "persona-1-starter",
+              title: "Persona 1 Starter",
+              renderer_type: "sprite_frames",
+              manifest_version: 1,
+              states_offered: ["idle"],
+              asset_count: 1,
+              total_bytes: 96,
+              tags: []
+            }
+          ]
+        })
+      })
+      await firstStarterResponse.promise
+    })
+
+    expect(screen.getByTestId("persona-visual-starter-pack-select")).toHaveValue(
+      "persona-2-starter"
+    )
+    expect(screen.getByTestId("persona-visual-starter-title-input")).toHaveValue(
+      "Persona 2 Starter"
+    )
   })
 
   it("surfaces reusable visual-pack routes through existing editor controls", async () => {
@@ -720,7 +835,7 @@ describe("VisualPackEditor", () => {
     expect(
       within(reusePanel).getByRole("button", { name: /duplicate to persona/i })
     ).toBeDisabled()
-    expect(within(reusePanel).getByRole("button", { name: /import archive/i })).toBeDisabled()
+    expect(within(reusePanel).getByRole("button", { name: /import archive/i })).toBeEnabled()
     expect(
       within(reusePanel).getByRole("button", { name: /use personal library/i })
     ).toBeEnabled()

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -188,7 +188,7 @@ describe("VisualPackEditor", () => {
               defaultValue?: string
             }
       ) => {
-        if (key === "common:loading") return "Localized loading"
+        if (key === "common:loading.title") return "Localized loading"
         if (key === "common:refresh") return "Localized refresh"
         if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
         if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
@@ -474,6 +474,110 @@ describe("VisualPackEditor", () => {
     expect(screen.getByTestId("persona-visual-generation-review-copy")).toHaveTextContent(
       "Generated candidates stay in review until accepted"
     )
+  })
+
+  it("copies a bundled starter pack as an inactive draft before activation", async () => {
+    const calls: string[] = []
+    const copiedPack = {
+      id: "starter-copy-1",
+      persona_id: "persona-1",
+      title: "Research Buddy Starter",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 1
+    }
+    let starterCopied = false
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse(starterCopied ? [copiedPack] : [])
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse({
+          starter_packs: [
+            {
+              id: "research-buddy-starter",
+              title: "Research Buddy Starter",
+              description: "A deterministic sprite-frame starter.",
+              renderer_type: "sprite_frames",
+              manifest_version: 1,
+              states_offered: ["idle", "listening", "thinking", "speaking", "error"],
+              asset_count: 1,
+              total_bytes: 92,
+              tags: ["starter", "sprite_frames"],
+              license_label: "bundled"
+            }
+          ]
+        })
+      }
+      if (
+        path === "/api/v1/persona/visual-starter-packs/research-buddy-starter/copy" &&
+        method === "POST"
+      ) {
+        starterCopied = true
+        expect(parseJsonBody(init?.body)).toMatchObject({
+          target_persona_id: "persona-1"
+        })
+        return okResponse(copiedPack)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/starter-copy-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/starter-copy-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-empty")).toHaveTextContent(
+        "does not have a visual pack yet"
+      )
+    )
+    expect(await screen.findByTestId("persona-visual-starter-pack-select")).toHaveValue(
+      "research-buddy-starter"
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-starter-copy-button"))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue(
+        "starter-copy-1"
+      )
+    )
+    expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent("draft")
+    expect(
+      calls.some((call) => call.includes("/starter-copy-1/activate"))
+    ).toBe(false)
   })
 
   it("surfaces reusable visual-pack routes through existing editor controls", async () => {

--- a/apps/packages/ui/src/services/__tests__/persona-visuals.test.ts
+++ b/apps/packages/ui/src/services/__tests__/persona-visuals.test.ts
@@ -10,7 +10,11 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   }
 }))
 
-import { getPersonaVisualRendererCapabilities } from "../persona-visuals"
+import {
+  copyPersonaVisualStarterPack,
+  getPersonaVisualRendererCapabilities,
+  listPersonaVisualStarterPacks
+} from "../persona-visuals"
 
 describe("persona visuals service", () => {
   beforeEach(() => {
@@ -81,5 +85,77 @@ describe("persona visuals service", () => {
     await expect(getPersonaVisualRendererCapabilities()).resolves.toEqual({
       renderers: []
     })
+  })
+
+  it("loads bundled starter packs through the starter catalog endpoint", async () => {
+    const starterPack = {
+      id: "research-buddy-starter",
+      title: "Research Buddy Starter",
+      description: "A deterministic sprite-frame starter.",
+      renderer_type: "sprite_frames",
+      manifest_version: 1,
+      states_offered: ["idle", "listening", "thinking", "speaking", "error"],
+      asset_count: 1,
+      total_bytes: 92,
+      tags: ["starter", "sprite_frames"],
+      license_label: "bundled"
+    }
+    mocks.fetchWithAuth.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ starter_packs: [starterPack] })
+    })
+
+    await expect(listPersonaVisualStarterPacks()).resolves.toEqual({
+      starter_packs: [starterPack]
+    })
+
+    expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+      "/api/v1/persona/visual-starter-packs",
+      expect.objectContaining({ method: "GET" })
+    )
+  })
+
+  it("copies a bundled starter pack into a target persona draft", async () => {
+    const copiedPack = {
+      id: "starter-copy-1",
+      persona_id: "persona-1",
+      title: "Research Buddy Starter",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: {
+        manifest_version: 1,
+        renderer_type: "sprite_frames",
+        states: {},
+        animations: {}
+      },
+      assets: []
+    }
+    mocks.fetchWithAuth.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => copiedPack
+    })
+
+    await expect(
+      copyPersonaVisualStarterPack("research-buddy-starter", {
+        target_persona_id: "persona-1",
+        title: "Starter copy"
+      })
+    ).resolves.toEqual(copiedPack)
+
+    expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+      "/api/v1/persona/visual-starter-packs/research-buddy-starter/copy",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json"
+        }),
+        body: JSON.stringify({
+          target_persona_id: "persona-1",
+          title: "Starter copy"
+        })
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/services/persona-visuals.ts
+++ b/apps/packages/ui/src/services/persona-visuals.ts
@@ -29,7 +29,9 @@ import type {
   PersonaVisualPackExportResponse,
   PersonaVisualPackListResponse,
   PersonaVisualPortabilityJobResponse,
-  PersonaVisualRendererCapabilitiesResponse
+  PersonaVisualRendererCapabilitiesResponse,
+  PersonaVisualStarterPackCopyRequest,
+  PersonaVisualStarterPackListResponse
 } from "@/types/persona-visuals"
 
 type PersonaVisualFetchInit = {
@@ -149,6 +151,32 @@ export async function getPersonaVisualRendererCapabilities(): Promise<
   return {
     renderers: Array.isArray(payload?.renderers) ? payload.renderers : []
   }
+}
+
+export async function listPersonaVisualStarterPacks(): Promise<
+  PersonaVisualStarterPackListResponse
+> {
+  const payload = await fetchPersonaVisualJson<PersonaVisualStarterPackListResponse>(
+    "/api/v1/persona/visual-starter-packs"
+  )
+  return {
+    starter_packs: Array.isArray(payload?.starter_packs)
+      ? payload.starter_packs
+      : []
+  }
+}
+
+export async function copyPersonaVisualStarterPack(
+  starterPackId: string,
+  payload: PersonaVisualStarterPackCopyRequest
+): Promise<PersonaVisualPack> {
+  return fetchPersonaVisualJson<PersonaVisualPack>(
+    `/api/v1/persona/visual-starter-packs/${encodeURIComponent(starterPackId)}/copy`,
+    {
+      method: "POST",
+      body: payload
+    }
+  )
 }
 
 export async function getPersonaVisualPack(

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -17,6 +17,10 @@ declare const personaVisualCustomStateIdBrand: unique symbol
 export type PersonaVisualCustomStateId = string & {
   readonly [personaVisualCustomStateIdBrand]: "PersonaVisualCustomStateId"
 }
+
+export const PERSONA_VISUAL_PACK_ACTIVATED_EVENT =
+  "tldw:persona-visual-pack-activated"
+
 export type PersonaVisualStateId =
   | PersonaVisualBuiltinStateId
   | PersonaVisualCustomStateId
@@ -77,6 +81,28 @@ export interface PersonaVisualRendererCapability {
 
 export interface PersonaVisualRendererCapabilitiesResponse {
   renderers: PersonaVisualRendererCapability[]
+}
+
+export interface PersonaVisualStarterPackSummary {
+  id: string
+  title: string
+  description?: string | null
+  renderer_type: PersonaVisualRendererType | string
+  manifest_version: number
+  states_offered: string[]
+  asset_count: number
+  total_bytes: number
+  tags: string[]
+  license_label?: string | null
+}
+
+export interface PersonaVisualStarterPackListResponse {
+  starter_packs: PersonaVisualStarterPackSummary[]
+}
+
+export interface PersonaVisualStarterPackCopyRequest {
+  target_persona_id: string
+  title?: string | null
 }
 
 export type PersonaVisualPackStatus =

--- a/apps/tldw-frontend/e2e/fixtures/persona-visual-packs.ts
+++ b/apps/tldw-frontend/e2e/fixtures/persona-visual-packs.ts
@@ -148,12 +148,21 @@ export const buildPortablePersonaVisualPackUpload = async () => {
     PERSONA_VISUAL_E2E_FRAME_DATA_URI.split(",")[1] || "",
     "base64"
   )
-  const visualManifest = buildPersonaVisualPackFixture("portable-source", {
-    packId: "portable-upload-pack",
-    title: "Uploaded Visual Pack",
-    status: "draft",
-    provenance: "portable_fixture"
-  }).manifest
+  const uploadedAssetId = "portable-upload-pack-frame-idle"
+  const visualManifest = {
+    manifest_version: 1,
+    renderer_type: "sprite_frames",
+    states: {
+      idle: { animation_id: "idle-loop" }
+    },
+    animations: {
+      "idle-loop": {
+        frames: [{ asset_id: uploadedAssetId, duration_ms: 250 }],
+        loop: true
+      }
+    },
+    fallbacks: {}
+  }
   const manifestBytes = stableJson({
     archive_profile: "backup",
     counts: { assets: 1, assets_with_bytes: 1 },
@@ -178,7 +187,7 @@ export const buildPortablePersonaVisualPackUpload = async () => {
         asset_sha256: sha256(frameBytes),
         mime_type: "image/png",
         original_filename: "uploaded-idle.png",
-        source_asset_id: "portable-upload-pack-frame-idle"
+        source_asset_id: uploadedAssetId
       }
     ]
   })

--- a/apps/tldw-frontend/e2e/fixtures/persona-visual-packs.ts
+++ b/apps/tldw-frontend/e2e/fixtures/persona-visual-packs.ts
@@ -1,0 +1,212 @@
+import { createHash } from "node:crypto"
+
+import JSZip from "jszip"
+
+export const PERSONA_VISUAL_E2E_PERSONA_ID = "visual_persona_e2e"
+export const PERSONA_VISUAL_E2E_SESSION_ID = "sess-visual-e2e-001"
+export const PERSONA_VISUAL_E2E_FRAME_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+
+export const PERSONA_VISUAL_E2E_STARTER_PACK = {
+  id: "research-buddy-starter",
+  title: "Research Buddy Starter",
+  description: "A deterministic bundled sprite-frame visual for Buddy setup.",
+  renderer_type: "sprite_frames",
+  manifest_version: 1,
+  states_offered: ["idle", "listening", "thinking", "speaking", "error"],
+  asset_count: 1,
+  total_bytes: 96,
+  tags: ["starter", "sprite_frames"],
+  license_label: "bundled"
+}
+
+type BuildPersonaVisualPackOptions = {
+  packId?: string
+  title?: string
+  status?: "draft" | "active"
+  provenance?: string
+}
+
+export const buildPersonaVisualPackFixture = (
+  personaId: string,
+  options: BuildPersonaVisualPackOptions = {}
+) => {
+  const packId = options.packId ?? "visual-pack-e2e"
+  const assetIds = {
+    idle: `${packId}-frame-idle`,
+    speaking: `${packId}-frame-speaking`,
+    tool: `${packId}-frame-tool`,
+    error: `${packId}-frame-error`
+  }
+  const buildAsset = (id: string) => ({
+    id,
+    pack_id: packId,
+    persona_id: personaId,
+    asset_role: "frame",
+    storage_key: `persona-visuals/${personaId}/${id}.png`,
+    url: PERSONA_VISUAL_E2E_FRAME_DATA_URI,
+    original_filename: `${id}.png`,
+    mime_type: "image/png",
+    byte_size: 96,
+    checksum_sha256: `${id}-checksum`,
+    width: 1,
+    height: 1,
+    provenance: "e2e_fixture",
+    created_at: "2026-05-08T00:00:00.000Z",
+    last_modified: "2026-05-08T00:00:00.000Z",
+    version: 1
+  })
+  const assetsById = {
+    [assetIds.idle]: buildAsset(assetIds.idle),
+    [assetIds.speaking]: buildAsset(assetIds.speaking),
+    [assetIds.tool]: buildAsset(assetIds.tool),
+    [assetIds.error]: buildAsset(assetIds.error)
+  }
+
+  return {
+    id: packId,
+    persona_id: personaId,
+    user_id: "e2e-user",
+    title: options.title ?? "Visual Runtime Pack",
+    renderer_type: "sprite_frames",
+    status: options.status ?? "active",
+    manifest_version: 1,
+    manifest: {
+      manifest_version: 1,
+      renderer_type: "sprite_frames",
+      states: {
+        idle: { animation_id: "idle-loop" },
+        listening: { animation_id: "idle-loop" },
+        thinking: { animation_id: "idle-loop" },
+        speaking: { animation_id: "speaking-loop" },
+        tool_running: { animation_id: "tool-loop" },
+        error: { animation_id: "error-loop" }
+      },
+      animations: {
+        "idle-loop": {
+          frames: [{ asset_id: assetIds.idle, duration_ms: 250 }],
+          loop: true
+        },
+        "speaking-loop": {
+          frames: [{ asset_id: assetIds.speaking, duration_ms: 250 }],
+          loop: true
+        },
+        "tool-loop": {
+          frames: [{ asset_id: assetIds.tool, duration_ms: 250 }],
+          loop: true
+        },
+        "error-loop": {
+          frames: [{ asset_id: assetIds.error, duration_ms: 250 }],
+          loop: false
+        }
+      },
+      fallbacks: {
+        speaking: ["idle"],
+        tool_running: ["idle"],
+        error: ["idle"]
+      },
+      authored_triggers: [
+        {
+          id: "mcp-runtime-override",
+          source: "mcp_runtime",
+          match: "persona_visuals.trigger_state",
+          state: "speaking",
+          duration_ms: 5000,
+          priority: 10
+        }
+      ]
+    },
+    active_at:
+      options.status === "draft" ? null : "2026-05-08T00:00:00.000Z",
+    assets: Object.values(assetsById),
+    assets_by_id: assetsById,
+    provenance: options.provenance ?? "e2e_fixture",
+    created_at: "2026-05-08T00:00:00.000Z",
+    last_modified: "2026-05-08T00:00:00.000Z",
+    version: 1
+  }
+}
+
+const sortJsonValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortJsonValue)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)])
+  )
+}
+
+const stableJson = (payload: unknown): Buffer =>
+  Buffer.from(JSON.stringify(sortJsonValue(payload)), "utf8")
+
+const sha256 = (payload: Buffer): string =>
+  createHash("sha256").update(payload).digest("hex")
+
+export const buildPortablePersonaVisualPackUpload = async () => {
+  const frameBytes = Buffer.from(
+    PERSONA_VISUAL_E2E_FRAME_DATA_URI.split(",")[1] || "",
+    "base64"
+  )
+  const visualManifest = buildPersonaVisualPackFixture("portable-source", {
+    packId: "portable-upload-pack",
+    title: "Uploaded Visual Pack",
+    status: "draft",
+    provenance: "portable_fixture"
+  }).manifest
+  const manifestBytes = stableJson({
+    archive_profile: "backup",
+    counts: { assets: 1, assets_with_bytes: 1 },
+    pack_title: "Uploaded Visual Pack",
+    renderer_type: "sprite_frames",
+    schema_version: "tldw.persona_visual_pack.v1"
+  })
+  const packBytes = stableJson({
+    pack: {
+      renderer_type: "sprite_frames",
+      source_persona_id: "portable-source",
+      title: "Uploaded Visual Pack",
+      visual_manifest: visualManifest
+    }
+  })
+  const assetsBytes = stableJson({
+    assets: [
+      {
+        asset_bytes_status: "present",
+        asset_path: "assets/persona_visuals/uploaded-idle.png",
+        asset_role: "frame",
+        asset_sha256: sha256(frameBytes),
+        mime_type: "image/png",
+        original_filename: "uploaded-idle.png",
+        source_asset_id: "portable-upload-pack-frame-idle"
+      }
+    ]
+  })
+  const entries = {
+    "manifest.json": manifestBytes,
+    "metadata/pack.json": packBytes,
+    "metadata/assets.json": assetsBytes,
+    "assets/persona_visuals/uploaded-idle.png": frameBytes
+  }
+  const checksumBytes = stableJson(
+    Object.fromEntries(
+      Object.entries(entries).map(([path, payload]) => [path, sha256(payload)])
+    )
+  )
+  const archive = new JSZip()
+  const fixedDate = new Date("2026-05-08T00:00:00.000Z")
+  for (const [path, payload] of Object.entries(entries)) {
+    archive.file(path, payload, { date: fixedDate })
+  }
+  archive.file("checksums/sha256.json", checksumBytes, { date: fixedDate })
+
+  return {
+    name: "uploaded-visual-pack.tldw-persona-vpack",
+    mimeType: "application/vnd.tldw.persona.visual-pack+zip",
+    buffer: await archive.generateAsync({
+      type: "nodebuffer",
+      compression: "DEFLATE",
+      compressionOptions: { level: 9 }
+    })
+  }
+}

--- a/apps/tldw-frontend/e2e/workflows/persona-live.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/persona-live.spec.ts
@@ -11,6 +11,13 @@ import {
   skipIfServerUnavailable
 } from "../utils/fixtures"
 import { TEST_CONFIG, fetchWithApiKey, seedAuth } from "../utils/helpers"
+import {
+  buildPersonaVisualPackFixture,
+  buildPortablePersonaVisualPackUpload,
+  PERSONA_VISUAL_E2E_PERSONA_ID,
+  PERSONA_VISUAL_E2E_SESSION_ID,
+  PERSONA_VISUAL_E2E_STARTER_PACK
+} from "../fixtures/persona-visual-packs"
 
 type DocsInfoPayload = {
   capabilities?: Record<string, unknown> | null
@@ -26,10 +33,8 @@ type PersonaProfilePayload = {
 }
 
 const DEFAULT_PERSONA_ID = "research_assistant"
-const VISUAL_PERSONA_ID = "visual_persona_e2e"
-const VISUAL_SESSION_ID = "sess-visual-e2e-001"
-const VISUAL_FRAME_DATA_URI =
-  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+const VISUAL_PERSONA_ID = PERSONA_VISUAL_E2E_PERSONA_ID
+const VISUAL_SESSION_ID = PERSONA_VISUAL_E2E_SESSION_ID
 const COMPLETED_SETUP_STEPS = [
   "persona",
   "voice",
@@ -57,7 +62,7 @@ const VISUAL_BUDDY_SUMMARY = {
   }
 }
 
-type PersonaVisualMockMode = "active-pack" | "broken-pack"
+type PersonaVisualMockMode = "active-pack" | "broken-pack" | "empty-pack"
 
 type PersonaMockWindow = Window & {
   __personaWsMock?: {
@@ -85,103 +90,17 @@ const extractProfilePersonaId = (route: Route): string => {
   return decodeURIComponent(parts[profileIndex + 1] || VISUAL_PERSONA_ID)
 }
 
-const buildPersonaVisualPack = (personaId: string) => {
-  const assetIds = {
-    idle: "frame-idle",
-    speaking: "frame-speaking",
-    tool: "frame-tool",
-    error: "frame-error"
-  }
-  const buildAsset = (id: string) => ({
-    id,
-    pack_id: "visual-pack-e2e",
-    persona_id: personaId,
-    asset_role: "frame",
-    storage_key: `persona-visuals/${personaId}/${id}.png`,
-    url: VISUAL_FRAME_DATA_URI,
-    original_filename: `${id}.png`,
-    mime_type: "image/png",
-    byte_size: 96,
-    checksum_sha256: `${id}-checksum`,
-    width: 1,
-    height: 1,
-    provenance: "e2e_fixture",
-    created_at: "2026-05-08T00:00:00.000Z",
-    last_modified: "2026-05-08T00:00:00.000Z",
-    version: 1
-  })
-  const assetsById = {
-    [assetIds.idle]: buildAsset(assetIds.idle),
-    [assetIds.speaking]: buildAsset(assetIds.speaking),
-    [assetIds.tool]: buildAsset(assetIds.tool),
-    [assetIds.error]: buildAsset(assetIds.error)
-  }
-
-  return {
-    id: "visual-pack-e2e",
-    persona_id: personaId,
-    user_id: "e2e-user",
-    title: "Visual Runtime Pack",
-    renderer_type: "sprite_frames",
-    status: "active",
-    manifest_version: 1,
-    manifest: {
-      manifest_version: 1,
-      renderer_type: "sprite_frames",
-      states: {
-        idle: { animation_id: "idle-loop" },
-        speaking: { animation_id: "speaking-loop" },
-        tool_running: { animation_id: "tool-loop" },
-        error: { animation_id: "error-loop" }
-      },
-      animations: {
-        "idle-loop": {
-          frames: [{ asset_id: assetIds.idle, duration_ms: 250 }],
-          loop: true
-        },
-        "speaking-loop": {
-          frames: [{ asset_id: assetIds.speaking, duration_ms: 250 }],
-          loop: true
-        },
-        "tool-loop": {
-          frames: [{ asset_id: assetIds.tool, duration_ms: 250 }],
-          loop: true
-        },
-        "error-loop": {
-          frames: [{ asset_id: assetIds.error, duration_ms: 250 }],
-          loop: false
-        }
-      },
-      fallbacks: {
-        speaking: ["idle"],
-        tool_running: ["idle"],
-        error: ["idle"]
-      },
-      authored_triggers: [
-        {
-          id: "mcp-runtime-override",
-          source: "mcp_runtime",
-          match: "persona_visuals.trigger_state",
-          state: "speaking",
-          duration_ms: 5000,
-          priority: 10
-        }
-      ]
-    },
-    active_at: "2026-05-08T00:00:00.000Z",
-    assets: Object.values(assetsById),
-    assets_by_id: assetsById,
-    created_at: "2026-05-08T00:00:00.000Z",
-    last_modified: "2026-05-08T00:00:00.000Z",
-    version: 1
-  }
-}
-
 const installPersonaVisualApiMocks = async (
   page: Page,
   options: { visualPackMode?: PersonaVisualMockMode } = {}
 ): Promise<void> => {
   const visualPackMode = options.visualPackMode ?? "active-pack"
+  let packs =
+    visualPackMode === "empty-pack" || visualPackMode === "broken-pack"
+      ? []
+      : [buildPersonaVisualPackFixture(VISUAL_PERSONA_ID)]
+  let previewCompleted = false
+  let importCommitted = false
 
   await page.route(/\/api\/v1\/health(?:\/live)?(?:\?.*)?$/, async (route) => {
     await fulfillJson(route, 200, {
@@ -256,6 +175,133 @@ const installPersonaVisualApiMocks = async (
     ])
   })
 
+  await page.route(/\/api\/v1\/persona\/visual-starter-packs(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, 200, {
+      starter_packs: [PERSONA_VISUAL_E2E_STARTER_PACK]
+    })
+  })
+
+  await page.route(/\/api\/v1\/persona\/visual-starter-packs\/[^/]+\/copy(?:\?.*)?$/, async (route) => {
+    const personaId = VISUAL_PERSONA_ID
+    const pack = buildPersonaVisualPackFixture(personaId, {
+      packId: "starter-copy-e2e",
+      title: "Research Buddy Starter",
+      status: "draft",
+      provenance: "imported"
+    })
+    packs = [pack]
+    await fulfillJson(route, 201, pack)
+  })
+
+  await page.route(/\/api\/v1\/persona\/profiles\/[^/]+\/visual-packs\/[^/]+\/activate(?:\?.*)?$/, async (route) => {
+    const url = new URL(route.request().url())
+    const parts = url.pathname.split("/").filter(Boolean)
+    const packId = decodeURIComponent(parts[parts.findIndex((part) => part === "visual-packs") + 1] || "")
+    packs = packs.map((pack) => ({
+      ...pack,
+      status: pack.id === packId ? "active" : "draft",
+      active_at:
+        pack.id === packId ? "2026-05-08T00:00:00.000Z" : null
+    }))
+    await fulfillJson(
+      route,
+      200,
+      packs.find((pack) => pack.id === packId) ?? packs[0]
+    )
+  })
+
+  await page.route(/\/api\/v1\/persona\/profiles\/[^/]+\/visual-packs\/import-previews(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, 200, {
+      preview_id: "preview-upload-e2e",
+      job_id: "preview-upload-job-e2e",
+      portability_job_id: "portability-preview-upload-e2e",
+      operation: "import_preview",
+      target_persona_id: VISUAL_PERSONA_ID,
+      status: "queued",
+      stage: "queued"
+    })
+  })
+
+  await page.route(/\/api\/v1\/persona\/profiles\/[^/]+\/visual-packs\/import-previews\/preview-upload-e2e(?:\?.*)?$/, async (route) => {
+    previewCompleted = true
+    await fulfillJson(route, 200, {
+      preview_id: "preview-upload-e2e",
+      job_id: "preview-upload-job-e2e",
+      portability_job_id: "portability-preview-upload-e2e",
+      operation: "import_preview",
+      target_persona_id: VISUAL_PERSONA_ID,
+      status: "completed",
+      visual_status: "completed",
+      stage: "completed",
+      archive_sha256: "sha-uploaded-e2e",
+      canonical_payload_fingerprint: "fingerprint-uploaded-e2e",
+      schema_version: "tldw.persona_visual_pack.v1",
+      bundle_summary: {
+        pack_title: "Uploaded Visual Pack",
+        asset_count: 1,
+        assets_with_bytes: 1
+      },
+      validation_warnings: [],
+      conflicts: [],
+      proposed_plan: {
+        target_mode: "create_new",
+        commit_eligible: true,
+        activation_eligible: true,
+        renderer_import_preview: {
+          status: "supported",
+          renderer_type: "sprite_frames",
+          manifest_version: 1,
+          renderer_contract_version: 1,
+          can_commit: true,
+          activation_eligible: true,
+          blockers: [],
+          warnings: [],
+          normalized_role_categories: { frame: ["portable-upload-pack-frame-idle"] },
+          setup_status: "supported",
+          setup_blockers: []
+        }
+      },
+      quota_estimate: { asset_bytes: 96 },
+      required_choices: [],
+      target_warnings: []
+    })
+  })
+
+  await page.route(/\/api\/v1\/persona\/profiles\/[^/]+\/visual-packs\/import-previews\/preview-upload-e2e\/commit(?:\?.*)?$/, async (route) => {
+    const pack = buildPersonaVisualPackFixture(VISUAL_PERSONA_ID, {
+      packId: "uploaded-pack-e2e",
+      title: "Uploaded Visual Pack",
+      status: "draft",
+      provenance: "imported"
+    })
+    importCommitted = true
+    packs = [pack]
+    await fulfillJson(route, 200, {
+      job_id: "import-upload-job-e2e",
+      portability_job_id: "portability-import-upload-e2e",
+      operation: "import_commit",
+      preview_id: "preview-upload-e2e",
+      target_persona_id: VISUAL_PERSONA_ID,
+      status: "queued",
+      stage: "queued"
+    })
+  })
+
+  await page.route(/\/api\/v1\/persona\/profiles\/[^/]+\/visual-packs\/imports\/import-upload-job-e2e(?:\?.*)?$/, async (route) => {
+    await fulfillJson(route, 200, {
+      job_id: "import-upload-job-e2e",
+      portability_job_id: "portability-import-upload-e2e",
+      operation: "import_commit",
+      persona_id: VISUAL_PERSONA_ID,
+      pack_id: "uploaded-pack-e2e",
+      status: importCommitted && previewCompleted ? "completed" : "processing",
+      visual_status: importCommitted && previewCompleted ? "completed" : "processing",
+      stage: importCommitted && previewCompleted ? "completed" : "commit",
+      progress: { asset_count: 1 },
+      warnings: []
+    })
+  })
+
   await page.route(/\/api\/v1\/persona\/profiles\/[^/]+\/visual-packs(?:\?.*)?$/, async (route) => {
     if (visualPackMode === "broken-pack") {
       await fulfillJson(route, 500, {
@@ -264,10 +310,10 @@ const installPersonaVisualApiMocks = async (
       return
     }
 
-    const pack = buildPersonaVisualPack(extractProfilePersonaId(route))
+    const activePack = packs.find((pack) => pack.status === "active") ?? null
     await fulfillJson(route, 200, {
-      packs: [pack],
-      active_pack: pack
+      packs,
+      active_pack: activePack
     })
   })
 
@@ -453,6 +499,17 @@ const emitPersonaVisualStateOverride = async (
   )
 }
 
+const openPersonaVisualsTab = async (page: Page): Promise<void> => {
+  const currentUrl = new URL(page.url())
+  currentUrl.searchParams.set("tab", "visuals")
+  await page.goto(`${currentUrl.pathname}${currentUrl.search}`, {
+    waitUntil: "domcontentloaded"
+  })
+  await expect(page.getByTestId("persona-visual-pack-editor")).toBeVisible({
+    timeout: 15_000
+  })
+}
+
 const parseBooleanish = (value: unknown): boolean | null => {
   if (typeof value === "boolean") return value
   if (typeof value === "number") return value !== 0
@@ -620,6 +677,123 @@ test.describe("Persona Live Workflow", () => {
         timeout: 10_000
       })
     }
+
+    expect(diagnostics.pageErrors).toHaveLength(0)
+  })
+
+  test("default starter setup path activates a draft and renders BuddyShell visual", async ({
+    authedPage,
+    diagnostics
+  }) => {
+    await installPersonaVisualApiMocks(authedPage, {
+      visualPackMode: "empty-pack"
+    })
+    await installMockPersonaWebSocket(authedPage)
+
+    await authedPage.goto(
+      `/persona?persona_id=${encodeURIComponent(VISUAL_PERSONA_ID)}`,
+      { waitUntil: "domcontentloaded" }
+    )
+
+    await expect(authedPage.getByTestId("assistant-setup-overlay")).toBeHidden({
+      timeout: 15_000
+    })
+    await expect(authedPage.getByTestId("persona-buddy-dock")).toContainText(
+      "Visual Persona",
+      { timeout: 15_000 }
+    )
+    await openPersonaVisualsTab(authedPage)
+
+    await expect(
+      authedPage.getByTestId("persona-visual-starter-pack-select")
+    ).toHaveValue(PERSONA_VISUAL_E2E_STARTER_PACK.id)
+
+    await authedPage.getByTestId("persona-visual-starter-copy-button").click()
+    await expect(authedPage.getByTestId("persona-visual-pack-select")).toHaveValue(
+      "starter-copy-e2e",
+      { timeout: 15_000 }
+    )
+    await expect(authedPage.getByTestId("persona-visual-pack-status")).toHaveText(
+      "draft"
+    )
+
+    await authedPage.getByTestId("persona-visual-activate-button").click()
+    await expect(authedPage.getByTestId("persona-visual-pack-status")).toHaveText(
+      "active",
+      { timeout: 15_000 }
+    )
+    await expect(authedPage.getByTestId("persona-visual-frame").first())
+      .toHaveAttribute("data-visual-state", "idle", { timeout: 15_000 })
+
+    expect(diagnostics.pageErrors).toHaveLength(0)
+  })
+
+  test("uploaded pack setup path imports, activates, and renders BuddyShell visual", async ({
+    authedPage,
+    diagnostics
+  }) => {
+    await installPersonaVisualApiMocks(authedPage, {
+      visualPackMode: "empty-pack"
+    })
+    await installMockPersonaWebSocket(authedPage)
+
+    await authedPage.goto(
+      `/persona?persona_id=${encodeURIComponent(VISUAL_PERSONA_ID)}`,
+      { waitUntil: "domcontentloaded" }
+    )
+
+    await expect(authedPage.getByTestId("assistant-setup-overlay")).toBeHidden({
+      timeout: 15_000
+    })
+    await openPersonaVisualsTab(authedPage)
+
+    await authedPage.getByTestId("persona-visual-starter-copy-button").click()
+    await expect(authedPage.getByTestId("persona-visual-pack-select")).toHaveValue(
+      "starter-copy-e2e",
+      { timeout: 15_000 }
+    )
+
+    const portableUpload = await buildPortablePersonaVisualPackUpload()
+    await authedPage
+      .getByTestId("persona-visual-import-preview-input")
+      .setInputFiles(portableUpload)
+    await authedPage.getByTestId("persona-visual-import-preview-button").click()
+    await expect(
+      authedPage.getByTestId("persona-visual-import-preview-status")
+    ).toHaveText("queued")
+
+    await authedPage
+      .getByTestId("persona-visual-import-preview-refresh-button")
+      .click()
+    await expect(
+      authedPage.getByTestId("persona-visual-import-preview-status")
+    ).toHaveText("completed", { timeout: 15_000 })
+    await expect(
+      authedPage.getByTestId("persona-visual-import-preview-summary")
+    ).toContainText("Uploaded Visual Pack")
+
+    await authedPage.getByTestId("persona-visual-import-commit-button").click()
+    await expect(
+      authedPage.getByTestId("persona-visual-import-commit-status")
+    ).toHaveText("queued")
+    await authedPage
+      .getByTestId("persona-visual-import-commit-refresh-button")
+      .click()
+    await expect(
+      authedPage.getByTestId("persona-visual-import-commit-status")
+    ).toHaveText("completed", { timeout: 15_000 })
+    await expect(authedPage.getByTestId("persona-visual-pack-select")).toHaveValue(
+      "uploaded-pack-e2e",
+      { timeout: 15_000 }
+    )
+
+    await authedPage.getByTestId("persona-visual-activate-button").click()
+    await expect(authedPage.getByTestId("persona-visual-pack-status")).toHaveText(
+      "active",
+      { timeout: 15_000 }
+    )
+    await expect(authedPage.getByTestId("persona-visual-frame").first())
+      .toHaveAttribute("data-visual-state", "idle", { timeout: 15_000 })
 
     expect(diagnostics.pageErrors).toHaveLength(0)
   })

--- a/apps/tldw-frontend/e2e/workflows/persona-live.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/persona-live.spec.ts
@@ -747,12 +747,6 @@ test.describe("Persona Live Workflow", () => {
     })
     await openPersonaVisualsTab(authedPage)
 
-    await authedPage.getByTestId("persona-visual-starter-copy-button").click()
-    await expect(authedPage.getByTestId("persona-visual-pack-select")).toHaveValue(
-      "starter-copy-e2e",
-      { timeout: 15_000 }
-    )
-
     const portableUpload = await buildPortablePersonaVisualPackUpload()
     await authedPage
       .getByTestId("persona-visual-import-preview-input")

--- a/backlog/tasks/task-377 - Add-Persona-Visual-happy-path-fixtures-and-E2E-coverage.md
+++ b/backlog/tasks/task-377 - Add-Persona-Visual-happy-path-fixtures-and-E2E-coverage.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-377
 title: Add Persona Visual happy-path fixtures and E2E coverage
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-15 06:09'
-updated_date: '2026-05-15 07:02'
+updated_date: '2026-05-15 19:21'
 labels:
   - persona
   - webui
@@ -34,6 +34,10 @@ priority: medium
 Implemented starter-pack service/UI copy flow, deterministic E2E sprite-frame fixtures, default/upload setup-path Playwright coverage, and BuddyShell refresh on visual-pack activation. Validation: focused Vitest passed (55 tests); setup-path Playwright passed (2 tests); git diff --check passed. Full persona-live file passed 4 visual-pack tests but the existing live-backend WebSocket proof timed out waiting for Disconnect.
 
 Portable upload fixture determinism verified with a Bun import check: two generated buffers were byte-identical (uploaded-visual-pack.tldw-persona-vpack, 2055 bytes).
+
+Addressed PR review findings: guarded starter pack loading against stale async responses, reset starter draft title on persona changes, localized starter labels/units, made uploaded fixture archive references consistent with its manifest, exercised upload import from true empty state, and aligned task status with completed DoD.
+
+Review-fix validation: focused Vitest passed (56 tests); portable fixture determinism passed (1888 byte archive, stable across builds); setup-path Playwright passed (2 tests) from a fresh port with the upload path starting from empty state; git diff --check passed; apps/tldw-frontend lint passed with existing warnings only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-377 - Add-Persona-Visual-happy-path-fixtures-and-E2E-coverage.md
+++ b/backlog/tasks/task-377 - Add-Persona-Visual-happy-path-fixtures-and-E2E-coverage.md
@@ -4,7 +4,7 @@ title: Add Persona Visual happy-path fixtures and E2E coverage
 status: In Progress
 assignee: []
 created_date: '2026-05-15 06:09'
-updated_date: '2026-05-15 07:01'
+updated_date: '2026-05-15 07:02'
 labels:
   - persona
   - webui
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1698'
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/pull/1723'
 documentation:
   - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
 priority: medium

--- a/backlog/tasks/task-377 - Add-Persona-Visual-happy-path-fixtures-and-E2E-coverage.md
+++ b/backlog/tasks/task-377 - Add-Persona-Visual-happy-path-fixtures-and-E2E-coverage.md
@@ -1,0 +1,52 @@
+---
+id: TASK-377
+title: Add Persona Visual happy-path fixtures and E2E coverage
+status: In Progress
+assignee: []
+created_date: '2026-05-15 06:09'
+updated_date: '2026-05-15 07:01'
+labels:
+  - persona
+  - webui
+  - e2e
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1698'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+documentation:
+  - Docs/Product/WebUI/Persona_Live_Visual_Packs_PRD.md
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Bundled default sprite_frames fixture path is portable and deterministic.
+- [x] #2 Uploaded .tldw-persona-vpack fixture path is portable and deterministic.
+- [x] #3 E2E coverage proves default-pack setup through activation and BuddyShell rendering.
+- [x] #4 E2E coverage proves uploaded-pack import commit through activation and BuddyShell rendering.
+- [x] #5 Coverage remains scoped to sprite_frames runtime rendering; non-sprite formats stay preview/diagnostic only.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented starter-pack service/UI copy flow, deterministic E2E sprite-frame fixtures, default/upload setup-path Playwright coverage, and BuddyShell refresh on visual-pack activation. Validation: focused Vitest passed (55 tests); setup-path Playwright passed (2 tests); git diff --check passed. Full persona-live file passed 4 visual-pack tests but the existing live-backend WebSocket proof timed out waiting for Disconnect.
+
+Portable upload fixture determinism verified with a Bun import check: two generated buffers were byte-identical (uploaded-visual-pack.tldw-persona-vpack, 2055 bytes).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Persona Visual starter-pack service/UI support, deterministic sprite_frames E2E fixtures including a portable .tldw-persona-vpack upload builder, default/upload happy-path Playwright coverage, and a BuddyShell activation refresh event so newly activated packs render immediately. Focused Vitest, fixture determinism, setup-path Playwright, and git diff checks passed; the broader persona-live file still has an unrelated live-backend WebSocket proof timeout.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add Persona Visual starter-pack list/copy support in the WebUI editor so bundled sprite_frames packs can be copied as inactive drafts.
- Add deterministic Persona Visual E2E fixtures, including a portable .tldw-persona-vpack upload builder.
- Cover default starter and uploaded-pack setup through explicit activation and BuddyShell sprite-frame rendering; refresh BuddyShell after activation.

## Validation
- bun run test:run ../packages/ui/src/services/__tests__/persona-visuals.test.ts ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx ../packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
- bun -e "import { buildPortablePersonaVisualPackUpload } from './e2e/fixtures/persona-visual-packs.ts'; ..."\n- TLDW_WEB_URL=http://localhost:18099 TLDW_WEB_CMD="bun run dev -- -p 18099" bunx playwright test e2e/workflows/persona-live.spec.ts --grep "setup path" --reporter=line --workers=1\n- git diff --check\n\n## Notes\n- Full persona-live file run passed the four visual-pack tests, but the existing live-backend WebSocket proof timed out waiting for Disconnect.\n- Bandit was not run because this slice touched TypeScript, JSON, Markdown, and Playwright fixture code only.\n\n## Change summary\nAI-authored draft. A human-authored Change summary is required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.\n\nCloses #1698

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds starter-pack setup to the Persona Visual editor and adds deterministic E2E coverage for the default and upload paths. BuddyShell now reloads on activation so `sprite_frames` visuals render immediately. Supports #1698.

- **New Features**
  - UI/service: list bundled starters and copy via `/api/v1/persona/visual-starter-packs` and `.../{id}/copy`; select a starter and draft title; new i18n strings.
  - Activation: editor dispatches `PERSONA_VISUAL_PACK_ACTIVATED_EVENT`; `BuddyShellHost` listens and refetches the active persona’s visual pack.
  - E2E: deterministic fixtures (sprite-frames builders and a portable `.tldw-persona-vpack` upload); Playwright covers starter copy → activate and upload preview → commit → activate, starting from an empty state.

- **Bug Fixes**
  - Guarded against stale starter responses on persona switch and reset draft title when personas change.
  - Enabled import flow when no pack is selected; aligned upload archive bytes/metadata; localized loading key to `common:loading.title`.

<sup>Written for commit a3bda5fb3efc1293967152a724e211b5de939103. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1723?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

