### PR TITLE
Harden prototype collaborator entry route state

### DIFF
--- a/Docs/superpowers/plans/2026-05-16-prototype-risk-gate-5-collaborator-entry-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-prototype-risk-gate-5-collaborator-entry-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Baseline And Contract Mapping
+**Goal**: Confirm the current public-share and prototype collaborator entry flow, then define the frontend-only contract mapping needed for Risk Gate 5.
+**Success Criteria**: Existing focused PublicShare, prototype workspace route, hook, and client tests pass before changes; the implementation uses frozen Risk Gate 4 categories and frontend state buckets without changing backend semantics.
+**Tests**: `bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx --maxWorkers=1 --no-file-parallelism`
+**Status**: Complete
+
+## Stage 2: Explicit Collaborator Entry State
+**Goal**: Make collaborator entry state explicit and route-scoped so token-only entries never inherit stale owner workspace/session state.
+**Success Criteria**: URL share/session tokens replace stale collaborator state; token-bearing route entries do not read owner workspace detail until the exchanged/created collaborator session provides a workspace id; transient passwords remain outside persistent store.
+**Tests**: Add failing component/store tests around token changes, stale owner workspace isolation, and password handoff persistence.
+**Status**: Complete
+
+## Stage 3: Contract Error Presentation
+**Goal**: Map prototype contract error categories and retryability into stable collaborator-entry UI states.
+**Success Criteria**: Public link exchange and collaborator branch-session failures show the frozen state buckets for invalid/unavailable links, password-required/rejected, inactive sessions, workspace unavailable, setup failed, and preview unavailable; retry affordances use `retryable`.
+**Tests**: Add failing session-view tests that inject structured prototype errors from exchange/session mutations and assert the rendered state and retry behavior.
+**Status**: Complete
+
+## Stage 4: Verification And Closeout
+**Goal**: Verify the frontend slice and record remaining release-gate evidence requirements.
+**Success Criteria**: Focused Vitest suite passes, formatting/type checks for touched files pass where practical, Backlog task records verification and any browser/E2E skip that Risk Gate 8 must pick up, and PR references issue #1457.
+**Tests**: Focused Vitest command from Stage 1 plus targeted tests added in Stages 2-3.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { usePrototypePrivateLinkExchange } from "@/hooks/useSharing"
 import {
@@ -123,9 +123,11 @@ export const PrototypeWorkspaceSessionView = ({
   const createPromotion = useCreatePromotionRequest()
 
   const isRouteTokenEntry = Boolean(sessionToken || shareToken)
+  const routeTokenMatchesStoredState =
+    (!shareToken || collaboratorShareToken === shareToken) &&
+    (!sessionToken || collaboratorSessionToken === sessionToken)
   const canUseStoredCollaboratorState =
-    !isRouteTokenEntry ||
-    (Boolean(shareToken) && collaboratorShareToken === shareToken)
+    !isRouteTokenEntry || routeTokenMatchesStoredState
   const routeScopedSessionToken = canUseStoredCollaboratorState
     ? collaboratorSessionToken
     : null
@@ -133,20 +135,55 @@ export const PrototypeWorkspaceSessionView = ({
     ? collaboratorSessionId
     : null
   const effectiveSessionToken = sessionToken ?? routeScopedSessionToken
+  const createSessionMatchesCurrentToken =
+    Boolean(effectiveSessionToken) &&
+    createSession.variables?.session_token === effectiveSessionToken
+  const routeScopedCreatedWorkspaceId = createSessionMatchesCurrentToken
+    ? createSession.data?.prototype_workspace_id
+    : null
+  const routeScopedCreatedSessionId = createSessionMatchesCurrentToken
+    ? createSession.data?.prototype_session_id
+    : null
   const resolvedWorkspaceId =
     prototypeWorkspaceId ??
-    createSession.data?.prototype_workspace_id ??
+    routeScopedCreatedWorkspaceId ??
     (!isRouteTokenEntry ? activeWorkspaceId : null) ??
     null
   const resolvedSessionId =
-    routeScopedSessionId ?? createSession.data?.prototype_session_id ?? null
+    routeScopedSessionId ?? routeScopedCreatedSessionId ?? null
   const workspaceQuery = usePrototypeWorkspace(
     workspace ? null : resolvedWorkspaceId
   )
   const resolvedWorkspace = workspace ?? workspaceQuery.data ?? null
+  const exchangeLinkMatchesCurrentShareToken =
+    Boolean(shareToken) && exchangeLink.variables?.token === shareToken
+  const routeScopedExchangeError =
+    !shareToken || exchangeLinkMatchesCurrentShareToken ? exchangeLink.error : null
+  const routeScopedCreateSessionError =
+    !isRouteTokenEntry || createSessionMatchesCurrentToken
+      ? createSession.error
+      : null
   const entryErrorState = getPrototypeEntryErrorState(
-    exchangeLink.error ?? createSession.error
+    routeScopedExchangeError ?? routeScopedCreateSessionError
   )
+
+  useEffect(() => {
+    if (!isRouteTokenEntry || canUseStoredCollaboratorState) {
+      return
+    }
+    setCollaboratorEntry({
+      collaboratorSessionId: null,
+      collaboratorSessionToken: sessionToken ?? null,
+      collaboratorShareToken: shareToken ?? null,
+      sharedActorId: null
+    })
+  }, [
+    canUseStoredCollaboratorState,
+    isRouteTokenEntry,
+    sessionToken,
+    setCollaboratorEntry,
+    shareToken
+  ])
 
   const handleExchangeLink = async () => {
     if (!shareToken) {

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react"
+import { useNavigate } from "react-router-dom"
 import { usePrototypePrivateLinkExchange } from "@/hooks/useSharing"
 import {
   usePrototypeWorkspace,
   useCreateCollaboratorBranchSession,
   useCreatePromotionRequest
 } from "@/hooks/usePrototypeWorkspaces"
+import { getStructuredApiErrorDetail } from "@/services/tldw/api-error"
 import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
 import type { PrototypeWorkspaceDetail } from "@/types/prototype-workspace"
 
@@ -16,6 +18,68 @@ interface PrototypeWorkspaceSessionViewProps {
   workspace?: PrototypeWorkspaceDetail | null
 }
 
+const PROTOTYPE_ENTRY_STATE_LABELS: Record<string, string> = {
+  link_unavailable: "Link unavailable",
+  password_required: "Password required",
+  password_rejected: "Password rejected",
+  workspace_unavailable: "Workspace unavailable",
+  session_inactive: "Session inactive",
+  setup_failed: "Setup failed",
+  preview_unavailable: "Preview unavailable",
+  promotion_stale: "Promotion stale",
+  promotion_conflict: "Promotion conflict",
+  promotion_failed: "Promotion failed"
+}
+
+const PROTOTYPE_ENTRY_CATEGORY_STATES: Record<string, string> = {
+  invalid_or_unavailable_link: "link_unavailable",
+  password_required: "password_required",
+  invalid_password: "password_rejected",
+  workspace_unavailable: "workspace_unavailable",
+  inactive_session: "session_inactive",
+  bootstrap_failed: "setup_failed",
+  preview_unavailable: "preview_unavailable",
+  stale_promotion: "promotion_stale",
+  promotion_conflict: "promotion_conflict",
+  promotion_validation_failed: "promotion_failed"
+}
+
+const toDisplayLabel = (value: string): string =>
+  value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+
+const getPrototypeEntryErrorState = (error: unknown) => {
+  const detail = getStructuredApiErrorDetail(error)
+  if (detail) {
+    const frontendState =
+      detail.frontend_state ??
+      (detail.category
+        ? PROTOTYPE_ENTRY_CATEGORY_STATES[detail.category]
+        : undefined)
+    const label =
+      (frontendState ? PROTOTYPE_ENTRY_STATE_LABELS[frontendState] : null) ??
+      (frontendState ? toDisplayLabel(frontendState) : "Request failed")
+    return {
+      label,
+      message: detail.message ?? label,
+      retryable: detail.retryable === true
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      label: "Request failed",
+      message: error.message,
+      retryable: false
+    }
+  }
+
+  return null
+}
+
 export const PrototypeWorkspaceSessionView = ({
   prototypeWorkspaceId,
   sessionToken,
@@ -23,6 +87,7 @@ export const PrototypeWorkspaceSessionView = ({
   initialPassword,
   workspace
 }: PrototypeWorkspaceSessionViewProps) => {
+  const navigate = useNavigate()
   const activeWorkspaceId = usePrototypeWorkspaceStore(
     (state) => state.activeWorkspaceId
   )
@@ -31,6 +96,9 @@ export const PrototypeWorkspaceSessionView = ({
   )
   const collaboratorSessionToken = usePrototypeWorkspaceStore(
     (state) => state.collaboratorSessionToken
+  )
+  const collaboratorShareToken = usePrototypeWorkspaceStore(
+    (state) => state.collaboratorShareToken
   )
   const setActiveWorkspaceId = usePrototypeWorkspaceStore(
     (state) => state.setActiveWorkspaceId
@@ -54,18 +122,31 @@ export const PrototypeWorkspaceSessionView = ({
   const createSession = useCreateCollaboratorBranchSession()
   const createPromotion = useCreatePromotionRequest()
 
-  const effectiveSessionToken = sessionToken ?? collaboratorSessionToken
+  const isRouteTokenEntry = Boolean(sessionToken || shareToken)
+  const canUseStoredCollaboratorState =
+    !isRouteTokenEntry ||
+    (Boolean(shareToken) && collaboratorShareToken === shareToken)
+  const routeScopedSessionToken = canUseStoredCollaboratorState
+    ? collaboratorSessionToken
+    : null
+  const routeScopedSessionId = canUseStoredCollaboratorState
+    ? collaboratorSessionId
+    : null
+  const effectiveSessionToken = sessionToken ?? routeScopedSessionToken
   const resolvedWorkspaceId =
     prototypeWorkspaceId ??
-    activeWorkspaceId ??
     createSession.data?.prototype_workspace_id ??
+    (!isRouteTokenEntry ? activeWorkspaceId : null) ??
     null
   const resolvedSessionId =
-    collaboratorSessionId ?? createSession.data?.prototype_session_id ?? null
+    routeScopedSessionId ?? createSession.data?.prototype_session_id ?? null
   const workspaceQuery = usePrototypeWorkspace(
     workspace ? null : resolvedWorkspaceId
   )
   const resolvedWorkspace = workspace ?? workspaceQuery.data ?? null
+  const entryErrorState = getPrototypeEntryErrorState(
+    exchangeLink.error ?? createSession.error
+  )
 
   const handleExchangeLink = async () => {
     if (!shareToken) {
@@ -97,6 +178,12 @@ export const PrototypeWorkspaceSessionView = ({
       collaboratorShareToken: shareToken,
       sharedActorId: result.shared_actor_id ?? null
     })
+    if (isRouteTokenEntry) {
+      navigate(
+        `/prototype-workspaces?workspace=${encodeURIComponent(result.prototype_workspace_id)}`,
+        { replace: true }
+      )
+    }
   }
 
   const handleCreatePromotionRequest = async () => {
@@ -125,6 +212,20 @@ export const PrototypeWorkspaceSessionView = ({
           and submit a promotion request back to the canonical prototype.
         </p>
       </div>
+
+      {entryErrorState ? (
+        <div
+          data-testid="prototype-entry-error-state"
+          className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm"
+          role="status"
+        >
+          <div className="font-medium">{entryErrorState.label}</div>
+          <p className="mt-1 text-muted-foreground">{entryErrorState.message}</p>
+          {entryErrorState.retryable ? (
+            <p className="mt-1 text-muted-foreground">Retry is available</p>
+          ) : null}
+        </div>
+      ) : null}
 
       <section className="rounded-lg border p-4">
         <div className="mb-3 space-y-1">

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx
@@ -3,6 +3,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
+import {
+  getPrototypeContractErrorDetail,
+  getPrototypeContractState,
+  type PrototypeContractErrorDetail
+} from "@/test-utils/prototype-contract-fixtures"
 import { PrototypeWorkspaceSessionView } from "../PrototypeWorkspaceSessionView"
 
 const hookState = vi.hoisted(() => ({
@@ -41,12 +46,7 @@ vi.mock("@/hooks/usePrototypeWorkspaces", () => ({
 }))
 
 const prototypeError = (
-  detail: {
-    category: string
-    frontend_state: string
-    retryable: boolean
-    message?: string
-  }
+  detail: PrototypeContractErrorDetail
 ) => {
   const error = new Error(detail.message ?? detail.category)
   return Object.assign(error, {
@@ -69,6 +69,7 @@ describe("PrototypeWorkspaceSessionView", () => {
       data: null,
       isPending: false,
       error: null,
+      variables: undefined,
       mutateAsync: vi.fn()
     })
     hookState.useCreatePromotionRequest.mockReturnValue({
@@ -113,6 +114,7 @@ describe("PrototypeWorkspaceSessionView", () => {
       data: null,
       isPending: false,
       error: null,
+      variables: undefined,
       mutateAsync: createSession
     })
 
@@ -138,39 +140,91 @@ describe("PrototypeWorkspaceSessionView", () => {
     )
   })
 
+  it("does not reuse mutation data from a previous route token", () => {
+    const store = usePrototypeWorkspaceStore.getState()
+    store.setCollaboratorEntry({
+      collaboratorSessionId: "pss_stale_store",
+      collaboratorSessionToken: "old-session-token",
+      collaboratorShareToken: "same-share-token",
+      sharedActorId: "psa_stale"
+    })
+    hookState.useCreateCollaboratorBranchSession.mockReturnValue({
+      data: {
+        job_id: "job-old",
+        job_type: "branch_session_bootstrap",
+        status: "queued",
+        message: "queued",
+        prototype_workspace_id: "pw_previous",
+        prototype_session_id: "pss_previous",
+        actor_type: "external_collaborator",
+        shared_actor_id: "psa_previous"
+      },
+      isPending: false,
+      error: null,
+      variables: { session_token: "old-session-token" },
+      mutateAsync: vi.fn()
+    })
+
+    render(
+      <PrototypeWorkspaceSessionView
+        shareToken="same-share-token"
+        sessionToken="new-session-token"
+      />
+    )
+
+    expect(hookState.usePrototypeWorkspace).toHaveBeenCalledWith(null)
+    expect(screen.queryByText("Workspace: pw_previous")).not.toBeInTheDocument()
+    expect(screen.queryByText("Session: pss_previous")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Session: pss_stale_store")
+    ).not.toBeInTheDocument()
+  })
+
+  it("does not show stale mutation errors from a previous route token", () => {
+    hookState.useCreateCollaboratorBranchSession.mockReturnValue({
+      data: null,
+      isPending: false,
+      error: prototypeError(getPrototypeContractErrorDetail("bootstrap_failed")),
+      variables: { session_token: "old-session-token" },
+      mutateAsync: vi.fn()
+    })
+
+    render(<PrototypeWorkspaceSessionView sessionToken="new-session-token" />)
+
+    expect(
+      screen.queryByTestId("prototype-entry-error-state")
+    ).not.toBeInTheDocument()
+  })
+
   it("maps frozen link exchange errors into collaborator entry route states", () => {
+    const invalidLink = getPrototypeContractState("invalid_link")
+    const invalidLinkDetail = invalidLink.mockResponse.detail
     hookState.usePrototypePrivateLinkExchange.mockReturnValue({
       isPending: false,
-      error: prototypeError({
-        category: "invalid_or_unavailable_link",
-        frontend_state: "link_unavailable",
-        retryable: false,
-        message: "Prototype link is unavailable"
-      }),
+      error: prototypeError(invalidLinkDetail),
+      variables: { token: "share-token-1" },
       mutateAsync: vi.fn()
     })
 
     render(<PrototypeWorkspaceSessionView shareToken="share-token-1" />)
 
     expect(screen.getByTestId("prototype-entry-error-state")).toHaveTextContent(
-      "Link unavailable"
+      invalidLink.frontendStateBucket
     )
     expect(screen.getByTestId("prototype-entry-error-state")).toHaveTextContent(
-      "Prototype link is unavailable"
+      invalidLinkDetail.message
     )
     expect(screen.queryByText("Retry is available")).not.toBeInTheDocument()
   })
 
   it("uses retryability from structured session errors for setup failures", () => {
+    const bootstrapFailedDetail =
+      getPrototypeContractErrorDetail("bootstrap_failed")
     hookState.useCreateCollaboratorBranchSession.mockReturnValue({
       data: null,
       isPending: false,
-      error: prototypeError({
-        category: "bootstrap_failed",
-        frontend_state: "setup_failed",
-        retryable: true,
-        message: "Prototype branch session could not be created"
-      }),
+      error: prototypeError(bootstrapFailedDetail),
+      variables: { session_token: "session-token-1" },
       mutateAsync: vi.fn()
     })
 

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx
@@ -1,0 +1,186 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
+import { PrototypeWorkspaceSessionView } from "../PrototypeWorkspaceSessionView"
+
+const hookState = vi.hoisted(() => ({
+  usePrototypePrivateLinkExchange: vi.fn(),
+  usePrototypeWorkspace: vi.fn(),
+  useCreateCollaboratorBranchSession: vi.fn(),
+  useCreatePromotionRequest: vi.fn()
+}))
+
+const routerState = vi.hoisted(() => ({
+  navigate: vi.fn()
+}))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  )
+  return {
+    ...actual,
+    useNavigate: () => routerState.navigate
+  }
+})
+
+vi.mock("@/hooks/useSharing", () => ({
+  usePrototypePrivateLinkExchange: (...args: unknown[]) =>
+    hookState.usePrototypePrivateLinkExchange(...args)
+}))
+
+vi.mock("@/hooks/usePrototypeWorkspaces", () => ({
+  usePrototypeWorkspace: (...args: unknown[]) =>
+    hookState.usePrototypeWorkspace(...args),
+  useCreateCollaboratorBranchSession: (...args: unknown[]) =>
+    hookState.useCreateCollaboratorBranchSession(...args),
+  useCreatePromotionRequest: (...args: unknown[]) =>
+    hookState.useCreatePromotionRequest(...args)
+}))
+
+const prototypeError = (
+  detail: {
+    category: string
+    frontend_state: string
+    retryable: boolean
+    message?: string
+  }
+) => {
+  const error = new Error(detail.message ?? detail.category)
+  return Object.assign(error, {
+    status: 403,
+    detail
+  })
+}
+
+describe("PrototypeWorkspaceSessionView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usePrototypeWorkspaceStore.getState().reset()
+    hookState.usePrototypeWorkspace.mockReturnValue({ data: null })
+    hookState.usePrototypePrivateLinkExchange.mockReturnValue({
+      isPending: false,
+      error: null,
+      mutateAsync: vi.fn()
+    })
+    hookState.useCreateCollaboratorBranchSession.mockReturnValue({
+      data: null,
+      isPending: false,
+      error: null,
+      mutateAsync: vi.fn()
+    })
+    hookState.useCreatePromotionRequest.mockReturnValue({
+      isPending: false,
+      error: null,
+      mutateAsync: vi.fn()
+    })
+  })
+
+  it("does not load stale owner workspace or stale collaborator session for a new share-token entry", () => {
+    const store = usePrototypeWorkspaceStore.getState()
+    store.setActiveWorkspaceId("pw_stale_owner")
+    store.setCollaboratorEntry({
+      collaboratorSessionId: "pss_old",
+      collaboratorSessionToken: "old-session-token",
+      collaboratorShareToken: "old-share-token",
+      sharedActorId: "psa_old"
+    })
+
+    render(<PrototypeWorkspaceSessionView shareToken="new-share-token" />)
+
+    expect(hookState.usePrototypeWorkspace).toHaveBeenCalledWith(null)
+    expect(screen.queryByText("Workspace: pw_stale_owner")).not.toBeInTheDocument()
+    expect(screen.queryByText("Session: pss_old")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Start collaborator session" })
+    ).toBeDisabled()
+  })
+
+  it("removes token-bearing route state after a collaborator branch session starts", async () => {
+    const createSession = vi.fn().mockResolvedValue({
+      job_id: "job-1",
+      job_type: "branch_session_bootstrap",
+      status: "queued",
+      message: "queued",
+      prototype_workspace_id: "pw_collab",
+      prototype_session_id: "pss_collab",
+      actor_type: "external_collaborator",
+      shared_actor_id: "psa_collab"
+    })
+    hookState.useCreateCollaboratorBranchSession.mockReturnValue({
+      data: null,
+      isPending: false,
+      error: null,
+      mutateAsync: createSession
+    })
+
+    render(
+      <PrototypeWorkspaceSessionView
+        shareToken="share-token-1"
+        sessionToken="session-token-1"
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Start collaborator session" })
+    )
+
+    await waitFor(() => {
+      expect(createSession).toHaveBeenCalledWith({
+        session_token: "session-token-1"
+      })
+    })
+    expect(routerState.navigate).toHaveBeenCalledWith(
+      "/prototype-workspaces?workspace=pw_collab",
+      { replace: true }
+    )
+  })
+
+  it("maps frozen link exchange errors into collaborator entry route states", () => {
+    hookState.usePrototypePrivateLinkExchange.mockReturnValue({
+      isPending: false,
+      error: prototypeError({
+        category: "invalid_or_unavailable_link",
+        frontend_state: "link_unavailable",
+        retryable: false,
+        message: "Prototype link is unavailable"
+      }),
+      mutateAsync: vi.fn()
+    })
+
+    render(<PrototypeWorkspaceSessionView shareToken="share-token-1" />)
+
+    expect(screen.getByTestId("prototype-entry-error-state")).toHaveTextContent(
+      "Link unavailable"
+    )
+    expect(screen.getByTestId("prototype-entry-error-state")).toHaveTextContent(
+      "Prototype link is unavailable"
+    )
+    expect(screen.queryByText("Retry is available")).not.toBeInTheDocument()
+  })
+
+  it("uses retryability from structured session errors for setup failures", () => {
+    hookState.useCreateCollaboratorBranchSession.mockReturnValue({
+      data: null,
+      isPending: false,
+      error: prototypeError({
+        category: "bootstrap_failed",
+        frontend_state: "setup_failed",
+        retryable: true,
+        message: "Prototype branch session could not be created"
+      }),
+      mutateAsync: vi.fn()
+    })
+
+    render(<PrototypeWorkspaceSessionView sessionToken="session-token-1" />)
+
+    expect(screen.getByTestId("prototype-entry-error-state")).toHaveTextContent(
+      "Setup failed"
+    )
+    expect(screen.getByTestId("prototype-entry-error-state")).toHaveTextContent(
+      "Retry is available"
+    )
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
@@ -265,6 +265,44 @@ describe("usePrototypeWorkspaces", () => {
     })
   })
 
+  it("preserves structured collaborator session errors for setup-failed UI states", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            category: "bootstrap_failed",
+            frontend_state: "setup_failed",
+            message: "Prototype branch session could not be created",
+            retryable: true
+          }
+        }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => useCreateCollaboratorBranchSession(), {
+      wrapper: buildWrapper()
+    })
+
+    await expect(
+      result.current.mutateAsync({
+        session_token: "session-token-1"
+      })
+    ).rejects.toMatchObject({
+      status: 503,
+      detail: {
+        category: "bootstrap_failed",
+        frontend_state: "setup_failed",
+        retryable: true,
+        message: "Prototype branch session could not be created"
+      },
+      message: "Prototype branch session could not be created"
+    })
+  })
+
   it("creates a prototype promotion request through the authenticated tldw fetch helper", async () => {
     fetchWithTldwAuthMock.mockResolvedValue(
       new Response(

--- a/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
@@ -22,6 +22,7 @@ import {
   useCreatePromotionRequest,
   useCreatePrototypeWorkspace
 } from "@/hooks/usePrototypeWorkspaces"
+import { getPrototypeContractState } from "@/test-utils/prototype-contract-fixtures"
 
 const buildWrapper = () => {
   const queryClient = new QueryClient({
@@ -266,18 +267,12 @@ describe("usePrototypeWorkspaces", () => {
   })
 
   it("preserves structured collaborator session errors for setup-failed UI states", async () => {
+    const bootstrapFailed = getPrototypeContractState("bootstrap_failed")
     fetchWithTldwAuthMock.mockResolvedValue(
       new Response(
-        JSON.stringify({
-          detail: {
-            category: "bootstrap_failed",
-            frontend_state: "setup_failed",
-            message: "Prototype branch session could not be created",
-            retryable: true
-          }
-        }),
+        JSON.stringify(bootstrapFailed.mockResponse),
         {
-          status: 503,
+          status: bootstrapFailed.httpStatus,
           headers: { "Content-Type": "application/json" }
         }
       )
@@ -292,14 +287,9 @@ describe("usePrototypeWorkspaces", () => {
         session_token: "session-token-1"
       })
     ).rejects.toMatchObject({
-      status: 503,
-      detail: {
-        category: "bootstrap_failed",
-        frontend_state: "setup_failed",
-        retryable: true,
-        message: "Prototype branch session could not be created"
-      },
-      message: "Prototype branch session could not be created"
+      status: bootstrapFailed.httpStatus,
+      detail: bootstrapFailed.mockResponse.detail,
+      message: bootstrapFailed.mockResponse.detail.message
     })
   })
 

--- a/apps/packages/ui/src/hooks/__tests__/useSharing.auth.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSharing.auth.test.tsx
@@ -19,6 +19,7 @@ import {
   usePrototypePrivateLinkExchange,
   useSharedWithMe
 } from "@/hooks/useSharing"
+import { getPrototypeContractState } from "@/test-utils/prototype-contract-fixtures"
 
 const buildWrapper = () => {
   const queryClient = new QueryClient({
@@ -136,18 +137,12 @@ describe("useSharing auth wiring", () => {
   })
 
   it("preserves structured prototype link exchange error details for route-state mapping", async () => {
+    const invalidLink = getPrototypeContractState("invalid_link")
     fetchWithTldwAuthMock.mockResolvedValue(
       new Response(
-        JSON.stringify({
-          detail: {
-            category: "invalid_or_unavailable_link",
-            frontend_state: "link_unavailable",
-            message: "Prototype link is unavailable",
-            retryable: false
-          }
-        }),
+        JSON.stringify(invalidLink.mockResponse),
         {
-          status: 404,
+          status: invalidLink.httpStatus,
           headers: { "Content-Type": "application/json" }
         }
       )
@@ -163,14 +158,9 @@ describe("useSharing auth wiring", () => {
         display_name: "Acme PM"
       })
     ).rejects.toMatchObject({
-      status: 404,
-      detail: {
-        category: "invalid_or_unavailable_link",
-        frontend_state: "link_unavailable",
-        retryable: false,
-        message: "Prototype link is unavailable"
-      },
-      message: "Prototype link is unavailable"
+      status: invalidLink.httpStatus,
+      detail: invalidLink.mockResponse.detail,
+      message: invalidLink.mockResponse.detail.message
     })
   })
 })

--- a/apps/packages/ui/src/hooks/__tests__/useSharing.auth.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSharing.auth.test.tsx
@@ -134,4 +134,43 @@ describe("useSharing auth wiring", () => {
       })
     )
   })
+
+  it("preserves structured prototype link exchange error details for route-state mapping", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            category: "invalid_or_unavailable_link",
+            frontend_state: "link_unavailable",
+            message: "Prototype link is unavailable",
+            retryable: false
+          }
+        }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => usePrototypePrivateLinkExchange(), {
+      wrapper: buildWrapper()
+    })
+
+    await expect(
+      result.current.mutateAsync({
+        token: "prototype-token",
+        display_name: "Acme PM"
+      })
+    ).rejects.toMatchObject({
+      status: 404,
+      detail: {
+        category: "invalid_or_unavailable_link",
+        frontend_state: "link_unavailable",
+        retryable: false,
+        message: "Prototype link is unavailable"
+      },
+      message: "Prototype link is unavailable"
+    })
+  })
 })

--- a/apps/packages/ui/src/hooks/useSharing.ts
+++ b/apps/packages/ui/src/hooks/useSharing.ts
@@ -3,6 +3,7 @@
  */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { getTldwServerURL } from "@/services/tldw-server"
+import { buildTldwApiError } from "@/services/tldw/api-error"
 import { fetchWithTldwAuth } from "@/services/tldw/auth-fetch"
 import type {
   ShareWorkspaceRequest,
@@ -33,8 +34,7 @@ const jsonPost = async <T>(path: string, body: unknown): Promise<T> => {
     body: JSON.stringify(body),
   })
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(err.detail || "Request failed")
+    throw await buildTldwApiError(res)
   }
   return res.json()
 }
@@ -47,8 +47,7 @@ const jsonPatch = async <T>(path: string, body: unknown): Promise<T> => {
     body: JSON.stringify(body),
   })
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(err.detail || "Request failed")
+    throw await buildTldwApiError(res)
   }
   return res.json()
 }
@@ -57,8 +56,7 @@ const jsonGet = async <T>(path: string): Promise<T> => {
   const url = await sharingUrl(path)
   const res = await fetchWithTldwAuth(url)
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(err.detail || "Request failed")
+    throw await buildTldwApiError(res)
   }
   return res.json()
 }
@@ -67,8 +65,7 @@ const jsonDelete = async (path: string): Promise<void> => {
   const url = await sharingUrl(path)
   const res = await fetchWithTldwAuth(url, { method: "DELETE" })
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(err.detail || "Request failed")
+    throw await buildTldwApiError(res)
   }
 }
 

--- a/apps/packages/ui/src/services/tldw/api-error.ts
+++ b/apps/packages/ui/src/services/tldw/api-error.ts
@@ -1,0 +1,71 @@
+export interface StructuredApiErrorDetail {
+  category?: string
+  frontend_state?: string
+  message?: string
+  retryable?: boolean
+  [key: string]: unknown
+}
+
+export class TldwApiError extends Error {
+  status: number
+  detail: unknown
+
+  constructor(message: string, status: number, detail: unknown) {
+    super(message)
+    this.name = "TldwApiError"
+    this.status = status
+    this.detail = detail
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const apiErrorMessage = (detail: unknown, fallback: string): string => {
+  if (typeof detail === "string" && detail.trim()) {
+    return detail
+  }
+  if (isRecord(detail)) {
+    const message = detail.message
+    if (typeof message === "string" && message.trim()) {
+      return message
+    }
+  }
+  return fallback
+}
+
+export const buildTldwApiError = async (
+  response: Response,
+  fallback = "Request failed"
+): Promise<TldwApiError> => {
+  const body = await response
+    .json()
+    .catch(() => ({ detail: response.statusText }))
+  const detail = isRecord(body) && "detail" in body ? body.detail : body
+  const message = apiErrorMessage(detail, response.statusText || fallback)
+  return new TldwApiError(message, response.status, detail)
+}
+
+export const getStructuredApiErrorDetail = (
+  error: unknown
+): StructuredApiErrorDetail | null => {
+  if (!isRecord(error)) {
+    return null
+  }
+
+  const detail = error.detail
+  if (!isRecord(detail)) {
+    return null
+  }
+
+  const structured: StructuredApiErrorDetail = { ...detail }
+  structured.category =
+    typeof detail.category === "string" ? detail.category : undefined
+  structured.frontend_state =
+    typeof detail.frontend_state === "string" ? detail.frontend_state : undefined
+  structured.message =
+    typeof detail.message === "string" ? detail.message : undefined
+  structured.retryable =
+    typeof detail.retryable === "boolean" ? detail.retryable : undefined
+  return structured
+}

--- a/apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts
+++ b/apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts
@@ -1,4 +1,5 @@
 import { fetchWithTldwAuth } from "@/services/tldw/auth-fetch"
+import { buildTldwApiError } from "@/services/tldw/api-error"
 import { getTldwServerURL } from "@/services/tldw-server"
 import type {
   PrototypeCollaboratorSessionCreateInput,
@@ -31,8 +32,7 @@ const jsonPost = async <T>(path: string, body: unknown): Promise<T> => {
   })
 
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(err.detail || "Request failed")
+    throw await buildTldwApiError(res)
   }
 
   return res.json()
@@ -43,8 +43,7 @@ const jsonGet = async <T>(path: string): Promise<T> => {
   const res = await fetchWithTldwAuth(url)
 
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(err.detail || "Request failed")
+    throw await buildTldwApiError(res)
   }
 
   return res.json()

--- a/apps/packages/ui/src/test-utils/prototype-contract-fixtures.ts
+++ b/apps/packages/ui/src/test-utils/prototype-contract-fixtures.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+export interface PrototypeContractErrorDetail {
+  category: string
+  message: string
+  frontend_state: string
+  retryable: boolean
+}
+
+export interface PrototypeContractStateFixture {
+  state: string
+  httpStatus: number
+  stableErrorCategory: string
+  frontendStateBucket: string
+  retryable: boolean
+  mockResponse: {
+    detail: PrototypeContractErrorDetail
+  }
+}
+
+const contractFixturePath = path.resolve(
+  __dirname,
+  "../../../../tldw-frontend/e2e/fixtures/prototype-workspaces/contract-states.json"
+)
+
+const contractFixture = JSON.parse(
+  readFileSync(contractFixturePath, "utf8")
+) as {
+  states: PrototypeContractStateFixture[]
+}
+
+export const getPrototypeContractState = (
+  state: string
+): PrototypeContractStateFixture => {
+  const fixture = contractFixture.states.find((item) => item.state === state)
+  if (!fixture) {
+    throw new Error(`Unknown prototype contract fixture state: ${state}`)
+  }
+  return fixture
+}
+
+export const getPrototypeContractErrorDetail = (
+  state: string
+): PrototypeContractErrorDetail =>
+  getPrototypeContractState(state).mockResponse.detail

--- a/backlog/tasks/task-405 - Risk-Gate-5-prototype-collaborator-entry-route-state-safety.md
+++ b/backlog/tasks/task-405 - Risk-Gate-5-prototype-collaborator-entry-route-state-safety.md
@@ -1,0 +1,78 @@
+---
+id: TASK-405
+title: Risk Gate 5 prototype collaborator entry route-state safety
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 06:47'
+labels:
+  - prototype-workspaces
+  - risk-gate
+  - frontend
+  - product
+dependencies:
+  - TASK-324
+  - TASK-399
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1457'
+  - 'https://github.com/rmusser01/tldw_server/issues/1440'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1457 under tracker #1440. Harden the Frontend/Product collaborator public-share entry path so prototype collaborator sessions use explicit exchanged session context, never fall back to stale owner workspace state, map frozen backend contract error categories to user-facing route states, and add focused frontend coverage for public-link exchange and route-state isolation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Frontend tests cover public link exchange and route-state isolation.
+- [x] #2 Collaborator session context is explicit and is not inferred from stale local owner state.
+- [x] #3 User-facing states map to backend error categories from the contract matrix.
+- [x] #4 The slice records any skipped browser-observed public-share handoff proof for Risk Gate 8 if not practical now.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-16-prototype-risk-gate-5-collaborator-entry-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-05-16: Created isolated worktree .worktrees/prototype-risk-gate-5-collaborator-entry on branch codex/prototype-risk-gate-5-collaborator-entry from origin/dev a304f5f58 after Risk Gate 4 PR #1739 merged.
+
+2026-05-16: Baseline focused frontend verification passed: bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx --maxWorkers=1 --no-file-parallelism reported 4 files and 17 tests passed. Initial run failed before bun install because the fresh worktree lacked workspace node_modules; bun install in apps restored dependencies without tracked lockfile changes.
+
+2026-05-16: Added staged implementation plan at Docs/superpowers/plans/2026-05-16-prototype-risk-gate-5-collaborator-entry-plan.md.
+
+2026-05-16: Added route-scoped collaborator entry handling. Share/session URL entries no longer use stale activeWorkspaceId or mismatched stored collaborator session state, and successful collaborator branch-session creation replaces token-bearing route state with the resolved workspace URL.
+
+2026-05-16: Added structured API error preservation for sharing/prototype workspace helpers and mapped frozen prototype contract frontend states into collaborator-entry UI messages with retryability.
+
+2026-05-16: Focused verification passed: bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx --maxWorkers=1 --no-file-parallelism reported 5 files and 23 tests passed. git diff --check passed.
+
+2026-05-16: Package typecheck command ./node_modules/.bin/tsc --noEmit -p tsconfig.json was attempted and failed on existing unrelated repo-wide TypeScript baseline errors outside this touched slice, including audio/composer/flashcards/playground/study-suggestions tests and existing domain exports. Bandit was not run because this slice touched frontend TypeScript/TSX and documentation only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+2026-05-16: Rebased codex/prototype-risk-gate-5-collaborator-entry onto latest origin/dev 41c27e6af. Post-rebase focused verification passed with 5 files and 23 tests; git diff --check HEAD~1..HEAD passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Risk Gate 5 frontend/product hardening for prototype collaborator entry. Token-bearing collaborator routes now avoid stale owner workspace/session fallback, successful branch-session creation clears tokenized route state, structured API error details are preserved, and collaborator-entry UI maps frozen backend frontend_state/category/retryable fields to stable user-facing states. Added focused component and hook regression coverage; browser/E2E proof remains a later release-gate item.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-405 - Risk-Gate-5-prototype-collaborator-entry-route-state-safety.md
+++ b/backlog/tasks/task-405 - Risk-Gate-5-prototype-collaborator-entry-route-state-safety.md
@@ -4,19 +4,29 @@ title: Risk Gate 5 prototype collaborator entry route-state safety
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 06:47'
+updated_date: 2026-05-16 06:47
 labels:
-  - prototype-workspaces
-  - risk-gate
-  - frontend
-  - product
+- prototype-workspaces
+- risk-gate
+- frontend
+- product
 dependencies:
-  - TASK-324
-  - TASK-399
+- TASK-324
+- TASK-399
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1457'
-  - 'https://github.com/rmusser01/tldw_server/issues/1440'
+- https://github.com/rmusser01/tldw_server/issues/1457
+- https://github.com/rmusser01/tldw_server/issues/1440
 priority: high
+modified_files:
+- Docs/superpowers/plans/2026-05-16-prototype-risk-gate-5-collaborator-entry-plan.md
+- apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
+- apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx
+- apps/packages/ui/src/hooks/useSharing.ts
+- apps/packages/ui/src/hooks/__tests__/useSharing.auth.test.tsx
+- apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
+- apps/packages/ui/src/services/tldw/api-error.ts
+- apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts
+- apps/packages/ui/src/test-utils/prototype-contract-fixtures.ts
 ---
 
 ## Description
@@ -41,7 +51,6 @@ Docs/superpowers/plans/2026-05-16-prototype-risk-gate-5-collaborator-entry-plan.
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-05-16: Created isolated worktree .worktrees/prototype-risk-gate-5-collaborator-entry on branch codex/prototype-risk-gate-5-collaborator-entry from origin/dev a304f5f58 after Risk Gate 4 PR #1739 merged.
 
@@ -56,10 +65,11 @@ Docs/superpowers/plans/2026-05-16-prototype-risk-gate-5-collaborator-entry-plan.
 2026-05-16: Focused verification passed: bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx --maxWorkers=1 --no-file-parallelism reported 5 files and 23 tests passed. git diff --check passed.
 
 2026-05-16: Package typecheck command ./node_modules/.bin/tsc --noEmit -p tsconfig.json was attempted and failed on existing unrelated repo-wide TypeScript baseline errors outside this touched slice, including audio/composer/flashcards/playground/study-suggestions tests and existing domain exports. Bandit was not run because this slice touched frontend TypeScript/TSX and documentation only.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 2026-05-16: Rebased codex/prototype-risk-gate-5-collaborator-entry onto latest origin/dev 41c27e6af. Post-rebase focused verification passed with 5 files and 23 tests; git diff --check HEAD~1..HEAD passed.
-<!-- SECTION:NOTES:END -->
+
+2026-05-16: Addressed PR #1761 review comments. Tests now load frozen Risk Gate 4 prototype contract states from apps/tldw-frontend/e2e/fixtures/prototype-workspaces/contract-states.json via a shared test helper instead of duplicating structured error payloads. PrototypeWorkspaceSessionView now scopes stored collaborator state, mutation data, and mutation errors to the current share/session route token and resets mismatched route-scoped store values on token changes. Focused verification passed: bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx --maxWorkers=1 --no-file-parallelism reported 5 files and 25 tests passed. git diff --check passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 


### PR DESCRIPTION
## Summary
- Scope prototype collaborator session state to the current share/session route so token entries do not inherit stale owner workspace or old collaborator session state.
- Replace token-bearing route state with the resolved workspace URL after collaborator branch-session creation.
- Preserve structured API error details and map frozen prototype frontend_state/category/retryable fields into collaborator-entry UI states.
- Add Risk Gate 5 Backlog/task plan records and focused regression coverage.

## Verification
- `bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx --maxWorkers=1 --no-file-parallelism` - 5 files, 23 tests passed after rebasing on latest `origin/dev`.
- `git diff --check HEAD~1..HEAD` - passed.
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` - attempted; fails on existing unrelated repo-wide TypeScript baseline errors outside this touched slice.
- Bandit not run: frontend TypeScript/TSX and docs/task metadata only.

## Change summary
Human-owned change summary required before merge.

Closes #1457

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened prototype collaborator entry so token routes are fully scoped to the current share/session and never reuse stale workspace, mutation data, or errors. After session creation, we replace tokenized URLs with the resolved workspace and map structured API errors to clear entry states with retry hints (per #1457 Risk Gate 5).

- **Bug Fixes**
  - Route-scope collaborator store, mutation data, and errors; reset mismatched state on token change.
  - Replace token URL with `/prototype-workspaces?workspace=<id>` after session creation.

- **New Features**
  - Preserve structured errors via `TldwApiError`; map `frontend_state`/`category`/`retryable` to entry UI and show retry availability.
  - Add focused tests for route-state isolation and error mapping; tests load frozen prototype contract fixtures.

<sup>Written for commit eba957339b71c5452901e5dfb20a85bd1251b383. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1761?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

