### PR TITLE
Add Persona Visual starter production metadata

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -242,6 +242,28 @@ the same explicit activation rule as user-created packs. The legacy
 `research-buddy-starter` id remains accepted as a compatibility alias for the
 research buddy scaffold, but it is not listed as a tenth catalog item.
 
+Starter catalog responses include production-readiness metadata so clients,
+review surfaces, and future generation workers can distinguish current
+scaffolds from final authored default assets:
+
+1. `complexity_tier` is one of `basic`, `intermediate`, or `intricate`.
+2. `production_status` is currently `scaffold` for all bundled starters.
+3. `neutral_anchor_required` is true when the final authored pack should begin
+   from a neutral identity anchor.
+4. `expected_asset_groups` lists the authored inputs expected before a scaffold
+   becomes production artwork, such as `identity_brief`, `neutral_anchor`,
+   `static_talking_reaction_sheet`, `animation_strips`, or
+   `animation_atlas`.
+5. `animation_coverage_notes` are bounded notes for reviewers and future
+   generation jobs. They describe the missing neutral-anchor-derived animation
+   work and do not grant runtime support by themselves.
+
+The neutral-anchor pipeline remains: identity brief, neutral anchor, optional
+static talking/reaction sheet, animation strips or atlas regions, review, then
+copy/import into an inactive draft with separate activation. The production
+metadata is catalog guidance for that pipeline; it does not create final art,
+run image generation, activate a pack, or change renderer support.
+
 Copying a bundled starter pack creates a normal user-owned draft pack attached
 to the selected target persona. The copy path validates the fixture manifest and
 assets, writes new asset files through the existing Persona Visual storage

--- a/backlog/tasks/task-401 - Add-Persona-Visual-starter-production-readiness-metadata.md
+++ b/backlog/tasks/task-401 - Add-Persona-Visual-starter-production-readiness-metadata.md
@@ -1,0 +1,55 @@
+---
+id: TASK-401
+title: Add Persona Visual starter production-readiness metadata
+status: In Progress
+assignee: []
+created_date: '2026-05-16 02:34'
+updated_date: '2026-05-16 02:38'
+labels:
+  - persona
+  - visual-packs
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1741'
+documentation:
+  - Docs/Code_Documentation/Persona_Visual_Packs.md
+  - >-
+    Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose bounded production-readiness metadata for the nine Persona Visual starter scaffolds so clients and future asset-generation workers can distinguish scaffold fixtures from final authored default buddy assets. Keep copy-to-draft and explicit activation semantics unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Starter catalog list/detail responses expose production/readiness metadata for each starter
+- [x] #2 The nine starters report scaffold status and tier-specific neutral-anchor/animation requirements
+- [x] #3 Focused backend/API tests cover the new fields and copy behavior remains unchanged
+- [x] #4 Persona Visual docs explain production metadata and the neutral-pose-to-animation pipeline boundary
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented production-readiness metadata for Persona Visual starter catalog summaries/details: complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. Added fixture validation for tier/status/neutral-anchor consistency while preserving existing copy-to-draft behavior. Verification: focused pytest 28 passed; py_compile exit 0; git diff --check exit 0; Bandit JSON results empty at /tmp/bandit_persona_visual_starter_production_1741.json.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added production-readiness metadata to bundled Persona Visual starter catalog responses and docs so the nine starter entries remain clearly labeled as scaffolds pending neutral-anchor-driven authored assets. Kept copy-to-draft/no-auto-activation behavior unchanged and covered the new contract with focused service/API tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-401 - Add-Persona-Visual-starter-production-readiness-metadata.md
+++ b/backlog/tasks/task-401 - Add-Persona-Visual-starter-production-readiness-metadata.md
@@ -4,7 +4,7 @@ title: Add Persona Visual starter production-readiness metadata
 status: In Progress
 assignee: []
 created_date: '2026-05-16 02:34'
-updated_date: '2026-05-16 02:38'
+updated_date: '2026-05-16 03:18'
 labels:
   - persona
   - visual-packs
