### PR TITLE
Migrate AssistantVoiceCard wake warning alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3949,17 +3949,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/PersonaGarden/AssistantVoiceCard.tsx:Alert",
-    "path": "src/components/PersonaGarden/AssistantVoiceCard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/PersonaGarden/AssistantVoiceCard.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Quiz/tabs/CreateTab.tsx:Alert#antd-alert-createtab-type-info-line-1003-u954tt",
     "path": "src/components/Quiz/tabs/CreateTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react"
-import { Alert, Button } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import {
   AlertTriangle,
   ArrowLeft,
@@ -247,34 +247,32 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
         </p>
 
         {!isOnlineForIngest && (
-          <Alert
-            type="warning"
-            showIcon
+          <DesignSystemAlert
+            variant="warning"
             icon={<AlertTriangle className="h-4 w-4" />}
             className="mt-3"
-            message={qi("wizard.offline.title", "Server offline")}
-            description={
+            title={qi("wizard.offline.title", "Server offline")}
+            action={
+              onRetryConnection
+                ? {
+                    label: isCheckingConnection
+                      ? qi("wizard.offline.checking", "Checking...")
+                      : qi("wizard.offline.retry", "Retry connection"),
+                    onClick: onRetryConnection,
+                    loading: isCheckingConnection,
+                    disabled: isCheckingConnection,
+                  }
+                : undefined
+            }
+          >
+            {
               connectionRecoveryMessage ||
               qi(
                 "wizard.offline.description",
                 "Reconnect to your tldw server before processing. You can go back and keep editing the queue."
               )
             }
-            action={
-              onRetryConnection ? (
-                <Button
-                  size="small"
-                  onClick={onRetryConnection}
-                  loading={isCheckingConnection}
-                  disabled={isCheckingConnection}
-                >
-                  {isCheckingConnection
-                    ? qi("wizard.offline.checking", "Checking...")
-                    : qi("wizard.offline.retry", "Retry connection")}
-                </Button>
-              ) : undefined
-            }
-          />
+          </DesignSystemAlert>
         )}
 
         {/* Contextual warnings */}

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -825,7 +825,11 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
     await waitFor(() => {
       expect(screen.getByText("Ready to Process")).toBeTruthy()
     })
-    expect(screen.getByText(/server offline/i)).toBeInTheDocument()
+    const offlineTitle = screen.getByText(/server offline/i)
+    expect(offlineTitle).toBeInTheDocument()
+    expect(
+      offlineTitle.closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
     expect(screen.getByText(/cannot reach your tldw server/i)).toBeInTheDocument()
 
     const startButton = screen.getByRole("button", { name: /start processing/i })

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Alert, Button, Checkbox, Select, Tag, Typography } from "antd"
+import { Button, Checkbox, Select, Tag, Typography } from "antd"
 
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import {
   PersonaTurnDetectionControls,
   type PersonaTurnDetectionPreset
@@ -304,7 +305,11 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
           </div>
         </div>
         {wakeWarning ? (
-          <Alert className="mt-2" type="warning" showIcon message={wakeWarning} />
+          <DesignSystemAlert
+            className="mt-2"
+            variant="warning"
+            title={wakeWarning}
+          />
         ) : null}
       </div>
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
@@ -162,6 +162,16 @@ describe("AssistantVoiceCard", () => {
     expect(props.onToggleWakeArmed).toHaveBeenCalledTimes(1)
   })
 
+  it("renders wake warnings through the design-system Alert primitive", () => {
+    const props = defaultVoiceCardProps()
+    props.wakeWarning = "Wake detector needs microphone permission."
+
+    render(<AssistantVoiceCard {...props} />)
+
+    const warning = screen.getByText("Wake detector needs microphone permission.")
+    expect(warning.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
   it("does not arm wake from resolved fallback trigger phrases when session wake props are omitted", () => {
     const props = defaultVoiceCardProps()
     props.resolvedDefaults = {

--- a/backlog/tasks/task-45.44.11.2 - Migrate-Persona-AssistantVoiceCard-wake-warning-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.11.2 - Migrate-Persona-AssistantVoiceCard-wake-warning-alert-to-design-system-Alert.md
@@ -1,0 +1,60 @@
+---
+id: TASK-45.44.11.2
+title: Migrate Persona AssistantVoiceCard wake warning alert to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- persona
+- product-state
+parent_task_id: TASK-45.44.11
+references:
+- https://github.com/rmusser01/tldw_server/issues/1668
+modified_files:
+- apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
+- apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the remaining Persona Garden AssistantVoiceCard AntD Alert product-state baseline entry by migrating the wake-warning message to the shared design-system Alert primitive while preserving live voice and wake behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AssistantVoiceCard wake-warning UI uses the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused Persona Garden coverage verifies the wake warning renders through the design-system Alert contract.
+- [x] #3 The AssistantVoiceCard AntD Alert entry is removed from the design-system product-state baseline.
+- [x] #4 `bun run verify:design-system-state` passes from `apps/packages/ui`.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Replaced the `AssistantVoiceCard` wake-warning AntD `Alert` usage with `Alert as DesignSystemAlert` from `@/components/ui/primitives`.
+- Added a focused regression test asserting the wake-warning text is rendered inside an element with `data-ds-component="Alert"`.
+- Removed the `AssistantVoiceCard.tsx:Alert` entry from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
+- Review follow-up: rebased onto current `dev`, migrated the newly inherited QuickIngest review-step offline warning to the design-system Alert primitive, and added coverage for that review-path alert contract.
+- `bun run verify:design-system-state` passes from `apps/packages/ui`; the report still lists existing allowed/stale baseline inventory, but no blocked product-state findings remain.
+- Bandit skipped because this is a TypeScript UI-only change.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the Persona Garden AssistantVoiceCard wake-warning UI from AntD Alert to the shared design-system Alert primitive, added focused coverage for the DS contract, removed the corresponding product-state baseline exception, and addressed the PR review by bringing the current QuickIngest review-step offline warning onto the same design-system Alert path so the product-state verifier passes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates Persona Garden `AssistantVoiceCard` wake-warning UI from AntD `Alert` to the shared design-system `Alert` primitive.
- Adds focused coverage that asserts the wake warning renders through the design-system Alert contract.
- Removes the corresponding `AssistantVoiceCard.tsx:Alert` product-state baseline exception.
- Addresses the review follow-up by migrating the current QuickIngest review-step offline warning to the same design-system Alert path so the product-state verifier passes after rebasing onto current `dev`.

Refs #1668

## Change summary
<!-- Human reviewer/requester: please replace this placeholder with a human-owned summary explaining what changed and why these implementation choices were made before merge. -->

## Verification
- `bunx vitest run src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx` - passed, 17 tests.
- `bunx vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx` - passed, 32 tests.
- `bunx vitest run src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx -t "Step 3 — blocks final processing while disconnected and allows going back"` - passed after the final formatting edit.
- `bun run verify:design-system-state` - passed from `apps/packages/ui`; report still lists existing allowed/stale baseline inventory, with no blocked findings.
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('json ok')"` - passed.
- `git diff --check` - passed.
- `bunx tsc --noEmit --project tsconfig.json --pretty false` - local repo-wide test-type baseline still exits 2; captured output contains no `AssistantVoiceCard`, `LiveSessionPanel`, `QuickIngest`, `ReviewStep`, or baseline-file matches. GitHub `Lint & Type Check` passed before this follow-up and will rerun on the pushed head.
- Bandit skipped: TypeScript UI-only change.