### PR TITLE
Add VZ helper resource diagnostics

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -266,7 +266,9 @@ It is admin-only and returns:
   classification, and any matching reconciliation/helper VM records
 - read-only observability for `vz_linux` helper stdout/stderr log pointers,
   per-VM serial log pointers, guest readiness metadata, and helper-provided
-  resource counters when available
+  resource counters when available. Current `vz_linux` resource snapshots are
+  configured VM facts (`cpu_count`, `memory_size_mb`) plus diagnostic uptime
+  (`wall_time_sec`); they are not live CPU/RSS/I/O utilization telemetry.
 - read-only `recovery_summary` metadata derived from reconciliation,
   image-store, and observability blocks, including recovery posture, stable
   issue codes, counts, and existing dry-run-first admin endpoint pointers

--- a/Docs/superpowers/plans/2026-05-16-vz-boot-resource-diagnostics-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-vz-boot-resource-diagnostics-implementation-plan.md
@@ -1,0 +1,100 @@
+# VZ Boot Resource Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make real `vz_linux` helper VMs populate accurate resource snapshot fields in existing admin diagnostics.
+
+**Architecture:** Keep diagnostics read-only and additive. The Swift helper owns VM configuration facts, stores them on the VM registry record, and emits them through existing status/list `details`; Python diagnostics continues to project only allowlisted integer details into `resource_snapshot`.
+
+**Tech Stack:** Swift 5.9 helper package, Python diagnostics module, pytest, Swift Testing, Backlog.md task `TASK-404`.
+
+---
+
+## Scope Review
+
+The existing Python diagnostics already expose helper log pointers, serial log
+pointers, guest readiness metadata, and an allowlisted `resource_snapshot`.
+This plan does not rewrite log discovery. It only makes the helper populate
+accurate configured resource facts and lets Python surface the new allowlisted
+keys.
+
+## Files
+
+- Modify: `tools/macos-vz-helper/Sources/Protocol/Response.swift`
+- Modify: `tools/macos-vz-helper/Sources/VM/VMRegistry.swift`
+- Modify: `tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift`
+- Modify: `tools/macos-vz-helper/Sources/VM/VirtualizationLinuxBootDriver.swift`
+- Modify: `tools/macos-vz-helper/Sources/Server/HelperService.swift`
+- Modify: `tools/macos-vz-helper/Tests/TestDoubles.swift`
+- Modify: `tools/macos-vz-helper/Tests/HelperServiceVMTests.swift`
+- Modify: `tools/macos-vz-helper/Tests/VMBootTests.swift`
+- Modify: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+- Modify: `tools/macos-vz-helper/PROTOCOL.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `backlog/tasks/task-404 - Add-VZ-boot-log-and-resource-diagnostics.md`
+
+## Task 1: Swift Helper Resource Snapshot Tests
+
+- [x] Add a failing test in `HelperServiceVMTests.swift` proving create/status/list details include `cpu_count`, `memory_size_mb`, and non-negative `wall_time_sec`.
+- [x] Add a failing test in `VMBootTests.swift` proving the VM registry preserves a boot driver resource snapshot through the running-state update.
+- [x] Run focused Swift tests and confirm they fail because resource snapshot support does not exist.
+
+Expected command:
+
+```bash
+cd tools/macos-vz-helper && swift test --filter 'HelperService|VMBoot'
+```
+
+## Task 2: Swift Helper Resource Snapshot Implementation
+
+- [x] Add `VMResourceSnapshot` with `cpuCount` and `memorySizeBytes`.
+- [x] Change `VZBootDriving.boot(...)` to return `VMResourceSnapshot`.
+- [x] Make `RecordingBootDriver` return configurable snapshots for tests.
+- [x] Store snapshots on `VMRecord` and preserve them through registry updates unless a new snapshot is supplied.
+- [x] Make `VirtualizationLinuxBootDriver.boot(...)` return the built configuration's CPU count and memory size.
+- [x] Emit `cpu_count`, `memory_size_mb`, and `wall_time_sec` from `HelperService.vmDetails(for:)`.
+- [x] Re-run focused Swift tests and confirm they pass.
+
+## Task 3: Python Diagnostics Allowlist Tests And Implementation
+
+- [x] Extend the existing `test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources` fixture with `cpu_count` and `memory_size_mb`.
+- [x] Run the focused pytest and confirm it fails because the new keys are filtered.
+- [x] Add `cpu_count` and `memory_size_mb` to `_VZ_LINUX_RESOURCE_DETAIL_KEYS`.
+- [x] Re-run the focused pytest and confirm it passes.
+
+Expected command:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py::test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources -q
+```
+
+## Task 4: Docs And Tracker
+
+- [x] Update `tools/macos-vz-helper/PROTOCOL.md` list/status examples and stability notes for the new resource detail fields.
+- [x] Update `Docs/Sandbox/macos-runtime-operator-notes.md` to clarify that current resource snapshots are configured VM facts plus uptime, not live utilization telemetry.
+- [x] Update `TASK-404` implementation notes with touched files and test results.
+
+## Task 5: Verification And Commit
+
+- [x] Run focused Swift helper tests.
+- [x] Run focused Python diagnostics tests.
+- [x] Run `git diff --check`.
+- [x] Run Bandit against touched Python diagnostics code.
+- [x] Commit the implementation.
+
+Expected commands:
+
+```bash
+cd tools/macos-vz-helper && swift test --filter 'HelperService|VMBoot'
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py::test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources -q
+git diff --check
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_diagnostics.py -f json -o /tmp/bandit_vz_boot_resource_diagnostics.json
+```
+
+## Plan Review
+
+- Avoid fake telemetry: only emit configured resource facts and uptime.
+- Keep diagnostics read-only: do not read log contents or mutate diagnostics state.
+- Keep helper details string-encoded to preserve the existing protocol shape.
+- Keep Python diagnostics permissive for mixed helper versions: absent new fields simply produce an empty or partial `resource_snapshot`.

