### PR TITLE
Migrate WatchlistsHealthBar attention badges

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3531,50 +3531,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx:Tag#antd-tag-watchlistshealthbar-color-error-line-307-tfw62m",
-    "path": "src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx:Tag#antd-tag-watchlistshealthbar-color-warning-line-296-1tu8zal",
-    "path": "src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx:Tag#antd-tag-watchlistshealthbar-color-warning-line-318-mqhw1g",
-    "path": "src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx:Tag#antd-tag-watchlistshealthbar-color-warning-line-329-n0qy8c",
-    "path": "src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx:Alert",
     "path": "src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppRuntimePanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppRuntimePanel.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import {
-  Alert,
   Button,
   Card,
   Empty,
@@ -16,6 +15,7 @@ import type {
   LlamacppRuntime,
   LlamacppRuntimeState
 } from "@/types/llamacpp-admin"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 
 const { Text } = Typography
 
@@ -117,7 +117,14 @@ export const LlamacppRuntimePanel: React.FC<LlamacppRuntimePanelProps> = ({
       aria-label="Runtime instances"
     >
       <Space orientation="vertical" size="middle" className="w-full">
-        {error && <Alert type="warning" showIcon title={error} />}
+        {error && (
+          <DesignSystemAlert
+            variant="warning"
+            title={error}
+            role="status"
+            aria-live="polite"
+          />
+        )}
 
         {rows.length === 0 ? (
           <Empty

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx
@@ -137,4 +137,28 @@ describe("LlamacppRuntimePanel", () => {
     expect(screen.getByLabelText("Vision draft is starting")).toBeDisabled()
     expect(onStart).not.toHaveBeenCalled()
   })
+
+  it("renders runtime load errors through the design-system alert primitive", () => {
+    render(
+      <LlamacppRuntimePanel
+        profiles={profiles}
+        runtimes={[]}
+        loading={false}
+        error="Runtime inventory failed to load."
+        actionProfileId={null}
+        onRefresh={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onUseInChat={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText("Runtime inventory failed to load.").closest(
+        '[data-ds-component="Alert"]'
+      )
+    ).toHaveAttribute("role", "status")
+  })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.run-notifications.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.run-notifications.test.tsx
@@ -2,6 +2,7 @@
 
 import React from "react"
 import { render, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { WatchlistsPlaygroundPage } from "../WatchlistsPlaygroundPage"
 
@@ -182,6 +183,13 @@ vi.mock("../shared/WatchlistsHealthBar", () => ({
   WatchlistsHealthBar: () => <div data-testid="watchlists-health-bar" />
 }))
 
+const renderWatchlistsPlaygroundPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/watchlists"]}>
+      <WatchlistsPlaygroundPage />
+    </MemoryRouter>
+  )
+
 describe("WatchlistsPlaygroundPage run notifications", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -253,7 +261,7 @@ describe("WatchlistsPlaygroundPage run notifications", () => {
   })
 
   it("groups repeat failures into one notification and deep-links to the newest run", async () => {
-    render(<WatchlistsPlaygroundPage />)
+    renderWatchlistsPlaygroundPage()
 
     await waitFor(() => {
       expect(mocks.notificationErrorMock).toHaveBeenCalledTimes(1)
@@ -278,7 +286,7 @@ describe("WatchlistsPlaygroundPage run notifications", () => {
     mocks.state.pollingActive = true
     mocks.fetchWatchlistRunsMock.mockReset()
 
-    render(<WatchlistsPlaygroundPage />)
+    renderWatchlistsPlaygroundPage()
 
     await new Promise((resolve) => {
       setTimeout(resolve, 250)
@@ -303,7 +311,7 @@ describe("WatchlistsPlaygroundPage run notifications", () => {
         has_more: false
       })
 
-    render(<WatchlistsPlaygroundPage />)
+    renderWatchlistsPlaygroundPage()
 
     await new Promise((resolve) => {
       setTimeout(resolve, 250)
@@ -340,7 +348,7 @@ describe("WatchlistsPlaygroundPage run notifications", () => {
       has_more: false
     })
 
-    render(<WatchlistsPlaygroundPage />)
+    renderWatchlistsPlaygroundPage()
 
     await waitFor(() => {
       expect(mocks.trackWatchlistsOnboardingTelemetryMock).toHaveBeenCalledWith({

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react"
-import { Button, Spin, Tag, Tooltip } from "antd"
+import { Button, Spin, Tooltip } from "antd"
 import {
   AlertTriangle,
   ChevronDown,
@@ -19,6 +19,7 @@ import {
   type WatchlistsOverviewHealthModel
 } from "@/services/watchlists-overview"
 import { formatRelativeTime } from "@/utils/dateFormatters"
+import { Badge, type BadgeVariant } from "@/components/ui/primitives"
 
 const HEALTH_BAR_STORAGE_KEY = "watchlists:health-bar-expanded:v1"
 const HEALTH_BAR_REFRESH_MS = 30_000
@@ -293,48 +294,44 @@ export const WatchlistsHealthBar: React.FC<HealthBarProps> = ({ onOpenSettings, 
           {hasAttention && (
             <div className="mt-3 flex flex-wrap gap-2" data-testid="watchlists-health-bar-attention">
               {(overviewHealth?.attention?.sources ?? 0) > 0 && (
-                <Tag
-                  color="warning"
-                  className="cursor-pointer"
+                <AttentionBadgeButton
+                  variant="warning"
                   onClick={() => goToTab("sources")}
                 >
                   {t("watchlists:overview.attention.sources", "Feeds need review ({{count}})", {
                     count: overviewHealth?.attention?.sources ?? 0
                   })}
-                </Tag>
+                </AttentionBadgeButton>
               )}
               {(overviewHealth?.attention?.runs ?? 0) > 0 && (
-                <Tag
-                  color="error"
-                  className="cursor-pointer"
+                <AttentionBadgeButton
+                  variant="danger"
                   onClick={() => goToTab("runs")}
                 >
                   {t("watchlists:overview.attention.runs", "Failed activity runs ({{count}})", {
                     count: overviewHealth?.attention?.runs ?? 0
                   })}
-                </Tag>
+                </AttentionBadgeButton>
               )}
               {(overviewHealth?.attention?.outputs ?? 0) > 0 && (
-                <Tag
-                  color="warning"
-                  className="cursor-pointer"
+                <AttentionBadgeButton
+                  variant="warning"
                   onClick={() => goToTab("outputs")}
                 >
                   {t("watchlists:overview.attention.outputs", "Reports with delivery issues ({{count}})", {
                     count: overviewHealth?.attention?.outputs ?? 0
                   })}
-                </Tag>
+                </AttentionBadgeButton>
               )}
               {(overviewHealth?.attention?.jobs ?? 0) > 0 && (
-                <Tag
-                  color="warning"
-                  className="cursor-pointer"
+                <AttentionBadgeButton
+                  variant="warning"
                   onClick={() => goToTab("jobs")}
                 >
                   {t("watchlists:overview.attention.jobs", "Monitors need schedule fixes ({{count}})", {
                     count: overviewHealth?.attention?.jobs ?? 0
                   })}
-                </Tag>
+                </AttentionBadgeButton>
               )}
             </div>
           )}
@@ -343,6 +340,28 @@ export const WatchlistsHealthBar: React.FC<HealthBarProps> = ({ onOpenSettings, 
     </div>
   )
 }
+
+interface AttentionBadgeButtonProps {
+  variant: BadgeVariant
+  children: React.ReactNode
+  onClick: () => void
+}
+
+const AttentionBadgeButton: React.FC<AttentionBadgeButtonProps> = ({
+  variant,
+  children,
+  onClick
+}) => (
+  <button
+    type="button"
+    className="rounded-full border-0 bg-transparent p-0 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+    onClick={onClick}
+  >
+    <Badge variant={variant} className="cursor-pointer">
+      {children}
+    </Badge>
+  </button>
+)
 
 interface HealthCardProps {
   icon: React.ReactNode

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { WatchlistsHealthBar } from "../WatchlistsHealthBar"
+
+const fetchWatchlistsOverviewDataMock = vi.hoisted(() => vi.fn())
+
+const watchlistsStoreState = vi.hoisted(() => ({
+  overviewHealth: {
+    statuses: {
+      sources: "attention",
+      jobs: "attention",
+      runs: "attention",
+      outputs: "attention"
+    },
+    attention: {
+      total: 10,
+      sources: 2,
+      jobs: 4,
+      runs: 1,
+      outputs: 3
+    },
+    tabBadges: {
+      sources: 2,
+      runs: 1,
+      outputs: 3
+    }
+  },
+  setOverviewHealth: vi.fn(),
+  setActiveTab: vi.fn()
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: unknown, options?: Record<string, unknown>) => {
+      if (typeof fallback !== "string") return _key
+      const values =
+        options && typeof options === "object"
+          ? options
+          : fallback && typeof fallback === "object"
+            ? fallback as Record<string, unknown>
+            : {}
+      return fallback.replace(/\{\{(\w+)\}\}/g, (_, token) => String(values[token] ?? ""))
+    }
+  })
+}))
+
+vi.mock("@/services/watchlists-overview", () => ({
+  fetchWatchlistsOverviewData: fetchWatchlistsOverviewDataMock
+}))
+
+vi.mock("@/store/watchlists", () => ({
+  useWatchlistsStore: (selector: (state: typeof watchlistsStoreState) => unknown) =>
+    selector(watchlistsStoreState)
+}))
+
+vi.mock("antd", () => ({
+  Button: ({ children, icon, onClick, ...props }: any) => (
+    <button type="button" onClick={onClick} {...props}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Spin: () => <span role="status">Loading</span>,
+  Tag: ({ children, onClick, ...props }: any) => (
+    <span onClick={onClick} {...props}>
+      {children}
+    </span>
+  ),
+  Tooltip: ({ children }: any) => <>{children}</>
+}))
+
+const makeOverviewData = () => ({
+  fetchedAt: "2026-05-16T12:00:00.000Z",
+  sources: {
+    total: 5,
+    healthy: 3,
+    degraded: 2,
+    inactive: 0,
+    unknown: 0
+  },
+  jobs: {
+    total: 6,
+    active: 4,
+    nextRunAt: null,
+    attention: 4
+  },
+  items: {
+    unread: 7
+  },
+  runs: {
+    running: 0,
+    pending: 0,
+    failed: 1,
+    recentFailed: []
+  },
+  outputs: {
+    total: 3,
+    expired: 0,
+    deliveryIssues: 3,
+    attention: 3
+  },
+  health: watchlistsStoreState.overviewHealth,
+  systemHealth: "degraded" as const
+})
+
+describe("WatchlistsHealthBar", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem("watchlists:health-bar-expanded:v1", "true")
+    fetchWatchlistsOverviewDataMock.mockReset()
+    fetchWatchlistsOverviewDataMock.mockResolvedValue(makeOverviewData())
+    watchlistsStoreState.setOverviewHealth.mockClear()
+    watchlistsStoreState.setActiveTab.mockClear()
+  })
+
+  it("renders attention items as design-system badges and preserves tab navigation", async () => {
+    const onNavigate = vi.fn()
+    const user = userEvent.setup()
+
+    render(<WatchlistsHealthBar onNavigate={onNavigate} />)
+
+    const attention = await screen.findByTestId("watchlists-health-bar-attention")
+
+    const expectedBadges = [
+      { label: "Feeds need review (2)", variant: "warning", tab: "sources" },
+      { label: "Failed activity runs (1)", variant: "danger", tab: "runs" },
+      { label: "Reports with delivery issues (3)", variant: "warning", tab: "outputs" },
+      { label: "Monitors need schedule fixes (4)", variant: "warning", tab: "jobs" }
+    ]
+
+    for (const { label, variant } of expectedBadges) {
+      const labelNode = within(attention).getByText(label)
+      const badge = labelNode.closest('[data-ds-component="Badge"]')
+      expect(badge).toHaveAttribute("data-ds-variant", variant)
+    }
+
+    for (const { label, tab } of expectedBadges) {
+      const control = within(attention).getByRole("button", { name: label })
+      await user.click(control)
+      expect(onNavigate).toHaveBeenLastCalledWith(tab)
+    }
+
+    await waitFor(() => {
+      expect(fetchWatchlistsOverviewDataMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx
@@ -58,12 +58,17 @@ vi.mock("@/store/watchlists", () => ({
 }))
 
 vi.mock("antd", () => ({
-  Button: ({ children, icon, onClick, ...props }: any) => (
-    <button type="button" onClick={onClick} {...props}>
-      {icon}
-      {children}
-    </button>
-  ),
+  Button: ({ children, icon, onClick, ...props }: any) => {
+    const { type: antdType, htmlType = "button", ...buttonProps } = props
+    void antdType
+
+    return (
+      <button {...buttonProps} type={htmlType} onClick={onClick}>
+        {icon}
+        {children}
+      </button>
+    )
+  },
   Spin: () => <span role="status">Loading</span>,
   Tag: ({ children, onClick, ...props }: any) => (
     <span onClick={onClick} {...props}>
@@ -124,6 +129,10 @@ describe("WatchlistsHealthBar", () => {
     render(<WatchlistsHealthBar onNavigate={onNavigate} />)
 
     const attention = await screen.findByTestId("watchlists-health-bar-attention")
+    expect(screen.getByTestId("watchlists-health-bar-refresh")).toHaveAttribute(
+      "type",
+      "button"
+    )
 
     const expectedBadges = [
       { label: "Feeds need review (2)", variant: "warning", tab: "sources" },

--- a/backlog/tasks/task-45.44.13.3 - Repair-LlamacppRuntimePanel-product-state-guard-drift.md
+++ b/backlog/tasks/task-45.44.13.3 - Repair-LlamacppRuntimePanel-product-state-guard-drift.md
@@ -1,0 +1,62 @@
+---
+id: TASK-45.44.13.3
+title: Repair LlamacppRuntimePanel product-state guard drift
+status: Done
+assignee:
+- Codex
+labels:
+- design-system
+- webui
+- product-state
+- guard
+priority: medium
+parent_task_id: TASK-45.44.13
+references:
+- apps/packages/ui/src/components/Option/Admin/LlamacppRuntimePanel.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Current origin/dev has an unbaselined AntD Alert product-state finding in LlamacppRuntimePanel. Replace that warning alert with the shared design-system Alert primitive so the product-state verifier is green for the next design-system migration slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 LlamacppRuntimePanel no longer imports or renders AntD Alert for the error notice.
+- [x] #2 The warning notice uses the shared design-system Alert primitive with non-urgent status semantics.
+- [x] #3 The design-system product-state verifier no longer reports LlamacppRuntimePanel as a blocked finding.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Import the shared Alert primitive under a non-conflicting alias and remove AntD Alert from the component imports.
+2. Replace the LlamacppRuntimePanel error notice with the shared Alert primitive using variant=warning, role=status, and aria-live=polite.
+3. Run the design-system verifier together with the WatchlistsHealthBar focused checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Migrated the new LlamacppRuntimePanel runtime inventory error notice from AntD Alert to the shared design-system Alert primitive with variant="warning", role="status", and aria-live="polite". Added focused component coverage proving the error notice renders through the design-system Alert primitive.
+
+Verification: bun run verify:design-system-state first failed on the unbaselined LlamacppRuntimePanel AntD Alert finding, then passed after the migration. The focused LlamacppRuntimePanel/WatchlistsHealthBar/product-state guard suite passed 56/56; git diff --check passed; section marker sanity check passed. Full UI TypeScript still exits 2 on existing repo-wide type debt outside touched files, with no touched-file errors observed in the output. Bandit is not applicable because this repair touches frontend TypeScript and Backlog metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Repaired the current origin/dev product-state guard drift by replacing LlamacppRuntimePanel's runtime inventory warning notice with the shared design-system Alert primitive and adding focused coverage for the design-system Alert marker.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.1 - Migrate-WatchlistsHealthBar-attention-tags-to-design-system-Badge.md
+++ b/backlog/tasks/task-45.44.3.1 - Migrate-WatchlistsHealthBar-attention-tags-to-design-system-Badge.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.44.3.1
+title: Migrate WatchlistsHealthBar attention tags to design-system Badge
+status: Done
+assignee:
+- Codex
+labels:
+- design-system
+- webui
+- product-state
+- watchlists
+priority: medium
+parent_task_id: TASK-45.44.3
+references:
+- apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx
+- apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace WatchlistsHealthBar's AntD Tag attention chips with shared design-system Badge primitives while preserving clickable navigation for sources, runs, outputs, and jobs attention items.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WatchlistsHealthBar no longer imports or renders AntD Tag for attention product-state UI.
+- [x] #2 Sources, runs, outputs, and jobs attention items render through shared design-system Badge variants that preserve warning/error severity.
+- [x] #3 Focused tests prove attention badges render design-system markers and still navigate to the matching watchlists tab.
+- [x] #4 The design-system product-state baseline no longer contains WatchlistsHealthBar AntD Tag exceptions and verifier results are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused WatchlistsHealthBar coverage that renders attention sources/runs/outputs/jobs and asserts the current implementation lacks design-system Badge markers for those attention items.
+2. Replace AntD Tag attention chips with a small local button wrapper around the shared Badge primitive, mapping warning items to variant=warning and failed runs to variant=danger.
+3. Remove WatchlistsHealthBar entries from the product-state baseline.
+4. Verify with focused Vitest, product-state guard tests, bun run verify:design-system-state, git diff --check, and document Bandit as not applicable for this UI-only slice.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented WatchlistsHealthBar attention chips with a local button wrapper around the shared design-system Badge primitive. Sources, outputs, and jobs use warning badges; failed runs use the danger badge. The focused regression first failed because the existing AntD Tag text had no design-system Badge marker, then passed after migration while preserving tab navigation.
+
+Removed the four WatchlistsHealthBar AntD Tag entries from the product-state baseline. Verification: focused WatchlistsHealthBar test passed; LlamacppRuntimePanel/WatchlistsHealthBar/product-state guard suite passed 56/56; bun run verify:design-system-state passed with 406 remaining allowed legacy exceptions; git diff --check passed; section marker sanity check passed. Full UI TypeScript still exits 2 on existing repo-wide type debt outside touched files, with no touched-file errors observed in the output. Bandit is not applicable because this slice touches frontend TypeScript, JSON baseline data, and Backlog metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated WatchlistsHealthBar attention chips from AntD Tag to shared design-system Badge primitives, kept each chip as a keyboard-addressable button that navigates to the matching watchlists tab, added focused coverage for Badge markers and navigation, and removed the four WatchlistsHealthBar baseline exceptions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.1.1 - Address-PR-1757-review-comments.md
+++ b/backlog/tasks/task-45.44.3.1.1 - Address-PR-1757-review-comments.md
@@ -1,0 +1,70 @@
+---
+id: TASK-45.44.3.1.1
+title: Address PR 1757 review comments
+status: Done
+assignee:
+- Codex
+labels:
+- design-system
+- webui
+- product-state
+- review
+priority: medium
+parent_task_id: TASK-45.44.3.1
+references:
+- https://github.com/rmusser01/tldw_server/pull/1757
+- apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable PR 1757 review feedback by preventing the WatchlistsHealthBar AntD Button test mock from forwarding AntD-only type props into native button semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The WatchlistsHealthBar AntD Button mock strips AntD's stylistic type prop and keeps native buttons type="button".
+- [x] #2 Focused coverage asserts the refresh control uses safe native button semantics.
+- [x] #3 Focused WatchlistsHealthBar verification passes after the review fix.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused assertion that the refresh button renders with native type="button", confirming the mock no longer forwards AntD stylistic type props into DOM semantics.
+2. Update the AntD Button mock to destructure and ignore the AntD `type` prop before spreading DOM props, while preserving `htmlType` when a test needs a different native type.
+3. Rerun the focused WatchlistsHealthBar test and relevant design-system guard checks, then push and resolve the review thread.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Qodo flagged that the AntD Button test mock forwarded `type="text"` into a native `<button>`, creating invalid/default submit semantics in the jsdom test surface. Added a regression assertion for the refresh control's native `type="button"`; the red run failed with received `type="text"`.
+
+Updated the mock to strip AntD's stylistic `type` prop and map `htmlType` to the native button type, defaulting to `button`.
+
+Verification:
+- `bunx vitest run src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx --reporter=dot --testTimeout=20000` passed 1 file / 1 test.
+- `bunx vitest run src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot --testTimeout=20000` passed 3 files / 56 tests.
+- `bun run verify:design-system-state` passed with the expected existing baseline summary and stale-baseline reporting.
+- `git diff --check` passed.
+- Backlog section marker sanity check passed.
+- Bandit is not applicable because the touched implementation is frontend test code plus this Backlog task record.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1757 review feedback by stripping AntD's stylistic `type` prop from the WatchlistsHealthBar Button mock, preserving native button semantics, and adding regression coverage for `type="button"`. Verification passed for the focused WatchlistsHealthBar test, the combined runtime/watchlists/guard suite, and `bun run verify:design-system-state`. Bandit is not applicable because the touched implementation is frontend test code plus this Backlog task record.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.1.2 - Fix-PR-1757-Watchlists-scale-gate-Router-context-failure.md
+++ b/backlog/tasks/task-45.44.3.1.2 - Fix-PR-1757-Watchlists-scale-gate-Router-context-failure.md
@@ -1,0 +1,77 @@
+---
+id: TASK-45.44.3.1.2
+title: Fix PR 1757 Watchlists scale gate Router context failure
+status: Done
+labels:
+- design-system
+- webui
+- watchlists
+- ci
+- review
+priority: medium
+parent_task_id: TASK-45.44.3.1
+references:
+- https://github.com/rmusser01/tldw_server/pull/1757
+- https://github.com/rmusser01/tldw_server/actions/runs/25955005494/job/76299980088
+- apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.run-notifications.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the actionable PR #1757 CI failure where Watchlists scale gate tests render WorkspaceConnectionGate without Router context after useLocation was introduced.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The WatchlistsPlaygroundPage run-notifications test harness provides Router context for WorkspaceConnectionGate.
+- [x] #2 The focused failing run-notifications test file passes locally.
+- [x] #3 The CI-equivalent Watchlists static typecheck and scale gate scripts pass locally.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the WatchlistsPlaygroundPage run-notifications failure locally with the focused failing test.
+2. Update the test harness to render WatchlistsPlaygroundPage under a Router-compatible provider while preserving the existing mocked `useNavigate`.
+3. Rerun the focused failing test, the Watchlists gate scripts, and relevant design-system checks before committing and pushing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+CI failure evidence:
+- Watchlists Scale Gate failed in `WatchlistsPlaygroundPage.run-notifications.test.tsx` with `useLocation() may be used only in the context of a <Router> component.`
+- The failure came from `WorkspaceConnectionGate`, which uses both `useNavigate()` and `useLocation()`.
+- The focused local red run reproduced the same 4 failures before the fix.
+
+Implementation:
+- Added `MemoryRouter` to the run-notifications test harness.
+- Introduced `renderWatchlistsPlaygroundPage()` so every test renders `WatchlistsPlaygroundPage` with Router context.
+- Kept the existing mocked `useNavigate` behavior intact for notification deep-link assertions.
+
+Verification:
+- `bunx vitest run src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.run-notifications.test.tsx --reporter=dot --testTimeout=20000` passed 1 file / 4 tests.
+- `bun run test:watchlists:typecheck` passed 1 file / 3 tests.
+- `bun run test:watchlists:scale` passed 7 files / 49 tests.
+- `bunx vitest run src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot --testTimeout=20000` passed 3 files / 56 tests.
+- `bun run verify:design-system-state` passed with the expected existing baseline summary and stale-baseline reporting.
+- `git diff --check` passed.
+- Bandit is not applicable because the touched implementation is frontend test code plus this Backlog task record.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the PR #1757 Watchlists Scale Gate failure by wrapping the WatchlistsPlaygroundPage run-notifications test harness in `MemoryRouter`, giving WorkspaceConnectionGate the Router context required for `useLocation()` while preserving existing notification navigation assertions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates WatchlistsHealthBar attention chips from AntD Tag to shared design-system Badge primitives while preserving sources/runs/outputs/jobs navigation.
- Repairs current dev product-state guard drift by moving LlamacppRuntimePanel's runtime inventory warning from AntD Alert to the shared design-system Alert primitive.
- Removes the four WatchlistsHealthBar AntD Tag baseline exceptions and records the Backlog tasks for both slices.

## Verification
- bunx vitest run src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx src/components/Option/Watchlists/shared/__tests__/WatchlistsHealthBar.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot --testTimeout=20000
- bun run verify:design-system-state
- git diff --check
- Backlog section marker sanity check

## Known Verification Note
- bunx tsc --noEmit --project tsconfig.json --pretty false still exits 2 on existing repo-wide UI/test type debt outside this slice. No touched file appeared in the reported failures.

## Change Summary
Human-authored change summary required before merge by the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WatchlistsHealthBar attention chips from `antd` Tag to the design-system `Badge` and replaced LlamacppRuntimePanel’s `antd` Alert with the design-system `Alert`. Fixed test button semantics and the run-notifications Router context; navigation to sources/runs/outputs/jobs is unchanged.

- **Refactors**
  - Replaced attention chips with design-system `Badge` variants (warning/danger) and wrapped them in buttons to keep tab navigation.
  - Swapped runtime inventory warning to the design-system `Alert` with role=status and aria-live=polite.
  - Removed four WatchlistsHealthBar `antd` Tag baseline exceptions and added focused tests for Badge markers, tab navigation, and the Alert rendering.
  - Updated test `antd` `Button` mock to ignore stylistic `type` and default native type="button"; added an assertion for the refresh control; wrapped run-notifications tests in a Router to fix `useLocation` context errors.

<sup>Written for commit 2b23fe079155c196fef04a513e2124c21c74ff39. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1757?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

