### PR TITLE
Fix helperctl launchd ping on system Python

### DIFF
--- a/backlog/tasks/task-389 - Fix-vz-helperctl-system-Python-launchd-ping-failure.md
+++ b/backlog/tasks/task-389 - Fix-vz-helperctl-system-Python-launchd-ping-failure.md
@@ -4,7 +4,7 @@ title: Fix vz-helperctl system Python launchd ping failure
 status: Done
 assignee: []
 created_date: '2026-05-15 19:56'
-updated_date: '2026-05-15 20:07'
+updated_date: '2026-05-16 01:03'
 labels:
   - sandbox
   - macos-vz-helper
@@ -38,12 +38,18 @@ The merged launchd-drill operator path works when run with the project Python, b
 2026-05-15: Reproduced the host failure during local launchd-drill validation: direct script invocation used macOS system Python 3.9 and helper_status failed with dataclass(slots=...) import incompatibility. Added a failing regression that blocks helper_client import and proves ping_helper_state can still ping a reachable helper socket through the operator CLI path.
 
 Implemented a narrow direct socket ping in vz-helperctl.py for default helper readiness checks. client_factory remains available for tests. Verified focused regression, launchd/ping helperctl slice, full helperctl tests, direct launchd-drill with the documented script invocation, git diff --check, and Bandit. No docs change was needed because direct script invocation now works without requiring project Python.
+
+2026-05-15 review pass: PR #1731 has two actionable Qodo review threads. Scope: add a docstring for _request_helper_ping and normalize direct socket transport/empty/invalid JSON failures to stable macos_virtualization_helper_* messages before resolving review threads.
+
+2026-05-15 review fix: Added _request_helper_ping docstring and stable-message regressions for empty response, invalid JSON, and missing helper socket. Normalized direct socket transport failures to macos_virtualization_helper_unavailable, empty responses to macos_virtualization_helper_empty_response, and decode/JSON failures to macos_virtualization_helper_invalid_json.
+
+Review-fix verification: focused review tests passed 3 passed; full helperctl pytest passed 129 passed, 1 skipped; direct launchd-drill --skip-smoke passed bootstrap/status/kickstart/helper_status/protocol/version/bootout; git diff --check passed; Bandit JSON at /tmp/bandit_vz_helperctl_python39_ping_review_fix.json reported errors=0 and results=0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed the system-Python launchd ping failure discovered during local validation. vz-helperctl now performs helper ping directly over the Unix socket instead of importing the full server helper client for operator readiness checks, avoiding Python 3.9 dataclass(slots=...) import incompatibility while preserving protocol/version validation and test injection through client_factory. Verified with full helperctl tests, direct launchd-drill execution, git diff --check, and Bandit.
+Fixed the system-Python launchd ping failure and the PR #1731 review findings. vz-helperctl now pings the helper directly over the Unix socket without importing server modules, documents that helper, and normalizes transport/protocol parse failures to stable macos_virtualization_helper_* messages. Regression coverage verifies the import-break fallback and stable messages for missing socket, empty response, and invalid JSON. Verified full helperctl tests, direct launchd-drill, git diff --check, and Bandit.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-389 - Fix-vz-helperctl-system-Python-launchd-ping-failure.md
+++ b/backlog/tasks/task-389 - Fix-vz-helperctl-system-Python-launchd-ping-failure.md
@@ -1,0 +1,57 @@
+---
+id: TASK-389
+title: Fix vz-helperctl system Python launchd ping failure
+status: Done
+assignee: []
+created_date: '2026-05-15 19:56'
+updated_date: '2026-05-15 20:07'
+labels:
+  - sandbox
+  - macos-vz-helper
+  - launchd
+  - cli
+dependencies: []
+documentation:
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - tools/macos-vz-helper/scripts/vz-helperctl.py
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The merged launchd-drill operator path works when run with the project Python, but direct script invocation on this macOS host used system Python 3.9 and failed helper ping with dataclass(slots=...) import incompatibility. Harden vz-helperctl so documented direct CLI usage does not fail before helper readiness validation on Python 3.9, or make the failure explicit and operator-safe.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Direct vz-helperctl launchd-drill/check paths do not crash or report helper ping failure because helper_client cannot import on Python 3.9.
+- [x] #2 Helper ping/status behavior remains protocol-compatible on supported project Python versions.
+- [x] #3 Focused helperctl regression coverage captures the Python 3.9 import fallback or explicit unsupported-interpreter behavior.
+- [x] #4 Operator docs or CLI guidance are updated if direct script invocation requires the project Python.
+- [x] #5 Focused helperctl tests pass and the touched helperctl code passes git diff --check and Bandit.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-15: Reproduced the host failure during local launchd-drill validation: direct script invocation used macOS system Python 3.9 and helper_status failed with dataclass(slots=...) import incompatibility. Added a failing regression that blocks helper_client import and proves ping_helper_state can still ping a reachable helper socket through the operator CLI path.
+
+Implemented a narrow direct socket ping in vz-helperctl.py for default helper readiness checks. client_factory remains available for tests. Verified focused regression, launchd/ping helperctl slice, full helperctl tests, direct launchd-drill with the documented script invocation, git diff --check, and Bandit. No docs change was needed because direct script invocation now works without requiring project Python.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the system-Python launchd ping failure discovered during local validation. vz-helperctl now performs helper ping directly over the Unix socket instead of importing the full server helper client for operator readiness checks, avoiding Python 3.9 dataclass(slots=...) import incompatibility while preserving protocol/version validation and test injection through client_factory. Verified with full helperctl tests, direct launchd-drill execution, git diff --check, and Bandit.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -2844,6 +2844,78 @@ def test_ping_helper_falls_back_to_socket_when_helper_client_import_breaks(monke
     )
 
 