@@ -35,7 +35,7 @@ Expose bounded production-readiness metadata for the nine Persona Visual starter
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented production-readiness metadata for Persona Visual starter catalog summaries/details: complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. Added fixture validation for tier/status/neutral-anchor consistency while preserving existing copy-to-draft behavior. Verification: focused pytest 28 passed; py_compile exit 0; git diff --check exit 0; Bandit JSON results empty at /tmp/bandit_persona_visual_starter_production_1741.json.
+Implemented production-readiness metadata for Persona Visual starter catalog summaries/details: complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. Added fixture validation for tier/status/neutral-anchor consistency while preserving existing copy-to-draft behavior. PR review follow-up: added canonical metadata validation for complexity_tier/production_status, explicit immutable tuple validation for expected_asset_groups/animation_coverage_notes, direct immutable tuple dataclass defaults, and regression coverage for malformed production metadata. Verification: focused pytest 36 passed; py_compile exit 0; git diff --check exit 0; Bandit JSON results empty at /tmp/bandit_persona_visual_starter_production_1741_review.json.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-401 - Add-Persona-Visual-starter-production-readiness-metadata.md
+++ b/backlog/tasks/task-401 - Add-Persona-Visual-starter-production-readiness-metadata.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-401
 title: Add Persona Visual starter production-readiness metadata
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-16 02:34'
-updated_date: '2026-05-16 03:18'
+updated_date: '2026-05-16 04:36'
 labels:
   - persona
   - visual-packs
@@ -35,7 +35,7 @@ Expose bounded production-readiness metadata for the nine Persona Visual starter
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented production-readiness metadata for Persona Visual starter catalog summaries/details: complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. Added fixture validation for tier/status/neutral-anchor consistency while preserving existing copy-to-draft behavior. PR review follow-up: added canonical metadata validation for complexity_tier/production_status, explicit immutable tuple validation for expected_asset_groups/animation_coverage_notes, direct immutable tuple dataclass defaults, and regression coverage for malformed production metadata. Verification: focused pytest 36 passed; py_compile exit 0; git diff --check exit 0; Bandit JSON results empty at /tmp/bandit_persona_visual_starter_production_1741_review.json.
+Implemented production-readiness metadata for Persona Visual starter catalog summaries/details: complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. Added fixture validation for tier/status/neutral-anchor consistency while preserving existing copy-to-draft behavior. PR review follow-up: added canonical metadata validation for complexity_tier/production_status, explicit immutable tuple validation for expected_asset_groups/animation_coverage_notes, strict boolean validation for neutral_anchor_required, direct immutable tuple dataclass defaults, and regression coverage for malformed production metadata. Verification: focused pytest 38 passed; py_compile exit 0; git diff --check exit 0; Bandit JSON results empty at /tmp/bandit_persona_visual_starter_production_1741_review2.json.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-403 - Add-Persona-Visual-starter-production-readiness-metadata.md
+++ b/backlog/tasks/task-403 - Add-Persona-Visual-starter-production-readiness-metadata.md
@@ -1,10 +1,10 @@
 ---
-id: TASK-401
+id: TASK-403
 title: Add Persona Visual starter production-readiness metadata
 status: Done
 assignee: []
 created_date: '2026-05-16 02:34'
-updated_date: '2026-05-16 04:36'
+updated_date: '2026-05-16 04:58'
 labels:
   - persona
   - visual-packs
@@ -35,7 +35,7 @@ Expose bounded production-readiness metadata for the nine Persona Visual starter
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented production-readiness metadata for Persona Visual starter catalog summaries/details: complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. Added fixture validation for tier/status/neutral-anchor consistency while preserving existing copy-to-draft behavior. PR review follow-up: added canonical metadata validation for complexity_tier/production_status, explicit immutable tuple validation for expected_asset_groups/animation_coverage_notes, strict boolean validation for neutral_anchor_required, direct immutable tuple dataclass defaults, and regression coverage for malformed production metadata. Verification: focused pytest 38 passed; py_compile exit 0; git diff --check exit 0; Bandit JSON results empty at /tmp/bandit_persona_visual_starter_production_1741_review2.json.
+Implemented production-readiness metadata for Persona Visual starter catalog summaries/details: complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. Added fixture validation for tier/status/neutral-anchor consistency while preserving existing copy-to-draft behavior. PR review follow-up: added canonical metadata validation for complexity_tier/production_status, explicit immutable tuple validation for expected_asset_groups/animation_coverage_notes, strict boolean validation for neutral_anchor_required, direct immutable tuple dataclass defaults, and regression coverage for malformed production metadata. Post-rebase tracker fix: renumbered this task from TASK-401 to TASK-403 to avoid colliding with the merged #1740 task. Verification: focused Persona Visual pytest 85 passed; py_compile exit 0; git diff --check exit 0; git diff --check origin/dev...HEAD exit 0; Bandit JSON written to /tmp/bandit_persona_visual_starter_production_1741_rebase.json with exit 0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -29,6 +29,8 @@ PersonaSetupTestType = Literal["dry_run", "live_session"]
 PersonaVisualPackStatus = Literal["draft", "review", "active", "archived", "failed"]
 PersonaVisualRendererType = Literal["sprite_frames", "sprite_sheet", "static_image", "live2d"]
 PersonaVisualAssetRole = Literal["frame", "still_pose", "sprite_sheet", "preview", "generated_candidate"]
