### PR TITLE
Fix Persona Visual active pack setup gating

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -1040,13 +1040,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       try {
         const response = await listPersonaVisualPacks(targetPersonaId)
         if (!isLatestRequest()) return false
-        const nextPacks = options.fallbackPack
+        const listedPacks = options.fallbackPack
           ? mergePack(response.packs || [], options.fallbackPack)
           : response.packs || []
         const activePack =
           response.active_pack ??
-          nextPacks.find((pack) => pack.status === "active") ??
+          listedPacks.find((pack) => pack.status === "active") ??
           null
+        const nextPacks = activePack ? mergePack(listedPacks, activePack) : listedPacks
         setActivePackId(activePack?.id || "")
         setPacks(nextPacks)
         const preferred =

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -283,6 +283,52 @@ describe("VisualPackEditor", () => {
     expect(screen.queryByTestId("visual-buddy-setup-choice-card")).not.toBeInTheDocument()
   })
 
+  it("hides the setup choice card when active_pack is returned outside packs", async () => {
+    const activePack = makeVisualPack({ id: "active-pack", status: "active" })
+    const draftPack = makeVisualPack({ id: "draft-pack", status: "draft" })
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse({ packs: [draftPack], active_pack: activePack })
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (path.endsWith("/generated-candidates") && method === "GET") {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    expect(await screen.findByTestId("persona-visual-pack-status")).toHaveTextContent(
+      "active"
+    )
+    expect(screen.queryByTestId("visual-buddy-setup-choice-card")).not.toBeInTheDocument()
+  })
+
   it("does not show setup choices before active pack state is known", async () => {
     const activePack = makeVisualPack({ status: "active" })
     const packsDeferred = deferredResponse<any>()

--- a/backlog/tasks/task-396 - Harden-Persona-Visual-setup-active-pack-detection.md
+++ b/backlog/tasks/task-396 - Harden-Persona-Visual-setup-active-pack-detection.md
@@ -1,0 +1,62 @@
+---
+id: TASK-396
+title: Harden Persona Visual setup active-pack detection
+status: Done
+assignee: []
+created_date: '2026-05-16 00:56'
+updated_date: '2026-05-16 01:15'
+labels:
+  - persona
+  - persona-visual
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1730'
+  - 'https://github.com/rmusser01/tldw_server/pull/1725'
+  - 'https://github.com/rmusser01/tldw_server/pull/1735'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the still-valid Persona Visual setup review finding from closed PR #1730 after PR #1725 merged: first-run setup choices must not appear when the visual-pack list response returns an active_pack separately from packs. Keep the follow-up focused on the setup gate and regression coverage against the merged dev implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VisualPackEditor treats a separately returned active_pack as an active visual for setup-choice gating.
+- [x] #2 A focused regression test covers a response with packs excluding active_pack and active_pack populated.
+- [x] #3 Review findings from the closed superseded PR are triaged with still-valid items fixed and obsolete items skipped with a reason.
+- [x] #4 Focused Persona Visual tests pass and diff whitespace validation is clean.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Triaged closed PR #1730 review comments against current origin/dev: setup error gating and draft-title helper coupling are obsolete in the superseding PR #1725 implementation; active_pack returned separately from packs remained valid and is fixed in this follow-up.
+
+Verification: added red regression for active_pack outside packs; initial focused file run failed on the new test as expected. After the fix, targeted regression passed, full VisualPackEditor suite passed with --testTimeout=20000, git diff --check passed, and bun run lint exited 0 with existing warnings only.
+
+Bandit skipped because the touched implementation is frontend TypeScript plus Backlog task metadata only.
+
+Follow-up draft PR opened: https://github.com/rmusser01/tldw_server/pull/1735
+
+Addressed PR #1735 CodeRabbit test-coverage comment by asserting the separate active_pack response is rendered with active status before asserting the setup card is absent. Validation: targeted regression passed, git diff --check passed, and bun run lint exited 0 with existing warnings only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Merged active_pack into VisualPackEditor local pack state when the backend returns it separately from packs, so first-run setup choices do not appear when an active visual pack exists. Added regression coverage for the separate active_pack response shape and validated the focused Persona Visual component suite plus lint/whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Fixes a still-valid review finding from the closed superseded PR #1730 after PR #1725 merged.
- Merges a separately returned `active_pack` into `VisualPackEditor` local pack state before setup gating and pack selection run.
- Adds regression coverage for the backend response shape where `packs` excludes the active pack but `active_pack` is populated.

## Review triage
- Still valid: `active_pack` can be returned separately from `packs`, so first-run setup choices could show despite an active visual.
- Already handled by the superseding implementation: setup choices are gated on successful pack load state, and draft title clearing is no longer coupled through the obsolete helper shape.

## Validation
- `bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "hides the setup choice card when active_pack is returned outside packs"`
- `bun run test src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testTimeout=30000`
- `git diff --check`
- `bun run lint` (0 errors, existing warnings only)
- Bandit skipped: frontend TypeScript-only code path plus Backlog task metadata.

## Change summary
Human-authored merge summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Persona Visual setup gating by merging any separately returned `active_pack` into the local pack list and setting it active before gating, so first-run setup choices stay hidden when an active visual exists.

- **Bug Fixes**
  - Merge `active_pack` into listed packs (even if missing from `packs`), set `activePackId`, then gate setup.
  - Add a regression test covering when `active_pack` is returned outside `packs`, confirming active status and a hidden setup card.

<sup>Written for commit 88c3290e855a3d9b2dc7e5dd7bd740b7bf8886da. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1735?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

