### PR TITLE
Add Persona Visual starter production recipes

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -257,12 +257,23 @@ scaffolds from final authored default assets:
 5. `animation_coverage_notes` are bounded notes for reviewers and future
    generation jobs. They describe the missing neutral-anchor-derived animation
    work and do not grant runtime support by themselves.
+6. `production_recipe` is structured handoff metadata for authored assets. It
+   includes an `identity_brief`, `neutral_anchor` guidance, `static_sheet`
+   guidance, expected `animation_outputs`, and `review_checks`.
 
 The neutral-anchor pipeline remains: identity brief, neutral anchor, optional
 static talking/reaction sheet, animation strips or atlas regions, review, then
 copy/import into an inactive draft with separate activation. The production
 metadata is catalog guidance for that pipeline; it does not create final art,
 run image generation, activate a pack, or change renderer support.
+
+Production recipes make the scaffold-to-art handoff explicit. Basic starters
+usually expect only required-state loops derived from a single neutral anchor.
+Intermediate starters add a static talking/reaction sheet and custom-state
+variants. Intricate starters add animation strips or atlas regions on top of the
+same neutral anchor. These recipes are not prompts that the server executes and
+are not proof that finished animation assets exist; they are bounded metadata
+for reviewers, future generation jobs, and custom provider handoffs.
 
 Copying a bundled starter pack creates a normal user-owned draft pack attached
 to the selected target persona. The copy path validates the fixture manifest and

--- a/Docs/superpowers/plans/2026-05-16-persona-visual-production-recipes-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-persona-visual-production-recipes-plan.md
@@ -1,0 +1,25 @@
+# Persona Visual Starter Production Recipes Plan
+
+## Stage 1: Contract Tests
+**Goal**: Define the backend/API recipe contract from the caller perspective.
+**Success Criteria**: Focused tests require every starter to expose a bounded production recipe that distinguishes neutral anchors, static sheets, animation outputs, and review checks.
+**Tests**: `test_persona_visual_starter_catalog.py` and `test_persona_visuals_api.py` fail before implementation.
+**Status**: Complete
+
+## Stage 2: Fixture and Service Metadata
+**Goal**: Add deterministic recipe metadata to immutable starter fixtures and service summaries/details without changing copy-to-draft behavior.
+**Success Criteria**: All nine starters carry tier-appropriate recipes; malformed recipe values fail fixture validation.
+**Tests**: Focused starter catalog tests pass.
+**Status**: Complete
+
+## Stage 3: API Schema and Documentation
+**Goal**: Expose recipes through the typed Persona starter catalog response and explain the authored-asset handoff in docs.
+**Success Criteria**: API tests see recipe fields; docs clarify recipes are production handoff metadata, not finished animation packs.
+**Tests**: Focused Persona Visual API tests pass.
+**Status**: Complete
+
+## Stage 4: Verification and PR
+**Goal**: Validate, commit, push, and open a reviewable PR against `dev`.
+**Success Criteria**: Focused tests, `git diff --check`, and Bandit on touched backend code pass or have documented skips.
+**Tests**: Focused pytest suite, Bandit, diff checks.
+**Status**: Complete