+PersonaVisualStarterComplexityTier = Literal["basic", "intermediate", "intricate"]
+PersonaVisualStarterProductionStatus = Literal["scaffold", "art_ready"]
 PersonaVisualCandidateStatus = Literal["review", "accepted", "rejected", "failed"]
 PersonaVisualCandidateReviewStatus = Literal["accepted", "rejected", "failed"]
 PersonaVisualPortabilityOperation = Literal["export", "import_preview", "import_commit"]
@@ -301,6 +303,11 @@ class PersonaVisualStarterPackResponse(BaseModel):
     total_bytes: int = 0
     tags: list[str] = Field(default_factory=list)
     license_label: str = "bundled"
+    complexity_tier: PersonaVisualStarterComplexityTier = "basic"
+    production_status: PersonaVisualStarterProductionStatus = "scaffold"
+    neutral_anchor_required: bool = True
+    expected_asset_groups: list[str] = Field(default_factory=list)
+    animation_coverage_notes: list[str] = Field(default_factory=list)
 
 
 class PersonaVisualStarterPackDetailResponse(PersonaVisualStarterPackResponse):

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -310,6 +310,11 @@ class PersonaVisualStarterCatalogService:
             field_name="animation_coverage_notes",
             starter_id=starter.id,
         )
+        neutral_anchor_required = PersonaVisualStarterCatalogService._starter_metadata_bool(
+            starter.neutral_anchor_required,
+            field_name="neutral_anchor_required",
+            starter_id=starter.id,
+        )
         return {
             "id": starter.id,
             "title": starter.title,
@@ -323,7 +328,7 @@ class PersonaVisualStarterCatalogService:
             "license_label": starter.license_label,
             "complexity_tier": complexity_tier,
             "production_status": production_status,
-            "neutral_anchor_required": bool(starter.neutral_anchor_required),
+            "neutral_anchor_required": neutral_anchor_required,
             "expected_asset_groups": list(expected_asset_groups),
             "animation_coverage_notes": list(animation_coverage_notes),
         }
@@ -389,8 +394,13 @@ class PersonaVisualStarterCatalogService:
             field_name="expected_asset_groups",
             starter_id=starter.id,
         )
+        neutral_anchor_required = PersonaVisualStarterCatalogService._starter_metadata_bool(
+            starter.neutral_anchor_required,
+            field_name="neutral_anchor_required",
+            starter_id=starter.id,
+        )
         if (
-            starter.neutral_anchor_required
+            neutral_anchor_required
             and "neutral_anchor" not in expected_asset_groups
         ):
             raise PersonaVisualStarterCatalogError(
@@ -485,6 +495,17 @@ class PersonaVisualStarterCatalogService:
                 details={"starter_pack_id": starter_id, "field_name": field_name},
             )
         return normalized