--- a/Docs/superpowers/specs/2026-05-16-vz-boot-resource-diagnostics-design.md
+++ b/Docs/superpowers/specs/2026-05-16-vz-boot-resource-diagnostics-design.md
@@ -1,0 +1,129 @@
+# VZ Boot Log And Resource Diagnostics Design
+
+## Goal
+
+Close the remaining `vz_linux` diagnostics gap by making real helper-backed VMs
+surface useful resource snapshot fields in admin diagnostics while preserving the
+existing read-only boot/serial/helper log pointer behavior.
+
+The existing Python diagnostics already report helper stdout/stderr pointers,
+per-VM serial log pointers, guest readiness metadata, and allowlisted resource
+snapshot fields. The gap is that the Swift helper currently does not populate
+real VM resource fields in `create_vm`, `get_vm_status`, or `list_vms`, so real
+operator diagnostics usually show an empty `resource_snapshot`.
+
+## Current State
+
+- `probe_vz_linux_observability()` reads only metadata: helper log file pointers,
+  serial log file pointers, VM status, guest metadata, and allowlisted integer
+  resource fields from helper `details`.
+- The diagnostics endpoint does not read log contents and should stay
+  side-effect-free.
+- `tools/macos-vz-helper` creates serial log files through
+  `TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR`.
+- `HelperService.vmDetails(for:)` emits transport, network policy, guest-agent
+  details, and helper generation metadata, but no resource snapshot fields.
+- The helper has accurate configured VM resource facts at boot time:
+  `VZVirtualMachineConfiguration.cpuCount` and `memorySize`.
+
+## Design
+
+### Resource Fields
+
+Add helper-owned resource snapshot fields to VM status `details`:
+
+- `cpu_count`: configured VCPU count for the VM.
+- `memory_size_mb`: configured VM memory in MiB.
+- `wall_time_sec`: elapsed seconds since the VM ownership metadata `created_at`
+  timestamp, when that timestamp parses successfully.
+
+These are intentionally not CPU utilization, process RSS, disk I/O, or network
+I/O counters. Apple `Virtualization.framework` does not currently expose cheap,
+stable per-VM utilization counters through the helper code path. Publishing
+configured facts plus uptime is accurate and immediately useful for operators;
+fake CPU/RSS values would create misleading diagnostics.
+
+### Swift Helper Contract
+
+- Introduce a small `VMResourceSnapshot` value in the helper protocol/model
+  layer.
+- Change `VZBootDriving.boot(...)` to return `VMResourceSnapshot`.
+- Have `VirtualizationLinuxBootDriver.boot(...)` derive the snapshot from the
+  validated `VZVirtualMachineConfiguration` it already builds.
+- Store the snapshot in `VMRecord` through `VMRegistry.upsert(...)`.
+- Preserve an existing snapshot on state-only updates unless a new snapshot is
+  supplied, mirroring the existing guest-info preservation behavior.
+- Emit resource fields from `HelperService.vmDetails(for:)` for create/status/list.
+- Compute `wall_time_sec` at detail-render time from `record.metadata.createdAt`;
+  omit it if the timestamp is missing or invalid.
+
+### Python Diagnostics Contract
+
+- Extend `_VZ_LINUX_RESOURCE_DETAIL_KEYS` to include `cpu_count` and
+  `memory_size_mb`.
+- Keep `_resource_snapshot()` integer-only and allowlist-only.
+- Do not add filesystem reads beyond existing file existence/size checks.
+- Do not change the public diagnostics shape; this remains an additive field
+  population in the existing `resource_snapshot` dictionary.
+
+### Documentation
+
+- Update `tools/macos-vz-helper/PROTOCOL.md` so `list_vms` examples show the new
+  resource fields.
+- Update sandbox operator notes to clarify that current resource snapshots are
+  configured VM resources plus uptime, not live utilization telemetry.
+
+## Design Review
+
+### Issue: misleading utilization counters
+
+The obvious but wrong improvement would be to populate `cpu_time_sec`,
+`peak_rss_mb`, or I/O counters from helper-process data. That would be
+misleading because the helper process can manage multiple VMs and does not own a
+clear per-VM RSS/CPU counter. This design avoids those fields until a real
+per-VM source exists.
+
+### Issue: boot driver protocol churn
+
+Changing `VZBootDriving.boot(...)` affects tests and fake drivers. The change is
+still the cleanest boundary because the boot driver is the component that builds
+the authoritative VM configuration. Returning a tiny snapshot avoids teaching
+`HelperService` or `VMRegistry` about `Virtualization.framework`.
+
+### Issue: uptime depends on wall clock
+
+`wall_time_sec` is diagnostic metadata, not scheduling logic. It should be
+non-negative, omitted on parse failure, and tested with a deterministic old
+timestamp rather than exact current-time assertions.
+
+### Issue: existing log pointer behavior is already implemented
+
+This PR should not rewrite serial/helper log discovery. It should preserve the
+existing read-only pointer contract and only tighten documentation/tests where
+needed.
+
+## Tests
+
+- Swift helper unit tests:
+  - `create_vm`, `get_vm_status`, and `list_vms` include `cpu_count`,
+    `memory_size_mb`, and `wall_time_sec` when the boot driver returns a
+    snapshot and metadata has a valid `created_at`.
+  - state updates preserve the resource snapshot.
+  - invalid or missing `created_at` omits `wall_time_sec`.
+- Python diagnostics tests:
+  - `_resource_snapshot()`/`probe_vz_linux_observability()` surfaces
+    `cpu_count` and `memory_size_mb`.
+  - unknown helper details remain filtered.
+- Verification:
+  - focused Python diagnostics tests
+  - focused Swift helper tests if Swift tooling is available
+  - `git diff --check`
+  - Bandit on touched Python files
+
+## Non-Goals
+
+- Reading or returning log contents.
+- Adding live CPU/RSS/I/O utilization telemetry.
+- Changing helper lifecycle, launchd behavior, image-store behavior, or repair
+  semantics.
+- Requiring real Apple VZ execution for portable unit coverage.