--- a/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
+++ b/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
@@ -1,0 +1,73 @@
+---
+id: TASK-405
+title: Add Persona Visual starter asset-production recipes
+status: In Progress
+labels:
+- persona
+- visual-packs
+- backend
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1760
+- https://github.com/rmusser01/tldw_server/issues/1510
+- https://github.com/rmusser01/tldw_server/pull/1762
+documentation:
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+- Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md
+- Docs/superpowers/plans/2026-05-16-persona-visual-production-recipes-plan.md
+modified_files:
+- tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+- tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+- tldw_Server_API/app/api/v1/schemas/persona.py
+- tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+- tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+- Docs/superpowers/plans/2026-05-16-persona-visual-production-recipes-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1760 by adding bounded, structured production recipe metadata for each bundled Persona Visual starter scaffold. Recipes should describe the neutral-anchor-first asset production handoff for identity brief, neutral anchor, static talking/reaction sheets, animation outputs, and review checks without bundling final art, expanding runtime renderers, executing MCP providers, or changing copy-to-draft activation semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Starter catalog list/detail responses expose bounded production recipe metadata for each bundled starter.
+- [x] #2 Recipes distinguish identity brief, neutral anchor, static talking/reaction sheet, animation outputs, and review checks.
+- [x] #3 Basic, intermediate, and intricate starters have tier-appropriate production outputs without claiming final art exists.
+- [x] #4 Focused backend/API tests cover the new recipe contract and copy-to-draft behavior remains unchanged.
+- [x] #5 Persona Visual docs explain recipes as the authored-asset handoff after scaffold metadata.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-16-persona-visual-production-recipes-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added immutable `PersonaVisualStarterProductionRecipe` metadata to bundled starter fixtures and exposed it through starter catalog summaries/details. Recipes describe identity brief, neutral anchor guidance, static talking/reaction sheet guidance, expected animation outputs, and review checks for each starter. Service validation keeps recipes immutable, bounded, non-empty, and explicitly requires the neutral identity consistency review check.
+
+Updated Persona starter response schemas and docs so the recipe contract is clear to API clients and future authored-asset generation/review flows. Copy-to-draft behavior is unchanged.
+
+Verification: focused Persona Visual starter/API pytest passed 88 tests; py_compile passed for touched backend/schema modules; Bandit JSON report for touched backend/schema modules had zero results; git diff --check passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Persona Visual starter catalog responses now include structured production recipes for all nine bundled starter scaffolds. The recipes make the neutral-anchor-first authored-asset handoff explicit without bundling final art, executing generation, changing renderer support, or auto-activating copied drafts.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
+++ b/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
@@ -51,9 +51,9 @@ Docs/superpowers/plans/2026-05-16-persona-visual-production-recipes-plan.md
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Added immutable `PersonaVisualStarterProductionRecipe` metadata to bundled starter fixtures and exposed it through starter catalog summaries/details. Recipes describe identity brief, neutral anchor guidance, static talking/reaction sheet guidance, expected animation outputs, and review checks for each starter. Service validation keeps recipes immutable, bounded, non-empty, and explicitly requires the neutral identity consistency review check.
 
-Updated Persona starter response schemas and docs so the recipe contract is clear to API clients and future authored-asset generation/review flows. Copy-to-draft behavior is unchanged.
+Updated Persona starter response schemas and docs so the recipe contract is clear to API clients and future authored-asset generation/review flows. Review follow-up aligned the response schema with the catalog validation bounds for non-empty recipe text, bounded recipe item lists, bounded item text, and the required neutral identity consistency review check. Copy-to-draft behavior is unchanged.
 
