### PR TITLE
Add Knowledge QA source health and evidence controls

### DIFF
--- a/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
@@ -1,0 +1,1305 @@
+# Knowledge Source Health Evidence Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add read-only pre-query source health, clearer evidence controls, answer trust summaries, and recovery copy to `/knowledge` without turning it into a source CRUD/import hub or adding durable evidence persistence.
+
+**Architecture:** Add a focused backend source-health contract that is separate from existing per-search `metadata.source_status`. Surface that contract through the existing tldw API client and KnowledgeQA provider, then render compact health summaries in the existing context/source controls and compact trust summaries in existing answer/evidence surfaces. Reuse current `SourceCard`, `AnswerPanel`, `EvidenceRail`, and recovery components instead of introducing a new panel or persistence model.
+
+**Tech Stack:** FastAPI, Pydantic, existing RAG retrieval/source registry, React, TypeScript, shared `@tldw/ui` KnowledgeQA components, Vitest, Playwright, pytest, Bandit.
+
+---
+
+## Source Spec
+
+Implement from: `Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md`
+
+Hard boundaries:
+
+- `/knowledge` remains QA-only.
+- Do not add inline source creation/import/edit/delete controls to `/knowledge`.
+- Do not add server-backed saved evidence, shared evidence sets, or cross-device saved views.
+- Do not rename or replace existing post-query `metadata.source_status` semantics.
+- Evidence actions must reuse existing handoffs. `Save to note` appears only if the existing note handoff preserves source backlinks without new evidence persistence.
+
+## File Structure
+
+Backend:
+
+- Create: `tldw_Server_API/app/core/RAG/rag_service/source_health.py`
+  - Owns canonical source-health construction and keeps it separate from search-response `source_status`.
+- Modify: `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py`
+  - Adds Pydantic response models and literal status types.
+- Modify: `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`
+  - Adds `GET /api/v1/rag/source-health` with search-like auth, but no query ledger usage.
+- Test: `tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py`
+  - Pure helper/schema contract tests.
+- Test: `tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`
+  - FastAPI endpoint shape/auth/sanitization tests.
+- Regression Test: `tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py`
+  - Add one assertion that source-health work does not alter canonical source id normalization.
+- Regression Test: existing tests around `_build_source_status`, if available, or add a focused assertion in `tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline.py`
+  - Protects existing post-query `metadata.source_status` values: `searched`, `empty`, `unavailable`.
+
+Frontend service/types:
+
+- Modify: `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
+  - Adds `ragSourceHealth()` to the domain client.
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+  - Adds the legacy/direct `ragSourceHealth()` method if this generated-style client still carries direct method mirrors.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/types.ts`
+  - Adds `KnowledgeSourceHealth`, `KnowledgeSourceHealthState`, and provider state/action fields distinct from `KnowledgeSourceStatus`.
+- Create: `apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts`
+  - Normalizes backend health payloads, builds aggregate summaries, labels statuses, and guards unknown/partial responses.
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts`
+  - Covers normalization, summary, compatibility with existing post-query status, and label copy.
+- Test: `apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts`
+  - Verifies client path and method.
+
+Frontend UI:
+
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx`
+  - Loads pre-query source health after server readiness, stores non-blocking load state, exposes retry action.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx`
+  - Passes source-health state into `CompactToolbar`, `KnowledgeContextBar`, `KnowledgeReadyState`, and recovery components as needed.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx`
+  - Renders aggregate health summary and per-source status chips.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx`
+  - Renders compact health summary for simple/mobile contexts.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx`
+  - Uses source-health copy for first-run/empty source readiness without adding inline import controls.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx`
+  - Adds compact answer trust summary from selected sources, citations, web fallback, model/provider, source-health caveats, and existing search details.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx`
+  - Audit existing copy/open/workspace actions; relabel `Copy text` to `Copy excerpt` only where evidence context benefits, avoiding duplicate actions.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/evidence/EvidenceRail.tsx`
+  - Adds compact action affordance or hint without adding a separate evidence persistence surface.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx`
+  - Uses pre-query source health plus existing post-query diagnostics without confusing their labels.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx`
+  - Adds health-aware copy when selected sources are stale/unavailable/unknown.
+
+Frontend tests:
+
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx`
+
+Extension and browser coverage:
+
+- Test: `apps/tldw-frontend/__tests__/extension/knowledge-route-parity.test.ts`
+- Test: `apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts` only if imports/lazy boundaries change.
+- Optional browser smoke: `apps/tldw-frontend/e2e/workflows/knowledge-qa.spec.ts` with local server when viable.
+
+Docs/backlog:
+
+- Modify: `Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md` only if implementation discovers a design mismatch.
+- Modify: Backlog task for implementation, to be created before code changes.
+
+## Task 1: Backend Source Health Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/RAG/rag_service/source_health.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`
+- Test: `tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py`
+- Test: `tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`
+- Test: `tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py`
+
+- [ ] **Step 1: Create the implementation Backlog task**
+
+Use Backlog before code edits:
+
+```bash
+backlog task create "Implement /knowledge source health and evidence controls" \
+  --status "In Progress" \
+  --priority high \
+  --labels "webui,knowledge,ux,feature" \
+  --doc "Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md" \
+  --doc "Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md" \
+  --ac "GET /api/v1/rag/source-health returns safe pre-query health for canonical Knowledge QA sources without altering search-response metadata.source_status." \
+  --ac "Knowledge QA shows source health before search and keeps search usable when health loading fails." \
+  --ac "Knowledge QA answer and evidence surfaces show compact trust/evidence controls without adding durable evidence persistence." \
+  --ac "Focused backend, frontend, extension parity, diff-check, and Bandit verification are recorded."
+```
+
+Expected: a new task id is created. Record it in commit/PR notes.
+
+- [ ] **Step 2: Write failing source-health unit tests**
+
+Create `tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py`:
+
+```python
+import pytest
+
+from tldw_Server_API.app.core.RAG.rag_service.source_health import (
+    CANONICAL_KNOWLEDGE_SOURCE_IDS,
+    build_source_health_entries,
+)
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_source_health_returns_all_canonical_knowledge_sources() -> None:
+    response = build_source_health_entries(configured_sources=set())
+
+    assert [entry.source_id for entry in response] == list(CANONICAL_KNOWLEDGE_SOURCE_IDS)
+
+
+def test_source_health_marks_configured_sources_searchable() -> None:
+    response = build_source_health_entries(
+        configured_sources={DataSource.MEDIA_DB, DataSource.NOTES}
+    )
+    by_source = {entry.source_id: entry for entry in response}
+
+    assert by_source["media_db"].available is True
+    assert by_source["media_db"].searchable is True
+    assert by_source["media_db"].index_status == "ready"
+    assert by_source["media_db"].embedding_status in {"unknown", "not_applicable", "ready"}
+    assert by_source["notes"].available is True
+    assert by_source["prompts"].available is False
+    assert by_source["prompts"].disabled_reason == "no_retriever_configured"
+
+
+def test_source_health_does_not_expose_content_or_arbitrary_metadata() -> None:
+    response = build_source_health_entries(
+        configured_sources={DataSource.MEDIA_DB},
+        unsafe_metadata={"media_db": {"title": "Secret title", "content": "secret"}},
+    )
+    payload = [entry.model_dump() for entry in response]
+
+    assert "Secret title" not in repr(payload)
+    assert "secret" not in repr(payload)
+```
+
+Expected: FAIL because `source_health.py` does not exist yet.
+
+- [ ] **Step 3: Run the failing unit test**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
+```
+
+Expected: FAIL with import/module error.
+
+- [ ] **Step 4: Add Pydantic source-health response models**
+
+Modify `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py` near the existing RAG response models:
+
+```python
+KnowledgeSourceIndexStatus = Literal[
+    "ready",
+    "indexing",
+    "stale",
+    "empty",
+    "unavailable",
+    "error",
+    "unknown",
+]
+KnowledgeSourceEmbeddingStatus = Literal[
+    "ready",
+    "indexing",
+    "missing",
+    "unavailable",
+    "not_applicable",
+    "error",
+    "unknown",
+]
+
+
+class KnowledgeSourceHealthEntry(BaseModel):
+    source_id: str
+    label: str
+    available: bool
+    searchable: bool
+    item_count: Optional[int] = None
+    indexed_count: Optional[int] = None
+    last_updated: Optional[str] = None
+    last_indexed: Optional[str] = None
+    index_status: KnowledgeSourceIndexStatus = "unknown"
+    embedding_status: KnowledgeSourceEmbeddingStatus = "unknown"
+    disabled_reason: Optional[str] = None
+    workspace_scoped: bool = False
+    hidden_by_default: bool = False
+    privacy_note: Optional[str] = None
+
+
+class KnowledgeSourceHealthResponse(BaseModel):
+    sources: list[KnowledgeSourceHealthEntry]
+```
+
+Keep this model separate from search response metadata and do not change `UnifiedRAGResponse`.
+
+- [ ] **Step 5: Implement the source-health helper**
+
+Create `tldw_Server_API/app/core/RAG/rag_service/source_health.py`:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Mapping, Set as AbstractSet
+from typing import Any
+
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
+    KnowledgeSourceHealthEntry,
+)
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+
+CANONICAL_KNOWLEDGE_SOURCE_IDS: tuple[str, ...] = (
+    "media_db",
+    "notes",
+    "chats",
+    "characters",
+    "kanban",
+    "prompts",
+    "world_books",
+    "dictionaries",
+)
+
+_SOURCE_LABELS: dict[str, str] = {
+    "media_db": "Documents & Media",
+    "notes": "Notes",
+    "chats": "Chats",
+    "characters": "Characters",
+    "kanban": "Task Boards",
+    "prompts": "Prompts",
+    "world_books": "World Books",
+    "dictionaries": "Dictionaries",
+}
+
+_SOURCE_TO_DATASOURCE: dict[str, DataSource] = {
+    "media_db": DataSource.MEDIA_DB,
+    "notes": DataSource.NOTES,
+    "chats": DataSource.CHAT_HISTORY,
+    "characters": DataSource.CHARACTER_CARDS,
+    "kanban": DataSource.KANBAN,
+    "prompts": DataSource.PROMPTS,
+    "world_books": DataSource.WORLD_BOOKS,
+    "dictionaries": DataSource.DICTIONARIES,
+}
+
+
+def build_source_health_entries(
+    *,
+    configured_sources: AbstractSet[DataSource],
+    unsafe_metadata: Mapping[str, Mapping[str, Any]] | None = None,
+) -> list[KnowledgeSourceHealthEntry]:
+    """Build safe pre-query source readiness entries for Knowledge QA."""
+    del unsafe_metadata  # Explicitly ignored to prevent accidental metadata leaks.
+    entries: list[KnowledgeSourceHealthEntry] = []
+    for source_id in CANONICAL_KNOWLEDGE_SOURCE_IDS:
+        data_source = _SOURCE_TO_DATASOURCE[source_id]
+        configured = data_source in configured_sources
+        entries.append(
+            KnowledgeSourceHealthEntry(
+                source_id=source_id,
+                label=_SOURCE_LABELS[source_id],
+                available=configured,
+                searchable=configured,
+                index_status="ready" if configured else "unavailable",
+                embedding_status="unknown" if configured else "unavailable",
+                disabled_reason=None if configured else "no_retriever_configured",
+            )
+        )
+    return entries
+```
+
+V1 intentionally leaves counts/timestamps null unless cheap, safe source-specific counts are added later.
+
+- [ ] **Step 6: Run source-health unit tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Write failing endpoint test**
+
+Create `tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`:
+
+```python
+import pytest
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.main import app
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def authorized_client():
+    async def _fake_get_auth_principal(_request: Request) -> AuthPrincipal:  # type: ignore[override]
+        return AuthPrincipal(
+            kind="service",
+            user_id="0",
+            api_key_id=None,
+            subject="service:rag-source-health-test",
+            token_type="access",
+            jti=None,
+            roles=["user"],
+            permissions=["media.read"],
+            is_admin=False,
+            org_ids=[],
+            team_ids=[],
+        )
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(auth_deps.get_auth_principal, None)
+
+
+def test_rag_source_health_returns_safe_canonical_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import rag_unified
+    from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+
+    class _FakeRetriever:
+        retrievers = {DataSource.MEDIA_DB: object(), DataSource.NOTES: object()}
+
+    monkeypatch.setattr(rag_unified, "MultiDatabaseRetriever", lambda *_, **__: _FakeRetriever())
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/rag/source-health")
+
+    assert response.status_code in (200, 401, 403)
+    if response.status_code == 200:
+        payload = response.json()
+        assert "sources" in payload
+        assert {entry["source_id"] for entry in payload["sources"]} >= {"media_db", "notes"}
+        assert "content" not in repr(payload).lower()
+
+
+def test_authorized_rag_source_health_returns_safe_canonical_shape(
+    authorized_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import rag_unified
+    from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+
+    class _FakeRetriever:
+        retrievers = {DataSource.MEDIA_DB: object(), DataSource.NOTES: object()}
+
+    monkeypatch.setattr(rag_unified, "MultiDatabaseRetriever", lambda *_, **__: _FakeRetriever())
+
+    response = authorized_client.get("/api/v1/rag/source-health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert {entry["source_id"] for entry in payload["sources"]} >= {"media_db", "notes"}
+    assert "content" not in repr(payload).lower()
+```
+
+Use existing auth-override patterns from `tldw_Server_API/tests/RAG_NEW/integration/test_rag_health_endpoints.py`; do not weaken endpoint permissions to make the test pass.
+
+Expected: FAIL because endpoint does not exist.
+
+- [ ] **Step 8: Add `GET /api/v1/rag/source-health` endpoint**
+
+Modify `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`:
+
+```python
+@router.get(
+    "/source-health",
+    response_model=KnowledgeSourceHealthResponse,
+    summary="Knowledge source health",
+    description="Read-only pre-query source readiness for Knowledge QA.",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(rbac_rate_limit("rag.source_health")),
+        Depends(RequirePermission(MEDIA_READ)),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="rag.source_health", count_as="call")),
+    ],
+)
+async def source_health_endpoint(
+    current_user: User = Depends(get_request_user),
+    media_db: Any = Depends(get_media_db_for_user),
+    chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
+) -> KnowledgeSourceHealthResponse:
+    db_paths: dict[str, str] = {}
+    if media_db is not None and getattr(media_db, "db_path", None):
+        db_paths["media_db"] = str(media_db.db_path)
+    if chacha_db is not None and getattr(chacha_db, "db_path", None):
+        chacha_path = str(chacha_db.db_path)
+        db_paths["notes_db"] = chacha_path
+        db_paths["character_cards_db"] = chacha_path
+        db_paths["world_books_db"] = chacha_path
+        db_paths["chat_dictionaries_db"] = chacha_path
+    if prompts_db is not None and getattr(prompts_db, "db_path_str", None):
+        db_paths["prompts_db"] = str(prompts_db.db_path_str)
+    kanban_db_path = _resolve_kanban_db_path(current_user)
+    if kanban_db_path:
+        db_paths["kanban_db"] = str(kanban_db_path)
+
+    retriever = MultiDatabaseRetriever(
+        db_paths=db_paths,
+        user_id=str(getattr(current_user, "id", None) or "0"),
+        media_db=media_db,
+        chacha_db=chacha_db,
+        prompts_db=prompts_db,
+    )
+    return KnowledgeSourceHealthResponse(
+        sources=build_source_health_entries(
+            configured_sources=set(retriever.retrievers.keys())
+        )
+    )
+```
+
+Use the normalized `MultiDatabaseRetriever` path keys shown above. Do not pass the search endpoint's `media_db_path`, `notes_db_path`, `character_db_path`, or `prompts_db_path` keys directly into `MultiDatabaseRetriever`, because those names are pipeline argument names rather than retriever constructor keys. Adjust signatures/imports to match current constructors. Do not record RAG query usage and do not call search.
+
+- [ ] **Step 9: Add compatibility regression for post-query `metadata.source_status`**
+
+Add or extend a focused test around `_build_source_status` in `tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline.py`:
+
+```python
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import _build_source_status
+
+
+def test_search_source_status_semantics_remain_backward_compatible() -> None:
+    class _Retriever:
+        retrievers = {DataSource.MEDIA_DB: object()}
+
+    status = _build_source_status(
+        ["media_db", "prompts"],
+        retriever=_Retriever(),
+        documents=[],
+        filtered_counts={},
+    )
+
+    assert status["media_db"]["status"] == "empty"
+    assert status["prompts"]["status"] == "unavailable"
+```
+
+Expected: PASS after implementation. This protects the old search-response contract.
+
+- [ ] **Step 10: Run backend focused tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py \
+  tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py \
+  tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py \
+  tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline.py -k "source_status or source_health or source_contract"
+```
+
+Expected: PASS. If unrelated tests in `test_unified_pipeline.py` are selected accidentally, narrow the `-k` expression to the new regression.
+
+- [ ] **Step 11: Commit backend contract**
+
+```bash
+git add \
+  tldw_Server_API/app/core/RAG/rag_service/source_health.py \
+  tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py \
+  tldw_Server_API/app/api/v1/endpoints/rag_unified.py \
+  tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py \
+  tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py \
+  tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py \
+  tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline.py
+git commit -m "feat: add knowledge source health contract"
+```
+
+## Task 2: Frontend Source Health Client And Normalization
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/types.ts`
+- Create: `apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts`
+- Test: `apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts`
+
+- [ ] **Step 1: Write failing client path test**
+
+Create `apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts` using the existing API-client test style:
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+import { chatRagMethods } from "@/services/tldw/domains/chat-rag"
+
+describe("ragSourceHealth client", () => {
+  it("requests the focused source health endpoint", async () => {
+    const request = vi.fn().mockResolvedValue({ sources: [] })
+
+    await chatRagMethods.ragSourceHealth.call({ request } as any)
+
+    expect(request).toHaveBeenCalledWith({
+      path: "/api/v1/rag/source-health",
+      method: "GET",
+    })
+  })
+})
+```
+
+Expected: FAIL because `ragSourceHealth` does not exist.
+
+- [ ] **Step 2: Write failing source health normalization tests**
+
+Create `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import {
+  buildSourceHealthSummary,
+  normalizeKnowledgeSourceHealth,
+} from "../sourceHealth"
+
+describe("Knowledge QA source health normalization", () => {
+  it("normalizes partial backend payloads without colliding with search source status", () => {
+    const normalized = normalizeKnowledgeSourceHealth({
+      sources: [
+        {
+          source_id: "media_db",
+          label: "Documents & Media",
+          available: true,
+          searchable: true,
+          index_status: "ready",
+          embedding_status: "not_applicable",
+          disabled_reason: null,
+        },
+      ],
+    })
+
+    expect(normalized.bySource.media_db?.indexStatus).toBe("ready")
+    expect(normalized.bySource.media_db?.embeddingStatus).toBe("not_applicable")
+    expect(normalized.bySource.media_db).not.toHaveProperty("status")
+  })
+
+  it("builds a compact summary", () => {
+    const normalized = normalizeKnowledgeSourceHealth({
+      sources: [
+        { source_id: "media_db", label: "Documents & Media", available: true, searchable: true, index_status: "ready", embedding_status: "unknown", disabled_reason: null },
+        { source_id: "prompts", label: "Prompts", available: false, searchable: false, index_status: "unavailable", embedding_status: "unavailable", disabled_reason: "no_retriever_configured" },
+      ],
+    })
+
+    expect(buildSourceHealthSummary(normalized)).toBe("Sources ready: 1 of 2")
+  })
+})
+```
+
+Expected: FAIL because `sourceHealth.ts` does not exist.
+
+- [ ] **Step 3: Add API client method**
+
+Modify `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`:
+
+```ts
+async ragSourceHealth(this: TldwApiClientCore): Promise<any> {
+  return await this.request<any>({
+    path: "/api/v1/rag/source-health",
+    method: "GET",
+  })
+},
+```
+
+If `apps/packages/ui/src/services/tldw/TldwApiClient.ts` still has direct method mirrors, add:
+
+```ts
+async ragSourceHealth(): Promise<any> {
+  return await this.request<any>({
+    path: "/api/v1/rag/source-health",
+    method: "GET",
+  })
+}
+```
+
+- [ ] **Step 4: Add source-health frontend types**
+
+Modify `apps/packages/ui/src/components/Option/KnowledgeQA/types.ts`:
+
+```ts
+export type KnowledgeSourceIndexStatus =
+  | "ready"
+  | "indexing"
+  | "stale"
+  | "empty"
+  | "unavailable"
+  | "error"
+  | "unknown"
+
+export type KnowledgeSourceEmbeddingStatus =
+  | "ready"
+  | "indexing"
+  | "missing"
+  | "unavailable"
+  | "not_applicable"
+  | "error"
+  | "unknown"
+
+export type KnowledgeSourceHealth = {
+  sourceId: RagSettings["sources"][number]
+  label: string
+  available: boolean
+  searchable: boolean
+  itemCount: number | null
+  indexedCount: number | null
+  lastUpdated: string | null
+  lastIndexed: string | null
+  indexStatus: KnowledgeSourceIndexStatus
+  embeddingStatus: KnowledgeSourceEmbeddingStatus
+  disabledReason: string | null
+  workspaceScoped: boolean
+  hiddenByDefault: boolean
+  privacyNote: string | null
+}
+
+export type KnowledgeSourceHealthState = {
+  bySource: Partial<Record<RagSettings["sources"][number], KnowledgeSourceHealth>>
+  sources: KnowledgeSourceHealth[]
+  loading: boolean
+  error: string | null
+  loadedAt: string | null
+}
+```
+
+Add state/action fields:
+
+```ts
+sourceHealth: KnowledgeSourceHealthState
+refreshSourceHealth: () => Promise<void>
+```
+
+Keep `KnowledgeSourceStatus` unchanged.
+
+- [ ] **Step 5: Implement normalization utilities**
+
+Create `apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts`:
+
+```ts
+import { isRagSource, getRagSourceLabel } from "@/services/rag/sourceMetadata"
+import type { KnowledgeSourceHealth, KnowledgeSourceHealthState } from "./types"
+
+export const EMPTY_SOURCE_HEALTH_STATE: KnowledgeSourceHealthState = {
+  bySource: {},
+  sources: [],
+  loading: false,
+  error: null,
+  loadedAt: null,
+}
+
+export function normalizeKnowledgeSourceHealth(payload: unknown): KnowledgeSourceHealthState {
+  const record = payload && typeof payload === "object" ? payload as Record<string, unknown> : {}
+  const rawSources = Array.isArray(record.sources) ? record.sources : []
+  const sources: KnowledgeSourceHealth[] = []
+
+  for (const raw of rawSources) {
+    const entry = raw && typeof raw === "object" ? raw as Record<string, unknown> : null
+    const sourceId = typeof entry?.source_id === "string" && isRagSource(entry.source_id)
+      ? entry.source_id
+      : null
+    if (!sourceId) continue
+    sources.push({
+      sourceId,
+      label: typeof entry?.label === "string" ? entry.label : getRagSourceLabel(sourceId),
+      available: entry?.available === true,
+      searchable: entry?.searchable === true,
+      itemCount: typeof entry?.item_count === "number" ? entry.item_count : null,
+      indexedCount: typeof entry?.indexed_count === "number" ? entry.indexed_count : null,
+      lastUpdated: typeof entry?.last_updated === "string" ? entry.last_updated : null,
+      lastIndexed: typeof entry?.last_indexed === "string" ? entry.last_indexed : null,
+      indexStatus: normalizeIndexStatus(entry?.index_status),
+      embeddingStatus: normalizeEmbeddingStatus(entry?.embedding_status),
+      disabledReason: typeof entry?.disabled_reason === "string" ? entry.disabled_reason : null,
+      workspaceScoped: entry?.workspace_scoped === true,
+      hiddenByDefault: entry?.hidden_by_default === true,
+      privacyNote: typeof entry?.privacy_note === "string" ? entry.privacy_note : null,
+    })
+  }
+
+  return {
+    bySource: Object.fromEntries(sources.map((source) => [source.sourceId, source])),
+    sources,
+    loading: false,
+    error: null,
+    loadedAt: new Date().toISOString(),
+  }
+}
+```
+
+Add small `normalizeIndexStatus`, `normalizeEmbeddingStatus`, `getSourceHealthStatusLabel`, and `buildSourceHealthSummary` helpers. Keep all copy in this helper or shared constants to avoid divergent labels.
+
+- [ ] **Step 6: Run frontend normalization/client tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+./node_modules/.bin/vitest run \
+  src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts \
+  src/services/__tests__/tldw-api-client.rag-source-health.test.ts
+```
+
+Expected: PASS. If service tests live outside `apps/packages/ui`, run the equivalent from repo root with `bunx vitest run`.
+
+- [ ] **Step 7: Commit frontend client/normalization**
+
+```bash
+git add \
+  apps/packages/ui/src/services/tldw/domains/chat-rag.ts \
+  apps/packages/ui/src/services/tldw/TldwApiClient.ts \
+  apps/packages/ui/src/components/Option/KnowledgeQA/types.ts \
+  apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts \
+  apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts
+git commit -m "feat: add knowledge source health client"
+```
+
+## Task 3: Provider State And Source Picker Health UI
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx`
+
+- [ ] **Step 1: Write failing KnowledgeContextBar health tests**
+
+Create `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { KnowledgeContextBar } from "../context/KnowledgeContextBar"
+import type { KnowledgeSourceHealthState } from "../types"
+
+const sourceHealth: KnowledgeSourceHealthState = {
+  loading: false,
+  error: null,
+  loadedAt: "2026-05-16T00:00:00Z",
+  sources: [
+    { sourceId: "media_db", label: "Documents & Media", available: true, searchable: true, itemCount: null, indexedCount: null, lastUpdated: null, lastIndexed: null, indexStatus: "ready", embeddingStatus: "not_applicable", disabledReason: null, workspaceScoped: false, hiddenByDefault: false, privacyNote: null },
+    { sourceId: "prompts", label: "Prompts", available: false, searchable: false, itemCount: null, indexedCount: null, lastUpdated: null, lastIndexed: null, indexStatus: "unavailable", embeddingStatus: "unavailable", disabledReason: "no_retriever_configured", workspaceScoped: false, hiddenByDefault: false, privacyNote: null },
+  ],
+  bySource: {},
+}
+
+it("shows aggregate source health and per-source status", () => {
+  render(<KnowledgeContextBar {...baseProps} sourceHealth={sourceHealth} onRefreshSourceHealth={vi.fn()} />)
+
+  expect(screen.getByText("Sources ready: 1 of 2")).toBeInTheDocument()
+  fireEvent.click(screen.getByRole("button", { name: /Sources:/i }))
+  expect(screen.getByText("Ready")).toBeInTheDocument()
+  expect(screen.getByText("Unavailable")).toBeInTheDocument()
+})
+```
+
+Define `baseProps` using existing test props from `KnowledgeContextBar.test.tsx`.
+
+Expected: FAIL because props/UI are missing.
+
+- [ ] **Step 2: Add provider state and refresh action**
+
+Modify `KnowledgeQAProvider.tsx`:
+
+- Add initial state:
+
+```ts
+sourceHealth: EMPTY_SOURCE_HEALTH_STATE,
+```
+
+- Add reducer actions or local state consistent with current provider patterns:
+
+```ts
+const refreshSourceHealth = useCallback(async () => {
+  dispatch({ type: "SET_SOURCE_HEALTH_LOADING" })
+  try {
+    const payload = await tldwClient.ragSourceHealth()
+    dispatch({ type: "SET_SOURCE_HEALTH", payload: normalizeKnowledgeSourceHealth(payload) })
+  } catch {
+    dispatch({ type: "SET_SOURCE_HEALTH_ERROR", payload: "Source health could not be loaded. You can still search selected sources." })
+  }
+}, [])
+```
+
+- Trigger once after server readiness/initialization succeeds. Do not block search while it loads or fails.
+
+- [ ] **Step 3: Thread source health through layout**
+
+Modify `KnowledgeQALayout.tsx` to pass:
+
+```tsx
+sourceHealth={sourceHealth}
+onRefreshSourceHealth={refreshSourceHealth}
+```
+
+to `KnowledgeContextBar`, `CompactToolbar`, `KnowledgeReadyState`, and recovery components where needed.
+
+- [ ] **Step 4: Render compact source health in context bars**
+
+Modify `KnowledgeContextBar.tsx`:
+
+- Add props:
+
+```ts
+sourceHealth?: KnowledgeSourceHealthState
+onRefreshSourceHealth?: () => void
+```
+
+- Render:
+
+```tsx
+<span className="text-[11px] text-text-muted">
+  {buildSourceHealthSummary(sourceHealth ?? EMPTY_SOURCE_HEALTH_STATE)}
+</span>
+```
+
+- In source menu rows, show one chip per selected/canonical source:
+
+```tsx
+<span className={getSourceHealthChipClass(health?.indexStatus)}>
+  {getSourceHealthStatusLabel(health)}
+</span>
+```
+
+Use existing color tokens; no new palette.
+
+Modify `CompactToolbar.tsx` with a one-line summary only. Avoid cluttering mobile toolbar.
+
+- [ ] **Step 5: Update ready/empty copy**
+
+Modify `KnowledgeReadyState.tsx` to prefer source health copy:
+
+- If all selected sources unavailable: `Selected sources are unavailable. Open source settings or choose a different scope.`
+- If health failed: `Source health could not be loaded. You can still search selected sources.`
+- If no searchable items: `No searchable items yet. Open Quick Ingest or the source owner page to add content.`
+
+Do not add inline creation controls.
+
+- [ ] **Step 6: Run source picker UI tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+./node_modules/.bin/vitest run \
+  src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit source picker UI**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+git commit -m "feat: show knowledge source health before search"
+```
+
+## Task 4: Evidence Actions And Answer Trust Summary
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/evidence/EvidenceRail.tsx`
+- Create: `apps/packages/ui/src/components/Option/KnowledgeQA/trustSummary.ts`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts`
+
+- [ ] **Step 1: Write failing trust summary helper test**
+
+Create `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { buildAnswerTrustSummary } from "../trustSummary"
+
+describe("buildAnswerTrustSummary", () => {
+  it("summarizes sources, citations, web fallback, and caveats", () => {
+    expect(
+      buildAnswerTrustSummary({
+        selectedSources: ["media_db", "notes"],
+        resultCount: 12,
+        citationCount: 5,
+        webFallbackEnabled: true,
+        webFallbackTriggered: false,
+        generationProvider: null,
+        generationModel: null,
+        sourceHealthCaveatCount: 2,
+        trustLabel: "Partial",
+      })
+    ).toEqual([
+      "Searched Documents & Media and Notes. 12 sources returned, 5 cited.",
+      "Web fallback enabled, not used.",
+      "AI model: Server default.",
+      "2 selected sources need attention.",
+      "Trust: Partial.",
+    ])
+  })
+})
+```
+
+Expected: FAIL because `trustSummary.ts` does not exist.
+
+- [ ] **Step 2: Implement trust summary helper**
+
+Create `apps/packages/ui/src/components/Option/KnowledgeQA/trustSummary.ts`:
+
+```ts
+import { getRagSourceLabel } from "@/services/rag/sourceMetadata"
+import type { RagSource } from "@/services/rag/unified-rag"
+
+export function formatSourceList(sources: RagSource[]): string {
+  const labels = sources.map(getRagSourceLabel)
+  if (labels.length <= 1) return labels[0] ?? "selected sources"
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`
+  return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`
+}
+```
+
+Add `buildAnswerTrustSummary` with deterministic copy and no viewport-specific logic.
+
+- [ ] **Step 3: Add AnswerPanel trust strip**
+
+Modify `AnswerPanel.tsx`:
+
+- Use selected `settings.sources`, `results.length`, `citations.length`, `searchDetails.webFallbackEnabled`, `searchDetails.webFallbackTriggered`, `settings.generation_provider`, `settings.generation_model`, and source-health caveats.
+- Render a compact strip near existing answer controls, not inside the markdown answer body.
+- Keep `SearchDetailsPanel` as the detailed diagnostics surface.
+
+Suggested markup:
+
+```tsx
+<div aria-label="Answer trust summary" className="rounded-md border border-border bg-surface2/60 px-3 py-2 text-xs text-text-muted">
+  {summaryLines.map((line) => <span key={line}>{line}</span>)}
+</div>
+```
+
+- [ ] **Step 4: Audit SourceCard evidence actions**
+
+Modify `SourceCard.tsx` only after reading existing action structure:
+
+- Keep existing `Copy citation`.
+- Relabel evidence-context `Copy text` to `Copy excerpt` if tests support it.
+- Do not add duplicate buttons for actions already present.
+- Do not add persistent `Pin evidence`.
+- Add `Save to note` only if the existing API contract is verified to preserve backlinks. Otherwise add a code comment in the test or plan notes that it is deferred.
+
+- [ ] **Step 5: Add EvidenceRail action affordance without a new panel**
+
+Modify `EvidenceRail.tsx`:
+
+- Add a concise hint above source list when sources exist:
+
+```tsx
+<p className="mb-2 text-xs text-text-muted">
+  Use each source card to copy citations, copy excerpts, or open supported sources.
+</p>
+```
+
+- Keep tabs and lazy details panel unchanged.
+
+- [ ] **Step 6: Update tests for evidence/trust UI**
+
+Extend:
+
+- `AnswerPanel.states.test.tsx`: assert `Answer trust summary` renders source/citation/web fallback/model copy.
+- `SourceCard.behavior.test.tsx`: assert accessible names include `Copy citation` and `Copy excerpt`, and no duplicate copy controls are added.
+- Add a small EvidenceRail test if current motion test is not enough; otherwise keep EvidenceRail change covered by layout test.
+
+- [ ] **Step 7: Run evidence/trust tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+./node_modules/.bin/vitest run \
+  src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts \
+  src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit evidence/trust UI**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/evidence/EvidenceRail.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/trustSummary.ts \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts
+git commit -m "feat: clarify knowledge evidence trust controls"
+```
+
+## Task 5: Recovery Copy And Extension Parity
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx`
+- Test: `apps/tldw-frontend/__tests__/extension/knowledge-route-parity.test.ts`
+
+- [ ] **Step 1: Write failing recovery copy tests**
+
+Extend `NoResultsRecovery.source-status.test.tsx`:
+
+```tsx
+it("distinguishes pre-query health from post-query source diagnostics", () => {
+  render(
+    <NoResultsRecovery
+      {...defaultProps}
+      sourceHealth={unavailableHealthState}
+      sourceStatus={{ media_db: { status: "empty", count: 0, reason: "no_matching_entries" } }}
+    />
+  )
+
+  expect(screen.getByText(/source readiness/i)).toBeInTheDocument()
+  expect(screen.getByText(/search diagnostics/i)).toBeInTheDocument()
+})
+```
+
+Expected: FAIL until props/UI are added.
+
+- [ ] **Step 2: Update NoResultsRecovery**
+
+Modify `NoResultsRecovery.tsx`:
+
+- Keep current `sourceStatus` section but label it `Search diagnostics`.
+- Add optional `sourceHealth` prop and render selected source readiness as `Source readiness`.
+- Use handoff copy:
+  - `Open Quick Ingest`
+  - `Open source page`
+  - no ambiguous `Add sources`
+- Keep `Show nearest matches` only if current metadata/UI already supports it.
+
+- [ ] **Step 3: Update LowQualityRecoveryBanner**
+
+Modify `LowQualityRecoveryBanner.tsx`:
+
+- Accept optional source-health caveat count or selected caveats.
+- Copy:
+
+```text
+This answer has limited evidence. Try expanding sources, checking source status, or enabling web fallback.
+```
+
+- Do not imply web fallback will be enabled automatically.
+
+- [ ] **Step 4: Run recovery tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+./node_modules/.bin/vitest run \
+  src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run extension parity/static tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run \
+  __tests__/extension/knowledge-route-parity.test.ts
+```
+
+If KnowledgeQA imports or lazy boundaries changed materially, also run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/extension/entry-shell-performance.test.ts
+```
+
+Expected: PASS or document unrelated baseline failure with exact output.
+
+- [ ] **Step 6: Commit recovery/parity work**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
+git commit -m "feat: improve knowledge recovery diagnostics"
+```
+
+## Task 6: Final Verification And PR Packaging
+
+**Files:**
+- Modify: implementation Backlog task created in Task 1.
+- Optional Modify: `Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md` only if implementation required design corrections.
+
+- [ ] **Step 1: Run backend focused verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py \
+  tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py \
+  tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend focused verification**
+
+Run:
+
+```bash
+cd apps/packages/ui
+./node_modules/.bin/vitest run \
+  src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts \
+  src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run extension parity verification**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/extension/knowledge-route-parity.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run browser smoke when local app is viable**
+
+If a frontend dev server and backend are already running:
+
+```bash
+cd apps/tldw-frontend
+TLDW_WEB_AUTOSTART=false TLDW_WEB_URL=http://localhost:3000 \
+  bunx playwright test e2e/workflows/knowledge-qa.spec.ts --grep "Knowledge QA" --reporter=line
+```
+
+If the local server is not viable, record the blocker in the Backlog task instead of fabricating browser evidence.
+
+- [ ] **Step 5: Run diff and security checks**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+Run Bandit for touched backend files:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/RAG/rag_service/source_health.py \
+  tldw_Server_API/app/api/v1/endpoints/rag_unified.py \
+  tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py \
+  -f json -o /tmp/bandit_knowledge_source_health.json
+```
+
+Expected: exit 0 with no new findings in touched code.
+
+- [ ] **Step 6: Update Backlog task**
+
+Use the implementation task id from Task 1:
+
+```bash
+backlog task edit TASK-ID \
+  --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 \
+  --check-dod 1 --check-dod 2 --check-dod 3 --check-dod 4 --check-dod 5 --check-dod 6 \
+  --append-notes "Verification: backend pytest ..., frontend Vitest ..., extension parity ..., git diff --check ..., Bandit ..." \
+  --final-summary "Implemented /knowledge source health and evidence controls. Source health is pre-query and read-only, post-query metadata.source_status remains backward compatible, evidence actions reuse existing handoffs, and /knowledge remains QA-only." \
+  --status Done
+```
+
+- [ ] **Step 7: Create or update PR**
+
+Push branch:
+
+```bash
+git push -u origin codex/knowledge-source-health-evidence-controls
+```
+
+Open PR against `dev`:
+
+```bash
+gh pr create \
+  --base dev \
+  --head codex/knowledge-source-health-evidence-controls \
+  --title "Add Knowledge QA source health and evidence controls" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add read-only pre-query source health for Knowledge QA sources.
+- Surface source readiness in /knowledge source controls.
+- Add compact answer trust summary and clearer evidence/recovery controls.
+
+## Scope
+- /knowledge remains QA-only.
+- No server-backed saved evidence or shared evidence sets.
+- Existing post-query metadata.source_status remains backward compatible.
+
+## Verification
+- [ ] Backend focused pytest
+- [ ] KnowledgeQA focused Vitest
+- [ ] Extension parity test
+- [ ] git diff --check
+- [ ] Bandit on touched backend files
+
+Change summary:
+<human-written summary required before merge>
+EOF
+)"
+```
+
+Leave the human-owned `Change summary` placeholder for the requester.

--- a/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
@@ -110,7 +110,7 @@ Docs/backlog:
 - Test: `tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`
 - Test: `tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py`
 
-- [ ] **Step 1: Create the implementation Backlog task**
+- [x] **Step 1: Create the implementation Backlog task**
 
 Use Backlog before code edits:
 
@@ -129,7 +129,7 @@ backlog task create "Implement /knowledge source health and evidence controls" \
 
 Expected: a new task id is created. Record it in commit/PR notes.
 
-- [ ] **Step 2: Write failing source-health unit tests**
+- [x] **Step 2: Write failing source-health unit tests**
 
 Create `tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py`:
 
@@ -180,7 +180,7 @@ def test_source_health_does_not_expose_content_or_arbitrary_metadata() -> None:
 
 Expected: FAIL because `source_health.py` does not exist yet.
 
-- [ ] **Step 3: Run the failing unit test**
+- [x] **Step 3: Run the failing unit test**
 
 Run:
 
@@ -191,7 +191,7 @@ python -m pytest -q tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
 
 Expected: FAIL with import/module error.
 
-- [ ] **Step 4: Add Pydantic source-health response models**
+- [x] **Step 4: Add Pydantic source-health response models**
 
 Modify `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py` near the existing RAG response models:
 
@@ -239,7 +239,7 @@ class KnowledgeSourceHealthResponse(BaseModel):
 
 Keep this model separate from search response metadata and do not change `UnifiedRAGResponse`.
 
-- [ ] **Step 5: Implement the source-health helper**
+- [x] **Step 5: Implement the source-health helper**
 
 Create `tldw_Server_API/app/core/RAG/rag_service/source_health.py`:
 
@@ -315,7 +315,7 @@ def build_source_health_entries(
 
 V1 intentionally leaves counts/timestamps null unless cheap, safe source-specific counts are added later.
 
-- [ ] **Step 6: Run source-health unit tests**
+- [x] **Step 6: Run source-health unit tests**
 
 Run:
 
@@ -326,7 +326,7 @@ python -m pytest -q tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
 
 Expected: PASS.
 
-- [ ] **Step 7: Write failing endpoint test**
+- [x] **Step 7: Write failing endpoint test**
 
 Create `tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`:
 
@@ -412,7 +412,7 @@ Use existing auth-override patterns from `tldw_Server_API/tests/RAG_NEW/integrat
 
 Expected: FAIL because endpoint does not exist.
 
