### PR TITLE
[Risk Gate 3] Harden prototype runtime job durability

### DIFF
--- a/Docs/API-related/Prototype_Workspaces_API.md
+++ b/Docs/API-related/Prototype_Workspaces_API.md
@@ -249,6 +249,42 @@ Query/index review:
 | cleanup retention sweep | global archived, revoked, expired, and inactive-preview cutoffs | `idx_prototype_workspaces_archived_at_cleanup`, `idx_prototype_sessions_revoked_at_cleanup`, `idx_prototype_sessions_expires_at_cleanup`, `idx_prototype_shared_actors_expires_revoked_cleanup`, `idx_prototype_preview_handles_inactive_revoked_cleanup` |
 | preview handle lookup | handle id, active scope replacement, workspace/session cleanup scans | primary key plus preview handle workspace/session/scope indexes |
 
+## Risk Gate 3 Runtime Job Contract
+
+Prototype runtime orchestration uses the shared Jobs module with domain `prototype_workspaces` and queue `default`.
+
+Runtime job types:
+
+- `branch_session_bootstrap`
+- `preview_boot`
+- `snapshot_save`
+- `publish_validate_and_promote`
+
+Worker result shape:
+
+- successful job handlers return `status`, `job_type`, and `retryable`
+- terminal publish outcomes also return stable `failure_code` and relevant snapshot ids
+- payload errors use `failure_code = "invalid_job_payload"` and `retryable = false`
+- expected permission failures use `failure_code = "permission_denied"` and `retryable = false`
+- retryable runtime failures use `failure_code = "runtime_retryable"` and `retryable = true`
+- terminal runtime failures such as archived workspaces, revoked actors, expired sessions, and missing resources use `failure_code = "runtime_terminal"` and `retryable = false`
+
+Retry/idempotency guarantees:
+
+- branch bootstrap jobs use workspace, actor, canonical snapshot, and request nonce in the idempotency key; repeated execution reuses an active compatible branch session
+- preview boot jobs use scope, snapshot, runtime profile version, and target fingerprint in the idempotency key; repeated execution for the same active scope/snapshot/target/profile renews the existing handle instead of minting a second handle
+- preview boot replacement with a different target revokes the previous active handle for the scope and rolls back to the previous active handle only when the scope is still unclaimed after persistence failure
+- snapshot-save jobs use session and save request id in the idempotency key; repeated execution with the same explicit snapshot id returns the existing session-owned snapshot and preserves a single saved snapshot row
+- publish validation and promotion jobs use workspace, candidate snapshot, and baseline snapshot in the idempotency key; stale or failed validation returns a terminal result without advancing canonical or last-known-good pointers
+
+Cancellation and timeout boundary:
+
+- queued prototype jobs inherit the shared Jobs cancellation behavior and can be cancelled before acquisition
+- processing cancellation is best-effort at the shared worker boundary; the current Risk Gate 3 handlers are short transactional units and rely on idempotent retry/compensation rather than mid-operation interruption
+- worker shutdown uses `WorkerSDK.stop()` via the injected stop event and does not acquire new prototype jobs after shutdown starts
+- lease expiry and retry are owned by the shared Jobs manager; retry-safe service operations are the prototype-specific protection against duplicate effects after worker restart or completion-ack failure
+- runtime host process termination, long-running sandbox teardown, and operator-facing timeout controls remain later runtime-hosting work; this gate documents that boundary rather than introducing a parallel timeout system
+
 ## Preview Broker Guarantees
 
 Preview access is brokered through `preview_handle` records and signed preview grants.

--- a/Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
+++ b/Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
@@ -12,7 +12,7 @@ Risk Gate 1 security model: ../Security/Prototype_Workspaces_Threat_Model.md
 
 - Draft owner: Backend/Core
 - Frontend reviewer: Frontend/Product
-- Current gate: Risk Gate 1 draft
+- Current gate: Risk Gate 3 runtime durability draft
 - Frozen by: Risk Gate 4
 
 ## Error And State Matrix
@@ -34,6 +34,15 @@ Risk Gate 1 security model: ../Security/Prototype_Workspaces_Threat_Model.md
 | stale_promotion | Candidate is stale versus canonical snapshot | 409 | stale_promotion | Promotion stale | No | Ask user to resubmit from current branch | Draft |
 | promotion_conflict | Promotion validation detects conflict | 409 | promotion_conflict | Promotion conflict | No | Show conflict/review state | Draft |
 | promotion_validation_failed | Validation failed without promoting | 409 | promotion_validation_failed | Promotion failed | Yes, if backend marks retryable | Show validation failure details | Draft |
+
+## Runtime Job Result Matrix
+
+| Job type | Success status | Terminal failure fields | Retryable failure fields | Idempotency basis | Frontend/operator note |
+| --- | --- | --- | --- | --- | --- |
+| `branch_session_bootstrap` | `status = "ok"`, `job_type`, `retryable = false`, `session_id`, `created` | `failure_code = "invalid_job_payload"`, `permission_denied`, or `runtime_terminal` | `failure_code = "runtime_retryable"`, `retryable = true` | workspace, actor, baseline snapshot, request nonce | Safe to retry from Jobs when retryable; terminal actor/workspace state needs a fresh session/link. |
+| `preview_boot` | `status = "ok"`, `job_type`, `retryable = false`, `preview_handle`, `preview_url` | `failure_code = "invalid_job_payload"` or `runtime_terminal` | `failure_code = "runtime_retryable"`, `retryable = true` | preview scope, snapshot, runtime profile version, target fingerprint | Same target retries renew the active handle; changed targets replace the handle for the scope. |
+| `snapshot_save` | `status = "ok"`, `job_type`, `retryable = false`, `snapshot_id` | `failure_code = "invalid_job_payload"` or `runtime_terminal` | `failure_code = "runtime_retryable"`, `retryable = true` | session and save request id; explicit snapshot id is reused on handler retry | UI can keep showing one saved revision for duplicate completion/retry paths. |
+| `publish_validate_and_promote` | `status = "promoted"`, `job_type`, `retryable = false`, canonical/candidate ids, optional `preview_handle` | `status = "failed"` or `"stale"`, `failure_code`, `retryable = false`, canonical/candidate ids | Reserved for future validators that explicitly return `retryable = true`; default validation failures are terminal | workspace, candidate snapshot, review baseline/canonical snapshot | Failed validation never advances canonical or last-known-good pointers. |
 
 ## Token And Session Security Dispositions
 