-Verification: focused Persona Visual starter/API pytest passed 88 tests; py_compile passed for touched backend/schema modules; Bandit JSON report for touched backend/schema modules had zero results; git diff --check passed.
+Verification: focused Persona Visual starter/API pytest passed 94 tests; py_compile passed for touched backend/schema modules; Bandit JSON report for touched backend/schema modules had zero results; git diff --check passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -5,7 +5,7 @@ Scaffold only - minimal models to enable endpoint stubs.
 """
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
@@ -33,6 +33,11 @@ PersonaVisualStarterComplexityTier = Literal["basic", "intermediate", "intricate
 PersonaVisualStarterProductionStatus = Literal["scaffold", "art_ready"]
 PersonaVisualCandidateStatus = Literal["review", "accepted", "rejected", "failed"]
 PersonaVisualCandidateReviewStatus = Literal["accepted", "rejected", "failed"]
+PersonaVisualStarterRecipeText = Annotated[str, Field(min_length=1, max_length=320)]
+PersonaVisualStarterRecipeItems = Annotated[
+    list[PersonaVisualStarterRecipeText],
+    Field(min_length=1, max_length=12),
+]
 PersonaVisualPortabilityOperation = Literal["export", "import_preview", "import_commit"]
 PersonaSetupEventType = Literal[
     "setup_started",
@@ -293,11 +298,18 @@ class PersonaVisualStarterAssetResponse(BaseModel):
 
 
 class PersonaVisualStarterProductionRecipeResponse(BaseModel):
-    identity_brief: str
-    neutral_anchor: str
-    static_sheet: str
-    animation_outputs: list[str] = Field(default_factory=list)
-    review_checks: list[str] = Field(default_factory=list)
+    identity_brief: PersonaVisualStarterRecipeText
+    neutral_anchor: PersonaVisualStarterRecipeText
+    static_sheet: PersonaVisualStarterRecipeText
+    animation_outputs: PersonaVisualStarterRecipeItems
+    review_checks: PersonaVisualStarterRecipeItems
+
+    @field_validator("review_checks")
+    @classmethod
+    def validate_review_checks(cls, value: list[str]) -> list[str]:
+        if "neutral_identity_consistency" not in value:
+            raise ValueError("review_checks must include neutral_identity_consistency")
+        return value
 
 
 class PersonaVisualStarterPackResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -292,6 +292,14 @@ class PersonaVisualStarterAssetResponse(BaseModel):
     byte_size: int
 
 
+class PersonaVisualStarterProductionRecipeResponse(BaseModel):
+    identity_brief: str
+    neutral_anchor: str
+    static_sheet: str
+    animation_outputs: list[str] = Field(default_factory=list)
+    review_checks: list[str] = Field(default_factory=list)
+
+
 class PersonaVisualStarterPackResponse(BaseModel):
     id: str
     title: str
@@ -308,6 +316,7 @@ class PersonaVisualStarterPackResponse(BaseModel):
     neutral_anchor_required: bool = True
     expected_asset_groups: list[str] = Field(default_factory=list)
     animation_coverage_notes: list[str] = Field(default_factory=list)
+    production_recipe: PersonaVisualStarterProductionRecipeResponse
 
 
 class PersonaVisualStarterPackDetailResponse(PersonaVisualStarterPackResponse):

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -31,6 +31,7 @@ from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
     DEFAULT_PERSONA_VISUAL_STARTER_PACKS,
     LEGACY_PERSONA_VISUAL_STARTER_PACK_ID,
     PersonaVisualStarterPack,
+    PersonaVisualStarterProductionRecipe,
 )
 from tldw_Server_API.app.core.Persona.visuals import (
     PersonaVisualManifestError,
@@ -52,6 +53,8 @@ _ALLOWED_STARTER_RESPONSE_ASSET_ROLES = frozenset(
 )
 _ALLOWED_STARTER_COMPLEXITY_TIERS = frozenset({"basic", "intermediate", "intricate"})
 _ALLOWED_STARTER_PRODUCTION_STATUSES = frozenset({"scaffold", "art_ready"})
+_MAX_STARTER_RECIPE_TEXT_LENGTH = 320
+_MAX_STARTER_RECIPE_ITEMS = 12
 
 
 class PersonaVisualStarterCatalogError(Exception):
@@ -315,6 +318,10 @@ class PersonaVisualStarterCatalogService:
             field_name="neutral_anchor_required",
             starter_id=starter.id,
         )
+        production_recipe = PersonaVisualStarterCatalogService._starter_production_recipe(
+            starter.production_recipe,
+            starter_id=starter.id,
+        )
         return {
             "id": starter.id,
             "title": starter.title,
@@ -331,6 +338,7 @@ class PersonaVisualStarterCatalogService:
             "neutral_anchor_required": neutral_anchor_required,
             "expected_asset_groups": list(expected_asset_groups),
             "animation_coverage_notes": list(animation_coverage_notes),
+            "production_recipe": production_recipe,
         }
 
     @staticmethod
@@ -419,6 +427,10 @@ class PersonaVisualStarterCatalogService:
                 "Bundled starter animation coverage notes are required.",
                 details={"starter_pack_id": starter.id},
             )
+        PersonaVisualStarterCatalogService._starter_production_recipe(
+            starter.production_recipe,
+            starter_id=starter.id,
+        )
 
         asset_keys: set[str] = set()
         for asset in starter.assets:
@@ -538,6 +550,105 @@ class PersonaVisualStarterCatalogService:
                 )
             items.append(normalized)
         return tuple(items)
+
+    @staticmethod
+    def _starter_production_recipe(
+        value: object,
+        *,
+        starter_id: str,
+    ) -> dict[str, Any]:
+        """Return validated starter production-recipe metadata for API output."""
+        if not isinstance(value, PersonaVisualStarterProductionRecipe):
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production_recipe must be immutable recipe metadata.",
+                details={"starter_pack_id": starter_id, "field_name": "production_recipe"},
+            )
+
+        identity_brief = PersonaVisualStarterCatalogService._starter_recipe_text(
+            value.identity_brief,
+            field_name="production_recipe.identity_brief",
+            starter_id=starter_id,
+        )
+        neutral_anchor = PersonaVisualStarterCatalogService._starter_recipe_text(
+            value.neutral_anchor,
+            field_name="production_recipe.neutral_anchor",
+            starter_id=starter_id,
+        )
+        static_sheet = PersonaVisualStarterCatalogService._starter_recipe_text(
+            value.static_sheet,
+            field_name="production_recipe.static_sheet",
+            starter_id=starter_id,
+        )
+        animation_outputs = PersonaVisualStarterCatalogService._starter_recipe_tuple(
+            value.animation_outputs,
+            field_name="production_recipe.animation_outputs",
+            starter_id=starter_id,
+        )
+        review_checks = PersonaVisualStarterCatalogService._starter_recipe_tuple(
+            value.review_checks,
+            field_name="production_recipe.review_checks",
+            starter_id=starter_id,
+        )
+        if "neutral_identity_consistency" not in review_checks:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production recipe must review neutral identity consistency.",
+                details={
+                    "starter_pack_id": starter_id,
+                    "field_name": "production_recipe.review_checks",
+                },
+            )
+        return {
+            "identity_brief": identity_brief,
+            "neutral_anchor": neutral_anchor,
+            "static_sheet": static_sheet,
+            "animation_outputs": list(animation_outputs),
+            "review_checks": list(review_checks),
+        }
+
+    @staticmethod
+    def _starter_recipe_text(value: object, *, field_name: str, starter_id: str) -> str:
+        """Return bounded production-recipe text or fail fixture validation."""
+        text = PersonaVisualStarterCatalogService._starter_metadata_text(
+            value,
+            field_name=field_name,
+            starter_id=starter_id,
+        )
+        if len(text) > _MAX_STARTER_RECIPE_TEXT_LENGTH:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production recipe text is too long.",
+                details={"starter_pack_id": starter_id, "field_name": field_name},
+            )
+        return text
+
+    @staticmethod
+    def _starter_recipe_tuple(
+        value: object,
+        *,
+        field_name: str,
+        starter_id: str,
+    ) -> tuple[str, ...]:
+        """Return bounded production-recipe entries or fail fixture validation."""
+        items = PersonaVisualStarterCatalogService._starter_metadata_tuple(
+            value,
+            field_name=field_name,
+            starter_id=starter_id,
+        )
+        if not items or len(items) > _MAX_STARTER_RECIPE_ITEMS:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production recipe entries must be bounded and non-empty.",
+                details={"starter_pack_id": starter_id, "field_name": field_name},
+            )
+        if any(len(item) > _MAX_STARTER_RECIPE_TEXT_LENGTH for item in items):
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production recipe entry text is too long.",
+                details={"starter_pack_id": starter_id, "field_name": field_name},
+            )
+        return items
 
     def _cleanup_partial_pack(
         self,

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -65,6 +65,53 @@ _INTRICATE_ANIMATION_NOTES = (
     "Scaffold fixture only: final intricate art should compile reviewed "
     "neutral-anchor-derived strips or atlas regions into runtime animations.",
 )
+_RECIPE_REVIEW_CHECKS = (
+    "neutral_identity_consistency",
+    "transparent_background",
+    "one_subject_per_frame",
+    "state_manifest_alignment",
+)
+
+
+@dataclass(frozen=True)
+class PersonaVisualStarterProductionRecipe:
+    """Authored-asset handoff recipe for one bundled starter scaffold."""
+
+    identity_brief: str
+    neutral_anchor: str
+    static_sheet: str
+    animation_outputs: tuple[str, ...]
+    review_checks: tuple[str, ...] = _RECIPE_REVIEW_CHECKS
+
+
+def _production_recipe(
+    *,
+    identity_brief: str,
+    neutral_anchor: str,
+    static_sheet: str,
+    animation_outputs: tuple[str, ...],
+    review_checks: tuple[str, ...] = _RECIPE_REVIEW_CHECKS,
+) -> PersonaVisualStarterProductionRecipe:
+    """Create one immutable starter production-recipe metadata block."""
+    return PersonaVisualStarterProductionRecipe(
+        identity_brief=identity_brief,
+        neutral_anchor=neutral_anchor,
+        static_sheet=static_sheet,
+        animation_outputs=animation_outputs,
+        review_checks=review_checks,
+    )
+
+
+def _default_basic_production_recipe() -> PersonaVisualStarterProductionRecipe:
+    """Return the default low-complexity starter production recipe."""
+    return _production_recipe(
+        identity_brief="Simple readable buddy with one strong silhouette and limited props.",
+        neutral_anchor="Create one front-facing neutral pose used as the identity anchor.",
+        static_sheet=(
+            "Optional small mouth or expression sheet; keep it separate from timed loops."
+        ),
+        animation_outputs=("required_state_loops",),
+    )
 
 
 @dataclass(frozen=True)
@@ -95,6 +142,9 @@ class PersonaVisualStarterPack:
     neutral_anchor_required: bool = True
     expected_asset_groups: tuple[str, ...] = _BASIC_EXPECTED_ASSET_GROUPS
     animation_coverage_notes: tuple[str, ...] = _BASIC_ANIMATION_NOTES
+    production_recipe: PersonaVisualStarterProductionRecipe = field(
+        default_factory=_default_basic_production_recipe
+    )
 
 
 def _png_chunk(kind: bytes, payload: bytes) -> bytes:
@@ -288,6 +338,17 @@ def _basic_pack(
         neutral_anchor_required=True,
         expected_asset_groups=_BASIC_EXPECTED_ASSET_GROUPS,
         animation_coverage_notes=_BASIC_ANIMATION_NOTES,
+        production_recipe=_production_recipe(
+            identity_brief=description,
+            neutral_anchor=(
+                "Author one clean neutral pose that preserves the starter silhouette."
+            ),
+            static_sheet=(
+                "Create a tiny optional expression sheet for speaking or reactions; "
+                "do not treat the sheet as animation unless cells are mapped as frames."
+            ),
+            animation_outputs=("required_state_loops",),
+        ),
     )
 
 
@@ -356,6 +417,31 @@ def _multi_asset_pack(
             if complexity_tier == "intricate"
             else _INTERMEDIATE_ANIMATION_NOTES
         ),
+        production_recipe=_production_recipe(
+            identity_brief=description,
+            neutral_anchor=(
+                "Author a neutral model sheet or pose set before generating state frames."
+            ),
+            static_sheet=(
+                "Create a static talking/reaction sheet for mouth, face, and small pose "
+                "changes before compiling timed animation loops."
+            ),
+            animation_outputs=(
+                (
+                    "required_state_loops",
+                    "static_talking_reaction_sheet",
+                    "animation_strips",
+                    "animation_atlas",
+                    "custom_state_variants",
+                )
+                if complexity_tier == "intricate"
+                else (
+                    "required_state_loops",
+                    "static_talking_reaction_sheet",
+                    "custom_state_variants",
+                )
+            ),
+        ),
     )
 
 
@@ -392,6 +478,23 @@ def _atlas_pack(
         neutral_anchor_required=True,
         expected_asset_groups=_INTRICATE_EXPECTED_ASSET_GROUPS,
         animation_coverage_notes=_INTRICATE_ANIMATION_NOTES,
+        production_recipe=_production_recipe(
+            identity_brief=description,
+            neutral_anchor=(
+                "Author a full neutral model sheet before generating atlas-backed loops."
+            ),
+            static_sheet=(
+                "Create a separate talking/reaction sheet for expression choices before "
+                "compiling timed atlas regions."
+            ),
+            animation_outputs=(
+                "required_state_loops",
+                "static_talking_reaction_sheet",
+                "animation_strips",
+                "animation_atlas",
+                "custom_state_variants",
+            ),
+        ),
     )
 
 
@@ -585,4 +688,5 @@ __all__ = [
     "LEGACY_PERSONA_VISUAL_STARTER_PACK_ID",
     "PersonaVisualStarterAsset",
     "PersonaVisualStarterPack",
+    "PersonaVisualStarterProductionRecipe",
 ]

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -8,7 +8,9 @@ from typing import Any
 
 import pytest
 from PIL import Image
+from pydantic import ValidationError
 
+from tldw_Server_API.app.api.v1.schemas.persona import PersonaVisualStarterProductionRecipeResponse
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
@@ -71,6 +73,16 @@ def _assert_recipe_shape(recipe: dict[str, Any], *, expected_output: str) -> Non
     assert recipe["static_sheet"].strip()
     assert expected_output in recipe["animation_outputs"]
     assert "neutral_identity_consistency" in recipe["review_checks"]
+
+
+def _valid_recipe_payload() -> dict[str, object]:
+    return {
+        "identity_brief": "Keep the starter identity consistent.",
+        "neutral_anchor": "Start from a neutral front-facing anchor.",
+        "static_sheet": "Author the required static sheet.",
+        "animation_outputs": ["required_state_loops"],
+        "review_checks": ["neutral_identity_consistency"],
+    }
 
 
 @pytest.fixture()
@@ -230,6 +242,25 @@ def test_list_starter_packs_rejects_malformed_production_metadata(
 
     assert exc_info.value.code == "invalid_starter_fixture"
     assert exc_info.value.details["starter_pack_id"] == malformed.id
+
+
+@pytest.mark.parametrize(
+    "patch",
+    (
+        {"identity_brief": ""},
+        {"neutral_anchor": "x" * 321},
+        {"animation_outputs": []},
+        {"animation_outputs": ["required_state_loops"] * 13},
+        {"animation_outputs": ["x" * 321]},
+        {"review_checks": ["transparent_background"]},
+    ),
+)
+def test_production_recipe_response_enforces_catalog_bounds(patch: dict[str, object]) -> None:
+    payload = _valid_recipe_payload()
+    payload.update(patch)
+
+    with pytest.raises(ValidationError):
+        PersonaVisualStarterProductionRecipeResponse.model_validate(payload)
 
 
 def test_get_starter_pack_accepts_legacy_research_buddy_alias(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -25,6 +25,7 @@ from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
     LEGACY_PERSONA_VISUAL_STARTER_PACK_ID,
     PersonaVisualStarterAsset,
     PersonaVisualStarterPack,
+    PersonaVisualStarterProductionRecipe,
 )
 
 
@@ -52,6 +53,24 @@ def _state_frame_asset_id(manifest: dict[str, Any], state: str) -> str:
     animation_id = manifest["states"][state]["animation_id"]
     frame = manifest["animations"][animation_id]["frames"][0]
     return str(frame["asset_id"])
+
+
+def _assert_recipe_shape(recipe: dict[str, Any], *, expected_output: str) -> None:
+    assert set(recipe) == {
+        "identity_brief",
+        "neutral_anchor",
+        "static_sheet",
+        "animation_outputs",
+        "review_checks",
+    }
+    assert isinstance(recipe["identity_brief"], str)
+    assert recipe["identity_brief"].strip()
+    assert isinstance(recipe["neutral_anchor"], str)
+    assert "neutral" in recipe["neutral_anchor"].lower()
+    assert isinstance(recipe["static_sheet"], str)
+    assert recipe["static_sheet"].strip()
+    assert expected_output in recipe["animation_outputs"]
+    assert "neutral_identity_consistency" in recipe["review_checks"]
 
 
 @pytest.fixture()
@@ -115,6 +134,7 @@ def test_starter_catalog_lists_bundled_scaffold_packs(
     assert all(starter["neutral_anchor_required"] for starter in starters)
     assert all("neutral_anchor" in starter["expected_asset_groups"] for starter in starters)
     assert all(starter["animation_coverage_notes"] for starter in starters)
+    assert all(starter["production_recipe"] for starter in starters)
 
 
 def test_get_starter_pack_returns_isolated_manifest_preview(
@@ -124,11 +144,13 @@ def test_get_starter_pack_returns_isolated_manifest_preview(
     first = service.get_starter_pack(DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID)
     first["manifest"]["states"]["idle"]["animation_id"] = "mutated"
     first["expected_asset_groups"].append("mutated")
+    first["production_recipe"]["animation_outputs"].append("mutated")
 
     second = service.get_starter_pack(DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID)
 
     assert second["manifest"]["states"]["idle"]["animation_id"] == "idle-loop"
     assert "mutated" not in second["expected_asset_groups"]
+    assert "mutated" not in second["production_recipe"]["animation_outputs"]
 
 
 @pytest.mark.parametrize(
@@ -154,6 +176,7 @@ def test_starter_pack_reports_production_readiness_metadata(
     assert detail["neutral_anchor_required"] is True
     assert required_group in detail["expected_asset_groups"]
     assert all("scaffold" in note.lower() for note in detail["animation_coverage_notes"])
+    _assert_recipe_shape(detail["production_recipe"], expected_output=required_group)
 
 
 @pytest.mark.parametrize(
@@ -169,6 +192,26 @@ def test_starter_pack_reports_production_readiness_metadata(
         ("animation_coverage_notes", ("Scaffold fixture only.", "")),
         ("neutral_anchor_required", "false"),
         ("neutral_anchor_required", 1),
+        ("production_recipe", {"identity_brief": "not immutable"}),
+        (
+            "production_recipe",
+            PersonaVisualStarterProductionRecipe(
+                identity_brief="Identity",
+                neutral_anchor="Neutral anchor",
+                static_sheet="Static sheet",
+                animation_outputs=(),
+            ),
+        ),
+        (
+            "production_recipe",
+            PersonaVisualStarterProductionRecipe(
+                identity_brief="Identity",
+                neutral_anchor="Neutral anchor",
+                static_sheet="Static sheet",
+                animation_outputs=("required_state_loops",),
+                review_checks=("transparent_background",),
+            ),
+        ),
     ),
 )
 def test_list_starter_packs_rejects_malformed_production_metadata(

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -202,6 +202,10 @@ def test_get_persona_visual_starter_pack_detail(persona_db: CharactersRAGDB) -> 
     assert payload["neutral_anchor_required"] is True
     assert "neutral_anchor" in payload["expected_asset_groups"]
     assert payload["animation_coverage_notes"]
+    assert payload["production_recipe"]["identity_brief"]
+    assert "neutral" in payload["production_recipe"]["neutral_anchor"].lower()
+    assert "required_state_loops" in payload["production_recipe"]["animation_outputs"]
+    assert "neutral_identity_consistency" in payload["production_recipe"]["review_checks"]
     assert payload["assets"][0]["mime_type"] == "image/png"
 
 
@@ -379,6 +383,8 @@ def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
     assert starter["complexity_tier"] == "basic"
     assert starter["neutral_anchor_required"] is True
     assert "neutral_anchor" in starter["expected_asset_groups"]
+    assert starter["production_recipe"]["identity_brief"]
+    assert "required_state_loops" in starter["production_recipe"]["animation_outputs"]
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
         set(starter["states_offered"])
     )


### PR DESCRIPTION
Closes #1760

## Summary
- Add immutable production recipe metadata for each bundled Persona Visual starter scaffold.
- Expose the recipe through starter catalog service/API responses and validate it as bounded immutable fixture metadata.
- Document recipes as the neutral-anchor-first authored-asset handoff, not finished art or runtime renderer support.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/api/v1/schemas/persona.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_visual_production_recipes_1760_rebase.json`
- [x] `git diff --check origin/dev...HEAD`

## Change summary
Human-written summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds immutable production recipes to all Persona Visual starter packs and exposes them in the catalog and API. Tightens the API schema to enforce bounded recipe text/items and require the neutral-identity review check. Closes #1760.

- New Features
  - Bundled fixtures include a `production_recipe` with `identity_brief`, `neutral_anchor`, `static_sheet`, `animation_outputs`, and `review_checks`; outputs are tiered: basic (`required_state_loops`), intermediate (+`static_talking_reaction_sheet`, `custom_state_variants`), intricate (+`animation_strips`, `animation_atlas`).
  - Catalog service validates and returns the recipe; enforces bounded text/item limits and requires `neutral_identity_consistency`.
  - API schema exposes `production_recipe` on starter list/detail and validates it (text 1–320 chars, items 1–12, and `review_checks` must include `neutral_identity_consistency`).
  - Docs clarify recipes are authored-asset handoff metadata, not finished art or renderer support.
  - Tests cover catalog and schema validation, immutability, and unchanged copy-to-draft flow.

<sup>Written for commit 59e62d2bf470f1e69e2b0e32131a427b374989b4. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1762?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