+@pytest.mark.parametrize(
+    ("chunks", "expected_message"),
+    [
+        ([b""], "macos_virtualization_helper_empty_response"),
+        ([b"not-json\n"], "macos_virtualization_helper_invalid_json"),
+    ],
+)
+def test_ping_helper_socket_fallback_reports_stable_protocol_errors(monkeypatch, chunks, expected_message):
+    helperctl = load_helperctl()
+
+    class FakeSocket:
+        def __init__(self, *_args, **_kwargs):
+            self._chunks = list(chunks)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, _timeout):
+            return None
+
+        def connect(self, _socket_path):
+            return None
+
+        def sendall(self, _payload):
+            return None
+
+        def recv(self, _size):
+            return self._chunks.pop(0)
+
+    monkeypatch.setattr(helperctl.socket, "socket", FakeSocket)
+
+    result = helperctl.ping_helper_state(Path("/tmp/helper.sock"))
+
+    CASE.assertEqual(
+        result.result,
+        helperctl.CheckResult(ok=False, reason="helper_ping_failed", message=expected_message),
+    )
+
+
+def test_ping_helper_socket_fallback_reports_stable_transport_error(monkeypatch):
+    helperctl = load_helperctl()
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, _timeout):
+            return None
+
+        def connect(self, _socket_path):
+            raise FileNotFoundError("missing helper socket")
+
+    monkeypatch.setattr(helperctl.socket, "socket", lambda *_args, **_kwargs: FakeSocket())
+
+    result = helperctl.ping_helper_state(Path("/tmp/helper.sock"))
+
+    CASE.assertEqual(
+        result.result,
+        helperctl.CheckResult(
+            ok=False,
+            reason="helper_ping_failed",
+            message="macos_virtualization_helper_unavailable",
+        ),
+    )
+
+
 def test_stop_helper_terminates_only_validated_pid(tmp_path):
     helperctl = load_helperctl()
     helper = tmp_path / "macos-vz-helper"

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -2781,6 +2781,69 @@ def test_ping_helper_reports_protocol_mismatch(monkeypatch, tmp_path):
     CASE.assertEqual(result.result, helperctl.CheckResult(ok=False, reason="helper_protocol_mismatch", message="macos_virtualization_helper_protocol_mismatch"))
 
 
