### PR TITLE
Deduplicate Persona Visual starter shared UI types

### DIFF
--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -83,28 +83,6 @@ export interface PersonaVisualRendererCapabilitiesResponse {
   renderers: PersonaVisualRendererCapability[]
 }
 
-export interface PersonaVisualStarterPackSummary {
-  id: string
-  title: string
-  description?: string | null
-  renderer_type: PersonaVisualRendererType | string
-  manifest_version: number
-  states_offered: string[]
-  asset_count: number
-  total_bytes: number
-  tags: string[]
-  license_label?: string | null
-}
-
-export interface PersonaVisualStarterPackListResponse {
-  starter_packs: PersonaVisualStarterPackSummary[]
-}
-
-export interface PersonaVisualStarterPackCopyRequest {
-  target_persona_id: string
-  title?: string | null
-}
-
 export type PersonaVisualPackStatus =
   | "draft"
   | "review"

--- a/backlog/tasks/task-401 - Deduplicate-Persona-Visual-starter-shared-UI-types.md
+++ b/backlog/tasks/task-401 - Deduplicate-Persona-Visual-starter-shared-UI-types.md
@@ -1,0 +1,53 @@
+---
+id: TASK-401
+title: Deduplicate Persona Visual starter shared UI types
+status: Done
+assignee: []
+created_date: '2026-05-16 02:33'
+updated_date: '2026-05-16 02:39'
+labels:
+  - persona
+  - visual-packs
+  - webui
+  - type-cleanup
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1740'
+  - 'https://github.com/rmusser01/tldw_server/pull/1743'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1740 by removing duplicate Persona Visual starter-pack shared UI type declarations while preserving exported names and existing starter catalog API behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 persona-visuals.ts declares each starter-pack request/response type once
+- [x] #2 Existing starter catalog service/component coverage continues to pass
+- [x] #3 Touched-path TypeScript or focused tests validate the cleanup
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Removed the duplicate starter-pack type declarations from apps/packages/ui/src/types/persona-visuals.ts, leaving the canonical declaration near PersonaVisualStarterPackAssetSummary/Detail. Validation: rg confirms one export each for PersonaVisualStarterPackSummary/ListResponse/CopyRequest; focused Vitest passed with 63 tests across persona-visuals service and VisualPackEditor; git diff --check passed. Package tsc still exits nonzero on existing repo-wide baseline errors; /tmp/persona_visual_starter_type_cleanup_tsc.log has no errors for apps/packages/ui/src/types/persona-visuals.ts. Bandit is not applicable because this is TypeScript-only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deduplicated the shared UI Persona Visual starter-pack request/response type declarations without changing exported names or runtime behavior. Focused Persona Visual service/editor tests pass; repo-wide TypeScript remains blocked by pre-existing unrelated baseline errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Removes duplicate `PersonaVisualStarterPackSummary`, `PersonaVisualStarterPackListResponse`, and `PersonaVisualStarterPackCopyRequest` declarations from the shared UI Persona Visual types.
- Keeps the canonical starter-pack type declarations and exported names unchanged.
- Adds Backlog tracking for #1740.

## Verification
- `rg -n "export interface PersonaVisualStarterPack(Summary|ListResponse|CopyRequest)" apps/packages/ui/src/types/persona-visuals.ts`
- `bunx vitest run src/services/__tests__/persona-visuals.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --testTimeout=30000`
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false` exits nonzero on existing repo-wide baseline errors; `/tmp/persona_visual_starter_type_cleanup_tsc.log` has no errors for `apps/packages/ui/src/types/persona-visuals.ts`.

## Change summary
Pending human-authored change summary before merge.

Closes #1740
Refs #1510

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate `PersonaVisualStarterPackSummary`, `PersonaVisualStarterPackListResponse`, and `PersonaVisualStarterPackCopyRequest` in `apps/packages/ui/src/types/persona-visuals.ts`, keeping canonical exports unchanged; also added a backlog task entry. No runtime changes; existing starter catalog tests pass, closing #1740.

<sup>Written for commit 82ddbe23b7e606890280e5a69eca260002580565. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1743?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

