### PR TITLE
Migrate StorageQuotaBanner alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -77,28 +77,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Common/StorageQuotaBanner.tsx:Alert#antd-alert-storagequotabanner-type-error-storage-nearly-t57dw4",
-    "path": "src/components/Common/StorageQuotaBanner.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/StorageQuotaBanner.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Common/StorageQuotaBanner.tsx:Alert#antd-alert-storagequotabanner-type-warning-storage-getti-owpvse",
-    "path": "src/components/Common/StorageQuotaBanner.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/StorageQuotaBanner.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Common/Workflow/steps/AnalyzeBookWorkflow.tsx:Alert#antd-alert-chunkingstep-type-warning-line-479-3p9wfj",
     "path": "src/components/Common/Workflow/steps/AnalyzeBookWorkflow.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/assets/locale/en/common.json
+++ b/apps/packages/ui/src/assets/locale/en/common.json
@@ -36,6 +36,12 @@
   "saving": "Saving...",
   "retry": "Retry",
   "close": "Close",
+  "storageQuota": {
+    "exceededTitle": "Storage nearly full",
+    "exceededDescription": "Workspace storage is {{pct}}% full ({{usedMB}}/{{budgetMB}} MB). New data may not save. Archive or delete old workspaces to free space.",
+    "warningTitle": "Storage getting full",
+    "warningDescription": "Workspace storage is {{pct}}% full ({{usedMB}}/{{budgetMB}} MB). Consider archiving old workspaces."
+  },
   "loadMore": "Load More...",
   "share": {
     "tooltip": {

--- a/apps/packages/ui/src/components/Common/StorageQuotaBanner.tsx
+++ b/apps/packages/ui/src/components/Common/StorageQuotaBanner.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Alert } from "antd"
+import { Alert } from "@/components/ui"
 import { useStorageQuota } from "@/hooks/useStorageQuota"
 
 const DISMISS_KEY = "tldw:storage-quota-banner-dismissed"
@@ -38,25 +38,26 @@ export function StorageQuotaBanner() {
   if (level === "exceeded") {
     return (
       <Alert
-        type="error"
-        showIcon
+        variant="error"
         data-testid="storage-quota-banner-exceeded"
         title="Storage nearly full"
-        description={`Workspace storage is ${pct}% full (${usedMB}/${budgetMB} MB). New data may not save. Archive or delete old workspaces to free space.`}
-      />
+      >
+        {`Workspace storage is ${pct}% full (${usedMB}/${budgetMB} MB). New data may not save. Archive or delete old workspaces to free space.`}
+      </Alert>
     )
   }
 
   // warning level
   return (
     <Alert
-      type="warning"
-      showIcon
-      closable
-      onClose={handleDismiss}
+      variant="warning"
+      dismissible
+      onDismiss={handleDismiss}
+      dismissLabel="Close"
       data-testid="storage-quota-banner-warning"
       title="Storage getting full"
-      description={`Workspace storage is ${pct}% full (${usedMB}/${budgetMB} MB). Consider archiving old workspaces.`}
-    />
+    >
+      {`Workspace storage is ${pct}% full (${usedMB}/${budgetMB} MB). Consider archiving old workspaces.`}
+    </Alert>
   )
 }

--- a/apps/packages/ui/src/components/Common/StorageQuotaBanner.tsx
+++ b/apps/packages/ui/src/components/Common/StorageQuotaBanner.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Alert } from "@/components/ui"
 import { useStorageQuota } from "@/hooks/useStorageQuota"
 
 const DISMISS_KEY = "tldw:storage-quota-banner-dismissed"
 
 export function StorageQuotaBanner() {
+  const { t } = useTranslation(["common"])
   const { level, ratio, usedBytes, budgetBytes } = useStorageQuota()
 
   // Session-scoped dismiss (sessionStorage, not localStorage -- re-shows next session)
@@ -40,9 +42,17 @@ export function StorageQuotaBanner() {
       <Alert
         variant="error"
         data-testid="storage-quota-banner-exceeded"
-        title="Storage nearly full"
+        title={t("common:storageQuota.exceededTitle", {
+          defaultValue: "Storage nearly full"
+        })}
       >
-        {`Workspace storage is ${pct}% full (${usedMB}/${budgetMB} MB). New data may not save. Archive or delete old workspaces to free space.`}
+        {t("common:storageQuota.exceededDescription", {
+          defaultValue:
+            "Workspace storage is {{pct}}% full ({{usedMB}}/{{budgetMB}} MB). New data may not save. Archive or delete old workspaces to free space.",
+          pct,
+          usedMB,
+          budgetMB
+        })}
       </Alert>
     )
   }