+def test_ping_helper_falls_back_to_socket_when_helper_client_import_breaks(monkeypatch):
+    helperctl = load_helperctl()
+    sent_payloads = []
+
+    original_import = __import__
+
+    def broken_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client":
+            raise TypeError("dataclass() got an unexpected keyword argument 'slots'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    class FakeSocket:
+        def __init__(self, *_args, **_kwargs):
+            self._chunks = [
+                json.dumps(
+                    {
+                        "protocol_version": helperctl.EXPECTED_HELPER_PROTOCOL_VERSION,
+                        "helper_version": "fallback-test",
+                        "status": "ok",
+                    }
+                ).encode("utf-8")
+                + b"\n",
+                b"",
+            ]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, timeout):
+            CASE.assertEqual(timeout, 5.0)
+
+        def connect(self, socket_path):
+            CASE.assertEqual(socket_path, "/tmp/helper.sock")
+
+        def sendall(self, payload):
+            sent_payloads.append(json.loads(payload.decode("utf-8").strip()))
+
+        def recv(self, _size):
+            return self._chunks.pop(0)
+
+    monkeypatch.setattr("builtins.__import__", broken_import)
+    monkeypatch.setattr(helperctl.socket, "socket", FakeSocket)
+
+    result = helperctl.ping_helper_state(Path("/tmp/helper.sock"))
+
+    CASE.assertEqual(result.result, helperctl.CheckResult(ok=True))
+    CASE.assertEqual(result.protocol_version, helperctl.EXPECTED_HELPER_PROTOCOL_VERSION)
+    CASE.assertEqual(result.helper_version, "fallback-test")
+    CASE.assertEqual(
+        sent_payloads,
+        [
+            {
+                "operation": "ping",
+                "protocol_version": helperctl.EXPECTED_HELPER_PROTOCOL_VERSION,
+                "request": {},
+            }
+        ],
+    )
+
+
 def test_stop_helper_terminates_only_validated_pid(tmp_path):
     helperctl = load_helperctl()
     helper = tmp_path / "macos-vz-helper"

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -732,25 +732,41 @@ def _kill_process(pid: int) -> None:
 
 
 def _request_helper_ping(socket_path: Path, *, timeout_sec: float = 5.0) -> dict[str, object]:
+    """Ping the helper over its Unix socket without importing server modules.
+
+    The request uses the helper's newline-delimited JSON protocol and returns
+    the decoded response object. Transport failures are normalized to
+    stable operator-facing helper error identifiers; malformed or empty
+    responses are treated as protocol errors.
+    """
     payload = {
         "operation": "ping",
         "protocol_version": str(EXPECTED_HELPER_PROTOCOL_VERSION),
         "request": {},
     }
 
-    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-        client.settimeout(timeout_sec)
-        client.connect(str(socket_path))
-        client.sendall(json.dumps(payload).encode("utf-8") + b"\n")
-        response_bytes = bytearray()
-        while b"\n" not in response_bytes:
-            chunk = client.recv(65536)
-            if not chunk:
-                break
-            response_bytes.extend(chunk)
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout_sec)
+            client.connect(str(socket_path))
+            client.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+            response_bytes = bytearray()
+            while b"\n" not in response_bytes:
+                chunk = client.recv(65536)
+                if not chunk:
+                    break
+                response_bytes.extend(chunk)
+    except (FileNotFoundError, ConnectionRefusedError, OSError, socket.timeout) as exc:
+        raise RuntimeError("macos_virtualization_helper_unavailable") from exc
 
-    response_text = bytes(response_bytes).split(b"\n", 1)[0].decode("utf-8")
-    response = json.loads(response_text)
+    raw_response = bytes(response_bytes).split(b"\n", 1)[0].strip()
+    if not raw_response:
+        raise RuntimeError("macos_virtualization_helper_empty_response")
+    try:
+        response_text = raw_response.decode("utf-8")
+        response = json.loads(response_text)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("macos_virtualization_helper_invalid_json") from exc
     if not isinstance(response, dict):
         raise RuntimeError("macos_virtualization_helper_protocol_error")
     return response

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -731,18 +731,49 @@ def _kill_process(pid: int) -> None:
         return
 
 
