### PR TITLE
Add launchd drill entitlement signing

### DIFF
--- a/backlog/tasks/task-390 - Add-launchd-drill-entitlement-signing-support.md
+++ b/backlog/tasks/task-390 - Add-launchd-drill-entitlement-signing-support.md
@@ -1,0 +1,53 @@
+---
+id: TASK-390
+title: Add launchd-drill entitlement signing support
+status: In Progress
+labels:
+- sandbox
+- macos
+- vz-linux
+- operator-workflow
+priority: medium
+modified_files:
+- tools/macos-vz-helper/scripts/vz-helperctl.py
+- tools/macos-vz-helper/Tests/test_vz_helperctl.py
+- tools/macos-vz-helper/README.md
+- tools/macos-vz-helper/macos-vz-helper.entitlements
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the macOS VZ helper launchd drill repeatable by allowing operators to pass an explicit entitlements plist for helper signing before launchd bootstrap. Keep signing opt-in and preserve existing behavior when no entitlements path is supplied.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `launchd-drill` accepts an explicit `--entitlements` plist without changing default behavior when omitted.
+- [x] #2 `launchd-drill` signs the helper after already-loaded preflight and before launchd bootstrap.
+- [x] #3 Failed signing aborts before bootstrap so the drill does not leave a launchd service running from that failure.
+- [x] #4 A checked-in local development entitlement template includes `com.apple.security.virtualization`.
+- [x] #5 Focused unit tests and real Apple VZ launchd smoke are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented opt-in launchd-drill signing through existing `sign_helper`, with an injectable `signing_runner` for unit tests and JSON subprocess capture. Added `tools/macos-vz-helper/macos-vz-helper.entitlements` as the default dev/operator entitlement template. Updated launchd-drill README examples to pass the checked-in entitlement file and explain signing order.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validation: focused new tests passed; full tools/macos-vz-helper/Tests/test_vz_helperctl.py passed with 133 passed, 1 skipped; real launchd-drill with --entitlements and /private/tmp/tldw-vz-linux-bundle-vmrun/bundle passed 3 selected VZ Linux host E2E tests and booted out cleanly; git diff --check passed; py_compile passed; Bandit reported 0 findings for vz-helperctl.py.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-390 - Add-launchd-drill-entitlement-signing-support.md
+++ b/backlog/tasks/task-390 - Add-launchd-drill-entitlement-signing-support.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-390
 title: Add launchd-drill entitlement signing support
-status: In Progress
+status: Done
 labels:
 - sandbox
 - macos
@@ -13,6 +13,8 @@ modified_files:
 - tools/macos-vz-helper/Tests/test_vz_helperctl.py
 - tools/macos-vz-helper/README.md
 - tools/macos-vz-helper/macos-vz-helper.entitlements
+references:
+- https://github.com/rmusser01/tldw_server/pull/1747
 ---
 
 ## Description

--- a/backlog/tasks/task-390 - Add-launchd-drill-entitlement-signing-support.md
+++ b/backlog/tasks/task-390 - Add-launchd-drill-entitlement-signing-support.md
@@ -28,20 +28,20 @@ Make the macOS VZ helper launchd drill repeatable by allowing operators to pass 
 - [x] #1 `launchd-drill` accepts an explicit `--entitlements` plist without changing default behavior when omitted.
 - [x] #2 `launchd-drill` signs the helper after already-loaded preflight and before launchd bootstrap.
 - [x] #3 Failed signing aborts before bootstrap so the drill does not leave a launchd service running from that failure.
-- [x] #4 A checked-in local development entitlement template includes `com.apple.security.virtualization`.
+- [x] #4 A checked-in least-privilege entitlement template includes `com.apple.security.virtualization`.
 - [x] #5 Focused unit tests and real Apple VZ launchd smoke are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented opt-in launchd-drill signing through existing `sign_helper`, with an injectable `signing_runner` for unit tests and JSON subprocess capture. Added `tools/macos-vz-helper/macos-vz-helper.entitlements` as the default dev/operator entitlement template. Updated launchd-drill README examples to pass the checked-in entitlement file and explain signing order.