--- a/backlog/tasks/task-404 - Add-VZ-boot-log-and-resource-diagnostics.md
+++ b/backlog/tasks/task-404 - Add-VZ-boot-log-and-resource-diagnostics.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-404
 title: Add VZ boot log and resource diagnostics
-status: In Progress
+status: Done
 labels:
 - sandbox
 - macos
@@ -10,6 +10,22 @@ labels:
 priority: medium
 documentation:
 - Docs/superpowers/specs/2026-05-16-vz-boot-resource-diagnostics-design.md
+implementation_plan:
+- Docs/superpowers/plans/2026-05-16-vz-boot-resource-diagnostics-implementation-plan.md
+modified_files:
+- Docs/Sandbox/macos-runtime-operator-notes.md
+- tldw_Server_API/app/core/Sandbox/README.md
+- tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+- tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+- tools/macos-vz-helper/PROTOCOL.md
+- tools/macos-vz-helper/Sources/Protocol/Response.swift
+- tools/macos-vz-helper/Sources/Server/HelperService.swift
+- tools/macos-vz-helper/Sources/VM/VMRegistry.swift
+- tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
+- tools/macos-vz-helper/Sources/VM/VirtualizationLinuxBootDriver.swift
+- tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+- tools/macos-vz-helper/Tests/TestDoubles.swift
+- tools/macos-vz-helper/Tests/VMBootTests.swift
 ---
 
 ## Description