+def _request_helper_ping(socket_path: Path, *, timeout_sec: float = 5.0) -> dict[str, object]:
+    payload = {
+        "operation": "ping",
+        "protocol_version": str(EXPECTED_HELPER_PROTOCOL_VERSION),
+        "request": {},
+    }
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout_sec)
+        client.connect(str(socket_path))
+        client.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+        response_bytes = bytearray()
+        while b"\n" not in response_bytes:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            response_bytes.extend(chunk)
+
+    response_text = bytes(response_bytes).split(b"\n", 1)[0].decode("utf-8")
+    response = json.loads(response_text)
+    if not isinstance(response, dict):
+        raise RuntimeError("macos_virtualization_helper_protocol_error")
+    return response
+
+
 def ping_helper_state(
     socket_path: Path,
     *,
     client_factory: Callable[[Path], object] | None = None,
 ) -> PingState:
     try:
-        from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
-            MacOSVirtualizationHelperClient,
-        )
-
-        factory = client_factory or (lambda path: MacOSVirtualizationHelperClient(socket_path=str(path)))
-        reply = factory(socket_path).ping()
+        if client_factory is not None:
+            reply = client_factory(socket_path).ping()
+            protocol_version = str(getattr(reply, "protocol_version", "") or "")
+            helper_version = str(getattr(reply, "helper_version", "") or "")
+        else:
+            payload = _request_helper_ping(socket_path)
+            error_code = str(payload.get("error_code") or "").strip()
+            if error_code:
+                message = str(payload.get("message") or "").strip() or error_code
+                raise RuntimeError(f"{error_code}: {message}")
+            protocol_version = str(payload.get("protocol_version") or "")
+            helper_version = str(payload.get("helper_version") or "")
     except Exception as exc:
         if (
             exc.__class__.__name__ == "MacOSVirtualizationHelperProtocolError"
@@ -752,8 +783,6 @@ def ping_helper_state(
                 result=CheckResult(ok=False, reason="helper_protocol_mismatch", message=str(exc)),
             )
         return PingState(result=CheckResult(ok=False, reason="helper_ping_failed", message=str(exc)))
-    protocol_version = str(getattr(reply, "protocol_version", "") or "")
-    helper_version = str(getattr(reply, "helper_version", "") or "")
     if protocol_version != str(EXPECTED_HELPER_PROTOCOL_VERSION):
         return PingState(
             result=CheckResult(ok=False, reason="helper_protocol_mismatch"),


### PR DESCRIPTION
## Summary

- Decouple `vz-helperctl.py` helper readiness ping from importing the server-side macOS helper client.
- Add a focused regression for the Python 3.9 `dataclass(slots=...)` import failure observed during local launchd-drill validation.
- Add Backlog task `TASK-389` with validation notes.

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py::test_ping_helper_falls_back_to_socket_when_helper_client_import_breaks -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k "ping_helper or launchd_drill" -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q`
- `tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill --socket /private/tmp/tldw-vz-launchd-drill.yMzSSx/helper.sock --log-dir /private/tmp/tldw-vz-launchd-drill.yMzSSx/logs --plist-output /private/tmp/tldw-vz-launchd-drill.yMzSSx/org.tldw.macos-vz-helper.drill.yMzSSx.plist --label org.tldw.macos-vz-helper.drill.yMzSSx --write-plist --create-dirs --skip-smoke --json`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_helperctl_python39_ping.json`

## Notes

Full `vz_linux` VM smoke was not run in this slice because no canonical bundle path is configured or present on this host. The launchd lifecycle drill itself was run against a real temporary LaunchAgent and booted out cleanly.

Human-authored Change summary: pending before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `launchd` ping failures on macOS system Python 3.9 by making `vz-helperctl` ping the helper directly over the Unix socket and normalizing failure messages to stable helper error codes. Restores `launchd-drill` usability on system Python and satisfies `TASK-389`.

- **Bug Fixes**
  - Added `_request_helper_ping` for newline-delimited JSON socket pings; normalizes errors to `macos_virtualization_helper_unavailable|_empty_response|_invalid_json`.
  - Updated `ping_helper_state` to prefer direct socket ping and keep protocol/version checks; still supports `client_factory` for tests.
  - Added regression tests for import-break fallback and stable socket error cases (empty response, invalid JSON, transport failure).
  - Added `TASK-389` notes documenting validation and outcomes.

<sup>Written for commit 4f9e29a1d282bc20deb0e938b09796ea806f7246. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1731?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

