### PR TITLE
Implement ACP artifact version exports

### DIFF
--- a/Docs/Product/ACP_Agent_Orchestration_PRD.md
+++ b/Docs/Product/ACP_Agent_Orchestration_PRD.md
@@ -351,6 +351,7 @@ Implementation should be split into:
 | --- | --- |
 | Storage/API | Backend foundation implemented by #1703 on `workspace_artifacts`: traceable artifact fields, version rows, source-lineage metadata, review metadata, export references, redaction posture, schema version, and ACP producer references. |
 | UI detail | Show artifact detail, source lineage, ACP provenance, review state, revise/retry/reject/accept controls, exports, and authenticated ACP drill-through links. |
+| Export identity | Backend foundation implemented by #1705 on `POST /api/v1/workspaces/{workspace_id}/artifacts/{artifact_id}/exports`: accepted Markdown/HTML/JSON exports preserve artifact/version/workspace identity, source lineage, review state, ACP producer metadata, generated timestamp, and export references. |
 | Verification | Contract tests for ACP-to-artifact promotion, redacted support-safe views, reviewer-loop state mapping, versioning, and export identity. |
 
 The initial implementation should target one golden-path deliverable, such as a
@@ -398,3 +399,7 @@ minimum, a release candidate needs:
 - 2026-05-14 storage/API foundation: #1703 added traceable workspace artifact
   fields, API exposure, and per-version storage while leaving UI detail, ACP
   promotion, export adapters, and broader signoff checks as follow-up slices.
+- 2026-05-15 accepted export foundation: #1705 added the backend
+  Markdown/HTML/JSON accepted-version export contract while leaving richer
+  file/document export channels, retention policy, and UI download workflows as
+  follow-up slices.

--- a/Docs/Product/Traceable_Work_Product_Artifact_Contract.md
+++ b/Docs/Product/Traceable_Work_Product_Artifact_Contract.md
@@ -134,6 +134,28 @@ Exports are representations of a work product, not the work product itself.
 | Chatbooks | Include artifact manifest, source references, version chain, and export references without assuming all large binaries are bundled. |
 | Prompt/output surfaces | Link back to source artifact and version rather than copying detached generated text where possible. |
 
+### Implemented Markdown/HTML/JSON Export Contract
+
+Issue #1705 implements the first accepted-version export contract at
+`POST /api/v1/workspaces/{workspace_id}/artifacts/{artifact_id}/exports`.
+The request accepts `format: "md" | "html" | "json"` and an optional
+`artifact_version_id`; omitting the version exports the current artifact
+version. Only `accepted` artifact versions are exportable. Draft, reviewing,
+needs-revision, rejected, assigned, archived, or otherwise non-accepted states
+fail closed with `workspace_artifact_not_accepted`.
+
+Each export response includes the rendered content, UTF-8 byte count, content
+type, generated timestamp, export reference, and metadata preserving workspace
+ID, artifact ID, artifact version ID, review state, source lineage, producer
+metadata, review metadata, version metadata, and redaction posture. The backend
+records the export reference back onto the workspace artifact without creating
+a new content version and without replacing existing export references.
+
+This implementation covers portable text representations. File-artifact
+materialization, Chatbook packaging, document/slides exports, table-specific
+sidecar manifests, retention controls, and support-safe redaction views remain
+separate follow-up slices.
+
 ## Existing Surface Mapping
 
 | Existing surface | Reuse path |
@@ -189,6 +211,17 @@ version record and carry the previous version ID forward.
 This does not complete the full product contract. Workspace artifact detail UI,
 ACP deliverable promotion flows, accepted-version export adapters, and broader
 redaction/retention verification remain separate follow-up slices.
+
+### Current Accepted Export Foundation
+
+Issue #1705 implements accepted workspace artifact version exports for Markdown,
+HTML, and JSON. The export endpoint renders from the exact accepted artifact
+version, embeds or exposes the traceability metadata required by this contract,
+and appends a version-specific export reference to the workspace artifact.
+
+This does not complete all export channels. Rich document/slides/table exports,
+external file-artifact storage, Chatbook bundling, export retention policies,
+and UI-triggered download workflows remain separate follow-up slices.
 
 ## Release Caveats
 

--- a/Docs/superpowers/plans/2026-05-15-acp-artifact-exports-1705-plan.md
+++ b/Docs/superpowers/plans/2026-05-15-acp-artifact-exports-1705-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Export Contract And Schemas
+**Goal**: Add the backend request/response contract for accepted artifact version exports.
+**Success Criteria**: Markdown, HTML, and JSON are explicit accepted formats; responses expose artifact id, artifact version id, workspace id, review state, export format, generated timestamp, metadata, content, byte count, and persisted export reference.
+**Tests**: Focused workspace API export tests fail before implementation and pass after implementation.
+**Status**: Complete
+
+## Stage 2: Accepted-Version Export Service
+**Goal**: Render accepted workspace artifact versions into Markdown, HTML, and JSON while preserving traceability metadata.
+**Success Criteria**: Exported payloads embed or expose source lineage, producer metadata, review metadata, version metadata, redaction posture, and stable artifact identity. Non-accepted review states fail closed.
+**Tests**: API tests cover all three formats and non-accepted rejection.
+**Status**: Complete
+
+## Stage 3: Export Reference Persistence
+**Goal**: Record export references back onto the workspace artifact without creating a new content version or losing existing references.
+**Success Criteria**: Existing export refs remain intact; each export adds a ref tied to the source artifact version.
+**Tests**: API tests fetch the artifact after export and verify legacy plus new refs.
+**Status**: Complete
+
+## Stage 4: Documentation And Verification
+**Goal**: Document the implemented contract and run focused verification for the touched backend scope.
+**Success Criteria**: Product docs name the concrete endpoint and remaining richer-export boundaries; pytest, syntax checks, Bandit, and diff checks are recorded.
+**Tests**: Focused workspace API/DB tests plus touched-scope security checks.
+**Status**: Complete