--- a/Docs/superpowers/plans/2026-05-15-prototype-workspace-risk-gate-3-runtime-durability.md
+++ b/Docs/superpowers/plans/2026-05-15-prototype-workspace-risk-gate-3-runtime-durability.md
@@ -1,0 +1,87 @@
+# Prototype Workspace Risk Gate 3 Runtime Durability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for implementation. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden prototype workspace runtime job orchestration and preview lifecycle behavior so retries, cancellation, validation failures, and preview replacement are deterministic and safe.
+
+**Architecture:** Keep the existing `PrototypeWorkspaceJobs`, `jobs_worker`, `PrototypeWorkspaceService`, and `PrototypePreviewBroker` boundaries. Use the shared Jobs manager and `WorkerSDK` semantics instead of creating a prototype-specific queue. Treat full production hosting and frontend UI work as later gates; this slice defines backend state contracts and tests.
+
+**Tech Stack:** FastAPI backend, AuthNZ prototype repository, shared Jobs `JobManager`/`WorkerSDK`, pytest, Bandit.
+
+---
+
+## Stage 1: Job Contract And Failure Semantics
+
+**Goal:** Make prototype job payloads and worker failures explicit enough for retries, cancellation, and operator inspection.
+
+**Success Criteria:** Each prototype job type has documented retryability, timeout/cancellation behavior, and stable result/error shape. Worker exceptions can be classified as retryable or terminal without relying on generic exception strings.
+
+**Tests:** Extend `tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py` with failing tests for retryable preview bootstrap failures, terminal validation failures, cancellation-sensitive archived/revoked state, and stable worker result payloads.
+
+**Status:** Complete
+
+- [x] Add failing tests for a retryable worker exception carrying `retryable=True` metadata.
+- [x] Add failing tests for terminal prototype domain errors carrying `retryable=False`.
+- [x] Add a small typed exception/result helper in `tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py` or `models.py`.
+- [x] Document job-type retry/cancel/timeout semantics in `Docs/API-related/Prototype_Workspaces_API.md`.
+
+## Stage 2: Idempotent Runtime State Transitions
+
+**Goal:** Ensure branch bootstrap, preview boot, and snapshot-save jobs can be safely retried without duplicating active sessions, preview handles, or snapshots.
+
+**Success Criteria:** Retried branch bootstrap reuses the same active session. Retried preview boot with the same idempotency key returns or preserves one active handle per scope. Retried snapshot save with the same request id does not produce duplicate snapshots or roll a session pointer backward.
+
+**Tests:** Add service/job tests covering duplicate branch bootstrap, same preview boot request, same snapshot save request id, and retry after expired/revoked session state.
+
+**Status:** Complete
+
+- [x] Add a failing test for preview boot retry with identical payload preserving one active handle per scope.
+- [x] Add a failing test for snapshot-save retry using explicit retry-safe snapshot identity.
+- [x] Extend `PrototypeWorkspaceJobs` preview payload metadata so runtime profile version matches preview idempotency and reuse checks.
+- [x] Update service/broker helpers only as needed to preserve monotonic session snapshot and preview-handle state.
+
+## Stage 3: Preview Lifecycle Durability
+
+**Goal:** Harden preview lookup, replacement, renewal, revocation, and cache refresh across process restarts and rollback paths.
+
+**Success Criteria:** Preview renewal and validation recover from persistent records after memory cache loss. Active-handle replacement revokes old handles and restores previous handles only when the scope is still unclaimed. Revocation updates both persistent state and in-memory cache. Renewal of revoked/expired/inactive actor/session state returns a stable failure.
+
+**Tests:** Extend `test_preview_broker.py` with persistent lookup, renewal after cache clear, replacement rollback, revoked actor/session renewal, and active-handle replacement assertions.
+
+**Status:** Complete
+
+- [x] Preserve existing tests for renewing after persistent lookup when cache is empty and revoked actor/session invalidation.
+- [x] Preserve existing tests for preview replacement rollback not overwriting a concurrent active handle.
+- [x] Ensure `PrototypePreviewBroker` reuses identical active handles and preserves persisted handle state on retry/replacement.
+- [x] Document preview lifecycle/runtime result categories in the contract matrix.
+
+## Stage 4: Publish Validation And Promotion Safety
+
+**Goal:** Prove failed publish validation, stale candidates, and post-preview persistence failures never advance canonical or last-known-good pointers.
+
+**Success Criteria:** Validation failures mark validation state without moving canonical pointers. Stale candidates do not promote. If preview grant succeeds but canonical pointer persistence fails, the new preview is revoked and workspace state is restored. Promotion request status reflects the terminal outcome.
+
+**Tests:** Extend `test_promotion_service.py` with failed validator, stale baseline, promotion request state, preview rollback, and retry-safe promote idempotency cases.
+
+**Status:** Complete
+
+- [x] Preserve existing tests for failed publish validation preserving canonical and last-known-good pointers.
+- [x] Preserve existing tests for preview-grant success followed by canonical update failure.
+- [x] Confirm existing `PrototypeWorkspaceService.promote_candidate` compensation boundaries pass the focused promotion suite.
+- [x] Ensure worker result payloads expose stable `failure_code`/`retryable` fields for frontend/operator surfaces.
+
+## Stage 5: Verification And PR Closeout
+
+**Goal:** Finish Risk Gate 3 with focused test evidence, security checks, and a PR linked to GitHub issue #1455.
+
+**Success Criteria:** Focused prototype runtime tests pass, Bandit runs on touched backend files, TASK-389 is updated, and the PR body includes the human-owned change-summary reminder.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q`; focused runtime/preview/promotion tests added above; Bandit on touched backend paths; `git diff --check`.
+
+**Status:** In Progress
+
+- [x] Run focused red/green tests as each stage lands.
+- [x] Run full `tldw_Server_API/tests/PrototypeWorkspaces -q`.
+- [x] Run Bandit on touched backend paths.
+- [ ] Update TASK-389 with verification/final summary.
+- [ ] Open/update PR linked to GitHub issue #1455.

--- a/backlog/tasks/task-389 - Risk-Gate-3-prototype-runtime-jobs-and-preview-lifecycle-durability.md
+++ b/backlog/tasks/task-389 - Risk-Gate-3-prototype-runtime-jobs-and-preview-lifecycle-durability.md
@@ -1,0 +1,107 @@
+---
+id: TASK-389
+title: Risk Gate 3 prototype runtime jobs and preview lifecycle durability
+status: In Progress
+assignee:
+  - Codex
+created_date: '2026-05-15 19:41'
+updated_date: '2026-05-15 20:05'
+labels:
+  - prototype-workspaces
+  - risk-gate
+  - backend
+  - jobs
+  - runtime
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1455'
+  - 'https://github.com/rmusser01/tldw_server/issues/1440'
+  - 'https://github.com/rmusser01/tldw_server/pull/1729'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-09-prototype-workspace-productionization-issue-tree-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-09-prototype-workspace-productionization-github-issue-bodies.md
+  - Docs/API-related/Prototype_Workspaces_API.md
+  - Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Burn down prototype workspace runtime durability risk after Risk Gates 1 and 2 by moving the runtime bootstrap, preview lifecycle, snapshot save, and publish validation/promotion paths toward retry-safe Jobs-backed orchestration where appropriate. This tracks GitHub issue #1455 and should stay scoped to backend/core runtime durability; frontend/product work is limited to documenting the runtime status fields that later UI slices need.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Prototype runtime jobs are idempotent and safe to retry for branch bootstrap, preview boot/replacement, snapshot save, and publish validation/promotion paths that this slice owns.
+- [x] #2 Cancellation, timeout, cleanup, and retry semantics are documented and covered by focused backend tests.
+- [x] #3 Preview handle revocation, renewal, active-handle replacement, and persistent lookup behavior are covered by backend tests.
+- [x] #4 Failed publish validation never advances canonical or last-known-good prototype workspace pointers.
+- [x] #5 Runtime bootstrap status, preview health, and promotion validation failure fields needed by later frontend/operator surfaces are implemented or explicitly documented for the contract freeze.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan: Docs/superpowers/plans/2026-05-15-prototype-workspace-risk-gate-3-runtime-durability.md
+
+Stage 1: Job contract and failure semantics
+- Add failing tests for retryable and terminal worker failures.
+- Add typed prototype job exception/result helpers where needed.
+- Document retry/cancel/timeout semantics.
+
+Stage 2: Idempotent runtime state transitions
+- Cover branch bootstrap, preview boot, and snapshot-save retry behavior.
+- Add missing request identifiers/payload fields needed for idempotency.
+- Preserve monotonic session snapshot state.
+
+Stage 3: Preview lifecycle durability
+- Cover persistent lookup after memory cache loss, renewal, replacement rollback, revocation, and inactive actor/session behavior.
+- Keep persistent and in-memory preview state aligned.
+
+Stage 4: Publish validation and promotion safety
+- Prove failed validation, stale candidates, and post-preview persistence failures never advance canonical pointers.
+- Preserve compensation behavior around preview grants and promotion request status.
+
+Stage 5: Verification and PR closeout
+- Run focused and full prototype tests, Bandit on touched backend paths, update TASK-389, and open PR linked to #1455.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-15: Created isolated worktree /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/prototype-risk-gate-3-runtime-durability on branch codex/prototype-risk-gate-3-runtime-durability from origin/dev 2184b2168 after PR #1719 / Risk Gate 2 was verified merged and issue #1454 was closed.
+
+2026-05-15: Baseline verification before implementation: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q passed with 90 passed, 5 warnings in 7.20s from the new worktree.
+
+Implemented Risk Gate 3 runtime durability slice in worktree `.worktrees/prototype-risk-gate-3-runtime-durability`: added worker retry/terminal metadata, stable job result envelopes, retry-safe preview handle reuse for identical scope/snapshot/target/profile, retry-safe snapshot save reuse for explicit session-owned snapshot ids, and Risk Gate 3 runtime job contract docs.
+
+Focused runtime/preview/promotion suite passed: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py -q` -> 30 passed, 5 warnings.
+
+Final verification after runtime profile-version fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q` -> 97 passed, 5 warnings.
+
+Security/hygiene verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Prototype_Workspaces/jobs.py tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py tldw_Server_API/app/core/Prototype_Workspaces/models.py tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py tldw_Server_API/app/core/Prototype_Workspaces/service.py -f json -o /tmp/bandit_prototype_risk_gate_3.json` -> 0 findings; `git diff --check` -> clean.
+
+Opened PR #1729: https://github.com/rmusser01/tldw_server/pull/1729
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Opened PR #1729 for Risk Gate 3 prototype runtime durability. The slice adds explicit prototype job retry/result metadata, typed terminal runtime failures, retry-safe preview handle reuse keyed by scope/snapshot/target/runtime profile version, retry-safe duplicate snapshot-save handling for session-owned snapshot ids, focused backend coverage, and Risk Gate 3 runtime contract documentation. Verification recorded: PrototypeWorkspaces tests passed with 97 passed and Bandit reported 0 findings on touched backend runtime modules.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused prototype runtime tests pass
+- [x] #8 Bandit runs on touched backend paths
+- [x] #9 GitHub issue #1455 is linked from the PR
+<!-- DOD:END -->

--- a/backlog/tasks/task-389 - Risk-Gate-3-prototype-runtime-jobs-and-preview-lifecycle-durability.md
+++ b/backlog/tasks/task-389 - Risk-Gate-3-prototype-runtime-jobs-and-preview-lifecycle-durability.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-389
 title: Risk Gate 3 prototype runtime jobs and preview lifecycle durability
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-05-15 19:41'
-updated_date: '2026-05-15 20:05'
+updated_date: '2026-05-16 00:43'
 labels:
   - prototype-workspaces
   - risk-gate
@@ -72,19 +72,23 @@ Stage 5: Verification and PR closeout
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-2026-05-15: Created isolated worktree /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/prototype-risk-gate-3-runtime-durability on branch codex/prototype-risk-gate-3-runtime-durability from origin/dev 2184b2168 after PR #1719 / Risk Gate 2 was verified merged and issue #1454 was closed.
+2026-05-15: Created isolated worktree `.worktrees/prototype-risk-gate-3-runtime-durability` on branch codex/prototype-risk-gate-3-runtime-durability from origin/dev 2184b2168 after PR #1719 / Risk Gate 2 was verified merged and issue #1454 was closed.
 
-2026-05-15: Baseline verification before implementation: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q passed with 90 passed, 5 warnings in 7.20s from the new worktree.
+2026-05-15: Baseline verification before implementation: `./.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q` passed with 90 passed, 5 warnings in 7.20s from the new worktree.
 
 Implemented Risk Gate 3 runtime durability slice in worktree `.worktrees/prototype-risk-gate-3-runtime-durability`: added worker retry/terminal metadata, stable job result envelopes, retry-safe preview handle reuse for identical scope/snapshot/target/profile, retry-safe snapshot save reuse for explicit session-owned snapshot ids, and Risk Gate 3 runtime job contract docs.
 
-Focused runtime/preview/promotion suite passed: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py -q` -> 30 passed, 5 warnings.
+Focused runtime/preview/promotion suite passed: `./.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py -q` -> 30 passed, 5 warnings.
 
-Final verification after runtime profile-version fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q` -> 97 passed, 5 warnings.
+Final verification after runtime profile-version fix: `./.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q` -> 97 passed, 5 warnings.
 
