### PR TITLE
Add Sync v2 attachment persistence

### DIFF
--- a/Docs/API/sync-v2.md
+++ b/Docs/API/sync-v2.md
@@ -18,7 +18,7 @@ uses the existing `/api/v1/sync` route family and keeps the older media-only
 | `POST` | `/api/v1/sync/conflicts/{conflict_id}/resolve` | Resolve or dismiss a conflict, optionally with a resolution envelope. |
 | `GET` | `/api/v1/sync/keys/recovery-bundle` | Retrieve stored opaque key-recovery bundles for an accessible dataset. |
 | `POST` | `/api/v1/sync/keys/recovery-bundle` | Store opaque key-recovery metadata for encrypted datasets. |
-| `POST` | `/api/v1/sync/attachments` | Feature-detect attachment upload support. Currently returns not enabled. |
+| `POST` | `/api/v1/sync/attachments` | Store or deduplicate a small client-encrypted attachment payload for an accessible dataset. |
 
 ## Envelope Shape
 
@@ -79,6 +79,27 @@ bundle records for a dataset the authenticated user can access. Optional
 is the only Sync v2 response that returns `wrapped_key_blob` and `kdf_metadata`;
 restore manifests continue to expose only `key_recovery_available`.
 
+## Attachment Uploads
+
+`POST /api/v1/sync/attachments` stores small opaque attachment ciphertext for
+later restore hydration. The server validates that the authenticated user owns
+the dataset, that the requested domain is enrolled for that dataset, and that
+the payload is within the advertised `max_attachment_bytes` capability.
+
+Requests must use `client_private_v1`; plaintext/server-trusted attachment
+storage is rejected. The response returns only storage metadata:
+
+- `attachment_id`
+- `dataset_id`
+- `stored`, which is `false` for an idempotent duplicate upload
+- `size_bytes`
+- `payload_hash`
+
+The route does not return `payload_ciphertext`, and validation/storage errors
+use sanitized messages so malformed or oversized uploads do not echo ciphertext.
+Restore manifests summarize persisted attachment availability and size classes
+without exposing attachment payloads.
+
 ## Conflict Policy
 
 Domain adapters decide whether an incoming envelope is accepted, rejected, or
@@ -105,9 +126,9 @@ restore-manifest endpoints.
 
 ## Known Limits
 
-- Attachment upload persistence is not enabled yet; the attachment route exists
-  for capability detection.
-- Large binary media replication is out of V1 scope.
+- Attachment upload persistence is limited to small client-encrypted payloads
+  within `max_attachment_bytes`.
+- Large binary media replication remains out of V1 scope.
 - Embeddings and vector stores are treated as rebuildable or reference data in
   V1.
 - `client_private_v1` recovery only works if the user configured and retained a

--- a/Docs/Design/Sync-Engine.md
+++ b/Docs/Design/Sync-Engine.md
@@ -80,11 +80,11 @@ Restore is intentionally two phase:
 1. Metadata preview with `GET /restore-manifest`.
 2. Selected hydration with `GET /pull`.
 
-The manifest includes dataset/domain counts, byte estimates, attachment
-availability, attachment size classes, registered device metadata, unresolved
-conflict counts, encryption policy, and key-recovery readiness. A new device can
-use that manifest to choose all or part of a dataset before downloading
-encrypted envelopes.
+The manifest includes dataset/domain counts, byte estimates, persisted
+attachment availability, attachment size classes, registered device metadata,
+unresolved conflict counts, encryption policy, and key-recovery readiness. A new
+device can use that manifest to choose all or part of a dataset before
+downloading encrypted envelopes and small encrypted attachment payloads.
 
 ## Conflict Model
 
@@ -103,8 +103,8 @@ store a validated resolution envelope before marking the conflict resolved.
   client coverage to migrate safely.
 - Do not expose UI controls that imply full sync support until the client can
   run the corresponding device, dataset, push, pull, and restore flow.
-- Keep large binary attachment replication outside V1 unless a later storage
-  tranche explicitly enables it.
+- Keep large binary replication outside V1; the first storage tranche is limited
+  to small `client_private_v1` attachment ciphertext uploaded through Sync v2.
 
 ## References
 

--- a/Docs/superpowers/plans/2026-05-16-sync-v2-attachment-persistence.md
+++ b/Docs/superpowers/plans/2026-05-16-sync-v2-attachment-persistence.md
@@ -1,0 +1,23 @@
+## Stage 1: Store Contract
+**Goal**: Add durable Sync v2 attachment rows for encrypted client payloads.
+**Success Criteria**: Store tests prove schema creation, idempotent insert, duplicate drift rejection, dataset ownership checks, enrolled-domain checks, and manifest aggregate summaries from persisted attachments.
+**Tests**: Focused `test_sync_v2_store.py` tests for attachment persistence and restore summaries.
+**Status**: Complete
+
+## Stage 2: Service Contract
+**Goal**: Expose attachment persistence through `SyncV2Service` with capability and validation gates.
+**Success Criteria**: Service tests prove attachments are supported, payloads over the configured byte limit are rejected, dataset/user/domain validation is enforced, and ciphertext is not included in safe error paths.
+**Tests**: Focused `test_sync_v2_service.py` tests for `store_attachment`.
+**Status**: Complete
+
+## Stage 3: API Contract
+**Goal**: Replace the `/api/v1/sync/attachments` 501 feature detector with a real upload endpoint.
+**Success Criteria**: Endpoint tests prove successful upload, idempotent dedupe, 400/404/413-style safe failure mapping, and restore-manifest attachment inventory updates.
+**Tests**: Focused `test_sync_v2_endpoints.py` tests for attachment upload and capabilities.
+**Status**: Complete
+
+## Stage 4: Docs and Verification
+**Goal**: Document supported encrypted attachment persistence and complete quality gates.
+**Success Criteria**: Sync v2 docs no longer describe attachment persistence as disabled, Backlog acceptance criteria are updated, focused pytest, Bandit, and `git diff --check` pass.
+**Tests**: Focused Sync v2 pytest, Bandit on touched production paths, `git diff --check`.
+**Status**: Complete

--- a/backlog/tasks/task-397 - Add-Sync-v2-attachment-persistence.md
+++ b/backlog/tasks/task-397 - Add-Sync-v2-attachment-persistence.md
@@ -47,6 +47,7 @@ Persist small encrypted Sync v2 attachment payloads server-side behind /api/v1/s
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_store.py tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py -q` passed with 86 tests.
 - Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_Server_API/app/api/v1/endpoints/sync.py tldw_Server_API/app/core/DB_Management/Sync_DB.py tldw_Server_API/app/core/Sync/v2/models.py tldw_Server_API/app/core/Sync/v2/service.py tldw_Server_API/app/core/Sync/v2/store.py` passed; Bandit printed existing `nosec encountered` warnings for annotated SQL lines but returned success.
 - Verification: `git diff --check` passed.