+Implemented opt-in launchd-drill signing through existing `sign_helper`, with an injectable `signing_runner` for unit tests and JSON subprocess capture. Added `tools/macos-vz-helper/macos-vz-helper.entitlements` as the default least-privilege operator entitlement template. Updated launchd-drill README examples to pass the checked-in entitlement file and explain signing order. PR review follow-up added a `sign_helper` docstring, normalized injected runner exit 127 to `helper_codesign_unavailable`, and removed `com.apple.security.get-task-allow` from the default template.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Validation: focused new tests passed; full tools/macos-vz-helper/Tests/test_vz_helperctl.py passed with 133 passed, 1 skipped; real launchd-drill with --entitlements and /private/tmp/tldw-vz-linux-bundle-vmrun/bundle passed 3 selected VZ Linux host E2E tests and booted out cleanly; git diff --check passed; py_compile passed; Bandit reported 0 findings for vz-helperctl.py.
+Validation: focused review regression tests passed; full tools/macos-vz-helper/Tests/test_vz_helperctl.py passed with 134 passed, 1 skipped; real launchd-drill with --entitlements and /private/tmp/tldw-vz-linux-bundle-vmrun/bundle passed 3 selected VZ Linux host E2E tests and booted out cleanly using a template containing only com.apple.security.virtualization; git diff --check passed; py_compile passed; Bandit reported 0 findings for vz-helperctl.py.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -99,9 +99,12 @@ Omit `--skip-smoke` and add `--bundle /path/to/canonical/bundle` to run the
 real `vz_linux` host smoke through the launchd-managed helper. When
 `--entitlements` is provided, the drill signs the helper after the
 already-loaded preflight and before bootstrap so a failed signing step does not
-leave a launchd service running. Keep drill labels isolated and plist paths
-private; the drill refuses to take over a service that is already loaded before
-bootstrap because cleanup ownership would be ambiguous.
+leave a launchd service running. The checked-in entitlements template is the
+least-privilege operator template and intentionally omits debugger attachment
+entitlements such as `com.apple.security.get-task-allow`. Keep drill labels
+isolated and plist paths private; the drill refuses to take over a service that
+is already loaded before bootstrap because cleanup ownership would be
+ambiguous.
 
 These commands never run automatically from `plist`, `status`, `smoke`, or
 server startup. They are operator-owned scaffolding and do not validate host

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -89,16 +89,19 @@ tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill \
   --log-dir "$runtime_dir/logs" \
   --plist-output "$runtime_dir/${label}.plist" \
   --label "$label" \
+  --entitlements tools/macos-vz-helper/macos-vz-helper.entitlements \
   --write-plist \
   --create-dirs \
   --skip-smoke
 ```
 
 Omit `--skip-smoke` and add `--bundle /path/to/canonical/bundle` to run the
-real `vz_linux` host smoke through the launchd-managed helper. Keep drill labels
-isolated and plist paths private; the drill refuses to take over a service that
-is already loaded before bootstrap because cleanup ownership would be
-ambiguous.
+real `vz_linux` host smoke through the launchd-managed helper. When
+`--entitlements` is provided, the drill signs the helper after the
+already-loaded preflight and before bootstrap so a failed signing step does not
+leave a launchd service running. Keep drill labels isolated and plist paths
+private; the drill refuses to take over a service that is already loaded before
+bootstrap because cleanup ownership would be ambiguous.
 
 These commands never run automatically from `plist`, `status`, `smoke`, or
 server startup. They are operator-owned scaffolding and do not validate host
@@ -115,5 +118,5 @@ For real host E2E smoke, prefer the managed wrapper:
 ```bash
 tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
   --bundle /path/to/canonical/bundle \