+
+    @staticmethod
+    def _starter_metadata_bool(value: object, *, field_name: str, starter_id: str) -> bool:
+        """Return one starter metadata boolean or fail fixture validation."""
+        if not isinstance(value, bool):
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter metadata boolean must be a boolean.",
+                details={"starter_pack_id": starter_id, "field_name": field_name},
+            )
+        return value
 
     @staticmethod
     def _starter_metadata_tuple(

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -290,6 +290,26 @@ class PersonaVisualStarterCatalogService:
     @staticmethod
     def _starter_summary(starter: PersonaVisualStarterPack) -> dict[str, Any]:
         states = starter.manifest.get("states") if isinstance(starter.manifest, dict) else {}
+        complexity_tier = PersonaVisualStarterCatalogService._starter_metadata_text(
+            starter.complexity_tier,
+            field_name="complexity_tier",
+            starter_id=starter.id,
+        )
+        production_status = PersonaVisualStarterCatalogService._starter_metadata_text(
+            starter.production_status,
+            field_name="production_status",
+            starter_id=starter.id,
+        )
+        expected_asset_groups = PersonaVisualStarterCatalogService._starter_metadata_tuple(
+            starter.expected_asset_groups,
+            field_name="expected_asset_groups",
+            starter_id=starter.id,
+        )
+        animation_coverage_notes = PersonaVisualStarterCatalogService._starter_metadata_tuple(
+            starter.animation_coverage_notes,
+            field_name="animation_coverage_notes",
+            starter_id=starter.id,
+        )
         return {
             "id": starter.id,
             "title": starter.title,
@@ -301,11 +321,11 @@ class PersonaVisualStarterCatalogService:
             "total_bytes": sum(len(asset.content) for asset in starter.assets),
             "tags": list(starter.tags),
             "license_label": starter.license_label,
-            "complexity_tier": starter.complexity_tier,
-            "production_status": starter.production_status,
+            "complexity_tier": complexity_tier,
+            "production_status": production_status,
             "neutral_anchor_required": bool(starter.neutral_anchor_required),
-            "expected_asset_groups": list(starter.expected_asset_groups),
-            "animation_coverage_notes": list(starter.animation_coverage_notes),
+            "expected_asset_groups": list(expected_asset_groups),
+            "animation_coverage_notes": list(animation_coverage_notes),
         }
 
     @staticmethod
@@ -336,7 +356,11 @@ class PersonaVisualStarterCatalogService:
                 },
             )
 
-        complexity_tier = str(starter.complexity_tier or "").strip()
+        complexity_tier = PersonaVisualStarterCatalogService._starter_metadata_text(
+            starter.complexity_tier,
+            field_name="complexity_tier",
+            starter_id=starter.id,
+        )
         if complexity_tier not in _ALLOWED_STARTER_COMPLEXITY_TIERS:
             raise PersonaVisualStarterCatalogError(
                 "invalid_starter_fixture",
@@ -346,7 +370,11 @@ class PersonaVisualStarterCatalogService:
                     "complexity_tier": complexity_tier,
                 },
             )
-        production_status = str(starter.production_status or "").strip()
+        production_status = PersonaVisualStarterCatalogService._starter_metadata_text(
+            starter.production_status,
+            field_name="production_status",
+            starter_id=starter.id,
+        )
         if production_status not in _ALLOWED_STARTER_PRODUCTION_STATUSES:
             raise PersonaVisualStarterCatalogError(
                 "invalid_starter_fixture",
@@ -356,15 +384,26 @@ class PersonaVisualStarterCatalogService:
                     "production_status": production_status,
                 },
             )