@@ -20,11 +36,11 @@ Design and implement the next sandbox roadmap slice for VZ Linux admin diagnosti
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Review the current diagnostics/helper contracts and document a focused design with risks and mitigations.
-- [ ] #2 Expose stable VZ Linux boot/serial/helper log metadata in admin diagnostics without returning log contents.
-- [ ] #3 Expose allowlisted resource snapshot fields when helper metadata provides them, with deterministic unavailable/unknown states when absent.
-- [ ] #4 Add focused portable tests for diagnostics behavior and schema stability.
-- [ ] #5 Update operator docs and record verification including Bandit for touched Python code when applicable.
+- [x] #1 Review the current diagnostics/helper contracts and document a focused design with risks and mitigations.
+- [x] #2 Expose stable VZ Linux boot/serial/helper log metadata in admin diagnostics without returning log contents.
+- [x] #3 Expose allowlisted resource snapshot fields when helper metadata provides them, with deterministic unavailable/unknown states when absent.
+- [x] #4 Add focused portable tests for diagnostics behavior and schema stability.
+- [x] #5 Update operator docs and record verification including Bandit for touched Python code when applicable.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,21 +52,21 @@ Design spec created for the narrowed diagnostics gap: keep existing read-only bo
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implemented helper-owned VM resource snapshots for `vz_linux` status/list/create responses. The helper now stores configured CPU count and memory size from the validated `Virtualization.framework` configuration, preserves that snapshot across registry state updates, and emits `cpu_count`, `memory_size_mb`, and diagnostic `wall_time_sec` in existing string-encoded helper details. Python diagnostics allowlists `cpu_count` and `memory_size_mb` into the existing read-only `resource_snapshot` block. Docs clarify these are configured VM facts plus uptime, not live CPU/RSS/I/O utilization telemetry.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Verification: focused Python red test failed before allowlist implementation, then `test_macos_diagnostics.py` passed with 26 passed and 2 warnings. Focused Swift red test failed before helper implementation, then full `tools/macos-vz-helper` Swift tests passed with 88 tests. `git diff --check` passed. Bandit on `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py` wrote `/tmp/bandit_vz_boot_resource_diagnostics.json` with errors=[] and results=[].
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-404 - Add-VZ-boot-log-and-resource-diagnostics.md
+++ b/backlog/tasks/task-404 - Add-VZ-boot-log-and-resource-diagnostics.md
@@ -1,0 +1,56 @@
+---
+id: TASK-404
+title: Add VZ boot log and resource diagnostics
+status: In Progress
+labels:
+- sandbox
+- macos
+- vz-linux
+- diagnostics
+priority: medium
+documentation:
+- Docs/superpowers/specs/2026-05-16-vz-boot-resource-diagnostics-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement the next sandbox roadmap slice for VZ Linux admin diagnostics: stable serial/boot log pointers, bounded helper log metadata, and resource snapshots without reading log contents or mutating diagnostics state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Review the current diagnostics/helper contracts and document a focused design with risks and mitigations.
+- [ ] #2 Expose stable VZ Linux boot/serial/helper log metadata in admin diagnostics without returning log contents.
+- [ ] #3 Expose allowlisted resource snapshot fields when helper metadata provides them, with deterministic unavailable/unknown states when absent.
+- [ ] #4 Add focused portable tests for diagnostics behavior and schema stability.
+- [ ] #5 Update operator docs and record verification including Bandit for touched Python code when applicable.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design spec created for the narrowed diagnostics gap: keep existing read-only boot/helper/serial log pointers, add accurate helper-owned resource snapshot fields (cpu_count, memory_size_mb, wall_time_sec), and explicitly reject fake CPU/RSS/I/O telemetry until real per-VM counters exist.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -130,8 +130,10 @@ Current limitations:
   low-level diagnostics collection remains app-agnostic.
 - `vz_linux` admin diagnostics include a read-only `observability` block with
   helper stdout/stderr log pointers, per-VM serial log pointers, guest readiness
