### PR TITLE
Surface Persona Visual starter readiness in Persona Garden

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualBuddySetupChoiceCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualBuddySetupChoiceCard.tsx
@@ -7,6 +7,20 @@ import type { PersonaVisualStarterPackSummary } from "@/types/persona-visuals"
 
 const { Text } = Typography
 
+export const formatStarterMetadataToken = (value: string | null | undefined): string =>
+  String(value || "")
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+
+export const formatStarterExpectedAssetGroups = (
+  expectedAssetGroups: string[] | undefined
+): string =>
+  (expectedAssetGroups || [])
+    .map(formatStarterMetadataToken)
+    .join(", ")
+
 export type VisualBuddySetupChoiceCardProps = {
   selectedPersonaId: string
   selectedPersonaName: string
@@ -84,6 +98,32 @@ const getDefaultDescription = ({
     t("sidepanel:personaGarden.visuals.setup.defaultFallbackDescription", {
       defaultValue: "Copy the recommended starter as a draft."
     })
+  )
+}
+
+const renderStarterReadinessTags = (
+  starter: PersonaVisualStarterPackSummary | null | undefined,
+  t: (key: string, options: { defaultValue: string }) => string
+): React.ReactNode => {
+  if (!starter) return null
+  const productionStatus = formatStarterMetadataToken(starter.production_status)
+  const complexityTier = formatStarterMetadataToken(starter.complexity_tier)
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {productionStatus ? (
+        <Tag color={starter.production_status === "art_ready" ? "green" : "orange"}>
+          {productionStatus}
+        </Tag>
+      ) : null}
+      {complexityTier ? <Tag>{complexityTier}</Tag> : null}
+      {starter.neutral_anchor_required ? (
+        <Tag color="blue">
+          {t("sidepanel:personaGarden.visuals.setup.neutralAnchorRequired", {
+            defaultValue: "Neutral anchor required"
+          })}
+        </Tag>
+      ) : null}
+    </div>
   )
 }
 
@@ -237,6 +277,7 @@ export const VisualBuddySetupChoiceCard: React.FC<
             <span className="block">
               {formatStarterCount(starterCount, starterCatalogLoading, t)}
             </span>
+            {renderStarterReadinessTags(recommendedStarter, t)}
           </div>
           <Button
             className="mt-2 w-full justify-center"

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -87,7 +87,11 @@ import {
   classifyPersonaVisualGenerationReadiness,
   type PersonaVisualGenerationReadinessView
 } from "./personaVisualGenerationReadiness"