--- a/backlog/tasks/task-381 - Implement-ACP-accepted-artifact-version-exports-for-issue-1705.md
+++ b/backlog/tasks/task-381 - Implement-ACP-accepted-artifact-version-exports-for-issue-1705.md
@@ -1,0 +1,71 @@
+---
+id: TASK-381
+title: Implement ACP accepted artifact version exports for issue 1705
+status: Done
+assignee: []
+created_date: '2026-05-15 15:25'
+updated_date: '2026-05-15 15:40'
+labels:
+  - acp
+  - artifacts
+  - backend
+dependencies:
+  - TASK-350
+  - TASK-357
+  - TASK-369
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1705'
+  - 'https://github.com/rmusser01/tldw_server/issues/1532'
+  - 'https://github.com/rmusser01/tldw_server/issues/1703'
+  - 'https://github.com/rmusser01/tldw_server/issues/1706'
+  - 'https://github.com/rmusser01/tldw_server/issues/1707'
+documentation:
+  - Docs/Product/Traceable_Work_Product_Artifact_Contract.md
+  - Docs/Product/ACP_Agent_Orchestration_PRD.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1705: export accepted traceable work-product artifact versions without losing artifact identity, version identity, source lineage, review state, ACP producer references, or export timestamp. Start with Markdown, HTML, and JSON exports for the golden-path workspace brief. Reuse the existing workspace_artifacts storage/API foundation and file/output artifact export patterns where practical; do not create an ACP-only artifact model.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Accepted artifact versions can be exported through a backend contract for Markdown, HTML, and JSON.
+- [x] #2 Export metadata preserves artifact id, artifact version id, workspace id, source lineage, review state, producer references, export format, and export timestamp.
+- [x] #3 Non-accepted artifact states fail closed with a contextual error instead of exporting silently.
+- [x] #4 Export references are recorded back onto the workspace artifact without losing existing refs.
+- [x] #5 Focused tests cover Markdown, HTML, JSON, non-accepted states, and metadata identity round-tripping.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add workspace artifact export request/response schemas and route contract for Markdown, HTML, and JSON accepted-version exports. 2. Implement a focused export helper/service that renders from the exact accepted artifact version and preserves artifact/version/workspace/source/review/producer metadata. 3. Persist export_refs back to the workspace artifact while preserving existing references. 4. Update traceable artifact docs and verify with focused pytest, ruff/py_compile, Bandit, and git diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Baseline before implementation: python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q passed with 64 passed and 5 warnings. Plan file: Docs/superpowers/plans/2026-05-15-acp-artifact-exports-1705-plan.md.
+
+Implemented accepted-version export schemas, renderer, POST endpoint, and export_refs persistence without content version bumps. Red run: workspace_artifact_export tests failed with 404 before route implementation. Green runs: export slice passed, then workspace API plus ChaChaNotes DB slice passed with 66 passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented ACP accepted artifact version exports for issue #1705. Added Markdown, HTML, and JSON export contract for accepted workspace artifact versions, fail-closed non-accepted state handling, traceability-preserving export payloads, and append-only export reference persistence. Updated the artifact contract and ACP PRD docs; focused pytest, ruff on changed non-DB Python files, compileall, Bandit, and git diff checks passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-381 - Implement-ACP-accepted-artifact-version-exports-for-issue-1705.md
+++ b/backlog/tasks/task-381 - Implement-ACP-accepted-artifact-version-exports-for-issue-1705.md
@@ -4,7 +4,7 @@ title: Implement ACP accepted artifact version exports for issue 1705
 status: Done
 assignee: []
 created_date: '2026-05-15 15:25'
-updated_date: '2026-05-15 15:40'
+updated_date: '2026-05-15 19:31'
 labels:
   - acp
   - artifacts
@@ -52,12 +52,22 @@ Implement GitHub issue #1705: export accepted traceable work-product artifact ve
 Baseline before implementation: python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q passed with 64 passed and 5 warnings. Plan file: Docs/superpowers/plans/2026-05-15-acp-artifact-exports-1705-plan.md.
 
 Implemented accepted-version export schemas, renderer, POST endpoint, and export_refs persistence without content version bumps. Red run: workspace_artifact_export tests failed with 404 before route implementation. Green runs: export slice passed, then workspace API plus ChaChaNotes DB slice passed with 66 passed.
+
+PR #1726 review sweep: addressing Qodo docstring/logging/version-row/markdown-marker/concurrency findings plus Gemini direct-version lookup and HTML export comment.
+
+PR #1726 review sweep addressed direct artifact version lookup, helper docstrings, contextual export error logging, base64 Markdown metadata marker, rendered HTML export bodies, transactional export_refs persistence, and missing version snapshot conflict handling. Verification: export slice passed (3 selected); broader workspace DB/API suite passed (67 passed, 5 warnings); Ruff passed on non-legacy touched files; compileall passed; Bandit touched scope reported 0 findings; git diff --check passed. Full ChaChaNotes_DB.py Ruff still reports existing baseline findings outside this patch.
+
+Late CodeRabbit review sweep addressed workspace lookup error mapping by moving _require_workspace into the export try block and centralized WorkspaceArtifactExportStateError in app/core/exceptions.py. Existing race and missing-version comments were already addressed by the transactional CAS-style export_refs update and loud missing-version conflict.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented ACP accepted artifact version exports for issue #1705. Added Markdown, HTML, and JSON export contract for accepted workspace artifact versions, fail-closed non-accepted state handling, traceability-preserving export payloads, and append-only export reference persistence. Updated the artifact contract and ACP PRD docs; focused pytest, ruff on changed non-DB Python files, compileall, Bandit, and git diff checks passed.
+
+PR #1726 review feedback addressed with direct version fetching, base64-safe Markdown metadata, rendered HTML export bodies, contextual logging, transactional export_ref persistence, missing-version conflict handling, and regression coverage for comment-boundary metadata plus missing artifact-version snapshots.
+
+Late CodeRabbit review feedback was also addressed by mapping workspace lookup failures through the export endpoint error block and moving the export-state exception into app/core/exceptions.py. Fresh verification after these changes passed: export slice 3 passed, broader workspace DB/API suite 67 passed, Ruff on non-legacy touched files, compileall, Bandit 0 findings, and git diff --check.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
-from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
+    WORKSPACES_DELETE_RATE_LIMIT,
+    WORKSPACES_READ_RATE_LIMIT,
+    WORKSPACES_WRITE_RATE_LIMIT,
+)
 from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     StatusResponse,
     WorkspaceArtifactCreateRequest,
+    WorkspaceArtifactExportRequest,
+    WorkspaceArtifactExportResponse,
     WorkspaceArtifactResponse,
     WorkspaceArtifactUpdateRequest,
     WorkspaceListResponse,
@@ -23,17 +30,16 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceSourceUpdateRequest,
     WorkspaceUpsertRequest,
 )
-from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
-    WORKSPACES_DELETE_RATE_LIMIT,
-    WORKSPACES_READ_RATE_LIMIT,
-    WORKSPACES_WRITE_RATE_LIMIT,
-)
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
+from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,
     ConflictError,
     InputError,