-  details, and helper-provided resource counters when available. Diagnostics
-  report file existence and byte sizes only; they do not read log contents.
+  details, and helper-provided resource counters when available. Current helper
+  resource snapshots are configured VM facts plus uptime, not live CPU/RSS/I/O
+  utilization telemetry. Diagnostics report file existence and byte sizes only;
+  they do not read log contents.
 - `vz_linux` admin diagnostics include a read-only `recovery_summary` block
   derived from reconciliation, image-store, and observability diagnostics. It
   reports recovery posture, issue codes, counts, and existing dry-run-first

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -37,8 +37,10 @@ _MACOS_IMAGE_STORE_CLEANUP_PLAN_ENDPOINT = "/api/v1/sandbox/admin/macos-image-st
 _HELPER_LOG_DIR_ENV = "TLDW_SANDBOX_MACOS_HELPER_LOG_DIR"
 _VZ_LINUX_SERIAL_LOG_DIR_ENV = "TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR"
 _VZ_LINUX_RESOURCE_DETAIL_KEYS = (
+    "cpu_count",
     "cpu_time_sec",
     "wall_time_sec",
+    "memory_size_mb",
     "peak_rss_mb",
     "memory_rss_mb",
     "disk_read_bytes",

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -996,6 +996,8 @@ def test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources(
                             "guest_capabilities_known": "true",
                             "guest_capabilities": "exec,output_cap_v1",
                             "cpu_time_sec": "7",
+                            "cpu_count": "2",
+                            "memory_size_mb": "1024",
                             "peak_rss_mb": 128,
                             "disk_read_bytes": "2048",
                             "unexpected_detail": "not surfaced",
@@ -1034,6 +1036,8 @@ def test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources(
     }
     assert vm["resource_snapshot"] == {
         "cpu_time_sec": 7,
+        "cpu_count": 2,
+        "memory_size_mb": 1024,
         "peak_rss_mb": 128,
         "disk_read_bytes": 2048,
     }

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -102,6 +102,9 @@ Successful `details` dictionaries may include helper-owned generation metadata:
     "helper_started_at": "2026-05-09T00:00:00Z",
     "transport": "vsock",
     "network_policy": "deny_all",
+    "cpu_count": "2",
+    "memory_size_mb": "1024",
+    "wall_time_sec": "123",
     "guest_version": "1.0.0",
     "guest_workspace_root": "/workspace",
     "guest_capabilities_known": "true",
@@ -195,6 +198,9 @@ Response:
     "helper_started_at": "2026-05-09T00:00:00Z",
     "transport": "vsock",
     "network_policy": "deny_all",
+    "cpu_count": "2",
+    "memory_size_mb": "1024",
+    "wall_time_sec": "123",
     "guest_version": "1.0.0",
     "guest_workspace_root": "/workspace",
     "guest_capabilities_known": "true",
@@ -338,6 +344,9 @@ the unprefixed keys when `guest_*` keys are absent during mixed-version rollouts
       "details": {
         "transport": "vsock",
         "network_policy": "deny_all",
+        "cpu_count": "2",
+        "memory_size_mb": "1024",
+        "wall_time_sec": "123",
         "guest_version": "1.0.0",
         "guest_workspace_root": "/workspace",
         "guest_capabilities_known": "true",
@@ -370,6 +379,11 @@ the unprefixed keys when `guest_*` keys are absent during mixed-version rollouts
   `guest_capabilities` are diagnostic details only. Older guests may omit
   capabilities, in which case helpers report `guest_capabilities_known=false`
   instead of failing VM readiness.
+- `vz_linux` VM resource metadata is additive in protocol version `1`.
+  `cpu_count` and `memory_size_mb` are configured VM resources derived from the
+  validated `Virtualization.framework` configuration; `wall_time_sec` is
+  diagnostic uptime derived from VM metadata `created_at`. These fields are not
+  live CPU/RSS/I/O utilization counters.
 - Template validation must report `boot_mode` and `validation_strength` when the
   helper can resolve the template successfully.
 - Python remains the source of truth for sandbox sessions; the helper only reports

--- a/tools/macos-vz-helper/Sources/Protocol/Response.swift
+++ b/tools/macos-vz-helper/Sources/Protocol/Response.swift
@@ -127,19 +127,31 @@ struct VMRecord {
     let healthy: Bool
     let metadata: VMOwnershipMetadata
     let guestInfo: GuestAgentInfo?
+    let resourceSnapshot: VMResourceSnapshot?
 
     init(
         vmID: String,
         state: String,
         healthy: Bool,
         metadata: VMOwnershipMetadata = .unknown,
-        guestInfo: GuestAgentInfo? = nil
+        guestInfo: GuestAgentInfo? = nil,
+        resourceSnapshot: VMResourceSnapshot? = nil
     ) {
         self.vmID = vmID
         self.state = state
         self.healthy = healthy
         self.metadata = metadata
         self.guestInfo = guestInfo
+        self.resourceSnapshot = resourceSnapshot
+    }
+}
+
+struct VMResourceSnapshot: Equatable {
+    let cpuCount: Int
+    let memorySizeBytes: UInt64
+
+    var memorySizeMB: UInt64 {
+        memorySizeBytes / 1_048_576
     }
 }
 

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -374,6 +374,13 @@ final class HelperService {
             "transport": "vsock",
             "network_policy": record.metadata.networkPolicy.isEmpty ? "deny_all" : record.metadata.networkPolicy,
         ]
+        if let resourceSnapshot = record.resourceSnapshot {
+            details["cpu_count"] = "\(resourceSnapshot.cpuCount)"
+            details["memory_size_mb"] = "\(resourceSnapshot.memorySizeMB)"
+        }
+        if let wallTimeSeconds = wallTimeSeconds(since: record.metadata.createdAt) {
+            details["wall_time_sec"] = "\(wallTimeSeconds)"
+        }
         if let guestInfo = record.guestInfo {
             details["guest_capabilities_known"] = guestInfo.capabilitiesKnown ? "true" : "false"
             if let guestVersion = guestInfo.guestVersion {
@@ -387,6 +394,14 @@ final class HelperService {
             }
         }
         return withHelperGeneration(details)
+    }
+
+    private func wallTimeSeconds(since createdAt: String) -> Int? {
+        guard !createdAt.isEmpty,
+              let createdAtDate = metadataDateFormatter.date(from: createdAt) else {
+            return nil
+        }
+        return max(0, Int(Date().timeIntervalSince(createdAtDate)))
     }
 
     private func helperGenerationDetails() -> [String: String] {

--- a/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
+++ b/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
@@ -10,19 +10,23 @@ final class VMRegistry {
         healthy: Bool,
         metadata: VMOwnershipMetadata? = nil,
         guestInfo: GuestAgentInfo? = nil,
-        preserveGuestInfo: Bool = true
+        resourceSnapshot: VMResourceSnapshot? = nil,
+        preserveGuestInfo: Bool = true,
+        preserveResourceSnapshot: Bool = true
     ) {
         lock.lock()
         defer { lock.unlock() }
         let existing = records[vmID]
         let existingMetadata = existing?.metadata ?? .unknown
         let resolvedGuestInfo = guestInfo ?? (preserveGuestInfo ? existing?.guestInfo : nil)
+        let resolvedResourceSnapshot = resourceSnapshot ?? (preserveResourceSnapshot ? existing?.resourceSnapshot : nil)
         records[vmID] = VMRecord(
             vmID: vmID,
             state: state,
             healthy: healthy,
             metadata: metadata ?? existingMetadata,
-            guestInfo: resolvedGuestInfo
+            guestInfo: resolvedGuestInfo,
+            resourceSnapshot: resolvedResourceSnapshot
         )
     }
 

--- a/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
+++ b/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 protocol VZBootDriving {
-    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws
+    @discardableResult
+    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws -> VMResourceSnapshot
     func stop(vmID: String) throws
 }
 
@@ -10,7 +11,8 @@ enum VZLinuxVMManagerError: Error {
 }
 
 final class PlaceholderVZBootDriver: VZBootDriving {
-    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws {
+    @discardableResult
+    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws -> VMResourceSnapshot {
         throw VZLinuxVMManagerError.bootNotImplemented
     }
 
@@ -46,10 +48,11 @@ final class VZLinuxVMManager {
             state: "booting",
             healthy: false,
             metadata: metadata,
-            preserveGuestInfo: false
+            preserveGuestInfo: false,
+            preserveResourceSnapshot: false
         )
         do {
-            try bootDriver.boot(
+            let resourceSnapshot = try bootDriver.boot(
                 vmID: vmID,
                 templatePath: templatePath,
                 workspacePath: workspacePath,
@@ -62,6 +65,7 @@ final class VZLinuxVMManager {
                 state: "running",
                 healthy: true,
                 guestInfo: guestInfo,
+                resourceSnapshot: resourceSnapshot,
                 preserveGuestInfo: false
             )
             return registry.status(vmID: vmID) ?? VMRecord(
@@ -69,7 +73,8 @@ final class VZLinuxVMManager {
                 state: "running",
                 healthy: true,
                 metadata: metadata,
-                guestInfo: guestInfo
+                guestInfo: guestInfo,
+                resourceSnapshot: resourceSnapshot
             )
         } catch {
             try? bootDriver.stop(vmID: vmID)

--- a/tools/macos-vz-helper/Sources/VM/VirtualizationLinuxBootDriver.swift
+++ b/tools/macos-vz-helper/Sources/VM/VirtualizationLinuxBootDriver.swift
@@ -110,7 +110,8 @@ final class VirtualizationLinuxBootDriver: VZBootDriving {
         self.connectionTokenFactory = connectionTokenFactory
     }
 
-    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws {
+    @discardableResult
+    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws -> VMResourceSnapshot {
         let spec = try templateValidator.resolve(runtime: "vz_linux", templatePath: templatePath)
         let guestTransport = GuestTransportMetadata(
             vmID: vmID,
@@ -130,10 +131,15 @@ final class VirtualizationLinuxBootDriver: VZBootDriving {
             guestTransport: guestTransport
         )
         let machine = try machineProvider.makeVirtualMachine(configuration: configuration)
+        let resourceSnapshot = VMResourceSnapshot(
+            cpuCount: configuration.cpuCount,
+            memorySizeBytes: configuration.memorySize
+        )
         do {
             try machine.installSocketListener(listener.listener, port: spec.vsockPort)
             try machine.start(timeoutSeconds: startupTimeoutSeconds)
             machines[vmID] = machine
+            return resourceSnapshot
         } catch {
             try? machine.stop()
             sessionManager.removeSession(vmID: vmID)

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -31,6 +31,53 @@ import Testing
     #expect(response.details["helper_started_at"] == "2026-05-09T00:00:00Z")
 }
 
+@Test func helperServiceSurfacesResourceSnapshotInCreateStatusAndList() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager,
+        helperInstanceID: "helper-test-1",
+        helperStartedAt: "2026-05-09T00:00:00Z"
+    )
+
+    let response = try service.createVM(
+        vmID: "vm-resource-details",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5,
+        metadata: VMOwnershipMetadata(
+            owner: "tldw",
+            runtime: "vz_linux",
+            runID: "run-resource-details",
+            sessionID: "",
+            sessionMode: false,
+            templateID: "",
+            templatePath: "",
+            runManifestPath: "",
+            planningSource: "",
+            workspacePath: "",
+            createdAt: "2026-05-09T00:00:00Z",
+            networkPolicy: "deny_all"
+        )
+    )
+    let status = service.getVMStatus(vmID: "vm-resource-details")
+    let listed = service.listVMs().vms.first
+
+    for details in [response.details, status?.details, listed?.details] {
+        #expect(details?["cpu_count"] == "2")
+        #expect(details?["memory_size_mb"] == "1024")
+        let wallTime = Int(details?["wall_time_sec"] ?? "")
+        #expect(wallTime != nil)
+        #expect((wallTime ?? -1) >= 0)
+    }
+}
+
 @Test func helperServiceSurfacesGuestAgentDetailsInCreateStatusAndList() throws {
     let registry = VMRegistry()
     let guestInfo = GuestAgentInfo(

--- a/tools/macos-vz-helper/Tests/TestDoubles.swift
+++ b/tools/macos-vz-helper/Tests/TestDoubles.swift
@@ -3,16 +3,23 @@ import Foundation
 
 final class RecordingBootDriver: VZBootDriving {
     private let onBoot: (String) -> Void
+    private let resourceSnapshot: VMResourceSnapshot
     private(set) var lastReadinessTimeoutSeconds: TimeInterval?
     private(set) var stoppedVMIDs: [String] = []
 
-    init(onBoot: @escaping (String) -> Void = { _ in }) {
+    init(
+        resourceSnapshot: VMResourceSnapshot = VMResourceSnapshot(cpuCount: 2, memorySizeBytes: 1_073_741_824),
+        onBoot: @escaping (String) -> Void = { _ in }
+    ) {
+        self.resourceSnapshot = resourceSnapshot
         self.onBoot = onBoot
     }
 
-    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws {
+    @discardableResult
+    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws -> VMResourceSnapshot {
         lastReadinessTimeoutSeconds = startupTimeoutSeconds
         onBoot(vmID)
+        return resourceSnapshot
     }
 
     func stop(vmID: String) throws {

--- a/tools/macos-vz-helper/Tests/VMBootTests.swift
+++ b/tools/macos-vz-helper/Tests/VMBootTests.swift
@@ -46,6 +46,54 @@ import Testing
     #expect(status?.healthy == true)
 }
 
+@Test func createVMPreservesBootResourceSnapshotWhenRunning() throws {
+    let registry = VMRegistry()
+    let resourceSnapshot = VMResourceSnapshot(cpuCount: 4, memorySizeBytes: 2_147_483_648)
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(resourceSnapshot: resourceSnapshot),
+        guestBridge: ReadyGuestBridge()
+    )
+
+    let result = try manager.createVM(
+        vmID: "vm-resource-snapshot",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5
+    )
+    let status = registry.status(vmID: "vm-resource-snapshot")
+
+    #expect(result.resourceSnapshot == resourceSnapshot)
+    #expect(status?.resourceSnapshot == resourceSnapshot)
+}
+
+@Test func createVMClearsStaleResourceSnapshotWhileBootingReusedVMID() throws {
+    let registry = VMRegistry()
+    registry.upsert(
+        vmID: "vm-reused-resource-snapshot",
+        state: "running",
+        healthy: true,
+        resourceSnapshot: VMResourceSnapshot(cpuCount: 8, memorySizeBytes: 4_294_967_296)
+    )
+    let bootDriver = RecordingBootDriver { vmID in
+        let status = registry.status(vmID: vmID)
+        #expect(status?.state == "booting")
+        #expect(status?.resourceSnapshot == nil)
+    }
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: bootDriver,
+        guestBridge: ReadyGuestBridge()
+    )
+
+    _ = try manager.createVM(
+        vmID: "vm-reused-resource-snapshot",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5
+    )
+}
+
 @Test func createVMPassesReadinessTimeoutToBootDriver() throws {
     let bootDriver = RecordingBootDriver()
     let manager = VZLinuxVMManager(


### PR DESCRIPTION
## Summary
- Add helper-owned VZ Linux VM resource snapshots for configured CPU count, configured memory, and diagnostic uptime.
- Surface the new allowlisted resource fields through existing macOS sandbox diagnostics without reading log contents or adding fake utilization telemetry.
- Update helper protocol docs, sandbox operator notes, implementation plan, and Backlog task TASK-404.

## Verification
- Swift helper suite: `swift test` in `tools/macos-vz-helper` -> 88 tests passed.
- Python diagnostics: `python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py -q` -> 26 passed, 2 warnings.
- `git diff --check origin/dev...HEAD` passed.
- Bandit: `python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_diagnostics.py -f json -o /tmp/bandit_vz_boot_resource_diagnostics.json` -> errors=[], results=[].

## Change summary
Human-authored summary required before merge.