@@ -53,11 +63,19 @@ export function StorageQuotaBanner() {
       variant="warning"
       dismissible
       onDismiss={handleDismiss}
-      dismissLabel="Close"
+      dismissLabel={t("common:close", { defaultValue: "Close" })}
       data-testid="storage-quota-banner-warning"
-      title="Storage getting full"
+      title={t("common:storageQuota.warningTitle", {
+        defaultValue: "Storage getting full"
+      })}
     >
-      {`Workspace storage is ${pct}% full (${usedMB}/${budgetMB} MB). Consider archiving old workspaces.`}
+      {t("common:storageQuota.warningDescription", {
+        defaultValue:
+          "Workspace storage is {{pct}}% full ({{usedMB}}/{{budgetMB}} MB). Consider archiving old workspaces.",
+        pct,
+        usedMB,
+        budgetMB
+      })}
     </Alert>
   )
 }

--- a/apps/packages/ui/src/components/Common/__tests__/StorageQuotaBanner.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/StorageQuotaBanner.test.tsx
@@ -17,6 +17,22 @@ vi.mock("@/hooks/useStorageQuota", () => ({
   useStorageQuota: () => mockQuota
 }))
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      options?: string | { defaultValue?: string; [key: string]: unknown }
+    ) => {
+      if (typeof options === "string") return options
+      const template = options?.defaultValue ?? key
+
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, token) =>
+        String(options?.[token] ?? "")
+      )
+    }
+  })
+}))
+
 import { StorageQuotaBanner } from "../StorageQuotaBanner"
 
 describe("StorageQuotaBanner", () => {

--- a/apps/packages/ui/src/components/Common/__tests__/StorageQuotaBanner.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/StorageQuotaBanner.test.tsx
@@ -36,7 +36,9 @@ describe("StorageQuotaBanner", () => {
     mockQuota.ratio = 0.82
     mockQuota.usedBytes = 4.1 * 1024 * 1024
     render(<StorageQuotaBanner />)
-    expect(screen.getByTestId("storage-quota-banner-warning")).toBeInTheDocument()
+    const banner = screen.getByTestId("storage-quota-banner-warning")
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute("data-ds-component", "Alert")
     expect(screen.getByText("Storage getting full")).toBeInTheDocument()
     expect(screen.getByText(/82%/)).toBeInTheDocument()
   })
@@ -46,7 +48,9 @@ describe("StorageQuotaBanner", () => {
     mockQuota.ratio = 0.97
     mockQuota.usedBytes = 4.85 * 1024 * 1024
     render(<StorageQuotaBanner />)
-    expect(screen.getByTestId("storage-quota-banner-exceeded")).toBeInTheDocument()
+    const banner = screen.getByTestId("storage-quota-banner-exceeded")
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute("data-ds-component", "Alert")
     expect(screen.getByText("Storage nearly full")).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/public/_locales/en/common.json
+++ b/apps/packages/ui/src/public/_locales/en/common.json
@@ -56,6 +56,18 @@
   "close": {
     "message": "Close"
   },
+  "storageQuota_exceededTitle": {
+    "message": "Storage nearly full"
+  },
+  "storageQuota_exceededDescription": {
+    "message": "Workspace storage is {{pct}}% full ({{usedMB}}/{{budgetMB}} MB). New data may not save. Archive or delete old workspaces to free space."
+  },
+  "storageQuota_warningTitle": {
+    "message": "Storage getting full"
+  },
+  "storageQuota_warningDescription": {
+    "message": "Workspace storage is {{pct}}% full ({{usedMB}}/{{budgetMB}} MB). Consider archiving old workspaces."
+  },
   "loadMore": {
     "message": "Load More..."
   },

--- a/backlog/tasks/task-45.47 - Migrate-StorageQuotaBanner-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.47 - Migrate-StorageQuotaBanner-alerts-to-design-system-Alert.md
@@ -47,12 +47,14 @@ Focused coverage asserts warning and exceeded banners render the design-system A
 Removed the two StorageQuotaBanner AntD Alert exceptions from apps/packages/ui/scripts/design-system-product-state-baseline.json.
 
 PR opened against dev: https://github.com/rmusser01/tldw_server/pull/1728.
+
+Review pass: localized StorageQuotaBanner warning/exceeded titles, descriptions, and dismiss label through common namespace keys while preserving English fallback copy. Verified the shared design-system Alert primitive already renders variant icons by default, so no icon-parity code change was needed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated StorageQuotaBanner warning and exceeded quota banners from AntD Alert to the shared design-system Alert primitive, added focused assertions that both states render the design-system primitive, and removed the StorageQuotaBanner AntD Alert baseline exceptions. Verification recorded: red test failed on missing design-system Alert marker, focused StorageQuotaBanner tests passed after implementation, combined StorageQuotaBanner/product-state guard suite passed, design-system verifier passed with 477 remaining AntD product-state baseline exceptions, baseline JSON parse passed, git diff --check passed, and package TypeScript still has existing unrelated diagnostics with no touched-file matches. Bandit is not applicable because this slice touched TypeScript, test, and JSON frontend files only.
+Migrated StorageQuotaBanner warning and exceeded quota banners from AntD Alert to the shared design-system Alert primitive, added focused assertions that both states render the design-system primitive, removed the StorageQuotaBanner AntD Alert baseline exceptions, and addressed PR review by routing the banner titles, descriptions, and dismiss label through i18n keys with English fallbacks. Verification recorded: red test failed on missing design-system Alert marker, focused StorageQuotaBanner tests passed after implementation and review fix, combined StorageQuotaBanner/product-state guard suite passed, design-system verifier passed with 477 remaining AntD product-state baseline exceptions, locale JSON parse passed, git diff --check passed, and the repo-wide frontend tsc pass was stopped after running long with no output. Bandit is not applicable because this slice touched TypeScript, test, and JSON frontend files only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.47 - Migrate-StorageQuotaBanner-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.47 - Migrate-StorageQuotaBanner-alerts-to-design-system-Alert.md
@@ -1,0 +1,66 @@
+---
+id: TASK-45.47
+title: Migrate StorageQuotaBanner alerts to design-system Alert
+status: Done
+assignee: []
+created_date: '2026-05-15 19:25'
+updated_date: '2026-05-15 19:36'
+labels:
+  - design-system
+  - webui
+  - product-state
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Common/StorageQuotaBanner.tsx
+  - apps/packages/ui/src/components/Common/__tests__/StorageQuotaBanner.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - https://github.com/rmusser01/tldw_server/pull/1728
+documentation:
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by replacing StorageQuotaBanner's remaining AntD Alert product-state usage with the shared design-system Alert primitive while preserving warning dismissal and exceeded-quota behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 StorageQuotaBanner renders warning and exceeded quota banners through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Existing warning dismissal and exceeded non-dismissable behavior remain covered by focused tests.
+- [x] #3 The design-system product-state baseline no longer contains StorageQuotaBanner AntD Alert exceptions.
+- [x] #4 Focused tests and design-system verifier results are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation completed on branch codex/design-system-next-slice-7 in the dedicated design-system worktree.
+
+StorageQuotaBanner now imports the shared design-system Alert primitive and maps exceeded quota to variant="error" and warning quota to variant="warning" with dismissible/onDismiss behavior.
+
+Focused coverage asserts warning and exceeded banners render the design-system Alert marker while preserving session dismissal and exceeded non-dismissable behavior.
+
+Removed the two StorageQuotaBanner AntD Alert exceptions from apps/packages/ui/scripts/design-system-product-state-baseline.json.
+
+PR opened against dev: https://github.com/rmusser01/tldw_server/pull/1728.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated StorageQuotaBanner warning and exceeded quota banners from AntD Alert to the shared design-system Alert primitive, added focused assertions that both states render the design-system primitive, and removed the StorageQuotaBanner AntD Alert baseline exceptions. Verification recorded: red test failed on missing design-system Alert marker, focused StorageQuotaBanner tests passed after implementation, combined StorageQuotaBanner/product-state guard suite passed, design-system verifier passed with 477 remaining AntD product-state baseline exceptions, baseline JSON parse passed, git diff --check passed, and package TypeScript still has existing unrelated diagnostics with no touched-file matches. Bandit is not applicable because this slice touched TypeScript, test, and JSON frontend files only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- replace StorageQuotaBanner AntD Alert usage with the shared design-system Alert primitive
- preserve exceeded quota non-dismissable behavior and warning session dismissal
- remove StorageQuotaBanner AntD Alert entries from the product-state baseline and close TASK-45.47

## Test plan
- bunx vitest run src/components/Common/__tests__/StorageQuotaBanner.test.tsx --reporter=dot
- bunx vitest run src/components/Common/__tests__/StorageQuotaBanner.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"
- git diff --check
- bunx tsc --noEmit --pretty false (known existing package-wide failures; touched-path filter returned no diagnostics)

## Change summary
TODO: human-authored summary required before merge per AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `StorageQuotaBanner` from `antd` `Alert` to the design-system `Alert` in `@/components/ui` and localized banner copy. Preserves warning dismissal and exceeded non-dismissable behavior; completes TASK-45.47.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert`; mapped props (`type`→`variant`, `closable`→`dismissible`, `onClose`→`onDismiss`, `description`→children) and set `dismissLabel` via `t("common:close")`.
  - Localized titles/descriptions with `react-i18next` keys `common:storageQuota.*` and fallbacks; added strings to `assets` and `public` locale JSON.
  - Updated tests to mock `react-i18next`, assert `data-ds-component="Alert"`, and removed two AntD `Alert` exceptions from `design-system-product-state-baseline.json`.

<sup>Written for commit a522006658fa1dc7aafcd28b23c6ebb71b9e929d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1728?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

