### PR TITLE
Add Persona Visual first-run setup choices

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/sidepanel.json
+++ b/apps/packages/ui/src/assets/locale/en/sidepanel.json
@@ -539,7 +539,22 @@
       "starterDraftTitleLabel": "Draft title",
       "starterCopyAsDraft": "Copy as draft",
       "starterAssetUnit": "assets",
-      "starterBytesUnit": "bytes"
+      "starterBytesUnit": "bytes",
+      "firstRunHeading": "Set up Persona Buddy visual",
+      "firstRunDescription": "Choose how to set up {{personaName}}'s visual.",
+      "firstRunDraftFirstCopy": "Each option creates or opens a draft first. Activate only after review.",
+      "firstRunDraftFirstBadge": "draft first",
+      "firstRunUseDefaultTitle": "Use default",
+      "firstRunUseDefaultDescription": "Copy the bundled sprite-frame starter as a draft for this persona.",
+      "firstRunUseDefaultButton": "Use default",
+      "firstRunImportTitle": "Import pack",
+      "firstRunImportDescription": "Validate a portable pack archive, then commit it as a draft.",
+      "firstRunImportButton": "Import pack",
+      "firstRunBlankTitle": "Start blank",
+      "firstRunBlankDescription": "Create an empty draft and add assets, states, and animations manually.",
+      "firstRunBlankButton": "Start blank",
+      "firstRunBlankDraftTitle": "{{personaName}} blank visual draft",
+      "firstRunBlankCreated": "Blank visual draft created. Add assets and activate it when ready."
     }
   },
   "persona": {

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -894,6 +894,13 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     starterPacks.find((starter) => starter.id === selectedStarterPackId) ??
     starterPacks[0] ??
     null
+  const personaVisualLabel = selectedPersonaName || selectedPersonaId
+  const hasActiveVisualPack = React.useMemo(
+    () => packs.some((pack) => pack.status === "active"),
+    [packs]
+  )
+  const showFirstRunSetup =
+    isActive && Boolean(selectedPersonaId) && !loading && !hasActiveVisualPack
   const selectedPackLibraryItem = React.useMemo(
     () =>
       selectedPack
@@ -1300,9 +1307,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     duplicateTargetSelectRef.current?.focus()
   }, [])
 
-  const handleCreateDraft = async () => {
-    const title = draftTitle.trim()
-    if (!selectedPersonaId || !title) return
+  const createDraftPack = async (
+    title: string,
+    successMessage: string
+  ): Promise<PersonaVisualPack | null> => {
+    if (!selectedPersonaId || !title) return null
     setSaving(true)
     setError(null)
     try {
@@ -1313,11 +1322,8 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       setPacks((current) => mergePack(current, created))
       setSelectedPackId(created.id)
       setDraftTitle("")
-      setStatusMessage(
-        t("sidepanel:personaGarden.visuals.created", {
-          defaultValue: "Draft created."
-        })
-      )
+      setStatusMessage(successMessage)
+      return created
     } catch (createError) {
       setError(
         createError instanceof Error
@@ -1326,9 +1332,34 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               defaultValue: "Failed to create visual pack."
             })
       )
+      return null
     } finally {
       setSaving(false)
     }
+  }
+
+  const handleCreateDraft = async () => {
+    const title = draftTitle.trim()
+    await createDraftPack(
+      title,
+      t("sidepanel:personaGarden.visuals.created", {
+        defaultValue: "Draft created."
+      })
+    )
+  }
+
+  const handleStartBlankDraft = async () => {
+    const title = t("sidepanel:personaGarden.visuals.firstRunBlankDraftTitle", {
+      personaName: personaVisualLabel,
+      defaultValue: `${personaVisualLabel} blank visual draft`
+    })
+    await createDraftPack(
+      title,
+      t("sidepanel:personaGarden.visuals.firstRunBlankCreated", {
+        defaultValue:
+          "Blank visual draft created. Add assets and activate it when ready."
+      })
+    )
   }
 
   const handleUploadAsset = async () => {
@@ -2493,6 +2524,117 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           </div>
         ) : null}
       </div>