-        if starter.neutral_anchor_required and "neutral_anchor" not in set(
-            starter.expected_asset_groups
+        expected_asset_groups = PersonaVisualStarterCatalogService._starter_metadata_tuple(
+            starter.expected_asset_groups,
+            field_name="expected_asset_groups",
+            starter_id=starter.id,
+        )
+        if (
+            starter.neutral_anchor_required
+            and "neutral_anchor" not in expected_asset_groups
         ):
             raise PersonaVisualStarterCatalogError(
                 "invalid_starter_fixture",
                 "Bundled starter neutral-anchor metadata is inconsistent.",
                 details={"starter_pack_id": starter.id},
             )
-        if not starter.animation_coverage_notes:
+        animation_coverage_notes = PersonaVisualStarterCatalogService._starter_metadata_tuple(
+            starter.animation_coverage_notes,
+            field_name="animation_coverage_notes",
+            starter_id=starter.id,
+        )
+        if not animation_coverage_notes:
             raise PersonaVisualStarterCatalogError(
                 "invalid_starter_fixture",
                 "Bundled starter animation coverage notes are required.",
@@ -428,6 +467,56 @@ class PersonaVisualStarterCatalogService:
                 str(exc),
                 details={"starter_pack_id": starter.id},
             ) from exc
+
+    @staticmethod
+    def _starter_metadata_text(value: object, *, field_name: str, starter_id: str) -> str:
+        """Return one canonical starter metadata string or fail fixture validation."""
+        if not isinstance(value, str):
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter metadata text must be a canonical non-empty string.",
+                details={"starter_pack_id": starter_id, "field_name": field_name},
+            )
+        normalized = value.strip()
+        if not normalized or normalized != value:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter metadata text must be a canonical non-empty string.",
+                details={"starter_pack_id": starter_id, "field_name": field_name},
+            )
+        return normalized
+
+    @staticmethod
+    def _starter_metadata_tuple(
+        value: object,
+        *,
+        field_name: str,
+        starter_id: str,
+    ) -> tuple[str, ...]:
+        """Return canonical immutable starter metadata entries or fail validation."""
+        if not isinstance(value, tuple):
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter metadata lists must be immutable tuples.",
+                details={"starter_pack_id": starter_id, "field_name": field_name},
+            )
+        items: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_fixture",
+                    "Bundled starter metadata entries must be canonical non-empty strings.",
+                    details={"starter_pack_id": starter_id, "field_name": field_name},
+                )
+            normalized = item.strip()
+            if not normalized or normalized != item:
+                raise PersonaVisualStarterCatalogError(
+                    "invalid_starter_fixture",
+                    "Bundled starter metadata entries must be canonical non-empty strings.",
+                    details={"starter_pack_id": starter_id, "field_name": field_name},
+                )
+            items.append(normalized)
+        return tuple(items)
 
     def _cleanup_partial_pack(
         self,

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -50,6 +50,8 @@ _ALLOWED_STARTER_RESPONSE_ASSET_ROLES = frozenset(
         "generated_candidate",
     }
 )
+_ALLOWED_STARTER_COMPLEXITY_TIERS = frozenset({"basic", "intermediate", "intricate"})
+_ALLOWED_STARTER_PRODUCTION_STATUSES = frozenset({"scaffold", "art_ready"})
 
 
 class PersonaVisualStarterCatalogError(Exception):
@@ -299,6 +301,11 @@ class PersonaVisualStarterCatalogService:
             "total_bytes": sum(len(asset.content) for asset in starter.assets),
             "tags": list(starter.tags),
             "license_label": starter.license_label,
+            "complexity_tier": starter.complexity_tier,
+            "production_status": starter.production_status,
+            "neutral_anchor_required": bool(starter.neutral_anchor_required),
+            "expected_asset_groups": list(starter.expected_asset_groups),
+            "animation_coverage_notes": list(starter.animation_coverage_notes),
         }
 
     @staticmethod
@@ -327,6 +334,41 @@ class PersonaVisualStarterCatalogService:
                     "renderer_type": renderer_type,
                     "manifest_renderer_type": manifest_renderer_type,
                 },
+            )
+
+        complexity_tier = str(starter.complexity_tier or "").strip()
+        if complexity_tier not in _ALLOWED_STARTER_COMPLEXITY_TIERS:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter complexity_tier is not supported.",
+                details={
+                    "starter_pack_id": starter.id,
+                    "complexity_tier": complexity_tier,
+                },
+            )
+        production_status = str(starter.production_status or "").strip()
+        if production_status not in _ALLOWED_STARTER_PRODUCTION_STATUSES:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production_status is not supported.",
+                details={
+                    "starter_pack_id": starter.id,
+                    "production_status": production_status,
+                },
+            )
+        if starter.neutral_anchor_required and "neutral_anchor" not in set(
+            starter.expected_asset_groups
+        ):
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter neutral-anchor metadata is inconsistent.",
+                details={"starter_pack_id": starter.id},
+            )
+        if not starter.animation_coverage_notes:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter animation coverage notes are required.",
+                details={"starter_pack_id": starter.id},
             )
 
         asset_keys: set[str] = set()

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -93,12 +93,8 @@ class PersonaVisualStarterPack:
     complexity_tier: str = "basic"
     production_status: str = "scaffold"
     neutral_anchor_required: bool = True