+- PR review follow-up: addressed Gemini comments by validating actual ciphertext text length against the attachment cap, short-circuiting duplicate attachment retries before the insert path, and aggregating attachment manifest counts/size classes in SQL. Re-ran focused Sync v2 pytest, Bandit, and diff checks successfully.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-397 - Add-Sync-v2-attachment-persistence.md
+++ b/backlog/tasks/task-397 - Add-Sync-v2-attachment-persistence.md
@@ -44,10 +44,10 @@ Persist small encrypted Sync v2 attachment payloads server-side behind /api/v1/s
 
 <!-- SECTION:NOTES:BEGIN -->
 - Added `Docs/superpowers/plans/2026-05-16-sync-v2-attachment-persistence.md`.
-- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_store.py tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py -q` passed with 86 tests.
-- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_Server_API/app/api/v1/endpoints/sync.py tldw_Server_API/app/core/DB_Management/Sync_DB.py tldw_Server_API/app/core/Sync/v2/models.py tldw_Server_API/app/core/Sync/v2/service.py tldw_Server_API/app/core/Sync/v2/store.py` passed; Bandit printed existing `nosec encountered` warnings for annotated SQL lines but returned success.
+- Verification: `python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_store.py tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py -q` passed with 86 tests.
+- Verification: `python -m bandit -q -r tldw_Server_API/app/api/v1/endpoints/sync.py tldw_Server_API/app/core/DB_Management/Sync_DB.py tldw_Server_API/app/core/Sync/v2/models.py tldw_Server_API/app/core/Sync/v2/service.py tldw_Server_API/app/core/Sync/v2/store.py` passed; Bandit printed existing `nosec encountered` warnings for annotated SQL lines but returned success.
 - Verification: `git diff --check` passed.
-- PR review follow-up: addressed Gemini comments by validating actual ciphertext text length against the attachment cap, short-circuiting duplicate attachment retries before the insert path, and aggregating attachment manifest counts/size classes in SQL. Re-ran focused Sync v2 pytest, Bandit, and diff checks successfully.
+- PR review follow-up: addressed Gemini/Qodo/CodeRabbit comments by validating actual ciphertext text length against the attachment cap, offloading the async endpoint's sync store call, deriving duplicate insert status from DB rowcount, aggregating attachment manifest counts/size classes in SQL, and removing local absolute paths from task verification notes. Re-ran focused Sync v2 pytest, Bandit, and diff checks successfully.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-397 - Add-Sync-v2-attachment-persistence.md
+++ b/backlog/tasks/task-397 - Add-Sync-v2-attachment-persistence.md
@@ -1,0 +1,56 @@
+---
+id: TASK-397
+title: Add Sync v2 attachment persistence
+status: Done
+assignee: []
+created_date: '2026-05-16 01:12'
+labels:
+  - sync
+  - server
+  - attachments
+dependencies: []
+references:
+  - Docs/API/sync-v2.md
+  - Docs/Design/Sync-Engine.md
+  - tldw_Server_API/app/api/v1/endpoints/sync.py
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Persist small encrypted Sync v2 attachment payloads server-side behind /api/v1/sync/attachments so Chatbook can upload ciphertext attachments for restore hydration while keeping large binary replication out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 POST /api/v1/sync/attachments stores or deduplicates encrypted attachment payloads for an accessible dataset and returns stored metadata.
+- [x] #2 Attachment persistence enforces dataset access and enrolled domain validation and rejects unsupported plaintext or oversize payloads without leaking ciphertext in errors or logs.
+- [x] #3 Restore manifests include attachment availability and size-class summaries from persisted attachments.
+- [x] #4 Focused Sync v2 store service endpoint tests plus Bandit and diff checks pass.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added `Docs/superpowers/plans/2026-05-16-sync-v2-attachment-persistence.md`.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_store.py tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py -q` passed with 86 tests.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_Server_API/app/api/v1/endpoints/sync.py tldw_Server_API/app/core/DB_Management/Sync_DB.py tldw_Server_API/app/core/Sync/v2/models.py tldw_Server_API/app/core/Sync/v2/service.py tldw_Server_API/app/core/Sync/v2/store.py` passed; Bandit printed existing `nosec encountered` warnings for annotated SQL lines but returned success.
+- Verification: `git diff --check` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented server-side Sync v2 attachment persistence for small `client_private_v1` ciphertext payloads. The endpoint now validates sanitized request bodies, stores or idempotently deduplicates attachments, enforces dataset ownership and enrolled-domain checks, rejects plaintext-policy and oversize uploads without echoing ciphertext, and restore manifests summarize persisted attachment availability and size classes. Updated Sync v2 API/design docs and focused store/service/endpoint coverage.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -20,6 +20,7 @@ from fastapi import (
     status,
 )
 from loguru import logger
