### PR TITLE
Add Persona Visual starter catalog scaffolds

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -208,11 +208,12 @@ Runtime state triggers are transient session behavior; library reuse is a
 durable draft-creation action that must preserve review and explicit activation
 semantics.
 
-## Bundled Starter Pack Catalog
+## Bundled Starter Catalog Scaffolds
 
-Bundled starter packs are immutable server fixtures for first-run or recovery
-flows. They are not global Persona Visual pack rows, shared library entries, or
-runtime assets. Listing the catalog returns safe fixture metadata only.
+Bundled starter catalog entries are immutable server fixtures for first-run or
+recovery flows. They are not global Persona Visual pack rows, shared library
+entries, runtime assets, final character artwork, or completed animation packs.
+Listing the catalog returns safe fixture metadata only.
 
 The current bundled catalog exposes nine starter IDs in stable order:
 
@@ -227,13 +228,19 @@ The current bundled catalog exposes nine starter IDs in stable order:
 9. `elaborate-persona-intricate`
 
 These map to the approved basic, intermediate, and intricate tiers from the
-Persona Buddy default catalog design. The fixtures are lightweight catalog
-fixtures, not the full art-generation pipeline. They establish stable
-copy-to-draft behavior, required-state coverage, custom-state examples, and an
-atlas-backed example while preserving the same explicit activation rule as
-user-created packs. The legacy `research-buddy-starter` id remains accepted as a
-compatibility alias for the research buddy default, but it is not listed as a
-tenth catalog item.
+Persona Buddy default catalog design, but this slice only adds backend catalog
+scaffolds. The included PNGs are deliberately tiny deterministic fixtures, and
+the manifest animations are metadata examples that validate state/asset copying;
+they are not the final generated/imported buddy art or expressive animation
+frames. Real default buddy assets still need to be created through the approved
+neutral-pose-to-animation pipeline and can replace these fixture assets without
+changing the catalog copy contract.
+
+The scaffold fixtures establish stable copy-to-draft behavior, required-state
+coverage, custom-state examples, and an atlas-backed example while preserving
+the same explicit activation rule as user-created packs. The legacy
+`research-buddy-starter` id remains accepted as a compatibility alias for the
+research buddy scaffold, but it is not listed as a tenth catalog item.
 
 Copying a bundled starter pack creates a normal user-owned draft pack attached
 to the selected target persona. The copy path validates the fixture manifest and

--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -214,6 +214,27 @@ Bundled starter packs are immutable server fixtures for first-run or recovery
 flows. They are not global Persona Visual pack rows, shared library entries, or
 runtime assets. Listing the catalog returns safe fixture metadata only.
 
+The current bundled catalog exposes nine starter IDs in stable order:
+
+1. `research-buddy-basic`
+2. `migu-marker-basic`
+3. `minimal-helper-basic`
+4. `study-desk-intermediate`
+5. `tool-helper-intermediate`
+6. `object-creature-intermediate`
+7. `lofi-study-intricate`
+8. `action-guide-intricate`
+9. `elaborate-persona-intricate`
+
+These map to the approved basic, intermediate, and intricate tiers from the
+Persona Buddy default catalog design. The fixtures are lightweight catalog
+fixtures, not the full art-generation pipeline. They establish stable
+copy-to-draft behavior, required-state coverage, custom-state examples, and an
+atlas-backed example while preserving the same explicit activation rule as
+user-created packs. The legacy `research-buddy-starter` id remains accepted as a
+compatibility alias for the research buddy default, but it is not listed as a
+tenth catalog item.
+
 Copying a bundled starter pack creates a normal user-owned draft pack attached
 to the selected target persona. The copy path validates the fixture manifest and
 assets, writes new asset files through the existing Persona Visual storage

--- a/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-scaffolds.md
+++ b/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-scaffolds.md
@@ -4,7 +4,7 @@ title: Expand bundled Persona Visual starter catalog scaffolds
 status: Done
 assignee: []
 created_date: '2026-05-16 00:36'
-updated_date: '2026-05-16 01:37'
+updated_date: '2026-05-16 02:23'
 labels:
   - persona
   - buddy
@@ -57,12 +57,14 @@ Reopened for wording correction after review: clarify that this PR adds backend 
 Clarified fixture descriptions, tags, tests, docs, and task language so the PR represents backend catalog scaffolds only. The real default buddy art/animation pipeline remains future work.
 
 Wording-correction verification: focused starter catalog/API pytest passed with 23 tests; git diff --check passed; Bandit JSON report for touched Persona starter backend modules reported zero findings.
+
+PR #1734 review fixes: wrapped the long fixture/test lines identified by Qodo and changed multi-custom-state scaffold generation so each custom state gets a distinct deterministic variant asset key. Added a regression test for action-guide and elaborate-persona custom-state asset separation.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added nine bundled Persona Visual starter catalog scaffold fixtures across basic, intermediate, and intricate tiers. Added deterministic fixture PNG generation, custom-state and atlas metadata examples, legacy research-buddy-starter alias handling, updated API/service coverage, and documented that these are backend scaffolds rather than finished buddy art or completed animation packs. Verification: focused starter catalog/API pytest passed with 23 tests after the wording correction; prior broader persona visual slice passed with 84 tests; git diff --check passed; Bandit on touched Persona starter backend modules reported zero findings. Known skips/blockers: real default buddy art and neutral-pose-to-animation asset creation remain future work.
+Added nine bundled Persona Visual starter catalog scaffold fixtures across basic, intermediate, and intricate tiers. Added deterministic fixture PNG generation, custom-state and atlas metadata examples, legacy research-buddy-starter alias handling, updated API/service coverage, and documented that these are backend scaffolds rather than finished buddy art or completed animation packs. PR review fixes also wrap newly touched long Python lines and ensure multi-custom-state scaffolds use distinct variant fixture assets. Verification: focused starter catalog/API pytest passed with 25 tests after review fixes; prior broader persona visual slice passed with 84 tests; git diff --check passed; Bandit on touched Persona starter backend modules reported zero findings. Known skips/blockers: real default buddy art and neutral-pose-to-animation asset creation remain future work.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-scaffolds.md
+++ b/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-scaffolds.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-394
-title: Expand bundled Persona Visual starter catalog to nine defaults
+title: Expand bundled Persona Visual starter catalog scaffolds
 status: Done
 assignee: []
 created_date: '2026-05-16 00:36'