-  --entitlements /path/to/helper.entitlements
+  --entitlements tools/macos-vz-helper/macos-vz-helper.entitlements
 ```

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -50,6 +50,16 @@ def test_default_helper_uses_debug_build_path():
     )
 
 
+def test_default_entitlements_template_includes_virtualization():
+    helperctl = load_helperctl()
+
+    entitlements_path = helperctl.HELPER_PACKAGE_DIR / "macos-vz-helper.entitlements"
+    entitlements = plistlib.loads(entitlements_path.read_bytes())
+
+    CASE.assertIs(entitlements["com.apple.security.virtualization"], True)
+    CASE.assertIs(entitlements["com.apple.security.get-task-allow"], True)
+
+
 def test_protocol_version_loads_from_helper_client():
     from tldw_Server_API.app.core.Sandbox.macos_virtualization import helper_client
 
@@ -883,6 +893,110 @@ def test_launchd_drill_runs_smoke_after_ping_before_bootout(tmp_path: Path) -> N
     )
 
 
+def test_launchd_drill_signs_helper_with_entitlements_before_bootstrap(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    entitlements = tmp_path / "helper.entitlements"
+    entitlements.write_text("<plist/>", encoding="utf-8")
+    calls: list[str] = []
+    status_command = "launchctl print gui/501/org.tldw.test"
+
+    def launchd_runner(argv: list[str], **kwargs: Any) -> int:
+        command = " ".join(argv)
+        calls.append(command)
+        if command == status_command and calls.count(status_command) == 1:
+            return 3
+        return 0
+
+    def signing_runner(argv: list[str], **kwargs: Any) -> int:
+        calls.append("sign " + " ".join(argv))
+        return 0
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=launchd_runner,
+        signing_runner=signing_runner,
+        entitlements_path=entitlements,
+        ping_checker=lambda path: helperctl.CheckResult(ok=True),
+    )
+
+    result_names = [name for name, _ in results]
+    CASE.assertLess(result_names.index("helper_signing"), result_names.index("launchd_bootstrap"))
+    CASE.assertIn(("helper_signing", helperctl.CheckResult(ok=True)), results)
+    CASE.assertEqual(
+        calls[:3],
+        [
+            status_command,
+            f"sign codesign --force --sign - --entitlements {entitlements} {helper}",
+            f"launchctl bootstrap gui/501 {plist_path}",
+        ],
+    )
+
+
+def test_launchd_drill_signing_failure_aborts_before_bootstrap(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
+    entitlements = tmp_path / "helper.entitlements"
+    entitlements.write_text("<plist/>", encoding="utf-8")
+    calls: list[str] = []
+    status_command = "launchctl print gui/501/org.tldw.test"
+
+    def launchd_runner(argv: list[str], **kwargs: Any) -> int:
+        command = " ".join(argv)
+        calls.append(command)
+        if command == status_command:
+            return 3
+        return 0
+
+    def signing_runner(argv: list[str], **kwargs: Any) -> int:
+        calls.append("sign " + " ".join(argv))
+        return 2
+
+    results = helperctl.run_launchd_drill(
+        helper_path=helper,
+        socket_path=socket_path,
+        log_dir=log_dir,
+        plist_path=plist_path,
+        label="org.tldw.test",
+        uid=501,
+        write_plist=True,
+        create_dirs=True,
+        launchd_runner=launchd_runner,
+        signing_runner=signing_runner,
+        entitlements_path=entitlements,
+        ping_checker=lambda path: helperctl.CheckResult(ok=True),
+    )
+
+    CASE.assertEqual(
+        results,
+        [
+            (
+                "launchd_preflight",
+                helperctl.CheckResult(
+                    ok=True,
+                    reason="launchd_service_absent",
+                    message="gui/501/org.tldw.test",
+                ),
+            ),
+            ("helper_signing", helperctl.CheckResult(ok=False, reason="helper_codesign_failed")),
+        ],
+    )
+    CASE.assertEqual(
+        calls,
+        [
+            status_command,
+            f"sign codesign --force --sign - --entitlements {entitlements} {helper}",
+        ],
+    )
+
+
 def test_launchd_drill_refuses_already_loaded_service_without_bootout(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     helper, socket_path, log_dir, plist_path = _make_launchd_drill_inputs(tmp_path)
@@ -1377,6 +1491,29 @@ def test_launchd_drill_cli_bundle_with_skip_smoke_passes_no_bundle(
 
     CASE.assertEqual(code, 0)
     CASE.assertIsNone(captured["bundle_path"])
+
+
+def test_launchd_drill_cli_passes_entitlements(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    entitlements = tmp_path / "helper.entitlements"
+    captured: dict[str, Any] = {}
+
+    def fake_run_launchd_drill(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        captured.update(kwargs)
+        return [("launchd_preflight", helperctl.CheckResult(ok=True))]
+
+    monkeypatch.setattr(helperctl, "run_launchd_drill", fake_run_launchd_drill)
+
+    code = helperctl.main(
+        ["launchd-drill", "--skip-smoke", "--entitlements", str(entitlements)]
+    )
+
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(captured["entitlements_path"], entitlements)
 
 
 def test_launchd_bootstrap_requires_existing_plist_without_write(tmp_path: Path) -> None:

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -57,7 +57,7 @@ def test_default_entitlements_template_includes_virtualization():
     entitlements = plistlib.loads(entitlements_path.read_bytes())
 
     CASE.assertIs(entitlements["com.apple.security.virtualization"], True)
-    CASE.assertIs(entitlements["com.apple.security.get-task-allow"], True)
+    CASE.assertNotIn("com.apple.security.get-task-allow", entitlements)
 
 
 def test_protocol_version_loads_from_helper_client():
@@ -2019,6 +2019,23 @@ def test_sign_reports_missing_codesign(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     CASE.assertEqual(code, 1)
     CASE.assertIn("helper_codesign_unavailable", captured.err)
+
+
+def test_sign_helper_maps_injected_runner_127_to_codesign_unavailable(tmp_path):
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    entitlements = tmp_path / "helper.entitlements"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    entitlements.write_text("<plist/>", encoding="utf-8")
+
+    result = helperctl.sign_helper(
+        helper,
+        entitlements,
+        command_runner=lambda argv, **kwargs: 127,
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(False, "helper_codesign_unavailable"))
 
 
 def test_compare_entitlements_without_expected_path_checks_signed_binary(monkeypatch, tmp_path):

--- a/tools/macos-vz-helper/macos-vz-helper.entitlements
+++ b/tools/macos-vz-helper/macos-vz-helper.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.virtualization</key>
+	<true/>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/macos-vz-helper/macos-vz-helper.entitlements
+++ b/tools/macos-vz-helper/macos-vz-helper.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>com.apple.security.virtualization</key>
 	<true/>
-	<key>com.apple.security.get-task-allow</key>
-	<true/>
 </dict>
 </plist>

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -487,6 +487,11 @@ def sign_helper(
     identity: str = "-",
     command_runner: Callable[..., int] | None = None,
 ) -> CheckResult:
+    """Codesign the helper with explicit entitlements for operator-managed runs.
+
+    `command_runner` exists so tests and JSON-mode callers can capture the
+    subprocess without changing the public failure reasons.
+    """
     if entitlements_path is None:
         return CheckResult(ok=False, reason="helper_entitlements_missing")
     helper_result = validate_helper_binary(helper_path)
@@ -510,6 +515,8 @@ def sign_helper(
         ],
         dry_run=dry_run,
     )
+    if code == 127:
+        return CheckResult(ok=False, reason="helper_codesign_unavailable")
     if code != 0:
         return CheckResult(ok=False, reason="helper_codesign_failed")
     return CheckResult(ok=True)

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -485,6 +485,7 @@ def sign_helper(
     *,
     dry_run: bool = False,
     identity: str = "-",
+    command_runner: Callable[..., int] | None = None,
 ) -> CheckResult:
     if entitlements_path is None:
         return CheckResult(ok=False, reason="helper_entitlements_missing")
@@ -493,10 +494,11 @@ def sign_helper(
         return helper_result
     if not entitlements_path.exists():
         return CheckResult(ok=False, reason="helper_entitlements_missing")
-    if not dry_run and shutil.which("codesign") is None:
+    if not dry_run and command_runner is None and shutil.which("codesign") is None:
         return CheckResult(ok=False, reason="helper_codesign_unavailable")
 
-    code = run_command(
+    runner = command_runner or run_command
+    code = runner(
         [
             "codesign",
             "--force",
@@ -849,6 +851,8 @@ def run_launchd_drill(
     dry_run: bool = False,
     ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
     launchd_runner: Callable[..., int] | None = None,
+    entitlements_path: Path | None = None,
+    signing_runner: Callable[..., int] | None = None,
     bundle_path: Path | None = None,
     python_path: Path | None = None,
     smoke_command_runner: Callable[..., int] | None = None,
@@ -871,6 +875,17 @@ def run_launchd_drill(
     results.append(("launchd_preflight", preflight))
     if not preflight.ok:
         return results
+
+    if entitlements_path is not None:
+        signing = sign_helper(
+            helper_path,
+            entitlements_path,
+            dry_run=dry_run,
+            command_runner=signing_runner,
+        )
+        results.append(("helper_signing", signing))
+        if not signing.ok:
+            return results
 
     bootstrap = run_launchd_action(
         "bootstrap",
@@ -1946,11 +1961,13 @@ def _launchd_drill_command(args: argparse.Namespace) -> int:
         "write_plist": args.write_plist,
         "create_dirs": args.create_dirs,
         "dry_run": args.dry_run,
+        "entitlements_path": Path(args.entitlements) if args.entitlements else None,
         "bundle_path": bundle_path,
         "python_path": Path(args.python) if args.python else None,
     }
     if args.json:
         drill_kwargs["launchd_runner"] = run_command_captured
+        drill_kwargs["signing_runner"] = run_command_captured
         drill_kwargs["smoke_command_runner"] = run_command_captured
         with contextlib.redirect_stdout(io.StringIO()):
             results = run_launchd_drill(**drill_kwargs)
@@ -2090,6 +2107,7 @@ def build_parser() -> argparse.ArgumentParser:
     launchd_drill.add_argument("--label")
     launchd_drill.add_argument("--uid", type=int)
     launchd_drill.add_argument("--python")
+    launchd_drill.add_argument("--entitlements")
     launchd_drill.add_argument("--write-plist", action="store_true")
     launchd_drill.add_argument("--create-dirs", action="store_true")
     launchd_drill.add_argument("--skip-smoke", action="store_true")


### PR DESCRIPTION
## Summary

- add a checked-in macOS VZ helper entitlement template with `com.apple.security.virtualization`
- let `vz-helperctl.py launchd-drill --entitlements` sign the helper after preflight and before bootstrap
- document the launchd drill signing path and add unit coverage for signing order, signing failure, CLI passthrough, and the entitlement template

## Validation

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q`
- `git diff --check origin/dev...HEAD`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_launchd_drill_entitlements.json`
- Real Apple VZ launchd smoke: `vz-helperctl.py launchd-drill --bundle /private/tmp/tldw-vz-linux-bundle-vmrun/bundle --entitlements tools/macos-vz-helper/macos-vz-helper.entitlements ...` passed 3 selected host E2E tests and booted out cleanly

## Change summary

Human-authored change summary pending.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in entitlement signing for the macOS VZ helper in the launchd drill. Implements TASK-390 by signing after preflight and before bootstrap with a least-privilege entitlements template; failures abort before bootstrap.

- **New Features**
  - `launchd-drill --entitlements <plist>` signs the helper with `codesign` after preflight and before bootstrap; failures stop before bootstrap.
  - Added `tools/macos-vz-helper/macos-vz-helper.entitlements` with only `com.apple.security.virtualization` (omits `com.apple.security.get-task-allow`).
  - `sign_helper` accepts an injectable runner for tests/JSON capture; CLI passes `--entitlements`; README updated; tests cover signing order, failure, CLI passthrough, and template content.

- **Bug Fixes**
  - `sign_helper` maps runner exit 127 to `helper_codesign_unavailable` and skips `codesign` availability checks when a runner is injected.

<sup>Written for commit 6b6e04fe1f5da79cf800bd57726638e3eaa8e5cf. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1747?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

