### PR TITLE
Migrate QuickIngest product-state UI

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -22,39 +22,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Common/QuickIngest/AddContentStep.tsx:Alert#antd-alert-addcontentstep-type-warning-line-298-3vldi3",
-    "path": "src/components/Common/QuickIngest/AddContentStep.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/QuickIngest/AddContentStep.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Common/QuickIngest/AddContentStep.tsx:Alert#antd-alert-addcontentstep-type-warning-line-343-w13em8",
-    "path": "src/components/Common/QuickIngest/AddContentStep.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/QuickIngest/AddContentStep.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Common/QuickIngest/AddContentStep.tsx:Tag",
-    "path": "src/components/Common/QuickIngest/AddContentStep.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Common/QuickIngest/AddContentStep.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Common/Settings/LlamaCppAdvancedControls.tsx:Alert#antd-alert-llamacppadvancedcontrols-type-info-line-225-1ac43xr",
     "path": "src/components/Common/Settings/LlamaCppAdvancedControls.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -423,7 +423,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
                           className="!m-0"
                         >
                           <AlertTriangle
-                            className="h-3 w-3"
+                            className="mr-0.5 h-3 w-3"
                             aria-hidden="true"
                           />
                           {item.detectedType.charAt(0).toUpperCase() +

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react"
-import { Alert, Button, Input, Tag, Tooltip, Typography } from "antd"
+import { Button, Input, Tooltip, Typography } from "antd"
 import { useTranslation } from "react-i18next"
 import {
   AlertTriangle,
@@ -16,6 +16,7 @@ import {
 import type { DetectedMediaType, WizardQueueItem, QueueItemValidation } from "./types"
 import { useIngestWizard } from "./IngestWizardContext"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
+import { Alert as DesignSystemAlert, Badge } from "@/components/ui/primitives"
 import { FileDropZone } from "./QueueTab/FileDropZone"
 import {
   QUICK_INGEST_ACCEPT_STRING,
@@ -157,6 +158,10 @@ const validateQueueItem = (
 
 // Warning uses >= (show at boundary); validation uses > (allow exactly at limit)
 const LARGE_FILE_WARNING_THRESHOLD = 500 * 1024 * 1024 // 500 MB
+const PASSIVE_ALERT_PROPS = {
+  role: "status",
+  "aria-live": "polite",
+} as const
 
 type AddContentStepProps = {
   isOnlineForIngest?: boolean
@@ -295,11 +300,11 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
         </Typography.Text>
 
         {hasLargeFiles && (
-          <Alert
-            type="warning"
-            showIcon
-            icon={<AlertTriangle className="h-4 w-4" />}
-            message={qi(
+          <DesignSystemAlert
+            variant="warning"
+            {...PASSIVE_ALERT_PROPS}
+            icon={<AlertTriangle className="h-4 w-4" aria-hidden="true" />}
+            title={qi(
               "largeFileWarning",
               "Large file -- upload may take several minutes. Consider using a smaller file if possible."
             )}
@@ -340,12 +345,12 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
 
       {/* FFmpeg missing warning for audio/video items */}
       {ffmpegMissing && hasAvMediaItems && (
-        <Alert
-          type="warning"
-          showIcon
-          icon={<AlertTriangle className="h-4 w-4" />}
+        <DesignSystemAlert
+          variant="warning"
+          {...PASSIVE_ALERT_PROPS}
+          icon={<AlertTriangle className="h-4 w-4" aria-hidden="true" />}
           className="mt-3"
-          message={qi(
+          title={qi(
             "ffmpegMissing",
             "FFmpeg is not installed on the server. Audio and video files may fail to process. Other file types (PDF, documents, ebooks) are unaffected."
           )}
@@ -412,25 +417,30 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
                           "FFmpeg is not installed on the server -- this file may fail to process"
                         )}
                       >
-                        <Tag
-                          color="warning"
-                          className="!text-[10px] !leading-tight !px-1 !py-0 !m-0"
+                        <Badge
+                          variant="warning"
+                          size="sm"
+                          className="!m-0"
                         >
-                          <AlertTriangle className="mr-0.5 inline h-3 w-3" />
+                          <AlertTriangle
+                            className="h-3 w-3"
+                            aria-hidden="true"
+                          />
                           {item.detectedType.charAt(0).toUpperCase() +
                             item.detectedType.slice(1)}
-                        </Tag>
+                        </Badge>
                       </Tooltip>
                     ) : (
-                      <Tag
-                        color="geekblue"
-                        className="!text-[10px] !leading-tight !px-1 !py-0 !m-0"
+                      <Badge
+                        variant="info"
+                        size="sm"
+                        className="!m-0"
                       >
                         {item.detectedType === "web"
                           ? "Web page"
                           : item.detectedType.charAt(0).toUpperCase() +
                             item.detectedType.slice(1)}
-                      </Tag>
+                      </Badge>
                     )}
                     {item.detectedType !== "unknown" && (
                       <span className="text-text-subtle">(auto)</span>

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -239,7 +239,11 @@ vi.mock("lucide-react", () => {
   const mocks: Record<string, any> = {}
   for (const name of iconNames) {
     mocks[name] = (props: any) => (
-      <span data-icon={name} aria-hidden={props?.["aria-hidden"]} />
+      <span
+        data-icon={name}
+        aria-hidden={props?.["aria-hidden"]}
+        className={props?.className}
+      />
     )
   }
   return mocks
@@ -556,6 +560,9 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
       .closest('[data-ds-component="Badge"]')
     expect(badge).toBeInTheDocument()
     expect(badge).toHaveAttribute("data-ds-variant", "warning")
+    expect(badge?.querySelector('[data-icon="AlertTriangle"]')).toHaveClass(
+      "mr-0.5"
+    )
   })
 
   it("Step 1 — renders detected media labels with the design-system badge", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -10,6 +10,10 @@ const getTranscriptionModelsMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ all_models: [] })
 )
 
+const capabilityMocks = vi.hoisted(() => ({
+  useServerCapabilities: vi.fn(),
+}))
+
 // react-i18next
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -38,8 +42,23 @@ vi.mock("antd", () => ({
       ) : null,
     { confirm: vi.fn(), destroyAll: vi.fn() }
   ),
-  Button: ({ children, onClick, disabled, type, ...props }: any) => (
-    <button onClick={onClick} disabled={disabled} data-type={type} {...props}>
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    type,
+    danger,
+    size,
+    ...props
+  }: any) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      data-type={type}
+      data-danger={danger ? "true" : undefined}
+      data-size={size}
+      {...props}
+    >
       {children}
     </button>
   ),
@@ -59,6 +78,8 @@ vi.mock("antd", () => ({
     placeholder,
     allowClear,
     popupMatchSelectWidth,
+    showSearch,
+    loading,
     ...props
   }: any) => {
     const selectProps: any = { ...props }
@@ -141,6 +162,13 @@ vi.mock("antd", () => ({
     </div>
   ),
   Tooltip: ({ children }: any) => <>{children}</>,
+  Alert: ({ message, children, icon, type, showIcon, ...props }: any) => (
+    <div data-alert-type={type} {...props}>
+      {showIcon ? icon : null}
+      {message}
+      {children}
+    </div>
+  ),
   Input: Object.assign(
     (props: any) => <input {...props} />,
     {
@@ -149,6 +177,7 @@ vi.mock("antd", () => ({
         onChange,
         onKeyDown,
         placeholder,
+        autoSize,
         ...props
       }: any) => (
         <textarea
@@ -164,7 +193,11 @@ vi.mock("antd", () => ({
   Tag: ({ children, ...props }: any) => <span {...props}>{children}</span>,
   Typography: {
     Title: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    Text: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+    Text: ({ children, strong, ...props }: any) => (
+      <span data-strong={strong ? "true" : undefined} {...props}>
+        {children}
+      </span>
+    ),
   },
   Progress: ({ percent, ...props }: any) => (
     <div data-testid="progress" data-percent={percent} {...props} />
@@ -191,6 +224,7 @@ vi.mock("lucide-react", () => {
     "X",
     "Plus",
     "Check",
+    "CheckCircle",
     "Circle",
     "Loader2",
     "Video",
@@ -233,10 +267,42 @@ vi.mock(
   "@/components/Common/QuickIngest/QueueTab/FileDropZone",
   () => ({
     FileDropZone: ({ onFilesAdded }: any) => (
-      <div data-testid="file-drop-zone">FileDropZone</div>
+      <div data-testid="file-drop-zone">
+        FileDropZone
+        <button
+          type="button"
+          onClick={() =>
+            onFilesAdded?.([
+              {
+                name: "large-audio.mp3",
+                size: 500 * 1024 * 1024,
+                type: "audio/mpeg",
+              },
+            ])
+          }
+        >
+          Add large audio file
+        </button>
+      </div>
     ),
     default: ({ onFilesAdded }: any) => (
-      <div data-testid="file-drop-zone">FileDropZone</div>
+      <div data-testid="file-drop-zone">
+        FileDropZone
+        <button
+          type="button"
+          onClick={() =>
+            onFilesAdded?.([
+              {
+                name: "large-audio.mp3",
+                size: 500 * 1024 * 1024,
+                type: "audio/mpeg",
+              },
+            ])
+          }
+        >
+          Add large audio file
+        </button>
+      </div>
     ),
   })
 )
@@ -259,6 +325,10 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   },
 }))
 
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => capabilityMocks.useServerCapabilities(),
+}))
+
 vi.mock("@/components/Common/QuickIngest/FloatingProgressWidget", () => ({
   FloatingProgressWidget: () => null,
 }))
@@ -268,6 +338,11 @@ let uuidCounter = 0
 beforeEach(() => {
   uuidCounter = 0
   getTranscriptionModelsMock.mockReset().mockResolvedValue({ all_models: [] })
+  capabilityMocks.useServerCapabilities.mockReset()
+  capabilityMocks.useServerCapabilities.mockReturnValue({
+    capabilities: { ffmpegAvailable: true },
+    loading: false,
+  })
 })
 vi.stubGlobal(
   "crypto",
@@ -443,6 +518,58 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
     const configureButton = screen.getByText(/Configure 1 items/i)
     expect(configureButton).toBeTruthy()
     expect(configureButton).not.toBeDisabled()
+  })
+
+  it("Step 1 — renders large-file guidance with the design-system alert", async () => {
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={onClose} />)
+
+    await user.click(
+      screen.getByRole("button", { name: /Add large audio file/i })
+    )
+
+    const warning = await screen.findByText(/Large file/i)
+    const alert = warning.closest('[data-ds-component="Alert"]')
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveAttribute("role", "status")
+    expect(alert).toHaveAttribute("aria-live", "polite")
+  })
+
+  it("Step 1 — renders FFmpeg media warnings with design-system state primitives", async () => {
+    capabilityMocks.useServerCapabilities.mockReturnValue({
+      capabilities: { ffmpegAvailable: false },
+      loading: false,
+    })
+
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={onClose} />)
+
+    const textarea = screen.getByPlaceholderText(/https:\/\/example\.com/i)
+    await user.type(textarea, "https://youtube.com/watch?v=test123")
+    await user.click(screen.getByRole("button", { name: /Add URLs to queue/i }))
+
+    const warning = await screen.findByText(/FFmpeg is not installed/i)
+    expect(warning.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
+    const badge = screen
+      .getByText("Video")
+      .closest('[data-ds-component="Badge"]')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveAttribute("data-ds-variant", "warning")
+  })
+
+  it("Step 1 — renders detected media labels with the design-system badge", async () => {
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={onClose} />)
+
+    const textarea = screen.getByPlaceholderText(/https:\/\/example\.com/i)
+    await user.type(textarea, "https://example.com/test-article")
+    await user.click(screen.getByRole("button", { name: /Add URLs to queue/i }))
+
+    const badge = await screen.findByText("Web page")
+    const badgeRoot = badge.closest('[data-ds-component="Badge"]')
+    expect(badgeRoot).toBeInTheDocument()
+    expect(badgeRoot).toHaveAttribute("data-ds-variant", "info")
   })
 
   // -------------------------------------------------------------------------

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts
@@ -1,17 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 const designSystemMocks = vi.hoisted(() => ({
-  getDesignSystemStateLabel: vi.fn(
-    (key: string, fallback: string) =>
-      ({
-        ready: "Registry Ready",
-        unavailable: "Registry Unavailable",
-      })[key] ?? fallback
-  ),
+  READY_STATE_LABEL: "Registry Ready",
+  UNAVAILABLE_STATE_LABEL: "Registry Unavailable",
 }))
 
 vi.mock("@/design-system", () => ({
-  getDesignSystemStateLabel: designSystemMocks.getDesignSystemStateLabel,
+  READY_STATE_LABEL: designSystemMocks.READY_STATE_LABEL,
+  UNAVAILABLE_STATE_LABEL: designSystemMocks.UNAVAILABLE_STATE_LABEL,
 }))
 
 import {
@@ -21,10 +17,6 @@ import {
 } from "../sourceHealth"
 
 describe("Knowledge QA source health normalization", () => {
-  beforeEach(() => {
-    designSystemMocks.getDesignSystemStateLabel.mockClear()
-  })
-
   it("normalizes partial backend payloads without colliding with search source status", () => {
     const normalized = normalizeKnowledgeSourceHealth({
       sources: [
@@ -138,14 +130,6 @@ describe("Knowledge QA source health normalization", () => {
     )
     expect(getSourceHealthStatusLabel(normalized.bySource.prompts)).toBe(
       "Registry Unavailable"
-    )
-    expect(designSystemMocks.getDesignSystemStateLabel).toHaveBeenCalledWith(
-      "ready",
-      ""
-    )
-    expect(designSystemMocks.getDesignSystemStateLabel).toHaveBeenCalledWith(
-      "unavailable",
-      ""
     )
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts
@@ -1,4 +1,18 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const designSystemMocks = vi.hoisted(() => ({
+  getDesignSystemStateLabel: vi.fn(
+    (key: string, fallback: string) =>
+      ({
+        ready: "Registry Ready",
+        unavailable: "Registry Unavailable",
+      })[key] ?? fallback
+  ),
+}))
+
+vi.mock("@/design-system", () => ({
+  getDesignSystemStateLabel: designSystemMocks.getDesignSystemStateLabel,
+}))
 
 import {
   buildSourceHealthSummary,
@@ -7,6 +21,10 @@ import {
 } from "../sourceHealth"
 
 describe("Knowledge QA source health normalization", () => {
+  beforeEach(() => {
+    designSystemMocks.getDesignSystemStateLabel.mockClear()
+  })
+
   it("normalizes partial backend payloads without colliding with search source status", () => {
     const normalized = normalizeKnowledgeSourceHealth({
       sources: [
@@ -80,5 +98,54 @@ describe("Knowledge QA source health normalization", () => {
     expect(normalized.bySource.notes?.indexStatus).toBe("unknown")
     expect(normalized.bySource.notes?.embeddingStatus).toBe("unknown")
     expect(getSourceHealthStatusLabel(normalized.bySource.notes)).toBe("Unknown")
+  })
+
+  it("uses design-system registry labels for canonical ready and unavailable statuses", () => {
+    const normalized = normalizeKnowledgeSourceHealth({
+      sources: [
+        {
+          source_id: "media_db",
+          label: "Documents & Media",
+          available: true,
+          searchable: true,
+          index_status: "ready",
+          embedding_status: "ready",
+        },
+        {
+          source_id: "notes",
+          label: "Notes",
+          available: true,
+          searchable: false,
+          index_status: "ready",
+          embedding_status: "missing",
+        },
+        {
+          source_id: "prompts",
+          label: "Prompts",
+          available: false,
+          searchable: false,
+          index_status: "unavailable",
+          embedding_status: "unavailable",
+        },
+      ],
+    })
+
+    expect(getSourceHealthStatusLabel(normalized.bySource.media_db)).toBe(
+      "Registry Ready"
+    )
+    expect(getSourceHealthStatusLabel(normalized.bySource.notes)).toBe(
+      "Registry Unavailable"
+    )
+    expect(getSourceHealthStatusLabel(normalized.bySource.prompts)).toBe(
+      "Registry Unavailable"
+    )
+    expect(designSystemMocks.getDesignSystemStateLabel).toHaveBeenCalledWith(
+      "ready",
+      ""
+    )
+    expect(designSystemMocks.getDesignSystemStateLabel).toHaveBeenCalledWith(
+      "unavailable",
+      ""
+    )
   })
 })

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
@@ -2,7 +2,7 @@ import {
   getRagSourceLabel,
   isRagSource,
 } from "@/services/rag/sourceMetadata"
-import { getDesignSystemStateLabel } from "@/design-system"
+import { READY_STATE_LABEL, UNAVAILABLE_STATE_LABEL } from "@/design-system"
 import type {
   KnowledgeSourceEmbeddingStatus,
   KnowledgeSourceHealth,
@@ -118,9 +118,7 @@ export function getSourceHealthStatusLabel(
   }
   switch (health.indexStatus) {
     case "ready":
-      return health.searchable
-        ? getDesignSystemStateLabel("ready", "")
-        : getDesignSystemStateLabel("unavailable", "")
+      return health.searchable ? READY_STATE_LABEL : UNAVAILABLE_STATE_LABEL
     case "indexing":
       return "Indexing"
     case "stale":
@@ -128,7 +126,7 @@ export function getSourceHealthStatusLabel(
     case "empty":
       return "Empty"
     case "unavailable":
-      return getDesignSystemStateLabel("unavailable", "")
+      return UNAVAILABLE_STATE_LABEL
     case "error":
       return "Error"
     case "unknown":

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/sourceHealth.ts
@@ -2,6 +2,7 @@ import {
   getRagSourceLabel,
   isRagSource,
 } from "@/services/rag/sourceMetadata"
+import { getDesignSystemStateLabel } from "@/design-system"
 import type {
   KnowledgeSourceEmbeddingStatus,
   KnowledgeSourceHealth,
@@ -117,7 +118,9 @@ export function getSourceHealthStatusLabel(
   }
   switch (health.indexStatus) {
     case "ready":
-      return health.searchable ? "Ready" : "Unavailable"
+      return health.searchable
+        ? getDesignSystemStateLabel("ready", "")
+        : getDesignSystemStateLabel("unavailable", "")
     case "indexing":
       return "Indexing"
     case "stale":
@@ -125,7 +128,7 @@ export function getSourceHealthStatusLabel(
     case "empty":
       return "Empty"
     case "unavailable":
-      return "Unavailable"
+      return getDesignSystemStateLabel("unavailable", "")
     case "error":
       return "Error"
     case "unknown":

--- a/apps/packages/ui/src/design-system/__tests__/states.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/states.test.ts
@@ -5,6 +5,7 @@ import {
   EMPTY_STATE_LABEL,
   LOADING_STATE_LABEL,
   READY_STATE_LABEL,
+  UNAVAILABLE_STATE_LABEL,
   getDesignSystemState,
   isDesignSystemStateKey
 } from "../states"
@@ -183,6 +184,9 @@ describe("design-system state registry", () => {
 
   it("exports canonical state labels through defensive fallbacks", () => {
     expect(READY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.ready.label)
+    expect(UNAVAILABLE_STATE_LABEL).toBe(
+      DESIGN_SYSTEM_STATES.unavailable.label
+    )
     expect(EMPTY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.empty.label)
     expect(LOADING_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.loading.label)
     expect(BLOCKED_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.blocked.label)

--- a/apps/packages/ui/src/design-system/states.ts
+++ b/apps/packages/ui/src/design-system/states.ts
@@ -212,6 +212,10 @@ export function getDesignSystemStateLabel(
 }
 
 export const READY_STATE_LABEL = getDesignSystemStateLabel("ready", "Ready")
+export const UNAVAILABLE_STATE_LABEL = getDesignSystemStateLabel(
+  "unavailable",
+  "Unavailable"
+)
 export const EMPTY_STATE_LABEL = getDesignSystemStateLabel("empty", "Empty")
 export const LOADING_STATE_LABEL = getDesignSystemStateLabel("loading", "Loading")
 export const DEGRADED_STATE_LABEL = getDesignSystemStateLabel("degraded", "Degraded")

--- a/backlog/tasks/task-45.44.2.1 - Migrate-QuickIngest-AddContentStep-product-state-UI-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.2.1 - Migrate-QuickIngest-AddContentStep-product-state-UI-to-design-system-primitives.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.2.1
+title: >-
+  Migrate QuickIngest AddContentStep product-state UI to design-system
+  primitives
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 04:48'
+labels:
+  - design-system
+  - webui
+  - product-state
+  - quick-ingest
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+  - >-
+    apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.2
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the QuickIngest AddContentStep product-state warnings and media-type badge from AntD Alert/Tag to shared design-system primitives while preserving large-file, FFmpeg-missing, and queued item behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AddContentStep no longer imports AntD Alert or Tag for product-state UI.
+- [x] #2 Large-file and FFmpeg-missing notices render the shared design-system Alert primitive with equivalent warning copy and icon treatment.
+- [x] #3 Queued item media type labels render the shared design-system Badge primitive while preserving warning styling when FFmpeg is missing.
+- [x] #4 Focused tests assert representative AddContentStep notices and badges render design-system markers.
+- [x] #5 The design-system product-state baseline no longer contains AddContentStep exceptions and verification results are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented AddContentStep product-state migration: AntD Alert/Tag product-state UI now uses design-system Alert and Badge primitives; removed AddContentStep entries from the design-system product-state baseline.
+
+Verification: RED focused Step 1 tests failed on missing data-ds Alert/Badge markers before implementation; GREEN QuickIngest integration passed 27/27; AddContentStep URL detection passed 2/2; product-state guard unit passed 52/52; verify:design-system-state exited 0; baseline JSON parsed with 0 AddContentStep entries; git diff --check exited 0.
+
+Known verification note: full UI TypeScript check still fails on existing repo-wide type debt outside touched files, starting in audio/composer/flashcards tests. Bandit is not applicable to this TypeScript-only frontend slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated QuickIngest AddContentStep warning notices and media labels to design-system Alert and Badge primitives, added regression coverage, and removed its three legacy product-state baseline entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+Migrated QuickIngest AddContentStep warning notices and media labels to design-system Alert and Badge primitives, added regression coverage, and removed its three legacy product-state baseline entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.2.1 - Migrate-QuickIngest-AddContentStep-product-state-UI-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.2.1 - Migrate-QuickIngest-AddContentStep-product-state-UI-to-design-system-primitives.md
@@ -53,11 +53,6 @@ Known verification note: full UI TypeScript check still fails on existing repo-w
 Migrated QuickIngest AddContentStep warning notices and media labels to design-system Alert and Badge primitives, added regression coverage, and removed its three legacy product-state baseline entries.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-Migrated QuickIngest AddContentStep warning notices and media labels to design-system Alert and Badge primitives, added regression coverage, and removed its three legacy product-state baseline entries.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-45.44.2.2 - Use-design-system-registry-labels-for-Knowledge-QA-source-health-status.md
+++ b/backlog/tasks/task-45.44.2.2 - Use-design-system-registry-labels-for-Knowledge-QA-source-health-status.md
@@ -1,0 +1,52 @@
+---
+id: TASK-45.44.2.2
+title: Use design-system registry labels for Knowledge QA source health status
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 04:48'
+labels: []
+dependencies: []
+parent_task_id: TASK-45.44.2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix unbaselined canonical-state-label guard findings in Knowledge QA source health by routing Ready and Unavailable labels through the design-system state registry helper.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 getSourceHealthStatusLabel uses design-system registry labels for ready and unavailable states.
+- [x] #2 Focused sourceHealth tests prove registry labels are used for ready/searchable, ready/not searchable, and unavailable statuses.
+- [x] #3 Repo-level design-system product-state guard no longer reports sourceHealth.ts as blocked.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Routed ready/searchable and unavailable source-health labels through getDesignSystemStateLabel with neutral fallbacks so canonical labels come from the design-system registry.
+
+Verification: RED sourceHealth registry-label test failed against hardcoded labels; GREEN sourceHealth test passed 4/4; product-state guard unit passed 52/52; verify:design-system-state exited 0 and no longer reports sourceHealth.ts as blocked.
+
+Known verification note: full UI TypeScript check still fails on existing repo-wide type debt outside touched files. Bandit is not applicable to this TypeScript-only frontend slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed Knowledge QA source-health canonical labels to use the design-system registry and added focused regression coverage for ready and unavailable status labels.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.2.2 - Use-design-system-registry-labels-for-Knowledge-QA-source-health-status.md
+++ b/backlog/tasks/task-45.44.2.2 - Use-design-system-registry-labels-for-Knowledge-QA-source-health-status.md
@@ -26,7 +26,7 @@ Fix unbaselined canonical-state-label guard findings in Knowledge QA source heal
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Routed ready/searchable and unavailable source-health labels through getDesignSystemStateLabel with neutral fallbacks so canonical labels come from the design-system registry.
+Routed ready/searchable and unavailable source-health labels through design-system registry label constants so canonical labels keep defensive non-empty fallbacks.
 
 Verification: RED sourceHealth registry-label test failed against hardcoded labels; GREEN sourceHealth test passed 4/4; product-state guard unit passed 52/52; verify:design-system-state exited 0 and no longer reports sourceHealth.ts as blocked.
 
@@ -37,8 +37,6 @@ Known verification note: full UI TypeScript check still fails on existing repo-w
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Fixed Knowledge QA source-health canonical labels to use the design-system registry and added focused regression coverage for ready and unavailable status labels.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.2.3 - Address-PR-1750-review-comments.md
+++ b/backlog/tasks/task-45.44.2.3 - Address-PR-1750-review-comments.md
@@ -1,0 +1,51 @@
+---
+id: TASK-45.44.2.3
+title: Address PR 1750 review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 05:51'
+labels: []
+dependencies: []
+parent_task_id: TASK-45.44.2
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address currently actionable PR #1750 review comments for QuickIngest icon spacing, Knowledge QA source-health label fallback safety, and duplicate Backlog final-summary markers.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 QuickIngest warning Badge icon spacing keeps text separated from the icon.
+- [x] #2 Knowledge QA source-health ready/unavailable labels use design-system registry-backed non-empty constants without reintroducing product-code canonical label literals.
+- [x] #3 New Backlog task files contain exactly one FINAL_SUMMARY BEGIN/END pair each.
+- [x] #4 Focused tests and product-state guard verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Addressed PR #1750 review comments: restored QuickIngest warning Badge icon spacing, added UNAVAILABLE_STATE_LABEL as a registry-backed non-empty fallback, routed Knowledge QA source-health labels through registry label constants, and removed duplicate FINAL_SUMMARY section markers from the new task files.
+
+Verification: RED focused tests failed for missing icon margin, missing unavailable label export, and sourceHealth helper import; GREEN QuickIngest integration passed 27/27; sourceHealth/states/product-state-guard tests passed 60/60; verify:design-system-state exited 0; task final-summary marker check passed for TASK-45.44.2.1, TASK-45.44.2.2, and TASK-45.44.2.3; git diff --check exited 0.
+
+Known verification note: full UI TypeScript remains blocked by existing repo-wide type debt outside this PR. Bandit is not applicable to this TypeScript-only frontend/docs slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1750 review feedback for QuickIngest icon spacing, source-health non-empty design-system label fallbacks, and duplicate Backlog final-summary markers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates QuickIngest AddContentStep product-state warnings from AntD Alert to the shared design-system Alert primitive.
- Migrates queued media labels from AntD Tag to the shared design-system Badge primitive and removes the AddContentStep baseline exceptions.
- Fixes Knowledge QA source-health Ready/Unavailable labels to come from the design-system state registry so the repo-level product-state guard passes.

## Verification
- bunx vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx --reporter=dot --testTimeout=20000
- bunx vitest run src/components/Option/KnowledgeQA/__tests__/sourceHealth.test.ts --reporter=dot --testTimeout=20000
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot --testTimeout=20000
- bun run verify:design-system-state
- git diff --check HEAD~1 HEAD

## Known Verification Note
- bunx tsc --noEmit --project tsconfig.json --pretty false still fails on existing repo-wide UI type debt outside this slice, starting in audio/composer/flashcards tests. No touched file appeared in the reported failures.

## Change Summary
Human-authored change summary required before merge by the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated QuickIngest AddContentStep product-state UI from `antd` to design-system primitives and aligned Knowledge QA status labels with the state registry. This removes the legacy baseline exceptions and keeps the product-state guard passing.

- **Refactors**
  - Replaced `antd` Alert/Tag with design-system `Alert` and `Badge` from `@/components/ui/primitives` for large-file, FFmpeg-missing, and media-type indicators; alerts use role=status and aria-live=polite, icons are aria-hidden, and warning-badge icon spacing is fixed.
  - Removed three AddContentStep exceptions from the design-system product-state baseline.

- **Bug Fixes**
  - Routed Knowledge QA “ready” and “unavailable” labels through `READY_STATE_LABEL` and `UNAVAILABLE_STATE_LABEL` from `@/design-system`.
  - Added tests for registry labels and for design-system Alert/Badge markers and variants.

<sup>Written for commit e40243ff42f9620f711af2b6711802d6a53e6330. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1750?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