-updated_date: '2026-05-16 01:25'
+updated_date: '2026-05-16 01:37'
 labels:
   - persona
   - buddy
@@ -21,7 +21,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Implement issue #1732 by expanding the server-owned Persona Visual starter fixture catalog from the single Research Buddy starter to the approved nine default buddy starter packs. Preserve copy-to-user-owned-inactive-draft behavior and avoid runtime renderer expansion.
+Implement issue #1732 by adding nine server-owned Persona Visual starter catalog scaffold fixtures. Preserve copy-to-user-owned-inactive-draft behavior, avoid runtime renderer expansion, and make clear this slice does not ship finished buddy artwork or completed animation packs.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -51,12 +51,18 @@ Implemented nine bundled Persona Visual starter fixture packs with stable IDs, r
 Verification: focused starter catalog pytest passed with 20 tests; broader persona visual slice passed with 84 tests across starter catalog, visual API, and visual service; git diff --check passed; Bandit JSON report for touched Persona backend starter modules reported zero findings.
 
 Post-docstring verification refreshed: persona visual starter catalog, visual API, and visual service pytest passed with 84 tests; git diff --check passed; Bandit JSON report still has zero findings.
+
+Reopened for wording correction after review: clarify that this PR adds backend catalog scaffold fixtures, not finished animated buddy art or completed default animation packs.
+
+Clarified fixture descriptions, tags, tests, docs, and task language so the PR represents backend catalog scaffolds only. The real default buddy art/animation pipeline remains future work.
+
+Wording-correction verification: focused starter catalog/API pytest passed with 23 tests; git diff --check passed; Bandit JSON report for touched Persona starter backend modules reported zero findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Expanded the bundled Persona Visual starter catalog to nine default sprite_frames packs across basic, intermediate, and intricate tiers. Added deterministic fixture PNG generation, custom-state and atlas examples, legacy research-buddy-starter alias handling, updated API/service coverage, and documented the nine-default catalog and non-goals. Verification: pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_service.py -q passed with 84 tests; git diff --check passed; Bandit on touched Persona starter backend modules reported zero findings. Known skips/blockers: none.
+Added nine bundled Persona Visual starter catalog scaffold fixtures across basic, intermediate, and intricate tiers. Added deterministic fixture PNG generation, custom-state and atlas metadata examples, legacy research-buddy-starter alias handling, updated API/service coverage, and documented that these are backend scaffolds rather than finished buddy art or completed animation packs. Verification: focused starter catalog/API pytest passed with 23 tests after the wording correction; prior broader persona visual slice passed with 84 tests; git diff --check passed; Bandit on touched Persona starter backend modules reported zero findings. Known skips/blockers: real default buddy art and neutral-pose-to-animation asset creation remain future work.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-to-nine-defaults.md
+++ b/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-to-nine-defaults.md
@@ -1,0 +1,70 @@
+---
+id: TASK-394
+title: Expand bundled Persona Visual starter catalog to nine defaults
+status: Done
+assignee: []
+created_date: '2026-05-16 00:36'
+updated_date: '2026-05-16 01:25'
+labels:
+  - persona
+  - buddy
+  - visuals
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1732'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement issue #1732 by expanding the server-owned Persona Visual starter fixture catalog from the single Research Buddy starter to the approved nine default buddy starter packs. Preserve copy-to-user-owned-inactive-draft behavior and avoid runtime renderer expansion.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Starter catalog lists all nine approved default starter IDs in stable order.
+- [x] #2 Each starter manifest includes required built-in states and validates under the existing sprite_frames V1 contract.
+- [x] #3 Copying every starter creates an inactive user-owned draft with remapped asset IDs and no fixture asset-key leakage.
+- [x] #4 Existing research-buddy-starter compatibility remains intentional and tested.
+- [x] #5 Relevant Persona Visual docs describe the nine-default catalog and non-goals.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing starter catalog fixture/service/tests. 2. Add reusable fixture helpers and nine starter definitions while preserving research-buddy-starter compatibility. 3. Expand focused unit coverage for listing, manifest validity, and copy behavior across all starters. 4. Update docs/tracker notes and run focused pytest, Bandit on touched backend scope, and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created after PR #1725 merged and issue #1695 closed. Issue #1732 tracks this next Persona/Buddy visual catalog slice under epic #1510.
+
+Implementation started in worktree .worktrees/persona-visual-nine-starters-1732. Baseline focused starter catalog pytest passed before edits: 9 tests.
+
+Implemented nine bundled Persona Visual starter fixture packs with stable IDs, required sprite_frames states, custom-state examples, an atlas-backed starter, legacy research-buddy-starter alias support, API/test expectation updates, and docs for the nine-default catalog.
+
+Verification: focused starter catalog pytest passed with 20 tests; broader persona visual slice passed with 84 tests across starter catalog, visual API, and visual service; git diff --check passed; Bandit JSON report for touched Persona backend starter modules reported zero findings.
+
+Post-docstring verification refreshed: persona visual starter catalog, visual API, and visual service pytest passed with 84 tests; git diff --check passed; Bandit JSON report still has zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Expanded the bundled Persona Visual starter catalog to nine default sprite_frames packs across basic, intermediate, and intricate tiers. Added deterministic fixture PNG generation, custom-state and atlas examples, legacy research-buddy-starter alias handling, updated API/service coverage, and documented the nine-default catalog and non-goals. Verification: pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_service.py -q passed with 84 tests; git diff --check passed; Bandit on touched Persona starter backend modules reported zero findings. Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -27,7 +27,9 @@ from tldw_Server_API.app.core.Persona.visual_service import (
     PersonaVisualServiceError,
 )
 from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
+    DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
     DEFAULT_PERSONA_VISUAL_STARTER_PACKS,