-Security/hygiene verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Prototype_Workspaces/jobs.py tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py tldw_Server_API/app/core/Prototype_Workspaces/models.py tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py tldw_Server_API/app/core/Prototype_Workspaces/service.py -f json -o /tmp/bandit_prototype_risk_gate_3.json` -> 0 findings; `git diff --check` -> clean.
+Security/hygiene verification: `./.venv/bin/python -m bandit -r tldw_Server_API/app/core/Prototype_Workspaces/jobs.py tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py tldw_Server_API/app/core/Prototype_Workspaces/models.py tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py tldw_Server_API/app/core/Prototype_Workspaces/service.py -f json -o /tmp/bandit_prototype_risk_gate_3.json` -> 0 findings; `git diff --check` -> clean.
 
 Opened PR #1729: https://github.com/rmusser01/tldw_server/pull/1729
+
+2026-05-15: Addressed PR #1729 review feedback: moved prototype job exceptions to app/core/exceptions.py, made worker programming/runtime-state failures terminal with stable failure codes, persisted failure_code through WorkerSDK.error_code, generated deterministic snapshot ids for Jobs-backed snapshot saves, propagated top-level preview runtime profile versions, made session preview retry reuse tolerant of archived workspaces, prevented metadata from overriding authoritative snapshot ids, removed new raw-SQL assertions from prototype tests, and cleaned machine-specific paths from the task log.
+
+2026-05-15: Review-fix verification: `./.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces tldw_Server_API/tests/Jobs/test_worker_sdk.py -q` -> 110 passed, 5 warnings; `./.venv/bin/python -m pytest tldw_Server_API/tests/Jobs/test_worker_sdk.py -q` -> 7 passed, 5 warnings after WorkerSDK jitter hardening; Bandit touched-scope run to `/tmp/bandit_prototype_risk_gate_3_review_fixes.json` -> 0 findings; `git diff --check` -> clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/Jobs/worker_sdk.py
+++ b/tldw_Server_API/app/core/Jobs/worker_sdk.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-import random
+import secrets
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -112,7 +112,7 @@ class WorkerSDK:
         iters = 0
         while not self._stop.is_set():
             # Sleep for lease - threshold, plus small jitter
-            sleep_for = max(1, lease - threshold) + (random.randint(0, jitter) if jitter else 0)
+            sleep_for = max(1, lease - threshold) + (secrets.randbelow(jitter + 1) if jitter else 0)
             await self._sleep_chunked(float(sleep_for))
             if self._stop.is_set():
                 return
@@ -185,6 +185,7 @@ class WorkerSDK:
             def _finalize_failure(exc: Exception) -> None:
                 retryable = self.cfg.retry_on_exception and bool(getattr(exc, "retryable", True))
                 backoff_s = int(getattr(exc, "backoff_seconds", self.cfg.retry_backoff_seconds))
+                error_code = str(getattr(exc, "failure_code", "worker_exception") or "worker_exception")
                 try:
                     self.jm.fail_job(
                         job_id,
@@ -195,7 +196,7 @@ class WorkerSDK:
                         lease_id=lease_id_str,
                         completion_token=(lease_id_str if is_truthy(os.getenv("JOBS_REQUIRE_COMPLETION_TOKEN")) else None),
                         enforce=enforce,
-                        error_code="worker_exception",
+                        error_code=error_code,
                         error_class=type(exc).__name__,
                     )
                 except _WORKER_SDK_NONCRITICAL_EXCEPTIONS:

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
@@ -195,6 +195,11 @@ class PrototypeWorkspaceJobs:
         if not workspace:
             raise ValueError("prototype workspace not found")
 
+        resolved_runtime_profile_version = runtime_profile_version or "v1"
+        runtime_metadata = {
+            **(metadata or {}),
+            "runtime_profile_version": resolved_runtime_profile_version,
+        }
         return self._normalize_job_row(self._jobs_manager.create_job(
             domain=PROTOTYPE_DOMAIN,
             queue=self._queue,
@@ -204,8 +209,8 @@ class PrototypeWorkspaceJobs:
                 "prototype_session_id": prototype_session_id,
                 "snapshot_id": snapshot_id,
                 "runtime_target_url": runtime_target_url,
-                "metadata": metadata or {},
-                "runtime_profile_version": runtime_profile_version or "v1",
+                "metadata": runtime_metadata,
+                "runtime_profile_version": resolved_runtime_profile_version,
             },
             owner_user_id=str(workspace["owner_user_id"]),
             idempotency_key=build_preview_boot_idempotency_key(
@@ -213,7 +218,7 @@ class PrototypeWorkspaceJobs:
                 prototype_session_id=prototype_session_id,
                 snapshot_id=snapshot_id,
                 runtime_target_url=runtime_target_url,
-                runtime_profile_version=runtime_profile_version,
+                runtime_profile_version=resolved_runtime_profile_version,
             ),
         ))
 

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
@@ -94,6 +94,18 @@ def build_snapshot_save_idempotency_key(
     return f"prototype:snapshot-save:{prototype_session_id}:{request_id}"
 
 
+def build_snapshot_save_snapshot_id(
+    *,
+    prototype_session_id: str,
+    save_request_id: str,
+) -> str:
+    request_id = str(save_request_id or "").strip()
+    if not request_id:
+        raise ValueError("save_request_id is required")
+    digest = hashlib.sha256(f"{prototype_session_id}:{request_id}".encode("utf-8")).hexdigest()[:32]
+    return f"psnap_{digest}"
+
+
 def build_promote_idempotency_key(
     *,
     prototype_workspace_id: str,
@@ -240,13 +252,17 @@ class PrototypeWorkspaceJobs:
         if not workspace:
             raise ValueError("prototype workspace not found")
 
+        resolved_snapshot_id = snapshot_id or build_snapshot_save_snapshot_id(
+            prototype_session_id=prototype_session_id,
+            save_request_id=save_request_id,
+        )
         return self._normalize_job_row(self._jobs_manager.create_job(
             domain=PROTOTYPE_DOMAIN,
             queue=self._queue,
             job_type=PrototypeJobType.SNAPSHOT_SAVE.value,
             payload={
                 "prototype_session_id": prototype_session_id,
-                "snapshot_id": snapshot_id,
+                "snapshot_id": resolved_snapshot_id,
                 "save_request_id": save_request_id,
                 "storage_ref": storage_ref,
                 "diff_summary": diff_summary or {},

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from loguru import logger
@@ -13,18 +14,78 @@ from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
 from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
 
 from .jobs import PROTOTYPE_DOMAIN, PROTOTYPE_QUEUE
-from .models import PrototypeJobType
+from .models import PrototypeJobError, PrototypeJobPayloadError, PrototypeJobType
 from .service import PrototypeWorkspaceService
+
+_TERMINAL_RUNTIME_ERROR_MARKERS = (
+    "archived",
+    "revoked",
+    "expired",
+    "not found",
+    "not authorized",
+    "no longer authorized",
+    "requires",
+    "must",
+    "invalid",
+)
+
+_TERMINAL_PROMOTION_STATUSES = {"failed", "stale", "rejected"}
 
 
 def _required_int_payload(payload: dict[str, Any], key: str) -> int:
     value = payload.get(key)
     if value is None or str(value).strip() == "":
-        raise ValueError(f"{key} is required")
+        raise PrototypeJobPayloadError(f"{key} is required")
     try:
         return int(value)
     except (TypeError, ValueError) as exc:
-        raise ValueError(f"{key} must be an integer") from exc
+        raise PrototypeJobPayloadError(f"{key} must be an integer") from exc
+
+
+def _is_terminal_runtime_error(exc: RuntimeError) -> bool:
+    message = str(exc).strip().lower()
+    return any(marker in message for marker in _TERMINAL_RUNTIME_ERROR_MARKERS)
+
+
+def _coerce_worker_exception(exc: Exception) -> Exception:
+    if hasattr(exc, "retryable") and hasattr(exc, "failure_code"):
+        return exc
+    if isinstance(exc, PermissionError):
+        return PrototypeJobError(str(exc), retryable=False, failure_code="permission_denied")
+    if isinstance(exc, ValueError):
+        return PrototypeJobPayloadError(str(exc))
+    if isinstance(exc, RuntimeError) and _is_terminal_runtime_error(exc):
+        return PrototypeJobError(str(exc), retryable=False, failure_code="runtime_terminal")
+    return PrototypeJobError(str(exc), retryable=True, failure_code="runtime_retryable")
+
+
+async def _run_service_operation(
+    operation: Callable[[], Awaitable[dict[str, Any]]],
+) -> dict[str, Any]:
+    try:
+        return await operation()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        raise _coerce_worker_exception(exc) from exc
+
+
+def _job_result(
+    job_type: str,
+    *,
+    status: str = "ok",
+    retryable: bool = False,
+    fields: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = dict(fields or {})
+    result.update({"status": status, "job_type": job_type, "retryable": retryable})
+    return result
+
+
+def _promotion_job_result(job_type: str, result: dict[str, Any]) -> dict[str, Any]:
+    status = str(result.get("status") or "").strip().lower()
+    retryable = bool(result.get("retryable")) and status not in _TERMINAL_PROMOTION_STATUSES
+    return _job_result(job_type, status=result.get("status") or "unknown", retryable=retryable, fields=result)
 
 
 async def handle_prototype_job(
@@ -36,67 +97,73 @@ async def handle_prototype_job(
     payload = job.get("payload") or {}
     job_type = str(job.get("job_type") or payload.get("job_type") or "").strip().lower()
     if not job_type:
-        raise ValueError("missing prototype job_type")
+        raise PrototypeJobPayloadError("missing prototype job_type")
 
     if job_type == PrototypeJobType.BRANCH_SESSION_BOOTSTRAP.value:
-        result = await service.create_or_reuse_branch_session(
-            prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
-            base_snapshot_id=payload.get("base_snapshot_id"),
-            actor_type=str(payload.get("actor_type") or ""),
-            actor_user_id=payload.get("actor_user_id"),
-            actor_shared_actor_id=payload.get("actor_shared_actor_id"),
-            request_nonce=payload.get("request_nonce"),
-            share_link_id=payload.get("share_link_id"),
-            expires_at=payload.get("expires_at"),
+        result = await _run_service_operation(
+            lambda: service.create_or_reuse_branch_session(
+                prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
+                base_snapshot_id=payload.get("base_snapshot_id"),
+                actor_type=str(payload.get("actor_type") or ""),
+                actor_user_id=payload.get("actor_user_id"),
+                actor_shared_actor_id=payload.get("actor_shared_actor_id"),
+                request_nonce=payload.get("request_nonce"),
+                share_link_id=payload.get("share_link_id"),
+                expires_at=payload.get("expires_at"),
+            )
         )
         session = result.get("session") or {}
-        return {
-            "status": "ok",
-            "session_id": session.get("id"),
-            "created": bool(result.get("created")),
-        }
+        return _job_result(
+            job_type,
+            fields={"session_id": session.get("id"), "created": bool(result.get("created"))},
+        )
 
     if job_type == PrototypeJobType.PREVIEW_BOOT.value:
-        grant = await service.boot_preview(
-            prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
-            prototype_session_id=payload.get("prototype_session_id"),
-            snapshot_id=str(payload.get("snapshot_id") or ""),
-            runtime_target_url=str(payload.get("runtime_target_url") or ""),
-            metadata=payload.get("metadata") or {},
-            runtime_policy_profile=payload.get("runtime_policy_profile"),
+        grant = await _run_service_operation(
+            lambda: service.boot_preview(
+                prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
+                prototype_session_id=payload.get("prototype_session_id"),
+                snapshot_id=str(payload.get("snapshot_id") or ""),
+                runtime_target_url=str(payload.get("runtime_target_url") or ""),
+                metadata=payload.get("metadata") or {},
+                runtime_policy_profile=payload.get("runtime_policy_profile"),
+            )
         )
-        return {
-            "status": "ok",
-            "preview_handle": grant.get("preview_handle"),
-            "preview_url": grant.get("preview_url"),
-        }
+        return _job_result(
+            job_type,
+            fields={
+                "preview_handle": grant.get("preview_handle"),
+                "preview_url": grant.get("preview_url"),
+            },
+        )
 
     if job_type == PrototypeJobType.SNAPSHOT_SAVE.value:
-        snapshot = await service.save_session_snapshot(
-            prototype_session_id=str(payload.get("prototype_session_id") or ""),
-            snapshot_id=payload.get("snapshot_id"),
-            storage_ref=payload.get("storage_ref"),
-            diff_summary=payload.get("diff_summary") or {},
-            prompt_summary=payload.get("prompt_summary"),
-            preview_health=payload.get("preview_health") or {},
+        snapshot = await _run_service_operation(
+            lambda: service.save_session_snapshot(
+                prototype_session_id=str(payload.get("prototype_session_id") or ""),
+                snapshot_id=payload.get("snapshot_id"),
+                storage_ref=payload.get("storage_ref"),
+                diff_summary=payload.get("diff_summary") or {},
+                prompt_summary=payload.get("prompt_summary"),
+                preview_health=payload.get("preview_health") or {},
+            )
         )
-        return {
-            "status": "ok",
-            "snapshot_id": snapshot.get("snapshot_id"),
-        }
+        return _job_result(job_type, fields={"snapshot_id": snapshot.get("snapshot_id")})
 
     if job_type == PrototypeJobType.PUBLISH_VALIDATE_AND_PROMOTE.value:
-        result = await service.promote_candidate(
-            prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
-            candidate_snapshot_id=str(payload.get("candidate_snapshot_id") or ""),
-            reviewer_user_id=_required_int_payload(payload, "reviewer_user_id"),
-            review_baseline_snapshot_id=payload.get("review_baseline_snapshot_id"),
-            promotion_request_id=payload.get("promotion_request_id"),
-            review_notes=payload.get("review_notes"),
+        result = await _run_service_operation(
+            lambda: service.promote_candidate(
+                prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
+                candidate_snapshot_id=str(payload.get("candidate_snapshot_id") or ""),
+                reviewer_user_id=_required_int_payload(payload, "reviewer_user_id"),
+                review_baseline_snapshot_id=payload.get("review_baseline_snapshot_id"),
+                promotion_request_id=payload.get("promotion_request_id"),
+                review_notes=payload.get("review_notes"),
+            )
         )
-        return result
+        return _promotion_job_result(job_type, result)
 
-    raise ValueError(f"unsupported prototype job_type: {job_type}")
+    raise PrototypeJobPayloadError(f"unsupported prototype job_type: {job_type}")
 
 
 async def run_prototype_jobs_worker(

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
@@ -9,12 +9,17 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.core.exceptions import (
+    PrototypeJobError,
+    PrototypeJobPayloadError,
+    PrototypeTerminalRuntimeError,
+)
 from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
 from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
 
 from .jobs import PROTOTYPE_DOMAIN, PROTOTYPE_QUEUE
-from .models import PrototypeJobError, PrototypeJobPayloadError, PrototypeJobType
+from .models import PrototypeJobType
 from .service import PrototypeWorkspaceService
 
 _TERMINAL_RUNTIME_ERROR_MARKERS = (
@@ -30,9 +35,11 @@ _TERMINAL_RUNTIME_ERROR_MARKERS = (
 )
 
 _TERMINAL_PROMOTION_STATUSES = {"failed", "stale", "rejected"}
+_TERMINAL_PROGRAMMING_ERRORS = (TypeError, AttributeError, KeyError, NameError)
 
 
 def _required_int_payload(payload: dict[str, Any], key: str) -> int:
+    """Return a required integer payload value or raise a terminal payload error."""
     value = payload.get(key)
     if value is None or str(value).strip() == "":
         raise PrototypeJobPayloadError(f"{key} is required")
@@ -43,17 +50,21 @@ def _required_int_payload(payload: dict[str, Any], key: str) -> int:
 
 
 def _is_terminal_runtime_error(exc: RuntimeError) -> bool:
+    """Classify runtime errors whose messages describe non-retryable state."""
     message = str(exc).strip().lower()
     return any(marker in message for marker in _TERMINAL_RUNTIME_ERROR_MARKERS)
 
 
 def _coerce_worker_exception(exc: Exception) -> Exception:
+    """Attach stable retry metadata to exceptions crossing the Jobs boundary."""
     if hasattr(exc, "retryable") and hasattr(exc, "failure_code"):
         return exc
     if isinstance(exc, PermissionError):
         return PrototypeJobError(str(exc), retryable=False, failure_code="permission_denied")
+    if isinstance(exc, _TERMINAL_PROGRAMMING_ERRORS):
+        return PrototypeJobError(str(exc), retryable=False, failure_code="worker_terminal")
     if isinstance(exc, ValueError):
-        return PrototypeJobPayloadError(str(exc))
+        return PrototypeTerminalRuntimeError(str(exc))
     if isinstance(exc, RuntimeError) and _is_terminal_runtime_error(exc):
         return PrototypeJobError(str(exc), retryable=False, failure_code="runtime_terminal")
     return PrototypeJobError(str(exc), retryable=True, failure_code="runtime_retryable")
@@ -62,6 +73,7 @@ def _coerce_worker_exception(exc: Exception) -> Exception:
 async def _run_service_operation(
     operation: Callable[[], Awaitable[dict[str, Any]]],
 ) -> dict[str, Any]:
+    """Run a service call and normalize service exceptions for WorkerSDK."""
     try:
         return await operation()
     except asyncio.CancelledError:
@@ -77,12 +89,14 @@ def _job_result(
     retryable: bool = False,
     fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    """Build the stable result envelope persisted for prototype runtime jobs."""
     result = dict(fields or {})
     result.update({"status": status, "job_type": job_type, "retryable": retryable})
     return result
 
 
 def _promotion_job_result(job_type: str, result: dict[str, Any]) -> dict[str, Any]:
+    """Build a promotion result envelope while making terminal outcomes non-retryable."""
     status = str(result.get("status") or "").strip().lower()
     retryable = bool(result.get("retryable")) and status not in _TERMINAL_PROMOTION_STATUSES
     return _job_result(job_type, status=result.get("status") or "unknown", retryable=retryable, fields=result)
@@ -119,13 +133,16 @@ async def handle_prototype_job(
         )
 
     if job_type == PrototypeJobType.PREVIEW_BOOT.value:
+        preview_metadata = dict(payload.get("metadata") or {})
+        if payload.get("runtime_profile_version") is not None:
+            preview_metadata["runtime_profile_version"] = str(payload["runtime_profile_version"])
         grant = await _run_service_operation(
             lambda: service.boot_preview(
                 prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
                 prototype_session_id=payload.get("prototype_session_id"),
                 snapshot_id=str(payload.get("snapshot_id") or ""),
                 runtime_target_url=str(payload.get("runtime_target_url") or ""),
-                metadata=payload.get("metadata") or {},
+                metadata=preview_metadata,
                 runtime_policy_profile=payload.get("runtime_policy_profile"),
             )
         )

--- a/tldw_Server_API/app/core/Prototype_Workspaces/models.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/models.py
@@ -74,6 +74,60 @@ class PrototypeJobRequest:
     owner_user_id: str | None
 
 
+class PrototypeJobError(RuntimeError):
+    """Worker-visible prototype job failure with explicit retry metadata."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retryable: bool,
+        failure_code: str,
+        backoff_seconds: int | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+        self.failure_code = failure_code
+        self.backoff_seconds = backoff_seconds
+        self.details = details or {}
+
+
+class PrototypeTerminalRuntimeError(PrototypeJobError):
+    """Terminal runtime state failure for archived, revoked, or expired resources."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_code: str = "runtime_terminal",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            retryable=False,
+            failure_code=failure_code,
+            details=details,
+        )
+
+
+class PrototypeJobPayloadError(ValueError):
+    """Terminal prototype job payload error that should not be retried."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_code: str = "invalid_job_payload",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retryable = False
+        self.failure_code = failure_code
+        self.backoff_seconds = None
+        self.details = details or {}
+
+
 @dataclass(slots=True)
 class PrototypePromotionResult:
     status: str

--- a/tldw_Server_API/app/core/Prototype_Workspaces/models.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/models.py
@@ -74,60 +74,6 @@ class PrototypeJobRequest:
     owner_user_id: str | None
 
 
-class PrototypeJobError(RuntimeError):
-    """Worker-visible prototype job failure with explicit retry metadata."""
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        retryable: bool,
-        failure_code: str,
-        backoff_seconds: int | None = None,
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.retryable = retryable
-        self.failure_code = failure_code
-        self.backoff_seconds = backoff_seconds
-        self.details = details or {}
-
-
-class PrototypeTerminalRuntimeError(PrototypeJobError):
-    """Terminal runtime state failure for archived, revoked, or expired resources."""
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        failure_code: str = "runtime_terminal",
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        super().__init__(
-            message,
-            retryable=False,
-            failure_code=failure_code,
-            details=details,
-        )
-
-
-class PrototypeJobPayloadError(ValueError):
-    """Terminal prototype job payload error that should not be retried."""
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        failure_code: str = "invalid_job_payload",
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.retryable = False
-        self.failure_code = failure_code
-        self.backoff_seconds = None
-        self.details = details or {}
-
-
 @dataclass(slots=True)
 class PrototypePromotionResult:
     status: str

--- a/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
@@ -16,12 +16,12 @@ from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
     PrototypeWorkspacesRepo,
 )
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+from tldw_Server_API.app.core.exceptions import PrototypeTerminalRuntimeError
 
 from .models import (
     PrototypePreviewHandleRecord,
     PrototypePreviewScope,
     PrototypePreviewStatus,
-    PrototypeTerminalRuntimeError,
     actor_key_for_session,
     preview_scope_id,
 )
@@ -110,8 +110,6 @@ class PrototypePreviewBroker:
         workspace = await self._repo.get_workspace(prototype_workspace_id)
         if not workspace:
             raise PrototypeTerminalRuntimeError("prototype workspace not found")
-        if workspace.get("is_archived"):
-            raise PrototypeTerminalRuntimeError("prototype workspace is archived")
         if not str(snapshot_id or "").strip():
             raise ValueError("snapshot_id is required")
         if not str(runtime_target_url or "").strip():
@@ -149,7 +147,8 @@ class PrototypePreviewBroker:
             prototype_workspace_id=prototype_workspace_id,
             prototype_session_id=prototype_session_id,
         )
-        requested_metadata = metadata or {}
+        requested_metadata = dict(metadata or {})
+        requested_metadata.pop("snapshot_id", None)
         existing_active = await self._repo.get_active_preview_handle_for_scope(scope_id)
         if self._active_record_matches_request(
             existing_active,
@@ -162,6 +161,8 @@ class PrototypePreviewBroker:
             record = self._record_from_dict(existing_active)
             self._sync_record_cache(record)
             return await self.renew_preview_grant(record.handle_id)
+        if workspace.get("is_archived"):
+            raise PrototypeTerminalRuntimeError("prototype workspace is archived")
 
         handle_id = f"pph_{uuid.uuid4().hex}"
         now = _utc_now()
@@ -175,8 +176,8 @@ class PrototypePreviewBroker:
             target_ref=str(runtime_target_url),
             runtime_policy_profile=resolved_runtime_policy,
             metadata={
-                "snapshot_id": str(snapshot_id),
                 **requested_metadata,
+                "snapshot_id": str(snapshot_id),
             },
             created_at=now.isoformat(),
         )

--- a/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
@@ -21,6 +21,7 @@ from .models import (
     PrototypePreviewHandleRecord,
     PrototypePreviewScope,
     PrototypePreviewStatus,
+    PrototypeTerminalRuntimeError,
     actor_key_for_session,
     preview_scope_id,
 )
@@ -72,7 +73,7 @@ def _resolve_stable_signing_secret(signing_secret: str | None) -> str:
     )
 
 
-class PrototypePreviewHandleNotFound(RuntimeError):
+class PrototypePreviewHandleNotFound(PrototypeTerminalRuntimeError):
     """Raised when a preview handle cannot be found or renewed."""
 
 
@@ -108,9 +109,9 @@ class PrototypePreviewBroker:
     ) -> dict[str, Any]:
         workspace = await self._repo.get_workspace(prototype_workspace_id)
         if not workspace:
-            raise RuntimeError("prototype workspace not found")
+            raise PrototypeTerminalRuntimeError("prototype workspace not found")
         if workspace.get("is_archived"):
-            raise RuntimeError("prototype workspace is archived")
+            raise PrototypeTerminalRuntimeError("prototype workspace is archived")
         if not str(snapshot_id or "").strip():
             raise ValueError("snapshot_id is required")
         if not str(runtime_target_url or "").strip():
@@ -125,12 +126,12 @@ class PrototypePreviewBroker:
             preview_scope = PrototypePreviewScope.SESSION
             session = await self._repo.get_session(prototype_session_id)
             if not session or session.get("prototype_workspace_id") != prototype_workspace_id:
-                raise RuntimeError("prototype session not found in workspace")
+                raise PrototypeTerminalRuntimeError("prototype session not found in workspace")
             if session.get("is_revoked"):
-                raise RuntimeError("revoked session cannot receive preview grants")
+                raise PrototypeTerminalRuntimeError("revoked session cannot receive preview grants")
             expires_at = _normalize_iso8601(session.get("expires_at"))
             if expires_at and expires_at <= _utc_now():
-                raise RuntimeError("expired session cannot receive preview grants")
+                raise PrototypeTerminalRuntimeError("expired session cannot receive preview grants")
             await self._assert_session_actor_active(session)
             actor_key = actor_key_for_session(
                 actor_type=str(session.get("actor_type") or ""),
@@ -148,6 +149,20 @@ class PrototypePreviewBroker:
             prototype_workspace_id=prototype_workspace_id,
             prototype_session_id=prototype_session_id,
         )
+        requested_metadata = metadata or {}
+        existing_active = await self._repo.get_active_preview_handle_for_scope(scope_id)
+        if self._active_record_matches_request(
+            existing_active,
+            actor_key=actor_key,
+            target_ref=str(runtime_target_url),
+            runtime_policy_profile=resolved_runtime_policy,
+            snapshot_id=str(snapshot_id),
+            runtime_profile_version=str(requested_metadata.get("runtime_profile_version") or "v1"),
+        ):
+            record = self._record_from_dict(existing_active)
+            self._sync_record_cache(record)
+            return await self.renew_preview_grant(record.handle_id)
+
         handle_id = f"pph_{uuid.uuid4().hex}"
         now = _utc_now()
         record = PrototypePreviewHandleRecord(
@@ -161,7 +176,7 @@ class PrototypePreviewBroker:
             runtime_policy_profile=resolved_runtime_policy,
             metadata={
                 "snapshot_id": str(snapshot_id),
-                **(metadata or {}),
+                **requested_metadata,
             },
             created_at=now.isoformat(),
         )
@@ -311,7 +326,7 @@ class PrototypePreviewBroker:
         record_dict = self._record_to_dict(record)
 
         if not await self._is_grant_still_authorized(record):
-            raise RuntimeError("preview handle is no longer authorized")
+            raise PrototypeTerminalRuntimeError("preview handle is no longer authorized")
 
         token, expires_at = self._mint_grant_token(
             preview_handle=handle_id,
@@ -398,8 +413,8 @@ class PrototypePreviewBroker:
         if not await self._session_actor_is_active(session):
             actor_type = str(session.get("actor_type") or "").strip().lower()
             if actor_type == "external_collaborator":
-                raise RuntimeError("revoked shared actor cannot receive preview grants")
-            raise RuntimeError("inactive session actor cannot receive preview grants")
+                raise PrototypeTerminalRuntimeError("revoked shared actor cannot receive preview grants")
+            raise PrototypeTerminalRuntimeError("inactive session actor cannot receive preview grants")
 
     async def _session_actor_is_active(self, session: dict[str, Any]) -> bool:
         actor_type = str(session.get("actor_type") or "").strip().lower()
@@ -491,6 +506,27 @@ class PrototypePreviewBroker:
         record.is_active = False
         record.revoked_at = revoked_at
         cls._active_scope_handles.pop(scope_id, None)
+
+    @staticmethod
+    def _active_record_matches_request(
+        row: dict[str, Any] | None,
+        *,
+        actor_key: str,
+        target_ref: str,
+        runtime_policy_profile: str,
+        snapshot_id: str,
+        runtime_profile_version: str,
+    ) -> bool:
+        if not row or not _coerce_bool(row.get("is_active")):
+            return False
+        metadata = row.get("metadata") or {}
+        return (
+            str(row.get("actor_key") or "") == actor_key
+            and str(row.get("target_ref") or "") == target_ref
+            and str(row.get("runtime_policy_profile") or "") == runtime_policy_profile
+            and str(metadata.get("snapshot_id") or "") == snapshot_id
+            and str(metadata.get("runtime_profile_version") or "v1") == runtime_profile_version
+        )
 
     @staticmethod
     def _record_from_dict(row: dict[str, Any]) -> PrototypePreviewHandleRecord:

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -9,9 +9,9 @@ from typing import Any
 from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
     PrototypeWorkspacesRepo,
 )
+from tldw_Server_API.app.core.exceptions import PrototypeTerminalRuntimeError
 
 from .models import (
-    PrototypeTerminalRuntimeError,
     PrototypePromotionResult,
     PrototypeRuntimeStatus,
 )
@@ -117,7 +117,7 @@ class PrototypeWorkspaceService:
     ) -> dict[str, Any]:
         workspace = await self._repo.get_workspace(prototype_workspace_id)
         if not workspace:
-            raise ValueError("prototype workspace not found")
+            raise PrototypeTerminalRuntimeError("prototype workspace not found")
         if workspace.get("is_archived"):
             raise PrototypeTerminalRuntimeError("archived workspaces cannot create branch sessions")
 
@@ -128,7 +128,7 @@ class PrototypeWorkspaceService:
             or ""
         ).strip()
         if not resolved_base_snapshot_id:
-            raise ValueError("prototype workspace does not have a canonical snapshot")
+            raise PrototypeTerminalRuntimeError("prototype workspace does not have a canonical snapshot")
         await self._assert_branch_actor_active(
             actor_type=actor_type,
             actor_shared_actor_id=actor_shared_actor_id,
@@ -204,10 +204,10 @@ class PrototypeWorkspaceService:
         async with self._repo.transaction() as repo:
             session = await repo.get_session(prototype_session_id)
             if not session:
-                raise ValueError("prototype session not found")
+                raise PrototypeTerminalRuntimeError("prototype session not found")
             workspace = await repo.get_workspace(str(session["prototype_workspace_id"]))
             if not workspace:
-                raise ValueError("prototype workspace not found")
+                raise PrototypeTerminalRuntimeError("prototype workspace not found")
 
             new_snapshot_id = str(snapshot_id or f"psnap_{uuid.uuid4().hex}")
             existing_snapshot = await repo.get_snapshot(new_snapshot_id) if snapshot_id else None
@@ -272,7 +272,7 @@ class PrototypeWorkspaceService:
     ) -> dict[str, Any]:
         workspace = await self._repo.get_workspace(prototype_workspace_id)
         if not workspace:
-            raise ValueError("prototype workspace not found")
+            raise PrototypeTerminalRuntimeError("prototype workspace not found")
 
         reviewer_id = int(reviewer_user_id)
         if not self._is_promoter(workspace, reviewer_id):
@@ -280,17 +280,17 @@ class PrototypeWorkspaceService:
 
         candidate = await self._repo.get_snapshot(candidate_snapshot_id)
         if not candidate or candidate.get("prototype_workspace_id") != prototype_workspace_id:
-            raise ValueError("candidate snapshot not found in prototype workspace")
+            raise PrototypeTerminalRuntimeError("candidate snapshot not found in prototype workspace")
 
         promotion_request = None
         if promotion_request_id:
             promotion_request = await self._repo.get_promotion_request(promotion_request_id)
             if not promotion_request:
-                raise ValueError("promotion request not found")
+                raise PrototypeTerminalRuntimeError("promotion request not found")
             if promotion_request.get("prototype_workspace_id") != prototype_workspace_id:
-                raise ValueError("promotion request does not belong to prototype workspace")
+                raise PrototypeTerminalRuntimeError("promotion request does not belong to prototype workspace")
             if promotion_request.get("candidate_snapshot_id") != candidate_snapshot_id:
-                raise ValueError("promotion request candidate does not match requested candidate")
+                raise PrototypeTerminalRuntimeError("promotion request candidate does not match requested candidate")
 
         canonical_snapshot_id = str(workspace.get("canonical_snapshot_id") or "").strip()
         resolved_review_baseline_snapshot_id = str(

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -11,6 +11,7 @@ from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
 )
 
 from .models import (
+    PrototypeTerminalRuntimeError,
     PrototypePromotionResult,
     PrototypeRuntimeStatus,
 )
@@ -118,7 +119,7 @@ class PrototypeWorkspaceService:
         if not workspace:
             raise ValueError("prototype workspace not found")
         if workspace.get("is_archived"):
-            raise RuntimeError("archived workspaces cannot create branch sessions")
+            raise PrototypeTerminalRuntimeError("archived workspaces cannot create branch sessions")
 
         resolved_base_snapshot_id = str(
             base_snapshot_id
@@ -207,11 +208,32 @@ class PrototypeWorkspaceService:
             workspace = await repo.get_workspace(str(session["prototype_workspace_id"]))
             if not workspace:
                 raise ValueError("prototype workspace not found")
-            if workspace.get("is_archived"):
-                raise RuntimeError("archived workspaces cannot save snapshots")
-            await self._assert_session_is_active(session, repo=repo)
 
             new_snapshot_id = str(snapshot_id or f"psnap_{uuid.uuid4().hex}")
+            existing_snapshot = await repo.get_snapshot(new_snapshot_id) if snapshot_id else None
+            if existing_snapshot:
+                if (
+                    existing_snapshot.get("prototype_workspace_id") != session.get("prototype_workspace_id")
+                    or existing_snapshot.get("created_from_session_id") != prototype_session_id
+                ):
+                    raise ValueError("snapshot_id already belongs to a different prototype save")
+                if session.get("last_saved_snapshot_id") != existing_snapshot.get("snapshot_id"):
+                    updated_session = await repo.update_session_state(
+                        prototype_session_id,
+                        last_saved_snapshot_id=existing_snapshot["snapshot_id"],
+                        last_activity_at=_utc_now(),
+                    )
+                    if (
+                        not updated_session
+                        or updated_session.get("last_saved_snapshot_id") != existing_snapshot.get("snapshot_id")
+                    ):
+                        raise RuntimeError("failed to persist session snapshot state")
+                return existing_snapshot
+
+            if workspace.get("is_archived"):
+                raise PrototypeTerminalRuntimeError("archived workspaces cannot save snapshots")
+            await self._assert_session_is_active(session, repo=repo)
+
             snapshot = await repo.create_snapshot(
                 prototype_workspace_id=str(session["prototype_workspace_id"]),
                 snapshot_id=new_snapshot_id,
@@ -452,10 +474,10 @@ class PrototypeWorkspaceService:
             return
         actor = await self._repo.get_shared_actor(str(actor_shared_actor_id or ""))
         if not actor or actor.get("is_revoked") or actor.get("revoked_at"):
-            raise RuntimeError("revoked shared actor cannot create or reuse branch sessions")
+            raise PrototypeTerminalRuntimeError("revoked shared actor cannot create or reuse branch sessions")
         expires_at = _normalize_datetime(actor.get("expires_at"))
         if expires_at and expires_at <= datetime.now(timezone.utc):
-            raise RuntimeError("expired shared actor cannot create or reuse branch sessions")
+            raise PrototypeTerminalRuntimeError("expired shared actor cannot create or reuse branch sessions")
 
     async def _assert_session_is_active(
         self,
@@ -464,20 +486,20 @@ class PrototypeWorkspaceService:
         repo: PrototypeWorkspacesRepo | None = None,
     ) -> None:
         if session.get("is_revoked") or session.get("revoked_at"):
-            raise RuntimeError("revoked session cannot save snapshots")
+            raise PrototypeTerminalRuntimeError("revoked session cannot save snapshots")
         expires_at = _normalize_datetime(session.get("expires_at"))
         if expires_at and expires_at <= datetime.now(timezone.utc):
-            raise RuntimeError("expired session cannot save snapshots")
+            raise PrototypeTerminalRuntimeError("expired session cannot save snapshots")
         actor_type = str(session.get("actor_type") or "").strip().lower()
         if actor_type != "external_collaborator":
             return
         actor_repo = repo or self._repo
         actor = await actor_repo.get_shared_actor(str(session.get("actor_shared_actor_id") or ""))
         if not actor or actor.get("is_revoked") or actor.get("revoked_at"):
-            raise RuntimeError("revoked shared actor cannot save snapshots")
+            raise PrototypeTerminalRuntimeError("revoked shared actor cannot save snapshots")
         actor_expires_at = _normalize_datetime(actor.get("expires_at"))
         if actor_expires_at and actor_expires_at <= datetime.now(timezone.utc):
-            raise RuntimeError("expired shared actor cannot save snapshots")
+            raise PrototypeTerminalRuntimeError("expired shared actor cannot save snapshots")
 
 
 class PrototypePromotionService(PrototypeWorkspaceService):

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -61,6 +61,60 @@ class CodeGraphJobError(RuntimeError):
         self.retryable = retryable
 
 
+class PrototypeJobError(RuntimeError):
+    """Worker-visible prototype job failure with explicit retry metadata."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retryable: bool,
+        failure_code: str,
+        backoff_seconds: int | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+        self.failure_code = failure_code
+        self.backoff_seconds = backoff_seconds
+        self.details = details or {}
+
+
+class PrototypeTerminalRuntimeError(PrototypeJobError):
+    """Terminal prototype runtime state failure that should not be retried."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_code: str = "runtime_terminal",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            retryable=False,
+            failure_code=failure_code,
+            details=details,
+        )
+
+
+class PrototypeJobPayloadError(ValueError):
+    """Terminal prototype job payload error that should not be retried."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_code: str = "invalid_job_payload",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retryable = False
+        self.failure_code = failure_code
+        self.backoff_seconds = None
+        self.details = details or {}
+
+
 class AuditLogError(RuntimeError):
     """Raised when persisting an audit event fails."""
 

--- a/tldw_Server_API/tests/Jobs/test_worker_sdk.py
+++ b/tldw_Server_API/tests/Jobs/test_worker_sdk.py
@@ -256,6 +256,7 @@ async def test_run_non_retryable_failure_marks_failed(monkeypatch, tmp_path):
 
     class NonRetryableErr(Exception):
         retryable = False
+        failure_code = "prototype_runtime_terminal"
 
     async def handler(job_row):
         raise NonRetryableErr("boom")
@@ -268,6 +269,7 @@ async def test_run_non_retryable_failure_marks_failed(monkeypatch, tmp_path):
     assert any(c.get("retryable") is False for c in calls)
     stored = jm.get_job(int(job["id"]))
     assert stored["status"] == "failed"
+    assert stored["error_code"] == "prototype_runtime_terminal"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
@@ -108,6 +108,67 @@ async def test_preview_broker_keeps_one_active_target_per_scope(repo, prototype_
 
 
 @pytest.mark.asyncio
+async def test_preview_broker_reuses_active_handle_for_same_scope_target_retry(
+    repo,
+    prototype_db,
+    preview_broker,
+):
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+
+    first = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+    )
+    second = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+    )
+    rows = prototype_db.execute(
+        "SELECT COUNT(*) FROM prototype_preview_handles WHERE prototype_session_id = ?",
+        (session["id"],),
+    ).fetchone()
+
+    assert second["preview_handle"] == first["preview_handle"]
+    assert second["token"]
+    assert rows[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_broker_replaces_active_handle_when_runtime_profile_version_changes(
+    repo,
+    prototype_db,
+    preview_broker,
+):
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+
+    first = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+        metadata={"runtime_profile_version": "v1"},
+    )
+    second = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+        metadata={"runtime_profile_version": "v2"},
+    )
+    first_record = await repo.get_preview_handle_record(first["preview_handle"])
+    second_record = await repo.get_preview_handle_record(second["preview_handle"])
+
+    assert second["preview_handle"] != first["preview_handle"]
+    assert first_record["is_active"] is False
+    assert second_record["is_active"] is True
+    assert second_record["metadata"]["runtime_profile_version"] == "v2"
+
+
+@pytest.mark.asyncio
 async def test_preview_broker_recovers_preview_record_after_memory_clear(repo, prototype_db, preview_broker):
     module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.preview_broker")
     broker_cls = _load_attr(module, "PrototypePreviewBroker", "PrototypeWorkspacePreviewBroker")

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
@@ -127,14 +127,64 @@ async def test_preview_broker_reuses_active_handle_for_same_scope_target_retry(
         snapshot_id="snap_preview_base",
         runtime_target_url="http://127.0.0.1:9011",
     )
-    rows = prototype_db.execute(
-        "SELECT COUNT(*) FROM prototype_preview_handles WHERE prototype_session_id = ?",
-        (session["id"],),
-    ).fetchone()
+    first_record = await repo.get_preview_handle_record(first["preview_handle"])
+    active_record = await repo.get_active_preview_handle_for_scope(f"session:{session['id']}")
 
     assert second["preview_handle"] == first["preview_handle"]
     assert second["token"]
-    assert rows[0] == 1
+    assert first_record is not None
+    assert active_record is not None
+    assert active_record["preview_handle"] == first["preview_handle"]
+
+
+@pytest.mark.asyncio
+async def test_preview_broker_reuses_existing_session_handle_after_workspace_archive(
+    repo,
+    prototype_db,
+    preview_broker,
+):
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+
+    first = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+    )
+    await repo.archive_workspace(workspace["id"])
+    second = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+    )
+
+    assert second["preview_handle"] == first["preview_handle"]
+    assert second["token"]
+
+
+@pytest.mark.asyncio
+async def test_preview_broker_metadata_cannot_override_authoritative_snapshot_id(
+    repo,
+    prototype_db,
+    preview_broker,
+):
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+
+    grant = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+        metadata={"snapshot_id": "snap_spoofed", "runtime_profile_version": "v1"},
+    )
+    record = await repo.get_preview_handle_record(grant["preview_handle"])
+    renewed = await preview_broker.renew_preview_grant(grant["preview_handle"])
+
+    assert grant["snapshot_id"] == "snap_preview_base"
+    assert renewed["snapshot_id"] == "snap_preview_base"
+    assert record is not None
+    assert record["metadata"]["snapshot_id"] == "snap_preview_base"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
@@ -49,6 +49,28 @@ class _RetryablePreviewFailureService:
         raise RuntimeError("preview runtime temporarily unavailable")
 
 
+class _RuntimeStatePreviewFailureService:
+    async def boot_preview(self, **_kwargs: Any) -> dict[str, Any]:
+        raise ValueError("prototype workspace not found")
+
+
+class _ProgrammingBugPreviewFailureService:
+    async def boot_preview(self, **_kwargs: Any) -> dict[str, Any]:
+        raise TypeError("unexpected preview argument")
+
+
+class _PreviewMetadataCaptureService:
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] | None = None
+
+    async def boot_preview(self, **kwargs: Any) -> dict[str, Any]:
+        self.kwargs = kwargs
+        return {
+            "preview_handle": "pph_metadata",
+            "preview_url": "http://127.0.0.1/preview/pph_metadata",
+        }
+
+
 class _NoopService:
     pass
 
@@ -148,6 +170,82 @@ async def test_preview_boot_transient_runtime_failure_is_retryable_for_worker() 
 
     assert getattr(exc_info.value, "retryable", False) is True
     assert getattr(exc_info.value, "failure_code", None) == "runtime_retryable"
+
+
+@pytest.mark.asyncio
+async def test_preview_boot_runtime_state_valueerror_is_terminal_for_worker() -> None:
+    worker_module = importlib.import_module(
+        "tldw_Server_API.app.core.Prototype_Workspaces.jobs_worker"
+    )
+
+    with pytest.raises(RuntimeError, match="prototype workspace not found") as exc_info:
+        await worker_module.handle_prototype_job(
+            {
+                "job_type": "preview_boot",
+                "payload": {
+                    "prototype_workspace_id": "pw_missing",
+                    "prototype_session_id": "session_1",
+                    "snapshot_id": "snap_1",
+                    "runtime_target_url": "http://127.0.0.1:9101",
+                },
+            },
+            service=_RuntimeStatePreviewFailureService(),
+        )
+
+    assert getattr(exc_info.value, "retryable", True) is False
+    assert getattr(exc_info.value, "failure_code", None) == "runtime_terminal"
+
+
+@pytest.mark.asyncio
+async def test_preview_boot_programming_error_is_terminal_for_worker() -> None:
+    worker_module = importlib.import_module(
+        "tldw_Server_API.app.core.Prototype_Workspaces.jobs_worker"
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected preview argument") as exc_info:
+        await worker_module.handle_prototype_job(
+            {
+                "job_type": "preview_boot",
+                "payload": {
+                    "prototype_workspace_id": "pw_1",
+                    "prototype_session_id": "session_1",
+                    "snapshot_id": "snap_1",
+                    "runtime_target_url": "http://127.0.0.1:9101",
+                },
+            },
+            service=_ProgrammingBugPreviewFailureService(),
+        )
+
+    assert getattr(exc_info.value, "retryable", True) is False
+    assert getattr(exc_info.value, "failure_code", None) == "worker_terminal"
+
+
+@pytest.mark.asyncio
+async def test_preview_boot_worker_propagates_top_level_runtime_profile_version() -> None:
+    worker_module = importlib.import_module(
+        "tldw_Server_API.app.core.Prototype_Workspaces.jobs_worker"
+    )
+    service = _PreviewMetadataCaptureService()
+
+    result = await worker_module.handle_prototype_job(
+        {
+            "job_type": "preview_boot",
+            "payload": {
+                "prototype_workspace_id": "pw_1",
+                "prototype_session_id": "session_1",
+                "snapshot_id": "snap_1",
+                "runtime_target_url": "http://127.0.0.1:9101",
+                "metadata": {"runtime_profile_version": "v1", "caller": "test"},
+                "runtime_profile_version": "v2",
+            },
+        },
+        service=service,
+    )
+
+    assert result["preview_handle"] == "pph_metadata"
+    assert service.kwargs is not None
+    assert service.kwargs["metadata"]["caller"] == "test"
+    assert service.kwargs["metadata"]["runtime_profile_version"] == "v2"
 
 
 @pytest.mark.asyncio
@@ -336,6 +434,36 @@ async def test_preview_boot_idempotency_distinguishes_runtime_profile_version(
 
 
 @pytest.mark.asyncio
+async def test_snapshot_save_job_derives_stable_snapshot_id_when_missing(
+    repo,
+    prototype_db,
+    prototype_jobs,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+    )
+
+    first = await prototype_jobs.enqueue_snapshot_save(
+        prototype_session_id=session["id"],
+        save_request_id="retry-save",
+        storage_ref="prototype://retry-save",
+    )
+    second = await prototype_jobs.enqueue_snapshot_save(
+        prototype_session_id=session["id"],
+        save_request_id="retry-save",
+        storage_ref="prototype://retry-save",
+    )
+
+    assert first["id"] == second["id"]
+    assert first["payload"]["snapshot_id"] == second["payload"]["snapshot_id"]
+    assert first["payload"]["snapshot_id"].startswith("psnap_")
+
+
+@pytest.mark.asyncio
 async def test_revoked_external_collaborator_cannot_reuse_branch_session(
     repo,
     prototype_db,
@@ -431,15 +559,14 @@ async def test_save_session_snapshot_reuses_existing_snapshot_for_same_snapshot_
         storage_ref="prototype://retry-safe",
         diff_summary={"step": 1},
     )
-    rows = prototype_db.execute(
-        "SELECT COUNT(*) FROM prototype_snapshots WHERE id = ?",
-        ("snap_retry_safe",),
-    ).fetchone()
+    persisted_snapshot = await repo.get_snapshot("snap_retry_safe")
     refreshed_session = await repo.get_session(session["id"])
 
     assert first["snapshot_id"] == "snap_retry_safe"
     assert second["snapshot_id"] == "snap_retry_safe"
-    assert rows[0] == 1
+    assert persisted_snapshot is not None
+    assert persisted_snapshot["snapshot_id"] == "snap_retry_safe"
+    assert persisted_snapshot["created_from_session_id"] == session["id"]
     assert refreshed_session["last_saved_snapshot_id"] == "snap_retry_safe"
 
 

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
@@ -1,6 +1,7 @@
 """Task 4 coverage for prototype runtime job orchestration."""
 from __future__ import annotations
 
+import asyncio
 import importlib
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -31,6 +32,25 @@ class _PromoteService:
     async def promote_candidate(self, **_kwargs: Any) -> dict[str, Any]:
         self.called = True
         return {"status": "promoted"}
+
+
+class _FailedPromotionService:
+    async def promote_candidate(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "failed",
+            "failure_code": "publish_validation_failed",
+            "canonical_snapshot_id": "snap_original",
+            "retryable": True,
+        }
+
+
+class _RetryablePreviewFailureService:
+    async def boot_preview(self, **_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("preview runtime temporarily unavailable")
+
+
+class _NoopService:
+    pass
 
 
 async def _seed_branch_workspace(repo, prototype_db):
@@ -89,7 +109,7 @@ async def test_publish_job_requires_reviewer_user_id_before_service_call() -> No
     )
     service = _PromoteService()
 
-    with pytest.raises(ValueError, match="reviewer_user_id is required"):
+    with pytest.raises(ValueError, match="reviewer_user_id is required") as exc_info:
         await worker_module.handle_prototype_job(
             {
                 "job_type": "publish_validate_and_promote",
@@ -102,6 +122,92 @@ async def test_publish_job_requires_reviewer_user_id_before_service_call() -> No
         )
 
     assert service.called is False
+    assert getattr(exc_info.value, "retryable", True) is False
+    assert getattr(exc_info.value, "failure_code", None) == "invalid_job_payload"
+
+
+@pytest.mark.asyncio
+async def test_preview_boot_transient_runtime_failure_is_retryable_for_worker() -> None:
+    worker_module = importlib.import_module(
+        "tldw_Server_API.app.core.Prototype_Workspaces.jobs_worker"
+    )
+
+    with pytest.raises(RuntimeError, match="temporarily unavailable") as exc_info:
+        await worker_module.handle_prototype_job(
+            {
+                "job_type": "preview_boot",
+                "payload": {
+                    "prototype_workspace_id": "pw_1",
+                    "prototype_session_id": "session_1",
+                    "snapshot_id": "snap_1",
+                    "runtime_target_url": "http://127.0.0.1:9101",
+                },
+            },
+            service=_RetryablePreviewFailureService(),
+        )
+
+    assert getattr(exc_info.value, "retryable", False) is True
+    assert getattr(exc_info.value, "failure_code", None) == "runtime_retryable"
+
+
+@pytest.mark.asyncio
+async def test_publish_validation_failure_returns_terminal_job_result() -> None:
+    worker_module = importlib.import_module(
+        "tldw_Server_API.app.core.Prototype_Workspaces.jobs_worker"
+    )
+
+    result = await worker_module.handle_prototype_job(
+        {
+            "job_type": "publish_validate_and_promote",
+            "payload": {
+                "prototype_workspace_id": "pw_1",
+                "candidate_snapshot_id": "snap_candidate",
+                "reviewer_user_id": 7,
+                "review_baseline_snapshot_id": "snap_original",
+            },
+        },
+        service=_FailedPromotionService(),
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "publish_validation_failed"
+    assert result["canonical_snapshot_id"] == "snap_original"
+    assert result["job_type"] == "publish_validate_and_promote"
+    assert result["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_jobs_worker_stops_when_stop_event_is_set(monkeypatch) -> None:
+    worker_module = importlib.import_module(
+        "tldw_Server_API.app.core.Prototype_Workspaces.jobs_worker"
+    )
+    captured: dict[str, Any] = {}
+
+    class FakeWorkerSDK:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.stop_called = False
+            self._stopped = asyncio.Event()
+            captured["sdk"] = self
+
+        def stop(self) -> None:
+            self.stop_called = True
+            self._stopped.set()
+
+        async def run(self, **_kwargs: Any) -> None:
+            await asyncio.wait_for(self._stopped.wait(), timeout=1)
+
+    monkeypatch.setattr(worker_module, "WorkerSDK", FakeWorkerSDK)
+    monkeypatch.setattr(worker_module, "_jobs_manager", lambda: object())
+    stop_event = asyncio.Event()
+    worker_task = asyncio.create_task(
+        worker_module.run_prototype_jobs_worker(service=_NoopService(), stop_event=stop_event)
+    )
+
+    await asyncio.sleep(0)
+    stop_event.set()
+    await asyncio.wait_for(worker_task, timeout=1)
+
+    assert captured["sdk"].stop_called is True
 
 
 @pytest.mark.asyncio
@@ -192,6 +298,41 @@ async def test_preview_boot_idempotency_distinguishes_runtime_target_url(
 
     assert first["id"] != second["id"]
     assert first["idempotency_key"] != second["idempotency_key"]
+    assert first["payload"]["metadata"]["runtime_profile_version"] == "v1"
+
+
+@pytest.mark.asyncio
+async def test_preview_boot_idempotency_distinguishes_runtime_profile_version(
+    repo,
+    prototype_db,
+    prototype_jobs,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+    )
+
+    first = await prototype_jobs.enqueue_preview_boot(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id=canonical["snapshot_id"],
+        runtime_target_url="http://127.0.0.1:9101",
+        runtime_profile_version="v1",
+    )
+    second = await prototype_jobs.enqueue_preview_boot(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id=canonical["snapshot_id"],
+        runtime_target_url="http://127.0.0.1:9101",
+        runtime_profile_version="v2",
+    )
+
+    assert first["id"] != second["id"]
+    assert first["idempotency_key"] != second["idempotency_key"]
+    assert second["payload"]["metadata"]["runtime_profile_version"] == "v2"
 
 
 @pytest.mark.asyncio
@@ -222,13 +363,16 @@ async def test_revoked_external_collaborator_cannot_reuse_branch_session(
     service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
     service = service_cls(repo=repo)
 
-    with pytest.raises(RuntimeError, match="revoked"):
+    with pytest.raises(RuntimeError, match="revoked") as exc_info:
         await service.create_or_reuse_branch_session(
             prototype_workspace_id=workspace["id"],
             actor_type="external_collaborator",
             actor_shared_actor_id=actor["id"],
             request_nonce="after-revoke",
         )
+
+    assert getattr(exc_info.value, "retryable", True) is False
+    assert getattr(exc_info.value, "failure_code", None) == "runtime_terminal"
 
 
 @pytest.mark.asyncio
@@ -249,11 +393,54 @@ async def test_expired_session_cannot_save_snapshot(
     service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
     service = service_cls(repo=repo)
 
-    with pytest.raises(RuntimeError, match="expired"):
+    with pytest.raises(RuntimeError, match="expired") as exc_info:
         await service.save_session_snapshot(
             prototype_session_id=session["id"],
             snapshot_id="snap_should_not_save",
         )
+
+    assert getattr(exc_info.value, "retryable", True) is False
+    assert getattr(exc_info.value, "failure_code", None) == "runtime_terminal"
+
+
+@pytest.mark.asyncio
+async def test_save_session_snapshot_reuses_existing_snapshot_for_same_snapshot_id(
+    repo,
+    prototype_db,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+    )
+    service_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
+    service = service_cls(repo=repo)
+
+    first = await service.save_session_snapshot(
+        prototype_session_id=session["id"],
+        snapshot_id="snap_retry_safe",
+        storage_ref="prototype://retry-safe",
+        diff_summary={"step": 1},
+    )
+    second = await service.save_session_snapshot(
+        prototype_session_id=session["id"],
+        snapshot_id="snap_retry_safe",
+        storage_ref="prototype://retry-safe",
+        diff_summary={"step": 1},
+    )
+    rows = prototype_db.execute(
+        "SELECT COUNT(*) FROM prototype_snapshots WHERE id = ?",
+        ("snap_retry_safe",),
+    ).fetchone()
+    refreshed_session = await repo.get_session(session["id"])
+
+    assert first["snapshot_id"] == "snap_retry_safe"
+    assert second["snapshot_id"] == "snap_retry_safe"
+    assert rows[0] == 1
+    assert refreshed_session["last_saved_snapshot_id"] == "snap_retry_safe"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds explicit prototype job result envelopes and retry metadata for worker success, payload, permission, transient, and terminal runtime paths.
- Makes preview boot and snapshot-save retries deterministic by reusing matching active preview handles, preserving runtime profile-version identity, and returning existing session-owned snapshots for duplicate save execution.
- Documents the Risk Gate 3 runtime job contract, cancellation/timeout boundary, and frontend/operator result matrix; records TASK-389 and the implementation plan.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q` -> 97 passed, 5 warnings
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Prototype_Workspaces/jobs.py tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py tldw_Server_API/app/core/Prototype_Workspaces/models.py tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py tldw_Server_API/app/core/Prototype_Workspaces/service.py -f json -o /tmp/bandit_prototype_risk_gate_3.json` -> 0 findings
- [x] `git diff --check` -> clean

Closes #1455

## Change summary
AI-assisted PR. Before merge, the human requester/reviewer should replace this reminder with their own change summary explaining what changed and why these implementation choices were made, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens prototype runtime job durability with stable job result envelopes, typed error handling, and idempotent preview boot/snapshot save keyed by runtime profile version. Persists stable failure codes to Jobs, prevents duplicate previews and snapshots, and documents the Risk Gate 3 runtime job contract (addresses TASK-389, GitHub #1455).

- **New Features**
  - Unified job results include `status`, `job_type`, `retryable`, and stable `failure_code`; publish terminal outcomes are non-retryable.
  - Worker coerces service exceptions into typed errors (`invalid_job_payload`, `permission_denied`, `runtime_retryable`, `runtime_terminal`, `worker_terminal`) and persists `failure_code` to the Jobs `error_code`.
  - Preview boot idempotency keys on scope, snapshot, target, and `runtime_profile_version`; identical requests renew the active handle (even if the workspace is later archived), changes replace it; metadata can’t override the authoritative `snapshot_id`.
  - Snapshot save derives a deterministic `snapshot_id` from session and `save_request_id` when missing, reuses existing snapshots on retry, and advances the session pointer without creating duplicates.
  - Docs add the runtime job contract and result matrix; tests cover error classification, `runtime_profile_version` propagation, preview reuse/replace, `error_code` persistence, and retry/idempotency paths.

<sup>Written for commit 9698af69d868a359410fd069b4eb9a2e502b8364. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1729?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

