### PR TITLE
Fix Persona Visual setup review findings

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -894,6 +894,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const importPreviewRequestIdRef = React.useRef(0)
   const importCommitRequestIdRef = React.useRef(0)
   const importCommitInFlightRef = React.useRef(false)
+  const importCommitRefreshInFlightRef = React.useRef(false)
   const selectedPersonaIdRef = React.useRef(selectedPersonaId)
   const selectedPackIdRef = React.useRef("")
 
@@ -1068,12 +1069,16 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         return true
       } catch (loadError) {
         if (!isLatestRequest()) return false
-        setPacks([])
-        setActivePackId("")
-        setPacksLoaded(false)
-        setPacksLoadedPersonaId("")
-        selectPackId("")
-        setDraftManifest(DEFAULT_MANIFEST)
+        if (options.fallbackPack) {
+          const fallbackPack = options.fallbackPack
+          setPacks((current) => mergePack(current, fallbackPack))
+          setActivePackId((current) =>
+            fallbackPack.status === "active" ? fallbackPack.id : current
+          )
+          setPacksLoaded(true)
+          setPacksLoadedPersonaId(targetPersonaId)
+          selectPackId(options.preferredPackId || fallbackPack.id)
+        }
         setError(
           loadError instanceof Error
             ? loadError.message
@@ -1353,6 +1358,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     importPreviewRequestIdRef.current += 1
     importCommitRequestIdRef.current += 1
     importCommitInFlightRef.current = false
+    importCommitRefreshInFlightRef.current = false
     setImportPreview(null)
     setImportCommitJob(null)
     setSelectedImportPreviewFile(null)
@@ -1895,6 +1901,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const handleRefreshImportCommit = async () => {
     if (!selectedPersonaId || !importCommitJob?.job_id) return
     if (importCommitInFlightRef.current) return
+    if (importCommitRefreshInFlightRef.current || refreshingImportCommit) return
     const targetPersonaId = selectedPersonaId
     const jobId = importCommitJob.job_id
     const requestId = importCommitRequestIdRef.current + 1
@@ -1902,6 +1909,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     const isCurrentImportCommitRequest = () =>
       importCommitRequestIdRef.current === requestId &&
       selectedPersonaIdRef.current === targetPersonaId
+    importCommitRefreshInFlightRef.current = true
     setRefreshingImportCommit(true)
     setError(null)
     try {
@@ -1934,6 +1942,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         )
       }
     } finally {
+      if (importCommitRequestIdRef.current === requestId) {
+        importCommitRefreshInFlightRef.current = false
+      }
       if (isCurrentImportCommitRequest()) setRefreshingImportCommit(false)
     }
   }
@@ -2527,6 +2538,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const importPreviewFileError = getImportPreviewFileError(selectedImportPreviewFile, t)
   const importPreviewJobCopy = getImportPreviewJobCopy(importPreview, t)
   const importCommitJobCopy = getImportCommitJobCopy(importCommitJob, t)