-- [ ] **Step 8: Add `GET /api/v1/rag/source-health` endpoint**
+- [x] **Step 8: Add `GET /api/v1/rag/source-health` endpoint**
 
 Modify `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`:
 
@@ -444,7 +444,7 @@ async def source_health_endpoint(
 
 Do not instantiate `MultiDatabaseRetriever` or source-specific databases in the source-health endpoint. Do not use request-scoped source DB dependencies such as `get_media_db_for_user`, `get_chacha_db_for_user`, or `get_prompts_db_for_user`. Derive source availability from existing files or metadata that can be checked without creating directories, schema, indexes, vector stores, records, or request-scoped database handles. Do not record RAG query usage and do not call search.
 
-- [ ] **Step 9: Add compatibility regression for post-query `metadata.source_status`**
+- [x] **Step 9: Add compatibility regression for post-query `metadata.source_status`**
 
 Add or extend a focused test around `_build_source_status` in `tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline.py`:
 
@@ -470,7 +470,7 @@ def test_search_source_status_semantics_remain_backward_compatible() -> None:
 
 Expected: PASS after implementation. This protects the old search-response contract.
 
-- [ ] **Step 10: Run backend focused tests**
+- [x] **Step 10: Run backend focused tests**
 
 Run:
 
@@ -485,7 +485,7 @@ python -m pytest -q \
 
 Expected: PASS. If unrelated tests in `test_unified_pipeline.py` are selected accidentally, narrow the `-k` expression to the new regression.
 
-- [ ] **Step 11: Commit backend contract**
+- [x] **Step 11: Commit backend contract**
 
 ```bash
 git add \
@@ -509,7 +509,7 @@ git commit -m "feat: add knowledge source health contract"
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts`
 - Test: `apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts`
 
-- [ ] **Step 1: Write failing client path test**
+- [x] **Step 1: Write failing client path test**
 
 Create `apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts` using the existing API-client test style:
 
@@ -533,7 +533,7 @@ describe("ragSourceHealth client", () => {
 
 Expected: FAIL because `ragSourceHealth` does not exist.
 
-- [ ] **Step 2: Write failing source health normalization tests**
+- [x] **Step 2: Write failing source health normalization tests**
 
 Create `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts`:
 
@@ -580,7 +580,7 @@ describe("Knowledge QA source health normalization", () => {
 
 Expected: FAIL because `sourceHealth.ts` does not exist.
 
-- [ ] **Step 3: Add API client method**
+- [x] **Step 3: Add API client method**
 
 Modify `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`:
 
@@ -604,7 +604,7 @@ async ragSourceHealth(): Promise<any> {
 }
 ```
 
-- [ ] **Step 4: Add source-health frontend types**
+- [x] **Step 4: Add source-health frontend types**
 
 Modify `apps/packages/ui/src/components/Option/KnowledgeQA/types.ts`:
 
@@ -662,7 +662,7 @@ refreshSourceHealth: () => Promise<void>
 
 Keep `KnowledgeSourceStatus` unchanged.
 
-- [ ] **Step 5: Implement normalization utilities**
+- [x] **Step 5: Implement normalization utilities**
 
 Create `apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts`:
 
@@ -719,7 +719,7 @@ export function normalizeKnowledgeSourceHealth(payload: unknown): KnowledgeSourc
 
 Add small `normalizeIndexStatus`, `normalizeEmbeddingStatus`, `getSourceHealthStatusLabel`, and `buildSourceHealthSummary` helpers. Keep all copy in this helper or shared constants to avoid divergent labels.
 
-- [ ] **Step 6: Run frontend normalization/client tests**
+- [x] **Step 6: Run frontend normalization/client tests**
 
 Run:
 
@@ -732,7 +732,7 @@ cd apps/packages/ui
 
 Expected: PASS. If service tests live outside `apps/packages/ui`, run the equivalent from repo root with `bunx vitest run`.
 
-- [ ] **Step 7: Commit frontend client/normalization**
+- [x] **Step 7: Commit frontend client/normalization**
 
 ```bash
 git add \
@@ -1155,7 +1155,7 @@ git commit -m "feat: improve knowledge recovery diagnostics"
 - Modify: implementation Backlog task created in Task 1.
 - Optional Modify: `Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md` only if implementation required design corrections.
 
-- [ ] **Step 1: Run backend focused verification**
+- [x] **Step 1: Run backend focused verification**
 
 Run:
 
@@ -1169,7 +1169,7 @@ python -m pytest -q \
 
 Expected: PASS.
 
-- [ ] **Step 2: Run frontend focused verification**
+- [x] **Step 2: Run frontend focused verification**
 
 Run:
 
@@ -1188,7 +1188,7 @@ cd apps/packages/ui
 
 Expected: PASS.
 
-- [ ] **Step 3: Run extension parity verification**
+- [x] **Step 3: Run extension parity verification**
 
 Run:
 
@@ -1199,7 +1199,7 @@ bunx vitest run __tests__/extension/knowledge-route-parity.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 4: Run browser smoke when local app is viable**
+- [x] **Step 4: Run browser smoke when local app is viable**
 
 If a frontend dev server and backend are already running:
 
@@ -1211,7 +1211,7 @@ TLDW_WEB_AUTOSTART=false TLDW_WEB_URL=http://localhost:3000 \
 
 If the local server is not viable, record the blocker in the Backlog task instead of fabricating browser evidence.
 
-- [ ] **Step 5: Run diff and security checks**
+- [x] **Step 5: Run diff and security checks**
 
 Run:
 
@@ -1234,7 +1234,7 @@ python -m bandit -r \
 
 Expected: exit 0 with no new findings in touched code.
 
-- [ ] **Step 6: Update Backlog task**
+- [x] **Step 6: Update Backlog task**
 
 Use the implementation task id from Task 1:
 
@@ -1247,7 +1247,7 @@ backlog task edit TASK-ID \
   --status Done
 ```
 
-- [ ] **Step 7: Create or update PR**
+- [x] **Step 7: Create or update PR**
 
 Push branch:
 
@@ -1274,16 +1274,19 @@ gh pr create \
 - Existing post-query metadata.source_status remains backward compatible.
 
 ## Verification
-- [ ] Backend focused pytest
-- [ ] KnowledgeQA focused Vitest
-- [ ] Extension parity test
-- [ ] git diff --check
-- [ ] Bandit on touched backend files
+- [x] Backend focused pytest
+- [x] KnowledgeQA focused Vitest
+- [x] Extension parity test
+- [x] Browser smoke: `/knowledge` navigation/search-bar test against `localhost:18001` and backend `127.0.0.1:8000`
+- [x] git diff --check
+- [x] Bandit on touched backend files
 
 Change summary:
 <human-written summary required before merge>
 EOF
 )"
 ```
+
+Created PR: https://github.com/rmusser01/tldw_server/pull/1745
 
 Leave the human-owned `Change summary` placeholder for the requester.

--- a/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
@@ -757,7 +757,7 @@ git commit -m "feat: add knowledge source health client"
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx`
 
-- [ ] **Step 1: Write failing KnowledgeContextBar health tests**
+- [x] **Step 1: Write failing KnowledgeContextBar health tests**
 
 Create `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx`:
 
@@ -792,7 +792,7 @@ Define `baseProps` using existing test props from `KnowledgeContextBar.test.tsx`
 
 Expected: FAIL because props/UI are missing.
 
-- [ ] **Step 2: Add provider state and refresh action**
+- [x] **Step 2: Add provider state and refresh action**
 
 Modify `KnowledgeQAProvider.tsx`:
 
@@ -818,7 +818,7 @@ const refreshSourceHealth = useCallback(async () => {
 
 - Trigger once after server readiness/initialization succeeds. Do not block search while it loads or fails.
 
-- [ ] **Step 3: Thread source health through layout**
+- [x] **Step 3: Thread source health through layout**
 
 Modify `KnowledgeQALayout.tsx` to pass:
 
@@ -829,7 +829,7 @@ onRefreshSourceHealth={refreshSourceHealth}
 
 to `KnowledgeContextBar`, `CompactToolbar`, `KnowledgeReadyState`, and recovery components where needed.
 
-- [ ] **Step 4: Render compact source health in context bars**
+- [x] **Step 4: Render compact source health in context bars**
 
 Modify `KnowledgeContextBar.tsx`:
 
@@ -860,7 +860,7 @@ Use existing color tokens; no new palette.
 
 Modify `CompactToolbar.tsx` with a one-line summary only. Avoid cluttering mobile toolbar.
 
-- [ ] **Step 5: Update ready/empty copy**
+- [x] **Step 5: Update ready/empty copy**
 
 Modify `KnowledgeReadyState.tsx` to prefer source health copy:
 
@@ -870,7 +870,7 @@ Modify `KnowledgeReadyState.tsx` to prefer source health copy:
 
 Do not add inline creation controls.
 
-- [ ] **Step 6: Run source picker UI tests**
+- [x] **Step 6: Run source picker UI tests**
 
 Run:
 
@@ -884,7 +884,7 @@ cd apps/packages/ui
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit source picker UI**
+- [x] **Step 7: Commit source picker UI**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
@@ -1055,9 +1055,10 @@ git commit -m "feat: clarify knowledge evidence trust controls"
 - Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx`
 - Test: `apps/tldw-frontend/__tests__/extension/knowledge-route-parity.test.ts`
 
-- [ ] **Step 1: Write failing recovery copy tests**
+- [x] **Step 1: Write failing recovery copy tests**
 
 Extend `NoResultsRecovery.source-status.test.tsx`:
 
@@ -1078,7 +1079,7 @@ it("distinguishes pre-query health from post-query source diagnostics", () => {
 
 Expected: FAIL until props/UI are added.
 
-- [ ] **Step 2: Update NoResultsRecovery**
+- [x] **Step 2: Update NoResultsRecovery**
 
 Modify `NoResultsRecovery.tsx`:
 
@@ -1090,7 +1091,7 @@ Modify `NoResultsRecovery.tsx`:
   - no ambiguous `Add sources`
 - Keep `Show nearest matches` only if current metadata/UI already supports it.
 
-- [ ] **Step 3: Update LowQualityRecoveryBanner**
+- [x] **Step 3: Update LowQualityRecoveryBanner**
 
 Modify `LowQualityRecoveryBanner.tsx`:
 
@@ -1103,7 +1104,7 @@ This answer has limited evidence. Try expanding sources, checking source status,
 
 - Do not imply web fallback will be enabled automatically.
 
-- [ ] **Step 4: Run recovery tests**
+- [x] **Step 4: Run recovery tests**
 
 Run:
 
@@ -1117,7 +1118,7 @@ cd apps/packages/ui
 
 Expected: PASS.
 
-- [ ] **Step 5: Run extension parity/static tests**
+- [x] **Step 5: Run extension parity/static tests**
 
 Run:
 
@@ -1136,7 +1137,7 @@ bunx vitest run __tests__/extension/entry-shell-performance.test.ts
 
 Expected: PASS or document unrelated baseline failure with exact output.
 
-- [ ] **Step 6: Commit recovery/parity work**
+- [x] **Step 6: Commit recovery/parity work**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
@@ -908,10 +908,11 @@ git commit -m "feat: show knowledge source health before search"
 - Create: `apps/packages/ui/src/components/Option/KnowledgeQA/trustSummary.ts`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx`
+- Regression Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceList.behavior.test.tsx`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts`
 
-- [ ] **Step 1: Write failing trust summary helper test**
+- [x] **Step 1: Write failing trust summary helper test**
 
 Create `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts`:
 
@@ -946,7 +947,7 @@ describe("buildAnswerTrustSummary", () => {
 
 Expected: FAIL because `trustSummary.ts` does not exist.
 
-- [ ] **Step 2: Implement trust summary helper**
+- [x] **Step 2: Implement trust summary helper**
 
 Create `apps/packages/ui/src/components/Option/KnowledgeQA/trustSummary.ts`:
 
@@ -964,7 +965,7 @@ export function formatSourceList(sources: RagSource[]): string {
 
 Add `buildAnswerTrustSummary` with deterministic copy and no viewport-specific logic.
 
-- [ ] **Step 3: Add AnswerPanel trust strip**
+- [x] **Step 3: Add AnswerPanel trust strip**
 
 Modify `AnswerPanel.tsx`:
 
@@ -980,7 +981,7 @@ Suggested markup:
 </div>
 ```
 
-- [ ] **Step 4: Audit SourceCard evidence actions**
+- [x] **Step 4: Audit SourceCard evidence actions**
 
 Modify `SourceCard.tsx` only after reading existing action structure:
 
@@ -990,7 +991,9 @@ Modify `SourceCard.tsx` only after reading existing action structure:
 - Do not add persistent `Pin evidence`.
 - Add `Save to note` only if the existing API contract is verified to preserve backlinks. Otherwise add a code comment in the test or plan notes that it is deferred.
 
-- [ ] **Step 5: Add EvidenceRail action affordance without a new panel**
+Implementation note: `Save to note` is deferred in this slice because a backlink-preserving note handoff contract was not verified.
+
+- [x] **Step 5: Add EvidenceRail action affordance without a new panel**
 
 Modify `EvidenceRail.tsx`:
 
@@ -1004,7 +1007,7 @@ Modify `EvidenceRail.tsx`:
 
 - Keep tabs and lazy details panel unchanged.
 
-- [ ] **Step 6: Update tests for evidence/trust UI**
+- [x] **Step 6: Update tests for evidence/trust UI**
 
 Extend:
 
@@ -1012,7 +1015,7 @@ Extend:
 - `SourceCard.behavior.test.tsx`: assert accessible names include `Copy citation` and `Copy excerpt`, and no duplicate copy controls are added.
 - Add a small EvidenceRail test if current motion test is not enough; otherwise keep EvidenceRail change covered by layout test.
 
-- [ ] **Step 7: Run evidence/trust tests**
+- [x] **Step 7: Run evidence/trust tests**
 
 Run:
 
@@ -1022,12 +1025,13 @@ cd apps/packages/ui
   src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts \
   src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx \
   src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx \
+  src/components/Option/KnowledgeQA/__tests__/SourceList.behavior.test.tsx \
   src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit evidence/trust UI**
+- [x] **Step 8: Commit evidence/trust UI**
 
 ```bash
 git add \
@@ -1038,6 +1042,7 @@ git add \
   apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts \
   apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx \
   apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceList.behavior.test.tsx \
   apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts
 git commit -m "feat: clarify knowledge evidence trust controls"
 ```

--- a/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
@@ -31,7 +31,7 @@ Backend:
 - Modify: `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py`
   - Adds Pydantic response models and literal status types.
 - Modify: `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`
-  - Adds `GET /api/v1/rag/source-health` with search-like auth, but no query ledger usage.
+  - Adds `GET /api/v1/rag/source-health` with search-like auth, but no query ledger usage or retriever/database creation.
 - Test: `tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py`
   - Pure helper/schema contract tests.
 - Test: `tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`
@@ -370,12 +370,12 @@ def authorized_client():
 
 def test_rag_source_health_returns_safe_canonical_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.api.v1.endpoints import rag_unified
-    from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
-
-    class _FakeRetriever:
-        retrievers = {DataSource.MEDIA_DB: object(), DataSource.NOTES: object()}
-
-    monkeypatch.setattr(rag_unified, "MultiDatabaseRetriever", lambda *_, **__: _FakeRetriever())
+    monkeypatch.setattr(
+        rag_unified,
+        "MultiDatabaseRetriever",
+        lambda *_, **__: pytest.fail("source health must not instantiate retrievers"),
+    )
+    monkeypatch.setattr(rag_unified, "_resolve_existing_kanban_db_path", lambda *_: None)
 
     with TestClient(app) as client:
         response = client.get("/api/v1/rag/source-health")
@@ -393,12 +393,12 @@ def test_authorized_rag_source_health_returns_safe_canonical_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tldw_Server_API.app.api.v1.endpoints import rag_unified
-    from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
-
-    class _FakeRetriever:
-        retrievers = {DataSource.MEDIA_DB: object(), DataSource.NOTES: object()}
-
-    monkeypatch.setattr(rag_unified, "MultiDatabaseRetriever", lambda *_, **__: _FakeRetriever())
+    monkeypatch.setattr(
+        rag_unified,
+        "MultiDatabaseRetriever",
+        lambda *_, **__: pytest.fail("source health must not instantiate retrievers"),
+    )
+    monkeypatch.setattr(rag_unified, "_resolve_existing_kanban_db_path", lambda *_: None)
 
     response = authorized_client.get("/api/v1/rag/source-health")
 
@@ -424,9 +424,9 @@ Modify `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`:
     description="Read-only pre-query source readiness for Knowledge QA.",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(rbac_rate_limit("rag.source_health")),
+        Depends(rbac_rate_limit("rag.search")),
         Depends(RequirePermission(MEDIA_READ)),
-        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="rag.source_health", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="rag.search", count_as="call")),
     ],
 )
 async def source_health_endpoint(
@@ -435,36 +435,20 @@ async def source_health_endpoint(
     chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
 ) -> KnowledgeSourceHealthResponse:
-    db_paths: dict[str, str] = {}
-    if media_db is not None and getattr(media_db, "db_path", None):
-        db_paths["media_db"] = str(media_db.db_path)
-    if chacha_db is not None and getattr(chacha_db, "db_path", None):
-        chacha_path = str(chacha_db.db_path)
-        db_paths["notes_db"] = chacha_path
-        db_paths["character_cards_db"] = chacha_path
-        db_paths["world_books_db"] = chacha_path
-        db_paths["chat_dictionaries_db"] = chacha_path
-    if prompts_db is not None and getattr(prompts_db, "db_path_str", None):
-        db_paths["prompts_db"] = str(prompts_db.db_path_str)
-    kanban_db_path = _resolve_kanban_db_path(current_user)
-    if kanban_db_path:
-        db_paths["kanban_db"] = str(kanban_db_path)
-
-    retriever = MultiDatabaseRetriever(
-        db_paths=db_paths,
-        user_id=str(getattr(current_user, "id", None) or "0"),
+    configured_sources = _build_source_health_configured_sources(
         media_db=media_db,
         chacha_db=chacha_db,
         prompts_db=prompts_db,
+        kanban_db_path=_resolve_existing_kanban_db_path(current_user),
     )
     return KnowledgeSourceHealthResponse(
         sources=build_source_health_entries(
-            configured_sources=set(retriever.retrievers.keys())
+            configured_sources=configured_sources
         )
     )
 ```
 
-Use the normalized `MultiDatabaseRetriever` path keys shown above. Do not pass the search endpoint's `media_db_path`, `notes_db_path`, `character_db_path`, or `prompts_db_path` keys directly into `MultiDatabaseRetriever`, because those names are pipeline argument names rather than retriever constructor keys. Adjust signatures/imports to match current constructors. Do not record RAG query usage and do not call search.
+Do not instantiate `MultiDatabaseRetriever` or source-specific databases in the source-health endpoint. Derive source availability from already-resolved request dependencies and existing files that can be checked without creating directories, schema, indexes, vector stores, or records. Do not record RAG query usage and do not call search.
 
 - [ ] **Step 9: Add compatibility regression for post-query `metadata.source_status`**
 

--- a/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
@@ -375,7 +375,7 @@ def test_rag_source_health_returns_safe_canonical_shape(monkeypatch: pytest.Monk
         "MultiDatabaseRetriever",
         lambda *_, **__: pytest.fail("source health must not instantiate retrievers"),
     )
-    monkeypatch.setattr(rag_unified, "_resolve_existing_kanban_db_path", lambda *_: None)
+    monkeypatch.setattr(rag_unified, "_resolve_existing_source_db_paths", lambda *_: {})
 
     with TestClient(app) as client:
         response = client.get("/api/v1/rag/source-health")
@@ -398,7 +398,7 @@ def test_authorized_rag_source_health_returns_safe_canonical_shape(
         "MultiDatabaseRetriever",
         lambda *_, **__: pytest.fail("source health must not instantiate retrievers"),
     )
-    monkeypatch.setattr(rag_unified, "_resolve_existing_kanban_db_path", lambda *_: None)
+    monkeypatch.setattr(rag_unified, "_resolve_existing_source_db_paths", lambda *_: {})
 
     response = authorized_client.get("/api/v1/rag/source-health")
 
@@ -431,15 +431,9 @@ Modify `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`:
 )
 async def source_health_endpoint(
     current_user: User = Depends(get_request_user),
-    media_db: Any = Depends(get_media_db_for_user),
-    chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
-    prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
 ) -> KnowledgeSourceHealthResponse:
     configured_sources = _build_source_health_configured_sources(
-        media_db=media_db,
-        chacha_db=chacha_db,
-        prompts_db=prompts_db,
-        kanban_db_path=_resolve_existing_kanban_db_path(current_user),
+        existing_paths=_resolve_existing_source_db_paths(current_user),
     )
     return KnowledgeSourceHealthResponse(
         sources=build_source_health_entries(
@@ -448,7 +442,7 @@ async def source_health_endpoint(
     )
 ```
 
-Do not instantiate `MultiDatabaseRetriever` or source-specific databases in the source-health endpoint. Derive source availability from already-resolved request dependencies and existing files that can be checked without creating directories, schema, indexes, vector stores, or records. Do not record RAG query usage and do not call search.
+Do not instantiate `MultiDatabaseRetriever` or source-specific databases in the source-health endpoint. Do not use request-scoped source DB dependencies such as `get_media_db_for_user`, `get_chacha_db_for_user`, or `get_prompts_db_for_user`. Derive source availability from existing files or metadata that can be checked without creating directories, schema, indexes, vector stores, records, or request-scoped database handles. Do not record RAG query usage and do not call search.
 
 - [ ] **Step 9: Add compatibility regression for post-query `metadata.source_status`**
 

--- a/Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
+++ b/Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
@@ -106,7 +106,7 @@ Rules:
 - `embedding_status` reflects vector readiness only where embeddings are part of the searchable path. Use `not_applicable` for sources or configurations that are intentionally FTS-only or non-vector.
 - Generated/test/workspace artifacts stay hidden by default unless explicit workspace scope is present.
 - The contract must pass through normal auth, ownership, workspace, and visibility checks. Imported IDs or saved profiles are not access grants.
-- The contract must not instantiate search retrievers or source databases just to compute health. Source availability should come from already-resolved request dependencies or existing files/metadata that can be checked without creating directories, schema, indexes, vector stores, or records.
+- The contract must not instantiate search retrievers or source databases just to compute health. Source availability should come from existing files or metadata that can be checked without creating directories, schema, indexes, vector stores, records, or request-scoped database handles.
 
 V1 minimum:
 

--- a/Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
+++ b/Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
@@ -1,0 +1,380 @@
+# Knowledge Source Health And Evidence Controls Design
+
+Date: 2026-05-16
+Status: Review-hardened draft for user review
+Owner: Codex brainstorming session
+Backlog: TASK-297.7
+
+## Summary
+
+Improve `/knowledge` as a QA-only surface by making source readiness visible before a query and making answer evidence easier to trust and reuse after a query. This slice is intentionally conservative: it adds read-only source health, clearer evidence controls, answer-level trust summaries, and recovery copy. It does not add server-backed saved evidence, shared evidence sets, new source CRUD, or a new knowledge management hub.
+
+The design keeps `/knowledge` focused on asking grounded questions over existing knowledge surfaces. Creation, import, editing, and full management stay in owner surfaces such as Quick Ingest, Media, Notes, Chats, Characters, Task Boards, Prompts, World Books, Dictionaries, and Workspaces.
+
+## Current Evidence
+
+The current active route is the shared Knowledge QA UI. `apps/tldw-frontend/pages/knowledge.tsx` delegates to `@/routes/option-knowledge`, and the shared implementation lives under `apps/packages/ui/src/components/Option/KnowledgeQA`.
+
+Relevant current surfaces:
+
+- `KnowledgeContextBar` controls presets, source categories, specific media/note selection, local profiles, web fallback, model/provider selection, and specific-source filters.
+- `SourceList` and `SourceCard` already support source filtering, source viewing, copy text, copy citation, citation jumping, feedback, and workspace navigation for supported source types.
+- `EvidenceRail` already exposes `Sources` and `Details` tabs and counts retrieved sources/citations.
+- `AnswerPanel` already renders inline citation buttons, copy-answer, confidence/recovery cues, and Continue in editor handoff.
+- `SearchDetailsPanel` already exposes retrieval details such as reranking, average relevance, web fallback status, candidate counts, coverage, latency, and verification metrics.
+- `NoResultsRecovery` already surfaces post-query source diagnostics when `metadata.source_status` is present.
+- Existing post-query source diagnostics use `KnowledgeSourceStatus` with statuses such as `searched`, `empty`, and `unavailable`. The new source health model must not replace or rename this search-response metadata.
+
+The gap is not the absence of evidence primitives. The gap is that readiness and trust are mostly reactive or scattered. Users still need a compact, pre-query answer to: what am I searching, is it indexed, what is unavailable, why was this answer grounded this way, and what can I do with the evidence now?
+
+## Goals
+
+- Show source health before the user runs a query.
+- Preserve `/knowledge` as QA-only and avoid new CRUD/import management responsibilities.
+- Make health metadata safe, read-only, and non-leaky.
+- Make evidence reuse obvious through existing low-risk actions: copy citation, copy excerpt/text, open source, continue in workspace, and save to note only if an existing service contract is available.
+- Explain answer trust in plain language: searched sources, results, citations, web fallback use, model/provider, and degraded source states.
+- Improve recovery from empty, stale, unavailable, or low-evidence states.
+- Keep WebUI and extension behavior aligned through shared components and parity tests.
+
+## Non-Goals
+
+- Do not add server-backed saved evidence or shared evidence sets.
+- Do not add new team/profile sharing APIs.
+- Do not make `/knowledge` the canonical place to create, import, edit, delete, or organize source records.
+- Do not auto-enable web fallback.
+- Do not expose generated, test, or workspace artifacts in normal source selection without explicit workspace scope.
+- Do not redesign unrelated pages or perform repo-wide frontend cleanup.
+- Do not store source excerpts, answers, query history, or citations in a new persistence model for this slice.
+
+## Product Decisions
+
+- `/knowledge` remains a QA workspace, not a knowledge CRUD hub.
+- Source health is read-only. It may include counts and status, but not content excerpts or arbitrary source metadata.
+- Evidence actions reuse existing capabilities. If a save-to-note API is already available, `/knowledge` may call it as a handoff action; otherwise the action should be hidden or disabled with clear copy.
+- Web fallback remains user-toggleable and follows the configured server default provider.
+- Health indicators must be useful in compact WebUI, mobile, and extension contexts.
+- Handoff labels must name the destination. Use `Open Quick Ingest` or `Open source page`, not ambiguous `Add sources` copy that implies inline creation inside `/knowledge`.
+- Implementation must map existing registry/source ids to this display taxonomy without renaming existing API values unless those ids are already part of the shared RAG contract.
+- Keep pre-query source health and post-query source diagnostics as separate concepts. Pre-query health answers "is this source ready to search?" Post-query `metadata.source_status` answers "what happened during this search?"
+
+## Approach
+
+Use an inline health and evidence polish approach rather than a dedicated new drawer or answer-only report.
+
+Why:
+
+- It improves the two highest-value moments: source selection before search and evidence review after search.
+- It fits existing component boundaries: `KnowledgeContextBar`, `SourceList`, `SourceCard`, `EvidenceRail`, `AnswerPanel`, and `SearchDetailsPanel`.
+- It avoids a large new panel that users must discover.
+- It keeps implementation PR-sized while leaving clean extension points for later server-backed evidence persistence.
+
+## Source Health Contract
+
+Add a safe source health model exposed through a read-only RAG source-health contract. Prefer a focused endpoint such as `GET /api/v1/rag/source-health` rather than overloading liveness/readiness endpoints like `/api/v1/rag/health`. If implementation finds an existing source-status endpoint by implementation time, it may reuse that endpoint only if the response remains read-only, stable for WebUI/extension clients, and clearly separate from per-search `metadata.source_status`.
+
+Recommended shape:
+
+```ts
+type KnowledgeSourceHealth = {
+  source_id: RagSource
+  label: string
+  available: boolean
+  searchable: boolean
+  item_count: number | null
+  indexed_count: number | null
+  last_updated: string | null
+  last_indexed: string | null
+  index_status: "ready" | "indexing" | "stale" | "empty" | "unavailable" | "error" | "unknown"
+  embedding_status: "ready" | "indexing" | "missing" | "unavailable" | "not_applicable" | "error" | "unknown"
+  disabled_reason: string | null
+  workspace_scoped: boolean
+  hidden_by_default: boolean
+  privacy_note: string | null
+}
+```
+
+Rules:
+
+- Use canonical source ids: `media_db`, `notes`, `chats`, `characters`, `kanban`, `prompts`, `world_books`, `dictionaries`.
+- Keep compatibility with existing frontend/backend aliases. If implementation code still receives aliases such as task boards, character cards, or worldbooks, normalize them at the existing source-contract boundary rather than introducing a second id system.
+- Return all canonical sources even when a source is empty or unavailable, so the UI can explain absence.
+- Counts may be `null` when a source cannot produce a cheap count safely.
+- `indexed_count` means searchable/indexed items for that source, not necessarily total records.
+- `last_updated` and `last_indexed` must be coarse source-level timestamps, not per-record private metadata.
+- `privacy_note` is short copy for trust-sensitive sources, such as web fallback or workspace-scoped data.
+- `embedding_status` reflects vector readiness only where embeddings are part of the searchable path. Use `not_applicable` for sources or configurations that are intentionally FTS-only or non-vector.
+- Generated/test/workspace artifacts stay hidden by default unless explicit workspace scope is present.
+- The contract must pass through normal auth, ownership, workspace, and visibility checks. Imported IDs or saved profiles are not access grants.
+
+V1 minimum:
+
+- Required for every source: `source_id`, `label`, `available`, `searchable`, `index_status`, `embedding_status`, and `disabled_reason`.
+- Optional in V1: `item_count`, `indexed_count`, `last_updated`, `last_indexed`, `workspace_scoped`, `hidden_by_default`, and `privacy_note`.
+- Counts and timestamps may be `null` until each source can compute them cheaply and safely.
+- `stale` should only be emitted when changed-since-index or source-specific freshness metadata already exists. Otherwise use `unknown` instead of guessing.
+
+Fallback behavior:
+
+- If health cannot be loaded, `/knowledge` remains usable and displays `Source health unavailable` with a retry action.
+- Health load failure must not block query submission when source selection is otherwise valid.
+- Partial health data should render per-source unknown states instead of hiding the source.
+
+## Source Picker UI
+
+Add compact health summaries to the existing source category and specific-source flows.
+
+Placement:
+
+- In `KnowledgeContextBar`, add a small health summary near the source selector: for example `6 ready, 1 stale, 1 unavailable`.
+- In source category selection, each source row shows one compact status chip plus a count when available.
+- In the specific media/note picker, keep the existing status filters but align labels with the new source health taxonomy.
+- On mobile and extension-sized layouts, show a single summary line and put detailed status in the source picker popover.
+
+Status labels:
+
+- `Ready`: searchable now.
+- `Indexing`: recently added or currently processing.
+- `Stale`: content changed since last index or health is older than the freshness threshold.
+- `Empty`: source exists but has no searchable items.
+- `Unavailable`: source cannot be searched in the current server/account state.
+- `Workspace only`: hidden globally because it belongs to an explicit workspace scope.
+- `Unknown`: health could not be determined.
+
+Suggested copy:
+
+- Summary: `Sources ready: 6 of 8`
+- Stale: `Stale index. Results may miss recent changes.`
+- Empty: `No searchable items yet. Open Quick Ingest or the source owner page to add content.`
+- Unavailable: `This source is not available in the current server configuration.`
+- Workspace only: `Hidden until a workspace scope is selected.`
+- Health failure: `Source health could not be loaded. You can still search selected sources.`
+
+## Evidence Actions
+
+Consolidate and clarify existing source/evidence actions rather than creating a new persistence model.
+
+Implementation should audit current `SourceCard` actions before adding controls. Prefer relabeling, grouping, or exposing existing actions more clearly over adding duplicate copy/open buttons.
+
+Actions:
+
+- `Copy citation`: copy a formatted citation for the source or citation index.
+- `Copy excerpt`: copy the retrieved excerpt/chunk text. If current UI uses `Copy text`, prefer `Copy excerpt` in evidence contexts.
+- `Open source`: open the source viewer or owner surface when resolvable.
+- `Continue in workspace`: reuse the existing workspace handoff for source-supported contexts.
+- `Save to note`: optional only if an existing note handoff already preserves source backlinks without creating a new evidence persistence model. If that is not already true, defer it.
+
+Interaction model:
+
+- Keep primary evidence actions inside `SourceCard`; do not move them into a detached global toolbar.
+- In `EvidenceRail`, add a compact action hint or per-card action row so users see evidence can be copied/opened without expanding every card.
+- Do not add `Pin evidence` in this slice unless it is purely in-memory for the current page session and clearly labeled as temporary. Prefer omitting pinning to avoid implying persistence.
+
+Accessibility:
+
+- Every icon action must have an accessible name and visible text in compact menus or tooltips.
+- Copy actions must announce success/failure through existing message/toast patterns.
+- Keyboard users must reach action controls in citation/source order without losing their place.
+- Focus returns to the invoking button after source viewer or menu close.
+
+## Answer Trust Summary
+
+Add a compact answer-level trust summary above or near the existing answer controls. This summary should reuse existing `searchDetails` where possible and add missing fields from the source health/search metadata only when needed.
+
+Recommended fields:
+
+- Source categories searched.
+- Retrieved sources count.
+- Citation count.
+- Web fallback status: disabled, enabled not used, or used with provider/engine if available.
+- Model/provider used for generation.
+- Source health caveat count: stale, unavailable, unknown, empty.
+- Verification/trust descriptor when available: strong, partial, weak.
+
+Suggested copy:
+
+- `Searched Documents & Media, Notes, and Chats. 12 sources returned, 5 cited.`
+- `Web fallback disabled.`
+- `Web fallback used via the configured server default.`
+- `2 selected sources were stale or unavailable.`
+- `Trust: Partial. Some claims are weakly supported.`
+
+The detailed diagnostics remain in `SearchDetailsPanel`. The summary should be a compact trust strip, not a replacement for the details tab.
+
+## Recovery States
+
+Update recovery copy and actions to use source health when available.
+
+No results:
+
+- Show which selected sources were empty, stale, unavailable, or unknown.
+- Offer `Broaden source scope`, `Enable web fallback`, `Show nearest matches`, `Open Quick Ingest`, or `Open source page` only where those actions already exist.
+- `Open Quick Ingest` and `Open source page` are navigation handoffs only. `/knowledge` must not add inline import/create/edit controls.
+- `Show nearest matches` is allowed only when nearest-match data already exists in current RAG/search response metadata or current UI behavior. Otherwise defer it.
+
+Low-confidence answer:
+
+- Keep `LowQualityRecoveryBanner`, but include source-health context when relevant.
+- Suggested copy: `This answer has limited evidence. Try expanding sources, checking source status, or enabling web fallback.`
+
+Health unavailable:
+
+- Do not block search.
+- Suggested copy: `Source health is unavailable. Search can continue, but readiness details may be incomplete.`
+
+Recently ingested:
+
+- Keep the current indexing hint. If source health says `Indexing`, use that instead of relying only on local quick-ingest state.
+
+## Data Flow
+
+1. `/knowledge` loads canonical source metadata from the frontend registry as it does today.
+2. The UI requests read-only source health after server readiness succeeds.
+3. The source health response is normalized into shared UI types distinct from existing `KnowledgeSourceStatus`.
+4. `KnowledgeContextBar` uses health to show category status and specific source filter labels.
+5. Search requests continue to use existing RAG settings and selected source ids.
+6. Search responses continue to populate `answer`, `results`, `citations`, and `searchDetails`.
+7. Answer trust summary combines selected source settings, source health caveats, and search response details, including post-query `metadata.source_status` when present.
+8. Evidence actions operate on existing source card/result metadata and existing handoff services only.
+
+## Error Handling
+
+- Health endpoint unavailable: show non-blocking unknown state and retry.
+- Source count expensive or unsupported: render count as unavailable, not zero.
+- Source unavailable: keep visible if canonical, but explain why it cannot be searched.
+- Copy failure: show `Unable to copy citation` or `Unable to copy excerpt`.
+- Open-source failure: show `Unable to open this source from Knowledge QA`.
+- Save-to-note unavailable: omit the action rather than presenting a broken control.
+- Save-to-note failure: show the backend error when safe, otherwise `Unable to save this evidence to notes`.
+- Quick Ingest or owner-page navigation failure: show `Unable to open the source owner page from Knowledge QA`.
+
+## Privacy And Trust
+
+- Do not expose source content, arbitrary metadata, provider keys, user identifiers, database paths, or workspace-private item titles in source health.
+- Health timestamps are coarse enough to explain freshness without revealing hidden item details.
+- Web fallback copy must state that web fallback uses the configured server default and is off unless enabled.
+- Export/import profile behavior remains browser-local and unchanged by this slice.
+- Existing auth and visibility checks remain authoritative for all source use and handoffs.
+
+## Testing Strategy
+
+Backend:
+
+- Contract test for source health response shape and canonical source ids.
+- Contract test that source health does not change the existing search-response `metadata.source_status` semantics.
+- Test empty, unavailable, stale, and workspace-scoped source states.
+- Test that hidden/generated/workspace artifacts do not affect global counts unless workspace scope is active.
+- Test that health response excludes arbitrary safe metadata and content excerpts.
+
+Frontend unit/Vitest:
+
+- `KnowledgeContextBar` renders health summary and per-source status chips.
+- Specific-source picker keeps existing filters and labels align with health taxonomy.
+- Health load failure does not disable search.
+- Pre-query source health and post-query `sourceStatus` diagnostics render without type or label collisions.
+- `AnswerPanel` renders trust summary from selected sources, citations, web fallback, model/provider, and health caveats.
+- `SourceCard` evidence actions expose accessible names, success/failure feedback, and do not offer unavailable handoffs.
+- `EvidenceRail` keeps source/details tabs reachable and action hints visible in desktop/mobile contexts.
+- `NoResultsRecovery` uses health diagnostics for empty/stale/unavailable/unknown states.
+
+Browser/Playwright:
+
+- WebUI `/knowledge` desktop: health visible before search, answer trust summary visible after search.
+- Mobile `/knowledge`: source health details reachable without overlapping the composer or evidence rail.
+- Extension options `#/knowledge`: shared health/evidence UI renders with the same labels.
+- No-results flow: selected stale/unavailable source diagnostics appear and recovery actions are reachable.
+
+Verification:
+
+- Focused backend pytest for touched RAG/source health code.
+- Focused KnowledgeQA Vitest tests for touched components.
+- Extension parity/static route tests if shared component imports change.
+- `git diff --check`.
+- Bandit for touched backend code if a backend contract is implemented.
+
+## Staged Implementation Plan
+
+### Stage 1: Source Health Contract
+
+Goal: expose safe read-only source health for all canonical `/knowledge` sources.
+
+Success criteria:
+
+- All canonical source ids return a health entry.
+- Endpoint placement prefers `GET /api/v1/rag/source-health` or an equivalent focused read-only source-health endpoint, not a liveness endpoint.
+- Empty/unavailable/stale/workspace-scoped states are representable.
+- Response excludes content and arbitrary metadata.
+- Health failure is non-fatal for existing search.
+- V1 requires only availability, searchability, index status, embedding status, and disabled reason; counts/timestamps may be null.
+- Existing post-query `metadata.source_status` remains backward compatible.
+
+### Stage 2: Source Picker Health UI
+
+Goal: make source readiness visible before users ask a question.
+
+Success criteria:
+
+- `KnowledgeContextBar` shows an aggregate health summary.
+- Source category rows show status and counts where available.
+- Specific-source picker filters remain intact and taxonomy is consistent.
+- Mobile and extension layouts remain usable.
+
+### Stage 3: Evidence Action Clarification
+
+Goal: make existing evidence reuse controls obvious and reliable.
+
+Success criteria:
+
+- Source cards expose clear copy/open/workspace actions where supported.
+- Save-to-note appears only when an existing note handoff already preserves backlinks without adding new persistence.
+- Unsupported actions are omitted or disabled with clear copy.
+- Copy success/failure is announced.
+- Keyboard and screen-reader access are covered.
+
+### Stage 4: Answer Trust Summary
+
+Goal: explain what powered the answer without replacing the detailed diagnostics panel.
+
+Success criteria:
+
+- Answer summary shows searched sources, result count, citation count, web fallback state, model/provider, and health caveats.
+- Trust descriptor reuses existing verification/faithfulness details where available.
+- Summary remains compact and does not crowd the answer body.
+
+### Stage 5: Recovery Copy And Diagnostics
+
+Goal: make empty, stale, unavailable, and low-evidence states actionable.
+
+Success criteria:
+
+- No-results and low-confidence recovery include source health when available.
+- Recovery actions are concrete and scoped: broaden sources, enable web fallback, show nearest matches only if existing nearest-match data is present, open Quick Ingest, open the source owner page, or continue in workspace.
+- Quick Ingest and owner-page actions are route handoffs only, never inline source creation inside `/knowledge`.
+- Health-unavailable state is visible but non-blocking.
+
+### Stage 6: Verification And PR Packaging
+
+Goal: ship a focused, reviewable PR without unrelated frontend cleanup.
+
+Success criteria:
+
+- Backend, frontend, and extension-relevant tests pass for touched scope.
+- Bandit is run for touched backend code.
+- Known unrelated verifier blockers are documented, not hidden.
+- Backlog task and PR notes record the QA-only boundary and excluded persistence features.
+
+## Open Questions
+
+- If implementation finds an existing source-status endpoint by implementation time, does it satisfy the read-only, pre-query, WebUI/extension-stable contract well enough to reuse instead of adding `GET /api/v1/rag/source-health`?
+- Which source types can cheaply provide `indexed_count` today, and which should initially return `null`?
+- Does the existing `/api/v1/chat/knowledge/save` contract preserve source backlinks for Knowledge QA citation types? If not, defer `Save to note` from this slice.
+- What freshness threshold should mark a source as `Stale`: fixed time window, changed-since-index metadata, or source-specific logic?
+
+## Deferred Follow-Ups
+
+- Server-backed saved evidence sets.
+- Shared source/evidence profiles.
+- Cross-device saved views.
+- Advanced evidence pinboards or research packets.
+- Source reindex controls from `/knowledge`.
+- Full source CRUD/import management from `/knowledge`.

--- a/Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
+++ b/Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
@@ -106,6 +106,7 @@ Rules:
 - `embedding_status` reflects vector readiness only where embeddings are part of the searchable path. Use `not_applicable` for sources or configurations that are intentionally FTS-only or non-vector.
 - Generated/test/workspace artifacts stay hidden by default unless explicit workspace scope is present.
 - The contract must pass through normal auth, ownership, workspace, and visibility checks. Imported IDs or saved profiles are not access grants.
+- The contract must not instantiate search retrievers or source databases just to compute health. Source availability should come from already-resolved request dependencies or existing files/metadata that can be checked without creating directories, schema, indexes, vector stores, or records.
 
 V1 minimum:
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
@@ -131,7 +131,7 @@ function describeFaithfulness(score: number | null): TrustDescriptor | null {
 function sourceHealthNeedsAttention(
   health: KnowledgeSourceHealth | null | undefined
 ): boolean {
-  if (!health) return false
+  if (!health) return true
   if (!health.available || !health.searchable) return true
   if (health.workspaceScoped || health.hiddenByDefault) return true
   if (health.indexStatus !== "ready") return true

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
@@ -18,6 +18,8 @@ import {
 import { trackKnowledgeQaSearchMetric } from "@/utils/knowledge-qa-search-metrics"
 import { remarkCitationLinks } from "./answerMarkdown"
 import { LowQualityRecoveryBanner } from "./panels/LowQualityRecoveryBanner"
+import { buildAnswerTrustSummary, type AnswerTrustLabel } from "./trustSummary"
+import type { KnowledgeSourceHealth } from "./types"
 
 type AnswerPanelProps = {
   className?: string
@@ -126,6 +128,16 @@ function describeFaithfulness(score: number | null): TrustDescriptor | null {
   }
 }
 
+function sourceHealthNeedsAttention(
+  health: KnowledgeSourceHealth | null | undefined
+): boolean {
+  if (!health) return false
+  if (!health.available || !health.searchable) return true
+  if (health.workspaceScoped || health.hiddenByDefault) return true
+  if (health.indexStatus !== "ready") return true
+  return ["missing", "unavailable", "error"].includes(health.embeddingStatus)
+}
+
 export function AnswerPanel({ className }: AnswerPanelProps) {
   const {
     answer,
@@ -144,6 +156,7 @@ export function AnswerPanel({ className }: AnswerPanelProps) {
     preset,
     settings,
     rerunWithTokenLimit,
+    sourceHealth,
     expertMode = false,
   } = useKnowledgeQA()
   const [isExpanded, setIsExpanded] = useState(false)
@@ -202,6 +215,41 @@ export function AnswerPanel({ className }: AnswerPanelProps) {
   const faithfulnessDescriptor = useMemo(
     () => describeFaithfulness(trustScore),
     [trustScore]
+  )
+  const sourceHealthCaveatCount = useMemo(() => {
+    const selectedSources = settings?.sources ?? []
+    return selectedSources.filter((source) =>
+      sourceHealthNeedsAttention(sourceHealth?.bySource[source])
+    ).length
+  }, [settings?.sources, sourceHealth?.bySource])
+  const answerTrustLabel: AnswerTrustLabel =
+    faithfulnessDescriptor?.label ?? (citations.length > 0 ? "Partial" : "Weak")
+  const answerTrustSummaryLines = useMemo(
+    () =>
+      buildAnswerTrustSummary({
+        selectedSources: settings?.sources ?? [],
+        resultCount: results.length,
+        citationCount: citations.length,
+        webFallbackEnabled:
+          searchDetails?.webFallbackEnabled ?? Boolean(settings?.enable_web_fallback),
+        webFallbackTriggered: Boolean(searchDetails?.webFallbackTriggered),
+        generationProvider: settings?.generation_provider,
+        generationModel: settings?.generation_model,
+        sourceHealthCaveatCount,
+        trustLabel: answerTrustLabel,
+      }),
+    [
+      answerTrustLabel,
+      citations.length,
+      results.length,
+      searchDetails?.webFallbackEnabled,
+      searchDetails?.webFallbackTriggered,
+      settings?.enable_web_fallback,
+      settings?.generation_model,
+      settings?.generation_provider,
+      settings?.sources,
+      sourceHealthCaveatCount,
+    ]
   )
   const lowConfidenceRecovery = useMemo(() => {
     if (!normalizedAnswer || results.length === 0) return null
@@ -690,6 +738,15 @@ export function AnswerPanel({ className }: AnswerPanelProps) {
               {workspaceHandoffPending ? "Opening..." : "Continue in editor"}
             </button>
           </div>
+        </div>
+        <div
+          role="note"
+          aria-label="Answer trust summary"
+          className="mt-3 flex flex-wrap gap-x-3 gap-y-1 rounded-md border border-border bg-surface2/60 px-3 py-2 text-xs text-text-muted"
+        >
+          {answerTrustSummaryLines.map((line) => (
+            <span key={line}>{line}</span>
+          ))}
         </div>
       </div>
       {showLowConfidenceRecovery ? (

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/AnswerPanel.tsx
@@ -758,6 +758,7 @@ export function AnswerPanel({ className }: AnswerPanelProps) {
             enableWebLabel="Include web sources"
             selectSourcesLabel="Adjust sources"
             sourceStatus={searchDetails?.sourceStatus}
+            sourceHealthCaveatCount={sourceHealthCaveatCount}
             onRefine={() => {
               const input = document.getElementById("knowledge-search-input")
               input?.focus()

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
@@ -26,6 +26,7 @@ import type {
   CitationRef,
   SearchRuntimeDetails,
   KnowledgeSourceStatus,
+  KnowledgeSourceHealthState,
   QueryStage,
   ScopeSnapshot,
   PinnedSourceFilters,
@@ -46,6 +47,10 @@ import { trackKnowledgeQaSearchMetric } from "@/utils/knowledge-qa-search-metric
 import { persistKnowledgeQaHistory } from "./historyStorage"
 import { mapKnowledgeQaSearchErrorMessage } from "./errorMessages"
 import { truncateAnswerPreview } from "./historyUtils"
+import {
+  EMPTY_SOURCE_HEALTH_STATE,
+  normalizeKnowledgeSourceHealth,
+} from "./sourceHealth"
 
 const LOCAL_THREAD_PREFIX = "local-"
 const DEFAULT_CHARACTER_NAME = "Helpful AI Assistant"
@@ -112,6 +117,7 @@ const initialState: KnowledgeQAState = {
     mediaIds: [],
     noteIds: [],
   },
+  sourceHealth: EMPTY_SOURCE_HEALTH_STATE,
 }
 
 const isLocalThreadId = (id: string | null | undefined) =>
@@ -175,6 +181,9 @@ type Action =
   | { type: "SET_QUERY_STAGE"; payload: QueryStage }
   | { type: "SET_LAST_SEARCH_SCOPE"; payload: ScopeSnapshot | null }
   | { type: "SET_PINNED_SOURCE_FILTERS"; payload: PinnedSourceFilters }
+  | { type: "SET_SOURCE_HEALTH_LOADING" }
+  | { type: "SET_SOURCE_HEALTH"; payload: KnowledgeSourceHealthState }
+  | { type: "SET_SOURCE_HEALTH_ERROR"; payload: string }
   | {
       type: "HYDRATE_RESTORED_SCOPE"
       payload: {
@@ -328,6 +337,26 @@ function reducer(state: KnowledgeQAState, action: Action): KnowledgeQAState {
       return { ...state, lastSearchScope: action.payload }
     case "SET_PINNED_SOURCE_FILTERS":
       return { ...state, pinnedSourceFilters: action.payload }
+    case "SET_SOURCE_HEALTH_LOADING":
+      return {
+        ...state,
+        sourceHealth: {
+          ...state.sourceHealth,
+          loading: true,
+          error: null,
+        },
+      }
+    case "SET_SOURCE_HEALTH":
+      return { ...state, sourceHealth: action.payload }
+    case "SET_SOURCE_HEALTH_ERROR":
+      return {
+        ...state,
+        sourceHealth: {
+          ...state.sourceHealth,
+          loading: false,
+          error: action.payload,
+        },
+      }
     case "HYDRATE_RESTORED_SCOPE": {
       const { nextPreset, nextSettings } = resolveHydratedScopeState(
         state.preset,
@@ -2818,6 +2847,23 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
     dispatch({ type: "SET_PINNED_SOURCE_FILTERS", payload: normalized })
   }, [])
 
+  const refreshSourceHealth = useCallback(async () => {
+    dispatch({ type: "SET_SOURCE_HEALTH_LOADING" })
+    try {
+      const payload = await tldwClient.ragSourceHealth()
+      dispatch({
+        type: "SET_SOURCE_HEALTH",
+        payload: normalizeKnowledgeSourceHealth(payload),
+      })
+    } catch {
+      dispatch({
+        type: "SET_SOURCE_HEALTH_ERROR",
+        payload:
+          "Source health could not be loaded. You can still search selected sources.",
+      })
+    }
+  }, [])
+
   const scrollToSource = useCallback((index: number) => {
     const element = document.getElementById(`source-card-${index}`)
     if (element) {
@@ -2953,6 +2999,7 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
       setEvidenceRailTab,
       setQueryStage,
       setPinnedSourceFilters,
+      refreshSourceHealth,
       persistRagContext,
       scrollToSource,
       scrollToCitation,
@@ -2986,6 +3033,7 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
       setEvidenceRailTab,
       setQueryStage,
       setPinnedSourceFilters,
+      refreshSourceHealth,
       persistRagContext,
       scrollToSource,
       scrollToCitation,

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
@@ -1416,6 +1416,7 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
   const activeSearchRequestIdRef = useRef(0)
   const activeThreadHydrationRequestIdRef = useRef(0)
   const activeHistoryLoadRequestIdRef = useRef(0)
+  const sourceHealthRequestIdRef = useRef(0)
   const historyMutationVersionRef = useRef(0)
   const focusedSourceTimeoutRef = useRef<number | null>(null)
   const persistenceWarningShownRef = useRef(false)
@@ -2843,14 +2844,18 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const refreshSourceHealth = useCallback(async () => {
+    const requestId = sourceHealthRequestIdRef.current + 1
+    sourceHealthRequestIdRef.current = requestId
     dispatch({ type: "SET_SOURCE_HEALTH_LOADING" })
     try {
       const payload = await tldwClient.ragSourceHealth()
+      if (sourceHealthRequestIdRef.current !== requestId) return
       dispatch({
         type: "SET_SOURCE_HEALTH",
         payload: normalizeKnowledgeSourceHealth(payload),
       })
     } catch {
+      if (sourceHealthRequestIdRef.current !== requestId) return
       dispatch({
         type: "SET_SOURCE_HEALTH_ERROR",
         payload:

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
@@ -1425,11 +1425,6 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
   const defaultCharacterIdRef = useRef<number | null>(null)
   const defaultCharacterPromiseRef = useRef<Promise<number | null> | null>(null)
 
-  // Initialize client
-  useEffect(() => {
-    tldwClient.initialize().catch(console.error)
-  }, [])
-
   useEffect(() => {
     if (state.currentThreadId || state.messages.length > 0) {
       hydratedDefaultsRef.current = null
@@ -2863,6 +2858,24 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
       })
     }
   }, [])
+
+  // Initialize client and load safe pre-query source health once when ready.
+  useEffect(() => {
+    let cancelled = false
+
+    tldwClient
+      .initialize()
+      .then(() => {
+        if (!cancelled) {
+          void refreshSourceHealth()
+        }
+      })
+      .catch(console.error)
+
+    return () => {
+      cancelled = true
+    }
+  }, [refreshSourceHealth])
 
   const scrollToSource = useCallback((index: number) => {
     const element = document.getElementById(`source-card-${index}`)

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx
@@ -123,7 +123,7 @@ export function SourceCard({
   className,
 }: SourceCardProps) {
   const { t } = useTranslation("knowledge")
-  const [copiedState, setCopiedState] = React.useState<"text" | "citation" | null>(null)
+  const [copiedState, setCopiedState] = React.useState<"excerpt" | "citation" | null>(null)
   const [isExpanded, setIsExpanded] = React.useState(false)
   const [overflowOpen, setOverflowOpen] = React.useState(false)
   const overflowRef = React.useRef<HTMLDivElement>(null)
@@ -226,20 +226,20 @@ export function SourceCard({
     }, 2000)
   }, [])
 
-  const handleCopyText = useCallback(async () => {
+  const handleCopyExcerpt = useCallback(async () => {
     const requestId = latestCopyRequestIdRef.current + 1
     latestCopyRequestIdRef.current = requestId
     try {
-      await navigator.clipboard.writeText(content)
+      await navigator.clipboard.writeText(excerpt)
       if (!isMountedRef.current || latestCopyRequestIdRef.current !== requestId) {
         return
       }
-      setCopiedState("text")
+      setCopiedState("excerpt")
       scheduleCopiedStateReset(requestId)
     } catch (error) {
-      console.error("Failed to copy source text:", error)
+      console.error("Failed to copy source excerpt:", error)
     }
-  }, [content, scheduleCopiedStateReset])
+  }, [excerpt, scheduleCopiedStateReset])
 
   const handleCopyCitation = useCallback(async () => {
     const requestId = latestCopyRequestIdRef.current + 1
@@ -548,6 +548,7 @@ export function SourceCard({
             onClick={handleCopyCitation}
             className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md border border-border bg-surface text-text-subtle hover:bg-hover hover:text-text transition-colors"
             title="Copy citation"
+            aria-label={`Copy citation for source ${index}`}
           >
             {copiedState === "citation" ? "Copied!" : "Cite"}
           </button>
@@ -621,18 +622,23 @@ export function SourceCard({
                 <button
                   type="button"
                   role="menuitem"
+                  aria-label={
+                    copiedState === "excerpt"
+                      ? `Copied excerpt from source ${index}`
+                      : `Copy excerpt from source ${index}`
+                  }
                   onClick={() => {
-                    handleCopyText()
+                    handleCopyExcerpt()
                     setOverflowOpen(false)
                   }}
                   className="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-text-subtle hover:bg-hover hover:text-text transition-colors"
                 >
-                  {copiedState === "text" ? (
+                  {copiedState === "excerpt" ? (
                     <Check className="w-3.5 h-3.5" />
                   ) : (
                     <Copy className="w-3.5 h-3.5" />
                   )}
-                  {copiedState === "text" ? "Copied text" : "Copy text"}
+                  {copiedState === "excerpt" ? "Copied excerpt" : "Copy excerpt"}
                 </button>
                 {url && (
                   <button

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SourceCard.tsx
@@ -550,7 +550,7 @@ export function SourceCard({
             title="Copy citation"
             aria-label={`Copy citation for source ${index}`}
           >
-            {copiedState === "citation" ? "Copied!" : "Cite"}
+            {copiedState === "citation" ? "Copied!" : "Copy citation"}
           </button>
 
           <div ref={overflowRef} className="relative">

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx
@@ -1,11 +1,105 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { AnswerPanel } from "../AnswerPanel"
+import type { RagSource } from "@/services/rag/unified-rag"
+import type { KnowledgeSourceHealthState } from "../types"
 
 const submitExplicitFeedbackMock = vi.fn()
 const messageOpenMock = vi.fn()
 const navigateMock = vi.fn()
 const trackMetricMock = vi.fn()
+
+type AnswerPanelTestSettings = {
+  max_generation_tokens: number
+  strip_min_relevance: number
+  enable_web_fallback: boolean
+  sources: RagSource[]
+  generation_provider: string | null
+  generation_model: string | null
+}
+
+const createSourceHealthState = (): KnowledgeSourceHealthState => ({
+  loading: false,
+  error: null,
+  loadedAt: "2026-05-16T00:00:00Z",
+  sources: [
+    {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: true,
+      searchable: true,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "ready",
+      embeddingStatus: "not_applicable",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+    {
+      sourceId: "notes",
+      label: "Notes",
+      available: true,
+      searchable: true,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "stale",
+      embeddingStatus: "ready",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  ],
+  bySource: {
+    media_db: {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: true,
+      searchable: true,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "ready",
+      embeddingStatus: "not_applicable",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+    notes: {
+      sourceId: "notes",
+      label: "Notes",
+      available: true,
+      searchable: true,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "stale",
+      embeddingStatus: "ready",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  },
+})
+
+const createSettings = (): AnswerPanelTestSettings => ({
+  max_generation_tokens: 800,
+  strip_min_relevance: 0.3,
+  enable_web_fallback: false,
+  sources: ["media_db", "notes"],
+  generation_provider: null,
+  generation_model: null,
+})
 
 const state = {
   answer: null as string | null,
@@ -15,21 +109,14 @@ const state = {
   results: [] as Array<{ id: string; score?: number; metadata?: { title?: string } }>,
   setSettingsPanelOpen: vi.fn(),
   updateSetting: vi.fn(),
-  settings: {
-    max_generation_tokens: 800,
-    strip_min_relevance: 0.3,
-    enable_web_fallback: false,
-  } as {
-    max_generation_tokens: number
-    strip_min_relevance: number
-    enable_web_fallback: boolean
-  },
+  settings: createSettings(),
   preset: "balanced" as "fast" | "balanced" | "thorough" | "custom",
   rerunWithTokenLimit: vi.fn(),
   searchDetails: null as
     | {
         tokensUsed?: number | null
         estimatedCostUsd?: number | null
+        webFallbackEnabled?: boolean
         webFallbackTriggered?: boolean
         webFallbackEngine?: string | null
         faithfulnessScore?: number | null
@@ -43,6 +130,7 @@ const state = {
   messages: [] as Array<{ id: string; role: string }>,
   scrollToSource: vi.fn(),
   focusedSourceIndex: null as number | null,
+  sourceHealth: createSourceHealthState(),
   expertMode: false,
 }
 
@@ -92,6 +180,7 @@ vi.mock("../KnowledgeQAProvider", () => ({
     rerunWithTokenLimit: state.rerunWithTokenLimit,
     scrollToSource: state.scrollToSource,
     focusedSourceIndex: state.focusedSourceIndex,
+    sourceHealth: state.sourceHealth,
     expertMode: state.expertMode,
   })
 }))
@@ -106,9 +195,7 @@ describe("AnswerPanel state guardrails", () => {
     state.results = []
     state.setSettingsPanelOpen = vi.fn()
     state.updateSetting = vi.fn()
-    state.settings.max_generation_tokens = 800
-    state.settings.strip_min_relevance = 0.3
-    state.settings.enable_web_fallback = false
+    state.settings = createSettings()
     state.preset = "balanced"
     state.rerunWithTokenLimit = vi.fn().mockResolvedValue(undefined)
     state.searchDetails = null
@@ -116,6 +203,7 @@ describe("AnswerPanel state guardrails", () => {
     state.currentThreadId = "thread-1"
     state.messages = []
     state.focusedSourceIndex = null
+    state.sourceHealth = createSourceHealthState()
     state.expertMode = false
     submitExplicitFeedbackMock.mockResolvedValue({ ok: true })
     trackMetricMock.mockResolvedValue(undefined)
@@ -220,6 +308,37 @@ describe("AnswerPanel state guardrails", () => {
 
     expect(screen.getByText("Source support: Strong")).toBeInTheDocument()
     expect(screen.getByText("Claim check (3 claims)")).toBeInTheDocument()
+  })
+
+  it("renders a compact answer trust summary outside the markdown answer body", () => {
+    state.answer = "Claim one [1]. Claim two."
+    state.citations = [{ index: 1 }]
+    state.results = [
+      { id: "r1", metadata: { title: "Doc 1" } },
+      { id: "r2", metadata: { title: "Note 1" } },
+    ]
+    state.settings.enable_web_fallback = true
+    state.settings.generation_provider = "openai"
+    state.settings.generation_model = "gpt-4o-mini"
+    state.searchDetails = {
+      webFallbackEnabled: true,
+      webFallbackTriggered: false,
+      faithfulnessScore: 0.72,
+    }
+
+    render(<AnswerPanel />)
+
+    const trustSummary = screen.getByLabelText("Answer trust summary")
+    expect(trustSummary).toHaveTextContent(
+      "Searched Documents & Media and Notes. 2 sources returned, 1 cited."
+    )
+    expect(trustSummary).toHaveTextContent("Web fallback enabled, not used.")
+    expect(trustSummary).toHaveTextContent("AI model: openai / gpt-4o-mini.")
+    expect(trustSummary).toHaveTextContent("1 selected source needs attention.")
+    expect(trustSummary).toHaveTextContent("Trust: Partial.")
+    expect(screen.getByTestId("knowledge-answer-content")).not.toContainElement(
+      trustSummary
+    )
   })
 
   it("uses verification rate as trust badge fallback when faithfulness is missing", () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/AnswerPanel.states.test.tsx
@@ -341,6 +341,25 @@ describe("AnswerPanel state guardrails", () => {
     )
   })
 
+  it("treats missing selected source-health entries as caveats", () => {
+    const health = createSourceHealthState()
+    const mediaHealth = health.bySource.media_db
+    state.answer = "Claim one."
+    state.results = [{ id: "r1", metadata: { title: "Doc 1" } }]
+    state.settings.sources = ["media_db", "prompts"]
+    state.sourceHealth = {
+      ...health,
+      sources: mediaHealth ? [mediaHealth] : [],
+      bySource: mediaHealth ? { media_db: mediaHealth } : {},
+    }
+
+    render(<AnswerPanel />)
+
+    expect(screen.getByLabelText("Answer trust summary")).toHaveTextContent(
+      "1 selected source needs attention."
+    )
+  })
+
   it("uses verification rate as trust badge fallback when faithfulness is missing", () => {
     state.answer = "Claim [1]."
     state.citations = [{ index: 1 }]

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/CompactToolbar.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React from "react"
 import type { RagSource } from "@/services/rag/unified-rag"
+import type { KnowledgeSourceHealthState } from "../types"
 
 vi.mock("@/libs/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
@@ -23,7 +24,9 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
 
 import { CompactToolbar } from "../context/CompactToolbar"
 
-const defaultProps = {
+type CompactToolbarTestProps = React.ComponentProps<typeof CompactToolbar>
+
+const defaultProps: CompactToolbarTestProps = {
   sources: [] as RagSource[],
   preset: "balanced" as const,
   webEnabled: false,
@@ -39,7 +42,48 @@ const defaultProps = {
   showAddSources: false,
 }
 
-function renderToolbar(overrides: Partial<typeof defaultProps> = {}) {
+const sourceHealth: KnowledgeSourceHealthState = {
+  loading: false,
+  error: null,
+  loadedAt: "2026-05-16T00:00:00Z",
+  sources: [
+    {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: true,
+      searchable: true,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "ready",
+      embeddingStatus: "not_applicable",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+    {
+      sourceId: "prompts",
+      label: "Prompts",
+      available: false,
+      searchable: false,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "unavailable",
+      embeddingStatus: "unavailable",
+      disabledReason: "no_retriever_configured",
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  ],
+  bySource: {},
+}
+
+function renderToolbar(overrides: Partial<CompactToolbarTestProps> = {}) {
   return render(<CompactToolbar {...defaultProps} {...overrides} />)
 }
 
@@ -52,6 +96,20 @@ describe("CompactToolbar", () => {
   it('renders source summary "None" when sources is empty', () => {
     renderToolbar({ sources: [] })
     expect(screen.getByText(/Sources:.*None/)).toBeDefined()
+  })
+
+  it("renders a compact source health summary when available", () => {
+    renderToolbar({ sourceHealth })
+    expect(screen.getByText("Sources ready: 1 of 2")).toBeInTheDocument()
+  })
+
+  it("lets users refresh source health from the compact summary", async () => {
+    const onRefreshSourceHealth = vi.fn()
+    renderToolbar({ sourceHealth, onRefreshSourceHealth })
+
+    await userEvent.click(screen.getByRole("button", { name: "Refresh source health" }))
+
+    expect(onRefreshSourceHealth).toHaveBeenCalledOnce()
   })
 
   it('renders single source label "Documents & Media" for media_db', () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/EvidenceRail.motion.test.ts
@@ -18,4 +18,12 @@ describe("EvidenceRail motion preferences", () => {
       /<aside className="absolute right-0 top-0 h-full w-\[88vw\] max-w-md border-l border-border bg-surface shadow-xl[^"]*motion-reduce:animate-none/
     )
   })
+
+  it("explains evidence actions without adding a separate persistence panel", () => {
+    const source = readFileSync(sourcePath, "utf8")
+
+    expect(source).toContain(
+      "Use each source card to copy citations, copy excerpts, or open supported sources."
+    )
+  })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { ComponentProps } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { KnowledgeContextBar } from "../context/KnowledgeContextBar"
+import type { KnowledgeSourceHealthState } from "../types"
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getProviders: vi.fn().mockResolvedValue({
+      default_provider: "openai",
+      providers: [
+        { name: "openai", display_name: "OpenAI", models: ["gpt-4o-mini"] },
+      ],
+    }),
+    listMedia: vi.fn().mockResolvedValue({ items: [] }),
+    listNotes: vi.fn().mockResolvedValue({ items: [] }),
+  },
+}))
+
+const sourceHealth: KnowledgeSourceHealthState = {
+  loading: false,
+  error: null,
+  loadedAt: "2026-05-16T00:00:00Z",
+  sources: [
+    {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: true,
+      searchable: true,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "ready",
+      embeddingStatus: "not_applicable",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+    {
+      sourceId: "prompts",
+      label: "Prompts",
+      available: false,
+      searchable: false,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "unavailable",
+      embeddingStatus: "unavailable",
+      disabledReason: "no_retriever_configured",
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  ],
+  bySource: {
+    media_db: {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: true,
+      searchable: true,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "ready",
+      embeddingStatus: "not_applicable",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+    prompts: {
+      sourceId: "prompts",
+      label: "Prompts",
+      available: false,
+      searchable: false,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "unavailable",
+      embeddingStatus: "unavailable",
+      disabledReason: "no_retriever_configured",
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  },
+}
+
+type KnowledgeContextBarTestProps = ComponentProps<typeof KnowledgeContextBar>
+
+const baseProps: KnowledgeContextBarTestProps = {
+  preset: "balanced" as const,
+  onPresetChange: vi.fn(),
+  sources: ["media_db", "prompts"],
+  onSourcesChange: vi.fn(),
+  includeMediaIds: [] as number[],
+  onIncludeMediaIdsChange: vi.fn(),
+  includeNoteIds: [] as string[],
+  onIncludeNoteIdsChange: vi.fn(),
+  webEnabled: false,
+  onToggleWeb: vi.fn(),
+  generationProvider: null as string | null,
+  generationModel: null as string | null,
+  onGenerationProviderChange: vi.fn(),
+  onGenerationModelChange: vi.fn(),
+  contextChangedSinceLastRun: false,
+  onOpenSettings: vi.fn(),
+}
+
+describe("KnowledgeContextBar source health", () => {
+  it("shows aggregate source health and per-source status", () => {
+    render(
+      <KnowledgeContextBar
+        {...baseProps}
+        sourceHealth={sourceHealth}
+        onRefreshSourceHealth={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Sources ready: 1 of 2")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /Sources:/i }))
+    expect(screen.getByText("Ready")).toBeInTheDocument()
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+  })
+
+  it("lets users retry source health from the source picker", () => {
+    const onRefreshSourceHealth = vi.fn()
+    render(
+      <KnowledgeContextBar
+        {...baseProps}
+        sourceHealth={{ ...sourceHealth, error: "Source health could not be loaded." }}
+        onRefreshSourceHealth={onRefreshSourceHealth}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Sources:/i }))
+    fireEvent.click(screen.getByRole("button", { name: "Refresh source health" }))
+
+    expect(onRefreshSourceHealth).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeContextBar.source-health.test.tsx
@@ -144,4 +144,23 @@ describe("KnowledgeContextBar source health", () => {
 
     expect(onRefreshSourceHealth).toHaveBeenCalledOnce()
   })
+
+  it("disables source health refresh while a refresh is loading", () => {
+    const onRefreshSourceHealth = vi.fn()
+    render(
+      <KnowledgeContextBar
+        {...baseProps}
+        sourceHealth={{ ...sourceHealth, loading: true }}
+        onRefreshSourceHealth={onRefreshSourceHealth}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Sources:/i }))
+    const refreshButton = screen.getByRole("button", { name: "Refresh source health" })
+    expect(refreshButton).toBeDisabled()
+    expect(refreshButton).toHaveAttribute("aria-busy", "true")
+
+    fireEvent.click(refreshButton)
+    expect(onRefreshSourceHealth).not.toHaveBeenCalled()
+  })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
@@ -57,6 +57,14 @@ const state = {
     mediaIds: [] as number[],
     noteIds: [] as string[],
   },
+  sourceHealth: {
+    loading: false,
+    error: null as string | null,
+    loadedAt: "2026-05-16T00:00:00Z",
+    sources: [] as unknown[],
+    bySource: {},
+  },
+  refreshSourceHealth: vi.fn(),
 }
 
 const layoutModeState = {
@@ -92,11 +100,19 @@ vi.mock("../history/HistoryPane", () => ({
 vi.mock("../context/KnowledgeContextBar", () => ({
   KnowledgeContextBar: ({
     contextChangedSinceLastRun,
+    sourceHealth,
+    onRefreshSourceHealth,
   }: {
     contextChangedSinceLastRun: boolean
+    sourceHealth?: { loadedAt: string | null }
+    onRefreshSourceHealth?: () => void
   }) => (
     <div data-testid="knowledge-context-bar">
       {contextChangedSinceLastRun ? "Scope changed" : "Scope unchanged"}
+      <span>{sourceHealth?.loadedAt ?? "No source health"}</span>
+      <button type="button" onClick={onRefreshSourceHealth}>
+        Refresh detailed source health
+      </button>
     </div>
   ),
 }))
@@ -104,11 +120,19 @@ vi.mock("../context/KnowledgeContextBar", () => ({
 vi.mock("../context/CompactToolbar", () => ({
   CompactToolbar: ({
     contextChangedSinceLastRun,
+    sourceHealth,
+    onRefreshSourceHealth,
   }: {
     contextChangedSinceLastRun: boolean
+    sourceHealth?: { loadedAt: string | null }
+    onRefreshSourceHealth?: () => void
   }) => (
     <div data-testid="knowledge-compact-toolbar">
       {contextChangedSinceLastRun ? "Scope changed" : "Scope unchanged"}
+      <span>{sourceHealth?.loadedAt ?? "No source health"}</span>
+      <button type="button" onClick={onRefreshSourceHealth}>
+        Refresh compact source health
+      </button>
     </div>
   ),
 }))
@@ -124,7 +148,15 @@ vi.mock("../composer/KnowledgeComposer", () => ({
 }))
 
 vi.mock("../empty/KnowledgeReadyState", () => ({
-  KnowledgeReadyState: () => <div data-testid="knowledge-ready-state" />,
+  KnowledgeReadyState: ({
+    sourceHealth,
+  }: {
+    sourceHealth?: { loadedAt: string | null }
+  }) => (
+    <div data-testid="knowledge-ready-state">
+      {sourceHealth?.loadedAt ?? "No source health"}
+    </div>
+  ),
 }))
 
 vi.mock("../empty/InlineRecentSessions", () => ({
@@ -184,6 +216,9 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     state.lastSearchScope = null
     state.pinnedSourceFilters.mediaIds = []
     state.pinnedSourceFilters.noteIds = []
+    state.sourceHealth.loadedAt = "2026-05-16T00:00:00Z"
+    state.sourceHealth.error = null
+    state.refreshSourceHealth.mockClear()
     layoutModeState.mode = "simple"
     layoutModeState.isSimple = true
     layoutModeState.isResearch = false
@@ -353,5 +388,36 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     renderLayout()
 
     expect(screen.getByText("Scope changed")).toBeInTheDocument()
+  })
+
+  it("passes source health and refresh through the simple toolbar and ready state", async () => {
+    renderLayout()
+
+    expect(screen.getByTestId("knowledge-compact-toolbar")).toHaveTextContent(
+      "2026-05-16T00:00:00Z"
+    )
+    expect(screen.getByTestId("knowledge-ready-state")).toHaveTextContent(
+      "2026-05-16T00:00:00Z"
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh compact source health" }))
+
+    expect(state.refreshSourceHealth).toHaveBeenCalledOnce()
+  })
+
+  it("passes source health and refresh through the detailed context bar", () => {
+    layoutModeState.mode = "research"
+    layoutModeState.isSimple = false
+    layoutModeState.isResearch = true
+
+    renderLayout()
+
+    expect(screen.getByTestId("knowledge-context-bar")).toHaveTextContent(
+      "2026-05-16T00:00:00Z"
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh detailed source health" }))
+
+    expect(state.refreshSourceHealth).toHaveBeenCalledOnce()
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
@@ -168,7 +168,23 @@ vi.mock("../panels/AnswerWorkspace", () => ({
 }))
 
 vi.mock("../panels/NoResultsRecovery", () => ({
-  NoResultsRecovery: () => <div data-testid="knowledge-no-results-recovery" />,
+  NoResultsRecovery: ({
+    sourceHealth,
+    selectedSources,
+    onOpenQuickIngest,
+  }: {
+    sourceHealth?: { loadedAt: string | null }
+    selectedSources?: string[]
+    onOpenQuickIngest?: () => void
+  }) => (
+    <div data-testid="knowledge-no-results-recovery">
+      <span>{sourceHealth?.loadedAt ?? "No source health"}</span>
+      <span>{selectedSources?.join(",") ?? "No selected sources"}</span>
+      <button type="button" onClick={onOpenQuickIngest}>
+        Open Quick Ingest
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock("../evidence/EvidenceRail", () => ({
@@ -219,6 +235,8 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     state.sourceHealth.loadedAt = "2026-05-16T00:00:00Z"
     state.sourceHealth.error = null
     state.refreshSourceHealth.mockClear()
+    delete (window as Window & { __tldwPendingQuickIngestOpen?: unknown })
+      .__tldwPendingQuickIngestOpen
     layoutModeState.mode = "simple"
     layoutModeState.isSimple = true
     layoutModeState.isResearch = false
@@ -419,5 +437,24 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh detailed source health" }))
 
     expect(state.refreshSourceHealth).toHaveBeenCalledOnce()
+  })
+
+  it("passes source health and selected scope into no-results recovery", async () => {
+    state.hasSearched = true
+    state.settings.sources = ["media_db"]
+
+    renderLayout()
+
+    const recovery = await screen.findByTestId("knowledge-no-results-recovery")
+    expect(recovery).toHaveTextContent("2026-05-16T00:00:00Z")
+    expect(recovery).toHaveTextContent("media_db")
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Quick Ingest" }))
+    expect(
+      (window as Window & { __tldwPendingQuickIngestOpen?: unknown })
+        .__tldwPendingQuickIngestOpen
+    ).toMatchObject({
+      detail: { source: "knowledge_qa" },
+    })
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQALayout.behavior.test.tsx
@@ -12,6 +12,15 @@ const state = {
   isSearching: false,
   error: null as string | null,
   queryStage: "idle" as string,
+  searchDetails: null as null | {
+    alsoConsidered?: Array<{
+      id: string
+      title: string
+      score: number | null
+      reason: string | null
+    }>
+    sourceStatus?: Record<string, unknown>
+  },
   preset: "balanced" as string,
   setPreset: vi.fn(),
   settings: {
@@ -172,10 +181,14 @@ vi.mock("../panels/NoResultsRecovery", () => ({
     sourceHealth,
     selectedSources,
     onOpenQuickIngest,
+    onShowNearestMatches,
+    showNearestMatchesAvailable,
   }: {
     sourceHealth?: { loadedAt: string | null }
     selectedSources?: string[]
     onOpenQuickIngest?: () => void
+    onShowNearestMatches?: () => void
+    showNearestMatchesAvailable?: boolean
   }) => (
     <div data-testid="knowledge-no-results-recovery">
       <span>{sourceHealth?.loadedAt ?? "No source health"}</span>
@@ -183,6 +196,11 @@ vi.mock("../panels/NoResultsRecovery", () => ({
       <button type="button" onClick={onOpenQuickIngest}>
         Open Quick Ingest
       </button>
+      {showNearestMatchesAvailable ? (
+        <button type="button" onClick={onShowNearestMatches}>
+          Show nearest matches
+        </button>
+      ) : null}
     </div>
   ),
 }))
@@ -219,6 +237,7 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     state.isSearching = false
     state.error = null
     state.queryStage = "idle"
+    state.searchDetails = null
     state.preset = "balanced"
     state.settings.sources = []
     state.settings.enable_web_fallback = true
@@ -456,5 +475,26 @@ describe("KnowledgeQALayout evidence-rail transitions", () => {
     ).toMatchObject({
       detail: { source: "knowledge_qa" },
     })
+  })
+
+  it("shows nearest misses in no-results recovery from search metadata", async () => {
+    state.hasSearched = true
+    state.searchDetails = {
+      alsoConsidered: [
+        {
+          id: "near-1",
+          title: "Near miss",
+          score: 0.42,
+          reason: "below threshold",
+        },
+      ],
+    }
+
+    renderLayout()
+
+    fireEvent.click(await screen.findByRole("button", { name: "Show nearest matches" }))
+    expect(state.setEvidenceRailOpen).toHaveBeenCalledWith(true)
+    expect(state.setEvidenceRailTab).toHaveBeenCalledWith("details")
+    expect(state.focusSource).not.toHaveBeenCalled()
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQAProvider.feature-flags.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQAProvider.feature-flags.test.tsx
@@ -5,6 +5,7 @@ import { KnowledgeQAProvider, useKnowledgeQA } from "../KnowledgeQAProvider"
 
 const ragSearchMock = vi.fn()
 const ragSearchStreamMock = vi.fn()
+const ragSourceHealthMock = vi.fn()
 const trackMetricMock = vi.fn()
 
 vi.mock("@plasmohq/storage/hook", () => ({
@@ -34,6 +35,7 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
     }),
     ragSearch: (...args: unknown[]) => ragSearchMock(...args),
     ragSearchStream: (...args: unknown[]) => ragSearchStreamMock(...args),
+    ragSourceHealth: (...args: unknown[]) => ragSourceHealthMock(...args),
   },
 }))
 
@@ -55,6 +57,32 @@ describe("KnowledgeQAProvider feature flags", () => {
     ragSearchStreamMock.mockImplementation(async function* () {
       yield { type: "delta", text: "stream should be disabled" }
     })
+    ragSourceHealthMock.mockResolvedValue({
+      sources: [
+        {
+          source_id: "media_db",
+          label: "Documents & Media",
+          available: true,
+          searchable: true,
+          index_status: "ready",
+          embedding_status: "not_applicable",
+        },
+      ],
+    })
+  })
+
+  it("loads source health once after mount without blocking search state", async () => {
+    render(
+      <KnowledgeQAProvider>
+        <ContextProbe />
+      </KnowledgeQAProvider>
+    )
+
+    await waitFor(() => expect(ragSourceHealthMock).toHaveBeenCalledOnce())
+    await waitFor(() =>
+      expect(latestContext?.sourceHealth.bySource.media_db?.indexStatus).toBe("ready")
+    )
+    expect(latestContext?.isSearching).toBe(false)
   })
 
   it("skips streaming path when streaming feature flag is disabled", async () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQAProvider.feature-flags.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQAProvider.feature-flags.test.tsx
@@ -85,6 +85,64 @@ describe("KnowledgeQAProvider feature flags", () => {
     expect(latestContext?.isSearching).toBe(false)
   })
 
+  it("ignores stale source health refresh responses", async () => {
+    const resolvers: Array<(value: unknown) => void> = []
+    ragSourceHealthMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+
+    render(
+      <KnowledgeQAProvider>
+        <ContextProbe />
+      </KnowledgeQAProvider>
+    )
+
+    await waitFor(() => expect(ragSourceHealthMock).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      void latestContext!.refreshSourceHealth()
+      void latestContext!.refreshSourceHealth()
+    })
+    expect(ragSourceHealthMock).toHaveBeenCalledTimes(3)
+
+    await act(async () => {
+      resolvers[2]?.({
+        sources: [
+          {
+            source_id: "prompts",
+            label: "Prompts",
+            available: true,
+            searchable: true,
+            index_status: "ready",
+            embedding_status: "not_applicable",
+          },
+        ],
+      })
+      await Promise.resolve()
+    })
+    expect(latestContext?.sourceHealth.bySource.prompts?.indexStatus).toBe("ready")
+
+    await act(async () => {
+      resolvers[1]?.({
+        sources: [
+          {
+            source_id: "notes",
+            label: "Notes",
+            available: true,
+            searchable: true,
+            index_status: "ready",
+            embedding_status: "not_applicable",
+          },
+        ],
+      })
+      await Promise.resolve()
+    })
+    expect(latestContext?.sourceHealth.bySource.prompts?.indexStatus).toBe("ready")
+    expect(latestContext?.sourceHealth.bySource.notes).toBeUndefined()
+  })
+
   it("skips streaming path when streaming feature flag is disabled", async () => {
     render(
       <KnowledgeQAProvider>

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeReadyState.activation.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeReadyState.activation.test.tsx
@@ -270,4 +270,54 @@ describe("KnowledgeReadyState activation", () => {
       screen.queryByText("No searchable items yet. Open Quick Ingest or the source owner page to add content.")
     ).not.toBeInTheDocument()
   })
+
+  it("does not classify indexing sources as unavailable", () => {
+    renderReadyState({
+      hasSources: true,
+      selectedSources: ["notes"],
+      sourceHealth: {
+        ...sourceHealth,
+        sources: [
+          {
+            sourceId: "notes",
+            label: "Notes",
+            available: true,
+            searchable: false,
+            itemCount: 4,
+            indexedCount: 1,
+            lastUpdated: null,
+            lastIndexed: null,
+            indexStatus: "indexing",
+            embeddingStatus: "indexing",
+            disabledReason: null,
+            workspaceScoped: false,
+            hiddenByDefault: false,
+            privacyNote: null,
+          },
+        ],
+        bySource: {
+          notes: {
+            sourceId: "notes",
+            label: "Notes",
+            available: true,
+            searchable: false,
+            itemCount: 4,
+            indexedCount: 1,
+            lastUpdated: null,
+            lastIndexed: null,
+            indexStatus: "indexing",
+            embeddingStatus: "indexing",
+            disabledReason: null,
+            workspaceScoped: false,
+            hiddenByDefault: false,
+            privacyNote: null,
+          },
+        },
+      },
+    })
+
+    expect(
+      screen.queryByText("Selected sources are unavailable. Open source settings or choose a different scope.")
+    ).not.toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeReadyState.activation.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeReadyState.activation.test.tsx
@@ -1,9 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react"
+import type { ComponentProps } from "react"
 import { MemoryRouter } from "react-router-dom"
 import { describe, expect, it, vi } from "vitest"
 import { KnowledgeReadyState } from "../empty/KnowledgeReadyState"
+import type { KnowledgeSourceHealthState } from "../types"
 
-const defaultProps = {
+type KnowledgeReadyStateTestProps = ComponentProps<typeof KnowledgeReadyState>
+
+const defaultProps: KnowledgeReadyStateTestProps = {
   suggestedPrompts: ["What changed?"],
   onPromptClick: vi.fn(),
   onContinueRecent: vi.fn(),
@@ -14,7 +18,81 @@ const defaultProps = {
   webFallbackEnabled: false,
 }
 
-function renderReadyState(overrides: Partial<typeof defaultProps> = {}) {
+const sourceHealth: KnowledgeSourceHealthState = {
+  loading: false,
+  error: null,
+  loadedAt: "2026-05-16T00:00:00Z",
+  sources: [
+    {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: true,
+      searchable: true,
+      itemCount: 3,
+      indexedCount: 3,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "ready",
+      embeddingStatus: "not_applicable",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+    {
+      sourceId: "prompts",
+      label: "Prompts",
+      available: false,
+      searchable: false,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "unavailable",
+      embeddingStatus: "unavailable",
+      disabledReason: "no_retriever_configured",
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  ],
+  bySource: {
+    media_db: {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: true,
+      searchable: true,
+      itemCount: 3,
+      indexedCount: 3,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "ready",
+      embeddingStatus: "not_applicable",
+      disabledReason: null,
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+    prompts: {
+      sourceId: "prompts",
+      label: "Prompts",
+      available: false,
+      searchable: false,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "unavailable",
+      embeddingStatus: "unavailable",
+      disabledReason: "no_retriever_configured",
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  },
+}
+
+function renderReadyState(overrides: Partial<KnowledgeReadyStateTestProps> = {}) {
   return render(
     <MemoryRouter>
       <KnowledgeReadyState {...defaultProps} {...overrides} />
@@ -61,5 +139,135 @@ describe("KnowledgeReadyState activation", () => {
     expect(
       screen.getByText(/Queries stay on your tldw server unless web fallback is enabled/i)
     ).toBeInTheDocument()
+  })
+
+  it("warns when selected sources are unavailable", () => {
+    renderReadyState({
+      hasSources: true,
+      selectedSources: ["prompts"],
+      sourceHealth,
+    })
+
+    expect(
+      screen.getByText("Selected sources are unavailable. Open source settings or choose a different scope.")
+    ).toBeInTheDocument()
+  })
+
+  it("keeps search usable when source health fails to load", () => {
+    renderReadyState({
+      hasSources: true,
+      selectedSources: ["media_db"],
+      sourceHealth: {
+        ...sourceHealth,
+        error: "Source health could not be loaded. You can still search selected sources.",
+      },
+    })
+
+    expect(
+      screen.getByText("Source health could not be loaded. You can still search selected sources.")
+    ).toBeInTheDocument()
+  })
+
+  it("points empty searchable sources back to owner pages instead of inline creation", () => {
+    renderReadyState({
+      hasSources: true,
+      selectedSources: ["notes"],
+      sourceHealth: {
+        ...sourceHealth,
+        sources: [
+          {
+            sourceId: "notes",
+            label: "Notes",
+            available: true,
+            searchable: false,
+            itemCount: 0,
+            indexedCount: 0,
+            lastUpdated: null,
+            lastIndexed: null,
+            indexStatus: "empty",
+            embeddingStatus: "not_applicable",
+            disabledReason: null,
+            workspaceScoped: false,
+            hiddenByDefault: false,
+            privacyNote: null,
+          },
+        ],
+        bySource: {
+          notes: {
+            sourceId: "notes",
+            label: "Notes",
+            available: true,
+            searchable: false,
+            itemCount: 0,
+            indexedCount: 0,
+            lastUpdated: null,
+            lastIndexed: null,
+            indexStatus: "empty",
+            embeddingStatus: "not_applicable",
+            disabledReason: null,
+            workspaceScoped: false,
+            hiddenByDefault: false,
+            privacyNote: null,
+          },
+        },
+      },
+    })
+
+    expect(
+      screen.getByText("No searchable items yet. Open Quick Ingest or the source owner page to add content.")
+    ).toBeInTheDocument()
+  })
+
+  it("prefers unavailable-source guidance over empty guidance when unavailable sources report zero items", () => {
+    renderReadyState({
+      hasSources: true,
+      selectedSources: ["prompts"],
+      sourceHealth: {
+        ...sourceHealth,
+        sources: [
+          {
+            sourceId: "prompts",
+            label: "Prompts",
+            available: false,
+            searchable: false,
+            itemCount: 0,
+            indexedCount: 0,
+            lastUpdated: null,
+            lastIndexed: null,
+            indexStatus: "unavailable",
+            embeddingStatus: "unavailable",
+            disabledReason: "no_retriever_configured",
+            workspaceScoped: false,
+            hiddenByDefault: false,
+            privacyNote: null,
+          },
+        ],
+        bySource: {
+          prompts: {
+            sourceId: "prompts",
+            label: "Prompts",
+            available: false,
+            searchable: false,
+            itemCount: 0,
+            indexedCount: 0,
+            lastUpdated: null,
+            lastIndexed: null,
+            indexStatus: "unavailable",
+            embeddingStatus: "unavailable",
+            disabledReason: "no_retriever_configured",
+            workspaceScoped: false,
+            hiddenByDefault: false,
+            privacyNote: null,
+          },
+        },
+      },
+    })
+
+    expect(
+      screen.getByText("Selected sources are unavailable. Open source settings or choose a different scope.")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("No searchable items yet. Open Quick Ingest or the source owner page to add content.")
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/LowQualityRecoveryBanner.test.tsx
@@ -17,7 +17,10 @@ describe("LowQualityRecoveryBanner", () => {
   it("renders the recovery message", () => {
     render(<LowQualityRecoveryBanner {...defaultProps} />)
     expect(
-      screen.getByText(/sources may not closely match/i)
+      screen.getByText(/This answer has limited evidence/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/checking source status, or enabling web fallback/i)
     ).toBeInTheDocument()
   })
 
@@ -25,7 +28,7 @@ describe("LowQualityRecoveryBanner", () => {
     render(<LowQualityRecoveryBanner {...defaultProps} />)
     expect(
       screen
-        .getByText(/sources may not closely match/i)
+        .getByText(/limited evidence/i)
         .closest("[data-ds-component]")
     ).toHaveAttribute("data-ds-component", "RecoveryCallout")
   })
@@ -36,7 +39,7 @@ describe("LowQualityRecoveryBanner", () => {
 
     expect(status).toHaveAttribute("aria-live", "polite")
     expect(status).toHaveAttribute("aria-atomic", "true")
-    expect(status).toHaveTextContent(/sources may not closely match/i)
+    expect(status).toHaveTextContent(/limited evidence/i)
   })
 
   it("calls onEnableWeb when web button clicked", () => {
@@ -83,5 +86,14 @@ describe("LowQualityRecoveryBanner", () => {
     expect(
       screen.getByText("Source diagnostics: 1 searched, 1 empty, 1 unavailable.")
     ).toBeInTheDocument()
+  })
+
+  it("surfaces selected source-health caveats without implying automatic web fallback", () => {
+    render(<LowQualityRecoveryBanner {...defaultProps} sourceHealthCaveatCount={2} />)
+
+    expect(
+      screen.getByText("2 selected sources need attention before search.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/will enable web fallback/i)).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { NoResultsRecovery } from "../panels/NoResultsRecovery"
+import type { KnowledgeSourceHealthState } from "../types"
 
 vi.mock("@/store/quick-ingest", () => ({
   useQuickIngestStore: (selector: (state: { recentlyIngestedDocs: unknown[] }) => unknown) =>
@@ -8,10 +9,52 @@ vi.mock("@/store/quick-ingest", () => ({
 }))
 
 const defaultProps = {
-  onBroadenScope: vi.fn(),
+  onOpenQuickIngest: vi.fn(),
   onEnableWeb: vi.fn(),
   onShowNearestMatches: vi.fn(),
   webEnabled: false,
+}
+
+const unavailableHealthState: KnowledgeSourceHealthState = {
+  loading: false,
+  error: null,
+  loadedAt: "2026-05-16T00:00:00Z",
+  sources: [
+    {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: false,
+      searchable: false,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      indexStatus: "unavailable",
+      embeddingStatus: "unavailable",
+      disabledReason: "no_retriever_configured",
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  ],
+  bySource: {
+    media_db: {
+      sourceId: "media_db",
+      label: "Documents & Media",
+      available: false,
+      searchable: false,
+      itemCount: null,
+      indexedCount: null,
+      lastUpdated: null,
+      lastIndexed: null,
+      disabledReason: "no_retriever_configured",
+      indexStatus: "unavailable",
+      embeddingStatus: "unavailable",
+      workspaceScoped: false,
+      hiddenByDefault: false,
+      privacyNote: null,
+    },
+  },
 }
 
 describe("NoResultsRecovery source diagnostics", () => {
@@ -34,9 +77,27 @@ describe("NoResultsRecovery source diagnostics", () => {
       />
     )
 
-    expect(screen.getByText("Source diagnostics")).toBeInTheDocument()
+    expect(screen.getByText("Search diagnostics")).toBeInTheDocument()
     expect(screen.getByText(/Documents & Media: empty/i)).toBeInTheDocument()
     expect(screen.getByText(/World Books: unavailable/i)).toBeInTheDocument()
+  })
+
+  it("distinguishes pre-query health from post-query source diagnostics", () => {
+    render(
+      <NoResultsRecovery
+        {...defaultProps}
+        selectedSources={["media_db"]}
+        sourceHealth={unavailableHealthState}
+        sourceStatus={{
+          media_db: { status: "empty", count: 0, reason: "no_matching_entries" },
+        }}
+      />
+    )
+
+    expect(screen.getByText("Source readiness")).toBeInTheDocument()
+    expect(screen.getByText(/Documents & Media: unavailable/i)).toBeInTheDocument()
+    expect(screen.getByText("Search diagnostics")).toBeInTheDocument()
+    expect(screen.getByText(/Documents & Media: empty/i)).toBeInTheDocument()
   })
 
   it("uses copy that preserves the user's provider/privacy decision for web recovery", () => {
@@ -51,5 +112,24 @@ describe("NoResultsRecovery source diagnostics", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Enable web fallback" }))
     expect(defaultProps.onEnableWeb).toHaveBeenCalledOnce()
+  })
+
+  it("uses concrete recovery handoff labels instead of ambiguous add-source copy", () => {
+    render(<NoResultsRecovery {...defaultProps} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Quick Ingest" }))
+    expect(defaultProps.onOpenQuickIngest).toHaveBeenCalledOnce()
+
+    expect(screen.getByRole("link", { name: "Open source page" })).toHaveAttribute(
+      "href",
+      "/sources"
+    )
+    expect(screen.queryByRole("button", { name: "Add sources" })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Broaden source scope" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Show nearest matches" })
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/NoResultsRecovery.source-status.test.tsx
@@ -8,6 +8,18 @@ vi.mock("@/store/quick-ingest", () => ({
     selector({ recentlyIngestedDocs: [] }),
 }))
 
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  )
+  return {
+    ...actual,
+    Link: ({ to, ...props }: { to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+      <a data-router-link="true" href={to} {...props} />
+    ),
+  }
+})
+
 const defaultProps = {
   onOpenQuickIngest: vi.fn(),
   onEnableWeb: vi.fn(),
@@ -123,6 +135,10 @@ describe("NoResultsRecovery source diagnostics", () => {
     expect(screen.getByRole("link", { name: "Open source page" })).toHaveAttribute(
       "href",
       "/sources"
+    )
+    expect(screen.getByRole("link", { name: "Open source page" })).toHaveAttribute(
+      "data-router-link",
+      "true"
     )
     expect(screen.queryByRole("button", { name: "Add sources" })).not.toBeInTheDocument()
     expect(

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx
@@ -61,10 +61,10 @@ describe("SourceCard copy interactions", () => {
       />
     )
 
-    // "Copy text" is now in the overflow menu
-    await clickOverflowItem(/Copy text/i)
-    // "Cite" is a primary button
-    fireEvent.click(screen.getByRole("button", { name: /Cite/i }))
+    // "Copy excerpt" is now in the overflow menu
+    await clickOverflowItem(/Copy excerpt/i)
+    // "Copy citation" is a primary button
+    fireEvent.click(screen.getByRole("button", { name: /Copy citation/i }))
 
     await act(async () => {
       await Promise.resolve()
@@ -79,10 +79,10 @@ describe("SourceCard copy interactions", () => {
 
     // The cite confirmation still shows; stale copy-text does not overwrite it
     expect(screen.getByText("Copied!")).toBeInTheDocument()
-    // The overflow menu item should NOT show "Copied text" from the stale first copy
+    // The overflow menu item should NOT show "Copied excerpt" from the stale first copy
     const moreButton = screen.getByRole("button", { name: /More actions/i })
     fireEvent.click(moreButton)
-    expect(screen.queryByRole("menuitem", { name: /Copied text/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: /Copied excerpt/i })).not.toBeInTheDocument()
   })
 
   it("keeps the latest copy confirmation visible until its own timeout completes", async () => {
@@ -124,20 +124,20 @@ describe("SourceCard copy interactions", () => {
       />
     )
 
-    // Copy text via overflow menu
-    await clickOverflowItem(/Copy text/i)
+    // Copy excerpt via overflow menu
+    await clickOverflowItem(/Copy excerpt/i)
     await act(async () => {
       await Promise.resolve()
     })
-    // Open overflow to verify "Copied text" label
+    // Open overflow to verify "Copied excerpt" label
     fireEvent.click(screen.getByRole("button", { name: /More actions/i }))
-    expect(screen.getByRole("menuitem", { name: /Copied text/i })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: /Copied excerpt/i })).toBeInTheDocument()
 
     act(() => {
       vi.advanceTimersByTime(1000)
     })
-    // Click Cite primary button
-    fireEvent.click(screen.getByRole("button", { name: /Cite/i }))
+    // Click Copy citation primary button
+    fireEvent.click(screen.getByRole("button", { name: /Copy citation/i }))
     await act(async () => {
       await Promise.resolve()
     })
@@ -146,14 +146,14 @@ describe("SourceCard copy interactions", () => {
     act(() => {
       vi.advanceTimersByTime(1000)
     })
-    // Still showing "Copied!" on the primary Cite button
+    // Still showing "Copied!" on the primary Copy citation button
     expect(screen.getByText("Copied!")).toBeInTheDocument()
 
     act(() => {
       vi.advanceTimersByTime(1000)
     })
-    // Timeout expired, label reverts to "Cite"
-    expect(screen.getByRole("button", { name: /Cite/i })).toBeInTheDocument()
+    // Timeout expired, accessible name reverts to "Copy citation"
+    expect(screen.getByRole("button", { name: /Copy citation/i })).toBeInTheDocument()
     expect(screen.queryByText("Copied!")).not.toBeInTheDocument()
 
     vi.useRealTimers()
@@ -204,8 +204,8 @@ describe("SourceCard copy interactions", () => {
       />
     )
 
-    // Copy text via overflow menu
-    await clickOverflowItem(/Copy text/i)
+    // Copy excerpt via overflow menu
+    await clickOverflowItem(/Copy excerpt/i)
     unmount()
 
     resolveCopy?.()
@@ -219,7 +219,7 @@ describe("SourceCard copy interactions", () => {
 })
 
 describe("SourceCard action structure", () => {
-  it("shows View and Cite as primary buttons and overflow menu with secondary actions", () => {
+  it("shows View and Copy citation as primary buttons and overflow menu with secondary actions", () => {
     Object.defineProperty(globalThis.navigator, "clipboard", {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
       configurable: true,
@@ -258,7 +258,7 @@ describe("SourceCard action structure", () => {
 
     // Primary buttons are always visible
     expect(screen.getByRole("button", { name: /View source 1/i })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /Cite/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Copy citation/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /More actions/i })).toBeInTheDocument()
 
     // Secondary actions are hidden until overflow is opened
@@ -270,8 +270,11 @@ describe("SourceCard action structure", () => {
     expect(screen.getByRole("menuitem", { name: /Tell me more/i })).toBeInTheDocument()
     expect(screen.getByRole("menuitem", { name: /Summarize/i })).toBeInTheDocument()
     expect(screen.getByRole("menuitem", { name: /Key quotes/i })).toBeInTheDocument()
-    expect(screen.getByRole("menuitem", { name: /Copy text/i })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: /Copy excerpt/i })).toBeInTheDocument()
     expect(screen.getByRole("menuitem", { name: /Open original/i })).toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: /Copy citation/i })).toHaveLength(1)
+    expect(screen.getAllByRole("menuitem", { name: /Copy excerpt/i })).toHaveLength(1)
+    expect(screen.queryByRole("menuitem", { name: /Copy text/i })).not.toBeInTheDocument()
   })
 
   it("calls onAskAbout with the correct template from overflow menu items", async () => {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceCard.behavior.test.tsx
@@ -258,7 +258,9 @@ describe("SourceCard action structure", () => {
 
     // Primary buttons are always visible
     expect(screen.getByRole("button", { name: /View source 1/i })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /Copy citation/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Copy citation/i })).toHaveTextContent(
+      "Copy citation"
+    )
     expect(screen.getByRole("button", { name: /More actions/i })).toBeInTheDocument()
 
     // Secondary actions are hidden until overflow is opened

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceList.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/SourceList.behavior.test.tsx
@@ -573,7 +573,7 @@ describe("SourceList researcher workflows", () => {
     Object.assign(navigator, { clipboard: { writeText } })
 
     render(<SourceList />)
-    fireEvent.click(screen.getAllByRole("button", { name: "Cite" })[0])
+    fireEvent.click(screen.getAllByRole("button", { name: /Copy citation/i })[0])
 
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildSourceHealthSummary,
+  getSourceHealthStatusLabel,
+  normalizeKnowledgeSourceHealth,
+} from "../sourceHealth"
+
+describe("Knowledge QA source health normalization", () => {
+  it("normalizes partial backend payloads without colliding with search source status", () => {
+    const normalized = normalizeKnowledgeSourceHealth({
+      sources: [
+        {
+          source_id: "media_db",
+          label: "Documents & Media",
+          available: true,
+          searchable: true,
+          index_status: "ready",
+          embedding_status: "not_applicable",
+          disabled_reason: null,
+        },
+      ],
+    })
+
+    expect(normalized.bySource.media_db?.indexStatus).toBe("ready")
+    expect(normalized.bySource.media_db?.embeddingStatus).toBe("not_applicable")
+    expect(normalized.bySource.media_db).not.toHaveProperty("status")
+  })
+
+  it("builds a compact summary", () => {
+    const normalized = normalizeKnowledgeSourceHealth({
+      sources: [
+        {
+          source_id: "media_db",
+          label: "Documents & Media",
+          available: true,
+          searchable: true,
+          index_status: "ready",
+          embedding_status: "unknown",
+          disabled_reason: null,
+        },
+        {
+          source_id: "prompts",
+          label: "Prompts",
+          available: false,
+          searchable: false,
+          index_status: "unavailable",
+          embedding_status: "unavailable",
+          disabled_reason: "no_retriever_configured",
+        },
+      ],
+    })
+
+    expect(buildSourceHealthSummary(normalized)).toBe("Sources ready: 1 of 2")
+  })
+
+  it("drops unknown source IDs and normalizes unknown statuses safely", () => {
+    const normalized = normalizeKnowledgeSourceHealth({
+      sources: [
+        {
+          source_id: "generated_test_artifacts",
+          label: "Generated",
+          available: true,
+          searchable: true,
+          index_status: "ready",
+          embedding_status: "ready",
+        },
+        {
+          source_id: "notes",
+          label: "Notes",
+          available: true,
+          searchable: false,
+          index_status: "surprising",
+          embedding_status: "unexpected",
+        },
+      ],
+    })
+
+    expect(normalized.sources).toHaveLength(1)
+    expect(normalized.bySource.notes?.indexStatus).toBe("unknown")
+    expect(normalized.bySource.notes?.embeddingStatus).toBe("unknown")
+    expect(getSourceHealthStatusLabel(normalized.bySource.notes)).toBe("Unknown")
+  })
+})

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/trustSummary.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { buildAnswerTrustSummary, formatSourceList } from "../trustSummary"
+
+describe("buildAnswerTrustSummary", () => {
+  it("formats selected source names with readable joining", () => {
+    expect(formatSourceList(["media_db", "notes", "prompts"])).toBe(
+      "Documents & Media, Notes, and Prompts"
+    )
+  })
+
+  it("summarizes sources, citations, web fallback, and caveats", () => {
+    expect(
+      buildAnswerTrustSummary({
+        selectedSources: ["media_db", "notes"],
+        resultCount: 12,
+        citationCount: 5,
+        webFallbackEnabled: true,
+        webFallbackTriggered: false,
+        generationProvider: null,
+        generationModel: null,
+        sourceHealthCaveatCount: 2,
+        trustLabel: "Partial",
+      })
+    ).toEqual([
+      "Searched Documents & Media and Notes. 12 sources returned, 5 cited.",
+      "Web fallback enabled, not used.",
+      "AI model: Server default.",
+      "2 selected sources need attention.",
+      "Trust: Partial.",
+    ])
+  })
+})

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/context/CompactToolbar.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/libs/utils"
 import type { RagPresetName, RagSource } from "@/services/rag/unified-rag"
 import { ALL_RAG_SOURCES, getRagSourceLabel } from "@/services/rag/sourceMetadata"
 import { AnswerModelMenu } from "./AnswerModelMenu"
+import type { KnowledgeSourceHealthState } from "../types"
+import { buildSourceHealthSummary } from "../sourceHealth"
 
 type CompactToolbarProps = {
   sources: RagSource[]
@@ -20,6 +22,8 @@ type CompactToolbarProps = {
   onGenerationModelChange: (model: string | null) => void
   contextChangedSinceLastRun: boolean
   scopeChangeDetails?: string[]
+  sourceHealth?: KnowledgeSourceHealthState
+  onRefreshSourceHealth?: () => void
   showAddSources?: boolean
   className?: string
 }
@@ -54,6 +58,8 @@ export function CompactToolbar({
   onGenerationModelChange,
   contextChangedSinceLastRun,
   scopeChangeDetails = [],
+  sourceHealth,
+  onRefreshSourceHealth,
   showAddSources = false,
   className,
 }: CompactToolbarProps) {
@@ -116,6 +122,22 @@ export function CompactToolbar({
         onGenerationProviderChange={onGenerationProviderChange}
         onGenerationModelChange={onGenerationModelChange}
       />
+
+      {sourceHealth && onRefreshSourceHealth ? (
+        <button
+          type="button"
+          onClick={onRefreshSourceHealth}
+          className="inline-flex h-7 items-center rounded-full border border-border bg-surface px-2.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text transition-colors"
+          aria-label="Refresh source health"
+          title="Refresh source health"
+        >
+          {buildSourceHealthSummary(sourceHealth)}
+        </button>
+      ) : sourceHealth ? (
+        <span className="inline-flex h-7 items-center rounded-full border border-border bg-surface px-2.5 text-[11px] font-medium text-text-muted">
+          {buildSourceHealthSummary(sourceHealth)}
+        </span>
+      ) : null}
 
       {/* Settings gear */}
       <button

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
@@ -925,6 +925,8 @@ export function KnowledgeContextBar({
                       {onRefreshSourceHealth ? (
                         <button
                           type="button"
+                          disabled={sourceHealthState.loading}
+                          aria-busy={sourceHealthState.loading}
                           className="rounded px-1.5 py-0.5 text-[11px] text-text-muted hover:bg-hover hover:text-text transition-colors"
                           onClick={onRefreshSourceHealth}
                         >

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/context/KnowledgeContextBar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { getDesignSystemState } from "@/design-system"
 import type { RagPresetName, RagSource } from "@/services/rag/unified-rag"
+import type { KnowledgeSourceHealthState } from "../types"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { cn } from "@/libs/utils"
 import { Popover, Tooltip } from "antd"
@@ -26,6 +27,12 @@ import {
   isRagSource,
 } from "@/services/rag/sourceMetadata"
 import { AnswerModelMenu } from "./AnswerModelMenu"
+import {
+  EMPTY_SOURCE_HEALTH_STATE,
+  buildSourceHealthSummary,
+  getSourceHealthChipClass,
+  getSourceHealthStatusLabel,
+} from "../sourceHealth"
 
 // ---------------------------------------------------------------------------
 // Saved search profiles
@@ -140,6 +147,8 @@ type KnowledgeContextBarProps = {
   onGenerationModelChange: (model: string | null) => void
   contextChangedSinceLastRun: boolean
   scopeChangeDetails?: string[]
+  sourceHealth?: KnowledgeSourceHealthState
+  onRefreshSourceHealth?: () => void
   onOpenSettings: () => void
 }
 
@@ -454,6 +463,8 @@ export function KnowledgeContextBar({
   onGenerationModelChange,
   contextChangedSinceLastRun,
   scopeChangeDetails = [],
+  sourceHealth,
+  onRefreshSourceHealth,
   onOpenSettings,
 }: KnowledgeContextBarProps) {
   const { t } = useTranslation("knowledge")
@@ -498,6 +509,8 @@ export function KnowledgeContextBar({
       ),
     [sources]
   )
+  const sourceHealthState = sourceHealth ?? EMPTY_SOURCE_HEALTH_STATE
+  const sourceHealthSummary = buildSourceHealthSummary(sourceHealthState)
 
   const normalizedMediaIds = useMemo(
     () =>
@@ -875,6 +888,9 @@ export function KnowledgeContextBar({
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               {t("contextBar.sourceScope", "Source Scope")}
             </h3>
+            <span className="ml-auto text-[11px] text-text-muted">
+              {sourceHealthSummary}
+            </span>
             <Tooltip title="Choose which types of content to include in your search. Select categories, then optionally pick specific items within each.">
               <Info className="h-3.5 w-3.5 text-text-subtle cursor-help" />
             </Tooltip>
@@ -906,6 +922,15 @@ export function KnowledgeContextBar({
                       {t("contextBar.sourceCategories", "Source categories")}
                     </span>
                     <div className="flex items-center gap-1">
+                      {onRefreshSourceHealth ? (
+                        <button
+                          type="button"
+                          className="rounded px-1.5 py-0.5 text-[11px] text-text-muted hover:bg-hover hover:text-text transition-colors"
+                          onClick={onRefreshSourceHealth}
+                        >
+                          {t("contextBar.refreshSourceHealth", "Refresh source health")}
+                        </button>
+                      ) : null}
                       <button
                         type="button"
                         className="rounded px-1.5 py-0.5 text-[11px] text-text-muted hover:bg-hover hover:text-text transition-colors"
@@ -925,6 +950,7 @@ export function KnowledgeContextBar({
                   <div className="space-y-1">
                     {SOURCE_OPTIONS.map((option) => {
                       const selected = normalizedSources.includes(option.key)
+                      const health = sourceHealthState.bySource[option.key]
                       return (
                         <button
                           key={option.key}
@@ -943,13 +969,23 @@ export function KnowledgeContextBar({
                               {getRagSourceDescription(option.key)}
                             </span>
                           </span>
-                          <span className="h-4 w-4 shrink-0">
-                            {selected ? <Check className="h-4 w-4" /> : null}
+                          <span className="flex shrink-0 items-center gap-1 pl-2">
+                            <span className={getSourceHealthChipClass(health)}>
+                              {getSourceHealthStatusLabel(health)}
+                            </span>
+                            <span className="h-4 w-4 shrink-0">
+                              {selected ? <Check className="h-4 w-4" /> : null}
+                            </span>
                           </span>
                         </button>
                       )
                     })}
                   </div>
+                  {sourceHealthState.error ? (
+                    <p className="mt-2 rounded-md border border-info/30 bg-info/10 px-2 py-1.5 text-[11px] text-info">
+                      {sourceHealthState.error}
+                    </p>
+                  ) : null}
                   {normalizedSources.length === 0 ? (
                     <p className="mt-2 rounded-md border border-warn/30 bg-warn/10 px-2 py-1.5 text-[11px] text-warn">
                       {t(

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx
@@ -51,8 +51,7 @@ function buildSourceHealthNotice(
     (source) =>
       !source.available ||
       source.indexStatus === "unavailable" ||
-      source.indexStatus === "error" ||
-      (!source.searchable && source.indexStatus !== "empty")
+      source.indexStatus === "error"
   )
   if (allSelectedUnavailable) {
     return {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/empty/KnowledgeReadyState.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from "react"
 import { Link } from "react-router-dom"
 import { BookOpen, ChevronDown, ChevronUp, CircleHelp, Clock3, FolderPlus, HelpCircle, MessageSquare, SlidersHorizontal } from "lucide-react"
 import { cn } from "@/libs/utils"
+import type { RagSource } from "@/services/rag/unified-rag"
+import type { KnowledgeSourceHealthState } from "../types"
 
 type KnowledgeReadyStateProps = {
   suggestedPrompts: string[]
@@ -10,9 +12,70 @@ type KnowledgeReadyStateProps = {
   onSelectSources: () => void
   onAddSources?: () => void
   hasSources: boolean
+  selectedSources?: RagSource[]
+  sourceHealth?: KnowledgeSourceHealthState
   hasRecentSession: boolean
   webFallbackEnabled?: boolean
   className?: string
+}
+
+type SourceHealthNotice = {
+  message: string
+  tone: "info" | "warn"
+  actionLabel: string
+  action: "add" | "select"
+}
+
+function buildSourceHealthNotice(
+  hasSources: boolean,
+  selectedSources: RagSource[],
+  sourceHealth: KnowledgeSourceHealthState | undefined
+): SourceHealthNotice | null {
+  if (!hasSources) return null
+  if (sourceHealth?.error) {
+    return {
+      message: sourceHealth.error,
+      tone: "info",
+      actionLabel: "Select sources",
+      action: "select",
+    }
+  }
+  if (!sourceHealth || selectedSources.length === 0) return null
+
+  const selectedHealth = selectedSources
+    .map((source) => sourceHealth.bySource[source])
+    .filter((source) => source != null)
+  if (selectedHealth.length === 0) return null
+
+  const allSelectedUnavailable = selectedHealth.every(
+    (source) =>
+      !source.available ||
+      source.indexStatus === "unavailable" ||
+      source.indexStatus === "error" ||
+      (!source.searchable && source.indexStatus !== "empty")
+  )
+  if (allSelectedUnavailable) {
+    return {
+      message: "Selected sources are unavailable. Open source settings or choose a different scope.",
+      tone: "warn",
+      actionLabel: "Open source settings",
+      action: "select",
+    }
+  }
+
+  const allSelectedEmpty = selectedHealth.every(
+    (source) => source.available && source.indexStatus === "empty"
+  )
+  if (allSelectedEmpty) {
+    return {
+      message: "No searchable items yet. Open Quick Ingest or the source owner page to add content.",
+      tone: "warn",
+      actionLabel: "Open Quick Ingest",
+      action: "add",
+    }
+  }
+
+  return null
 }
 
 export function KnowledgeReadyState({
@@ -22,6 +85,8 @@ export function KnowledgeReadyState({
   onSelectSources,
   onAddSources,
   hasSources,
+  selectedSources = [],
+  sourceHealth,
   hasRecentSession,
   webFallbackEnabled = false,
   className,
@@ -29,6 +94,11 @@ export function KnowledgeReadyState({
   const isReturningUser = hasRecentSession
   const [guideExpanded, setGuideExpanded] = useState(!isReturningUser)
   const handleAddSources = onAddSources ?? onSelectSources
+  const sourceHealthNotice = buildSourceHealthNotice(
+    hasSources,
+    selectedSources,
+    sourceHealth
+  )
 
   // Collapse guide when history finishes loading and reveals a returning user
   useEffect(() => {
@@ -154,34 +224,41 @@ export function KnowledgeReadyState({
         ))}
       </div>
 
-      {!hasSources ? (
+      {sourceHealthNotice || !hasSources ? (
         <div
           className={cn(
             "mx-auto max-w-2xl rounded-lg px-4 py-3 text-left text-sm",
-            webFallbackEnabled
+            sourceHealthNotice?.tone === "info" || (!sourceHealthNotice && webFallbackEnabled)
               ? "border border-info/30 bg-info/10 text-info"
               : "border border-warn/30 bg-warn/10 text-warn"
           )}
         >
           <p>
-            {webFallbackEnabled
+            {sourceHealthNotice?.message ??
+            (webFallbackEnabled
               ? "No document sources are selected. Web fallback uses your configured server default provider."
-              : "No sources are selected. Select source categories to search, or enable web fallback."}
+              : "No sources are selected. Select source categories to search, or enable web fallback.")}
           </p>
-          <p className="mt-1">
-            Queries stay on your tldw server unless web fallback is enabled.
-          </p>
+          {!sourceHealthNotice ? (
+            <p className="mt-1">
+              Queries stay on your tldw server unless web fallback is enabled.
+            </p>
+          ) : null}
           <button
             type="button"
-            onClick={handleAddSources}
+            onClick={
+              sourceHealthNotice?.action === "select"
+                ? onSelectSources
+                : handleAddSources
+            }
             className={cn(
               "mt-2 inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
-              webFallbackEnabled
+              sourceHealthNotice?.tone === "info" || (!sourceHealthNotice && webFallbackEnabled)
                 ? "border-info/40 hover:bg-info/20"
                 : "border-warn/40 hover:bg-warn/20"
             )}
           >
-            Add sources
+            {sourceHealthNotice?.actionLabel ?? "Add sources"}
           </button>
         </div>
       ) : null}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/evidence/EvidenceRail.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/evidence/EvidenceRail.tsx
@@ -89,7 +89,12 @@ function EvidenceRailContent({
       <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
         {tab === "sources" ? (
           resultsCount > 0 ? (
-            <SourceList layout="rail" />
+            <>
+              <p className="mb-2 text-xs text-text-muted">
+                Use each source card to copy citations, copy excerpts, or open supported sources.
+              </p>
+              <SourceList layout="rail" />
+            </>
           ) : (
             <div className="rounded-lg border border-border bg-muted/20 p-3 text-sm text-text-muted">
               No sources yet. Run a query to inspect retrieval evidence.

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
@@ -356,11 +356,6 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
     })
   }
 
-  const handleBroadenScope = () => {
-    updateSetting("top_k", Math.min(50, Math.max(settings.top_k + 5, 10)))
-    setSettingsPanelOpen(true)
-  }
-
   const handleEnableWeb = () => {
     if (!settings.enable_web_fallback) {
       updateSetting("enable_web_fallback", true)
@@ -566,11 +561,14 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                 {showNoResultsState ? (
                   <React.Suspense fallback={null}>
                     <LazyNoResultsRecovery
-                      onBroadenScope={handleBroadenScope}
+                      onOpenQuickIngest={handleAddSources}
                       onEnableWeb={handleEnableWeb}
                       onShowNearestMatches={handleShowNearestMatches}
                       webEnabled={settings.enable_web_fallback}
+                      selectedSources={settings.sources}
+                      sourceHealth={sourceHealth}
                       sourceStatus={knowledgeQa.searchDetails?.sourceStatus}
+                      showNearestMatchesAvailable={results.length > 0}
                     />
                   </React.Suspense>
                 ) : null}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
@@ -161,6 +161,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
   }
   const focusSource = knowledgeQa.focusSource ?? (() => undefined)
   const settingsPanelOpen = knowledgeQa.settingsPanelOpen ?? false
+  const sourceHealth = knowledgeQa.sourceHealth
+  const refreshSourceHealth = knowledgeQa.refreshSourceHealth ?? (async () => undefined)
 
   const isMobile = useMobile()
   const { mode, setLayoutMode, isSimple, isResearch, showPromotionToast, dismissPromotion, acceptPromotion } =
@@ -462,6 +464,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                   }
                   contextChangedSinceLastRun={contextChangedSinceLastRun}
                   scopeChangeDetails={scopeChangeDetails}
+                  sourceHealth={sourceHealth}
+                  onRefreshSourceHealth={refreshSourceHealth}
                   showAddSources={isMobile}
                   className={isDesktopReadyState ? "justify-center" : undefined}
                 />
@@ -491,6 +495,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                   }
                   contextChangedSinceLastRun={contextChangedSinceLastRun}
                   scopeChangeDetails={scopeChangeDetails}
+                  sourceHealth={sourceHealth}
+                  onRefreshSourceHealth={refreshSourceHealth}
                   onOpenSettings={() => setSettingsPanelOpen(true)}
                 />
               )}
@@ -508,6 +514,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                     onSelectSources={handleOpenSourceSelector}
                     onAddSources={handleAddSources}
                     hasSources={settings.sources.length > 0}
+                    selectedSources={settings.sources}
+                    sourceHealth={sourceHealth}
                     hasRecentSession={Boolean(recentHistoryItem)}
                     webFallbackEnabled={settings.enable_web_fallback}
                   />

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/layout/KnowledgeQALayout.tsx
@@ -178,6 +178,8 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
   const hasResults = results.length > 0 || Boolean(answer)
   const showNoResultsState =
     hasSearched && !isSearching && !error && results.length === 0 && !answer
+  const nearestMatchesAvailable =
+    (knowledgeQa.searchDetails?.alsoConsidered?.length ?? 0) > 0
   const hasVisibleResultsArea =
     hasResults || showNoResultsState || Boolean(error) || isSearching
   const recentHistoryItem = useMemo(() => {
@@ -364,7 +366,7 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
 
   const handleShowNearestMatches = () => {
     setEvidenceRailOpen(true)
-    setEvidenceRailTab("sources")
+    setEvidenceRailTab(results.length > 0 ? "sources" : "details")
     if (results.length > 0) {
       focusSource(0)
     }
@@ -568,7 +570,7 @@ export function KnowledgeQALayout({ onExportClick }: KnowledgeQALayoutProps) {
                       selectedSources={settings.sources}
                       sourceHealth={sourceHealth}
                       sourceStatus={knowledgeQa.searchDetails?.sourceStatus}
-                      showNearestMatchesAvailable={results.length > 0}
+                      showNearestMatchesAvailable={nearestMatchesAvailable}
                     />
                   </React.Suspense>
                 ) : null}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/panels/LowQualityRecoveryBanner.tsx
@@ -14,6 +14,7 @@ type LowQualityRecoveryBannerProps = {
   enableWebLabel?: string
   selectSourcesLabel?: string
   sourceStatus?: Record<string, KnowledgeSourceStatus>
+  sourceHealthCaveatCount?: number
 }
 
 type ActionLabelProps = {
@@ -52,24 +53,37 @@ export function LowQualityRecoveryBanner({
   onEnableWeb,
   onSelectSources,
   onDismiss,
-  title = "These sources may not closely match your question.",
-  description = "Try refining your search:",
+  title = "This answer has limited evidence.",
+  description = "Try expanding sources, checking source status, or enabling web fallback.",
   refineLabel = "Use more specific terms",
   enableWebLabel = "Include web sources",
   selectSourcesLabel = "Select different sources",
   sourceStatus,
+  sourceHealthCaveatCount = 0,
 }: LowQualityRecoveryBannerProps) {
   const sourceDiagnosticsSummary = formatSourceDiagnosticsSummary(sourceStatus)
+  const sourceHealthSummary =
+    sourceHealthCaveatCount > 0
+      ? `${sourceHealthCaveatCount} selected source${
+          sourceHealthCaveatCount === 1 ? "" : "s"
+        } ${sourceHealthCaveatCount === 1 ? "needs" : "need"} attention before search.`
+      : null
+  const hasRecoveryDetails = Boolean(sourceDiagnosticsSummary || sourceHealthSummary)
 
   return (
     <RecoveryCallout
       state="degraded"
       title={title}
       message={
-        sourceDiagnosticsSummary ? (
+        hasRecoveryDetails ? (
           <>
             <p>{description}</p>
-            <p className="mt-1">{sourceDiagnosticsSummary}</p>
+            {sourceHealthSummary ? (
+              <p className="mt-1">{sourceHealthSummary}</p>
+            ) : null}
+            {sourceDiagnosticsSummary ? (
+              <p className="mt-1">{sourceDiagnosticsSummary}</p>
+            ) : null}
           </>
         ) : (
           description

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx
@@ -3,22 +3,34 @@ import { useTranslation } from "react-i18next"
 import { SearchX } from "lucide-react"
 import { useQuickIngestStore } from "@/store/quick-ingest"
 import { getRagSourceLabel, isRagSource } from "@/services/rag/sourceMetadata"
-import type { KnowledgeSourceStatus } from "../types"
+import type { RagSource } from "@/services/rag/unified-rag"
+import type {
+  KnowledgeSourceHealth,
+  KnowledgeSourceHealthState,
+  KnowledgeSourceStatus,
+} from "../types"
+import { getSourceHealthStatusLabel } from "../sourceHealth"
 
 type NoResultsRecoveryProps = {
-  onBroadenScope: () => void
+  onOpenQuickIngest: () => void
   onEnableWeb: () => void
   onShowNearestMatches: () => void
   webEnabled: boolean
+  selectedSources?: RagSource[]
+  sourceHealth?: KnowledgeSourceHealthState
   sourceStatus?: Record<string, KnowledgeSourceStatus>
+  showNearestMatchesAvailable?: boolean
 }
 
 export function NoResultsRecovery({
-  onBroadenScope,
+  onOpenQuickIngest,
   onEnableWeb,
   onShowNearestMatches,
   webEnabled,
+  selectedSources = [],
+  sourceHealth,
   sourceStatus,
+  showNearestMatchesAvailable = false,
 }: NoResultsRecoveryProps) {
   const { t } = useTranslation("knowledge")
   const recentlyIngestedDocs = useQuickIngestStore(s => s.recentlyIngestedDocs)
@@ -32,6 +44,16 @@ export function NoResultsRecovery({
       })),
     [sourceStatus]
   )
+  const sourceReadiness = React.useMemo(() => {
+    if (!sourceHealth || sourceHealth.error) return []
+    const sourceIds =
+      selectedSources.length > 0
+        ? selectedSources
+        : sourceHealth.sources.map((source) => source.sourceId)
+    return sourceIds
+      .map((sourceId) => sourceHealth.bySource[sourceId])
+      .filter((source): source is KnowledgeSourceHealth => Boolean(source))
+  }, [selectedSources, sourceHealth])
 
   return (
     <div className="rounded-xl border border-border bg-surface p-6">
@@ -40,7 +62,7 @@ export function NoResultsRecovery({
         <div className="min-w-0 flex-1">
           <h2 className="text-base font-semibold">No results found</h2>
           <p className="mt-1 text-sm text-text-muted">
-            Try broader sources, check source diagnostics, or enable web fallback for recovery.
+            Try broader keywords, check source readiness and search diagnostics, or enable web fallback for recovery.
           </p>
           <p className="mt-1 text-sm text-text-muted">
             Web fallback uses your configured server default provider. Queries stay on your
@@ -53,10 +75,27 @@ export function NoResultsRecovery({
               </p>
             </div>
           )}
+          {sourceReadiness.length > 0 ? (
+            <div className="mt-3 rounded-md border border-border/80 bg-surface2/50 px-3 py-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                Source readiness
+              </h3>
+              <ul className="mt-1 space-y-1 text-xs text-text-muted">
+                {sourceReadiness.map((health) => (
+                  <li key={health.sourceId}>
+                    {health.label}: {getSourceHealthStatusLabel(health).toLowerCase()}
+                    {health.disabledReason
+                      ? `, ${health.disabledReason.replaceAll("_", " ")}`
+                      : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
           {sourceDiagnostics.length > 0 ? (
             <div className="mt-3 rounded-md border border-border/80 bg-surface2/50 px-3 py-2">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-                Source diagnostics
+                Search diagnostics
               </h3>
               <ul className="mt-1 space-y-1 text-xs text-text-muted">
                 {sourceDiagnostics.map(({ sourceId, label, status }) => (
@@ -77,11 +116,17 @@ export function NoResultsRecovery({
           <div className="mt-3 flex flex-wrap items-center gap-2">
             <button
               type="button"
-              onClick={onBroadenScope}
+              onClick={onOpenQuickIngest}
               className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle hover:bg-hover hover:text-text transition-colors"
             >
-              Broaden source scope
+              Open Quick Ingest
             </button>
+            <a
+              href="/sources"
+              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle hover:bg-hover hover:text-text transition-colors"
+            >
+              Open source page
+            </a>
             <button
               type="button"
               onClick={onEnableWeb}
@@ -90,13 +135,15 @@ export function NoResultsRecovery({
             >
               {webEnabled ? "Web fallback enabled" : "Enable web fallback"}
             </button>
-            <button
-              type="button"
-              onClick={onShowNearestMatches}
-              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle hover:bg-hover hover:text-text transition-colors"
-            >
-              Show nearest matches
-            </button>
+            {showNearestMatchesAvailable ? (
+              <button
+                type="button"
+                onClick={onShowNearestMatches}
+                className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle hover:bg-hover hover:text-text transition-colors"
+              >
+                Show nearest matches
+              </button>
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/panels/NoResultsRecovery.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { SearchX } from "lucide-react"
+import { Link } from "react-router-dom"
 import { useQuickIngestStore } from "@/store/quick-ingest"
 import { getRagSourceLabel, isRagSource } from "@/services/rag/sourceMetadata"
 import type { RagSource } from "@/services/rag/unified-rag"
@@ -121,12 +122,12 @@ export function NoResultsRecovery({
             >
               Open Quick Ingest
             </button>
-            <a
-              href="/sources"
+            <Link
+              to="/sources"
               className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-subtle hover:bg-hover hover:text-text transition-colors"
             >
               Open source page
-            </a>
+            </Link>
             <button
               type="button"
               onClick={onEnableWeb}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
@@ -134,6 +134,36 @@ export function getSourceHealthStatusLabel(
   }
 }
 
+export function getSourceHealthChipClass(
+  health: KnowledgeSourceHealth | null | undefined
+): string {
+  const base =
+    "inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium"
+  if (!health) {
+    return `${base} border-border bg-surface2 text-text-muted`
+  }
+  if (health.workspaceScoped) {
+    return `${base} border-info/30 bg-info/10 text-info`
+  }
+  switch (health.indexStatus) {
+    case "ready":
+      return health.searchable
+        ? `${base} border-success/30 bg-success/10 text-success`
+        : `${base} border-warn/30 bg-warn/10 text-warn`
+    case "indexing":
+      return `${base} border-info/30 bg-info/10 text-info`
+    case "stale":
+    case "empty":
+      return `${base} border-warn/30 bg-warn/10 text-warn`
+    case "unavailable":
+    case "error":
+      return `${base} border-danger/30 bg-danger/10 text-danger`
+    case "unknown":
+    default:
+      return `${base} border-border bg-surface2 text-text-muted`
+  }
+}
+
 export function buildSourceHealthSummary(
   state: KnowledgeSourceHealthState | null | undefined
 ): string {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
@@ -1,0 +1,154 @@
+import {
+  getRagSourceLabel,
+  isRagSource,
+} from "@/services/rag/sourceMetadata"
+import type {
+  KnowledgeSourceEmbeddingStatus,
+  KnowledgeSourceHealth,
+  KnowledgeSourceHealthState,
+  KnowledgeSourceIndexStatus,
+} from "./types"
+
+const INDEX_STATUSES = new Set<KnowledgeSourceIndexStatus>([
+  "ready",
+  "indexing",
+  "stale",
+  "empty",
+  "unavailable",
+  "error",
+  "unknown",
+])
+
+const EMBEDDING_STATUSES = new Set<KnowledgeSourceEmbeddingStatus>([
+  "ready",
+  "indexing",
+  "missing",
+  "unavailable",
+  "not_applicable",
+  "error",
+  "unknown",
+])
+
+export const EMPTY_SOURCE_HEALTH_STATE: KnowledgeSourceHealthState = {
+  bySource: {},
+  sources: [],
+  loading: false,
+  error: null,
+  loadedAt: null,
+}
+
+const toRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const toOptionalNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const toOptionalString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null
+
+export function normalizeIndexStatus(value: unknown): KnowledgeSourceIndexStatus {
+  return typeof value === "string" && INDEX_STATUSES.has(value as KnowledgeSourceIndexStatus)
+    ? (value as KnowledgeSourceIndexStatus)
+    : "unknown"
+}
+
+export function normalizeEmbeddingStatus(
+  value: unknown
+): KnowledgeSourceEmbeddingStatus {
+  return typeof value === "string" &&
+    EMBEDDING_STATUSES.has(value as KnowledgeSourceEmbeddingStatus)
+    ? (value as KnowledgeSourceEmbeddingStatus)
+    : "unknown"
+}
+
+export function normalizeKnowledgeSourceHealth(
+  payload: unknown
+): KnowledgeSourceHealthState {
+  const record = toRecord(payload) ?? {}
+  const rawSources = Array.isArray(record.sources) ? record.sources : []
+  const sources: KnowledgeSourceHealth[] = []
+
+  for (const raw of rawSources) {
+    const entry = toRecord(raw)
+    const sourceId = isRagSource(entry?.source_id) ? entry.source_id : null
+    if (!sourceId) {
+      continue
+    }
+
+    sources.push({
+      sourceId,
+      label: toOptionalString(entry?.label) ?? getRagSourceLabel(sourceId),
+      available: entry?.available === true,
+      searchable: entry?.searchable === true,
+      itemCount: toOptionalNumber(entry?.item_count),
+      indexedCount: toOptionalNumber(entry?.indexed_count),
+      lastUpdated: toOptionalString(entry?.last_updated),
+      lastIndexed: toOptionalString(entry?.last_indexed),
+      indexStatus: normalizeIndexStatus(entry?.index_status),
+      embeddingStatus: normalizeEmbeddingStatus(entry?.embedding_status),
+      disabledReason: toOptionalString(entry?.disabled_reason),
+      workspaceScoped: entry?.workspace_scoped === true,
+      hiddenByDefault: entry?.hidden_by_default === true,
+      privacyNote: toOptionalString(entry?.privacy_note),
+    })
+  }
+
+  return {
+    bySource: Object.fromEntries(
+      sources.map((source) => [source.sourceId, source])
+    ),
+    sources,
+    loading: false,
+    error: null,
+    loadedAt: new Date().toISOString(),
+  }
+}
+
+export function getSourceHealthStatusLabel(
+  health: KnowledgeSourceHealth | null | undefined
+): string {
+  if (!health) {
+    return "Unknown"
+  }
+  if (health.workspaceScoped) {
+    return "Workspace only"
+  }
+  switch (health.indexStatus) {
+    case "ready":
+      return health.searchable ? "Ready" : "Unavailable"
+    case "indexing":
+      return "Indexing"
+    case "stale":
+      return "Stale"
+    case "empty":
+      return "Empty"
+    case "unavailable":
+      return "Unavailable"
+    case "error":
+      return "Error"
+    case "unknown":
+    default:
+      return "Unknown"
+  }
+}
+
+export function buildSourceHealthSummary(
+  state: KnowledgeSourceHealthState | null | undefined
+): string {
+  if (!state || state.error) {
+    return "Source health unavailable"
+  }
+  if (state.loading) {
+    return "Checking source health..."
+  }
+  if (state.sources.length === 0) {
+    return "Source health unavailable"
+  }
+
+  const readyCount = state.sources.filter(
+    (source) => source.searchable && source.indexStatus === "ready"
+  ).length
+  return `Sources ready: ${readyCount} of ${state.sources.length}`
+}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/trustSummary.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/trustSummary.ts
@@ -1,0 +1,83 @@
+import { getRagSourceLabel } from "@/services/rag/sourceMetadata"
+import type { RagSource } from "@/services/rag/unified-rag"
+
+export type AnswerTrustLabel = "Strong" | "Partial" | "Weak"
+
+type BuildAnswerTrustSummaryInput = {
+  selectedSources: RagSource[]
+  resultCount: number
+  citationCount: number
+  webFallbackEnabled: boolean
+  webFallbackTriggered: boolean
+  generationProvider: string | null | undefined
+  generationModel: string | null | undefined
+  sourceHealthCaveatCount: number
+  trustLabel: AnswerTrustLabel | null | undefined
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural
+}
+
+function formatGenerationModel(
+  provider: string | null | undefined,
+  model: string | null | undefined
+): string {
+  const normalizedProvider = provider?.trim() || null
+  const normalizedModel = model?.trim() || null
+
+  if (normalizedProvider && normalizedModel) {
+    return `${normalizedProvider} / ${normalizedModel}`
+  }
+  return normalizedProvider ?? normalizedModel ?? "Server default"
+}
+
+export function formatSourceList(sources: RagSource[]): string {
+  const labels = sources.map(getRagSourceLabel)
+  if (labels.length <= 1) return labels[0] ?? "selected sources"
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`
+  return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`
+}
+
+export function buildAnswerTrustSummary({
+  selectedSources,
+  resultCount,
+  citationCount,
+  webFallbackEnabled,
+  webFallbackTriggered,
+  generationProvider,
+  generationModel,
+  sourceHealthCaveatCount,
+  trustLabel,
+}: BuildAnswerTrustSummaryInput): string[] {
+  const lines = [
+    `Searched ${formatSourceList(selectedSources)}. ${resultCount} ${pluralize(
+      resultCount,
+      "source"
+    )} returned, ${citationCount} cited.`,
+  ]
+
+  lines.push(
+    webFallbackEnabled
+      ? `Web fallback enabled, ${webFallbackTriggered ? "used" : "not used"}.`
+      : "Web fallback disabled."
+  )
+  lines.push(`AI model: ${formatGenerationModel(generationProvider, generationModel)}.`)
+
+  if (sourceHealthCaveatCount > 0) {
+    lines.push(
+      `${sourceHealthCaveatCount} selected ${pluralize(
+        sourceHealthCaveatCount,
+        "source"
+      )} ${sourceHealthCaveatCount === 1 ? "needs" : "need"} attention.`
+    )
+  } else {
+    lines.push("Selected sources look ready.")
+  }
+
+  if (trustLabel) {
+    lines.push(`Trust: ${trustLabel}.`)
+  }
+
+  return lines
+}

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/types.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/types.ts
@@ -138,6 +138,49 @@ export type KnowledgeSourceStatus = {
   reason?: string
 }
 
+export type KnowledgeSourceIndexStatus =
+  | "ready"
+  | "indexing"
+  | "stale"
+  | "empty"
+  | "unavailable"
+  | "error"
+  | "unknown"
+
+export type KnowledgeSourceEmbeddingStatus =
+  | "ready"
+  | "indexing"
+  | "missing"
+  | "unavailable"
+  | "not_applicable"
+  | "error"
+  | "unknown"
+
+export type KnowledgeSourceHealth = {
+  sourceId: RagSettings["sources"][number]
+  label: string
+  available: boolean
+  searchable: boolean
+  itemCount: number | null
+  indexedCount: number | null
+  lastUpdated: string | null
+  lastIndexed: string | null
+  indexStatus: KnowledgeSourceIndexStatus
+  embeddingStatus: KnowledgeSourceEmbeddingStatus
+  disabledReason: string | null
+  workspaceScoped: boolean
+  hiddenByDefault: boolean
+  privacyNote: string | null
+}
+
+export type KnowledgeSourceHealthState = {
+  bySource: Partial<Record<RagSettings["sources"][number], KnowledgeSourceHealth>>
+  sources: KnowledgeSourceHealth[]
+  loading: boolean
+  error: string | null
+  loadedAt: string | null
+}
+
 // Search history item
 export type SearchHistoryItem = {
   id: string
@@ -212,6 +255,7 @@ export type KnowledgeQAState = {
   queryStage: QueryStage
   lastSearchScope: ScopeSnapshot | null
   pinnedSourceFilters: PinnedSourceFilters
+  sourceHealth: KnowledgeSourceHealthState
 }
 
 // Actions for KnowledgeQA
@@ -251,6 +295,7 @@ export type KnowledgeQAActions = {
   setEvidenceRailTab: (tab: "sources" | "details") => void
   setQueryStage: (stage: QueryStage) => void
   setPinnedSourceFilters: (filters: PinnedSourceFilters) => void
+  refreshSourceHealth: () => Promise<void>
 
   // Citation actions
   persistRagContext: (messageId: string, context: RagContextData) => Promise<boolean>

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.rag-source-health.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { chatRagMethods } from "@/services/tldw/domains/chat-rag"
+
+describe("ragSourceHealth client", () => {
+  it("requests the focused source health endpoint", async () => {
+    const request = vi.fn().mockResolvedValue({ sources: [] })
+
+    await chatRagMethods.ragSourceHealth.call({ request } as any)
+
+    expect(request).toHaveBeenCalledWith({
+      path: "/api/v1/rag/source-health",
+      method: "GET",
+    })
+  })
+})

--- a/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
+++ b/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
@@ -320,6 +320,13 @@ export const chatRagMethods = {
     return await this.request<any>({ path: '/api/v1/rag/health', method: 'GET' })
   },
 
+  async ragSourceHealth(this: TldwApiClientCore): Promise<any> {
+    return await this.request<any>({
+      path: "/api/v1/rag/source-health",
+      method: "GET",
+    })
+  },
+
   async ragSearch(this: TldwApiClientCore, query: string, options?: any): Promise<any> {
     const { timeoutMs, signal, ...rest } = options || {}
     const normalizedQuery = this.normalizeRagQuery(query)

--- a/backlog/tasks/task-297.7 - Design-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-297.7 - Design-knowledge-source-health-and-evidence-controls.md
@@ -1,0 +1,53 @@
+---
+id: TASK-297.7
+title: Design /knowledge source health and evidence controls
+status: Done
+assignee: []
+created_date: '2026-05-16 00:13'
+updated_date: '2026-05-16 00:19'
+labels:
+  - webui
+  - knowledge
+  - ux
+  - design
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the approved design/spec for the next /knowledge QA-only improvement slice. Scope is read-only source health plus stronger evidence actions using existing handoff surfaces where available. Do not add durable evidence persistence or turn /knowledge into the canonical CRUD/import hub.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec states the QA-only boundary and explicitly excludes server-backed saved evidence for this slice.
+- [x] #2 Spec defines source health metadata, UI placement, evidence actions, answer trust summary, recovery copy, and verification strategy.
+- [x] #3 Spec is self-contained for a future implementation agent and references current KnowledgeQA surfaces.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Spec written at Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md. First review found scope-hardening issues around ambiguous Add Sources copy, save-to-note scope, nearest-match scope, source-health V1 requirements, and source-id compatibility. Spec was updated to address those issues; second review approved it. Additional self-review fixed implementation risks: pre-query source health is now explicitly separate from existing post-query metadata.source_status, endpoint placement prefers a focused read-only RAG source-health endpoint, embedding_status supports not_applicable for non-vector sources, SourceCard action duplication is discouraged, and the erroneous parent_task_id was removed because TASK-297 is unrelated in this clean dev worktree. Verification: git diff --check passed. Bandit not applicable because this is a docs/backlog-only design slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and review-hardened the /knowledge source health and evidence controls design spec. The spec preserves the QA-only boundary, limits the slice to read-only source health plus existing evidence handoffs, defers durable evidence persistence, and defines staged implementation, recovery copy, privacy constraints, and verification expectations.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-395 - Create-knowledge-source-health-and-evidence-implementation-plan.md
+++ b/backlog/tasks/task-395 - Create-knowledge-source-health-and-evidence-implementation-plan.md
@@ -1,0 +1,63 @@
+---
+id: TASK-395
+title: Create /knowledge source health and evidence implementation plan
+status: Done
+assignee: []
+created_date: '2026-05-16 00:27'
+labels:
+  - webui
+  - knowledge
+  - ux
+  - plan
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a staged implementation plan for the approved /knowledge source health and evidence controls slice. Scope stays QA-only: read-only pre-query source health, clearer evidence actions, answer trust summary, and recovery copy using existing handoffs. Do not implement code in this task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan references the approved design spec and preserves the QA-only, no-new-persistence boundary.
+- [x] #2 Plan names exact backend, frontend, test, docs, and verification files/commands for each stage.
+- [x] #3 Plan separates pre-query source health from existing post-query metadata.source_status diagnostics.
+- [x] #4 Plan uses TDD-style bite-sized steps and defines focused verification for backend, frontend, extension parity, diff check, and Bandit when backend code is touched.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created `Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md` from the approved `/knowledge` source health and evidence controls design spec.
+
+The plan keeps `/knowledge` QA-only, excludes source CRUD/import and durable evidence persistence, separates pre-query source health from existing post-query `metadata.source_status`, and decomposes the work into backend contract, frontend normalization, provider/source-picker UI, evidence/trust UI, recovery/parity, and final verification tasks.
+
+Local review found and corrected a backend implementation risk in the first draft: the source-health endpoint snippet originally used search pipeline `*_path` keys when constructing `MultiDatabaseRetriever`. The final plan now uses constructor keys such as `media_db`, `notes_db`, `character_cards_db`, `world_books_db`, `chat_dictionaries_db`, `prompts_db`, and `kanban_db`, and explicitly warns implementers not to pass the search endpoint's pipeline argument names directly.
+
+Verification recorded for this planning-only task: `git diff --check` passed; targeted `rg` checks confirmed the obsolete `media:read` permission string was removed and the old `*_path` key names only remain in the explicit warning text. Bandit is not applicable because this task changed only docs and Backlog task metadata.
+
+The plan-document-reviewer subagent was not dispatched because current session tool policy only permits delegated subagents when the user explicitly asks for them. A code-grounded local critique pass was performed instead, including checks against current RAG `DataSource`, `MultiDatabaseRetriever`, auth permission, and frontend `RagSource` contracts.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the `/knowledge` source health and evidence controls implementation plan at `Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md`. The plan is scoped to QA-only improvements, preserves the no-new-persistence boundary, maps exact backend/frontend/test files, uses bite-sized TDD steps, and includes focused backend pytest, frontend Vitest, extension parity, browser smoke, `git diff --check`, and Bandit verification gates. During review, the backend source-health endpoint steps were corrected to use the actual `MultiDatabaseRetriever` constructor contract. No product code was changed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -4,7 +4,7 @@ title: Implement /knowledge source health and evidence controls
 status: In Progress
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 02:19'
+updated_date: '2026-05-16 02:37'
 labels:
   - webui
   - knowledge
@@ -41,6 +41,8 @@ Task 2 frontend client/normalization implemented. Added tldw API ragSourceHealth
 Task 3 source-picker UI slice complete: provider now loads /api/v1/rag/source-health once after tldw client initialization, KnowledgeQALayout threads sourceHealth/refresh through simple and detailed /knowledge surfaces, KnowledgeContextBar and CompactToolbar render compact health summaries, source picker rows show per-source status chips and retry, and KnowledgeReadyState now surfaces health failure, unavailable selected sources, and empty-source guidance without inline creation/import. Verification: red tests failed before implementation; focused Vitest passed 38 tests across sourceHealth, tldw-api-client.rag-source-health, KnowledgeContextBar.source-health, CompactToolbar, KnowledgeQALayout.behavior, KnowledgeReadyState.activation, and KnowledgeQAProvider.feature-flags. git diff --check passed. Full UI tsc remains red on existing baseline; rg over captured output found no KnowledgeQA/sourceHealth/touched-file errors.
 
 Task 3 quality-review fixes: ready-state source-health notice now prioritizes unavailable/error selected sources over empty-source guidance and only treats sources as empty when available with explicit index_status=empty. CompactToolbar now wires onRefreshSourceHealth to a real one-line source-health retry button instead of carrying an unused prop. Verification: targeted Vitest passed CompactToolbar + KnowledgeReadyState activation (23 tests), broader Task 3 focused Vitest passed 40 tests, git diff --check passed.
+
+Task 4 evidence/trust UI slice implemented. Added deterministic answer trust-summary helper, AnswerPanel trust note outside markdown body, clearer SourceCard Copy citation/Copy excerpt accessible names without duplicate actions, EvidenceRail source-action hint, and SourceList regression expectation for the citation accessible name. Save-to-note remains deferred because a backlink-preserving note handoff contract was not verified in this slice. Verification: red Task 4 tests failed before implementation; updated focused Vitest passed 63 tests across trustSummary, AnswerPanel.states, SourceCard.behavior, SourceList.behavior, and EvidenceRail.motion. git diff --check passed. Full UI tsc --noEmit remains blocked by existing unrelated baseline errors; filtered compiler diagnostics produced no KnowledgeQA/trustSummary/AnswerPanel/SourceCard/SourceList/EvidenceRail matches. Bandit is not applicable to this frontend-only slice.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-396
 title: Implement /knowledge source health and evidence controls
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 02:45'
+updated_date: '2026-05-16 02:59'
 labels:
   - webui
   - knowledge
@@ -21,10 +21,10 @@ priority: high
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GET /api/v1/rag/source-health returns safe pre-query health for canonical Knowledge QA sources without altering search-response metadata.source_status.
-- [ ] #2 Knowledge QA shows source health before search and keeps search usable when health loading fails.
-- [ ] #3 Knowledge QA answer and evidence surfaces show compact trust/evidence controls without adding durable evidence persistence.
-- [ ] #4 Focused backend, frontend, extension parity, diff-check, and Bandit verification are recorded.
+- [x] #1 GET /api/v1/rag/source-health returns safe pre-query health for canonical Knowledge QA sources without altering search-response metadata.source_status.
+- [x] #2 Knowledge QA shows source health before search and keeps search usable when health loading fails.
+- [x] #3 Knowledge QA answer and evidence surfaces show compact trust/evidence controls without adding durable evidence persistence.
+- [x] #4 Focused backend, frontend, extension parity, diff-check, and Bandit verification are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -45,14 +45,22 @@ Task 3 quality-review fixes: ready-state source-health notice now prioritizes un
 Task 4 evidence/trust UI slice implemented. Added deterministic answer trust-summary helper, AnswerPanel trust note outside markdown body, clearer SourceCard Copy citation/Copy excerpt accessible names without duplicate actions, EvidenceRail source-action hint, and SourceList regression expectation for the citation accessible name. Save-to-note remains deferred because a backlink-preserving note handoff contract was not verified in this slice. Verification: red Task 4 tests failed before implementation; updated focused Vitest passed 63 tests across trustSummary, AnswerPanel.states, SourceCard.behavior, SourceList.behavior, and EvidenceRail.motion. git diff --check passed. Full UI tsc --noEmit remains blocked by existing unrelated baseline errors; filtered compiler diagnostics produced no KnowledgeQA/trustSummary/AnswerPanel/SourceCard/SourceList/EvidenceRail matches. Bandit is not applicable to this frontend-only slice.
 
 Task 5 recovery/parity slice implemented. No-results recovery now separates pre-query Source readiness from post-query Search diagnostics, uses concrete handoff labels (Open Quick Ingest, Open source page), and hides Show nearest matches unless evidence exists. Low-quality recovery uses limited-evidence copy and receives selected source-health caveat counts from AnswerPanel without implying automatic web fallback. KnowledgeQALayout passes sourceHealth and selected sources into recovery, and extension /knowledge route parity was rechecked. Verification: red Task 5 tests failed before implementation; focused Vitest passed 23 tests across NoResultsRecovery.source-status, LowQualityRecoveryBanner, and KnowledgeQALayout.behavior. Extension parity passed 4 tests in apps/tldw-frontend. git diff --check passed. Full UI tsc remains blocked by unrelated baseline errors; filtered compiler diagnostics produced no KnowledgeQA/NoResultsRecovery/LowQualityRecoveryBanner/KnowledgeQALayout/AnswerPanel matches. Bandit is not applicable to this frontend-only slice.
+
+Task 6 final verification completed after rebasing onto origin/dev. Backend focused pytest passed: 8 passed, 4 warnings. KnowledgeQA focused Vitest passed: 14 files, 117 tests. Extension parity passed: 1 file, 4 tests. Browser smoke passed after rerunning Playwright outside the macOS sandbox: /knowledge navigation/search-bar test passed against frontend localhost:18001 and backend 127.0.0.1:8000. git diff --check passed. Bandit touched backend files passed with 0 findings at /tmp/bandit_knowledge_source_health.json. Opened PR https://github.com/rmusser01/tldw_server/pull/1745.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented /knowledge source health and evidence controls. Source health is pre-query and read-only, post-query metadata.source_status remains backward compatible, evidence actions reuse existing handoffs, recovery copy separates source readiness from search diagnostics, and /knowledge remains QA-only. PR: https://github.com/rmusser01/tldw_server/pull/1745.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -4,7 +4,7 @@ title: Implement /knowledge source health and evidence controls
 status: In Progress
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 01:44'
+updated_date: '2026-05-16 01:53'
 labels:
   - webui
   - knowledge
@@ -35,6 +35,8 @@ Task 1 backend source-health contract implemented. Focused tests passed: pytest 
 Quality review fix: source-health no longer instantiates MultiDatabaseRetriever or source-specific databases during health polling. Endpoint derives configured source IDs from resolved request handles and existing Kanban DB files only; integration regression now fails if retriever construction is attempted. Re-ran focused backend tests (8 passed, 23 deselected), git diff --check, and Bandit touched backend scope (0 findings at /tmp/bandit_knowledge_source_health_task1_fix.json).
 
 Spec re-review fix: removed source DB dependencies from /api/v1/rag/source-health. The endpoint now depends only on the authenticated user and computes source availability from existing per-user DB files without creating directories, schemas, retrievers, or request-scoped DB handles. Re-ran focused backend tests (8 passed, 23 deselected), git diff --check, and Bandit touched backend scope (0 findings at /tmp/bandit_knowledge_source_health_task1_fix2.json).
+
+Task 2 frontend client/normalization implemented. Added tldw API ragSourceHealth client method, Knowledge QA source-health types/state, normalization helpers, and focused tests. Verification: vitest run sourceHealth.test.ts + tldw-api-client.rag-source-health.test.ts passed (4 tests); provider-focused vitest with KnowledgeQAProvider.feature-flags passed (5 tests total). Full UI tsc --noEmit remains blocked by existing unrelated baseline type errors in audio/chat/flashcards/playground/services tests; no sourceHealth or KnowledgeQAProvider errors appeared in the reported output. Optional ownership guard sanity check also still fails on existing OpenWebUI overlap inventory, not ragSourceHealth.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -4,7 +4,7 @@ title: Implement /knowledge source health and evidence controls
 status: In Progress
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 01:25'
+updated_date: '2026-05-16 01:37'
 labels:
   - webui
   - knowledge
@@ -31,6 +31,8 @@ priority: high
 
 <!-- SECTION:NOTES:BEGIN -->
 Task 1 backend source-health contract implemented. Focused tests passed: pytest -q test_source_health.py test_rag_source_health_endpoint.py test_source_contract.py test_unified_pipeline.py -k 'source_status or source_health or source_contract' (8 passed, 23 deselected). git diff --check passed. Bandit touched backend scope passed with 0 findings at /tmp/bandit_knowledge_source_health_task1.json.
+
+Quality review fix: source-health no longer instantiates MultiDatabaseRetriever or source-specific databases during health polling. Endpoint derives configured source IDs from resolved request handles and existing Kanban DB files only; integration regression now fails if retriever construction is attempted. Re-ran focused backend tests (8 passed, 23 deselected), git diff --check, and Bandit touched backend scope (0 findings at /tmp/bandit_knowledge_source_health_task1_fix.json).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -4,7 +4,7 @@ title: Implement /knowledge source health and evidence controls
 status: In Progress
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 02:37'
+updated_date: '2026-05-16 02:45'
 labels:
   - webui
   - knowledge
@@ -43,6 +43,8 @@ Task 3 source-picker UI slice complete: provider now loads /api/v1/rag/source-he
 Task 3 quality-review fixes: ready-state source-health notice now prioritizes unavailable/error selected sources over empty-source guidance and only treats sources as empty when available with explicit index_status=empty. CompactToolbar now wires onRefreshSourceHealth to a real one-line source-health retry button instead of carrying an unused prop. Verification: targeted Vitest passed CompactToolbar + KnowledgeReadyState activation (23 tests), broader Task 3 focused Vitest passed 40 tests, git diff --check passed.
 
 Task 4 evidence/trust UI slice implemented. Added deterministic answer trust-summary helper, AnswerPanel trust note outside markdown body, clearer SourceCard Copy citation/Copy excerpt accessible names without duplicate actions, EvidenceRail source-action hint, and SourceList regression expectation for the citation accessible name. Save-to-note remains deferred because a backlink-preserving note handoff contract was not verified in this slice. Verification: red Task 4 tests failed before implementation; updated focused Vitest passed 63 tests across trustSummary, AnswerPanel.states, SourceCard.behavior, SourceList.behavior, and EvidenceRail.motion. git diff --check passed. Full UI tsc --noEmit remains blocked by existing unrelated baseline errors; filtered compiler diagnostics produced no KnowledgeQA/trustSummary/AnswerPanel/SourceCard/SourceList/EvidenceRail matches. Bandit is not applicable to this frontend-only slice.
+
+Task 5 recovery/parity slice implemented. No-results recovery now separates pre-query Source readiness from post-query Search diagnostics, uses concrete handoff labels (Open Quick Ingest, Open source page), and hides Show nearest matches unless evidence exists. Low-quality recovery uses limited-evidence copy and receives selected source-health caveat counts from AnswerPanel without implying automatic web fallback. KnowledgeQALayout passes sourceHealth and selected sources into recovery, and extension /knowledge route parity was rechecked. Verification: red Task 5 tests failed before implementation; focused Vitest passed 23 tests across NoResultsRecovery.source-status, LowQualityRecoveryBanner, and KnowledgeQALayout.behavior. Extension parity passed 4 tests in apps/tldw-frontend. git diff --check passed. Full UI tsc remains blocked by unrelated baseline errors; filtered compiler diagnostics produced no KnowledgeQA/NoResultsRecovery/LowQualityRecoveryBanner/KnowledgeQALayout/AnswerPanel matches. Bandit is not applicable to this frontend-only slice.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -4,7 +4,7 @@ title: Implement /knowledge source health and evidence controls
 status: In Progress
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 01:37'
+updated_date: '2026-05-16 01:44'
 labels:
   - webui
   - knowledge
@@ -33,6 +33,8 @@ priority: high
 Task 1 backend source-health contract implemented. Focused tests passed: pytest -q test_source_health.py test_rag_source_health_endpoint.py test_source_contract.py test_unified_pipeline.py -k 'source_status or source_health or source_contract' (8 passed, 23 deselected). git diff --check passed. Bandit touched backend scope passed with 0 findings at /tmp/bandit_knowledge_source_health_task1.json.
 
 Quality review fix: source-health no longer instantiates MultiDatabaseRetriever or source-specific databases during health polling. Endpoint derives configured source IDs from resolved request handles and existing Kanban DB files only; integration regression now fails if retriever construction is attempted. Re-ran focused backend tests (8 passed, 23 deselected), git diff --check, and Bandit touched backend scope (0 findings at /tmp/bandit_knowledge_source_health_task1_fix.json).
+
+Spec re-review fix: removed source DB dependencies from /api/v1/rag/source-health. The endpoint now depends only on the authenticated user and computes source availability from existing per-user DB files without creating directories, schemas, retrievers, or request-scoped DB handles. Re-ran focused backend tests (8 passed, 23 deselected), git diff --check, and Bandit touched backend scope (0 findings at /tmp/bandit_knowledge_source_health_task1_fix2.json).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -4,7 +4,7 @@ title: Implement /knowledge source health and evidence controls
 status: Done
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 02:59'
+updated_date: '2026-05-16 03:34'
 labels:
   - webui
   - knowledge
@@ -47,6 +47,10 @@ Task 4 evidence/trust UI slice implemented. Added deterministic answer trust-sum
 Task 5 recovery/parity slice implemented. No-results recovery now separates pre-query Source readiness from post-query Search diagnostics, uses concrete handoff labels (Open Quick Ingest, Open source page), and hides Show nearest matches unless evidence exists. Low-quality recovery uses limited-evidence copy and receives selected source-health caveat counts from AnswerPanel without implying automatic web fallback. KnowledgeQALayout passes sourceHealth and selected sources into recovery, and extension /knowledge route parity was rechecked. Verification: red Task 5 tests failed before implementation; focused Vitest passed 23 tests across NoResultsRecovery.source-status, LowQualityRecoveryBanner, and KnowledgeQALayout.behavior. Extension parity passed 4 tests in apps/tldw-frontend. git diff --check passed. Full UI tsc remains blocked by unrelated baseline errors; filtered compiler diagnostics produced no KnowledgeQA/NoResultsRecovery/LowQualityRecoveryBanner/KnowledgeQALayout/AnswerPanel matches. Bandit is not applicable to this frontend-only slice.
 
 Task 6 final verification completed after rebasing onto origin/dev. Backend focused pytest passed: 8 passed, 4 warnings. KnowledgeQA focused Vitest passed: 14 files, 117 tests. Extension parity passed: 1 file, 4 tests. Browser smoke passed after rerunning Playwright outside the macOS sandbox: /knowledge navigation/search-bar test passed against frontend localhost:18001 and backend 127.0.0.1:8000. git diff --check passed. Bandit touched backend files passed with 0 findings at /tmp/bandit_knowledge_source_health.json. Opened PR https://github.com/rmusser01/tldw_server/pull/1745.
+
+PR review sweep for #1745 started. Actionable unresolved threads verified: Gemini core_settings.get, async filesystem threadpool, internal /sources Link; Qodo async filesystem, PostgreSQL/non-file health detection, TEST_MODE base-dir parity. Implementing fixes on the same PR branch.
+
+PR review sweep for #1745 completed. Addressed Gemini/Qodo source-health review by moving filesystem checks into a threadpool, reusing DatabasePaths read-only base-dir resolution, adding single-user ID fallback, and avoiding file-only false negatives for PostgreSQL/lazy sources. Addressed CodeRabbit UI review by using router Link for /sources, disabling refresh while source health is loading, guarding source-health refresh races, treating missing health entries as caveats, avoiding indexing-as-unavailable copy, restoring no-results nearest-match access from search metadata, and making the SourceCard visible action label "Copy citation". Verification: backend focused pytest passed 15 selected tests; KnowledgeQA focused Vitest passed 7 files / 63 tests; git diff --check passed; Bandit touched backend files passed with 0 findings at /tmp/bandit_knowledge_source_health_review.json.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -4,7 +4,7 @@ title: Implement /knowledge source health and evidence controls
 status: In Progress
 assignee: []
 created_date: '2026-05-16 00:51'
-updated_date: '2026-05-16 01:53'
+updated_date: '2026-05-16 02:19'
 labels:
   - webui
   - knowledge
@@ -37,6 +37,10 @@ Quality review fix: source-health no longer instantiates MultiDatabaseRetriever 
 Spec re-review fix: removed source DB dependencies from /api/v1/rag/source-health. The endpoint now depends only on the authenticated user and computes source availability from existing per-user DB files without creating directories, schemas, retrievers, or request-scoped DB handles. Re-ran focused backend tests (8 passed, 23 deselected), git diff --check, and Bandit touched backend scope (0 findings at /tmp/bandit_knowledge_source_health_task1_fix2.json).
 
 Task 2 frontend client/normalization implemented. Added tldw API ragSourceHealth client method, Knowledge QA source-health types/state, normalization helpers, and focused tests. Verification: vitest run sourceHealth.test.ts + tldw-api-client.rag-source-health.test.ts passed (4 tests); provider-focused vitest with KnowledgeQAProvider.feature-flags passed (5 tests total). Full UI tsc --noEmit remains blocked by existing unrelated baseline type errors in audio/chat/flashcards/playground/services tests; no sourceHealth or KnowledgeQAProvider errors appeared in the reported output. Optional ownership guard sanity check also still fails on existing OpenWebUI overlap inventory, not ragSourceHealth.
+
+Task 3 source-picker UI slice complete: provider now loads /api/v1/rag/source-health once after tldw client initialization, KnowledgeQALayout threads sourceHealth/refresh through simple and detailed /knowledge surfaces, KnowledgeContextBar and CompactToolbar render compact health summaries, source picker rows show per-source status chips and retry, and KnowledgeReadyState now surfaces health failure, unavailable selected sources, and empty-source guidance without inline creation/import. Verification: red tests failed before implementation; focused Vitest passed 38 tests across sourceHealth, tldw-api-client.rag-source-health, KnowledgeContextBar.source-health, CompactToolbar, KnowledgeQALayout.behavior, KnowledgeReadyState.activation, and KnowledgeQAProvider.feature-flags. git diff --check passed. Full UI tsc remains red on existing baseline; rg over captured output found no KnowledgeQA/sourceHealth/touched-file errors.
+
+Task 3 quality-review fixes: ready-state source-health notice now prioritizes unavailable/error selected sources over empty-source guidance and only treats sources as empty when available with explicit index_status=empty. CompactToolbar now wires onRefreshSourceHealth to a real one-line source-health retry button instead of carrying an unused prop. Verification: targeted Vitest passed CompactToolbar + KnowledgeReadyState activation (23 tests), broader Task 3 focused Vitest passed 40 tests, git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
+++ b/backlog/tasks/task-396 - Implement-knowledge-source-health-and-evidence-controls.md
@@ -1,0 +1,44 @@
+---
+id: TASK-396
+title: Implement /knowledge source health and evidence controls
+status: In Progress
+assignee: []
+created_date: '2026-05-16 00:51'
+updated_date: '2026-05-16 01:25'
+labels:
+  - webui
+  - knowledge
+  - ux
+  - feature
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-16-knowledge-source-health-evidence-controls-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-16-knowledge-source-health-evidence-controls-plan.md
+priority: high
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GET /api/v1/rag/source-health returns safe pre-query health for canonical Knowledge QA sources without altering search-response metadata.source_status.
+- [ ] #2 Knowledge QA shows source health before search and keeps search usable when health loading fails.
+- [ ] #3 Knowledge QA answer and evidence surfaces show compact trust/evidence controls without adding durable evidence persistence.
+- [ ] #4 Focused backend, frontend, extension parity, diff-check, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Task 1 backend source-health contract implemented. Focused tests passed: pytest -q test_source_health.py test_rag_source_health_endpoint.py test_source_contract.py test_unified_pipeline.py -k 'source_status or source_health or source_contract' (8 passed, 23 deselected). git diff --check passed. Bandit touched backend scope passed with 0 findings at /tmp/bandit_knowledge_source_health_task1.json.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -11,6 +11,7 @@ import inspect
 import json
 import os
 import time
+from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
@@ -70,7 +71,8 @@ from tldw_Server_API.app.core.RAG.rag_service.response_mapping import (
 )
 from tldw_Server_API.app.core.RAG.rag_service.source_health import build_source_health_entries
 from tldw_Server_API.app.core.RAG.rag_service.streaming_executor import stream_rag_events
-from tldw_Server_API.app.core.config import get_config_value
+from tldw_Server_API.app.core.config import get_config_value, settings as core_settings
+from tldw_Server_API.app.core.Utils.Utils import get_project_root
 
 # Unified Pipeline
 from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import (
@@ -372,6 +374,74 @@ def _resolve_kanban_db_path(current_user: Optional[User], request_user_id: Optio
     except (RuntimeError, ValueError, OSError, TypeError):
         logger.debug("Failed to resolve kanban DB path", exc_info=True)
         return None
+
+
+def _resolve_source_health_user_id(current_user: Optional[User], request_user_id: Optional[str] = None) -> Optional[str]:
+    """Resolve a filesystem-safe user directory component without creating storage."""
+    candidates: list[Any] = []
+    if current_user is not None:
+        for attr in ("id", "id_int"):
+            candidates.append(getattr(current_user, attr, None))
+    candidates.append(request_user_id)
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        raw = str(candidate).strip()
+        if raw.isdigit() and int(raw) > 0:
+            return raw
+    return None
+
+
+def _resolve_source_health_user_db_base_dir() -> Path:
+    """Resolve the user DB base directory path without ensuring directories."""
+    raw_base = os.getenv("USER_DB_BASE_DIR") or core_settings.get("USER_DB_BASE_DIR")
+    if raw_base:
+        base_path = Path(raw_base).expanduser()
+        if not base_path.is_absolute():
+            base_path = Path(get_project_root()) / base_path
+        return base_path.resolve(strict=False)
+    return (Path(get_project_root()) / "Databases" / "user_databases").resolve(strict=False)
+
+
+def _resolve_existing_kanban_db_path(
+    current_user: Optional[User],
+    request_user_id: Optional[str] = None,
+) -> Optional[str]:
+    """Return an existing Kanban DB path without creating user directories or schema."""
+    user_id = _resolve_source_health_user_id(current_user, request_user_id)
+    if user_id is None:
+        return None
+    candidate = _resolve_source_health_user_db_base_dir() / user_id / DatabasePaths.KANBAN_DB_NAME
+    return str(candidate) if candidate.is_file() else None
+
+
+def _build_source_health_configured_sources(
+    *,
+    media_db: Any,
+    chacha_db: Any,
+    prompts_db: Any,
+    kanban_db_path: Optional[str],
+) -> set[Any]:
+    """Derive source availability from already-resolved handles and existing files."""
+    configured: set[Any] = set()
+    if media_db is not None:
+        configured.add("media_db")
+    if chacha_db is not None:
+        configured.update(
+            {
+                "notes",
+                "chats",
+                "characters",
+                "world_books",
+                "dictionaries",
+            }
+        )
+    if prompts_db is not None:
+        configured.add("prompts")
+    if kanban_db_path:
+        configured.add("kanban")
+    return configured
 
 
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -1000,40 +1070,14 @@ async def source_health_endpoint(
     prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
 ) -> KnowledgeSourceHealthResponse:
     """Return safe pre-query readiness for canonical Knowledge QA sources."""
-    db_paths: dict[str, str] = {}
-    media_db_path = getattr(media_db, "db_path", None) if media_db is not None else None
-    if media_db_path:
-        db_paths["media_db"] = str(media_db_path)
-
-    chacha_db_path = getattr(chacha_db, "db_path", None) if chacha_db is not None else None
-    if chacha_db_path:
-        chacha_path = str(chacha_db_path)
-        db_paths["notes_db"] = chacha_path
-        db_paths["character_cards_db"] = chacha_path
-        db_paths["world_books_db"] = chacha_path
-        db_paths["chat_dictionaries_db"] = chacha_path
-
-    prompts_db_path = None
-    if prompts_db is not None:
-        prompts_db_path = getattr(prompts_db, "db_path_str", None) or getattr(prompts_db, "db_path", None)
-    if prompts_db_path:
-        db_paths["prompts_db"] = str(prompts_db_path)
-
-    kanban_db_path = _resolve_kanban_db_path(current_user)
-    if kanban_db_path:
-        db_paths["kanban_db"] = str(kanban_db_path)
-
-    retriever = MultiDatabaseRetriever(
-        db_paths=db_paths,
-        user_id=_resolve_implicit_feedback_user_id(None, current_user) or "0",
+    configured_sources = _build_source_health_configured_sources(
         media_db=media_db,
         chacha_db=chacha_db,
         prompts_db=prompts_db,
+        kanban_db_path=_resolve_existing_kanban_db_path(current_user),
     )
     return KnowledgeSourceHealthResponse(
-        sources=build_source_health_entries(
-            configured_sources=set(retriever.retrievers.keys())
-        )
+        sources=build_source_health_entries(configured_sources=configured_sources)
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -11,11 +11,11 @@ import inspect
 import json
 import os
 import time
-from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, TokenScopeGuard, User
@@ -71,8 +71,7 @@ from tldw_Server_API.app.core.RAG.rag_service.response_mapping import (
 )
 from tldw_Server_API.app.core.RAG.rag_service.source_health import build_source_health_entries
 from tldw_Server_API.app.core.RAG.rag_service.streaming_executor import stream_rag_events
-from tldw_Server_API.app.core.config import get_config_value, settings as core_settings
-from tldw_Server_API.app.core.Utils.Utils import get_project_root
+from tldw_Server_API.app.core.config import get_config_value, settings
 
 # Unified Pipeline
 from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import (
@@ -390,18 +389,14 @@ def _resolve_source_health_user_id(current_user: Optional[User], request_user_id
         raw = str(candidate).strip()
         if raw.isdigit() and int(raw) > 0:
             return raw
+    try:
+        fallback = DatabasePaths.get_single_user_id()
+        fallback_raw = str(fallback).strip()
+        if fallback_raw.isdigit() and int(fallback_raw) > 0:
+            return fallback_raw
+    except (RuntimeError, ValueError, OSError, TypeError):
+        logger.debug("Failed to resolve single-user ID for source health path", exc_info=True)
     return None
-
-
-def _resolve_source_health_user_db_base_dir() -> Path:
-    """Resolve the user DB base directory path without ensuring directories."""
-    raw_base = os.getenv("USER_DB_BASE_DIR") or core_settings.get("USER_DB_BASE_DIR")
-    if raw_base:
-        base_path = Path(raw_base).expanduser()
-        if not base_path.is_absolute():
-            base_path = Path(get_project_root()) / base_path
-        return base_path.resolve(strict=False)
-    return (Path(get_project_root()) / "Databases" / "user_databases").resolve(strict=False)
 
 
 def _resolve_existing_source_db_paths(
@@ -413,7 +408,7 @@ def _resolve_existing_source_db_paths(
     if user_id is None:
         return {}
 
-    user_dir = _resolve_source_health_user_db_base_dir() / user_id
+    user_dir = DatabasePaths.resolve_user_db_base_dir() / user_id
     candidates = {
         "media_db": user_dir / DatabasePaths.MEDIA_DB_NAME,
         "chacha_db": user_dir / DatabasePaths.CHACHA_DB_NAME,
@@ -427,14 +422,28 @@ def _resolve_existing_source_db_paths(
     }
 
 
-def _build_source_health_configured_sources(
+def _media_db_uses_non_file_storage() -> bool:
+    """Return whether Media DB search is configured for non-file content storage."""
+    backend_mode_hint = (
+        os.getenv("CONTENT_DB_MODE")
+        or os.getenv("TLDW_CONTENT_DB_BACKEND")
+        or str(settings.get("CONTENT_DB_BACKEND", "sqlite"))
+    )
+    return backend_mode_hint.strip().lower() in {"postgres", "postgresql"}
+
+
+def _build_source_health_source_sets(
     *,
     existing_paths: dict[str, str],
-) -> set[Any]:
-    """Derive source availability from existing source database files."""
+    media_backend_uses_non_file_storage: bool = False,
+) -> tuple[set[Any], set[Any]]:
+    """Derive ready and empty source sets without creating source storage."""
     configured: set[Any] = set()
-    if "media_db" in existing_paths:
+    empty: set[Any] = set()
+    if "media_db" in existing_paths or media_backend_uses_non_file_storage:
         configured.add("media_db")
+    else:
+        empty.add("media_db")
     if "chacha_db" in existing_paths:
         configured.update(
             {
@@ -445,11 +454,25 @@ def _build_source_health_configured_sources(
                 "dictionaries",
             }
         )
+    else:
+        empty.update(
+            {
+                "notes",
+                "chats",
+                "characters",
+                "world_books",
+                "dictionaries",
+            }
+        )
     if "prompts_db" in existing_paths:
         configured.add("prompts")
+    else:
+        empty.add("prompts")
     if "kanban_db" in existing_paths:
         configured.add("kanban")
-    return configured
+    else:
+        empty.add("kanban")
+    return configured, empty
 
 
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -1075,11 +1098,16 @@ async def source_health_endpoint(
     current_user: User = Depends(get_request_user),
 ) -> KnowledgeSourceHealthResponse:
     """Return safe pre-query readiness for canonical Knowledge QA sources."""
-    configured_sources = _build_source_health_configured_sources(
-        existing_paths=_resolve_existing_source_db_paths(current_user),
+    existing_paths = await run_in_threadpool(_resolve_existing_source_db_paths, current_user)
+    configured_sources, empty_sources = _build_source_health_source_sets(
+        existing_paths=existing_paths,
+        media_backend_uses_non_file_storage=_media_db_uses_non_file_storage(),
     )
     return KnowledgeSourceHealthResponse(
-        sources=build_source_health_entries(configured_sources=configured_sources)
+        sources=build_source_health_entries(
+            configured_sources=configured_sources,
+            empty_sources=empty_sources,
+        )
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -29,6 +29,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 # Schemas
 from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
     ImplicitFeedbackEvent,
+    KnowledgeSourceHealthResponse,
     UnifiedBatchRequest,
     UnifiedBatchResponse,
     UnifiedRAGRequest,
@@ -67,6 +68,7 @@ from tldw_Server_API.app.core.RAG.rag_service.response_mapping import (
     rag_result_from_unified_search_result,
     rag_result_to_response,
 )
+from tldw_Server_API.app.core.RAG.rag_service.source_health import build_source_health_entries
 from tldw_Server_API.app.core.RAG.rag_service.streaming_executor import stream_rag_events
 from tldw_Server_API.app.core.config import get_config_value
 
@@ -977,6 +979,62 @@ async def list_vlm_backends():
     except Exception:  # noqa: BLE001 - optional registry failures should not break endpoint
         backends = {}
     return {"backends": backends}
+
+
+@router.get(
+    "/source-health",
+    response_model=KnowledgeSourceHealthResponse,
+    summary="Knowledge source health",
+    description="Read-only pre-query source readiness for Knowledge QA.",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(rbac_rate_limit("rag.search")),
+        Depends(RequirePermission(MEDIA_READ)),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="rag.search", count_as="call")),
+    ],
+)
+async def source_health_endpoint(
+    current_user: User = Depends(get_request_user),
+    media_db: Any = Depends(get_media_db_for_user),
+    chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
+) -> KnowledgeSourceHealthResponse:
+    """Return safe pre-query readiness for canonical Knowledge QA sources."""
+    db_paths: dict[str, str] = {}
+    media_db_path = getattr(media_db, "db_path", None) if media_db is not None else None
+    if media_db_path:
+        db_paths["media_db"] = str(media_db_path)
+
+    chacha_db_path = getattr(chacha_db, "db_path", None) if chacha_db is not None else None
+    if chacha_db_path:
+        chacha_path = str(chacha_db_path)
+        db_paths["notes_db"] = chacha_path
+        db_paths["character_cards_db"] = chacha_path
+        db_paths["world_books_db"] = chacha_path
+        db_paths["chat_dictionaries_db"] = chacha_path
+
+    prompts_db_path = None
+    if prompts_db is not None:
+        prompts_db_path = getattr(prompts_db, "db_path_str", None) or getattr(prompts_db, "db_path", None)
+    if prompts_db_path:
+        db_paths["prompts_db"] = str(prompts_db_path)
+
+    kanban_db_path = _resolve_kanban_db_path(current_user)
+    if kanban_db_path:
+        db_paths["kanban_db"] = str(kanban_db_path)
+
+    retriever = MultiDatabaseRetriever(
+        db_paths=db_paths,
+        user_id=_resolve_implicit_feedback_user_id(None, current_user) or "0",
+        media_db=media_db,
+        chacha_db=chacha_db,
+        prompts_db=prompts_db,
+    )
+    return KnowledgeSourceHealthResponse(
+        sources=build_source_health_entries(
+            configured_sources=set(retriever.retrievers.keys())
+        )
+    )
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -404,30 +404,38 @@ def _resolve_source_health_user_db_base_dir() -> Path:
     return (Path(get_project_root()) / "Databases" / "user_databases").resolve(strict=False)
 
 
-def _resolve_existing_kanban_db_path(
+def _resolve_existing_source_db_paths(
     current_user: Optional[User],
     request_user_id: Optional[str] = None,
-) -> Optional[str]:
-    """Return an existing Kanban DB path without creating user directories or schema."""
+) -> dict[str, str]:
+    """Return existing source database paths without creating source storage."""
     user_id = _resolve_source_health_user_id(current_user, request_user_id)
     if user_id is None:
-        return None
-    candidate = _resolve_source_health_user_db_base_dir() / user_id / DatabasePaths.KANBAN_DB_NAME
-    return str(candidate) if candidate.is_file() else None
+        return {}
+
+    user_dir = _resolve_source_health_user_db_base_dir() / user_id
+    candidates = {
+        "media_db": user_dir / DatabasePaths.MEDIA_DB_NAME,
+        "chacha_db": user_dir / DatabasePaths.CHACHA_DB_NAME,
+        "prompts_db": user_dir / DatabasePaths.PROMPTS_SUBDIR / DatabasePaths.PROMPTS_DB_NAME,
+        "kanban_db": user_dir / DatabasePaths.KANBAN_DB_NAME,
+    }
+    return {
+        source_key: str(path)
+        for source_key, path in candidates.items()
+        if path.is_file()
+    }
 
 
 def _build_source_health_configured_sources(
     *,
-    media_db: Any,
-    chacha_db: Any,
-    prompts_db: Any,
-    kanban_db_path: Optional[str],
+    existing_paths: dict[str, str],
 ) -> set[Any]:
-    """Derive source availability from already-resolved handles and existing files."""
+    """Derive source availability from existing source database files."""
     configured: set[Any] = set()
-    if media_db is not None:
+    if "media_db" in existing_paths:
         configured.add("media_db")
-    if chacha_db is not None:
+    if "chacha_db" in existing_paths:
         configured.update(
             {
                 "notes",
@@ -437,9 +445,9 @@ def _build_source_health_configured_sources(
                 "dictionaries",
             }
         )
-    if prompts_db is not None:
+    if "prompts_db" in existing_paths:
         configured.add("prompts")
-    if kanban_db_path:
+    if "kanban_db" in existing_paths:
         configured.add("kanban")
     return configured
 
@@ -1065,16 +1073,10 @@ async def list_vlm_backends():
 )
 async def source_health_endpoint(
     current_user: User = Depends(get_request_user),
-    media_db: Any = Depends(get_media_db_for_user),
-    chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
-    prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
 ) -> KnowledgeSourceHealthResponse:
     """Return safe pre-query readiness for canonical Knowledge QA sources."""
     configured_sources = _build_source_health_configured_sources(
-        media_db=media_db,
-        chacha_db=chacha_db,
-        prompts_db=prompts_db,
-        kanban_db_path=_resolve_existing_kanban_db_path(current_user),
+        existing_paths=_resolve_existing_source_db_paths(current_user),
     )
     return KnowledgeSourceHealthResponse(
         sources=build_source_health_entries(configured_sources=configured_sources)

--- a/tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py
+++ b/tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py
@@ -1649,6 +1649,51 @@ class UnifiedRAGRequest(BaseModel):
             return self
 
 
+KnowledgeSourceIndexStatus = Literal[
+    "ready",
+    "indexing",
+    "stale",
+    "empty",
+    "unavailable",
+    "error",
+    "unknown",
+]
+KnowledgeSourceEmbeddingStatus = Literal[
+    "ready",
+    "indexing",
+    "missing",
+    "unavailable",
+    "not_applicable",
+    "error",
+    "unknown",
+]
+
+
+class KnowledgeSourceHealthEntry(BaseModel):
+    """Safe pre-query readiness details for a canonical Knowledge QA source."""
+
+    source_id: str
+    label: str
+    available: bool
+    searchable: bool
+    item_count: Optional[int] = None
+    indexed_count: Optional[int] = None
+    last_updated: Optional[str] = None
+    last_indexed: Optional[str] = None
+    index_status: KnowledgeSourceIndexStatus = "unknown"
+    embedding_status: KnowledgeSourceEmbeddingStatus = "unknown"
+    disabled_reason: Optional[str] = None
+    workspace_scoped: bool = False
+    hidden_by_default: bool = False
+    privacy_note: Optional[str] = None
+
+
+class KnowledgeSourceHealthResponse(BaseModel):
+    """Read-only source health response for Knowledge QA clients."""
+
+    sources: list[KnowledgeSourceHealthEntry]
+
+
 class UnifiedRAGResponse(BaseModel):
     """Unified response structure for RAG queries."""
 

--- a/tldw_Server_API/app/core/DB_Management/db_path_utils.py
+++ b/tldw_Server_API/app/core/DB_Management/db_path_utils.py
@@ -426,7 +426,13 @@ class DatabasePaths:
     PERSONA_VISUALS_SUBDIR = "persona_visuals"
 
     @staticmethod
-    def get_user_db_base_dir(*, allow_legacy_alias: bool = False) -> Path:
+    def resolve_user_db_base_dir(*, allow_legacy_alias: bool = False) -> Path:
+        """
+        Resolve the configured per-user database base directory without creating it.
+
+        This mirrors ``get_user_db_base_dir`` path selection, including isolated
+        test fallbacks, for read-only checks that must not create storage.
+        """
         env_user_db_base = os.getenv("USER_DB_BASE_DIR")
         settings_user_db_base = settings.get("USER_DB_BASE_DIR")
         project_root = Path(get_project_root())
@@ -486,6 +492,13 @@ class DatabasePaths:
                 logger.warning(f"USER_DB_BASE_DIR not configured, using fallback: {base_path}")
         else:
             base_path = _normalize_user_db_base_dir(Path(user_db_base))
+        return base_path
+
+    @staticmethod
+    def get_user_db_base_dir(*, allow_legacy_alias: bool = False) -> Path:
+        base_path = DatabasePaths.resolve_user_db_base_dir(
+            allow_legacy_alias=allow_legacy_alias
+        )
         _ensure_dir(base_path, label="user database base")
         return base_path
 

--- a/tldw_Server_API/app/core/RAG/rag_service/source_health.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/source_health.py
@@ -1,0 +1,104 @@
+"""Safe source readiness summaries for Knowledge QA."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
+    KnowledgeSourceHealthEntry,
+)
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+
+CANONICAL_KNOWLEDGE_SOURCE_IDS: tuple[str, ...] = (
+    "media_db",
+    "notes",
+    "chats",
+    "characters",
+    "kanban",
+    "prompts",
+    "world_books",
+    "dictionaries",
+)
+
+_SOURCE_LABELS: dict[str, str] = {
+    "media_db": "Documents & Media",
+    "notes": "Notes",
+    "chats": "Chats",
+    "characters": "Characters",
+    "kanban": "Task Boards",
+    "prompts": "Prompts",
+    "world_books": "World Books",
+    "dictionaries": "Dictionaries",
+}
+
+_SOURCE_TO_DATASOURCE: dict[str, DataSource] = {
+    "media_db": DataSource.MEDIA_DB,
+    "notes": DataSource.NOTES,
+    "chats": DataSource.CHAT_HISTORY,
+    "characters": DataSource.CHARACTER_CARDS,
+    "kanban": DataSource.KANBAN,
+    "prompts": DataSource.PROMPTS,
+    "world_books": DataSource.WORLD_BOOKS,
+    "dictionaries": DataSource.DICTIONARIES,
+}
+
+_ALIASES_TO_DATASOURCE: dict[str, DataSource] = {
+    source_id: data_source
+    for source_id, data_source in _SOURCE_TO_DATASOURCE.items()
+}
+_ALIASES_TO_DATASOURCE.update(
+    {
+        data_source.value: data_source
+        for data_source in _SOURCE_TO_DATASOURCE.values()
+    }
+)
+
+
+def _normalize_configured_sources(
+    configured_sources: Iterable[DataSource | str] | Mapping[Any, Any],
+) -> set[DataSource]:
+    """Normalize configured source identifiers without reading metadata values."""
+    raw_sources: Iterable[Any]
+    if isinstance(configured_sources, Mapping):
+        raw_sources = configured_sources.keys()
+    else:
+        raw_sources = configured_sources
+
+    normalized: set[DataSource] = set()
+    for source in raw_sources:
+        if isinstance(source, DataSource):
+            normalized.add(source)
+            continue
+        if isinstance(source, str):
+            data_source = _ALIASES_TO_DATASOURCE.get(source)
+            if data_source is not None:
+                normalized.add(data_source)
+    return normalized
+
+
+def build_source_health_entries(
+    *,
+    configured_sources: Iterable[DataSource | str] | Mapping[Any, Any],
+    unsafe_metadata: Mapping[str, Mapping[str, Any]] | None = None,
+) -> list[KnowledgeSourceHealthEntry]:
+    """Build safe pre-query source readiness entries for Knowledge QA."""
+    del unsafe_metadata
+    configured = _normalize_configured_sources(configured_sources)
+
+    entries: list[KnowledgeSourceHealthEntry] = []
+    for source_id in CANONICAL_KNOWLEDGE_SOURCE_IDS:
+        data_source = _SOURCE_TO_DATASOURCE[source_id]
+        is_configured = data_source in configured
+        entries.append(
+            KnowledgeSourceHealthEntry(
+                source_id=source_id,
+                label=_SOURCE_LABELS[source_id],
+                available=is_configured,
+                searchable=is_configured,
+                index_status="ready" if is_configured else "unavailable",
+                embedding_status="unknown" if is_configured else "unavailable",
+                disabled_reason=None if is_configured else "no_retriever_configured",
+            )
+        )
+    return entries

--- a/tldw_Server_API/app/core/RAG/rag_service/source_health.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/source_health.py
@@ -80,25 +80,29 @@ def _normalize_configured_sources(
 def build_source_health_entries(
     *,
     configured_sources: Iterable[DataSource | str] | Mapping[Any, Any],
+    empty_sources: Iterable[DataSource | str] | Mapping[Any, Any] = (),
     unsafe_metadata: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> list[KnowledgeSourceHealthEntry]:
     """Build safe pre-query source readiness entries for Knowledge QA."""
     del unsafe_metadata
     configured = _normalize_configured_sources(configured_sources)
+    empty = _normalize_configured_sources(empty_sources)
 
     entries: list[KnowledgeSourceHealthEntry] = []
     for source_id in CANONICAL_KNOWLEDGE_SOURCE_IDS:
         data_source = _SOURCE_TO_DATASOURCE[source_id]
         is_configured = data_source in configured
+        is_empty = data_source in empty and not is_configured
+        available = is_configured or is_empty
         entries.append(
             KnowledgeSourceHealthEntry(
                 source_id=source_id,
                 label=_SOURCE_LABELS[source_id],
-                available=is_configured,
-                searchable=is_configured,
-                index_status="ready" if is_configured else "unavailable",
-                embedding_status="unknown" if is_configured else "unavailable",
-                disabled_reason=None if is_configured else "no_retriever_configured",
+                available=available,
+                searchable=available,
+                index_status="ready" if is_configured else "empty" if is_empty else "unavailable",
+                embedding_status="unknown" if available else "unavailable",
+                disabled_reason=None if available else "no_retriever_configured",
             )
         )
     return entries

--- a/tldw_Server_API/tests/DB_Management/test_db_path_utils.py
+++ b/tldw_Server_API/tests/DB_Management/test_db_path_utils.py
@@ -169,6 +169,27 @@ def test_user_db_base_dir_test_fallback_is_not_repo_local(monkeypatch):
     )
 
 
+def test_resolve_user_db_base_dir_matches_test_fallback_without_creating(monkeypatch, tmp_path):
+    """Read-only base resolution should match DB creation fallback without creating storage."""
+    monkeypatch.delenv("USER_DB_BASE_DIR", raising=False)
+    monkeypatch.delenv("USER_DB_BASE", raising=False)
+    monkeypatch.setenv("TLDW_TEST_RUN_ID", f"readonly-{tmp_path.name}")
+    monkeypatch.setitem(settings, "USER_DB_BASE_DIR", None)
+    monkeypatch.setitem(settings, "USER_DB_BASE", None)
+    monkeypatch.setattr(db_path_utils, "_is_test_context", lambda: True)
+
+    resolved = DatabasePaths.resolve_user_db_base_dir()
+
+    _expect_true(
+        "tldw_user_databases_test" in str(resolved),
+        "read-only resolver should use the same isolated test fallback tree",
+    )
+    _expect_true(
+        not resolved.exists(),
+        "read-only resolver must not create the user DB base directory",
+    )
+
+
 def test_user_db_base_dir_test_fallback_uses_unique_run_tag(monkeypatch):
     monkeypatch.delenv("USER_DB_BASE_DIR", raising=False)
     monkeypatch.delenv("USER_DB_BASE", raising=False)

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
@@ -1,0 +1,149 @@
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+from tldw_Server_API.app.main import app as fastapi_app
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _test_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+
+
+@pytest.fixture()
+def client_with_source_health_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_headers: dict[str, str],
+) -> Iterator[TestClient]:
+    async def override_user() -> User:
+        return User(id=1, username="tester", email=None, is_active=True)
+
+    async def _noop() -> None:
+        return None
+
+    async def _fake_principal(request: Request) -> AuthPrincipal:  # noqa: ARG001
+        return AuthPrincipal(
+            kind="service",
+            user_id=None,
+            api_key_id=None,
+            subject="service:rag-source-health-test",
+            token_type="access",
+            jti=None,
+            roles=["admin"],
+            permissions=["system.logs", "media.read"],
+            is_admin=True,
+            org_ids=[],
+            team_ids=[],
+        )
+
+    async def _no_rbac(*args: Any, **kwargs: Any) -> None:  # noqa: ARG001
+        return None
+
+    class StubDB:
+        def __init__(self, db_path: str) -> None:
+            self.db_path = db_path
+
+    async def _stub_media_db() -> StubDB:
+        return StubDB("stub_media.db")
+
+    async def _stub_chacha_db() -> StubDB:
+        return StubDB("stub_chacha.db")
+
+    async def _stub_prompts_db() -> StubDB:
+        return StubDB("stub_prompts.db")
+
+    monkeypatch.setattr(auth_deps, "enforce_rbac_rate_limit", _no_rbac)
+
+    fastapi_app.dependency_overrides[get_request_user] = override_user
+    fastapi_app.dependency_overrides[get_auth_principal] = _fake_principal
+    fastapi_app.dependency_overrides[check_rate_limit] = _noop
+
+    from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+    from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+    from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
+
+    fastapi_app.dependency_overrides[get_media_db_for_user] = _stub_media_db
+    fastapi_app.dependency_overrides[get_chacha_db_for_user] = _stub_chacha_db
+    fastapi_app.dependency_overrides[get_prompts_db_for_user] = _stub_prompts_db
+
+    with TestClient(fastapi_app, headers=auth_headers, raise_server_exceptions=False) as client:
+        yield client
+
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_rag_source_health_returns_safe_canonical_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_source_health_overrides: TestClient,
+) -> None:
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    captured: dict[str, Any] = {}
+
+    class StubRetriever:
+        def __init__(self, db_paths: dict[str, str], user_id: str = "0", **kwargs: Any) -> None:
+            captured["db_paths"] = dict(db_paths)
+            captured["user_id"] = user_id
+            captured["kwargs"] = dict(kwargs)
+            self.retrievers = {
+                DataSource.MEDIA_DB: object(),
+                DataSource.NOTES: object(),
+                DataSource.CHAT_HISTORY: object(),
+                DataSource.CHARACTER_CARDS: object(),
+                DataSource.KANBAN: object(),
+                DataSource.PROMPTS: object(),
+                DataSource.WORLD_BOOKS: object(),
+                DataSource.DICTIONARIES: object(),
+            }
+
+        async def retrieve(self, *args: Any, **kwargs: Any) -> list[Any]:  # noqa: ARG002
+            raise AssertionError("source health must not execute retrieval")
+
+    monkeypatch.setattr(rag_ep, "MultiDatabaseRetriever", StubRetriever)
+    monkeypatch.setattr(rag_ep, "_resolve_kanban_db_path", lambda *args, **kwargs: "stub_kanban.db")
+
+    response = client_with_source_health_overrides.get("/api/v1/rag/source-health")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert [source["source_id"] for source in payload["sources"]] == [
+        "media_db",
+        "notes",
+        "chats",
+        "characters",
+        "kanban",
+        "prompts",
+        "world_books",
+        "dictionaries",
+    ]
+    assert all(source["available"] is True for source in payload["sources"])
+    assert all(source["searchable"] is True for source in payload["sources"])
+    assert all("title" not in source for source in payload["sources"])
+    assert all("metadata" not in source for source in payload["sources"])
+    assert "stub_media.db" not in response.text
+    assert "stub_chacha.db" not in response.text
+    assert "stub_prompts.db" not in response.text
+    assert captured["db_paths"] == {
+        "media_db": "stub_media.db",
+        "notes_db": "stub_chacha.db",
+        "character_cards_db": "stub_chacha.db",
+        "world_books_db": "stub_chacha.db",
+        "chat_dictionaries_db": "stub_chacha.db",
+        "prompts_db": "stub_prompts.db",
+        "kanban_db": "stub_kanban.db",
+    }
+    assert "media_db_path" not in captured["db_paths"]
+    assert "notes_db_path" not in captured["db_paths"]
+    assert "character_db_path" not in captured["db_paths"]
+    assert "prompts_db_path" not in captured["db_paths"]

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
@@ -9,7 +9,6 @@ from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
 from tldw_Server_API.app.main import app as fastapi_app
 
 
@@ -89,29 +88,11 @@ def test_rag_source_health_returns_safe_canonical_sources(
 ) -> None:
     import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
 
-    captured: dict[str, Any] = {}
+    def fail_retriever_construction(*args: Any, **kwargs: Any) -> None:  # noqa: ARG001
+        raise AssertionError("source health must not instantiate retrievers")
 
-    class StubRetriever:
-        def __init__(self, db_paths: dict[str, str], user_id: str = "0", **kwargs: Any) -> None:
-            captured["db_paths"] = dict(db_paths)
-            captured["user_id"] = user_id
-            captured["kwargs"] = dict(kwargs)
-            self.retrievers = {
-                DataSource.MEDIA_DB: object(),
-                DataSource.NOTES: object(),
-                DataSource.CHAT_HISTORY: object(),
-                DataSource.CHARACTER_CARDS: object(),
-                DataSource.KANBAN: object(),
-                DataSource.PROMPTS: object(),
-                DataSource.WORLD_BOOKS: object(),
-                DataSource.DICTIONARIES: object(),
-            }
-
-        async def retrieve(self, *args: Any, **kwargs: Any) -> list[Any]:  # noqa: ARG002
-            raise AssertionError("source health must not execute retrieval")
-
-    monkeypatch.setattr(rag_ep, "MultiDatabaseRetriever", StubRetriever)
-    monkeypatch.setattr(rag_ep, "_resolve_kanban_db_path", lambda *args, **kwargs: "stub_kanban.db")
+    monkeypatch.setattr(rag_ep, "MultiDatabaseRetriever", fail_retriever_construction)
+    monkeypatch.setattr(rag_ep, "_resolve_existing_kanban_db_path", lambda *args, **kwargs: "stub_kanban.db")
 
     response = client_with_source_health_overrides.get("/api/v1/rag/source-health")
 
@@ -134,16 +115,4 @@ def test_rag_source_health_returns_safe_canonical_sources(
     assert "stub_media.db" not in response.text
     assert "stub_chacha.db" not in response.text
     assert "stub_prompts.db" not in response.text
-    assert captured["db_paths"] == {
-        "media_db": "stub_media.db",
-        "notes_db": "stub_chacha.db",
-        "character_cards_db": "stub_chacha.db",
-        "world_books_db": "stub_chacha.db",
-        "chat_dictionaries_db": "stub_chacha.db",
-        "prompts_db": "stub_prompts.db",
-        "kanban_db": "stub_kanban.db",
-    }
-    assert "media_db_path" not in captured["db_paths"]
-    assert "notes_db_path" not in captured["db_paths"]
-    assert "character_db_path" not in captured["db_paths"]
-    assert "prompts_db_path" not in captured["db_paths"]
+    assert "stub_kanban.db" not in response.text

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
@@ -49,18 +49,8 @@ def client_with_source_health_overrides(
     async def _no_rbac(*args: Any, **kwargs: Any) -> None:  # noqa: ARG001
         return None
 
-    class StubDB:
-        def __init__(self, db_path: str) -> None:
-            self.db_path = db_path
-
-    async def _stub_media_db() -> StubDB:
-        return StubDB("stub_media.db")
-
-    async def _stub_chacha_db() -> StubDB:
-        return StubDB("stub_chacha.db")
-
-    async def _stub_prompts_db() -> StubDB:
-        return StubDB("stub_prompts.db")
+    async def _fail_source_db_dependency() -> None:
+        raise AssertionError("source health must not instantiate source databases")
 
     monkeypatch.setattr(auth_deps, "enforce_rbac_rate_limit", _no_rbac)
 
@@ -72,9 +62,9 @@ def client_with_source_health_overrides(
     from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
     from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
 
-    fastapi_app.dependency_overrides[get_media_db_for_user] = _stub_media_db
-    fastapi_app.dependency_overrides[get_chacha_db_for_user] = _stub_chacha_db
-    fastapi_app.dependency_overrides[get_prompts_db_for_user] = _stub_prompts_db
+    fastapi_app.dependency_overrides[get_media_db_for_user] = _fail_source_db_dependency
+    fastapi_app.dependency_overrides[get_chacha_db_for_user] = _fail_source_db_dependency
+    fastapi_app.dependency_overrides[get_prompts_db_for_user] = _fail_source_db_dependency
 
     with TestClient(fastapi_app, headers=auth_headers, raise_server_exceptions=False) as client:
         yield client
@@ -92,7 +82,16 @@ def test_rag_source_health_returns_safe_canonical_sources(
         raise AssertionError("source health must not instantiate retrievers")
 
     monkeypatch.setattr(rag_ep, "MultiDatabaseRetriever", fail_retriever_construction)
-    monkeypatch.setattr(rag_ep, "_resolve_existing_kanban_db_path", lambda *args, **kwargs: "stub_kanban.db")
+    monkeypatch.setattr(
+        rag_ep,
+        "_resolve_existing_source_db_paths",
+        lambda *args, **kwargs: {
+            "media_db": "stub_media.db",
+            "chacha_db": "stub_chacha.db",
+            "prompts_db": "stub_prompts.db",
+            "kanban_db": "stub_kanban.db",
+        },
+    )
 
     response = client_with_source_health_overrides.get("/api/v1/rag/source-health")
 

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py
@@ -115,3 +115,111 @@ def test_rag_source_health_returns_safe_canonical_sources(
     assert "stub_chacha.db" not in response.text
     assert "stub_prompts.db" not in response.text
     assert "stub_kanban.db" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_rag_source_health_offloads_filesystem_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    calls: list[str] = []
+
+    async def fake_run_in_threadpool(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(getattr(fn, "__name__", repr(fn)))
+        return fn(*args, **kwargs)
+
+    def fake_resolve_existing_source_db_paths(*args: Any, **kwargs: Any) -> dict[str, str]:
+        return {"media_db": "stub_media.db"}
+
+    monkeypatch.setattr(rag_ep, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(
+        rag_ep,
+        "_resolve_existing_source_db_paths",
+        fake_resolve_existing_source_db_paths,
+    )
+    monkeypatch.setattr(rag_ep, "_media_db_uses_non_file_storage", lambda: False)
+
+    response = await rag_ep.source_health_endpoint(
+        User(id=1, username="tester", email=None, is_active=True)
+    )
+
+    assert calls == ["fake_resolve_existing_source_db_paths"]
+    assert {source.source_id for source in response.sources if source.searchable} == {
+        "media_db",
+        "notes",
+        "chats",
+        "characters",
+        "kanban",
+        "prompts",
+        "world_books",
+        "dictionaries",
+    }
+
+
+def test_rag_source_health_uses_canonical_user_db_base_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    media_db = tmp_path / "1" / "Media_DB_v2.db"
+    media_db.parent.mkdir(parents=True)
+    media_db.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        rag_ep.DatabasePaths,
+        "resolve_user_db_base_dir",
+        staticmethod(lambda: tmp_path),
+    )
+
+    paths = rag_ep._resolve_existing_source_db_paths(User(id=1, username="tester", email=None, is_active=True))
+
+    assert paths == {"media_db": str(media_db)}
+
+
+def test_rag_source_health_user_id_falls_back_to_single_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    monkeypatch.setattr(
+        rag_ep.DatabasePaths,
+        "get_single_user_id",
+        staticmethod(lambda: 7),
+    )
+
+    assert rag_ep._resolve_source_health_user_id(None) == "7"
+
+
+def test_rag_source_health_marks_non_file_media_backend_available() -> None:
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    configured, empty = rag_ep._build_source_health_source_sets(
+        existing_paths={},
+        media_backend_uses_non_file_storage=True,
+    )
+
+    assert "media_db" in configured
+    assert "media_db" not in empty
+    assert {"notes", "chats", "characters", "world_books", "dictionaries"}.issubset(empty)
+
+
+def test_rag_source_health_marks_absent_lazy_sqlite_sources_empty() -> None:
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    configured, empty = rag_ep._build_source_health_source_sets(
+        existing_paths={},
+        media_backend_uses_non_file_storage=False,
+    )
+
+    assert configured == set()
+    assert {
+        "media_db",
+        "notes",
+        "chats",
+        "characters",
+        "kanban",
+        "prompts",
+        "world_books",
+        "dictionaries",
+    }.issubset(empty)

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_source_contract.py
@@ -1,10 +1,11 @@
 import pytest
 
 from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import (
+    _build_source_status,
     _normalize_pipeline_sources,
     _sources_to_data_sources,
 )
-from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource, Document
 
 
 pytestmark = pytest.mark.unit
@@ -50,3 +51,41 @@ def test_pipeline_maps_world_books_and_dictionaries_to_distinct_data_sources() -
         DataSource.WORLD_BOOKS,
         DataSource.DICTIONARIES,
     ]
+
+
+def test_post_query_source_status_keeps_search_result_semantics() -> None:
+    class Retriever:
+        retrievers = {
+            DataSource.MEDIA_DB: object(),
+            DataSource.NOTES: object(),
+        }
+
+    status = _build_source_status(
+        ["media_db", "notes", "prompts"],
+        retriever=Retriever(),
+        documents=[
+            Document(
+                id="media-1",
+                content="source status remains post-query metadata",
+                metadata={},
+                source=DataSource.MEDIA_DB,
+            )
+        ],
+        filtered_counts={"media_db": 2},
+    )
+
+    assert status["media_db"] == {
+        "status": "searched",
+        "count": 1,
+        "filtered_artifact_count": 2,
+    }
+    assert status["notes"] == {
+        "status": "empty",
+        "count": 0,
+        "reason": "no_matching_entries",
+    }
+    assert status["prompts"] == {
+        "status": "unavailable",
+        "count": 0,
+        "reason": "no_retriever_configured",
+    }

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
@@ -1,0 +1,79 @@
+import pytest
+
+from tldw_Server_API.app.core.RAG.rag_service.source_health import (
+    CANONICAL_KNOWLEDGE_SOURCE_IDS,
+    build_source_health_entries,
+)
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_source_health_returns_all_canonical_knowledge_sources() -> None:
+    entries = build_source_health_entries(configured_sources=[])
+
+    assert [entry.source_id for entry in entries] == list(CANONICAL_KNOWLEDGE_SOURCE_IDS)
+    assert [entry.source_id for entry in entries] == [
+        "media_db",
+        "notes",
+        "chats",
+        "characters",
+        "kanban",
+        "prompts",
+        "world_books",
+        "dictionaries",
+    ]
+
+
+def test_source_health_marks_configured_sources_searchable() -> None:
+    entries = build_source_health_entries(
+        configured_sources=[
+            DataSource.MEDIA_DB,
+            "notes",
+            DataSource.CHAT_HISTORY,
+        ]
+    )
+    by_id = {entry.source_id: entry for entry in entries}
+
+    assert by_id["media_db"].available is True
+    assert by_id["media_db"].searchable is True
+    assert by_id["media_db"].index_status == "ready"
+    assert by_id["notes"].available is True
+    assert by_id["notes"].searchable is True
+    assert by_id["chats"].available is True
+    assert by_id["chats"].searchable is True
+
+    assert by_id["characters"].available is False
+    assert by_id["characters"].searchable is False
+    assert by_id["characters"].index_status == "unavailable"
+    assert by_id["characters"].disabled_reason == "no_retriever_configured"
+
+
+def test_source_health_ignores_unsafe_source_metadata() -> None:
+    entries = build_source_health_entries(
+        configured_sources={DataSource.MEDIA_DB},
+        unsafe_metadata={
+            "media_db": {
+                "title": "Sensitive imported title",
+                "metadata": {"provider_key": "sk-secret"},
+                "user_id": "42",
+                "db_path": "/private/var/folders/media.db",
+                "item_count": 999,
+            }
+        }
+    )
+    media = {entry.source_id: entry for entry in entries}["media_db"]
+
+    assert media.available is True
+    assert media.searchable is True
+    assert media.item_count is None
+    payload = media.model_dump() if hasattr(media, "model_dump") else media.dict()
+    assert "title" not in payload
+    assert "metadata" not in payload
+    assert "user_id" not in payload
+    assert "db_path" not in payload
+    rendered = repr([payload])
+    assert "Sensitive imported title" not in rendered
+    assert "sk-secret" not in rendered
+    assert "/private/var/folders/media.db" not in rendered

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_source_health.py
@@ -50,6 +50,27 @@ def test_source_health_marks_configured_sources_searchable() -> None:
     assert by_id["characters"].disabled_reason == "no_retriever_configured"
 
 
+def test_source_health_marks_lazy_sources_empty_without_disabling_search() -> None:
+    entries = build_source_health_entries(
+        configured_sources=[DataSource.MEDIA_DB],
+        empty_sources=["notes", DataSource.PROMPTS],
+    )
+    by_id = {entry.source_id: entry for entry in entries}
+
+    assert by_id["notes"].available is True
+    assert by_id["notes"].searchable is True
+    assert by_id["notes"].index_status == "empty"
+    assert by_id["notes"].disabled_reason is None
+    assert by_id["prompts"].available is True
+    assert by_id["prompts"].searchable is True
+    assert by_id["prompts"].index_status == "empty"
+    assert by_id["prompts"].disabled_reason is None
+
+    assert by_id["characters"].available is False
+    assert by_id["characters"].searchable is False
+    assert by_id["characters"].index_status == "unavailable"
+
+
 def test_source_health_ignores_unsafe_source_metadata() -> None:
     entries = build_source_health_entries(
         configured_sources={DataSource.MEDIA_DB},


### PR DESCRIPTION
## Summary
- Add read-only pre-query source health for Knowledge QA sources.
- Surface source readiness in /knowledge source controls without turning /knowledge into an import or management hub.
- Add compact answer trust summaries, clearer evidence actions, and health-aware recovery copy.

## Scope
- /knowledge remains QA-only.
- No server-backed saved evidence or shared evidence sets.
- Existing post-query metadata.source_status semantics remain backward compatible.

## Verification
- [x] Backend focused pytest: 8 passed.
- [x] KnowledgeQA focused Vitest: 14 files, 117 tests passed.
- [x] Extension parity: 4 tests passed.
- [x] Browser smoke: /knowledge navigation/search-bar test passed against localhost:18001 + backend 8000.
- [x] git diff --check.
- [x] Bandit touched backend files: 0 findings.

Change summary:
<human-written summary required before merge>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read‑only source health to Knowledge QA with status chips and refresh. Clarifies evidence and trust controls, and improves recovery with Quick Ingest and nearest matches.

- **New Features**
  - Backend: `GET /api/v1/rag/source-health` with a typed schema; returns safe pre‑query health for canonical sources; leaves post‑query `metadata.source_status` unchanged.
  - Client: `ragSourceHealth` added to `chat-rag`; provider normalizes into `sourceHealth` state and exposes a refresh action.
  - UI: Context bar and compact toolbar show health summaries, status chips, and last‑checked time; ready state shows health notices and refresh. Evidence Rail adds a short guidance blurb. Source cards switch to “Copy citation” (primary) and “Copy excerpt” (overflow).
  - Answer trust: Compact summary covers selected sources, result/citation counts, web fallback state, model, and health caveats.
  - Recovery: No‑results and low‑quality banners use source health with clearer actions (check status, enable web, open Quick Ingest) and show nearest matches when available.

- **Bug Fixes**
  - Read‑only health checks avoid creating user DB paths (`resolve_user_db_base_dir`) and preserve search‑response source status semantics; backend/client tests added.

<sup>Written for commit f4d131503e1193688e23008c71a35b96ece7d097. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1745?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