-import { VisualBuddySetupChoiceCard } from "./VisualBuddySetupChoiceCard"
+import {
+  formatStarterExpectedAssetGroups,
+  formatStarterMetadataToken,
+  VisualBuddySetupChoiceCard
+} from "./VisualBuddySetupChoiceCard"
 import { VisualPackReusePanel } from "./VisualPackReusePanel"
 
 type VisualPackEditorProps = {
@@ -2968,38 +2972,94 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           data-testid="persona-visual-starter-picker"
           className="space-y-2"
         >
-          {starterPacks.map((starter) => (
-            <div
-              key={starter.id}
-              className="rounded border border-border bg-bg p-2 text-xs"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-2">
-                <div>
-                  <div className="font-medium text-text">{starter.title}</div>
-                  <div className="mt-1 text-text-muted">{starter.description}</div>
-                </div>
-                <Tag>{starter.renderer_type}</Tag>
-              </div>
-              <div className="mt-2 flex flex-wrap gap-1">
-                {starter.tags.map((tag) => (
-                  <Tag key={tag}>{tag}</Tag>
-                ))}
-                <Tag>{starter.license_label}</Tag>
-              </div>
-              <Button
-                data-testid={`persona-visual-copy-starter-${starter.id}`}
-                className="mt-2"
-                size="small"
-                type="primary"
-                icon={<Copy className="h-3.5 w-3.5" />}
-                loading={copyingStarterId === starter.id}
-                disabled={Boolean(copyingStarterId)}
-                onClick={() => void handleCopyStarterPack(starter.id)}
+          {starterPacks.map((starter) => {
+            const productionStatus = formatStarterMetadataToken(
+              starter.production_status
+            )
+            const complexityTier = formatStarterMetadataToken(
+              starter.complexity_tier
+            )
+            const expectedAssetGroups = formatStarterExpectedAssetGroups(
+              starter.expected_asset_groups
+            )
+            const animationCoverageNotes = (
+              starter.animation_coverage_notes || []
+            ).join("; ")
+            return (
+              <div
+                key={starter.id}
+                className="rounded border border-border bg-bg p-2 text-xs"
               >
-                Copy as draft
-              </Button>
-            </div>
-          ))}
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <div className="font-medium text-text">{starter.title}</div>
+                    <div className="mt-1 text-text-muted">{starter.description}</div>
+                  </div>
+                  <Tag>{starter.renderer_type}</Tag>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {productionStatus ? (
+                    <Tag color={starter.production_status === "art_ready" ? "green" : "orange"}>
+                      {productionStatus}
+                    </Tag>
+                  ) : null}
+                  {complexityTier ? <Tag>{complexityTier}</Tag> : null}
+                  {starter.neutral_anchor_required ? (
+                    <Tag color="blue">
+                      {t(
+                        "sidepanel:personaGarden.visuals.setup.neutralAnchorRequired",
+                        {
+                          defaultValue: "Neutral anchor required"
+                        }
+                      )}
+                    </Tag>
+                  ) : null}
+                  {starter.tags.map((tag) => (
+                    <Tag key={tag}>{tag}</Tag>
+                  ))}
+                  <Tag>{starter.license_label}</Tag>
+                </div>
+                {expectedAssetGroups ? (
+                  <div className="mt-2 text-[11px] leading-5 text-text-muted">
+                    <span className="font-medium text-text">
+                      {t(
+                        "sidepanel:personaGarden.visuals.setup.expectedAssetsLabel",
+                        {
+                          defaultValue: "Expected assets:"
+                        }
+                      )}{" "}
+                    </span>
+                    {expectedAssetGroups}
+                  </div>
+                ) : null}
+                {animationCoverageNotes ? (
+                  <div className="mt-1 text-[11px] leading-5 text-text-muted">
+                    <span className="font-medium text-text">
+                      {t(
+                        "sidepanel:personaGarden.visuals.setup.coverageLabel",
+                        {
+                          defaultValue: "Coverage:"
+                        }
+                      )}{" "}
+                    </span>
+                    {animationCoverageNotes}
+                  </div>
+                ) : null}
+                <Button
+                  data-testid={`persona-visual-copy-starter-${starter.id}`}
+                  className="mt-2"
+                  size="small"
+                  type="primary"
+                  icon={<Copy className="h-3.5 w-3.5" />}
+                  loading={copyingStarterId === starter.id}
+                  disabled={Boolean(copyingStarterId)}
+                  onClick={() => void handleCopyStarterPack(starter.id)}
+                >
+                  Copy as draft
+                </Button>
+              </div>
+            )
+          })}
         </div>
       </Modal>
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx
@@ -34,7 +34,12 @@ const starter = {
   asset_count: 1,
   total_bytes: 512,
   tags: ["starter"],
-  license_label: "bundled"
+  license_label: "bundled",
+  complexity_tier: "basic",
+  production_status: "scaffold",
+  neutral_anchor_required: true,
+  expected_asset_groups: ["neutral_anchor", "required_state_loops"],
+  animation_coverage_notes: ["Scaffold fixture only; replace with authored loops."]
 }
 
 describe("VisualBuddySetupChoiceCard", () => {
@@ -58,6 +63,27 @@ describe("VisualBuddySetupChoiceCard", () => {
     expect(screen.getByRole("button", { name: /import pack/i })).toBeEnabled()
     expect(screen.getByRole("button", { name: /start blank/i })).toBeEnabled()
     expect(screen.getByText(/no visual buddy is active/i)).toBeInTheDocument()
+  })
+
+  it("surfaces starter production readiness metadata", () => {
+    render(
+      <VisualBuddySetupChoiceCard
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        hasActiveVisual={false}
+        packCount={0}
+        recommendedStarter={starter}
+        starterCount={1}
+        onUseDefault={vi.fn()}
+        onImportPack={vi.fn()}
+        onStartBlank={vi.fn()}
+      />
+    )
+
+    const setupCard = screen.getByTestId("visual-buddy-setup-choice-card")
+    expect(setupCard).toHaveTextContent(/scaffold/i)
+    expect(setupCard).toHaveTextContent(/basic/i)
+    expect(setupCard).toHaveTextContent(/neutral anchor/i)
   })
 
   it("frames existing drafts as reviewable but inactive", () => {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1119,7 +1119,17 @@ describe("VisualPackEditor", () => {
           asset_count: 2,
           total_bytes: 1024,
           tags: ["alt", "starter"],
-          license_label: "bundled-alt"
+          license_label: "bundled-alt",
+          complexity_tier: "intermediate",
+          production_status: "scaffold",
+          neutral_anchor_required: true,
+          expected_asset_groups: [
+            "neutral_anchor",
+            "static_talking_reaction_sheet"
+          ],
+          animation_coverage_notes: [
+            "Scaffold fixture only; replace with authored reactions."
+          ]
         }
       ]
     }
@@ -1175,6 +1185,11 @@ describe("VisualPackEditor", () => {
     expect(picker).toHaveTextContent("sprite_frames")
     expect(picker).toHaveTextContent("alt")
     expect(picker).toHaveTextContent("bundled-alt")
+    expect(picker).toHaveTextContent(/scaffold/i)
+    expect(picker).toHaveTextContent(/intermediate/i)
+    expect(picker).toHaveTextContent(/neutral anchor/i)
+    expect(picker).toHaveTextContent(/static talking reaction sheet/i)
+    expect(picker).toHaveTextContent("Scaffold fixture only")
 
     fireEvent.click(within(picker).getByTestId("persona-visual-copy-starter-alt-starter"))
 

--- a/apps/packages/ui/src/services/__tests__/persona-visuals.test.ts
+++ b/apps/packages/ui/src/services/__tests__/persona-visuals.test.ts
@@ -99,7 +99,12 @@ describe("persona visuals service", () => {
       asset_count: 1,
       total_bytes: 92,
       tags: ["starter", "sprite_frames"],
-      license_label: "bundled"
+      license_label: "bundled",
+      complexity_tier: "basic",
+      production_status: "scaffold",
+      neutral_anchor_required: true,
+      expected_asset_groups: ["neutral_anchor", "required_state_loops"],
+      animation_coverage_notes: ["Scaffold fixture only; replace with authored loops."]
     }
     mocks.fetchWithAuth.mockResolvedValueOnce({
       ok: true,

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -229,6 +229,13 @@ export interface PersonaVisualStarterPackAssetSummary {
   byte_size: number
 }
 
+export type PersonaVisualStarterComplexityTier =
+  | "basic"
+  | "intermediate"
+  | "intricate"
+
+export type PersonaVisualStarterProductionStatus = "scaffold" | "art_ready"
+
 export interface PersonaVisualStarterPackSummary {
   id: string
   title: string
@@ -240,6 +247,11 @@ export interface PersonaVisualStarterPackSummary {
   total_bytes: number
   tags: string[]
   license_label: string
+  complexity_tier: PersonaVisualStarterComplexityTier
+  production_status: PersonaVisualStarterProductionStatus
+  neutral_anchor_required: boolean
+  expected_asset_groups: string[]
+  animation_coverage_notes: string[]
 }
 
 export interface PersonaVisualStarterPackDetail

--- a/backlog/tasks/task-404 - Surface-Persona-Visual-starter-production-metadata-in-Persona-Garden.md
+++ b/backlog/tasks/task-404 - Surface-Persona-Visual-starter-production-metadata-in-Persona-Garden.md
@@ -1,0 +1,58 @@
+---
+id: TASK-404
+title: Surface Persona Visual starter production metadata in Persona Garden
+status: Done
+labels:
+- persona
+- visual-packs
+- webui
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1752
+- https://github.com/rmusser01/tldw_server/pull/1754
+documentation:
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+modified_files:
+- apps/packages/ui/src/types/persona-visuals.ts
+- apps/packages/ui/src/components/PersonaGarden/VisualBuddySetupChoiceCard.tsx
+- apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+- apps/packages/ui/src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx
+- apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+- apps/packages/ui/src/services/__tests__/persona-visuals.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Surface the Persona Visual starter catalog production-readiness metadata added in #1741 / PR #1744 inside Persona Garden setup and bundled-default picker, without changing copy-to-draft or activation behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Garden starter setup surfaces scaffold/production status and complexity tier for the recommended starter
+- [x] #2 Bundled-default picker shows neutral-anchor/expected asset group/animation coverage hints for each starter
+- [x] #3 Shared TypeScript starter-pack types include the backend production-readiness metadata fields
+- [x] #4 Focused Vitest coverage verifies the new display and preserves copy-to-draft actions
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Persona Garden starter production metadata display for the recommended default card and bundled-default picker. Added shared UI starter metadata types for complexity_tier, production_status, neutral_anchor_required, expected_asset_groups, and animation_coverage_notes. PR review follow-up: moved new readiness labels through the existing translation function and cached formatted picker metadata per starter row. Verification: focused Vitest suite passed 73 tests; git diff --check passed. Full package tsc --noEmit was attempted and failed on pre-existing repo-wide UI type-test debt outside this slice. Bandit is not applicable because this is a frontend-only TypeScript/UI change.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Persona Garden now surfaces starter scaffold readiness context from the backend starter catalog so users can see scaffold status, complexity tier, neutral-anchor requirements, expected authored asset groups, and coverage notes before copying a bundled starter as an inactive draft.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- surface Persona Visual starter production-readiness metadata in the setup card and bundled-default picker
- add shared UI starter metadata types for scaffold status, complexity tier, neutral-anchor requirements, expected asset groups, and coverage notes
- add focused Persona Garden and service test coverage while preserving copy-to-draft behavior

## Validation
- bunx vitest run src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx src/services/__tests__/persona-visuals.test.ts --testTimeout=30000
- git diff --check
- attempted: bunx tsc --noEmit --project tsconfig.json; fails on pre-existing repo-wide UI type-test debt outside this slice

## Change summary
Human-authored summary required before merge.

Closes #1752

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Persona Visual starter production-readiness metadata in Persona Garden so users can see scaffold status, complexity tier, and asset expectations before copying a starter. Adds shared types, token formatting helpers, and focused tests; copy-to-draft behavior is unchanged.

- New Features
  - Show readiness badges in the setup card and bundled-default picker: production status (green for `art_ready`, orange otherwise), complexity tier, and “Neutral anchor required”.
  - Display expected asset groups and coverage notes in the picker with labels; format tokens for readability.
  - Add shared TypeScript types for `complexity_tier`, `production_status`, `neutral_anchor_required`, `expected_asset_groups`, and `animation_coverage_notes`; tests verify display and preserve copy-to-draft. Aligns with #1752.

<sup>Written for commit 93efdb2714ec87dd07ba7289dd31c11b28355b37. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1754?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