+  const importCommitJobPackIsSelected =
+    !importCommitJob ||
+    !("pack_id" in importCommitJob) ||
+    !importCommitJob.pack_id ||
+    selectedPack?.id === importCommitJob.pack_id
   const importPreviewWarnings = fullImportPreview
     ? [
         ...(fullImportPreview.validation_warnings || []),
@@ -2864,7 +2880,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                       {importCommitJob.job_id}
                     </span>
                   </div>
-                  {selectedPack && importCommitJobCopy ? (
+                  {selectedPack && importCommitJobCopy && importCommitJobPackIsSelected ? (
                     <div data-testid="persona-visual-import-commit-job-copy">
                       {importCommitJobCopy}
                     </div>

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1620,6 +1620,88 @@ describe("VisualPackEditor", () => {
     ).toBe(false)
   })
 
+  it("keeps a copied starter draft visible when the post-copy pack refresh fails", async () => {
+    const copiedPack = {
+      id: "starter-copy-1",
+      persona_id: "persona-1",
+      title: "Research Buddy Starter",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 1
+    }
+    let packListRequests = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        packListRequests += 1
+        if (packListRequests > 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            error: "Pack refresh failed",
+            json: async () => ({ detail: "Pack refresh failed" })
+          })
+        }
+        return okResponse([])
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (
+        path === "/api/v1/persona/visual-starter-packs/research-buddy-starter/copy" &&
+        method === "POST"
+      ) {
+        expect(parseJsonBody(init?.body)).toMatchObject({
+          target_persona_id: "persona-1"
+        })
+        return okResponse(copiedPack)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/starter-copy-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/starter-copy-1/generation-readiness" &&
+        method === "GET"
+      ) {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const setupCard = await screen.findByTestId("visual-buddy-setup-choice-card")
+    fireEvent.click(within(setupCard).getByRole("button", { name: "Use default" }))
+
+    await waitFor(() => expect(screen.getByText("Pack refresh failed")).toBeInTheDocument())
+    expect(screen.getByTestId("persona-visual-pack-select")).toHaveValue(
+      "starter-copy-1"
+    )
+  })
+
   it("ignores stale starter pack responses after switching personas", async () => {
     const firstStarterResponse = deferredResponse<{
       ok: boolean
@@ -4951,6 +5033,172 @@ describe("VisualPackEditor", () => {
     expect(commitAttempts).toBe(2)
     expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
       "queued"
+    )
+  })
+
+  it("ignores duplicate import commit refresh clicks while a status request is in flight", async () => {
+    const pack = {
+      id: "pack-1",
+      persona_id: "persona-1",
+      title: "Animated pack",
+      renderer_type: "sprite_frames",
+      status: "draft",
+      manifest: structuredClone(baseManifest),
+      assets: visualAssets,
+      version: 3
+    }
+    const statusResponse = deferredResponse<{
+      ok: boolean
+      json: () => Promise<unknown>
+    }>()
+    let statusRequests = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          bundle_summary: {
+            pack_title: "Imported Visuals",
+            asset_count: 2,
+            assets_with_bytes: 2
+          },
+          validation_warnings: [],
+          conflicts: [],
+          proposed_plan: { target_mode: "create_new" },
+          quota_estimate: {},
+          required_choices: [],
+          target_warnings: []
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1/commit" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          job_id: "import-job-1",
+          portability_job_id: "portability-import-1",
+          operation: "import_commit",
+          preview_id: "preview-1",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/imports/import-job-1" &&
+        method === "GET"
+      ) {
+        statusRequests += 1
+        return statusResponse.promise
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "completed"
+      )
+    )
+    fireEvent.click(screen.getByTestId("persona-visual-import-commit-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    const refreshButton = screen.getByTestId(
+      "persona-visual-import-commit-refresh-button"
+    )
+    await act(async () => {
+      refreshButton.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      refreshButton.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    })
+
+    expect(statusRequests).toBe(1)
+    statusResponse.resolve({
+      ok: true,
+      json: async () => ({
+        job_id: "import-job-1",
+        portability_job_id: "portability-import-1",
+        operation: "import_commit",
+        persona_id: "persona-1",
+        pack_id: null,
+        status: "failed",
+        visual_status: "failed",
+        stage: "failed",
+        error_message: "Archive failed validation"
+      })
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "failed"
+      )
     )
   })
 

--- a/apps/packages/ui/src/routes/hooks/usePersonaSetupOrchestrator.ts
+++ b/apps/packages/ui/src/routes/hooks/usePersonaSetupOrchestrator.ts
@@ -1313,13 +1313,12 @@ export function usePersonaSetupOrchestrator(
       source: "wizard_optional_card",
       returnStep: personaSetupWizard.currentStep,
     })
-    setActiveTab("visuals")
     void emitSetupAnalyticsEvent({
       eventType: "detour_started",
       step: personaSetupWizard.currentStep,
       detourSource: "wizard_optional_visuals",
     })
-  }, [emitSetupAnalyticsEvent, personaSetupWizard.currentStep, setActiveTab])
+  }, [emitSetupAnalyticsEvent, personaSetupWizard.currentStep])
 
   const handleReturnToSetupFromVisualDetour = React.useCallback(() => {
     const returnStep = setupVisualDetour?.returnStep || personaSetupWizard.currentStep

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -1980,7 +1980,7 @@ const SidepanelPersona = ({
         <LazyVisualPackEditor
           selectedPersonaId={selectedPersonaId}
           selectedPersonaName={selectedPersonaName}
-          isActive={activeTab === "visuals"}
+          isActive={effectiveActiveTab === "visuals"}
           onOpenPersonaVisuals={(personaId) => {
             setSelectedPersonaId(personaId)
             setActiveTab("visuals")

--- a/backlog/tasks/task-402 - Address-PR-1746-Persona-Visual-setup-review-findings.md
+++ b/backlog/tasks/task-402 - Address-PR-1746-Persona-Visual-setup-review-findings.md
@@ -1,0 +1,55 @@
+---
+id: TASK-402
+title: Address PR 1746 Persona Visual setup review findings
+status: Done
+labels:
+- persona
+- buddy
+- visuals
+- frontend
+- review-fix
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/1746
+- https://github.com/rmusser01/tldw_server/pull/1748
+- https://github.com/rmusser01/tldw_server/issues/1695
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify unresolved PR #1746 review findings against current dev, fix only still-valid Persona Visual setup defects, skip stale or incorrect findings with documented reasons, and validate the focused frontend slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Verify every unresolved PR #1746 review thread against current dev and document stale or incorrect findings.
+- [x] #2 Fix still-valid Visual Buddy setup defects with focused regression tests.
+- [x] #3 Validate focused frontend tests and diff hygiene.
+- [x] #4 Document Bandit skip because the touched implementation scope is frontend TypeScript/TSX only.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Initial verification: PR #1746 was closed as a duplicate/outdated PR because its branch was not carrying unique patches over current dev. GraphQL review-thread sweep then surfaced unresolved inline findings. Stale/incorrect findings so far: duplicate starter-pack type declarations are not present in current dev, and TASK-362.1 references to PR #1725 are correct because PR #1725 is the merged PR that carried the work.
+Validated PR #1746 review threads against current dev. Fixed still-valid issues: import commit refresh now has a synchronous in-flight guard; loadPacks preserves a fallback copied draft when the follow-up list refresh fails; visual setup detour no longer mutates global activeTab and VisualPackEditor receives the derived effective active tab. Skipped stale/incorrect items: duplicate starter-pack type declarations are already absent on dev; TASK-362.1 PR #1725 references are correct because #1725 is the merged work; compact wizard mode is intentional per TASK-362.1 acceptance criteria; starter catalog failure already surfaces the load error while preserving import/blank options, so no new retry contract was added in this review-fix slice.
+
+Opened draft follow-up PR #1748 for the valid current-dev fixes because PR #1746 is a closed duplicate/outdated branch.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the valid PR #1746 Persona Visual setup review findings on a clean dev-based branch. Added regressions for preserving copied starter drafts across post-copy refresh failure and blocking duplicate import-commit status refreshes. Patched VisualPackEditor fallback preservation/status-refresh locking, hid completed-import success copy until the completed pack is actually selected, and removed the visual detour's global active-tab mutation while keeping the visual editor active through effectiveActiveTab. Focused Vitest suite passed with 160 tests. git diff --check passed. Frontend lint completed with zero errors and existing warnings only. Design-system state guard still fails on unrelated current-baseline Llama.cpp/Admin product-state findings outside the touched files. Bandit not applicable because the touched implementation is frontend TypeScript/TSX plus task tracking.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Draft PR. A human-authored Change summary is required before this is marked ready for merge.

## What changed

- Added regressions for two still-valid PR #1746 review defects:
  - copied starter drafts remain selected when the post-copy pack-list refresh fails
  - rapid import-commit refresh clicks do not start duplicate status requests
- Preserved fallback copied drafts in `loadPacks()` when the follow-up refresh errors.
- Added a synchronous import-commit refresh lock.
- Avoided showing completed-import success copy until the completed `pack_id` is actually selected.
- Removed the visual setup detour's direct global active-tab mutation and let `effectiveActiveTab` drive the Visuals editor while the detour is active.
- Added Backlog tracking in `TASK-402`.

## Review findings handled

- Fixed: duplicate import commit refresh requests.
- Fixed: refresh error dropping a newly copied starter draft.
- Fixed: visual detour mutating global `activeTab`.
- Verified stale/incorrect: duplicate starter-pack type declarations are not present on current `dev`.
- Verified incorrect: `TASK-362.1` references to PR #1725 are correct because #1725 is the merged PR that carried the work; PR #1746 was a duplicate/outdated branch.
- Skipped as intentional: compact setup card in the assistant setup wizard, per TASK-362.1 acceptance criteria.
- Skipped as already covered: starter catalog failure shows the actual load error and keeps Import/Start blank available.

## Verification

- `bunx vitest run src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/components/PersonaGarden/__tests__/AssistantSetupWizard.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx src/services/__tests__/persona-visuals.test.ts --testTimeout=30000` -> 5 files passed, 160 tests passed
- `git diff --check` -> passed
- `../../tldw-frontend/node_modules/.bin/eslint --config ../../tldw-frontend/eslint.config.mjs src/components/PersonaGarden/VisualPackEditor.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/routes/hooks/usePersonaSetupOrchestrator.ts src/routes/sidepanel-persona.tsx` -> 0 errors, existing warnings only
- `bun run verify:design-system-state` -> fails on unrelated current-baseline Llama.cpp/Admin product-state findings outside the touched files

Bandit not applicable: touched implementation is frontend TypeScript/TSX plus Backlog Markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes key Persona Visual setup issues: preserves copied drafts on refresh errors, prevents duplicate import-commit refreshes, and keeps the Visuals tab state isolated during the setup detour. Tracked in TASK-402.

- **Bug Fixes**
  - Keep a copied starter draft visible and selected when the post-copy pack refresh fails.
  - Add an in-flight lock to import-commit status refresh to ignore rapid clicks.
  - Show completed-import success copy only when the completed pack is actually selected.
  - Drive the Visuals editor via effectiveActiveTab during the detour; stop mutating the global activeTab.
  - Add focused regression tests for the fallback copied draft and refresh-lock behavior.

<sup>Written for commit f40d2979b11430c173a74373d6e8a7e5011c6183. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1748?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