+)
+from tldw_Server_API.app.core.Workspaces.workspace_artifact_exports import (
+    WorkspaceArtifactExportStateError,
+    export_workspace_artifact_version,
 )
 
 router = APIRouter()
@@ -111,6 +117,41 @@ def _art_to_response(art: dict) -> WorkspaceArtifactResponse:
         completed_at=str(art["completed_at"]) if art.get("completed_at") else None,
         version=version,
     )
+
+
+def _workspace_artifact_version_for_export(
+    db: CharactersRAGDB,
+    workspace_id: str,
+    artifact_id: str,
+    artifact_version_id: str | None,
+) -> dict:
+    """Fetch the current artifact or a version snapshot for export."""
+    artifact = db.get_workspace_artifact(workspace_id, artifact_id)
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="Workspace artifact not found")
+    if artifact_version_id is None:
+        return artifact
+
+    versions = db.list_workspace_artifact_versions(workspace_id, artifact_id)
+    version = next(
+        (item for item in versions if item.get("artifact_version_id") == artifact_version_id),
+        None,
+    )
+    if version is None:
+        raise HTTPException(status_code=404, detail="Workspace artifact version not found")
+    merged = {**artifact, **version}
+    merged["id"] = artifact_id
+    merged["workspace_id"] = workspace_id
+    merged["artifact_type"] = artifact.get("artifact_type")
+    merged["content_type"] = artifact.get("content_type") or "text/markdown"
+    merged["status"] = artifact.get("status")
+    merged["owner_scope"] = artifact.get("owner_scope")
+    merged["owner_id"] = artifact.get("owner_id")
+    merged["project_id"] = artifact.get("project_id")
+    merged["task_id"] = artifact.get("task_id")
+    merged["source_collection_id"] = artifact.get("source_collection_id")
+    merged["schema_version"] = artifact.get("schema_version") or 1
+    return merged
 
 
 def _note_to_response(note: dict) -> WorkspaceNoteResponse:
