### PR TITLE
Surface Persona Visual starter metadata in Persona Garden

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualBuddySetupChoiceCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualBuddySetupChoiceCard.tsx
@@ -7,6 +7,11 @@ import type { PersonaVisualStarterPackSummary } from "@/types/persona-visuals"
 
 const { Text } = Typography
 
+type StarterReadinessTranslate = (
+  key: string,
+  options: { defaultValue: string }
+) => string
+
 export const formatStarterMetadataToken = (value: string | null | undefined): string =>
   String(value || "")
     .split(/[_\s-]+/)
@@ -20,6 +25,28 @@ export const formatStarterExpectedAssetGroups = (
   (expectedAssetGroups || [])
     .map(formatStarterMetadataToken)
     .join(", ")
+
+export const getStarterProductionStatusLabel = (
+  value: string | null | undefined,
+  t: StarterReadinessTranslate
+): string => {
+  const fallback = formatStarterMetadataToken(value)
+  if (!fallback) return ""
+  return t(`sidepanel:personaGarden.visuals.metadata.productionStatus.${value}`, {
+    defaultValue: fallback
+  })
+}
+
+export const getStarterComplexityTierLabel = (
+  value: string | null | undefined,
+  t: StarterReadinessTranslate
+): string => {
+  const fallback = formatStarterMetadataToken(value)
+  if (!fallback) return ""
+  return t(`sidepanel:personaGarden.visuals.metadata.complexityTier.${value}`, {
+    defaultValue: fallback
+  })
+}
 
 export type VisualBuddySetupChoiceCardProps = {
   selectedPersonaId: string
@@ -106,8 +133,11 @@ const renderStarterReadinessTags = (
   t: (key: string, options: { defaultValue: string }) => string
 ): React.ReactNode => {
   if (!starter) return null
-  const productionStatus = formatStarterMetadataToken(starter.production_status)
-  const complexityTier = formatStarterMetadataToken(starter.complexity_tier)
+  const productionStatus = getStarterProductionStatusLabel(
+    starter.production_status,
+    t
+  )
+  const complexityTier = getStarterComplexityTierLabel(starter.complexity_tier, t)
   return (
     <div className="mt-1 flex flex-wrap gap-1">
       {productionStatus ? (

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -89,7 +89,8 @@ import {
 } from "./personaVisualGenerationReadiness"
 import {
   formatStarterExpectedAssetGroups,
-  formatStarterMetadataToken,
+  getStarterComplexityTierLabel,
+  getStarterProductionStatusLabel,
   VisualBuddySetupChoiceCard
 } from "./VisualBuddySetupChoiceCard"
 import { VisualPackReusePanel } from "./VisualPackReusePanel"
@@ -2973,11 +2974,13 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           className="space-y-2"
         >
           {starterPacks.map((starter) => {
-            const productionStatus = formatStarterMetadataToken(
-              starter.production_status
+            const productionStatus = getStarterProductionStatusLabel(
+              starter.production_status,
+              t
             )
-            const complexityTier = formatStarterMetadataToken(
-              starter.complexity_tier
+            const complexityTier = getStarterComplexityTierLabel(
+              starter.complexity_tier,
+              t
             )
             const expectedAssetGroups = formatStarterExpectedAssetGroups(
               starter.expected_asset_groups

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { PersonaVisualStarterPackSummary } from "@/types/persona-visuals"
+
 const mocks = vi.hoisted(() => ({
   translate: vi.fn(
     (
@@ -30,7 +32,7 @@ vi.mock("react-i18next", () => ({
 
 import { VisualBuddySetupChoiceCard } from "../VisualBuddySetupChoiceCard"
 
-const starter = {
+const starter: PersonaVisualStarterPackSummary = {
   id: "research-buddy-starter",
   title: "Research Buddy Starter",
   description: "Starter sprite pack",

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (
+const mocks = vi.hoisted(() => ({
+  translate: vi.fn(
+    (
       _key: string,
       options?:
         | string
@@ -19,6 +19,12 @@ vi.mock("react-i18next", () => ({
       }
       return options?.defaultValue ?? _key
     }
+  )
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (...args: Parameters<typeof mocks.translate>) => mocks.translate(...args)
   })
 }))
 
@@ -43,6 +49,10 @@ const starter = {
 }
 
 describe("VisualBuddySetupChoiceCard", () => {
+  beforeEach(() => {
+    mocks.translate.mockClear()
+  })
+
   it("renders first-run setup actions", () => {
     render(
       <VisualBuddySetupChoiceCard
@@ -63,6 +73,14 @@ describe("VisualBuddySetupChoiceCard", () => {
     expect(screen.getByRole("button", { name: /import pack/i })).toBeEnabled()
     expect(screen.getByRole("button", { name: /start blank/i })).toBeEnabled()
     expect(screen.getByText(/no visual buddy is active/i)).toBeInTheDocument()
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.metadata.productionStatus.scaffold",
+      expect.objectContaining({ defaultValue: "Scaffold" })
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.metadata.complexityTier.basic",
+      expect.objectContaining({ defaultValue: "Basic" })
+    )
   })
 
   it("surfaces starter production readiness metadata", () => {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -1128,7 +1128,8 @@ describe("VisualPackEditor", () => {
             "static_talking_reaction_sheet"
           ],
           animation_coverage_notes: [
-            "Scaffold fixture only; replace with authored reactions."
+            "Scaffold fixture only; replace with authored reactions.",
+            "Secondary motion pass still needs review."
           ]
         }
       ]
@@ -1190,6 +1191,23 @@ describe("VisualPackEditor", () => {
     expect(picker).toHaveTextContent(/neutral anchor/i)
     expect(picker).toHaveTextContent(/static talking reaction sheet/i)
     expect(picker).toHaveTextContent("Scaffold fixture only")
+    expect(picker).toHaveTextContent("Secondary motion pass still needs review")
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.metadata.productionStatus.scaffold",
+      expect.objectContaining({ defaultValue: "Scaffold" })
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.metadata.complexityTier.intermediate",
+      expect.objectContaining({ defaultValue: "Intermediate" })
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.setup.neutralAnchorRequired",
+      expect.objectContaining({ defaultValue: "Neutral anchor required" })
+    )
+    expect(mocks.translate).toHaveBeenCalledWith(
+      "sidepanel:personaGarden.visuals.setup.expectedAssetsLabel",
+      expect.objectContaining({ defaultValue: "Expected assets:" })
+    )
 
     fireEvent.click(within(picker).getByTestId("persona-visual-copy-starter-alt-starter"))
 

--- a/apps/packages/ui/src/services/__tests__/persona-visuals.test.ts
+++ b/apps/packages/ui/src/services/__tests__/persona-visuals.test.ts
@@ -129,7 +129,16 @@ describe("persona visuals service", () => {
     })
 
     await expect(listPersonaVisualStarterPacks()).resolves.toEqual({
-      starter_packs: [expect.objectContaining({ id: "starter-1" })]
+      starter_packs: [
+        expect.objectContaining({
+          id: "starter-1",
+          complexity_tier: "basic",
+          production_status: "scaffold",
+          neutral_anchor_required: true,
+          expected_asset_groups: [],
+          animation_coverage_notes: []
+        })
+      ]
     })
   })
 

--- a/apps/packages/ui/src/services/persona-visuals.ts
+++ b/apps/packages/ui/src/services/persona-visuals.ts
@@ -29,11 +29,14 @@ import type {
   PersonaVisualPackExportResponse,
   PersonaVisualPackListResponse,
   PersonaVisualPortabilityJobResponse,
+  PersonaVisualRendererType,
   PersonaVisualRendererCapabilitiesResponse,
+  PersonaVisualStarterComplexityTier,
   PersonaVisualStarterPackCopyRequest,
   PersonaVisualStarterPackDetail,
   PersonaVisualStarterPackListResponse,
-  PersonaVisualStarterPackSummary
+  PersonaVisualStarterPackSummary,
+  PersonaVisualStarterProductionStatus
 } from "@/types/persona-visuals"
 
 type PersonaVisualFetchInit = {
@@ -153,13 +156,91 @@ export const normalizePersonaVisualPackList = (
   }
 }
 
+const starterComplexityTiers = new Set<PersonaVisualStarterComplexityTier>([
+  "basic",
+  "intermediate",
+  "intricate"
+])
+
+const starterProductionStatuses = new Set<PersonaVisualStarterProductionStatus>([
+  "scaffold",
+  "art_ready"
+])
+
+const starterRendererTypes = new Set<PersonaVisualRendererType>([
+  "sprite_frames",
+  "sprite_sheet",
+  "static_image",
+  "live2d"
+])
+
+const normalizeStarterText = (value: unknown, fallback = ""): string =>
+  typeof value === "string" ? value : fallback
+
+const normalizeStarterNumber = (value: unknown, fallback = 0): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback
+
+const normalizeStarterStringList = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : []
+
+const normalizePersonaVisualStarterPackSummary = (
+  starter: PersonaVisualStarterPackSummary | Record<string, unknown>
+): PersonaVisualStarterPackSummary => {
+  const item = starter as Record<string, unknown>
+  const rendererType = normalizeStarterText(item.renderer_type, "sprite_frames")
+  const complexityTier = normalizeStarterText(item.complexity_tier, "basic")
+  const productionStatus = normalizeStarterText(item.production_status, "scaffold")
+
+  return {
+    id: normalizeStarterText(item.id),
+    title: normalizeStarterText(item.title),
+    description: normalizeStarterText(item.description),
+    renderer_type: starterRendererTypes.has(rendererType as PersonaVisualRendererType)
+      ? (rendererType as PersonaVisualRendererType)
+      : "sprite_frames",
+    manifest_version: normalizeStarterNumber(item.manifest_version, 1),
+    states_offered: normalizeStarterStringList(item.states_offered),
+    asset_count: normalizeStarterNumber(item.asset_count),
+    total_bytes: normalizeStarterNumber(item.total_bytes),
+    tags: normalizeStarterStringList(item.tags),
+    license_label: normalizeStarterText(item.license_label, "bundled"),
+    complexity_tier: starterComplexityTiers.has(
+      complexityTier as PersonaVisualStarterComplexityTier
+    )
+      ? (complexityTier as PersonaVisualStarterComplexityTier)
+      : "basic",
+    production_status: starterProductionStatuses.has(
+      productionStatus as PersonaVisualStarterProductionStatus
+    )
+      ? (productionStatus as PersonaVisualStarterProductionStatus)
+      : "scaffold",
+    neutral_anchor_required:
+      typeof item.neutral_anchor_required === "boolean"
+        ? item.neutral_anchor_required
+        : true,
+    expected_asset_groups: normalizeStarterStringList(item.expected_asset_groups),
+    animation_coverage_notes: normalizeStarterStringList(
+      item.animation_coverage_notes
+    )
+  }
+}
+
 export const normalizePersonaVisualStarterPackList = (
   payload: PersonaVisualStarterPackSummary[] | PersonaVisualStarterPackListResponse
 ): PersonaVisualStarterPackListResponse => {
-  if (Array.isArray(payload)) return { starter_packs: payload }
+  if (Array.isArray(payload)) {
+    return {
+      starter_packs: payload.map(normalizePersonaVisualStarterPackSummary)
+    }
+  }
   return {
     starter_packs: Array.isArray(payload?.starter_packs)
-      ? payload.starter_packs
+      ? payload.starter_packs.map(normalizePersonaVisualStarterPackSummary)
       : []
   }
 }

--- a/backlog/tasks/task-404 - Surface-Persona-Visual-starter-production-metadata-in-Persona-Garden.md
+++ b/backlog/tasks/task-404 - Surface-Persona-Visual-starter-production-metadata-in-Persona-Garden.md
@@ -10,6 +10,7 @@ priority: medium
 references:
 - https://github.com/rmusser01/tldw_server/issues/1752
 - https://github.com/rmusser01/tldw_server/pull/1754
+- https://github.com/rmusser01/tldw_server/pull/1755
 documentation:
 - Docs/Code_Documentation/Persona_Visual_Packs.md
 modified_files:
@@ -44,7 +45,7 @@ Implemented Persona Garden starter production metadata display for the recommend
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Persona Garden now surfaces starter scaffold readiness context from the backend starter catalog so users can see scaffold status, complexity tier, neutral-anchor requirements, expected authored asset groups, and coverage notes before copying a bundled starter as an inactive draft.
+Persona Garden now surfaces starter scaffold readiness context from the backend starter catalog so users can see scaffold status, complexity tier, neutral-anchor requirements, expected authored asset groups, and coverage notes before copying a bundled starter as an inactive draft. PR #1755 now rebases cleanly over the merged #1754 implementation and adds the remaining service normalization plus localization review fixes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- What changed: surfaced Persona Visual starter production metadata in shared UI types/service normalization, the setup choice card, and the bundled-default picker.
- Why: users need to distinguish scaffold starter defaults by readiness, complexity, neutral-anchor needs, expected asset groups, and animation coverage before copying a starter draft.

Closes #1752
Part of #1510

## Change Summary (human-authored before merge)

Maintainer to complete before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally: `cd apps/packages/ui && bunx vitest run src/services/__tests__/persona-visuals.test.ts src/components/PersonaGarden/__tests__/VisualBuddySetupChoiceCard.test.tsx src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` (72 passed)
- [x] Docs updated (if behavior, routes, or config changed): not needed; UI surfaces existing documented backend metadata
- [x] `git diff --check`
- [ ] `bun run verify:design-system-state`: fails on existing unrelated product-state baseline findings, including `src/components/Option/KnowledgeQA/sourceHealth.ts`; no touched Persona Visual files were reported as blocked
- [ ] `bunx tsc --noEmit --project tsconfig.json --pretty false`: fails on existing repo-wide TypeScript baseline errors. Filtered output for this slice leaves only the existing `src/components/PersonaGarden/MCPExternalCatalog.tsx` issue, not the touched metadata files.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` (not browser-verified; no new uses added)
- [x] No `Maximum update depth exceeded` warnings on audited routes (not browser-verified; no state loop changes)
- [x] No unresolved `{{...}}` placeholders on audited routes (focused tests use rendered labels)
- [x] WebUI/extension parity validated for shared UI fixes through shared package tests
- [x] For Flashcards UI changes: not applicable
- [x] For Flashcards drawer changes: not applicable
- [x] For Flashcards help/copy/import UX changes: not applicable

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Watchlists UI behavior did not change

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Watchlists UI behavior did not change

## Risk & Rollback

- Risk level: Low
- Rollback plan: revert this commit to remove the metadata surfacing and return starter UI to the prior title/description/tag-only display.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced Persona Visual starter production metadata in Persona Garden with i18n-backed labels and strict service normalization so users can gauge readiness and complexity before copying a starter draft. Closes #1752.

- **New Features**
  - Shared UI types/service: added starter fields (complexity tier, production status, neutral-anchor flag, expected asset groups, coverage notes) with strict normalization (enum checks for renderer/complexity/status, list cleanup), safe defaults (`neutral_anchor_required` defaults to true), and translation-friendly tokens.
  - Setup choice card: shows localized tags for production status and complexity tier, plus “Neutral anchor required” when applicable.
  - Bundled-default picker: shows the same localized tags, a localized “Expected assets” label with summarized groups (top 3 + overflow), and all coverage notes; existing tags/license kept; copy-as-draft behavior unchanged.

<sup>Written for commit fcee8f5000baacbc783bc48e6f7c266b0dbf2371. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1755?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