-    expected_asset_groups: tuple[str, ...] = field(
-        default_factory=lambda: _BASIC_EXPECTED_ASSET_GROUPS
-    )
-    animation_coverage_notes: tuple[str, ...] = field(
-        default_factory=lambda: _BASIC_ANIMATION_NOTES
-    )
+    expected_asset_groups: tuple[str, ...] = _BASIC_EXPECTED_ASSET_GROUPS
+    animation_coverage_notes: tuple[str, ...] = _BASIC_ANIMATION_NOTES
 
 
 def _png_chunk(kind: bytes, payload: bytes) -> bytes:

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -31,6 +31,40 @@ DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS: tuple[str, ...] = (
 )
 
 _REQUIRED_STATE_IDS = ("idle", "listening", "thinking", "speaking", "error")
+_BASIC_EXPECTED_ASSET_GROUPS = (
+    "identity_brief",
+    "neutral_anchor",
+    "preview_image",
+    "required_state_loops",
+)
+_INTERMEDIATE_EXPECTED_ASSET_GROUPS = (
+    "identity_brief",
+    "neutral_anchor",
+    "static_talking_reaction_sheet",
+    "required_state_loops",
+    "custom_state_variants",
+)
+_INTRICATE_EXPECTED_ASSET_GROUPS = (
+    "identity_brief",
+    "neutral_anchor",
+    "model_sheet",
+    "static_talking_reaction_sheet",
+    "animation_strips",
+    "animation_atlas",
+    "custom_state_variants",
+)
+_BASIC_ANIMATION_NOTES = (
+    "Scaffold fixture only: final basic art should replace the tiny PNG with "
+    "neutral-anchor-derived required-state loops.",
+)
+_INTERMEDIATE_ANIMATION_NOTES = (
+    "Scaffold fixture only: final intermediate art should add a neutral model "
+    "sheet, talking/reaction sheet, and short custom-state loops.",
+)
+_INTRICATE_ANIMATION_NOTES = (
+    "Scaffold fixture only: final intricate art should compile reviewed "
+    "neutral-anchor-derived strips or atlas regions into runtime animations.",
+)
 
 
 @dataclass(frozen=True)
@@ -56,6 +90,15 @@ class PersonaVisualStarterPack:
     assets: tuple[PersonaVisualStarterAsset, ...]
     tags: tuple[str, ...] = field(default_factory=tuple)
     license_label: str = "bundled"
+    complexity_tier: str = "basic"
+    production_status: str = "scaffold"
+    neutral_anchor_required: bool = True
+    expected_asset_groups: tuple[str, ...] = field(
+        default_factory=lambda: _BASIC_EXPECTED_ASSET_GROUPS
+    )
+    animation_coverage_notes: tuple[str, ...] = field(
+        default_factory=lambda: _BASIC_ANIMATION_NOTES
+    )
 
 
 def _png_chunk(kind: bytes, payload: bytes) -> bytes:
@@ -244,6 +287,11 @@ def _basic_pack(
         manifest=_sprite_manifest(base_asset_key=asset.asset_key),
         assets=(asset,),
         tags=("starter", "sprite_frames", "catalog:scaffold", "tier:basic", *tags),
+        complexity_tier="basic",
+        production_status="scaffold",
+        neutral_anchor_required=True,
+        expected_asset_groups=_BASIC_EXPECTED_ASSET_GROUPS,
+        animation_coverage_notes=_BASIC_ANIMATION_NOTES,
     )
 
 
@@ -254,6 +302,7 @@ def _multi_asset_pack(
     description: str,
     palette: tuple[tuple[int, int, int, int], ...],
     tags: tuple[str, ...],
+    complexity_tier: str = "intermediate",
     custom_states: dict[str, dict[str, Any]] | None = None,
     authored_triggers: list[dict[str, Any]] | None = None,
     fallbacks: dict[str, list[str]] | None = None,
@@ -298,6 +347,19 @@ def _multi_asset_pack(
         ),
         assets=assets,
         tags=("starter", "sprite_frames", "catalog:scaffold", *tags),
+        complexity_tier=complexity_tier,
+        production_status="scaffold",
+        neutral_anchor_required=True,
+        expected_asset_groups=(
+            _INTRICATE_EXPECTED_ASSET_GROUPS
+            if complexity_tier == "intricate"
+            else _INTERMEDIATE_EXPECTED_ASSET_GROUPS
+        ),
+        animation_coverage_notes=(
+            _INTRICATE_ANIMATION_NOTES
+            if complexity_tier == "intricate"
+            else _INTERMEDIATE_ANIMATION_NOTES
+        ),
     )
 
 