@@ -442,6 +483,37 @@ async def update_artifact(
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to update workspace artifact") from exc
     return _art_to_response(art)
+
+
+@router.post(
+    "/{workspace_id}/artifacts/{artifact_id}/exports",
+    response_model=WorkspaceArtifactExportResponse,
+    dependencies=[Depends(WORKSPACES_WRITE_RATE_LIMIT)],
+    summary="Export accepted workspace artifact version",
+)
+async def export_artifact(
+    workspace_id: str,
+    artifact_id: str,
+    body: WorkspaceArtifactExportRequest,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceArtifactExportResponse:
+    """Export an accepted workspace artifact version as Markdown, HTML, or JSON."""
+    _require_workspace(db, workspace_id)
+    try:
+        artifact = _workspace_artifact_version_for_export(
+            db,
+            workspace_id,
+            artifact_id,
+            body.artifact_version_id,
+        )
+        payload = export_workspace_artifact_version(artifact, export_format=body.format)
+        db.append_workspace_artifact_export_ref(workspace_id, artifact_id, payload["export_ref"])
+    except WorkspaceArtifactExportStateError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to export workspace artifact") from exc
+    return WorkspaceArtifactExportResponse(**payload)
 
 
 @router.delete(

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
@@ -37,8 +38,8 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     ConflictError,
     InputError,
 )
+from tldw_Server_API.app.core.exceptions import WorkspaceArtifactExportStateError
 from tldw_Server_API.app.core.Workspaces.workspace_artifact_exports import (
-    WorkspaceArtifactExportStateError,
     export_workspace_artifact_version,
 )
 
@@ -132,11 +133,7 @@ def _workspace_artifact_version_for_export(
     if artifact_version_id is None:
         return artifact
 
-    versions = db.list_workspace_artifact_versions(workspace_id, artifact_id)
-    version = next(
-        (item for item in versions if item.get("artifact_version_id") == artifact_version_id),
-        None,
-    )
+    version = db.get_workspace_artifact_version(workspace_id, artifact_id, artifact_version_id)
     if version is None:
         raise HTTPException(status_code=404, detail="Workspace artifact version not found")
     merged = {**artifact, **version}
@@ -499,8 +496,8 @@ async def export_artifact(
     current_user: User = Depends(get_request_user),
 ) -> WorkspaceArtifactExportResponse:
     """Export an accepted workspace artifact version as Markdown, HTML, or JSON."""
-    _require_workspace(db, workspace_id)
     try:
+        _require_workspace(db, workspace_id)
         artifact = _workspace_artifact_version_for_export(
             db,
             workspace_id,
@@ -510,9 +507,29 @@ async def export_artifact(
         payload = export_workspace_artifact_version(artifact, export_format=body.format)
         db.append_workspace_artifact_export_ref(workspace_id, artifact_id, payload["export_ref"])
     except WorkspaceArtifactExportStateError as exc:
+        logger.warning(
+            "Workspace artifact export rejected: workspace_id={} artifact_id={} artifact_version_id={} "
+            "format={} reason={}",
+            workspace_id,
+            artifact_id,
+            body.artifact_version_id,
+            body.format,
+            str(exc),
+        )
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
-        raise map_db_error_to_http(exc, default_detail="Failed to export workspace artifact") from exc
+        logger.exception(
+            "Workspace artifact export failed: workspace_id={} artifact_id={} artifact_version_id={} format={}",
+            workspace_id,
+            artifact_id,
+            body.artifact_version_id,
+            body.format,
+        )
+        raise map_db_error_to_http(
+            exc,
+            default_detail="Failed to export workspace artifact",
+            log_error=False,
+        ) from exc
     return WorkspaceArtifactExportResponse(**payload)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -108,6 +108,8 @@ WorkspaceArtifactReviewState = Literal[
     "archived",
 ]
 
+WorkspaceArtifactExportFormat = Literal["md", "html", "json"]
+
 
 class WorkspaceArtifactRedaction(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -199,6 +201,28 @@ class WorkspaceArtifactResponse(BaseModel):
     created_at: str
     completed_at: str | None = None
     version: int
+
+
+class WorkspaceArtifactExportRequest(BaseModel):
+    format: WorkspaceArtifactExportFormat
+    artifact_version_id: str | None = Field(
+        default=None,
+        description="Optional artifact version id to export. Defaults to the current artifact version.",
+    )
+
+
+class WorkspaceArtifactExportResponse(BaseModel):
+    workspace_id: str
+    artifact_id: str
+    artifact_version_id: str
+    review_state: WorkspaceArtifactReviewState
+    format: WorkspaceArtifactExportFormat
+    content_type: str
+    content: str
+    bytes: int
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    export_ref: dict[str, Any] = Field(default_factory=dict)
+    generated_at: str
 
 
 # --- Note schemas ---

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15299,6 +15299,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         row = cursor.fetchone()
         return self._normalize_workspace_artifact_row(row)
 
+    def get_workspace_artifact(self, workspace_id: str, artifact_id: str) -> dict[str, Any] | None:
+        """Fetch a workspace artifact by id."""
+        return self._get_workspace_artifact(workspace_id, artifact_id)
+
     def list_workspace_artifacts(self, workspace_id: str) -> list[dict[str, Any]]:
         """List all artifacts for a workspace."""
         cursor = self.execute_query(
@@ -15328,6 +15332,62 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 )
             versions.append(item)
         return versions
+
+    def append_workspace_artifact_export_ref(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        export_ref: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Append an export reference without creating a new artifact content version."""
+        existing = self._get_workspace_artifact(workspace_id, artifact_id)
+        if existing is None:
+            raise ConflictError(  # noqa: TRY003
+                f"Workspace artifact '{artifact_id}' not found.",
+                entity="workspace_artifacts",
+                entity_id=artifact_id,
+            )
+        artifact_version_id = str(export_ref.get("artifact_version_id") or existing.get("artifact_version_id") or "")
+        existing_export_refs = existing.get("export_refs") or []
+        if not isinstance(existing_export_refs, list):
+            raise InputError("Workspace artifact export_refs must be a list.")  # noqa: TRY003
+        export_refs = list(existing_export_refs)
+        export_refs.append(dict(export_ref))
+        export_refs_json = self._dump_workspace_artifact_json(export_refs, [])
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                "UPDATE workspace_artifacts SET export_refs_json = ? WHERE workspace_id = ? AND id = ?",
+                (export_refs_json, workspace_id, artifact_id),
+            )
+            if cursor.rowcount == 0:
+                raise ConflictError(  # noqa: TRY003
+                    f"Artifact '{artifact_id}' export ref update failed.",
+                    entity="workspace_artifacts",
+                    entity_id=artifact_id,
+            )
+            if artifact_version_id:
+                version_row = conn.execute(
+                    "SELECT export_refs_json FROM workspace_artifact_versions "
+                    "WHERE workspace_id = ? AND artifact_id = ? AND artifact_version_id = ?",
+                    (workspace_id, artifact_id, artifact_version_id),
+                ).fetchone()
+                version_export_refs_json = export_refs_json
+                if version_row is not None:
+                    version_export_refs = self._load_workspace_artifact_json(
+                        version_row["export_refs_json"],
+                        [],
+                        field_name="workspace_artifact_versions.export_refs_json",
+                    )
+                    if not isinstance(version_export_refs, list):
+                        raise InputError("Workspace artifact version export_refs must be a list.")  # noqa: TRY003
+                    version_export_refs.append(dict(export_ref))
+                    version_export_refs_json = self._dump_workspace_artifact_json(version_export_refs, [])
+                conn.execute(
+                    "UPDATE workspace_artifact_versions SET export_refs_json = ? "
+                    "WHERE workspace_id = ? AND artifact_id = ? AND artifact_version_id = ?",
+                    (version_export_refs_json, workspace_id, artifact_id, artifact_version_id),
+                )
+        return self._get_workspace_artifact(workspace_id, artifact_id)  # type: ignore[return-value]
 
     def update_workspace_artifact(
         self,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15333,6 +15333,30 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             versions.append(item)
         return versions
 
+    def get_workspace_artifact_version(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        artifact_version_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch one workspace artifact version snapshot by stable version id."""
+        cursor = self.execute_query(
+            "SELECT * FROM workspace_artifact_versions "
+            "WHERE workspace_id = ? AND artifact_id = ? AND artifact_version_id = ?",
+            (workspace_id, artifact_id, artifact_version_id),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        item = dict(row)
+        for column_name, response_name, default in self._WORKSPACE_ARTIFACT_JSON_FIELDS:
+            item[response_name] = self._load_workspace_artifact_json(
+                item.get(column_name),
+                default,
+                field_name=column_name,
+            )
+        return item
+
     def append_workspace_artifact_export_ref(
         self,
         workspace_id: str,
@@ -15340,54 +15364,93 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         export_ref: Mapping[str, Any],
     ) -> dict[str, Any]:
         """Append an export reference without creating a new artifact content version."""
-        existing = self._get_workspace_artifact(workspace_id, artifact_id)
-        if existing is None:
-            raise ConflictError(  # noqa: TRY003
-                f"Workspace artifact '{artifact_id}' not found.",
-                entity="workspace_artifacts",
-                entity_id=artifact_id,
-            )
-        artifact_version_id = str(export_ref.get("artifact_version_id") or existing.get("artifact_version_id") or "")
-        existing_export_refs = existing.get("export_refs") or []
-        if not isinstance(existing_export_refs, list):
-            raise InputError("Workspace artifact export_refs must be a list.")  # noqa: TRY003
-        export_refs = list(existing_export_refs)
-        export_refs.append(dict(export_ref))
-        export_refs_json = self._dump_workspace_artifact_json(export_refs, [])
-        with self.transaction() as conn:
-            cursor = conn.execute(
-                "UPDATE workspace_artifacts SET export_refs_json = ? WHERE workspace_id = ? AND id = ?",
-                (export_refs_json, workspace_id, artifact_id),
-            )
-            if cursor.rowcount == 0:
-                raise ConflictError(  # noqa: TRY003
-                    f"Artifact '{artifact_id}' export ref update failed.",
-                    entity="workspace_artifacts",
-                    entity_id=artifact_id,
-            )
-            if artifact_version_id:
+        for _attempt in range(3):
+            with self.transaction() as conn:
+                artifact_row = conn.execute(
+                    "SELECT artifact_version_id, export_refs_json FROM workspace_artifacts "
+                    "WHERE workspace_id = ? AND id = ?",
+                    (workspace_id, artifact_id),
+                ).fetchone()
+                if artifact_row is None:
+                    raise ConflictError(  # noqa: TRY003
+                        f"Workspace artifact '{artifact_id}' not found.",
+                        entity="workspace_artifacts",
+                        entity_id=artifact_id,
+                    )
+
+                artifact_export_refs_json = artifact_row["export_refs_json"]
+                artifact_version_id = str(
+                    export_ref.get("artifact_version_id") or artifact_row["artifact_version_id"] or ""
+                )
+                if not artifact_version_id:
+                    raise InputError("Workspace artifact export_ref artifact_version_id is required.")  # noqa: TRY003
+
+                artifact_export_refs = self._load_workspace_artifact_json(
+                    artifact_export_refs_json,
+                    [],
+                    field_name="workspace_artifacts.export_refs_json",
+                )
+                if not isinstance(artifact_export_refs, list):
+                    raise InputError("Workspace artifact export_refs must be a list.")  # noqa: TRY003
+                artifact_export_refs = list(artifact_export_refs)
+                artifact_export_refs.append(dict(export_ref))
+                updated_artifact_export_refs_json = self._dump_workspace_artifact_json(artifact_export_refs, [])
+
+                if artifact_export_refs_json is None:
+                    artifact_cursor = conn.execute(
+                        "UPDATE workspace_artifacts SET export_refs_json = ? "
+                        "WHERE workspace_id = ? AND id = ? AND export_refs_json IS NULL",
+                        (updated_artifact_export_refs_json, workspace_id, artifact_id),
+                    )
+                else:
+                    artifact_cursor = conn.execute(
+                        "UPDATE workspace_artifacts SET export_refs_json = ? "
+                        "WHERE workspace_id = ? AND id = ? AND export_refs_json = ?",
+                        (updated_artifact_export_refs_json, workspace_id, artifact_id, artifact_export_refs_json),
+                    )
+                if artifact_cursor.rowcount == 0:
+                    continue
+
                 version_row = conn.execute(
                     "SELECT export_refs_json FROM workspace_artifact_versions "
                     "WHERE workspace_id = ? AND artifact_id = ? AND artifact_version_id = ?",
                     (workspace_id, artifact_id, artifact_version_id),
                 ).fetchone()
-                version_export_refs_json = export_refs_json
-                if version_row is not None:
-                    version_export_refs = self._load_workspace_artifact_json(
-                        version_row["export_refs_json"],
-                        [],
-                        field_name="workspace_artifact_versions.export_refs_json",
+                if version_row is None:
+                    raise ConflictError(  # noqa: TRY003
+                        f"Workspace artifact version '{artifact_version_id}' missing for artifact '{artifact_id}'.",
+                        entity="workspace_artifact_versions",
+                        entity_id=artifact_version_id,
                     )
-                    if not isinstance(version_export_refs, list):
-                        raise InputError("Workspace artifact version export_refs must be a list.")  # noqa: TRY003
-                    version_export_refs.append(dict(export_ref))
-                    version_export_refs_json = self._dump_workspace_artifact_json(version_export_refs, [])
-                conn.execute(
+
+                version_export_refs = self._load_workspace_artifact_json(
+                    version_row["export_refs_json"],
+                    [],
+                    field_name="workspace_artifact_versions.export_refs_json",
+                )
+                if not isinstance(version_export_refs, list):
+                    raise InputError("Workspace artifact version export_refs must be a list.")  # noqa: TRY003
+                version_export_refs = list(version_export_refs)
+                version_export_refs.append(dict(export_ref))
+                version_export_refs_json = self._dump_workspace_artifact_json(version_export_refs, [])
+                version_cursor = conn.execute(
                     "UPDATE workspace_artifact_versions SET export_refs_json = ? "
                     "WHERE workspace_id = ? AND artifact_id = ? AND artifact_version_id = ?",
                     (version_export_refs_json, workspace_id, artifact_id, artifact_version_id),
                 )
-        return self._get_workspace_artifact(workspace_id, artifact_id)  # type: ignore[return-value]
+                if version_cursor.rowcount == 0:
+                    raise ConflictError(  # noqa: TRY003
+                        f"Artifact version '{artifact_version_id}' export ref update failed.",
+                        entity="workspace_artifact_versions",
+                        entity_id=artifact_version_id,
+                    )
+                return self._get_workspace_artifact(workspace_id, artifact_id)  # type: ignore[return-value]
+
+        raise ConflictError(  # noqa: TRY003
+            f"Artifact '{artifact_id}' export ref update conflicted with another writer.",
+            entity="workspace_artifacts",
+            entity_id=artifact_id,
+        )
 
     def update_workspace_artifact(
         self,

--- a/tldw_Server_API/app/core/Workspaces/__init__.py
+++ b/tldw_Server_API/app/core/Workspaces/__init__.py
@@ -1,0 +1,1 @@
+"""Workspace domain helpers."""

--- a/tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py
+++ b/tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py
@@ -1,24 +1,27 @@
 """Export helpers for traceable workspace artifact versions."""
 from __future__ import annotations
 
+import base64
 import json
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from html import escape
 from typing import Any
 
+import markdown
+
+from tldw_Server_API.app.core.exceptions import WorkspaceArtifactExportStateError
+
 ALLOWED_WORKSPACE_ARTIFACT_EXPORT_FORMATS = ("md", "html", "json")
 
 
-class WorkspaceArtifactExportStateError(ValueError):
-    """Raised when an artifact version is not eligible for export."""
-
-
 def _utc_now_iso() -> str:
+    """Return a second-precision UTC timestamp for deterministic export metadata."""
     return datetime.now(UTC).replace(microsecond=0).isoformat()
 
 
 def _artifact_identity(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the stable artifact identity block shared by all export formats."""
     artifact_id = str(artifact.get("id") or artifact.get("artifact_id") or "")
     version = int(artifact.get("version") or 1)
     return {
@@ -36,6 +39,7 @@ def _artifact_identity(artifact: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _export_metadata(artifact: Mapping[str, Any], *, export_format: str, generated_at: str) -> dict[str, Any]:
+    """Collect traceability metadata that travels with an artifact export."""
     return {
         "artifact": _artifact_identity(artifact),
         "review_state": artifact.get("review_state") or "draft",
@@ -51,10 +55,26 @@ def _export_metadata(artifact: Mapping[str, Any], *, export_format: str, generat
     }
 
 
+def _metadata_json(metadata: Mapping[str, Any]) -> str:
+    """Serialize export metadata with stable ordering for reproducible payloads."""
+    return json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+
+
+def _metadata_base64(metadata: Mapping[str, Any]) -> str:
+    """Encode metadata for HTML-comment-safe Markdown embedding."""
+    return base64.b64encode(_metadata_json(metadata).encode("utf-8")).decode("ascii")
+
+
+def _render_markdown_body_html(body: Any) -> str:
+    """Render artifact Markdown to HTML while escaping raw inline HTML."""
+    safe_markdown = escape(str(body or ""))
+    return markdown.markdown(safe_markdown, extensions=["extra", "sane_lists"], output_format="html5")
+
+
 def _render_markdown_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    """Render an accepted artifact version as Markdown with trace metadata."""
     identity = metadata["artifact"]
     body = artifact.get("content") or ""
-    metadata_json = json.dumps(metadata, ensure_ascii=True, sort_keys=True)
     return (
         "---\n"
         f"artifact_id: {identity['id']}\n"
@@ -64,17 +84,18 @@ def _render_markdown_export(artifact: Mapping[str, Any], metadata: Mapping[str, 
         f"format: {metadata['export']['format']}\n"
         f"generated_at: {metadata['export']['generated_at']}\n"
         "---\n\n"
-        "<!-- tldw-artifact-metadata: "
-        f"{metadata_json}"
+        "<!-- tldw-artifact-metadata-base64: "
+        f"{_metadata_base64(metadata)}"
         " -->\n\n"
         f"{body}"
     )
 
 
 def _render_html_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    """Render an accepted artifact version as standalone HTML."""
     identity = metadata["artifact"]
     body = artifact.get("content") or ""
-    metadata_json = json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+    metadata_json = _metadata_json(metadata)
     script_metadata_json = (
         metadata_json
         .replace("&", "\\u0026")
@@ -99,7 +120,7 @@ def _render_html_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]
         f' data-review-state="{escape(str(metadata["review_state"]), quote=True)}"'
         ">\n"
         f"    <h1>{escape(str(title))}</h1>\n"
-        f"    <pre>{escape(str(body))}</pre>\n"
+        f"    <section class=\"artifact-content\">\n{_render_markdown_body_html(body)}\n    </section>\n"
         "  </article>\n"
         '  <script type="application/json" data-tldw-artifact-metadata>'
         f"{script_metadata_json}"
@@ -110,6 +131,7 @@ def _render_html_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]
 
 
 def _render_json_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    """Render an accepted artifact version as a structured JSON document."""
     return json.dumps(
         {
             "artifact": metadata["artifact"],

--- a/tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py
+++ b/tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py
@@ -1,0 +1,176 @@
+"""Export helpers for traceable workspace artifact versions."""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from html import escape
+from typing import Any
+
+ALLOWED_WORKSPACE_ARTIFACT_EXPORT_FORMATS = ("md", "html", "json")
+
+
+class WorkspaceArtifactExportStateError(ValueError):
+    """Raised when an artifact version is not eligible for export."""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def _artifact_identity(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    artifact_id = str(artifact.get("id") or artifact.get("artifact_id") or "")
+    version = int(artifact.get("version") or 1)
+    return {
+        "id": artifact_id,
+        "workspace_id": artifact.get("workspace_id"),
+        "artifact_type": artifact.get("artifact_type"),
+        "title": artifact.get("title"),
+        "root_artifact_id": artifact.get("root_artifact_id") or artifact_id,
+        "artifact_version_id": artifact.get("artifact_version_id") or f"{artifact_id}:v{version}",
+        "previous_version_id": artifact.get("previous_version_id"),
+        "content_type": artifact.get("content_type") or "text/markdown",
+        "schema_version": artifact.get("schema_version") or 1,
+        "version": version,
+    }
+
+
+def _export_metadata(artifact: Mapping[str, Any], *, export_format: str, generated_at: str) -> dict[str, Any]:
+    return {
+        "artifact": _artifact_identity(artifact),
+        "review_state": artifact.get("review_state") or "draft",
+        "producer_metadata": artifact.get("producer_metadata") or {},
+        "source_lineage": artifact.get("source_lineage") or {},
+        "review_metadata": artifact.get("review_metadata") or {},
+        "version_metadata": artifact.get("version_metadata") or {},
+        "redaction": artifact.get("redaction") or {"support_safe": True, "redacted": False},
+        "export": {
+            "format": export_format,
+            "generated_at": generated_at,
+        },
+    }
+
+
+def _render_markdown_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    identity = metadata["artifact"]
+    body = artifact.get("content") or ""
+    metadata_json = json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+    return (
+        "---\n"
+        f"artifact_id: {identity['id']}\n"
+        f"artifact_version_id: {identity['artifact_version_id']}\n"
+        f"workspace_id: {identity['workspace_id']}\n"
+        f"review_state: {metadata['review_state']}\n"
+        f"format: {metadata['export']['format']}\n"
+        f"generated_at: {metadata['export']['generated_at']}\n"
+        "---\n\n"
+        "<!-- tldw-artifact-metadata: "
+        f"{metadata_json}"
+        " -->\n\n"
+        f"{body}"
+    )
+
+
+def _render_html_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    identity = metadata["artifact"]
+    body = artifact.get("content") or ""
+    metadata_json = json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+    script_metadata_json = (
+        metadata_json
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+    )
+    title = identity.get("title") or identity["id"]
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '  <meta charset="utf-8">\n'
+        f'  <meta name="tldw-artifact-id" content="{escape(str(identity["id"]), quote=True)}">\n'
+        f'  <meta name="tldw-artifact-version-id" content="{escape(str(identity["artifact_version_id"]), quote=True)}">\n'
+        f"  <title>{escape(str(title))}</title>\n"
+        "</head>\n"
+        "<body>\n"
+        "  <article"
+        f' data-artifact-id="{escape(str(identity["id"]), quote=True)}"'
+        f' data-artifact-version-id="{escape(str(identity["artifact_version_id"]), quote=True)}"'
+        f' data-workspace-id="{escape(str(identity["workspace_id"]), quote=True)}"'
+        f' data-review-state="{escape(str(metadata["review_state"]), quote=True)}"'
+        ">\n"
+        f"    <h1>{escape(str(title))}</h1>\n"
+        f"    <pre>{escape(str(body))}</pre>\n"
+        "  </article>\n"
+        '  <script type="application/json" data-tldw-artifact-metadata>'
+        f"{script_metadata_json}"
+        "</script>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def _render_json_export(artifact: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    return json.dumps(
+        {
+            "artifact": metadata["artifact"],
+            "metadata": metadata,
+            "content": artifact.get("content") or "",
+        },
+        ensure_ascii=True,
+        indent=2,
+        sort_keys=True,
+    )
+
+
+def export_workspace_artifact_version(
+    artifact: Mapping[str, Any],
+    *,
+    export_format: str,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Render an accepted workspace artifact version into an export payload."""
+    if export_format not in ALLOWED_WORKSPACE_ARTIFACT_EXPORT_FORMATS:
+        raise ValueError(f"Unsupported workspace artifact export format '{export_format}'.")
+
+    review_state = str(artifact.get("review_state") or "draft")
+    if review_state != "accepted":
+        raise WorkspaceArtifactExportStateError("workspace_artifact_not_accepted")
+
+    generated_at = generated_at or _utc_now_iso()
+    metadata = _export_metadata(artifact, export_format=export_format, generated_at=generated_at)
+    content_by_format = {
+        "md": _render_markdown_export,
+        "html": _render_html_export,
+        "json": _render_json_export,
+    }
+    content = content_by_format[export_format](artifact, metadata)
+    content_type = {
+        "md": "text/markdown",
+        "html": "text/html",
+        "json": "application/json",
+    }[export_format]
+    encoded_length = len(content.encode("utf-8"))
+    identity = metadata["artifact"]
+    export_ref = {
+        "source": "workspace_artifact_export",
+        "format": export_format,
+        "workspace_id": identity["workspace_id"],
+        "artifact_id": identity["id"],
+        "artifact_version_id": identity["artifact_version_id"],
+        "content_type": content_type,
+        "bytes": encoded_length,
+        "exported_at": generated_at,
+    }
+    return {
+        "workspace_id": identity["workspace_id"],
+        "artifact_id": identity["id"],
+        "artifact_version_id": identity["artifact_version_id"],
+        "review_state": review_state,
+        "format": export_format,
+        "content_type": content_type,
+        "content": content,
+        "bytes": encoded_length,
+        "metadata": metadata,
+        "export_ref": export_ref,
+        "generated_at": generated_at,
+    }

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -180,6 +180,10 @@ class StorageUnavailableError(StoragePathValidationError):
     """Raised when storage base directories cannot be resolved."""
 
 
+class WorkspaceArtifactExportStateError(ValueError):
+    """Raised when a workspace artifact version is not eligible for export."""
+
+
 class InvalidStorageUserIdError(StoragePathValidationError):
     """Raised when a storage path resolution is attempted with an invalid user id."""
 

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -1,4 +1,5 @@
 """Tests for workspace CRUD endpoints and scoped chat session isolation."""
+import base64
 import json
 from types import SimpleNamespace
 
@@ -614,7 +615,7 @@ def test_workspace_artifact_export_accepted_version_preserves_identity_and_refs(
             {
                 "id": "brief-1",
                 "artifact_type": "workspace_brief",
-                "title": "ACP Research Brief",
+                "title": "ACP Research Brief --> Review",
                 "status": "completed",
                 "content": "# Brief\nGrounded <answer>.",
                 "content_type": "text/markdown",
@@ -624,6 +625,7 @@ def test_workspace_artifact_export_accepted_version_preserves_identity_and_refs(
                 "producer_metadata": {
                     "producer_type": "acp",
                     "producer_id": "task-42",
+                    "marker": "json --> comment boundary",
                     "run_id": "run-7",
                     "session_id": "session-abc",
                 },
@@ -642,9 +644,12 @@ def test_workspace_artifact_export_accepted_version_preserves_identity_and_refs(
         with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
             by_format = {}
             for export_format in ("md", "html", "json"):
+                request_json = {"format": export_format}
+                if export_format == "json":
+                    request_json["artifact_version_id"] = "brief-1:v1"
                 response = client.post(
                     "/api/v1/workspaces/ws-export-api/artifacts/brief-1/exports",
-                    json={"format": export_format},
+                    json=request_json,
                 )
                 assert response.status_code == 200, response.text
                 payload = response.json()
@@ -659,8 +664,15 @@ def test_workspace_artifact_export_accepted_version_preserves_identity_and_refs(
                 assert payload["metadata"]["producer_metadata"]["run_id"] == "run-7"
                 assert payload["export_ref"]["artifact_version_id"] == "brief-1:v1"
 
-            assert "artifact_id: brief-1" in by_format["md"]["content"]
+            md_content = by_format["md"]["content"]
+            assert "artifact_id: brief-1" in md_content
+            assert "tldw-artifact-metadata-base64:" in md_content
+            marker = md_content.split("<!-- tldw-artifact-metadata-base64: ", 1)[1].split(" -->", 1)[0]
+            decoded_metadata = json.loads(base64.b64decode(marker).decode("utf-8"))
+            assert decoded_metadata["artifact"]["title"] == "ACP Research Brief --> Review"
+            assert decoded_metadata["producer_metadata"]["marker"] == "json --> comment boundary"
             assert 'data-artifact-id="brief-1"' in by_format["html"]["content"]
+            assert "<h1>Brief</h1>" in by_format["html"]["content"]
             assert "&lt;answer&gt;" in by_format["html"]["content"]
             exported_json = json.loads(by_format["json"]["content"])
             assert exported_json["artifact"]["id"] == "brief-1"
@@ -673,6 +685,68 @@ def test_workspace_artifact_export_accepted_version_preserves_identity_and_refs(
             assert export_refs[0]["format"] == "legacy"
             assert [ref["format"] for ref in export_refs[-3:]] == ["md", "html", "json"]
             assert {ref["artifact_version_id"] for ref in export_refs[-3:]} == {"brief-1:v1"}
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
+def test_workspace_artifact_export_missing_version_snapshot_fails_loudly(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    def _db() -> CharactersRAGDB:
+        return db
+
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = _db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        db.upsert_workspace("ws-export-api", "Workspace Exports")
+        db.add_workspace_artifact(
+            "ws-export-api",
+            {
+                "id": "brief-1",
+                "artifact_type": "workspace_brief",
+                "title": "ACP Research Brief",
+                "content": "# Brief\nGrounded answer.",
+                "review_state": "accepted",
+                "source_lineage": {"sources": [{"source_id": "src-1"}]},
+            },
+        )
+        with db.transaction() as conn:
+            conn.execute(
+                "DELETE FROM workspace_artifact_versions "
+                "WHERE workspace_id = ? AND artifact_id = ? AND artifact_version_id = ?",
+                ("ws-export-api", "brief-1", "brief-1:v1"),
+            )
+
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/v1/workspaces/ws-export-api/artifacts/brief-1/exports",
+                json={"format": "md"},
+            )
+            assert response.status_code == 409, response.text
+            assert "missing" in response.json()["detail"].lower()
+
+            fetch_response = client.get("/api/v1/workspaces/ws-export-api/artifacts")
+            assert fetch_response.status_code == 200, fetch_response.text
+            assert fetch_response.json()[0]["export_refs"] == []
     finally:
         workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
         workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -13,8 +13,8 @@ from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
 )
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
-    CharactersRAGDBError,
     CharactersRAGDB,
+    CharactersRAGDBError,
     ConflictError,
     InputError,
 )
@@ -107,11 +107,11 @@ class TestWorkspaceLifecycle:
 
 @pytest.mark.integration
 def test_workspace_api_accepts_and_returns_study_materials_policy(workspace_fastapi_app, db):
-    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user, User
     from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
         WORKSPACES_READ_RATE_LIMIT,
         WORKSPACES_WRITE_RATE_LIMIT,
     )
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 
     async def _allow_rate_limit() -> None:
         return None
@@ -581,6 +581,159 @@ def test_workspace_artifact_redaction_schema_requires_typed_posture():
     redaction_schema = schema["$defs"][redaction_ref.rsplit("/", 1)[-1]]
     assert redaction_schema["properties"]["support_safe"]["type"] == "boolean"
     assert redaction_schema["properties"]["redacted"]["type"] == "boolean"
+
+
+@pytest.mark.integration
+def test_workspace_artifact_export_accepted_version_preserves_identity_and_refs(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    def _db() -> CharactersRAGDB:
+        return db
+
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = _db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        db.upsert_workspace("ws-export-api", "Workspace Exports")
+        db.add_workspace_artifact(
+            "ws-export-api",
+            {
+                "id": "brief-1",
+                "artifact_type": "workspace_brief",
+                "title": "ACP Research Brief",
+                "status": "completed",
+                "content": "# Brief\nGrounded <answer>.",
+                "content_type": "text/markdown",
+                "review_state": "accepted",
+                "owner_scope": "workspace",
+                "owner_id": "ws-export-api",
+                "producer_metadata": {
+                    "producer_type": "acp",
+                    "producer_id": "task-42",
+                    "run_id": "run-7",
+                    "session_id": "session-abc",
+                },
+                "source_lineage": {
+                    "sources": [
+                        {"source_id": "src-1", "source_type": "media", "label": "Transcript"}
+                    ]
+                },
+                "review_metadata": {"decision": "accepted"},
+                "version_metadata": {"revision_reason": "initial"},
+                "export_refs": [{"format": "legacy", "artifact_version_id": "brief-1:v1"}],
+                "redaction": {"support_safe": True, "redacted": False},
+            },
+        )
+
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            by_format = {}
+            for export_format in ("md", "html", "json"):
+                response = client.post(
+                    "/api/v1/workspaces/ws-export-api/artifacts/brief-1/exports",
+                    json={"format": export_format},
+                )
+                assert response.status_code == 200, response.text
+                payload = response.json()
+                by_format[export_format] = payload
+                assert payload["workspace_id"] == "ws-export-api"
+                assert payload["artifact_id"] == "brief-1"
+                assert payload["artifact_version_id"] == "brief-1:v1"
+                assert payload["review_state"] == "accepted"
+                assert payload["format"] == export_format
+                assert payload["bytes"] == len(payload["content"].encode("utf-8"))
+                assert payload["metadata"]["source_lineage"]["sources"][0]["source_id"] == "src-1"
+                assert payload["metadata"]["producer_metadata"]["run_id"] == "run-7"
+                assert payload["export_ref"]["artifact_version_id"] == "brief-1:v1"
+
+            assert "artifact_id: brief-1" in by_format["md"]["content"]
+            assert 'data-artifact-id="brief-1"' in by_format["html"]["content"]
+            assert "&lt;answer&gt;" in by_format["html"]["content"]
+            exported_json = json.loads(by_format["json"]["content"])
+            assert exported_json["artifact"]["id"] == "brief-1"
+            assert exported_json["metadata"]["source_lineage"]["sources"][0]["source_id"] == "src-1"
+
+            fetch_response = client.get("/api/v1/workspaces/ws-export-api/artifacts")
+            assert fetch_response.status_code == 200, fetch_response.text
+            exported_artifact = fetch_response.json()[0]
+            export_refs = exported_artifact["export_refs"]
+            assert export_refs[0]["format"] == "legacy"
+            assert [ref["format"] for ref in export_refs[-3:]] == ["md", "html", "json"]
+            assert {ref["artifact_version_id"] for ref in export_refs[-3:]} == {"brief-1:v1"}
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
+def test_workspace_artifact_export_rejects_non_accepted_state(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    def _db() -> CharactersRAGDB:
+        return db
+
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = _db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        db.upsert_workspace("ws-export-api", "Workspace Exports")
+        db.add_workspace_artifact(
+            "ws-export-api",
+            {
+                "id": "brief-1",
+                "artifact_type": "workspace_brief",
+                "title": "ACP Research Brief",
+                "content": "# Draft\nNeeds more evidence.",
+                "review_state": "needs_revision",
+                "source_lineage": {"sources": [{"source_id": "src-1"}]},
+            },
+        )
+
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/v1/workspaces/ws-export-api/artifacts/brief-1/exports",
+                json={"format": "md"},
+            )
+            assert response.status_code == 409, response.text
+            assert response.json()["detail"] == "workspace_artifact_not_accepted"
+
+            fetch_response = client.get("/api/v1/workspaces/ws-export-api/artifacts")
+            assert fetch_response.status_code == 200, fetch_response.text
+            assert fetch_response.json()[0]["export_refs"] == []
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/workspaces/{workspace_id}/artifacts/{artifact_id}/exports` for accepted workspace artifact version exports.
- Renders Markdown, HTML, and JSON export payloads that preserve artifact/version/workspace identity, source lineage, review state, producer metadata, generated timestamp, byte count, and export reference metadata.
- Appends export refs without creating a new content version and updates ACP artifact contract docs plus the Backlog task/plan.

Closes #1705.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q` -> 66 passed, 5 warnings
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m compileall -q tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_acp_artifact_exports_1705.json` -> 0 findings
- `git diff --check` -> passed

## Change Summary

Human-authored change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds POST /api/v1/workspaces/{workspace_id}/artifacts/{artifact_id}/exports to export accepted artifact versions as Markdown, HTML, or JSON. Exports preserve artifact/workspace/version identity and append an export reference on the artifact and matching version without creating a new content version.

- **New Features**
  - Adds export request/response schemas and a renderer for `md`, `html`, and `json` with identity, lineage, producer/review metadata, redaction posture, timestamp, and byte count; Markdown embeds a base64 metadata comment, and HTML renders escaped Markdown with a JSON metadata script tag.
  - Supports an optional `artifact_version_id`; persists `export_refs` transactionally on the artifact and the corresponding version without a content bump.
  - Enforces accepted-only exports (409 `workspace_artifact_not_accepted`); missing version snapshots return 409 with conflict details; missing artifact/version returns 404; adds contextual export logging.
  - Updates product/contract docs and adds focused API tests for all formats, metadata boundaries, non-accepted rejection, and missing-version conflicts.

<sup>Written for commit 09cd205fd42ff4d2034f575fe33f52b3a1ad415f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1726?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