+
+      {showFirstRunSetup ? (
+        <div
+          data-testid="persona-visual-first-run-setup"
+          className="rounded-lg border border-border bg-surface p-3"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+                {t("sidepanel:personaGarden.visuals.firstRunHeading", {
+                  defaultValue: "Set up Persona Buddy visual"
+                })}
+              </div>
+              <div className="mt-1 text-sm font-medium text-text">
+                {t("sidepanel:personaGarden.visuals.firstRunDescription", {
+                  personaName: personaVisualLabel,
+                  defaultValue: `Choose how to set up ${personaVisualLabel}'s visual.`
+                })}
+              </div>
+              <div className="mt-1 max-w-3xl text-xs leading-5 text-text-muted">
+                {t("sidepanel:personaGarden.visuals.firstRunDraftFirstCopy", {
+                  defaultValue:
+                    "Each option creates or opens a draft first. Activate only after review."
+                })}
+              </div>
+            </div>
+            <Tag>
+              {t("sidepanel:personaGarden.visuals.firstRunDraftFirstBadge", {
+                defaultValue: "draft first"
+              })}
+            </Tag>
+          </div>
+          <div className="mt-3 grid gap-2 md:grid-cols-3">
+            <div className="space-y-2">
+              <div className="text-xs font-medium text-text">
+                {t("sidepanel:personaGarden.visuals.firstRunUseDefaultTitle", {
+                  defaultValue: "Use default"
+                })}
+              </div>
+              <div className="text-xs leading-5 text-text-muted">
+                {t("sidepanel:personaGarden.visuals.firstRunUseDefaultDescription", {
+                  defaultValue:
+                    "Copy the bundled sprite-frame starter as a draft for this persona."
+                })}
+              </div>
+              <Button
+                data-testid="persona-visual-first-run-default-button"
+                size="small"
+                icon={<Copy className="h-3.5 w-3.5" />}
+                loading={copyingStarterPack}
+                disabled={
+                  starterPacksLoading || !selectedStarterPack || copyingStarterPack
+                }
+                onClick={() => void handleCopyStarterPack()}
+              >
+                {t("sidepanel:personaGarden.visuals.firstRunUseDefaultButton", {
+                  defaultValue: "Use default"
+                })}
+              </Button>
+            </div>
+            <div className="space-y-2">
+              <div className="text-xs font-medium text-text">
+                {t("sidepanel:personaGarden.visuals.firstRunImportTitle", {
+                  defaultValue: "Import pack"
+                })}
+              </div>
+              <div className="text-xs leading-5 text-text-muted">
+                {t("sidepanel:personaGarden.visuals.firstRunImportDescription", {
+                  defaultValue:
+                    "Validate a portable pack archive, then commit it as a draft."
+                })}
+              </div>
+              <Button
+                data-testid="persona-visual-first-run-import-button"
+                size="small"
+                icon={<Upload className="h-3.5 w-3.5" />}
+                onClick={openImportArchivePicker}
+              >
+                {t("sidepanel:personaGarden.visuals.firstRunImportButton", {
+                  defaultValue: "Import pack"
+                })}
+              </Button>
+            </div>
+            <div className="space-y-2">
+              <div className="text-xs font-medium text-text">
+                {t("sidepanel:personaGarden.visuals.firstRunBlankTitle", {
+                  defaultValue: "Start blank"
+                })}
+              </div>
+              <div className="text-xs leading-5 text-text-muted">
+                {t("sidepanel:personaGarden.visuals.firstRunBlankDescription", {
+                  defaultValue:
+                    "Create an empty draft and add assets, states, and animations manually."
+                })}
+              </div>
+              <Button
+                data-testid="persona-visual-first-run-blank-button"
+                size="small"
+                icon={<Edit3 className="h-3.5 w-3.5" />}
+                loading={saving}
+                disabled={saving}
+                onClick={() => void handleStartBlankDraft()}
+              >
+                {t("sidepanel:personaGarden.visuals.firstRunBlankButton", {
+                  defaultValue: "Start blank"
+                })}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       <VisualPackReusePanel
         selectedPersonaName={selectedPersonaName || selectedPersonaId}

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -583,6 +583,205 @@ describe("VisualPackEditor", () => {
     ).toBe(false)
   })
 
+  it("surfaces first-run default and import choices for personas without an active visual", async () => {
+    const calls: string[] = []
+    const clickFileInput = vi
+      .spyOn(HTMLInputElement.prototype, "click")
+      .mockImplementation(() => undefined)
+    const copiedPack = {
+      id: "starter-copy-1",
+      persona_id: "persona-1",
+      title: "Research Buddy Starter",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 1
+    }
+    let starterCopied = false
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse(starterCopied ? [copiedPack] : [])
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse({
+          starter_packs: [
+            {
+              id: "research-buddy-starter",
+              title: "Research Buddy Starter",
+              description: "A deterministic sprite-frame starter.",
+              renderer_type: "sprite_frames",
+              manifest_version: 1,
+              states_offered: ["idle", "listening", "thinking", "speaking", "error"],
+              asset_count: 1,
+              total_bytes: 92,
+              tags: ["starter", "sprite_frames"],
+              license_label: "bundled"
+            }
+          ]
+        })
+      }
+      if (
+        path === "/api/v1/persona/visual-starter-packs/research-buddy-starter/copy" &&
+        method === "POST"
+      ) {
+        starterCopied = true
+        expect(parseJsonBody(init?.body)).toMatchObject({
+          target_persona_id: "persona-1",
+          title: "Research Buddy Starter"
+        })
+        return okResponse(copiedPack)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/starter-copy-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/starter-copy-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const setupPanel = await screen.findByTestId("persona-visual-first-run-setup")
+    expect(setupPanel).toHaveTextContent("Choose how to set up Garden Helper's visual")
+    expect(
+      within(setupPanel).getByRole("button", { name: /use default/i })
+    ).toBeEnabled()
+    expect(
+      within(setupPanel).getByRole("button", { name: /import pack/i })
+    ).toBeEnabled()
+    expect(
+      within(setupPanel).getByRole("button", { name: /start blank/i })
+    ).toBeEnabled()
+
+    fireEvent.click(within(setupPanel).getByRole("button", { name: /import pack/i }))
+    expect(clickFileInput).toHaveBeenCalled()
+
+    fireEvent.click(within(setupPanel).getByRole("button", { name: /use default/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue(
+        "starter-copy-1"
+      )
+    )
+    expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent("draft")
+    expect(
+      calls.some((call) => call.includes("/starter-copy-1/activate"))
+    ).toBe(false)
+  })
+
+  it("starts a blank first-run visual draft without activating it", async () => {
+    const calls: string[] = []
+    const createdBodies: any[] = []
+    let packs: any[] = []
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse(packs)
+      }
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "POST") {
+        const body = parseJsonBody(init?.body)
+        createdBodies.push(body)
+        const pack = {
+          id: "blank-pack-1",
+          persona_id: "persona-1",
+          title: body.title,
+          renderer_type: "sprite_frames",
+          status: "draft",
+          manifest: body.manifest,
+          assets: [],
+          version: 1
+        }
+        packs = [pack]
+        return okResponse(pack)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/blank-pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/blank-pack-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse({ starter_packs: [] })
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const setupPanel = await screen.findByTestId("persona-visual-first-run-setup")
+    fireEvent.click(within(setupPanel).getByRole("button", { name: /start blank/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue(
+        "blank-pack-1"
+      )
+    )
+    expect(createdBodies[0]).toMatchObject({
+      title: "Garden Helper blank visual draft",
+      manifest: {
+        manifest_version: 1,
+        renderer_type: "sprite_frames",
+        states: {},
+        animations: {}
+      }
+    })
+    expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent("draft")
+    expect(calls.some((call) => call.includes("/blank-pack-1/activate"))).toBe(false)
+  })
+
   it("ignores stale starter pack responses after switching personas", async () => {
     const firstStarterResponse = deferredResponse<{
       ok: boolean

--- a/backlog/tasks/task-390 - Implement-first-run-Persona-Visual-Buddy-setup-choices.md
+++ b/backlog/tasks/task-390 - Implement-first-run-Persona-Visual-Buddy-setup-choices.md
@@ -1,0 +1,69 @@
+---
+id: TASK-390
+title: Implement first-run Persona Visual Buddy setup choices
+status: Done
+assignee: []
+created_date: '2026-05-15 21:34'
+labels:
+  - persona
+  - webui
+  - persona-visuals
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/issues/1695'
+documentation:
+  - apps/packages/ui/src/routes/sidepanel-persona.tsx
+  - apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+  - apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1695 under epic #1510. The user-facing goal is a clear first-run Persona Garden setup path for personas without an active visual: use a bundled default pack, import a portable pack, or start blank, while preserving the existing draft-first and explicit-activation Persona Visual contract. Keep scope on Persona Garden / Buddy visual setup and avoid VN/CYOA, Live2D runtime adapter work, or external provider execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Garden exposes discoverable first-run setup choices for a persona with no active visual.
+- [x] #2 Choosing a default pack creates and selects a draft without activating it.
+- [x] #3 Choosing import enters the existing import preview/commit flow and lands on the committed draft without activating it.
+- [x] #4 Choosing blank leaves a coherent editable no-visual or empty-draft state consistent with current backend support.
+- [x] #5 Focused UI tests cover the setup choice rendering and primary state transitions.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a first-run setup panel in `VisualPackEditor` that appears when the selected persona has no active visual pack.
+- The setup panel routes to existing draft-first primitives: bundled starter copy, import archive picker, and blank draft creation.
+- Added localized copy for the setup panel and default blank draft title/status message.
+- Added focused VisualPackEditor tests covering default/import choice rendering, no implicit activation, and blank draft creation.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFY:BEGIN -->
+- `bun run test:run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed: 33 tests.
+- `git diff --check` passed.
+- `bun run lint` passed with existing warnings only: 0 errors, 155 warnings.
+- Bandit skipped: frontend-only TypeScript/locale/task change, no Python touched.
+<!-- SECTION:VERIFY:END -->
+
+## Final Summary
+
+<!-- SECTION:SUMMARY:BEGIN -->
+Implemented the first-run Persona Visual Buddy setup choice layer for issue #1695. Users without an active visual now see a clear setup panel with Use default, Import pack, and Start blank paths, all preserving the existing draft-first and explicit-activation contract.
+<!-- SECTION:SUMMARY:END -->


### PR DESCRIPTION
Parent: #1510
Addresses: #1695

## Change summary
TODO: human-authored summary required before this AI-generated PR is merge-ready.

## What changed
- Added a first-run Persona Visual setup panel when a persona has no active visual pack.
- Wired Use default to the bundled starter copy flow without activation.
- Wired Import pack to the existing archive picker/import preview flow.
- Wired Start blank to create an empty sprite_frames draft without activation.
- Added localized setup copy and focused VisualPackEditor coverage.

## Validation
- `bun run test:run ../packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- `git diff --check`
- `bun run lint` (0 errors, existing warnings only)
- Bandit skipped: frontend-only TypeScript/locale/task changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-run Persona Visual setup panel that appears when a persona has no active visual pack. Meets #1695 by giving clear choices (use default, import, start blank) that always create/select a draft without auto-activation.

- **New Features**
  - Show setup panel when no active visual pack.
  - Use default: copy bundled starter to a draft and select it (no activation).
  - Import pack: open archive picker/preview, then commit as draft (no activation).
  - Start blank: create an empty `sprite_frames` draft with a localized title (no activation).
  - Added localized strings and focused `VisualPackEditor` tests.

<sup>Written for commit bb9eeeb32f260435b696cb5601161f4b911a2a67. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1730?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