@@ -329,6 +391,11 @@ def _atlas_pack(
             "atlas",
             *tags,
         ),
+        complexity_tier="intricate",
+        production_status="scaffold",
+        neutral_anchor_required=True,
+        expected_asset_groups=_INTRICATE_EXPECTED_ASSET_GROUPS,
+        animation_coverage_notes=_INTRICATE_ANIMATION_NOTES,
     )
 
 
@@ -450,6 +517,7 @@ DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
             (232, 132, 92, 255),
         ),
         tags=("tier:intricate", "action", "reaction"),
+        complexity_tier="intricate",
         custom_states={
             "reaction.anticipation": {
                 "label": "Anticipation",
@@ -481,6 +549,7 @@ DEFAULT_PERSONA_VISUAL_STARTER_PACKS: tuple[PersonaVisualStarterPack, ...] = (
             (148, 124, 192, 255),
         ),
         tags=("tier:intricate", "fantasy", "sci-fi"),
+        complexity_tier="intricate",
         custom_states={
             "mood.focused": {
                 "label": "Focused mood",

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -167,6 +167,8 @@ def test_starter_pack_reports_production_readiness_metadata(
         ("animation_coverage_notes", None),
         ("animation_coverage_notes", "Scaffold fixture only."),
         ("animation_coverage_notes", ("Scaffold fixture only.", "")),
+        ("neutral_anchor_required", "false"),
+        ("neutral_anchor_required", 1),
     ),
 )
 def test_list_starter_packs_rejects_malformed_production_metadata(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from dataclasses import replace
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,7 @@ from tldw_Server_API.app.core.Persona.visual_starter_catalog import (
 from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
     DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
     DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS,
+    DEFAULT_PERSONA_VISUAL_STARTER_PACKS,
     LEGACY_PERSONA_VISUAL_STARTER_PACK_ID,
     PersonaVisualStarterAsset,
     PersonaVisualStarterPack,
@@ -152,6 +154,37 @@ def test_starter_pack_reports_production_readiness_metadata(
     assert detail["neutral_anchor_required"] is True
     assert required_group in detail["expected_asset_groups"]
     assert all("scaffold" in note.lower() for note in detail["animation_coverage_notes"])
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    (
+        ("complexity_tier", "basic "),
+        ("production_status", " scaffold"),
+        ("expected_asset_groups", None),
+        ("expected_asset_groups", "neutral_anchor"),
+        ("expected_asset_groups", ("neutral_anchor", "")),
+        ("animation_coverage_notes", None),
+        ("animation_coverage_notes", "Scaffold fixture only."),
+        ("animation_coverage_notes", ("Scaffold fixture only.", "")),
+    ),
+)
+def test_list_starter_packs_rejects_malformed_production_metadata(
+    db_instance: CharactersRAGDB,
+    field_name: str,
+    value: Any,
+) -> None:
+    malformed = replace(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0],
+        **{field_name: value},
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.list_starter_packs()
+
+    assert exc_info.value.code == "invalid_starter_fixture"
+    assert exc_info.value.details["starter_pack_id"] == malformed.id
 
 
 def test_get_starter_pack_accepts_legacy_research_buddy_alias(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -104,6 +104,15 @@ def test_starter_catalog_lists_bundled_scaffold_packs(
     assert all("scaffold" in starter["description"].lower() for starter in starters)
     assert any("tier:intricate" in starter["tags"] for starter in starters)
     assert any("tool.notes_search" in starter["states_offered"] for starter in starters)
+    assert {starter["production_status"] for starter in starters} == {"scaffold"}
+    assert {starter["complexity_tier"] for starter in starters} == {
+        "basic",
+        "intermediate",
+        "intricate",
+    }
+    assert all(starter["neutral_anchor_required"] for starter in starters)
+    assert all("neutral_anchor" in starter["expected_asset_groups"] for starter in starters)
+    assert all(starter["animation_coverage_notes"] for starter in starters)
 
 
 def test_get_starter_pack_returns_isolated_manifest_preview(
@@ -112,10 +121,37 @@ def test_get_starter_pack_returns_isolated_manifest_preview(
     service = PersonaVisualStarterCatalogService(db_instance)
     first = service.get_starter_pack(DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID)
     first["manifest"]["states"]["idle"]["animation_id"] = "mutated"
+    first["expected_asset_groups"].append("mutated")
 
     second = service.get_starter_pack(DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID)
 
     assert second["manifest"]["states"]["idle"]["animation_id"] == "idle-loop"
+    assert "mutated" not in second["expected_asset_groups"]
+
+
+@pytest.mark.parametrize(
+    ("starter_pack_id", "complexity_tier", "required_group"),
+    (
+        ("research-buddy-basic", "basic", "required_state_loops"),
+        ("study-desk-intermediate", "intermediate", "static_talking_reaction_sheet"),
+        ("lofi-study-intricate", "intricate", "animation_atlas"),
+    ),
+)
+def test_starter_pack_reports_production_readiness_metadata(
+    db_instance: CharactersRAGDB,
+    starter_pack_id: str,
+    complexity_tier: str,
+    required_group: str,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    detail = service.get_starter_pack(starter_pack_id)
+
+    assert detail["production_status"] == "scaffold"
+    assert detail["complexity_tier"] == complexity_tier
+    assert detail["neutral_anchor_required"] is True
+    assert required_group in detail["expected_asset_groups"]
+    assert all("scaffold" in note.lower() for note in detail["animation_coverage_notes"])
 
 
 def test_get_starter_pack_accepts_legacy_research_buddy_alias(

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -197,6 +197,11 @@ def test_get_persona_visual_starter_pack_detail(persona_db: CharactersRAGDB) -> 
     assert payload["manifest"]["renderer_type"] == "sprite_frames"
     assert "catalog:scaffold" in payload["tags"]
     assert "scaffold" in payload["description"].lower()
+    assert payload["production_status"] == "scaffold"
+    assert payload["complexity_tier"] == "basic"
+    assert payload["neutral_anchor_required"] is True
+    assert "neutral_anchor" in payload["expected_asset_groups"]
+    assert payload["animation_coverage_notes"]
     assert payload["assets"][0]["mime_type"] == "image/png"
 
 
@@ -370,6 +375,10 @@ def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
     assert starter["asset_count"] == 1
     assert "catalog:scaffold" in starter["tags"]
     assert "scaffold" in starter["description"].lower()
+    assert starter["production_status"] == "scaffold"
+    assert starter["complexity_tier"] == "basic"
+    assert starter["neutral_anchor_required"] is True
+    assert "neutral_anchor" in starter["expected_asset_groups"]
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
         set(starter["states_offered"])
     )


### PR DESCRIPTION
## Summary
- Adds production-readiness metadata to Persona Visual starter catalog summaries/details: complexity tier, scaffold status, neutral-anchor requirement, expected asset groups, and animation coverage notes.
- Bounds the new starter metadata in fixture validation and Pydantic response schemas while preserving copy-to-draft/no-auto-activation behavior.
- Updates Persona Visual docs and TASK-401 so the nine bundled defaults are clearly scaffolds pending neutral-anchor-derived authored assets.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_get_persona_visual_starter_pack_detail tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_list_persona_visual_starter_packs tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_copy_visual_starter_pack_creates_draft_without_activation -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/api/v1/schemas/persona.py`
- [x] `git diff --check`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_visual_starter_production_1741.json`

## Change summary
Human-authored change summary required before merge.

Closes #1741.
Updates #1510.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production-readiness metadata to Persona Visual starter catalog responses and enforces stricter fixture validation so clients can tell scaffolds from finished assets. Copy-to-draft and activation behavior are unchanged and align with #1741.

- **New Features**
  - Exposes `complexity_tier`, `production_status`, `neutral_anchor_required`, `expected_asset_groups`, and `animation_coverage_notes` in list/detail.
  - Tightens validation: allowed tiers/status only; canonical strings; strict boolean checks; immutable tuple fixture metadata; requires `neutral_anchor` when `neutral_anchor_required` is true; requires animation notes; responses return isolated lists.
  - Updates tiered fixtures (basic/intermediate/intricate) and docs to clarify the neutral-anchor-to-animation pipeline; all nine defaults remain `scaffold`. Adds tests for the new fields and malformed metadata (including anchor consistency); copy-to-draft remains without auto-activation.

<sup>Written for commit a41931870e65e3b7f750f5ff1fb5907453d6670d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1744?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