+    LEGACY_PERSONA_VISUAL_STARTER_PACK_ID,
     PersonaVisualStarterPack,
 )
 from tldw_Server_API.app.core.Persona.visuals import (
@@ -269,6 +271,11 @@ class PersonaVisualStarterCatalogService:
 
     def _get_starter(self, starter_pack_id: str) -> PersonaVisualStarterPack:
         starter_id = str(starter_pack_id or "").strip()
+        if (
+            starter_id == LEGACY_PERSONA_VISUAL_STARTER_PACK_ID
+            and starter_id not in self._starter_packs
+        ):
+            starter_id = DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID
         starter = self._starter_packs.get(starter_id)
         if starter is None:
             raise PersonaVisualStarterCatalogError(

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -2,17 +2,34 @@
 
 The fixtures in this module are immutable server-owned source material. Runtime
 code must copy their assets and manifests into normal user-owned draft visual
-packs before a persona can use them.
+packs before a persona can use them. The fixture artwork is intentionally
+lightweight; it establishes catalog contracts and copy semantics rather than a
+production image-generation pipeline.
 """
 
 from __future__ import annotations
 
-import base64
+import struct
+import zlib
 from dataclasses import dataclass, field
 from typing import Any
 
 
-DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID = "research-buddy-starter"
+DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID = "research-buddy-basic"
+LEGACY_PERSONA_VISUAL_STARTER_PACK_ID = "research-buddy-starter"
+DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS: tuple[str, ...] = (
+    "research-buddy-basic",
+    "migu-marker-basic",
+    "minimal-helper-basic",
+    "study-desk-intermediate",
+    "tool-helper-intermediate",
+    "object-creature-intermediate",
+    "lofi-study-intricate",
+    "action-guide-intricate",
+    "elaborate-persona-intricate",
+)
+
+_REQUIRED_STATE_IDS = ("idle", "listening", "thinking", "speaking", "error")
 
 
 @dataclass(frozen=True)
@@ -40,54 +57,436 @@ class PersonaVisualStarterPack:
     license_label: str = "bundled"
 
 
-_STARTER_IDLE_PNG = base64.b64decode(
-    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFUlEQVR4nGM0SFjwn4GBgYEJRIAwACC4AjN5lYLvAAAAAElFTkSuQmCC"
-)
+def _png_chunk(kind: bytes, payload: bytes) -> bytes:
+    """Build one PNG chunk with length and CRC fields."""
+    return (
+        struct.pack(">I", len(payload))
+        + kind
+        + payload
+        + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
+    )
 
 
-def _research_buddy_manifest() -> dict[str, Any]:
+def _solid_png(width: int, height: int, rgba: tuple[int, int, int, int]) -> bytes:
+    """Return deterministic RGBA PNG bytes without requiring Pillow at runtime."""
+    pixel = bytes(rgba)
+    scanline = b"\x00" + pixel * width
+    raw = scanline * height
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", ihdr)
+        + _png_chunk(b"IDAT", zlib.compress(raw))
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def _asset(
+    starter_id: str,
+    key: str,
+    rgba: tuple[int, int, int, int],
+    *,
+    size: tuple[int, int] = (4, 4),
+    role: str = "frame",
+) -> PersonaVisualStarterAsset:
+    """Create one deterministic raster fixture asset for a starter pack."""
+    return PersonaVisualStarterAsset(
+        asset_key=key,
+        filename=f"{starter_id}-{key}.png",
+        mime_type="image/png",
+        content=_solid_png(size[0], size[1], rgba),
+        asset_role=role,
+    )
+
+
+def _animation(asset_key: str, *, duration_ms: int = 250) -> dict[str, Any]:
+    """Create a single-frame sprite animation for a fixture asset key."""
+    return {
+        "frames": [{"asset_id": asset_key, "duration_ms": duration_ms}],
+        "frame_rate": 1,
+        "preview_asset_id": asset_key,
+    }
+
+
+def _atlas_animation(
+    asset_key: str,
+    *,
+    y: int,
+    duration_ms: int = 160,
+) -> dict[str, Any]:
+    """Create a two-frame atlas animation using bounded sprite-sheet regions."""
+    return {
+        "frames": [
+            {
+                "asset_id": asset_key,
+                "region": {"x": 0, "y": y, "width": 2, "height": 2},
+                "duration_ms": duration_ms,
+            },
+            {
+                "asset_id": asset_key,
+                "region": {"x": 2, "y": y, "width": 2, "height": 2},
+                "duration_ms": duration_ms,
+            },
+        ],
+        "frame_rate": 8,
+        "preview_frame": 0,
+    }
+
+
+def _sprite_manifest(
+    *,
+    base_asset_key: str,
+    state_asset_keys: dict[str, str] | None = None,
+    custom_states: dict[str, dict[str, Any]] | None = None,
+    custom_state_assets: dict[str, str] | None = None,
+    authored_triggers: list[dict[str, Any]] | None = None,
+    fallbacks: dict[str, list[str]] | None = None,
+) -> dict[str, Any]:
+    """Create a sprite_frames manifest with required and optional custom states."""
+    state_asset_keys = state_asset_keys or {}
+    animations: dict[str, Any] = {}
+    states: dict[str, dict[str, str]] = {}
+    for state in _REQUIRED_STATE_IDS:
+        asset_key = state_asset_keys.get(state, base_asset_key)
+        animation_id = f"{state}-loop"
+        animations[animation_id] = _animation(asset_key)
+        states[state] = {"animation_id": animation_id}
+
+    for state, asset_key in (custom_state_assets or {}).items():
+        animation_id = state.replace(".", "-").replace(":", "-") + "-loop"
+        animations[animation_id] = _animation(asset_key, duration_ms=180)
+        states[state] = {"animation_id": animation_id}
+
+    manifest: dict[str, Any] = {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "states": states,
+        "animations": animations,
+    }
+    if custom_states:
+        manifest["state_catalog"] = custom_states
+    if authored_triggers:
+        manifest["authored_triggers"] = authored_triggers
+    if fallbacks:
+        manifest["fallbacks"] = fallbacks
+    return manifest
+
+
+def _atlas_manifest(asset_key: str) -> dict[str, Any]:
+    """Create a sprite_frames manifest that demonstrates atlas-backed frames."""
     states = {
-        state: {"animation_id": "idle"}
-        for state in ("idle", "listening", "thinking", "speaking", "error")
+        "idle": {"animation_id": "idle-loop"},
+        "listening": {"animation_id": "listening-loop"},
+        "thinking": {"animation_id": "thinking-loop"},
+        "speaking": {"animation_id": "speaking-loop"},
+        "error": {"animation_id": "error-loop"},
+        "tool.research": {"animation_id": "tool-research-loop"},
     }
     return {
         "manifest_version": 1,
         "renderer_type": "sprite_frames",
-        "states": states,
-        "animations": {
-            "idle": {
-                "frames": [{"asset_id": "starter_idle", "duration_ms": 250}],
-                "frame_rate": 1,
-                "preview_asset_id": "starter_idle",
+        "state_catalog": {
+            "tool.research": {
+                "label": "Researching",
+                "kind": "tool_variant",
+                "description": "Used while research or retrieval tools are running.",
+                "tags": ["tool", "search"],
             }
+        },
+        "states": states,
+        "fallbacks": {"tool.research": ["tool_running", "thinking", "idle"]},
+        "authored_triggers": [
+            {
+                "id": "research-tool-category",
+                "source": "tool_category",
+                "match": "search",
+                "state": "tool.research",
+                "duration_ms": 2400,
+                "priority": 70,
+            }
+        ],
+        "animations": {
+            "idle-loop": _atlas_animation(asset_key, y=0),
+            "listening-loop": _atlas_animation(asset_key, y=0),
+            "thinking-loop": _atlas_animation(asset_key, y=2),
+            "speaking-loop": _atlas_animation(asset_key, y=2, duration_ms=120),
+            "error-loop": _atlas_animation(asset_key, y=0, duration_ms=300),
+            "tool-research-loop": _atlas_animation(asset_key, y=2, duration_ms=140),
         },
     }
 
 
-DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
-    PersonaVisualStarterPack(
-        id=DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
-        title="Research Buddy Starter",
-        description="A minimal bundled sprite-frame visual for first-run Buddy setup.",
+def _basic_pack(
+    *,
+    starter_id: str,
+    title: str,
+    description: str,
+    rgba: tuple[int, int, int, int],
+    tags: tuple[str, ...],
+) -> PersonaVisualStarterPack:
+    """Create a low-complexity starter whose states reuse one neutral asset."""
+    asset = _asset(starter_id, "neutral", rgba)
+    return PersonaVisualStarterPack(
+        id=starter_id,
+        title=title,
+        description=description,
         renderer_type="sprite_frames",
-        manifest=_research_buddy_manifest(),
-        assets=(
-            PersonaVisualStarterAsset(
-                asset_key="starter_idle",
-                filename="research-buddy-idle.png",
-                mime_type="image/png",
-                content=_STARTER_IDLE_PNG,
-                asset_role="frame",
-            ),
+        manifest=_sprite_manifest(base_asset_key=asset.asset_key),
+        assets=(asset,),
+        tags=("starter", "sprite_frames", "tier:basic", *tags),
+    )
+
+
+def _multi_asset_pack(
+    *,
+    starter_id: str,
+    title: str,
+    description: str,
+    palette: tuple[tuple[int, int, int, int], ...],
+    tags: tuple[str, ...],
+    custom_states: dict[str, dict[str, Any]] | None = None,
+    authored_triggers: list[dict[str, Any]] | None = None,
+    fallbacks: dict[str, list[str]] | None = None,
+) -> PersonaVisualStarterPack:
+    """Create an intermediate starter with separate required-state assets."""
+    asset_keys = (
+        "idle",
+        "listening",
+        "thinking",
+        "speaking",
+        "error",
+        *(("variant",) if custom_states else ()),
+    )
+    assets = tuple(
+        _asset(starter_id, key, palette[index % len(palette)])
+        for index, key in enumerate(asset_keys)
+    )
+    state_asset_keys = {state: state for state in _REQUIRED_STATE_IDS}
+    custom_state_assets = {
+        state: "variant"
+        for state in (custom_states or {})
+    }
+    return PersonaVisualStarterPack(
+        id=starter_id,
+        title=title,
+        description=description,
+        renderer_type="sprite_frames",
+        manifest=_sprite_manifest(
+            base_asset_key="idle",
+            state_asset_keys=state_asset_keys,
+            custom_states=custom_states,
+            custom_state_assets=custom_state_assets,
+            authored_triggers=authored_triggers,
+            fallbacks=fallbacks,
         ),
-        tags=("starter", "sprite_frames"),
+        assets=assets,
+        tags=("starter", "sprite_frames", *tags),
+    )
+
+
+def _atlas_pack(
+    *,
+    starter_id: str,
+    title: str,
+    description: str,
+    rgba: tuple[int, int, int, int],
+    tags: tuple[str, ...],
+) -> PersonaVisualStarterPack:
+    """Create an intricate starter that uses one sprite-sheet fixture asset."""
+    asset = _asset(starter_id, "atlas", rgba, size=(4, 4), role="sprite_sheet")
+    return PersonaVisualStarterPack(
+        id=starter_id,
+        title=title,
+        description=description,
+        renderer_type="sprite_frames",
+        manifest=_atlas_manifest(asset.asset_key),
+        assets=(asset,),
+        tags=("starter", "sprite_frames", "tier:intricate", "atlas", *tags),
+    )
+
+
+DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
+    _basic_pack(
+        starter_id="research-buddy-basic",
+        title="Research Buddy Basic",
+        description=(
+            "Clean assistant mascot starter with readable required-state coverage."
+        ),
+        rgba=(48, 96, 160, 255),
+        tags=("research", "mascot"),
+    ),
+    _basic_pack(
+        starter_id="migu-marker-basic",
+        title="Migu Marker Basic",
+        description=(
+            "Rough marker-line inspired starter that keeps a playful user-art feel."
+        ),
+        rgba=(12, 190, 200, 255),
+        tags=("user-art", "marker"),
+    ),
+    _basic_pack(
+        starter_id="minimal-helper-basic",
+        title="Minimal Helper Basic",
+        description="Geometric low-complexity starter for quick custom Buddy setup.",
+        rgba=(92, 118, 48, 255),
+        tags=("minimal", "geometric"),
+    ),
+    _multi_asset_pack(
+        starter_id="study-desk-intermediate",
+        title="Study Desk Intermediate",
+        description=(
+            "Calm study companion starter with separate required-state frame assets."
+        ),
+        palette=(
+            (76, 106, 146, 255),
+            (95, 128, 176, 255),
+            (126, 111, 168, 255),
+        ),
+        tags=("tier:intermediate", "study", "desk"),
+    ),
+    _multi_asset_pack(
+        starter_id="tool-helper-intermediate",
+        title="Tool Helper Intermediate",
+        description=(
+            "Utility-themed starter with a declared exact tool animation variant."
+        ),
+        palette=(
+            (44, 132, 116, 255),
+            (72, 150, 132, 255),
+            (96, 166, 148, 255),
+        ),
+        tags=("tier:intermediate", "tool", "variant"),
+        custom_states={
+            "tool.notes_search": {
+                "label": "Searching notes",
+                "kind": "tool_variant",
+                "description": "Used when a notes search tool is running.",
+                "tags": ["tool", "notes"],
+            }
+        },
+        authored_triggers=[
+            {
+                "id": "notes-search-tool",
+                "source": "tool_name",
+                "match": "notes.search",
+                "state": "tool.notes_search",
+                "duration_ms": 2400,
+                "priority": 80,
+            }
+        ],
+        fallbacks={"tool.notes_search": ["tool_running", "thinking", "idle"]},
+    ),
+    _multi_asset_pack(
+        starter_id="object-creature-intermediate",
+        title="Object Creature Intermediate",
+        description=(
+            "Non-human expressive object starter to show the format is not humanoid-only."
+        ),
+        palette=(
+            (144, 92, 72, 255),
+            (168, 118, 88, 255),
+            (190, 142, 108, 255),
+        ),
+        tags=("tier:intermediate", "object", "creature"),
+        custom_states={
+            "reaction.success": {
+                "label": "Success reaction",
+                "kind": "reaction",
+                "description": "Small celebratory reaction for completed work.",
+                "tags": ["reaction"],
+            }
+        },
+        fallbacks={"reaction.success": ["speaking", "idle"]},
+    ),
+    _atlas_pack(
+        starter_id="lofi-study-intricate",
+        title="Lo-fi Study Intricate",
+        description=(
+            "Original study companion starter with atlas-backed loops and tool variant metadata."
+        ),
+        rgba=(108, 84, 164, 255),
+        tags=("lofi", "study"),
+    ),
+    _multi_asset_pack(
+        starter_id="action-guide-intricate",
+        title="Action Guide Intricate",
+        description=(
+            "Energetic guide starter with reaction beats and richer state metadata."
+        ),
+        palette=(
+            (186, 72, 76, 255),
+            (208, 96, 88, 255),
+            (232, 132, 92, 255),
+        ),
+        tags=("tier:intricate", "action", "reaction"),
+        custom_states={
+            "reaction.anticipation": {
+                "label": "Anticipation",
+                "kind": "reaction",
+                "description": "Short anticipation beat before high-energy responses.",
+                "tags": ["reaction", "motion"],
+            },
+            "reaction.success": {
+                "label": "Success",
+                "kind": "reaction",
+                "description": "Celebratory response after successful tool completion.",
+                "tags": ["reaction"],
+            },
+        },
+        fallbacks={
+            "reaction.anticipation": ["thinking", "idle"],
+            "reaction.success": ["speaking", "idle"],
+        },
+    ),
+    _multi_asset_pack(
+        starter_id="elaborate-persona-intricate",
+        title="Elaborate Persona Intricate",
+        description=(
+            "High-detail fantasy/sci-fi starter demonstrating multiple custom-state rows."
+        ),
+        palette=(
+            (92, 78, 142, 255),
+            (116, 96, 166, 255),
+            (148, 124, 192, 255),
+        ),
+        tags=("tier:intricate", "fantasy", "sci-fi"),
+        custom_states={
+            "mood.focused": {
+                "label": "Focused mood",
+                "kind": "mood",
+                "description": "A concentrated state for deep work sessions.",
+                "tags": ["mood"],
+            },
+            "tool.media_import": {
+                "label": "Importing media",
+                "kind": "tool_variant",
+                "description": "Used while media import or ingestion tools are running.",
+                "tags": ["tool", "media"],
+            },
+        },
+        authored_triggers=[
+            {
+                "id": "media-import-category",
+                "source": "tool_category",
+                "match": "ingestion",
+                "state": "tool.media_import",
+                "duration_ms": 2400,
+                "priority": 75,
+            }
+        ],
+        fallbacks={
+            "mood.focused": ["thinking", "idle"],
+            "tool.media_import": ["tool_running", "thinking", "idle"],
+        },
     ),
 )
 
 
 __all__ = [
     "DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID",
+    "DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS",
     "DEFAULT_PERSONA_VISUAL_STARTER_PACKS",
+    "LEGACY_PERSONA_VISUAL_STARTER_PACK_ID",
     "PersonaVisualStarterAsset",
     "PersonaVisualStarterPack",
 ]

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -4,7 +4,8 @@ The fixtures in this module are immutable server-owned source material. Runtime
 code must copy their assets and manifests into normal user-owned draft visual
 packs before a persona can use them. The fixture artwork is intentionally
 lightweight; it establishes catalog contracts and copy semantics rather than a
-production image-generation pipeline.
+production image-generation pipeline. These are catalog scaffolds, not claims
+that final default buddy art or character animation packs have been authored.
 """
 
 from __future__ import annotations
@@ -100,7 +101,7 @@ def _asset(
 
 
 def _animation(asset_key: str, *, duration_ms: int = 250) -> dict[str, Any]:
-    """Create a single-frame sprite animation for a fixture asset key."""
+    """Create single-frame sprite animation metadata for a fixture asset key."""
     return {
         "frames": [{"asset_id": asset_key, "duration_ms": duration_ms}],
         "frame_rate": 1,
@@ -114,7 +115,7 @@ def _atlas_animation(
     y: int,
     duration_ms: int = 160,
 ) -> dict[str, Any]:
-    """Create a two-frame atlas animation using bounded sprite-sheet regions."""
+    """Create two-frame atlas animation metadata with bounded sheet regions."""
     return {
         "frames": [
             {
@@ -229,11 +230,14 @@ def _basic_pack(
     return PersonaVisualStarterPack(
         id=starter_id,
         title=title,
-        description=description,
+        description=(
+            "Catalog scaffold fixture, not final character art or animation: "
+            f"{description}"
+        ),
         renderer_type="sprite_frames",
         manifest=_sprite_manifest(base_asset_key=asset.asset_key),
         assets=(asset,),
-        tags=("starter", "sprite_frames", "tier:basic", *tags),
+        tags=("starter", "sprite_frames", "catalog:scaffold", "tier:basic", *tags),
     )
 
 
@@ -269,7 +273,10 @@ def _multi_asset_pack(
     return PersonaVisualStarterPack(
         id=starter_id,
         title=title,
-        description=description,
+        description=(
+            "Catalog scaffold fixture, not final character art or animation: "
+            f"{description}"
+        ),
         renderer_type="sprite_frames",
         manifest=_sprite_manifest(
             base_asset_key="idle",
@@ -280,7 +287,7 @@ def _multi_asset_pack(
             fallbacks=fallbacks,
         ),
         assets=assets,
-        tags=("starter", "sprite_frames", *tags),
+        tags=("starter", "sprite_frames", "catalog:scaffold", *tags),
     )
 
 
@@ -297,11 +304,21 @@ def _atlas_pack(
     return PersonaVisualStarterPack(
         id=starter_id,
         title=title,
-        description=description,
+        description=(
+            "Catalog scaffold fixture, not final character art or animation: "
+            f"{description}"
+        ),
         renderer_type="sprite_frames",
         manifest=_atlas_manifest(asset.asset_key),
         assets=(asset,),
-        tags=("starter", "sprite_frames", "tier:intricate", "atlas", *tags),
+        tags=(
+            "starter",
+            "sprite_frames",
+            "catalog:scaffold",
+            "tier:intricate",
+            "atlas",
+            *tags,
+        ),
     )
 
 

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -109,6 +109,12 @@ def _animation(asset_key: str, *, duration_ms: int = 250) -> dict[str, Any]:
     }
 
 
+def _custom_state_asset_key(state: str) -> str:
+    """Return a stable fixture asset key for one custom state id."""
+    normalized_state = state.replace(".", "-").replace(":", "-")
+    return f"variant-{normalized_state}"
+
+
 def _atlas_animation(
     asset_key: str,
     *,
@@ -253,13 +259,17 @@ def _multi_asset_pack(
     fallbacks: dict[str, list[str]] | None = None,
 ) -> PersonaVisualStarterPack:
     """Create an intermediate starter with separate required-state assets."""
+    custom_state_asset_keys = tuple(
+        _custom_state_asset_key(state)
+        for state in (custom_states or {})
+    )
     asset_keys = (
         "idle",
         "listening",
         "thinking",
         "speaking",
         "error",
-        *(("variant",) if custom_states else ()),
+        *custom_state_asset_keys,
     )
     assets = tuple(
         _asset(starter_id, key, palette[index % len(palette)])
@@ -267,7 +277,7 @@ def _multi_asset_pack(
     )
     state_asset_keys = {state: state for state in _REQUIRED_STATE_IDS}
     custom_state_assets = {
-        state: "variant"
+        state: _custom_state_asset_key(state)
         for state in (custom_states or {})
     }
     return PersonaVisualStarterPack(
@@ -344,7 +354,9 @@ DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
     _basic_pack(
         starter_id="minimal-helper-basic",
         title="Minimal Helper Basic",
-        description="Geometric low-complexity starter for quick custom Buddy setup.",
+        description=(
+            "Geometric low-complexity starter for quick custom Buddy setup."
+        ),
         rgba=(92, 118, 48, 255),
         tags=("minimal", "geometric"),
     ),
@@ -397,7 +409,8 @@ DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
         starter_id="object-creature-intermediate",
         title="Object Creature Intermediate",
         description=(
-            "Non-human expressive object starter to show the format is not humanoid-only."
+            "Non-human expressive object starter to show the format is not "
+            "humanoid-only."
         ),
         palette=(
             (144, 92, 72, 255),
@@ -419,7 +432,8 @@ DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
         starter_id="lofi-study-intricate",
         title="Lo-fi Study Intricate",
         description=(
-            "Original study companion starter with atlas-backed loops and tool variant metadata."
+            "Original study companion starter with atlas-backed loops and "
+            "tool variant metadata."
         ),
         rgba=(108, 84, 164, 255),
         tags=("lofi", "study"),

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -67,7 +67,7 @@ def visual_storage_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
     return root
 
 
-def test_starter_catalog_lists_bundled_sprite_pack(
+def test_starter_catalog_lists_bundled_scaffold_packs(
     db_instance: CharactersRAGDB,
 ) -> None:
     service = PersonaVisualStarterCatalogService(db_instance)
@@ -85,6 +85,8 @@ def test_starter_catalog_lists_bundled_sprite_pack(
     assert starter["asset_count"] >= 1
     assert starter["total_bytes"] > 0
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(set(starter["states_offered"]))
+    assert all("catalog:scaffold" in starter["tags"] for starter in starters)
+    assert all("scaffold" in starter["description"].lower() for starter in starters)
     assert any("tier:intricate" in starter["tags"] for starter in starters)
     assert any("tool.notes_search" in starter["states_offered"] for starter in starters)
 
@@ -167,7 +169,7 @@ def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
 
 
 @pytest.mark.parametrize("starter_pack_id", DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS)
-def test_copy_every_default_starter_creates_inactive_user_owned_draft(
+def test_copy_every_default_scaffold_creates_inactive_user_owned_draft(
     db_instance: CharactersRAGDB,
     starter_pack_id: str,
 ) -> None:

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import pytest
 from PIL import Image
@@ -16,6 +17,8 @@ from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
 )
 from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
     DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+    DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS,
+    LEGACY_PERSONA_VISUAL_STARTER_PACK_ID,
     PersonaVisualStarterAsset,
     PersonaVisualStarterPack,
 )
@@ -28,6 +31,17 @@ def _png_bytes(width: int = 2, height: int = 2) -> bytes:
     buffer = BytesIO()
     Image.new("RGBA", (width, height), (48, 96, 160, 255)).save(buffer, format="PNG")
     return buffer.getvalue()
+
+
+def _manifest_frame_asset_ids(manifest: dict[str, Any]) -> set[str]:
+    asset_ids: set[str] = set()
+    for animation in manifest.get("animations", {}).values():
+        if not isinstance(animation, dict):
+            continue
+        for frame in animation.get("frames", []):
+            if isinstance(frame, dict) and frame.get("asset_id"):
+                asset_ids.add(str(frame["asset_id"]))
+    return asset_ids
 
 
 @pytest.fixture()
@@ -60,14 +74,19 @@ def test_starter_catalog_lists_bundled_sprite_pack(
 
     starters = service.list_starter_packs()
 
-    assert [starter["id"] for starter in starters] == [DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID]
+    assert [starter["id"] for starter in starters] == list(DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS)
+    assert LEGACY_PERSONA_VISUAL_STARTER_PACK_ID not in {
+        starter["id"] for starter in starters
+    }
     starter = starters[0]
-    assert starter["title"] == "Research Buddy Starter"
+    assert starter["title"] == "Research Buddy Basic"
     assert starter["renderer_type"] == "sprite_frames"
     assert starter["manifest_version"] == 1
     assert starter["asset_count"] >= 1
     assert starter["total_bytes"] > 0
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(set(starter["states_offered"]))
+    assert any("tier:intricate" in starter["tags"] for starter in starters)
+    assert any("tool.notes_search" in starter["states_offered"] for starter in starters)
 
 
 def test_get_starter_pack_returns_isolated_manifest_preview(
@@ -79,7 +98,18 @@ def test_get_starter_pack_returns_isolated_manifest_preview(
 
     second = service.get_starter_pack(DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID)
 
-    assert second["manifest"]["states"]["idle"]["animation_id"] == "idle"
+    assert second["manifest"]["states"]["idle"]["animation_id"] == "idle-loop"
+
+
+def test_get_starter_pack_accepts_legacy_research_buddy_alias(
+    db_instance: CharactersRAGDB,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    detail = service.get_starter_pack(LEGACY_PERSONA_VISUAL_STARTER_PACK_ID)
+
+    assert detail["id"] == DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID
+    assert detail["title"] == "Research Buddy Basic"
 
 
 def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
@@ -110,7 +140,7 @@ def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
     assert copied["status"] == "draft"
     assert copied["persona_id"] == persona_id
     assert copied["user_id"] == user_id
-    assert copied["title"] == "Research Buddy Starter"
+    assert copied["title"] == "Research Buddy Basic"
     assert copied["provenance"] == "imported"
     assert copied["active_at"] is None
     assert (
@@ -133,7 +163,64 @@ def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
 
     copied_asset_ids = {str(asset["id"]) for asset in copied_assets}
     assert collect_visual_manifest_asset_ids(copied["manifest"]) == copied_asset_ids
-    assert "starter_idle" not in str(copied["manifest"])
+    assert "neutral" not in str(copied["manifest"])
+
+
+@pytest.mark.parametrize("starter_pack_id", DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS)
+def test_copy_every_default_starter_creates_inactive_user_owned_draft(
+    db_instance: CharactersRAGDB,
+    starter_pack_id: str,
+) -> None:
+    user_id = "user-1"
+    persona_id = db_instance.create_persona_profile(
+        {"user_id": user_id, "name": f"Target {starter_pack_id}"}
+    )
+    service = PersonaVisualStarterCatalogService(db_instance)
+    starter_detail = service.get_starter_pack(starter_pack_id)
+    fixture_asset_keys = {
+        str(asset["asset_key"])
+        for asset in starter_detail["assets"]
+    }
+
+    copied = service.copy_starter_pack_to_persona(
+        starter_pack_id=starter_pack_id,
+        persona_id=persona_id,
+        user_id=user_id,
+    )
+
+    assert copied["status"] == "draft"
+    assert copied["active_at"] is None
+    assert copied["title"] == starter_detail["title"]
+    assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
+        set(copied["manifest"]["states"])
+    )
+    copied_assets = db_instance.list_persona_visual_assets(
+        pack_id=copied["id"],
+        persona_id=persona_id,
+        user_id=user_id,
+    )
+    copied_asset_ids = {str(asset["id"]) for asset in copied_assets}
+    assert collect_visual_manifest_asset_ids(copied["manifest"]) == copied_asset_ids
+    frame_asset_ids = _manifest_frame_asset_ids(copied["manifest"])
+    assert frame_asset_ids == copied_asset_ids
+    assert not (fixture_asset_keys & frame_asset_ids)
+
+
+def test_copy_legacy_research_buddy_alias_creates_default_draft(
+    db_instance: CharactersRAGDB,
+) -> None:
+    user_id = "user-1"
+    persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    copied = service.copy_starter_pack_to_persona(
+        starter_pack_id=LEGACY_PERSONA_VISUAL_STARTER_PACK_ID,
+        persona_id=persona_id,
+        user_id=user_id,
+    )
+
+    assert copied["status"] == "draft"
+    assert copied["title"] == "Research Buddy Basic"
 
 
 def test_copy_starter_pack_rejects_malformed_fixture_manifest(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -10,7 +10,9 @@ from PIL import Image
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
-from tldw_Server_API.app.core.Persona.visual_manifest_assets import collect_visual_manifest_asset_ids
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
+    collect_visual_manifest_asset_ids,
+)
 from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
     PersonaVisualStarterCatalogError,
     PersonaVisualStarterCatalogService,
@@ -44,9 +46,18 @@ def _manifest_frame_asset_ids(manifest: dict[str, Any]) -> set[str]:
     return asset_ids
 
 
+def _state_frame_asset_id(manifest: dict[str, Any], state: str) -> str:
+    animation_id = manifest["states"][state]["animation_id"]
+    frame = manifest["animations"][animation_id]["frames"][0]
+    return str(frame["asset_id"])
+
+
 @pytest.fixture()
 def db_instance(tmp_path: Path) -> Iterator[CharactersRAGDB]:
-    db = CharactersRAGDB(tmp_path / "persona_visual_starter_catalog.sqlite", "persona-visual-starter-test")
+    db = CharactersRAGDB(
+        tmp_path / "persona_visual_starter_catalog.sqlite",
+        "persona-visual-starter-test",
+    )
     yield db
     db.close_connection()
 
@@ -74,7 +85,9 @@ def test_starter_catalog_lists_bundled_scaffold_packs(
 
     starters = service.list_starter_packs()
 
-    assert [starter["id"] for starter in starters] == list(DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS)
+    assert [starter["id"] for starter in starters] == list(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS
+    )
     assert LEGACY_PERSONA_VISUAL_STARTER_PACK_ID not in {
         starter["id"] for starter in starters
     }
@@ -84,7 +97,9 @@ def test_starter_catalog_lists_bundled_scaffold_packs(
     assert starter["manifest_version"] == 1
     assert starter["asset_count"] >= 1
     assert starter["total_bytes"] > 0
-    assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(set(starter["states_offered"]))
+    assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
+        set(starter["states_offered"])
+    )
     assert all("catalog:scaffold" in starter["tags"] for starter in starters)
     assert all("scaffold" in starter["description"].lower() for starter in starters)
     assert any("tier:intricate" in starter["tags"] for starter in starters)
@@ -112,6 +127,35 @@ def test_get_starter_pack_accepts_legacy_research_buddy_alias(
 
     assert detail["id"] == DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID
     assert detail["title"] == "Research Buddy Basic"
+
+
+@pytest.mark.parametrize(
+    ("starter_pack_id", "custom_states"),
+    (
+        (
+            "action-guide-intricate",
+            ("reaction.anticipation", "reaction.success"),
+        ),
+        (
+            "elaborate-persona-intricate",
+            ("mood.focused", "tool.media_import"),
+        ),
+    ),
+)
+def test_multi_custom_state_scaffolds_use_distinct_variant_assets(
+    db_instance: CharactersRAGDB,
+    starter_pack_id: str,
+    custom_states: tuple[str, ...],
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    detail = service.get_starter_pack(starter_pack_id)
+    state_asset_ids = {
+        _state_frame_asset_id(detail["manifest"], state)
+        for state in custom_states
+    }
+
+    assert len(state_asset_ids) == len(custom_states)
 
 
 def test_copy_starter_pack_to_persona_creates_inactive_user_owned_draft(
@@ -212,7 +256,9 @@ def test_copy_legacy_research_buddy_alias_creates_default_draft(
     db_instance: CharactersRAGDB,
 ) -> None:
     user_id = "user-1"
-    persona_id = db_instance.create_persona_profile({"user_id": user_id, "name": "Target"})
+    persona_id = db_instance.create_persona_profile(
+        {"user_id": user_id, "name": "Target"}
+    )
     service = PersonaVisualStarterCatalogService(db_instance)
 
     copied = service.copy_starter_pack_to_persona(

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -195,6 +195,8 @@ def test_get_persona_visual_starter_pack_detail(persona_db: CharactersRAGDB) -> 
     payload = response.json()
     assert payload["id"] == DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID
     assert payload["manifest"]["renderer_type"] == "sprite_frames"
+    assert "catalog:scaffold" in payload["tags"]
+    assert "scaffold" in payload["description"].lower()
     assert payload["assets"][0]["mime_type"] == "image/png"
 
 
@@ -366,6 +368,8 @@ def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
     assert starter["title"] == "Research Buddy Basic"
     assert starter["renderer_type"] == "sprite_frames"
     assert starter["asset_count"] == 1
+    assert "catalog:scaffold" in starter["tags"]
+    assert "scaffold" in starter["description"].lower()
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
         set(starter["states_offered"])
     )

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -14,6 +14,8 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Persona.visual_library_service import PersonaVisualLibraryServiceError
 from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
     DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
+    DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS,
+    LEGACY_PERSONA_VISUAL_STARTER_PACK_ID,
 )
 
 
@@ -354,11 +356,14 @@ def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
 
     assert response.status_code == 200, response.text
     payload = response.json()
-    assert [item["id"] for item in payload["starter_packs"]] == [
-        DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID
-    ]
+    assert [item["id"] for item in payload["starter_packs"]] == list(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS
+    )
+    assert LEGACY_PERSONA_VISUAL_STARTER_PACK_ID not in {
+        item["id"] for item in payload["starter_packs"]
+    }
     starter = payload["starter_packs"][0]
-    assert starter["title"] == "Research Buddy Starter"
+    assert starter["title"] == "Research Buddy Basic"
     assert starter["renderer_type"] == "sprite_frames"
     assert starter["asset_count"] == 1
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
@@ -391,7 +396,7 @@ def test_copy_visual_starter_pack_creates_draft_without_activation(
 
         assert response.status_code == 201, response.text
         payload = response.json()
-        assert payload["title"] == "Research Buddy Starter"
+        assert payload["title"] == "Research Buddy Basic"
         assert payload["persona_id"] == persona_id
         assert payload["status"] == "draft"
         assert payload["provenance"] == "imported"
@@ -399,7 +404,7 @@ def test_copy_visual_starter_pack_creates_draft_without_activation(
         assert payload["active_at"] is None
         assert len(payload["assets"]) == 1
         assert payload["assets"][0]["provenance"] == "imported"
-        assert "starter_idle" not in str(payload["manifest"])
+        assert "neutral" not in str(payload["manifest"])
         assert persona_db.get_active_persona_visual_pack(
             persona_id=persona_id,
             user_id="1",


### PR DESCRIPTION
## Summary
- Adds nine bundled Persona Visual starter catalog scaffold IDs across the approved basic, intermediate, and intricate tiers.
- Marks the bundled entries as scaffold fixtures with tiny deterministic PNGs and manifest metadata examples, not finished buddy artwork or completed character animation packs.
- Preserves copy-to-user-owned inactive draft semantics, asset-id remapping, explicit activation, and the legacy research-buddy-starter alias.

## Verification
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_get_persona_visual_starter_pack_detail tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_list_persona_visual_starter_packs tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_copy_visual_starter_pack_creates_draft_without_activation -q
- Previously: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_service.py -q
- git diff --check
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/core/Persona/visual_starter_catalog.py -f json -o /tmp/bandit_persona_visual_nine_starters_wording.json

## Change summary
Pending human-authored change summary before merge.

Closes #1732
Refs #1510