+from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 
@@ -35,6 +36,8 @@ from tldw_Server_API.app.api.v1.schemas.sync_server_models import (
 from tldw_Server_API.app.api.v1.schemas.sync_v2_models import (
     ConflictStatus,
     SyncCapabilitiesResponse,
+    SyncAttachmentUploadRequest,
+    SyncAttachmentUploadResponse,
     SyncConflictRecord,
     SyncConflictResolveRequest,
     SyncDatasetEnrollRequest,
@@ -207,6 +210,14 @@ def _safe_sync_v2_http_error(exc: Exception, **context: object) -> HTTPException
         )
     if isinstance(exc, SyncStoreError):
         lowered = str(exc).lower()
+        if "attachment payload exceeds" in lowered:
+            return HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail={
+                    "error_code": "sync_attachment_too_large",
+                    "message": "Sync attachment exceeds the server size limit.",
+                },
+            )
         if (
             "invalid sync cursor" in lowered
             or "page_size" in lowered
@@ -612,21 +623,55 @@ def list_sync_v2_key_recovery_bundles(
 
 @router.post(
     "/attachments",
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
-    summary="Feature-detect Sync v2 attachment upload support",
+    response_model=SyncAttachmentUploadResponse,
+    summary="Upload a small encrypted Sync v2 attachment",
 )
-def upload_sync_v2_attachment(
-    _request: Request,
+async def upload_sync_v2_attachment(
+    raw_request: Request,
+    user: User = Depends(get_request_user),
     service: SyncV2Service = Depends(get_sync_v2_service),
 ):
-    supports_attachments = service.capabilities().supports_attachments
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail={
-            "error_code": "sync_attachments_not_enabled",
-            "message": "Sync v2 attachment persistence is not enabled on this server.",
-            "supports_attachments": supports_attachments,
-        },
+    try:
+        request = SyncAttachmentUploadRequest.model_validate(await raw_request.json())
+    except (json.JSONDecodeError, ValidationError) as exc:
+        logger.bind(error_type=type(exc).__name__).warning(
+            "Sync v2 attachment request validation failed"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error_code": "sync_validation_failed",
+                "message": "Sync attachment request is invalid.",
+            },
+        ) from exc
+    try:
+        attachment = service.store_attachment(
+            user_id=_sync_user_id(user),
+            dataset_id=request.dataset_id,
+            domain=request.domain,
+            entity_id=request.entity_id,
+            attachment_id=request.attachment_id,
+            content_type=request.content_type,
+            size_bytes=request.size_bytes,
+            payload_ciphertext=request.payload_ciphertext,
+            payload_hash=request.payload_hash,
+            encryption_policy=request.encryption_policy,
+            metadata=request.metadata,
+        )
+    except Exception as exc:
+        raise _safe_sync_v2_http_error(
+            exc,
+            user_id=_sync_user_id(user),
+            dataset_id=request.dataset_id,
+            domain=request.domain,
+            attachment_id=request.attachment_id,
+        ) from exc
+    return SyncAttachmentUploadResponse(
+        attachment_id=attachment.attachment_id,
+        dataset_id=attachment.dataset_id,
+        stored=attachment.stored,
+        size_bytes=attachment.size_bytes,
+        payload_hash=attachment.payload_hash,
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -645,7 +645,8 @@ async def upload_sync_v2_attachment(
             },
         ) from exc
     try:
-        attachment = service.store_attachment(
+        attachment = await asyncio.to_thread(
+            service.store_attachment,
             user_id=_sync_user_id(user),
             dataset_id=request.dataset_id,
             domain=request.domain,

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -631,6 +631,8 @@ async def upload_sync_v2_attachment(
     user: User = Depends(get_request_user),
     service: SyncV2Service = Depends(get_sync_v2_service),
 ):
+    """Validate and persist a small encrypted Sync v2 attachment upload."""
+
     try:
         request = SyncAttachmentUploadRequest.model_validate(await raw_request.json())
     except (json.JSONDecodeError, ValidationError) as exc:

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -539,6 +539,8 @@ def _key_record_from_row(row: dict[str, Any]) -> SyncKeyRecord:
 
 
 def _attachment_from_row(row: dict[str, Any], *, stored: bool = True) -> SyncAttachment:
+    """Convert a sync_attachments row into a core attachment model."""
+
     return SyncAttachment(
         attachment_id=row["attachment_id"],
         dataset_id=row["dataset_id"],
@@ -638,6 +640,8 @@ def _key_record_fingerprint_from_row(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _attachment_fingerprint_from_create(attachment: SyncAttachmentCreate) -> dict[str, Any]:
+    """Return idempotency-comparable fields from an attachment create model."""
+
     return {
         "attachment_id": attachment.attachment_id,
         "dataset_id": attachment.dataset_id,
@@ -653,6 +657,8 @@ def _attachment_fingerprint_from_create(attachment: SyncAttachmentCreate) -> dic
 
 
 def _attachment_fingerprint_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Return idempotency-comparable fields from a stored attachment row."""
+
     return {
         "attachment_id": row["attachment_id"],
         "dataset_id": row["dataset_id"],

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -1513,42 +1513,46 @@ class SyncDatabase:
                     connection=conn,
                 )
             )
-            self.execute(
-                """
-                INSERT INTO sync_attachments (
-                    attachment_id, dataset_id, domain, entity_id, content_type,
-                    size_bytes, payload_ciphertext, payload_hash, encryption_policy,
-                    metadata_json, created_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT (dataset_id, attachment_id) DO NOTHING
-                """,
-                (
-                    attachment.attachment_id,
-                    attachment.dataset_id,
-                    attachment.domain,
-                    attachment.entity_id,
-                    attachment.content_type,
-                    attachment.size_bytes,
-                    attachment.payload_ciphertext,
-                    attachment.payload_hash,
-                    attachment.encryption_policy,
-                    encode_json(attachment.metadata, default={}),
-                    now,
-                ),
-                connection=conn,
-            )
-            inserted = existing is None
-            row = _first(
+            if existing is not None:
+                inserted = False
+                row = existing
+            else:
                 self.execute(
                     """
-                    SELECT * FROM sync_attachments
-                     WHERE dataset_id = ? AND attachment_id = ?
+                    INSERT INTO sync_attachments (
+                        attachment_id, dataset_id, domain, entity_id, content_type,
+                        size_bytes, payload_ciphertext, payload_hash, encryption_policy,
+                        metadata_json, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT (dataset_id, attachment_id) DO NOTHING
                     """,
-                    (attachment.dataset_id, attachment.attachment_id),
+                    (
+                        attachment.attachment_id,
+                        attachment.dataset_id,
+                        attachment.domain,
+                        attachment.entity_id,
+                        attachment.content_type,
+                        attachment.size_bytes,
+                        attachment.payload_ciphertext,
+                        attachment.payload_hash,
+                        attachment.encryption_policy,
+                        encode_json(attachment.metadata, default={}),
+                        now,
+                    ),
                     connection=conn,
                 )
-            )
+                inserted = True
+                row = _first(
+                    self.execute(
+                        """
+                        SELECT * FROM sync_attachments
+                         WHERE dataset_id = ? AND attachment_id = ?
+                        """,
+                        (attachment.dataset_id, attachment.attachment_id),
+                        connection=conn,
+                    )
+                )
             if row is None:
                 raise SyncStoreError(
                     "Sync attachment insert did not produce a retrievable record"
@@ -1619,22 +1623,36 @@ class SyncDatabase:
 
             params = [dataset_id]
             sql = """
-                SELECT domain, size_bytes
+                SELECT COUNT(*) AS attachment_count,
+                       COALESCE(SUM(CASE WHEN size_bytes <= 1048576 THEN 1 ELSE 0 END), 0)
+                           AS small_count,
+                       COALESCE(SUM(
+                           CASE
+                               WHEN size_bytes > 1048576 AND size_bytes <= 16777216
+                               THEN 1 ELSE 0
+                           END
+                       ), 0) AS medium_count,
+                       COALESCE(SUM(CASE WHEN size_bytes > 16777216 THEN 1 ELSE 0 END), 0)
+                           AS large_count
                   FROM sync_attachments
                  WHERE dataset_id = ?
             """
             sql += _domain_filter_sql(domain_list if domain_filter_enabled else None, params)
-            for row in self.execute(sql, tuple(params)).rows:
-                attachment_availability["available"] = (
-                    attachment_availability.get("available", 0) + 1
-                )
-                try:
-                    size_bytes = int(row.get("size_bytes") or 0)
-                except (TypeError, ValueError):
-                    size_bytes = 0
-                size_class = _manifest_attachment_size_class(size_bytes)
-                attachment_size_classes[size_class] = (
-                    attachment_size_classes.get(size_class, 0) + 1
+            attachment_row = _first(self.execute(sql, tuple(params)))
+            attachment_count = int((attachment_row or {}).get("attachment_count") or 0)
+            if attachment_count:
+                attachment_availability["available"] = attachment_count
+                size_counts = {
+                    "small": int((attachment_row or {}).get("small_count") or 0),
+                    "medium": int((attachment_row or {}).get("medium_count") or 0),
+                    "large": int((attachment_row or {}).get("large_count") or 0),
+                }
+                attachment_size_classes.update(
+                    {
+                        size_class: count
+                        for size_class, count in size_counts.items()
+                        if count > 0
+                    }
                 )
 
         key_row = _first(

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -20,6 +20,8 @@ from tldw_Server_API.app.core.Sync.v2.errors import (
 )
 from tldw_Server_API.app.core.Sync.v2.models import (
     ConflictStatus,
+    SyncAttachment,
+    SyncAttachmentCreate,
     SyncConflict,
     SyncConflictCreate,
     SyncDataset,
@@ -166,6 +168,25 @@ CREATE INDEX IF NOT EXISTS idx_sync_key_records_dataset
     ON sync_key_records(dataset_id, key_purpose, created_at);
 CREATE INDEX IF NOT EXISTS idx_sync_key_records_device
     ON sync_key_records(dataset_id, device_id);
+
+CREATE TABLE IF NOT EXISTS sync_attachments (
+    attachment_id TEXT NOT NULL,
+    dataset_id TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    payload_ciphertext TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    encryption_policy TEXT NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (dataset_id, attachment_id)
+);
+CREATE INDEX IF NOT EXISTS idx_sync_attachments_dataset_domain
+    ON sync_attachments(dataset_id, domain, created_at);
+CREATE INDEX IF NOT EXISTS idx_sync_attachments_dataset_hash
+    ON sync_attachments(dataset_id, payload_hash);
 """
 
 SYNC_POSTGRES_SCHEMA = """
@@ -294,6 +315,25 @@ CREATE INDEX IF NOT EXISTS idx_sync_key_records_dataset
     ON sync_key_records(dataset_id, key_purpose, created_at);
 CREATE INDEX IF NOT EXISTS idx_sync_key_records_device
     ON sync_key_records(dataset_id, device_id);
+
+CREATE TABLE IF NOT EXISTS sync_attachments (
+    attachment_id TEXT NOT NULL,
+    dataset_id TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    payload_ciphertext TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    encryption_policy TEXT NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (dataset_id, attachment_id)
+);
+CREATE INDEX IF NOT EXISTS idx_sync_attachments_dataset_domain
+    ON sync_attachments(dataset_id, domain, created_at);
+CREATE INDEX IF NOT EXISTS idx_sync_attachments_dataset_hash
+    ON sync_attachments(dataset_id, payload_hash);
 """
 
 
@@ -498,6 +538,23 @@ def _key_record_from_row(row: dict[str, Any]) -> SyncKeyRecord:
     )
 
 
+def _attachment_from_row(row: dict[str, Any], *, stored: bool = True) -> SyncAttachment:
+    return SyncAttachment(
+        attachment_id=row["attachment_id"],
+        dataset_id=row["dataset_id"],
+        domain=row["domain"],
+        entity_id=row["entity_id"],
+        content_type=row["content_type"],
+        size_bytes=int(row["size_bytes"]),
+        payload_ciphertext=row["payload_ciphertext"],
+        payload_hash=row["payload_hash"],
+        encryption_policy=row["encryption_policy"],
+        metadata=decode_json(row.get("metadata_json"), default={}),
+        created_at=row["created_at"],
+        stored=stored,
+    )
+
+
 def _dataset_domains_from_row(row: dict[str, Any]) -> set[str]:
     domains = decode_json(row.get("domain_set_json"), default=[])
     return {str(domain) for domain in domains}
@@ -577,6 +634,36 @@ def _key_record_fingerprint_from_row(row: dict[str, Any]) -> dict[str, Any]:
         "recovery_hint": row.get("recovery_hint"),
         "rotation_of_key_record_id": row.get("rotation_of_key_record_id"),
         "revoked_at": row.get("revoked_at"),
+    }
+
+
+def _attachment_fingerprint_from_create(attachment: SyncAttachmentCreate) -> dict[str, Any]:
+    return {
+        "attachment_id": attachment.attachment_id,
+        "dataset_id": attachment.dataset_id,
+        "domain": attachment.domain,
+        "entity_id": attachment.entity_id,
+        "content_type": attachment.content_type,
+        "size_bytes": attachment.size_bytes,
+        "payload_ciphertext": attachment.payload_ciphertext,
+        "payload_hash": attachment.payload_hash,
+        "encryption_policy": attachment.encryption_policy,
+        "metadata": attachment.metadata,
+    }
+
+
+def _attachment_fingerprint_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "attachment_id": row["attachment_id"],
+        "dataset_id": row["dataset_id"],
+        "domain": row["domain"],
+        "entity_id": row["entity_id"],
+        "content_type": row["content_type"],
+        "size_bytes": int(row["size_bytes"]),
+        "payload_ciphertext": row["payload_ciphertext"],
+        "payload_hash": row["payload_hash"],
+        "encryption_policy": row["encryption_policy"],
+        "metadata": decode_json(row.get("metadata_json"), default={}),
     }
 
 
@@ -1406,6 +1493,75 @@ class SyncDatabase:
         result = self.execute(sql, tuple(params))
         return [_key_record_from_row(row) for row in result.rows]
 
+    def store_attachment(self, attachment: SyncAttachmentCreate) -> SyncAttachment:
+        """Store or idempotently deduplicate an encrypted Sync v2 attachment."""
+
+        now = utcnow_iso()
+        with self.backend.transaction() as conn:
+            self._require_dataset_domain(
+                attachment.dataset_id,
+                attachment.domain,
+                connection=conn,
+            )
+            existing = _first(
+                self.execute(
+                    """
+                    SELECT * FROM sync_attachments
+                     WHERE dataset_id = ? AND attachment_id = ?
+                    """,
+                    (attachment.dataset_id, attachment.attachment_id),
+                    connection=conn,
+                )
+            )
+            self.execute(
+                """
+                INSERT INTO sync_attachments (
+                    attachment_id, dataset_id, domain, entity_id, content_type,
+                    size_bytes, payload_ciphertext, payload_hash, encryption_policy,
+                    metadata_json, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (dataset_id, attachment_id) DO NOTHING
+                """,
+                (
+                    attachment.attachment_id,
+                    attachment.dataset_id,
+                    attachment.domain,
+                    attachment.entity_id,
+                    attachment.content_type,
+                    attachment.size_bytes,
+                    attachment.payload_ciphertext,
+                    attachment.payload_hash,
+                    attachment.encryption_policy,
+                    encode_json(attachment.metadata, default={}),
+                    now,
+                ),
+                connection=conn,
+            )
+            inserted = existing is None
+            row = _first(
+                self.execute(
+                    """
+                    SELECT * FROM sync_attachments
+                     WHERE dataset_id = ? AND attachment_id = ?
+                    """,
+                    (attachment.dataset_id, attachment.attachment_id),
+                    connection=conn,
+                )
+            )
+            if row is None:
+                raise SyncStoreError(
+                    "Sync attachment insert did not produce a retrievable record"
+                )
+            if (
+                _attachment_fingerprint_from_row(row)
+                != _attachment_fingerprint_from_create(attachment)
+            ):
+                raise SyncIdempotencyConflictError(
+                    "Sync attachment ID was reused with different content"
+                )
+        return _attachment_from_row(row, stored=inserted)
+
     def summarize_restore_manifest_dataset(
         self,
         dataset_id: str,
@@ -1463,23 +1619,17 @@ class SyncDatabase:
 
             params = [dataset_id]
             sql = """
-                SELECT payload_clear_json
-                  FROM sync_envelopes
+                SELECT domain, size_bytes
+                  FROM sync_attachments
                  WHERE dataset_id = ?
-                   AND payload_clear_json LIKE ?
             """
-            params.append('%"attachment_id"%')
             sql += _domain_filter_sql(domain_list if domain_filter_enabled else None, params)
             for row in self.execute(sql, tuple(params)).rows:
-                payload_clear = decode_json(row.get("payload_clear_json"), default={})
-                if not isinstance(payload_clear, dict) or not payload_clear.get("attachment_id"):
-                    continue
-                availability = str(payload_clear.get("availability", "unknown"))
-                attachment_availability[availability] = (
-                    attachment_availability.get(availability, 0) + 1
+                attachment_availability["available"] = (
+                    attachment_availability.get("available", 0) + 1
                 )
                 try:
-                    size_bytes = int(payload_clear.get("size_bytes") or 0)
+                    size_bytes = int(row.get("size_bytes") or 0)
                 except (TypeError, ValueError):
                     size_bytes = 0
                 size_class = _manifest_attachment_size_class(size_bytes)

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -1503,7 +1503,33 @@ class SyncDatabase:
                 attachment.domain,
                 connection=conn,
             )
-            existing = _first(
+            insert_result = self.execute(
+                """
+                INSERT INTO sync_attachments (
+                    attachment_id, dataset_id, domain, entity_id, content_type,
+                    size_bytes, payload_ciphertext, payload_hash, encryption_policy,
+                    metadata_json, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (dataset_id, attachment_id) DO NOTHING
+                """,
+                (
+                    attachment.attachment_id,
+                    attachment.dataset_id,
+                    attachment.domain,
+                    attachment.entity_id,
+                    attachment.content_type,
+                    attachment.size_bytes,
+                    attachment.payload_ciphertext,
+                    attachment.payload_hash,
+                    attachment.encryption_policy,
+                    encode_json(attachment.metadata, default={}),
+                    now,
+                ),
+                connection=conn,
+            )
+            inserted = insert_result.rowcount > 0
+            row = _first(
                 self.execute(
                     """
                     SELECT * FROM sync_attachments
@@ -1513,46 +1539,6 @@ class SyncDatabase:
                     connection=conn,
                 )
             )
-            if existing is not None:
-                inserted = False
-                row = existing
-            else:
-                self.execute(
-                    """
-                    INSERT INTO sync_attachments (
-                        attachment_id, dataset_id, domain, entity_id, content_type,
-                        size_bytes, payload_ciphertext, payload_hash, encryption_policy,
-                        metadata_json, created_at
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT (dataset_id, attachment_id) DO NOTHING
-                    """,
-                    (
-                        attachment.attachment_id,
-                        attachment.dataset_id,
-                        attachment.domain,
-                        attachment.entity_id,
-                        attachment.content_type,
-                        attachment.size_bytes,
-                        attachment.payload_ciphertext,
-                        attachment.payload_hash,
-                        attachment.encryption_policy,
-                        encode_json(attachment.metadata, default={}),
-                        now,
-                    ),
-                    connection=conn,
-                )
-                inserted = True
-                row = _first(
-                    self.execute(
-                        """
-                        SELECT * FROM sync_attachments
-                         WHERE dataset_id = ? AND attachment_id = ?
-                        """,
-                        (attachment.dataset_id, attachment.attachment_id),
-                        connection=conn,
-                    )
-                )
             if row is None:
                 raise SyncStoreError(
                     "Sync attachment insert did not produce a retrievable record"

--- a/tldw_Server_API/app/core/Sync/v2/models.py
+++ b/tldw_Server_API/app/core/Sync/v2/models.py
@@ -205,6 +205,40 @@ class SyncKeyRecord:
 
 
 @dataclass(frozen=True, slots=True)
+class SyncAttachmentCreate:
+    """Encrypted attachment payload accepted by the Sync v2 store."""
+
+    attachment_id: str
+    dataset_id: str
+    domain: SyncDomain
+    entity_id: str
+    content_type: str
+    size_bytes: int
+    payload_ciphertext: str
+    payload_hash: str
+    encryption_policy: EncryptionPolicy = "client_private_v1"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class SyncAttachment:
+    """Stored encrypted attachment payload metadata."""
+
+    attachment_id: str
+    dataset_id: str
+    domain: SyncDomain
+    entity_id: str
+    content_type: str
+    size_bytes: int
+    payload_ciphertext: str
+    payload_hash: str
+    encryption_policy: EncryptionPolicy
+    metadata: dict[str, Any]
+    created_at: str
+    stored: bool = True
+
+
+@dataclass(frozen=True, slots=True)
 class SyncRestoreManifestStats:
     """Database-side aggregate statistics for one restore-manifest dataset."""
 
@@ -221,6 +255,8 @@ __all__ = [
     "ConflictStatus",
     "DatasetScopeType",
     "EncryptionPolicy",
+    "SyncAttachment",
+    "SyncAttachmentCreate",
     "SyncConflict",
     "SyncConflictCreate",
     "SyncDataset",

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -538,7 +538,13 @@ class SyncV2Service:
             raise SyncStoreError(
                 "Sync attachment persistence requires client_private_v1 encryption"
             )
-        if size_bytes > self.settings.max_attachment_bytes:
+        if (
+            size_bytes > self.settings.max_attachment_bytes
+            or _ciphertext_exceeds_attachment_limit(
+                payload_ciphertext,
+                self.settings.max_attachment_bytes,
+            )
+        ):
             raise SyncStoreError("Sync attachment payload exceeds the server size limit")
         if not payload_ciphertext:
             raise SyncStoreError("Sync attachment payload_ciphertext is required")
@@ -905,6 +911,15 @@ def _compact_json_size(value: object) -> int:
             "utf-8"
         )
     )
+
+
+def _ciphertext_exceeds_attachment_limit(
+    payload_ciphertext: str,
+    max_attachment_bytes: int,
+) -> bool:
+    """Return whether textual ciphertext is implausibly large for the binary cap."""
+
+    return len(payload_ciphertext.encode("utf-8")) > max_attachment_bytes * 2
 
 
 def _call_adapter_evaluate(

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -26,6 +26,8 @@ from .errors import (
 from .models import (
     ConflictStatus,
     EncryptionPolicy,
+    SyncAttachment,
+    SyncAttachmentCreate,
     SyncConflict,
     SyncConflictCreate,
     SyncDataset,
@@ -53,7 +55,7 @@ class SyncV2Settings:
     max_pull_page_size: int = 100
     max_envelope_payload_bytes: int = 262_144
     max_attachment_bytes: int = 1_048_576
-    supports_attachments: bool = False
+    supports_attachments: bool = True
     encryption_policies: list[EncryptionPolicy] = field(
         default_factory=lambda: [
             "client_private_v1",
@@ -75,7 +77,7 @@ class SyncV2Capabilities:
     max_attachment_bytes: int
     supports_restore_manifest: bool = True
     supports_conflicts: bool = True
-    supports_attachments: bool = False
+    supports_attachments: bool = True
     server_time: str | None = None
 
 
@@ -511,6 +513,55 @@ class SyncV2Service:
                 "dataset_ids": list(dataset_ids or []),
                 "domains": list(domains or []),
             },
+        )
+
+    def store_attachment(
+        self,
+        *,
+        user_id: str,
+        dataset_id: str,
+        domain: SyncDomain,
+        entity_id: str,
+        attachment_id: str,
+        content_type: str,
+        size_bytes: int,
+        payload_ciphertext: str,
+        payload_hash: str,
+        encryption_policy: EncryptionPolicy = "client_private_v1",
+        metadata: dict[str, object] | None = None,
+    ) -> SyncAttachment:
+        """Persist a small encrypted attachment payload for later restore."""
+
+        if not self.settings.supports_attachments:
+            raise SyncStoreError("Sync v2 attachment persistence is not enabled")
+        if encryption_policy != "client_private_v1":
+            raise SyncStoreError(
+                "Sync attachment persistence requires client_private_v1 encryption"
+            )
+        if size_bytes > self.settings.max_attachment_bytes:
+            raise SyncStoreError("Sync attachment payload exceeds the server size limit")
+        if not payload_ciphertext:
+            raise SyncStoreError("Sync attachment payload_ciphertext is required")
+        dataset = self.store.get_dataset(dataset_id, owner_user_id=user_id)
+        if dataset is None:
+            raise SyncStoreError("Sync dataset was not found or is not accessible")
+        if domain not in dataset.domains:
+            raise SyncInvalidDomainError(
+                f"Sync domain is not enrolled for this dataset: {domain}"
+            )
+        return self.store.store_attachment(
+            SyncAttachmentCreate(
+                attachment_id=attachment_id,
+                dataset_id=dataset_id,
+                domain=domain,
+                entity_id=entity_id,
+                content_type=content_type,
+                size_bytes=size_bytes,
+                payload_ciphertext=payload_ciphertext,
+                payload_hash=payload_hash,
+                encryption_policy=encryption_policy,
+                metadata=dict(metadata or {}),
+            )
         )
 
     def list_conflicts(

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -917,9 +917,9 @@ def _ciphertext_exceeds_attachment_limit(
     payload_ciphertext: str,
     max_attachment_bytes: int,
 ) -> bool:
-    """Return whether textual ciphertext is implausibly large for the binary cap."""
+    """Return whether persisted ciphertext text exceeds the attachment cap."""
 
-    return len(payload_ciphertext.encode("utf-8")) > max_attachment_bytes * 2
+    return len(payload_ciphertext.encode("utf-8")) > max_attachment_bytes
 
 
 def _call_adapter_evaluate(

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -167,6 +167,8 @@ class SyncV2Store:
         )
 
     def store_attachment(self, attachment: SyncAttachmentCreate) -> SyncAttachment:
+        """Store or deduplicate an encrypted attachment through the DB layer."""
+
         return self.db.store_attachment(attachment)
 
     def summarize_restore_manifest_dataset(

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -8,6 +8,8 @@ from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
 
 from .models import (
     ConflictStatus,
+    SyncAttachment,
+    SyncAttachmentCreate,
     SyncConflict,
     SyncConflictCreate,
     SyncDataset,
@@ -163,6 +165,9 @@ class SyncV2Store:
             device_id=device_id,
             key_purpose=key_purpose,
         )
+
+    def store_attachment(self, attachment: SyncAttachmentCreate) -> SyncAttachment:
+        return self.db.store_attachment(attachment)
 
     def summarize_restore_manifest_dataset(
         self,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -149,7 +149,7 @@ def test_capabilities_endpoint_returns_sync_v2_contract(client: TestClient):
     assert body["supported_domains"] == ["chat", "notes", "source_cache"]
     assert body["supports_restore_manifest"] is True
     assert body["supports_conflicts"] is True
-    assert body["supports_attachments"] is False
+    assert body["supports_attachments"] is True
     assert body["server_time"] == _clock()
 
 
@@ -488,7 +488,10 @@ def test_conflict_resolve_endpoint_returns_client_error_for_invalid_private_reso
     assert "known plaintext" not in str(response.json())
 
 
-def test_attachments_endpoint_returns_feature_detect_response(client: TestClient):
+def test_attachments_endpoint_stores_and_deduplicates_ciphertext(client: TestClient):
+    _register_device(client)
+    _enroll_dataset(client, domains=["notes"])
+
     response = client.post(
         "/api/v1/sync/attachments",
         json={
@@ -502,21 +505,82 @@ def test_attachments_endpoint_returns_feature_detect_response(client: TestClient
             "payload_hash": "sha256:attachment",
         },
     )
+    duplicate = client.post(
+        "/api/v1/sync/attachments",
+        json={
+            "dataset_id": "dataset-1",
+            "domain": "notes",
+            "entity_id": "note-1",
+            "attachment_id": "attachment-1",
+            "content_type": "application/octet-stream",
+            "size_bytes": 12,
+            "payload_ciphertext": "ciphertext:attachment-secret",
+            "payload_hash": "sha256:attachment",
+        },
+    )
+    manifest = client.get("/api/v1/sync/restore-manifest")
 
-    assert response.status_code == 501
-    assert response.json()["detail"]["error_code"] == "sync_attachments_not_enabled"
+    assert response.status_code == 200
+    assert duplicate.status_code == 200
+    assert response.json()["stored"] is True
+    assert duplicate.json()["stored"] is False
+    assert response.json()["payload_hash"] == "sha256:attachment"
+    assert manifest.json()["datasets"][0]["attachment_availability"] == {"available": 1}
+    assert manifest.json()["datasets"][0]["attachment_size_classes"] == {"small": 1}
     assert "attachment-secret" not in str(response.json())
+    assert "attachment-secret" not in str(duplicate.json())
+    assert "attachment-secret" not in str(manifest.json())
 
 
-def test_attachments_endpoint_feature_detects_without_strict_body_validation(client: TestClient):
+def test_attachments_endpoint_validates_request_and_hides_ciphertext(client: TestClient):
     response = client.post(
         "/api/v1/sync/attachments",
         json={"payload_ciphertext": "ciphertext:attachment-secret"},
     )
 
-    assert response.status_code == 501
-    assert response.json()["detail"]["error_code"] == "sync_attachments_not_enabled"
+    assert response.status_code == 422
     assert "attachment-secret" not in str(response.json())
+
+
+def test_attachments_endpoint_rejects_oversize_and_inaccessible_dataset(
+    client: TestClient,
+):
+    _register_device(client)
+    _enroll_dataset(client, domains=["notes"])
+
+    oversize = client.post(
+        "/api/v1/sync/attachments",
+        json={
+            "dataset_id": "dataset-1",
+            "domain": "notes",
+            "entity_id": "note-1",
+            "attachment_id": "attachment-large",
+            "content_type": "application/octet-stream",
+            "size_bytes": 1_048_577,
+            "payload_ciphertext": "ciphertext:large-secret",
+            "payload_hash": "sha256:large",
+        },
+    )
+    missing = client.post(
+        "/api/v1/sync/attachments",
+        json={
+            "dataset_id": "missing-dataset",
+            "domain": "notes",
+            "entity_id": "note-1",
+            "attachment_id": "attachment-missing",
+            "content_type": "application/octet-stream",
+            "size_bytes": 12,
+            "payload_ciphertext": "ciphertext:missing-secret",
+            "payload_hash": "sha256:missing",
+        },
+    )
+
+    assert oversize.status_code == 413
+    assert oversize.json()["detail"]["error_code"] == "sync_attachment_too_large"
+    assert missing.status_code == 404
+    assert missing.json()["detail"]["error_code"] == "sync_resource_not_found"
+    assert "large-secret" not in str(oversize.json())
+    assert "missing-secret" not in str(missing.json())
 
 
 def test_key_recovery_bundle_endpoint_stores_safe_metadata(client: TestClient):

--- a/tldw_Server_API/tests/Sync/test_sync_v2_service.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_service.py
@@ -113,6 +113,7 @@ def test_capabilities_returns_protocol_domains_limits_and_encryption_policies(
         "server_trusted",
         "shared_workspace_v1",
     ]
+    assert capabilities.supports_attachments is True
 
 
 def test_device_registration_creates_and_refreshes_same_device(sync_service: SyncV2Service):
@@ -1472,6 +1473,18 @@ def test_restore_manifest_is_metadata_only_and_includes_inventory_status(
             ),
         ],
     )
+    sync_service.store_attachment(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domain="source_cache",
+        entity_id="source-1",
+        attachment_id="attachment-1",
+        content_type="application/octet-stream",
+        size_bytes=512,
+        payload_ciphertext="ciphertext:attachment-secret",
+        payload_hash="sha256:attachment",
+        encryption_policy="client_private_v1",
+    )
     sync_store.insert_conflict(
         SyncConflictCreate(
             conflict_id="conflict-1",
@@ -1515,3 +1528,100 @@ def test_restore_manifest_is_metadata_only_and_includes_inventory_status(
     assert "known private label" not in repr(manifest)
     assert "ciphertext:known-private-note" not in repr(manifest)
     assert "wrapped:secret-key" not in repr(manifest)
+
+
+def test_store_attachment_persists_encrypted_payload_and_updates_manifest(
+    sync_service: SyncV2Service,
+):
+    sync_service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domains=["notes"],
+    )
+
+    stored = sync_service.store_attachment(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domain="notes",
+        entity_id="note-1",
+        attachment_id="attachment-1",
+        content_type="application/octet-stream",
+        size_bytes=512,
+        payload_ciphertext="ciphertext:attachment-secret",
+        payload_hash="sha256:attachment",
+        encryption_policy="client_private_v1",
+        metadata={"slot": "body-image"},
+    )
+    duplicate = sync_service.store_attachment(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domain="notes",
+        entity_id="note-1",
+        attachment_id="attachment-1",
+        content_type="application/octet-stream",
+        size_bytes=512,
+        payload_ciphertext="ciphertext:attachment-secret",
+        payload_hash="sha256:attachment",
+        encryption_policy="client_private_v1",
+        metadata={"slot": "body-image"},
+    )
+    manifest = sync_service.restore_manifest(user_id="user-1")
+
+    assert stored.stored is True
+    assert duplicate.stored is False
+    assert duplicate.payload_hash == "sha256:attachment"
+    assert manifest.datasets[0].attachment_availability == {"available": 1}
+    assert manifest.datasets[0].attachment_size_classes == {"small": 1}
+    assert "attachment-secret" not in repr(manifest)
+
+
+def test_store_attachment_rejects_forbidden_domain_oversize_and_plaintext_policy(
+    sync_service: SyncV2Service,
+):
+    sync_service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domains=["notes"],
+    )
+
+    with pytest.raises(SyncStoreError, match="payload exceeds"):
+        sync_service.store_attachment(
+            user_id="user-1",
+            dataset_id="dataset-1",
+            domain="notes",
+            entity_id="note-1",
+            attachment_id="attachment-large",
+            content_type="application/octet-stream",
+            size_bytes=4097,
+            payload_ciphertext="ciphertext:large",
+            payload_hash="sha256:large",
+            encryption_policy="client_private_v1",
+        )
+
+    with pytest.raises(SyncStoreError, match="client_private_v1"):
+        sync_service.store_attachment(
+            user_id="user-1",
+            dataset_id="dataset-1",
+            domain="notes",
+            entity_id="note-1",
+            attachment_id="attachment-plaintext-policy",
+            content_type="text/plain",
+            size_bytes=128,
+            payload_ciphertext="known plaintext",
+            payload_hash="sha256:plaintext",
+            encryption_policy="server_trusted",
+        )
+
+    with pytest.raises(SyncStoreError, match="not accessible"):
+        sync_service.store_attachment(
+            user_id="user-2",
+            dataset_id="dataset-1",
+            domain="notes",
+            entity_id="note-1",
+            attachment_id="attachment-forbidden",
+            content_type="application/octet-stream",
+            size_bytes=128,
+            payload_ciphertext="ciphertext:forbidden",
+            payload_hash="sha256:forbidden",
+            encryption_policy="client_private_v1",
+        )

--- a/tldw_Server_API/tests/Sync/test_sync_v2_service.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_service.py
@@ -1607,7 +1607,7 @@ def test_store_attachment_rejects_forbidden_domain_oversize_and_plaintext_policy
             attachment_id="attachment-oversized-ciphertext",
             content_type="application/octet-stream",
             size_bytes=12,
-            payload_ciphertext="x" * 8193,
+            payload_ciphertext="x" * 4097,
             payload_hash="sha256:oversized-ciphertext",
             encryption_policy="client_private_v1",
         )

--- a/tldw_Server_API/tests/Sync/test_sync_v2_service.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_service.py
@@ -1598,6 +1598,20 @@ def test_store_attachment_rejects_forbidden_domain_oversize_and_plaintext_policy
             encryption_policy="client_private_v1",
         )
 
+    with pytest.raises(SyncStoreError, match="payload exceeds"):
+        sync_service.store_attachment(
+            user_id="user-1",
+            dataset_id="dataset-1",
+            domain="notes",
+            entity_id="note-1",
+            attachment_id="attachment-oversized-ciphertext",
+            content_type="application/octet-stream",
+            size_bytes=12,
+            payload_ciphertext="x" * 8193,
+            payload_hash="sha256:oversized-ciphertext",
+            encryption_policy="client_private_v1",
+        )
+
     with pytest.raises(SyncStoreError, match="client_private_v1"):
         sync_service.store_attachment(
             user_id="user-1",

--- a/tldw_Server_API/tests/Sync/test_sync_v2_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_store.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.core.Sync.v2.errors import (
 )
 from tldw_Server_API.app.core.Sync.v2.models import (
     SyncConflictCreate,
+    SyncAttachmentCreate,
     SyncDatasetCreate,
     SyncDeviceCursor,
     SyncDeviceUpsert,
@@ -116,6 +117,23 @@ def _key_record(**overrides) -> SyncKeyRecordCreate:
     return SyncKeyRecordCreate(**payload)
 
 
+def _attachment(**overrides) -> SyncAttachmentCreate:
+    payload = {
+        "attachment_id": "attachment-1",
+        "dataset_id": "dataset-1",
+        "domain": "notes",
+        "entity_id": "note-1",
+        "content_type": "application/octet-stream",
+        "size_bytes": 512,
+        "payload_ciphertext": "ciphertext:attachment",
+        "payload_hash": "sha256:attachment",
+        "encryption_policy": "client_private_v1",
+        "metadata": {"slot": "body-image"},
+    }
+    payload.update(overrides)
+    return SyncAttachmentCreate(**payload)
+
+
 def test_sync_database_rejects_unsupported_database_url_scheme(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("SYNC_V2_DATABASE_URL", "mysql://sync.example/sync_v2")
     monkeypatch.delenv("SYNC_V2_SQLITE_PATH", raising=False)
@@ -133,6 +151,7 @@ def test_sync_database_bootstrap_creates_required_tables(sync_store: SyncV2Store
         "sync_device_cursors",
         "sync_conflicts",
         "sync_key_records",
+        "sync_attachments",
     }
 
     for table_name in required_tables:
@@ -485,3 +504,78 @@ def test_key_record_duplicate_drift_raises(sync_store: SyncV2Store):
 
     with pytest.raises(SyncIdempotencyConflictError):
         sync_store.store_key_record(_key_record(user_id="user-2"))
+
+
+def test_attachment_store_is_idempotent_and_keeps_ciphertext_out_of_manifest(
+    sync_store: SyncV2Store,
+):
+    sync_store.enroll_dataset(_dataset())
+
+    stored = sync_store.store_attachment(_attachment())
+    duplicate = sync_store.store_attachment(_attachment())
+    stats = sync_store.summarize_restore_manifest_dataset(
+        "dataset-1",
+        user_id="user-1",
+        domains=["notes"],
+    )
+
+    assert stored.stored is True
+    assert duplicate.stored is False
+    assert duplicate.attachment_id == stored.attachment_id
+    assert duplicate.payload_hash == "sha256:attachment"
+    assert duplicate.payload_ciphertext == "ciphertext:attachment"
+    assert stats.attachment_availability == {"available": 1}
+    assert stats.attachment_size_classes == {"small": 1}
+    assert "ciphertext:attachment" not in repr(stats)
+
+
+def test_attachment_store_rejects_duplicate_drift_and_unenrolled_domain(
+    sync_store: SyncV2Store,
+):
+    sync_store.enroll_dataset(_dataset(domains=["notes"]))
+    sync_store.store_attachment(_attachment())
+
+    with pytest.raises(SyncIdempotencyConflictError):
+        sync_store.store_attachment(_attachment(payload_hash="sha256:changed"))
+
+    with pytest.raises(SyncInvalidDomainError):
+        sync_store.store_attachment(
+            _attachment(
+                attachment_id="attachment-chat",
+                domain="chat",
+                entity_id="conversation-1",
+                payload_hash="sha256:chat-attachment",
+            )
+        )
+
+
+def test_attachment_store_restore_summary_respects_domain_filter(
+    sync_store: SyncV2Store,
+):
+    sync_store.enroll_dataset(_dataset(domains=["notes", "chat"]))
+    sync_store.store_attachment(_attachment(domain="notes", size_bytes=512))
+    sync_store.store_attachment(
+        _attachment(
+            attachment_id="attachment-chat",
+            domain="chat",
+            entity_id="conversation-1",
+            size_bytes=2_097_152,
+            payload_hash="sha256:chat-attachment",
+        )
+    )
+
+    notes_stats = sync_store.summarize_restore_manifest_dataset(
+        "dataset-1",
+        user_id="user-1",
+        domains=["notes"],
+    )
+    all_stats = sync_store.summarize_restore_manifest_dataset(
+        "dataset-1",
+        user_id="user-1",
+        domains=["notes", "chat"],
+    )
+
+    assert notes_stats.attachment_availability == {"available": 1}
+    assert notes_stats.attachment_size_classes == {"small": 1}
+    assert all_stats.attachment_availability == {"available": 2}
+    assert all_stats.attachment_size_classes == {"medium": 1, "small": 1}


### PR DESCRIPTION
## Change summary
Human-authored change summary required before merge.

## Summary
- Adds durable Sync v2 attachment storage for small `client_private_v1` ciphertext payloads.
- Wires `POST /api/v1/sync/attachments` to validate, store, and idempotently deduplicate uploads without echoing ciphertext in errors.
- Updates restore manifests, docs, focused tests, implementation plan, and Backlog task `TASK-397`.

## Validation
- [x] `python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_store.py tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py -q`
- [x] `python -m bandit -q -r tldw_Server_API/app/api/v1/endpoints/sync.py tldw_Server_API/app/core/DB_Management/Sync_DB.py tldw_Server_API/app/core/Sync/v2/models.py tldw_Server_API/app/core/Sync/v2/service.py tldw_Server_API/app/core/Sync/v2/store.py`
- [x] `git diff --check`
- [x] PR review threads resolved after Gemini, Qodo, and CodeRabbit feedback.

## Risk assessment
Risk: Medium. This adds a new Sync v2 persistence table and activates a previously feature-detect-only endpoint. The implementation limits scope to small `client_private_v1` ciphertext, validates dataset ownership and enrolled domain, enforces actual ciphertext byte caps, sanitizes invalid request errors, and keeps upload responses metadata-only.

## Rollback plan
Revert this PR to restore the previous `/api/v1/sync/attachments` non-persistent behavior. Existing `sync_attachments` rows are isolated to the new Sync v2 table and are not required by envelope push/pull or key recovery paths.

## Review follow-up
- Added actual ciphertext byte-size enforcement for attachment uploads and regression coverage for underreported `size_bytes`.
- Offloaded the async attachment endpoint store call through `asyncio.to_thread`.
- Reworked attachment insert status to use DB `rowcount`.
- Moved attachment manifest availability and size-class summaries into SQL aggregation.
- Replaced local absolute verification paths in `TASK-397` with repo-relative commands.

<!-- This PR was materially authored with AI assistance. The repository merge gate requires the human requester to replace the Change summary placeholder with a human-authored explanation of what changed and why before merge. -->