### PR TITLE
Implement llama.cpp asset inventory v2

### DIFF
--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -252,7 +252,7 @@ git commit -m "Add llama.cpp asset inventory schema contract"
 - Modify: `tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py`
 - Test: `tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py`
 
-- [ ] **Step 1: Write failing asset discovery tests**
+- [x] **Step 1: Write failing asset discovery tests**
 
 Append:
 
@@ -305,7 +305,7 @@ def test_scan_assets_reports_stale_imported_folder_without_failing(monkeypatch, 
     assert any("missing" in warning.lower() for warning in folder.warnings)
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run:
 
@@ -317,7 +317,7 @@ Run:
 
 Expected: FAIL because `scan_assets` does not exist.
 
-- [ ] **Step 3: Implement asset scanning helpers**
+- [x] **Step 3: Implement asset scanning helpers**
 
 In `llamacpp_inventory_service.py`:
 
@@ -341,7 +341,7 @@ Implementation notes:
 - keep de-duplication by `asset_id`;
 - return assets sorted by source, kind, display name, and path for stable UI/tests.
 
-- [ ] **Step 4: Run tests to verify pass**
+- [x] **Step 4: Run tests to verify pass**
 
 Run:
 
@@ -352,7 +352,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Run legacy inventory tests**
+- [x] **Step 5: Run legacy inventory tests**
 
 Run:
 
@@ -364,7 +364,7 @@ Run:
 
 Expected: PASS. If these fail because legacy inventory changed shape, fix the adapter instead of changing the tests.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py \

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -967,7 +967,7 @@ git commit -m "Wire llama.cpp assets into admin page"
 - All touched files.
 - Backlog task for the implementation slice.
 
-- [ ] **Step 1: Run backend tests**
+- [x] **Step 1: Run backend tests**
 
 Run:
 
@@ -980,7 +980,9 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 2: Run frontend tests**
+Verification note: passed with 32 tests, 5 warnings.
+
+- [x] **Step 2: Run frontend tests**
 
 Run:
 
@@ -992,7 +994,9 @@ bunx vitest run apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppA
 
 Expected: PASS.
 
-- [ ] **Step 3: Run Bandit on touched Python scope**
+Verification note: `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppInventoryPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx` passed from `apps/packages/ui` with 3 test files and 20 tests.
+
+- [x] **Step 3: Run Bandit on touched Python scope**
 
 Run:
 
@@ -1006,7 +1010,9 @@ Run:
 
 Expected: PASS with no new findings in touched code. If Bandit reports existing baseline issues outside the changed lines, document them separately and do not hide new issues.
 
-- [ ] **Step 4: Run whitespace check**
+Verification note: Bandit wrote `/tmp/bandit_llamacpp_asset_inventory_v2.json` with 0 results.
+
+- [x] **Step 4: Run whitespace check**
 
 Run:
 
@@ -1016,7 +1022,9 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 5: Update Backlog task**
+Verification note: `git diff --check` produced no output.
+
+- [x] **Step 5: Update Backlog task**
 
 Update the implementation task with:
 
@@ -1026,7 +1034,7 @@ Update the implementation task with:
 - known skips or blockers;
 - PR link if one is opened.
 
-- [ ] **Step 6: Final commit**
+- [x] **Step 6: Final commit**
 
 If any verification/backlog edits remain:
 

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -379,7 +379,7 @@ git commit -m "Add llama.cpp local asset discovery"
 - Modify: `tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py`
 - Test: `tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py`
 
-- [ ] **Step 1: Write failing pairing tests**
+- [x] **Step 1: Write failing pairing tests**
 
 Append:
 
@@ -409,7 +409,7 @@ def test_scan_assets_adds_inferred_mmproj_candidates_with_warnings(monkeypatch, 
     assert any("inferred" in warning.lower() for warning in base_asset.warnings)
 ```
 
-- [ ] **Step 2: Run test to verify failure**
+- [x] **Step 2: Run test to verify failure**
 
 Run:
 
@@ -420,7 +420,7 @@ Run:
 
 Expected: FAIL because candidate pairing is not populated.
 
-- [ ] **Step 3: Implement conservative pairing**
+- [x] **Step 3: Implement conservative pairing**
 
 Add a helper such as `_attach_mmproj_candidates(assets: list[LlamaCppAsset]) -> None`.
 
@@ -433,7 +433,7 @@ Rules:
 - Never remove or hide assets because pairing is ambiguous.
 - Never auto-populate profile `mmproj_model_id` from candidate metadata.
 
-- [ ] **Step 4: Run pairing and service tests**
+- [x] **Step 4: Run pairing and service tests**
 
 Run:
 
@@ -444,7 +444,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py \

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -460,7 +460,7 @@ git commit -m "Infer llama.cpp mmproj asset candidates"
 - Modify: `tldw_Server_API/app/api/v1/endpoints/llamacpp.py`
 - Modify: `tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py`
 
-- [ ] **Step 1: Write failing API tests**
+- [x] **Step 1: Write failing API tests**
 
 Append tests to `test_llamacpp_inventory_api.py`:
 
@@ -515,7 +515,7 @@ def test_import_folder_persists_allowlisted_folder_and_returns_folder_asset(monk
     assert updates[-1]["LlamaCpp"]["imported_asset_folders"] == str(imported)
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run:
 
@@ -527,7 +527,7 @@ Run:
 
 Expected: FAIL because routes/service methods do not exist.
 
-- [ ] **Step 3: Add service mutation methods**
+- [x] **Step 3: Add service mutation methods**
 
 In `llamacpp_inventory_service.py`:
 
@@ -541,7 +541,7 @@ In `llamacpp_inventory_service.py`:
 - persist folders to `imported_asset_folders`;
 - preserve existing registered paths/folders by stable ID and unresolved-path fallback.
 
-- [ ] **Step 4: Add endpoints**
+- [x] **Step 4: Add endpoints**
 
 In `llamacpp.py`, add routes near the legacy inventory routes:
 
@@ -561,7 +561,7 @@ async def get_llamacpp_assets_endpoint(
 
 Add `POST /llamacpp/assets/register-path` and `POST /llamacpp/assets/import-folder` with `ServerError` mapped to HTTP 400 and `from e` exception chaining.
 
-- [ ] **Step 5: Run API tests**
+- [x] **Step 5: Run API tests**
 
 Run:
 
@@ -572,7 +572,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py \

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -686,7 +686,7 @@ git commit -m "Preserve llama.cpp legacy inventory compatibility"
 - Modify: `apps/packages/ui/src/services/tldw/domains/models-audio.ts`
 - Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
 
-- [ ] **Step 1: Write failing type/client tests if a client test harness exists**
+- [x] **Step 1: Write failing type/client tests if a client test harness exists**
 
 Search first:
 
@@ -702,7 +702,9 @@ If an existing service test harness covers `models-audio`, add tests for:
 
 If no matching harness exists, document the skip in the commit body and rely on component/Admin page tests in Tasks 7 and 8.
 
-- [ ] **Step 2: Add TypeScript asset types**
+Implementation note: no dedicated `models-audio` service test harness exists; coverage for the new methods is deferred to the component/Admin tests in Tasks 7 and 8.
+
+- [x] **Step 2: Add TypeScript asset types**
 
 Add:
 
@@ -741,7 +743,7 @@ export interface LlamacppAssetsResponse {
 }
 ```
 
-- [ ] **Step 3: Add API methods**
+- [x] **Step 3: Add API methods**
 
 Add methods to the domain client and mirrored client:
 
@@ -759,7 +761,9 @@ bunx tsc --noEmit --pretty false
 
 Expected: PASS or known repo-wide baseline failures unrelated to touched files. If repo-wide failures occur, run the narrow touched-path TypeScript check used in this repo's design-system slices and document the baseline separately.
 
-- [ ] **Step 5: Commit**
+Implementation note: `bunx tsc --noEmit --pretty false` was attempted, but Bun could not write to its temp directory inside the sandbox. The required escalated rerun was rejected by the approval reviewer, and retrying with `TMPDIR=/private/tmp` failed with the same tempdir access error. Frontend behavioral validation continues through Vitest in Tasks 7 and 8.
+
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/packages/ui/src/types/llamacpp-admin.ts \

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -903,7 +903,7 @@ git commit -m "Add llama.cpp assets panel"
 - Modify: `apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx`
 - Modify: `apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx`
 
-- [ ] **Step 1: Write failing Admin page tests**
+- [x] **Step 1: Write failing Admin page tests**
 
 Add tests for:
 
@@ -912,7 +912,7 @@ Add tests for:
 - import folder calls the folder endpoint and reloads assets;
 - asset endpoint failure is shown without hiding the legacy inventory panel.
 
-- [ ] **Step 2: Run selected Admin page tests**
+- [x] **Step 2: Run selected Admin page tests**
 
 Run:
 
@@ -922,7 +922,9 @@ bunx vitest run apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppA
 
 Expected: FAIL because Admin page does not yet load/render assets.
 
-- [ ] **Step 3: Integrate asset state**
+Verification note: `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx` failed with 5 expected asset-integration failures before implementation.
+
+- [x] **Step 3: Integrate asset state**
 
 In `LlamacppAdminPage.tsx`:
 
@@ -937,7 +939,7 @@ In `LlamacppAdminPage.tsx`:
 - render `<LlamacppAssetsPanel />` near the existing inventory panel;
 - keep the existing `LlamacppInventoryPanel` and launch flow intact.
 
-- [ ] **Step 4: Run Admin tests**
+- [x] **Step 4: Run Admin tests**
 
 Run:
 
@@ -948,7 +950,9 @@ bunx vitest run apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppA
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+Verification note: `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx` passed from `apps/packages/ui`.
+
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx \

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -588,7 +588,7 @@ git commit -m "Add llama.cpp asset inventory APIs"
 - Modify: `tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py`
 - Modify: `tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py`
 
-- [ ] **Step 1: Write failing regression tests**
+- [x] **Step 1: Write failing regression tests**
 
 Append:
 
@@ -631,7 +631,7 @@ def test_resolve_model_id_rejects_mmproj_asset_id(monkeypatch, tmp_path: Path):
         llamacpp_inventory_service.resolve_model_id(llamacpp_inventory_service.asset_id_for_path(projector, "mmproj"))
 ```
 
-- [ ] **Step 2: Run tests to verify current behavior**
+- [x] **Step 2: Run tests to verify current behavior**
 
 Run:
 
@@ -647,6 +647,8 @@ Expected: FAIL only if the adapter has not been corrected yet. If they already p
 
 Update `scan_inventory()` so it can call `scan_assets()` internally, filter `kind == "gguf"`, and convert to `LlamaCppInventoryItem`.
 
+Implementation note: no production adapter change was made in this step because the regression tests passed with the current legacy scanner, and adapting it directly through `scan_assets()` would risk dropping existing non-GGUF registered-path warning entries that legacy tests still protect.
+
 Keep:
 
 - `model_id_for_path(path)` returning `gguf:<hash>`;
@@ -655,7 +657,7 @@ Keep:
 - `scan_limited` behavior;
 - `resolve_model_id()` resolving only available GGUF files.
 
-- [ ] **Step 4: Run focused backend tests**
+- [x] **Step 4: Run focused backend tests**
 
 Run:
 
@@ -668,7 +670,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py \

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -152,7 +152,7 @@ If Python 3.10 compatibility rejects dynamic `Literal` usage during tests, repla
 - Modify: `tldw_Server_API/app/core/Local_LLM/llamacpp_config_service.py`
 - Test: `tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py`
 
-- [ ] **Step 1: Write failing schema/config tests**
+- [x] **Step 1: Write failing schema/config tests**
 
 Create `tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py` with:
 
@@ -199,7 +199,7 @@ def test_config_state_reads_imported_asset_folders(monkeypatch, tmp_path: Path):
     assert state["saved_config"]["imported_asset_folders"] == [str(imported)]
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run:
 
@@ -210,7 +210,7 @@ Run:
 
 Expected: FAIL because `imported_asset_folders` is not parsed yet.
 
-- [ ] **Step 3: Add schemas and saved config field**
+- [x] **Step 3: Add schemas and saved config field**
 
 In `llamacpp_admin_schemas.py`:
 
@@ -225,7 +225,7 @@ In `llamacpp_config_service.py`:
 - do not add it to `RESTART_FIELDS`; registering a folder changes inventory, not an active process;
 - do not add an environment override in this slice unless existing config docs already define one.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run:
 
@@ -236,7 +236,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py \

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
@@ -779,7 +779,7 @@ git commit -m "Add llama.cpp asset API client types"
 - Create: `apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx`
 - Create: `apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx`
 
-- [ ] **Step 1: Write failing component tests**
+- [x] **Step 1: Write failing component tests**
 
 Create tests that render:
 
@@ -849,7 +849,7 @@ it("renders asset groups warnings and inferred projector candidates", async () =
 })
 ```
 
-- [ ] **Step 2: Run test to verify failure**
+- [x] **Step 2: Run test to verify failure**
 
 Run:
 
@@ -859,7 +859,9 @@ bunx vitest run apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppA
 
 Expected: FAIL because component does not exist.
 
-- [ ] **Step 3: Implement minimal panel**
+Verification note: `bunx vitest run packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx` from `apps/` failed red because `../LlamacppAssetsPanel` did not exist. Earlier root/package attempts exposed missing worktree dependency links; `bun install` in `apps/` repaired local test dependencies, and the unrelated tracked dependency-link pruning was restored before continuing.
+
+- [x] **Step 3: Implement minimal panel**
 
 Use existing local conventions from `LlamacppInventoryPanel.tsx`:
 
@@ -874,7 +876,7 @@ Use existing local conventions from `LlamacppInventoryPanel.tsx`:
 - show candidate IDs as labels, not as automatic "paired" state;
 - keep text compact and avoid redesigning the whole Admin page.
 
-- [ ] **Step 4: Run panel tests**
+- [x] **Step 4: Run panel tests**
 
 Run:
 
@@ -884,7 +886,9 @@ bunx vitest run apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppA
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+Verification note: `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx` passed from `apps/packages/ui`.
+
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx \

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
@@ -5,6 +5,7 @@ import { PageShell } from "@/components/Common/PageShell"
 import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import type {
+  LlamacppAssetsResponse,
   LlamacppConfigResponse,
   LlamacppHardwareSnapshotResponse,
   LlamacppInventoryResponse,
@@ -22,6 +23,7 @@ import {
   sanitizeAdminErrorMessage,
   type AdminGuardState
 } from "./admin-error-utils"
+import { LlamacppAssetsPanel } from "./LlamacppAssetsPanel"
 import { LlamacppInventoryPanel } from "./LlamacppInventoryPanel"
 import { LlamacppLaunchPanel } from "./LlamacppLaunchPanel"
 import { LlamacppReadinessPanel } from "./LlamacppReadinessPanel"
@@ -119,6 +121,7 @@ export const LlamacppAdminPage: React.FC = () => {
   const [config, setConfig] = React.useState<LlamacppConfigResponse | null>(null)
   const [status, setStatus] = React.useState<LlamacppStatus | null>(null)
   const [inventory, setInventory] = React.useState<LlamacppInventoryResponse | null>(null)
+  const [assets, setAssets] = React.useState<LlamacppAssetsResponse | null>(null)
   const [hardware, setHardware] = React.useState<LlamacppHardwareSnapshotResponse | null>(null)
   const [runtimeProfiles, setRuntimeProfiles] = React.useState<LlamacppProfile[]>([])
   const [runtimeInstances, setRuntimeInstances] = React.useState<LlamacppRuntime[]>([])
@@ -126,11 +129,15 @@ export const LlamacppAdminPage: React.FC = () => {
   const [loadingConfig, setLoadingConfig] = React.useState(false)
   const [loadingStatus, setLoadingStatus] = React.useState(false)
   const [loadingInventory, setLoadingInventory] = React.useState(true)
+  const [loadingAssets, setLoadingAssets] = React.useState(true)
   const [loadingRuntimes, setLoadingRuntimes] = React.useState(true)
   const [registeringPath, setRegisteringPath] = React.useState(false)
+  const [registeringAssetPath, setRegisteringAssetPath] = React.useState(false)
+  const [importingAssetFolder, setImportingAssetFolder] = React.useState(false)
 
   const [statusError, setStatusError] = React.useState<string | null>(null)
   const [inventoryError, setInventoryError] = React.useState<string | null>(null)
+  const [assetError, setAssetError] = React.useState<string | null>(null)
   const [runtimeError, setRuntimeError] = React.useState<string | null>(null)
   const [runtimeUnsupported, setRuntimeUnsupported] = React.useState(false)
   const [adminGuard, setAdminGuard] = React.useState<AdminGuardState>(null)
@@ -208,6 +215,22 @@ export const LlamacppAdminPage: React.FC = () => {
     }
   }, [markAdminGuardFromError])
 
+  const loadAssets = React.useCallback(async () => {
+    try {
+      setLoadingAssets(true)
+      setAssetError(null)
+      const data = await tldwClient.getLlamacppAssets()
+      setAssets(data)
+    } catch (error: unknown) {
+      setAssets(null)
+      setAssetError(
+        sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp assets.")
+      )
+    } finally {
+      setLoadingAssets(false)
+    }
+  }, [])
+
   const loadHardware = React.useCallback(async () => {
     try {
       const data = await tldwClient.getLlamacppHardware()
@@ -263,10 +286,18 @@ export const LlamacppAdminPage: React.FC = () => {
       loadConfig(),
       loadStatus(),
       loadInventory(),
+      loadAssets(),
       loadHardware(),
       loadRuntimePlane()
     ])
-  }, [loadConfig, loadHardware, loadInventory, loadRuntimePlane, loadStatus])
+  }, [
+    loadAssets,
+    loadConfig,
+    loadHardware,
+    loadInventory,
+    loadRuntimePlane,
+    loadStatus
+  ])
 
   const effectiveState =
     status?.state || status?.status || status?.backend || "unknown"
@@ -309,6 +340,43 @@ export const LlamacppAdminPage: React.FC = () => {
       return false
     } finally {
       setRegisteringPath(false)
+    }
+  }
+
+  const handleRegisterAssetPath = async (path: string): Promise<boolean> => {
+    try {
+      setRegisteringAssetPath(true)
+      setAssetError(null)
+      const asset = await tldwClient.registerLlamacppAssetPath(path)
+      await loadAssets()
+      if (asset.kind === "gguf") {
+        await loadInventory()
+      }
+      return true
+    } catch (error: unknown) {
+      setAssetError(
+        sanitizeAdminErrorMessage(error, "Failed to register Llama.cpp asset path.")
+      )
+      return false
+    } finally {
+      setRegisteringAssetPath(false)
+    }
+  }
+
+  const handleImportAssetFolder = async (path: string): Promise<boolean> => {
+    try {
+      setImportingAssetFolder(true)
+      setAssetError(null)
+      await tldwClient.importLlamacppAssetFolder(path)
+      await loadAssets()
+      return true
+    } catch (error: unknown) {
+      setAssetError(
+        sanitizeAdminErrorMessage(error, "Failed to import Llama.cpp asset folder.")
+      )
+      return false
+    } finally {
+      setImportingAssetFolder(false)
     }
   }
 
@@ -620,6 +688,17 @@ export const LlamacppAdminPage: React.FC = () => {
                 }}
               />
             )}
+
+            <LlamacppAssetsPanel
+              assets={assets}
+              loading={loadingAssets}
+              registeringPath={registeringAssetPath}
+              importingFolder={importingAssetFolder}
+              error={assetError}
+              onRegisterPath={handleRegisterAssetPath}
+              onImportFolder={handleImportAssetFolder}
+              onReload={loadAssets}
+            />
 
             <LlamacppInventoryPanel
               inventory={inventory}

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
@@ -1,0 +1,248 @@
+import React from "react"
+import { Button, Card, Input, List, Space, Tag, Typography } from "antd"
+import { RefreshCw } from "lucide-react"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
+import type {
+  LlamacppAsset,
+  LlamacppAssetKind,
+  LlamacppAssetsResponse
+} from "@/types/llamacpp-admin"
+
+const { Text, Title } = Typography
+const passiveAlertProps = {
+  role: "status",
+  "aria-live": "polite"
+} as const
+
+interface LlamacppAssetsPanelProps {
+  assets: LlamacppAssetsResponse | null
+  loading?: boolean
+  registeringPath?: boolean
+  importingFolder?: boolean
+  error?: string | null
+  onRegisterPath: (path: string) => boolean | Promise<boolean>
+  onImportFolder: (path: string) => boolean | Promise<boolean>
+  onReload: () => void
+}
+
+const groupLabels: Record<LlamacppAssetKind, string> = {
+  gguf: "GGUF models",
+  mmproj: "mmproj projectors",
+  folder: "Imported folders",
+  unknown: "Other assets"
+}
+
+const groupOrder: LlamacppAssetKind[] = ["gguf", "mmproj", "folder", "unknown"]
+
+const formatBytes = (value?: number | null) => {
+  if (!value || value <= 0) return null
+  const units = ["B", "KB", "MB", "GB", "TB"]
+  let size = value
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+  return `${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`
+}
+
+const toAssetGroups = (assetList: LlamacppAsset[]) =>
+  groupOrder
+    .map((kind) => ({
+      kind,
+      label: groupLabels[kind],
+      items: assetList.filter((asset) => asset.kind === kind)
+    }))
+    .filter((group) => group.items.length > 0)
+
+const renderMetadataTags = (asset: LlamacppAsset) => (
+  <>
+    {asset.metadata.parameter_hint && (
+      <Tag color="geekblue">{asset.metadata.parameter_hint}</Tag>
+    )}
+    {asset.metadata.quantization && (
+      <Tag color="purple">{asset.metadata.quantization}</Tag>
+    )}
+    {asset.metadata.context_hint && <Tag>{asset.metadata.context_hint} ctx</Tag>}
+    {asset.metadata.family_hint && <Tag>{asset.metadata.family_hint}</Tag>}
+  </>
+)
+
+const CandidateLabels: React.FC<{ asset: LlamacppAsset }> = ({ asset }) => (
+  <Space orientation="vertical" size={2}>
+    {asset.mmproj_asset_ids.length > 0 && (
+      <Text type="secondary">
+        Projector candidates: {asset.mmproj_asset_ids.join(", ")}
+      </Text>
+    )}
+    {asset.base_model_asset_ids.length > 0 && (
+      <Text type="secondary">
+        Base model candidates: {asset.base_model_asset_ids.join(", ")}
+      </Text>
+    )}
+  </Space>
+)
+
+export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
+  assets,
+  loading = false,
+  registeringPath = false,
+  importingFolder = false,
+  error,
+  onRegisterPath,
+  onImportFolder,
+  onReload
+}) => {
+  const [assetPath, setAssetPath] = React.useState("")
+  const [folderPath, setFolderPath] = React.useState("")
+  const assetList = assets?.assets || []
+  const assetGroups = toAssetGroups(assetList)
+
+  const handleRegisterPath = async () => {
+    const trimmed = assetPath.trim()
+    if (!trimmed) return
+    try {
+      const registered = await onRegisterPath(trimmed)
+      if (registered) {
+        setAssetPath("")
+      }
+    } catch {
+      // Parent owns the error display; keep input available for correction.
+    }
+  }
+
+  const handleImportFolder = async () => {
+    const trimmed = folderPath.trim()
+    if (!trimmed) return
+    try {
+      const imported = await onImportFolder(trimmed)
+      if (imported) {
+        setFolderPath("")
+      }
+    } catch {
+      // Parent owns the error display; keep input available for correction.
+    }
+  }
+
+  return (
+    <Card
+      title="Assets"
+      loading={loading}
+      extra={
+        <Button size="small" icon={<RefreshCw size={14} />} onClick={onReload}>
+          Rescan
+        </Button>
+      }
+    >
+      <Space orientation="vertical" size="middle" className="w-full">
+        {error && <DesignSystemAlert variant="error" title={error} />}
+
+        <Space.Compact className="w-full">
+          <Input
+            aria-label="Register local asset path"
+            value={assetPath}
+            onChange={(event) => setAssetPath(event.target.value)}
+            placeholder="/absolute/path/to/model-or-mmproj.gguf"
+            disabled={registeringPath}
+          />
+          <Button
+            onClick={handleRegisterPath}
+            loading={registeringPath}
+            disabled={!assetPath.trim()}
+          >
+            Register asset
+          </Button>
+        </Space.Compact>
+
+        <Space.Compact className="w-full">
+          <Input
+            aria-label="Import local asset folder"
+            value={folderPath}
+            onChange={(event) => setFolderPath(event.target.value)}
+            placeholder="/absolute/path/to/model-folder"
+            disabled={importingFolder}
+          />
+          <Button
+            onClick={handleImportFolder}
+            loading={importingFolder}
+            disabled={!folderPath.trim()}
+          >
+            Import folder
+          </Button>
+        </Space.Compact>
+
+        {assets?.warnings.map((warning) => (
+          <DesignSystemAlert
+            key={warning}
+            variant="warning"
+            {...passiveAlertProps}
+            title={warning}
+          />
+        ))}
+
+        {assets?.scan_limited && (
+          <DesignSystemAlert
+            variant="warning"
+            {...passiveAlertProps}
+            title="Asset scan limit reached"
+          />
+        )}
+
+        {assetGroups.length > 0 ? (
+          <Space orientation="vertical" size="middle" className="w-full">
+            {assetGroups.map((group) => (
+              <section key={group.kind} aria-label={group.label}>
+                <Title level={5}>{group.label}</Title>
+                <List
+                  size="small"
+                  bordered
+                  dataSource={group.items}
+                  renderItem={(asset) => {
+                    const size = formatBytes(asset.size_bytes)
+                    return (
+                      <List.Item>
+                        <Space orientation="vertical" size={4} className="w-full">
+                          <Space wrap size="small">
+                            <Text strong>{asset.display_name}</Text>
+                            <Tag>{asset.source}</Tag>
+                            {size && <Tag>{size}</Tag>}
+                            {renderMetadataTags(asset)}
+                            {asset.capabilities.map((capability) => (
+                              <Tag key={capability}>{capability}</Tag>
+                            ))}
+                          </Space>
+                          <Space wrap size="small">
+                            <Text code>{asset.asset_id}</Text>
+                            <Text type="secondary" className="break-all">
+                              {asset.path}
+                            </Text>
+                          </Space>
+                          <CandidateLabels asset={asset} />
+                          {asset.warnings.length > 0 && (
+                            <Space wrap size="small">
+                              {asset.warnings.map((warning) => (
+                                <Tag key={warning} color="orange">
+                                  {warning}
+                                </Tag>
+                              ))}
+                            </Space>
+                          )}
+                        </Space>
+                      </List.Item>
+                    )
+                  }}
+                />
+              </section>
+            ))}
+          </Space>
+        ) : (
+          <Text type="secondary">
+            No llama.cpp assets detected. Rescan or register a local asset path.
+          </Text>
+        )}
+      </Space>
+    </Card>
+  )
+}
+
+export default LlamacppAssetsPanel

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
@@ -101,26 +101,18 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
   const handleRegisterPath = async () => {
     const trimmed = assetPath.trim()
     if (!trimmed) return
-    try {
-      const registered = await onRegisterPath(trimmed)
-      if (registered) {
-        setAssetPath("")
-      }
-    } catch {
-      // Parent owns the error display; keep input available for correction.
+    const registered = await onRegisterPath(trimmed)
+    if (registered) {
+      setAssetPath("")
     }
   }
 
   const handleImportFolder = async () => {
     const trimmed = folderPath.trim()
     if (!trimmed) return
-    try {
-      const imported = await onImportFolder(trimmed)
-      if (imported) {
-        setFolderPath("")
-      }
-    } catch {
-      // Parent owns the error display; keep input available for correction.
+    const imported = await onImportFolder(trimmed)
+    if (imported) {
+      setFolderPath("")
     }
   }
 
@@ -196,6 +188,7 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
                 <List
                   size="small"
                   bordered
+                  rowKey="asset_id"
                   dataSource={group.items}
                   renderItem={(asset) => {
                     const size = formatBytes(asset.size_bytes)

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
@@ -7,6 +7,7 @@ const apiMock = vi.hoisted(() => ({
   getLlamacppConfig: vi.fn(),
   getLlamacppStatus: vi.fn(),
   getLlamacppInventory: vi.fn(),
+  getLlamacppAssets: vi.fn(),
   getLlamacppHardware: vi.fn(),
   listLlamacppProfiles: vi.fn(),
   listLlamacppInstances: vi.fn(),
@@ -20,7 +21,9 @@ const apiMock = vi.hoisted(() => ({
   startLlamacppServer: vi.fn(),
   stopLlamacppServer: vi.fn(),
   useLlamacppInChat: vi.fn(),
-  registerLlamacppModelPath: vi.fn()
+  registerLlamacppModelPath: vi.fn(),
+  registerLlamacppAssetPath: vi.fn(),
+  importLlamacppAssetFolder: vi.fn()
 }))
 
 vi.mock("react-i18next", () => ({
@@ -195,6 +198,7 @@ const mockConfig = {
     default_ctx_size: 4096,
     allowed_paths: ["/srv/models"],
     registered_model_paths: [],
+    imported_asset_folders: [],
     log_output_file: null
   },
   active_config: {
@@ -237,6 +241,66 @@ const mockInventory = {
     }
   ],
   warnings: ["One registered path was skipped."],
+  scan_limited: false
+}
+
+const mockAssets = {
+  assets: [
+    {
+      asset_id: "gguf:toy-model-id",
+      kind: "gguf",
+      identity_basis: "resolved_path",
+      path: "/srv/models/gguf/toy-7b-q4_k_m.gguf",
+      resolved_path: "/srv/models/gguf/toy-7b-q4_k_m.gguf",
+      display_name: "Toy 7B Q4_K_M",
+      source: "models_dir",
+      size_bytes: 4_200_000_000,
+      modified_at: "2026-05-15T10:00:00Z",
+      metadata: {
+        quantization: "Q4_K_M",
+        parameter_hint: "7B",
+        context_hint: 4096,
+        family_hint: "toy"
+      },
+      capabilities: ["unknown"],
+      mmproj_asset_ids: ["mmproj:toy-vision"],
+      base_model_asset_ids: [],
+      warnings: ["Projector pairing is inferred."]
+    },
+    {
+      asset_id: "mmproj:toy-vision",
+      kind: "mmproj",
+      identity_basis: "resolved_path",
+      path: "/srv/models/gguf/mmproj-toy.gguf",
+      resolved_path: "/srv/models/gguf/mmproj-toy.gguf",
+      display_name: "mmproj-toy",
+      source: "models_dir",
+      size_bytes: 50_000_000,
+      modified_at: null,
+      metadata: {},
+      capabilities: ["vision_projector"],
+      mmproj_asset_ids: [],
+      base_model_asset_ids: ["gguf:toy-model-id"],
+      warnings: []
+    },
+    {
+      asset_id: "folder:external",
+      kind: "folder",
+      identity_basis: "resolved_path",
+      path: "/srv/models/imported",
+      resolved_path: "/srv/models/imported",
+      display_name: "imported",
+      source: "imported_folder",
+      size_bytes: null,
+      modified_at: null,
+      metadata: {},
+      capabilities: ["asset_folder"],
+      mmproj_asset_ids: [],
+      base_model_asset_ids: [],
+      warnings: []
+    }
+  ],
+  warnings: ["One imported folder could not be read."],
   scan_limited: false
 }
 
@@ -343,6 +407,7 @@ describe("LlamacppAdminPage", () => {
       port: 8080
     })
     apiMock.getLlamacppInventory.mockResolvedValue(mockInventory)
+    apiMock.getLlamacppAssets.mockResolvedValue(mockAssets)
     apiMock.getLlamacppHardware.mockResolvedValue({
       ram_total_bytes: 16_000_000_000,
       ram_available_bytes: 8_000_000_000,
@@ -398,6 +463,8 @@ describe("LlamacppAdminPage", () => {
       warnings: []
     })
     apiMock.registerLlamacppModelPath.mockResolvedValue(mockInventory.models[0])
+    apiMock.registerLlamacppAssetPath.mockResolvedValue(mockAssets.assets[0])
+    apiMock.importLlamacppAssetFolder.mockResolvedValue(mockAssets.assets[2])
   })
 
   it("renders readiness from saved config and restart-required state", async () => {
@@ -414,9 +481,9 @@ describe("LlamacppAdminPage", () => {
   it("renders inventory display names warnings and stable model selection", async () => {
     render(<LlamacppAdminPage />)
 
-    expect(await screen.findByText("Toy 7B Q4_K_M")).toBeTruthy()
+    expect((await screen.findAllByText("Toy 7B Q4_K_M")).length).toBeGreaterThan(0)
     expect(screen.getByText("toy-7b-q4_k_m.gguf")).toBeTruthy()
-    expect(screen.getByText("/srv/models/gguf/toy-7b-q4_k_m.gguf")).toBeTruthy()
+    expect(screen.getAllByText("/srv/models/gguf/toy-7b-q4_k_m.gguf").length).toBeGreaterThan(0)
     expect(screen.getByText("Metadata is filename-derived.")).toBeTruthy()
     expect(screen.getByText("Selected")).toBeTruthy()
   })
@@ -567,7 +634,59 @@ describe("LlamacppAdminPage", () => {
     })
   })
 
-  it("loads config status inventory and hardware only once during strict-mode mount", async () => {
+  it("renders asset inventory groups and warnings next to legacy inventory", async () => {
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByText("Assets")).toBeTruthy()
+    expect(screen.getByText("GGUF models")).toBeTruthy()
+    expect(screen.getByText("mmproj projectors")).toBeTruthy()
+    expect(screen.getByText("Imported folders")).toBeTruthy()
+    expect(screen.getByText("One imported folder could not be read.")).toBeTruthy()
+    expect(screen.getByText("Projector candidates: mmproj:toy-vision")).toBeTruthy()
+    expect(screen.getByText("Base model candidates: gguf:toy-model-id")).toBeTruthy()
+    expect(screen.getByText("Inventory")).toBeTruthy()
+  })
+
+  it("registers an asset path and reloads assets plus legacy GGUF inventory", async () => {
+    render(<LlamacppAdminPage />)
+
+    fireEvent.change(await screen.findByLabelText("Register local asset path"), {
+      target: { value: "/external/model.gguf" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Register asset" }))
+
+    await waitFor(() => {
+      expect(apiMock.registerLlamacppAssetPath).toHaveBeenCalledWith("/external/model.gguf")
+      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(2)
+      expect(apiMock.getLlamacppInventory).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it("imports an asset folder and reloads assets", async () => {
+    render(<LlamacppAdminPage />)
+
+    fireEvent.change(await screen.findByLabelText("Import local asset folder"), {
+      target: { value: "/srv/models/imported" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Import folder" }))
+
+    await waitFor(() => {
+      expect(apiMock.importLlamacppAssetFolder).toHaveBeenCalledWith("/srv/models/imported")
+      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it("shows asset load failure without hiding legacy inventory", async () => {
+    apiMock.getLlamacppAssets.mockRejectedValueOnce(new Error("asset scan failed"))
+
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByText("Inventory")).toBeTruthy()
+    expect(await screen.findByText("asset scan failed")).toBeTruthy()
+    expect(screen.getAllByText("Toy 7B Q4_K_M").length).toBeGreaterThan(0)
+  })
+
+  it("loads config status inventory assets and hardware only once during strict-mode mount", async () => {
     render(
       <React.StrictMode>
         <LlamacppAdminPage />
@@ -578,6 +697,7 @@ describe("LlamacppAdminPage", () => {
       expect(apiMock.getLlamacppConfig).toHaveBeenCalledTimes(1)
       expect(apiMock.getLlamacppStatus).toHaveBeenCalledTimes(1)
       expect(apiMock.getLlamacppInventory).toHaveBeenCalledTimes(1)
+      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(1)
       expect(apiMock.getLlamacppHardware).toHaveBeenCalledTimes(1)
       expect(apiMock.listLlamacppProfiles).toHaveBeenCalledTimes(1)
       expect(apiMock.listLlamacppInstances).toHaveBeenCalledTimes(1)

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
@@ -125,4 +125,40 @@ describe("LlamacppAssetsPanel", () => {
     })
     expect(folderInput.value).toBe("")
   })
+
+  it("keeps inputs available when actions report failure", async () => {
+    const onRegisterPath = vi.fn().mockResolvedValue(false)
+    const onImportFolder = vi.fn().mockResolvedValue(false)
+
+    render(
+      <LlamacppAssetsPanel
+        assets={{ assets: [], warnings: [], scan_limited: false }}
+        loading={false}
+        registeringPath={false}
+        importingFolder={false}
+        error={null}
+        onRegisterPath={onRegisterPath}
+        onImportFolder={onImportFolder}
+        onReload={vi.fn()}
+      />
+    )
+
+    const assetInput = screen.getByLabelText("Register local asset path") as HTMLInputElement
+    fireEvent.change(assetInput, { target: { value: "/external/model.gguf" } })
+    fireEvent.click(screen.getByRole("button", { name: "Register asset" }))
+
+    await waitFor(() => {
+      expect(onRegisterPath).toHaveBeenCalledWith("/external/model.gguf")
+    })
+    expect(assetInput.value).toBe("/external/model.gguf")
+
+    const folderInput = screen.getByLabelText("Import local asset folder") as HTMLInputElement
+    fireEvent.change(folderInput, { target: { value: "/external/models" } })
+    fireEvent.click(screen.getByRole("button", { name: "Import folder" }))
+
+    await waitFor(() => {
+      expect(onImportFolder).toHaveBeenCalledWith("/external/models")
+    })
+    expect(folderInput.value).toBe("/external/models")
+  })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
@@ -1,0 +1,128 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { LlamacppAssetsPanel } from "../LlamacppAssetsPanel"
+import type { LlamacppAssetsResponse } from "@/types/llamacpp-admin"
+
+const mockAssets: LlamacppAssetsResponse = {
+  assets: [
+    {
+      asset_id: "gguf:base",
+      kind: "gguf",
+      identity_basis: "resolved_path",
+      path: "/models/base-q4_k_m.gguf",
+      resolved_path: "/models/base-q4_k_m.gguf",
+      display_name: "base-q4_k_m",
+      source: "models_dir",
+      size_bytes: 4_000_000_000,
+      modified_at: null,
+      metadata: {
+        quantization: "Q4_K_M",
+        parameter_hint: "7B",
+        context_hint: null,
+        family_hint: "base"
+      },
+      capabilities: ["unknown"],
+      mmproj_asset_ids: ["mmproj:vision"],
+      base_model_asset_ids: [],
+      warnings: ["Projector pairing is inferred."]
+    },
+    {
+      asset_id: "mmproj:vision",
+      kind: "mmproj",
+      identity_basis: "resolved_path",
+      path: "/models/mmproj-base.gguf",
+      resolved_path: "/models/mmproj-base.gguf",
+      display_name: "mmproj-base",
+      source: "models_dir",
+      size_bytes: 50_000_000,
+      modified_at: null,
+      metadata: {},
+      capabilities: ["vision_projector"],
+      mmproj_asset_ids: [],
+      base_model_asset_ids: ["gguf:base"],
+      warnings: []
+    },
+    {
+      asset_id: "folder:external",
+      kind: "folder",
+      identity_basis: "resolved_path",
+      path: "/external/models",
+      resolved_path: "/external/models",
+      display_name: "models",
+      source: "imported_folder",
+      size_bytes: null,
+      modified_at: null,
+      metadata: {},
+      capabilities: ["asset_folder"],
+      mmproj_asset_ids: [],
+      base_model_asset_ids: [],
+      warnings: ["Folder is outside the configured models directory but allowlisted."]
+    }
+  ],
+  warnings: ["One imported folder could not be read."],
+  scan_limited: false
+}
+
+describe("LlamacppAssetsPanel", () => {
+  it("renders asset groups warnings and inferred projector candidates", () => {
+    render(
+      <LlamacppAssetsPanel
+        assets={mockAssets}
+        loading={false}
+        registeringPath={false}
+        importingFolder={false}
+        error={null}
+        onRegisterPath={vi.fn()}
+        onImportFolder={vi.fn()}
+        onReload={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("GGUF models")).toBeTruthy()
+    expect(screen.getByText("mmproj projectors")).toBeTruthy()
+    expect(screen.getByText("Imported folders")).toBeTruthy()
+    expect(screen.getByText("One imported folder could not be read.")).toBeTruthy()
+    expect(screen.getByText("Projector pairing is inferred.")).toBeTruthy()
+    expect(screen.getByText("Projector candidates: mmproj:vision")).toBeTruthy()
+    expect(screen.getByText("Base model candidates: gguf:base")).toBeTruthy()
+    expect(screen.getByLabelText("Register local asset path")).toBeTruthy()
+    expect(screen.getByLabelText("Import local asset folder")).toBeTruthy()
+  })
+
+  it("submits register and import actions and clears successful inputs", async () => {
+    const onRegisterPath = vi.fn().mockResolvedValue(true)
+    const onImportFolder = vi.fn().mockResolvedValue(true)
+
+    render(
+      <LlamacppAssetsPanel
+        assets={{ assets: [], warnings: [], scan_limited: false }}
+        loading={false}
+        registeringPath={false}
+        importingFolder={false}
+        error={null}
+        onRegisterPath={onRegisterPath}
+        onImportFolder={onImportFolder}
+        onReload={vi.fn()}
+      />
+    )
+
+    const assetInput = screen.getByLabelText("Register local asset path") as HTMLInputElement
+    fireEvent.change(assetInput, { target: { value: "/external/model.gguf" } })
+    fireEvent.click(screen.getByRole("button", { name: "Register asset" }))
+
+    await waitFor(() => {
+      expect(onRegisterPath).toHaveBeenCalledWith("/external/model.gguf")
+    })
+    expect(assetInput.value).toBe("")
+
+    const folderInput = screen.getByLabelText("Import local asset folder") as HTMLInputElement
+    fireEvent.change(folderInput, { target: { value: "/external/models" } })
+    fireEvent.click(screen.getByRole("button", { name: "Import folder" }))
+
+    await waitFor(() => {
+      expect(onImportFolder).toHaveBeenCalledWith("/external/models")
+    })
+    expect(folderInput.value).toBe("")
+  })
+})

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -1,6 +1,8 @@
 import type { ChatScope } from "@/types/chat-scope"
 import { toChatScopeParams } from "@/types/chat-scope"
 import type {
+  LlamacppAsset,
+  LlamacppAssetsResponse,
   LlamacppConfigResponse,
   LlamacppConfigUpdateRequest,
   LlamacppHardwareSnapshotResponse,
@@ -2201,9 +2203,34 @@ export class TldwApiClientBase {
     })
   }
 
+  async getLlamacppAssets(): Promise<LlamacppAssetsResponse> {
+    return await bgRequest<LlamacppAssetsResponse>({
+      path: "/api/v1/llamacpp/assets",
+      method: "GET"
+    })
+  }
+
   async registerLlamacppModelPath(path: string): Promise<LlamacppInventoryItem> {
     return await bgRequest<LlamacppInventoryItem>({
       path: "/api/v1/llamacpp/models/register-path",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { path }
+    })
+  }
+
+  async registerLlamacppAssetPath(path: string): Promise<LlamacppAsset> {
+    return await bgRequest<LlamacppAsset>({
+      path: "/api/v1/llamacpp/assets/register-path",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { path }
+    })
+  }
+
+  async importLlamacppAssetFolder(path: string): Promise<LlamacppAsset> {
+    return await bgRequest<LlamacppAsset>({
+      path: "/api/v1/llamacpp/assets/import-folder",
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: { path }

--- a/apps/packages/ui/src/services/tldw/domains/models-audio.ts
+++ b/apps/packages/ui/src/services/tldw/domains/models-audio.ts
@@ -2,6 +2,8 @@ import { bgRequest } from "@/services/background-proxy"
 import { buildQuery } from "../client-utils"
 import { appendPathQuery } from "../path-utils"
 import type {
+  LlamacppAsset,
+  LlamacppAssetsResponse,
   LlamacppConfigResponse,
   LlamacppConfigUpdateRequest,
   LlamacppHardwareSnapshotResponse,
@@ -351,9 +353,34 @@ export const modelsAudioMethods = {
     })
   },
 
+  async getLlamacppAssets(): Promise<LlamacppAssetsResponse> {
+    return await bgRequest<LlamacppAssetsResponse>({
+      path: "/api/v1/llamacpp/assets",
+      method: "GET"
+    })
+  },
+
   async registerLlamacppModelPath(path: string): Promise<LlamacppInventoryItem> {
     return await bgRequest<LlamacppInventoryItem>({
       path: "/api/v1/llamacpp/models/register-path",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { path }
+    })
+  },
+
+  async registerLlamacppAssetPath(path: string): Promise<LlamacppAsset> {
+    return await bgRequest<LlamacppAsset>({
+      path: "/api/v1/llamacpp/assets/register-path",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { path }
+    })
+  },
+
+  async importLlamacppAssetFolder(path: string): Promise<LlamacppAsset> {
+    return await bgRequest<LlamacppAsset>({
+      path: "/api/v1/llamacpp/assets/import-folder",
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: { path }

--- a/apps/packages/ui/src/types/llamacpp-admin.ts
+++ b/apps/packages/ui/src/types/llamacpp-admin.ts
@@ -13,6 +13,7 @@ export interface LlamacppSavedConfig {
   port_probe_max?: number | null
   allowed_paths: string[]
   registered_model_paths: string[]
+  imported_asset_folders: string[]
   log_output_file?: string | null
 }
 
@@ -91,6 +92,42 @@ export interface LlamacppInventoryItem {
 
 export interface LlamacppInventoryResponse {
   models: LlamacppInventoryItem[]
+  warnings: string[]
+  scan_limited: boolean
+}
+
+export type LlamacppAssetKind = "gguf" | "mmproj" | "folder" | "unknown"
+export type LlamacppAssetSource =
+  | "models_dir"
+  | "registered_path"
+  | "imported_folder"
+
+export interface LlamacppAssetMetadata {
+  quantization?: string | null
+  parameter_hint?: string | null
+  context_hint?: number | null
+  family_hint?: string | null
+}
+
+export interface LlamacppAsset {
+  asset_id: string
+  kind: LlamacppAssetKind
+  identity_basis: "resolved_path" | "manual"
+  path: string
+  resolved_path?: string | null
+  display_name: string
+  source: LlamacppAssetSource
+  size_bytes?: number | null
+  modified_at?: string | null
+  metadata: LlamacppAssetMetadata
+  capabilities: string[]
+  mmproj_asset_ids: string[]
+  base_model_asset_ids: string[]
+  warnings: string[]
+}
+
+export interface LlamacppAssetsResponse {
+  assets: LlamacppAsset[]
   warnings: string[]
   scan_limited: boolean
 }

--- a/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
+++ b/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
@@ -1,0 +1,60 @@
+---
+id: TASK-397.5
+title: Implement llama.cpp asset inventory v2
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 06:37'
+labels:
+  - llamacpp
+  - backend
+  - webui
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md
+parent_task_id: TASK-397
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the merged Asset Inventory V2 plan: local asset schemas, imported folder config parsing, GGUF/mmproj/folder asset discovery, stale-path warnings, candidate mmproj pairing, asset register/import endpoints, legacy inventory compatibility, frontend API/types, and a minimal Admin assets panel. Remote downloads and model-family routing remain deferred.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Backend exposes asset schemas, imported folder config parsing, and local asset scanning for GGUF, mmproj, folder, and unknown assets.
+- [ ] #2 Backend supports admin-only asset list/register-path/import-folder endpoints while preserving legacy inventory and start-by-model compatibility.
+- [ ] #3 Asset discovery reports stale-path, allowlist, unknown-capability, and inferred mmproj pairing warnings without remote download behavior.
+- [ ] #4 WebUI shared client/types and Admin page expose a minimal assets panel with register/import actions and warnings.
+- [ ] #5 Focused backend, frontend, Bandit, and diff verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Executing Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md inline with TDD in worktree .worktrees/llamacpp-asset-inventory-v2.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
+++ b/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-397.5
 title: Implement llama.cpp asset inventory v2
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 06:37'
+updated_date: '2026-05-16 07:00'
 labels:
   - llamacpp
   - backend
@@ -26,35 +26,51 @@ Implement the merged Asset Inventory V2 plan: local asset schemas, imported fold
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Backend exposes asset schemas, imported folder config parsing, and local asset scanning for GGUF, mmproj, folder, and unknown assets.
-- [ ] #2 Backend supports admin-only asset list/register-path/import-folder endpoints while preserving legacy inventory and start-by-model compatibility.
-- [ ] #3 Asset discovery reports stale-path, allowlist, unknown-capability, and inferred mmproj pairing warnings without remote download behavior.
-- [ ] #4 WebUI shared client/types and Admin page expose a minimal assets panel with register/import actions and warnings.
-- [ ] #5 Focused backend, frontend, Bandit, and diff verification are recorded.
+- [x] #1 Backend exposes asset schemas, imported folder config parsing, and local asset scanning for GGUF, mmproj, folder, and unknown assets.
+- [x] #2 Backend supports admin-only asset list/register-path/import-folder endpoints while preserving legacy inventory and start-by-model compatibility.
+- [x] #3 Asset discovery reports stale-path, allowlist, unknown-capability, and inferred mmproj pairing warnings without remote download behavior.
+- [x] #4 WebUI shared client/types and Admin page expose a minimal assets panel with register/import actions and warnings.
+- [x] #5 Focused backend, frontend, Bandit, and diff verification are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Executing Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md inline with TDD in worktree .worktrees/llamacpp-asset-inventory-v2.
+Executed Docs/superpowers/plans/2026-05-16-llamacpp-asset-inventory-v2-implementation-plan.md inline with TDD in worktree .worktrees/llamacpp-asset-inventory-v2.
+
+Implementation commits:
+- dc0ab2d7c Add llama.cpp asset inventory schema contract
+- 9ed473e40 Add llama.cpp local asset discovery
+- 2819c1d92 Infer llama.cpp mmproj asset candidates
+- eba5b9a32 Add llama.cpp asset inventory APIs
+- 9658889e9 Preserve llama.cpp legacy inventory compatibility
+- 0a21954c7 Add llama.cpp asset API client types
+- 334cb100b Add llama.cpp assets panel
+- 1334a5062 Wire llama.cpp assets into admin page
+
+Known verification skip: bunx tsc --noEmit --pretty false could not run because Bun could not write to its tempdir inside the sandbox; the required escalated rerun was rejected by the approval reviewer. Frontend behavior was validated through focused Vitest coverage instead.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented llama.cpp Asset Inventory V2 across backend and WebUI. The backend now exposes asset schemas, imported folder config parsing, GGUF/mmproj/folder/unknown scanning, inferred mmproj candidate metadata, asset register/import endpoints, and legacy inventory/start-by-model compatibility. The WebUI now has shared asset types/client methods plus an Admin assets panel with register/import actions, grouped assets, warnings, and inferred candidate labels.
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-<!-- SECTION:FINAL_SUMMARY:END -->
+Verification recorded:
+- Backend: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py -v -> 32 passed, 5 warnings.
+- Frontend: ./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppInventoryPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx from apps/packages/ui -> 3 files passed, 20 tests passed.
+- Bandit: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r touched llama.cpp Python files -f json -o /tmp/bandit_llamacpp_asset_inventory_v2.json -> 0 results.
+- Whitespace: git diff --check -> clean.
 
+Deferred by design: remote downloads, model-family routing, automatic profile mutation, and automatic mmproj pairing.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
+++ b/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
@@ -4,7 +4,7 @@ title: Implement llama.cpp asset inventory v2
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 07:00'
+updated_date: '2026-05-16 07:10'
 labels:
   - llamacpp
   - backend
@@ -63,6 +63,8 @@ Verification recorded:
 - Whitespace: git diff --check -> clean.
 
 Deferred by design: remote downloads, model-family routing, automatic profile mutation, and automatic mmproj pairing.
+
+PR: https://github.com/rmusser01/tldw_server/pull/1764
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
+++ b/backlog/tasks/task-397.5 - Implement-llama.cpp-asset-inventory-v2.md
@@ -4,7 +4,7 @@ title: Implement llama.cpp asset inventory v2
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 07:10'
+updated_date: '2026-05-16 14:40'
 labels:
   - llamacpp
   - backend
@@ -49,16 +49,20 @@ Implementation commits:
 - 1334a5062 Wire llama.cpp assets into admin page
 
 Known verification skip: bunx tsc --noEmit --pretty false could not run because Bun could not write to its tempdir inside the sandbox; the required escalated rerun was rejected by the approval reviewer. Frontend behavior was validated through focused Vitest coverage instead.
+
+Review-fix pass for PR #1764: verified live review comments and fixed only still-valid findings. Fixed: asset endpoint blocking I/O by offloading asset/config scans and mutations to the threadpool, registered mmproj/projector leakage in legacy inventory/resolve paths, missing Ant List rowKey on grouped assets, and silent frontend catch handling. Skipped as already satisfied in current code: Gemini backend symbol/import warnings for datetime/UTC, _QUANT_RE, _canonical_path, and _unresolved_path_key. Skipped as incompatible with the installed Ant Design version: changing Space orientation to direction; the local Vitest run warned direction is deprecated and orientation is the current compatible prop.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented llama.cpp Asset Inventory V2 across backend and WebUI. The backend now exposes asset schemas, imported folder config parsing, GGUF/mmproj/folder/unknown scanning, inferred mmproj candidate metadata, asset register/import endpoints, and legacy inventory/start-by-model compatibility. The WebUI now has shared asset types/client methods plus an Admin assets panel with register/import actions, grouped assets, warnings, and inferred candidate labels.
+Implemented llama.cpp Asset Inventory V2 across backend and WebUI. The backend now exposes asset schemas, imported folder config parsing, GGUF/mmproj/folder/unknown scanning, inferred mmproj candidate metadata, asset register/import endpoints, and legacy inventory/start-by-model compatibility. The WebUI now has shared asset types/client methods plus an Admin assets panel with register/import actions, grouped assets, warnings, row keys, and inferred candidate labels.
+
+Review fixes for PR #1764 added threadpool offloading for blocking asset endpoint work, stricter exclusion of registered mmproj/projector assets from legacy GGUF inventory and model-id resolution, and frontend callback handling that leaves retry inputs intact without swallowing errors.
 
 Verification recorded:
-- Backend: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py -v -> 32 passed, 5 warnings.
-- Frontend: ./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppInventoryPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx from apps/packages/ui -> 3 files passed, 20 tests passed.
+- Backend: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py -v -> 34 passed, 5 warnings.
+- Frontend: ./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppInventoryPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx from apps/packages/ui -> 3 files passed, 21 tests passed.
 - Bandit: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r touched llama.cpp Python files -f json -o /tmp/bandit_llamacpp_asset_inventory_v2.json -> 0 results.
 - Whitespace: git diff --check -> clean.
 

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -13,9 +13,12 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from starlette.concurrency import run_in_threadpool
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, RequireRole, User
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
+    LlamaCppAsset,
+    LlamaCppAssetsResponse,
     LlamaCppConfigResponse,
     LlamaCppConfigUpdateRequest,
     LlamaCppHardwareSnapshotResponse,
+    LlamaCppImportAssetFolderRequest,
     LlamaCppInventoryItem,
     LlamaCppInventoryResponse,
     LlamaCppLifecycleActionResponse,
@@ -25,6 +28,7 @@ from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppProfileListResponse,
     LlamaCppProfileResponse,
     LlamaCppProfileUpdateRequest,
+    LlamaCppRegisterAssetPathRequest,
     LlamaCppRegisterModelPathRequest,
     LlamaCppRuntimeListResponse,
     LlamaCppRuntimeResponse,
@@ -369,6 +373,53 @@ async def validate_llamacpp_binary_endpoint(
         llm_manager=llm_manager,
         run_probe=payload.run_probe,
     )
+
+
+@router.get(
+    "/llamacpp/assets",
+    summary="List llama.cpp Local Assets",
+    response_model=LlamaCppAssetsResponse,
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
+)
+async def get_llamacpp_assets_endpoint(
+    llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager),
+) -> LlamaCppAssetsResponse:
+    config_state = llamacpp_config_service.get_config_state(llm_manager)
+    return llamacpp_inventory_service.scan_assets(config_state)
+
+
+@router.post(
+    "/llamacpp/assets/register-path",
+    summary="Register a llama.cpp Asset Path",
+    response_model=LlamaCppAsset,
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
+)
+async def register_llamacpp_asset_path_endpoint(
+    payload: LlamaCppRegisterAssetPathRequest,
+    llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager),
+) -> LlamaCppAsset:
+    _ = llm_manager
+    try:
+        return llamacpp_inventory_service.register_asset_path(Path(payload.path))
+    except ServerError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post(
+    "/llamacpp/assets/import-folder",
+    summary="Import a llama.cpp Asset Folder",
+    response_model=LlamaCppAsset,
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
+)
+async def import_llamacpp_asset_folder_endpoint(
+    payload: LlamaCppImportAssetFolderRequest,
+    llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager),
+) -> LlamaCppAsset:
+    _ = llm_manager
+    try:
+        return llamacpp_inventory_service.import_asset_folder(Path(payload.path))
+    except ServerError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -384,8 +384,8 @@ async def validate_llamacpp_binary_endpoint(
 async def get_llamacpp_assets_endpoint(
     llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager),
 ) -> LlamaCppAssetsResponse:
-    config_state = llamacpp_config_service.get_config_state(llm_manager)
-    return llamacpp_inventory_service.scan_assets(config_state)
+    config_state = await run_in_threadpool(llamacpp_config_service.get_config_state, llm_manager)
+    return await run_in_threadpool(llamacpp_inventory_service.scan_assets, config_state)
 
 
 @router.post(
@@ -400,7 +400,7 @@ async def register_llamacpp_asset_path_endpoint(
 ) -> LlamaCppAsset:
     _ = llm_manager
     try:
-        return llamacpp_inventory_service.register_asset_path(Path(payload.path))
+        return await run_in_threadpool(llamacpp_inventory_service.register_asset_path, Path(payload.path))
     except ServerError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -417,7 +417,7 @@ async def import_llamacpp_asset_folder_endpoint(
 ) -> LlamaCppAsset:
     _ = llm_manager
     try:
-        return llamacpp_inventory_service.import_asset_folder(Path(payload.path))
+        return await run_in_threadpool(llamacpp_inventory_service.import_asset_folder, Path(payload.path))
     except ServerError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
@@ -28,6 +30,7 @@ class LlamaCppSavedConfig(BaseModel):
     port_probe_max: int | None = None
     allowed_paths: list[str] = Field(default_factory=list)
     registered_model_paths: list[str] = Field(default_factory=list)
+    imported_asset_folders: list[str] = Field(default_factory=list)
     log_output_file: str | None = None
 
 
@@ -119,6 +122,58 @@ class LlamaCppModelMetadata(BaseModel):
     quantization: str | None = None
     parameter_hint: str | None = None
     context_hint: int | None = None
+
+
+class LlamaCppAssetMetadata(BaseModel):
+    """Best-effort metadata parsed from a local llama.cpp asset."""
+
+    quantization: str | None = None
+    parameter_hint: str | None = None
+    context_hint: int | None = None
+    family_hint: str | None = None
+
+
+class LlamaCppAsset(BaseModel):
+    """A local llama.cpp file or folder discovered by asset inventory."""
+
+    asset_id: str
+    kind: Literal["gguf", "mmproj", "folder", "unknown"]
+    identity_basis: Literal["resolved_path", "manual"]
+    path: str
+    resolved_path: str | None = None
+    display_name: str
+    source: Literal["models_dir", "registered_path", "imported_folder"]
+    size_bytes: int | None = None
+    modified_at: str | None = None
+    metadata: LlamaCppAssetMetadata = Field(default_factory=LlamaCppAssetMetadata)
+    capabilities: list[str] = Field(default_factory=list)
+    mmproj_asset_ids: list[str] = Field(default_factory=list)
+    base_model_asset_ids: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class LlamaCppAssetsResponse(BaseModel):
+    """Bounded local llama.cpp asset inventory response."""
+
+    assets: list[LlamaCppAsset]
+    warnings: list[str] = Field(default_factory=list)
+    scan_limited: bool = False
+
+
+class LlamaCppRegisterAssetPathRequest(BaseModel):
+    """Request to register an allowlisted local llama.cpp asset path."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(..., min_length=1)
+
+
+class LlamaCppImportAssetFolderRequest(BaseModel):
+    """Request to import an existing allowlisted local asset folder."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(..., min_length=1)
 
 
 class LlamaCppInventoryItem(BaseModel):

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_config_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_config_service.py
@@ -63,6 +63,7 @@ _INT_FIELDS = {
 _LIST_FIELDS = {
     "allowed_paths",
     "registered_model_paths",
+    "imported_asset_folders",
 }
 _LIST_VALUE_DELIMITERS = {",", os.pathsep}
 _SAVED_FIELDS = (
@@ -80,6 +81,7 @@ _SAVED_FIELDS = (
     "port_probe_max",
     "allowed_paths",
     "registered_model_paths",
+    "imported_asset_folders",
     "log_output_file",
 )
 
@@ -200,6 +202,7 @@ def _read_saved_config(warnings: list[str] | None = None) -> dict[str, Any]:
         "enabled": False,
         "allowed_paths": [],
         "registered_model_paths": [],
+        "imported_asset_folders": [],
     }
     if section is None:
         return saved

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -217,14 +217,98 @@ def register_model_path(path: Path) -> LlamaCppInventoryItem:
     return item
 
 
+def register_asset_path(path: Path) -> LlamaCppAsset:
+    """Persist a local registered asset path and return its asset representation."""
+    canonical = _canonical_path(path, "Registered asset")
+    _validate_path_for_config(canonical, "registered_model_paths", "Registered asset path")
+    try:
+        with llamacpp_config_write_lock():
+            saved_config = _read_saved_config()
+            allowed_bases = _allowed_bases_for_config(saved_config)
+            if not allowed_bases or not handler_utils.is_path_allowed(canonical, allowed_bases):
+                raise ServerError("Registered asset path is outside allowed llama.cpp paths.")
+            existing = _path_list(saved_config.get("registered_model_paths"))
+            existing_by_id: dict[str, Path] = {}
+            for item in existing:
+                try:
+                    existing_canonical = _canonical_path(item, "Registered asset")
+                    existing_by_id[asset_id_for_path(existing_canonical, _asset_kind_for_path(existing_canonical))] = (
+                        existing_canonical
+                    )
+                except ServerError:
+                    existing_by_id[_unresolved_path_key(item)] = item.expanduser()
+            existing_by_id.setdefault(asset_id_for_path(canonical, _asset_kind_for_path(canonical)), canonical)
+
+            registered_value = ", ".join(str(item) for item in existing_by_id.values())
+            setup_manager.update_config({"LlamaCpp": {"registered_model_paths": registered_value}})
+            refresh_config_cache()
+    except Exception as exc:
+        if isinstance(exc, LockAcquisitionError):
+            raise ServerError("Failed to acquire the llama.cpp config write lock.") from exc
+        if isinstance(exc, ServerError):
+            raise
+        raise ServerError("Failed to persist registered llama.cpp asset path.") from exc
+
+    saved_config["registered_model_paths"] = [registered_value]
+    allowed_bases = _allowed_bases_for_config(saved_config)
+    asset = _asset_for_path(canonical, source="registered_path", allowed_bases=allowed_bases)
+    if asset is None:
+        raise ServerError("Registered asset path could not be resolved.")
+    return asset
+
+
+def import_asset_folder(path: Path) -> LlamaCppAsset:
+    """Register an existing allowlisted local folder for asset scanning."""
+    canonical = _canonical_path(path, "Imported asset folder")
+    _validate_path_for_config(canonical, "imported_asset_folders", "Imported asset folder")
+    if not canonical.exists():
+        raise ServerError("Imported asset folder does not exist.")
+    if not canonical.is_dir():
+        raise ServerError("Imported asset path is not a folder.")
+
+    try:
+        with llamacpp_config_write_lock():
+            saved_config = _read_saved_config()
+            allowed_bases = _allowed_bases_for_config(saved_config)
+            if not allowed_bases or not handler_utils.is_path_allowed(canonical, allowed_bases):
+                raise ServerError("Imported asset folder is outside allowed llama.cpp paths.")
+            existing = _path_list(saved_config.get("imported_asset_folders"))
+            existing_by_id: dict[str, Path] = {}
+            for item in existing:
+                try:
+                    existing_canonical = _canonical_path(item, "Imported asset folder")
+                    existing_by_id[asset_id_for_path(existing_canonical, "folder")] = existing_canonical
+                except ServerError:
+                    existing_by_id[_unresolved_path_key(item)] = item.expanduser()
+            existing_by_id.setdefault(asset_id_for_path(canonical, "folder"), canonical)
+
+            imported_value = ", ".join(str(item) for item in existing_by_id.values())
+            setup_manager.update_config({"LlamaCpp": {"imported_asset_folders": imported_value}})
+            refresh_config_cache()
+    except Exception as exc:
+        if isinstance(exc, LockAcquisitionError):
+            raise ServerError("Failed to acquire the llama.cpp config write lock.") from exc
+        if isinstance(exc, ServerError):
+            raise
+        raise ServerError("Failed to persist imported llama.cpp asset folder.") from exc
+
+    saved_config["imported_asset_folders"] = [imported_value]
+    allowed_bases = _allowed_bases_for_config(saved_config)
+    return _folder_asset_for_path(canonical, allowed_bases=allowed_bases)
+
+
 def _validate_registered_path_for_config(path: Path) -> None:
+    _validate_path_for_config(path, "registered_model_paths", "Registered model path")
+
+
+def _validate_path_for_config(path: Path, field: str, label: str) -> None:
     text = str(path)
     try:
-        setup_manager.validate_config_value_single_line("LlamaCpp", "registered_model_paths", text)
+        setup_manager.validate_config_value_single_line("LlamaCpp", field, text)
     except ValueError as exc:
-        raise ServerError("Registered model path contains unsupported config characters.") from exc
+        raise ServerError(f"{label} contains unsupported config characters.") from exc
     if any(delimiter in text for delimiter in _REGISTERED_PATH_DELIMITERS):
-        raise ServerError("Registered model path contains unsupported list delimiter characters.")
+        raise ServerError(f"{label} contains unsupported list delimiter characters.")
 
 
 def resolve_model_id(model_id: str) -> Path:

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -138,6 +138,8 @@ def scan_inventory(config_state: dict[str, Any] | None = None, limit: int = 500)
 
     allowed_bases = _allowed_bases_for_config(saved_config)
     for path in registered_paths:
+        if _is_projector_asset_path(path):
+            continue
         item = _item_for_path(path, source="registered_path", allowed_bases=allowed_bases, warnings=warnings)
         if item is None:
             continue
@@ -323,7 +325,7 @@ def resolve_model_id(model_id: str) -> Path:
     for item in inventory.models:
         if item.model_id == wanted:
             path = _canonical_path(Path(item.path), "Model")
-            if path.suffix.lower() != ".gguf" or not path.is_file():
+            if path.suffix.lower() != ".gguf" or _asset_kind_for_path(path) != "gguf" or not path.is_file():
                 raise ModelNotFoundError(f"Model ID {wanted} does not reference an available GGUF file.")
             if not allowed_bases or not handler_utils.is_path_allowed(path, allowed_bases):
                 raise ServerError("Model path is outside allowed llama.cpp paths.")
@@ -352,7 +354,7 @@ def _iter_gguf_models(models_dir: Path, warnings: list[str], limit: int):
             lowered = filename.lower()
             if not lowered.endswith(".gguf"):
                 continue
-            if lowered.startswith("mmproj"):
+            if _asset_kind_for_path(Path(filename)) != "gguf":
                 continue
             yield Path(root) / filename
 
@@ -364,7 +366,7 @@ def _has_scannable_gguf(models_dir: Path, warnings: list[str]) -> bool:
     for _root, _dirs, files in os.walk(models_dir, topdown=True, onerror=_on_error):
         for filename in files:
             lowered = filename.lower()
-            if lowered.endswith(".gguf") and not lowered.startswith("mmproj"):
+            if lowered.endswith(".gguf") and _asset_kind_for_path(Path(filename)) == "gguf":
                 return True
     return False
 
@@ -492,6 +494,14 @@ def _asset_kind_for_path(path: Path) -> str:
     if "mmproj" in stem or "projector" in stem:
         return "mmproj"
     return "gguf"
+
+
+def _is_projector_asset_path(path: Path) -> bool:
+    try:
+        candidate = _canonical_path(path, "Model")
+    except ServerError:
+        candidate = path
+    return _asset_kind_for_path(candidate) == "mmproj"
 
 
 def _capabilities_for_asset(kind: str) -> list[str]:

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -28,6 +28,14 @@ _CTX_RE = re.compile(r"(?:^|[-_.])(?:ctx|context)[-_.]?(\d{3,6})(?:[-_.]|$)", re
 _REGISTERED_PATH_DELIMITERS = {",", os.pathsep}
 _ASSET_SOURCE_ORDER = {"registered_path": 0, "models_dir": 1, "imported_folder": 2}
 _ASSET_KIND_ORDER = {"folder": 0, "gguf": 1, "mmproj": 2, "unknown": 3}
+_PAIRING_DROP_TOKENS = {
+    "bf16",
+    "f16",
+    "f32",
+    "gguf",
+    "mmproj",
+    "projector",
+}
 
 
 def model_id_for_path(path: Path) -> str:
@@ -106,6 +114,7 @@ def scan_assets(config_state: dict[str, Any] | None = None, limit: int = 500) ->
                     )
                 )
 
+    _attach_mmproj_candidates(assets)
     assets.sort(
         key=lambda asset: (
             _ASSET_SOURCE_ORDER.get(asset.source, 99),
@@ -407,6 +416,52 @@ def _capabilities_for_asset(kind: str) -> list[str]:
     if kind == "gguf":
         return ["unknown"]
     return []
+
+
+def _attach_mmproj_candidates(assets: list[LlamaCppAsset]) -> None:
+    by_parent: dict[Path, list[LlamaCppAsset]] = {}
+    for asset in assets:
+        if asset.kind not in {"gguf", "mmproj"} or not asset.resolved_path:
+            continue
+        by_parent.setdefault(Path(asset.resolved_path).parent, []).append(asset)
+
+    for grouped_assets in by_parent.values():
+        base_assets = [asset for asset in grouped_assets if asset.kind == "gguf"]
+        projector_assets = [asset for asset in grouped_assets if asset.kind == "mmproj"]
+        if not base_assets or not projector_assets:
+            continue
+
+        for base_asset in base_assets:
+            base_tokens = _pairing_tokens(base_asset.display_name)
+            candidates = [
+                projector
+                for projector in projector_assets
+                if len(projector_assets) == 1 or base_tokens.intersection(_pairing_tokens(projector.display_name))
+            ]
+            for projector in candidates:
+                if projector.asset_id not in base_asset.mmproj_asset_ids:
+                    base_asset.mmproj_asset_ids.append(projector.asset_id)
+                if base_asset.asset_id not in projector.base_model_asset_ids:
+                    projector.base_model_asset_ids.append(base_asset.asset_id)
+            if candidates:
+                _append_unique_warning(
+                    base_asset.warnings,
+                    "mmproj pairing is inferred; verify the projector before launching vision profiles.",
+                )
+
+
+def _pairing_tokens(value: str) -> set[str]:
+    tokens = {token for token in re.split(r"[^a-zA-Z0-9]+", value.lower()) if token}
+    return {
+        token
+        for token in tokens
+        if token not in _PAIRING_DROP_TOKENS and not _QUANT_RE.fullmatch(token) and not _PARAM_RE.fullmatch(token)
+    }
+
+
+def _append_unique_warning(warnings: list[str], warning: str) -> None:
+    if warning not in warnings:
+        warnings.append(warning)
 
 
 def _item_for_path(

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from typing import Any
 
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
+    LlamaCppAsset,
+    LlamaCppAssetMetadata,
+    LlamaCppAssetsResponse,
     LlamaCppInventoryItem,
     LlamaCppInventoryResponse,
     LlamaCppModelMetadata,
@@ -23,6 +26,8 @@ _QUANT_RE = re.compile(r"(?:^|[-_.])(Q\d(?:_[A-Z0-9]+)*|F16|F32|BF16|IQ\d_[A-Z0-
 _PARAM_RE = re.compile(r"(?:^|[-_.])(\d+(?:\.\d+)?[bm])(?:[-_.]|$)", re.IGNORECASE)
 _CTX_RE = re.compile(r"(?:^|[-_.])(?:ctx|context)[-_.]?(\d{3,6})(?:[-_.]|$)", re.IGNORECASE)
 _REGISTERED_PATH_DELIMITERS = {",", os.pathsep}
+_ASSET_SOURCE_ORDER = {"registered_path": 0, "models_dir": 1, "imported_folder": 2}
+_ASSET_KIND_ORDER = {"folder": 0, "gguf": 1, "mmproj": 2, "unknown": 3}
 
 
 def model_id_for_path(path: Path) -> str:
@@ -30,6 +35,86 @@ def model_id_for_path(path: Path) -> str:
     canonical = str(_canonical_path(path, "Model"))
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:24]
     return f"gguf:{digest}"
+
+
+def asset_id_for_path(path: Path, kind: str) -> str:
+    """Return the stable local asset ID for a canonical path and asset kind."""
+    normalized_kind = str(kind).strip().lower() or "unknown"
+    canonical = str(_canonical_path(path, "Asset"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:24]
+    return f"{normalized_kind}:{digest}"
+
+
+def scan_assets(config_state: dict[str, Any] | None = None, limit: int = 500) -> LlamaCppAssetsResponse:
+    """Return a bounded local llama.cpp asset inventory."""
+    saved_config = _saved_config_from_state(config_state)
+    models_dir = _optional_path(saved_config.get("models_dir"))
+    registered_paths = _path_list(saved_config.get("registered_model_paths"))
+    imported_folders = _path_list(saved_config.get("imported_asset_folders"))
+    allowed_bases = _allowed_bases_for_config(saved_config)
+    warnings: list[str] = []
+    assets: list[LlamaCppAsset] = []
+    seen_ids: set[str] = set()
+    scan_limited = False
+
+    def add_asset(asset: LlamaCppAsset | None) -> bool:
+        if asset is None or asset.asset_id in seen_ids:
+            return False
+        assets.append(asset)
+        seen_ids.add(asset.asset_id)
+        return True
+
+    for path in registered_paths:
+        if len(assets) >= limit:
+            scan_limited = True
+            break
+        add_asset(_asset_for_path(path, source="registered_path", allowed_bases=allowed_bases, warnings=warnings))
+
+    if models_dir is None:
+        warnings.append("LlamaCpp.models_dir is not configured; only registered asset paths and imported folders were checked.")
+    elif not models_dir.exists():
+        warnings.append(f"Configured models_dir '{models_dir}' does not exist.")
+    elif not models_dir.is_dir():
+        warnings.append(f"Configured models_dir '{models_dir}' is not a directory.")
+    else:
+        for path in _iter_asset_files(models_dir, warnings, max(limit - len(assets), 0)):
+            if len(assets) >= limit:
+                scan_limited = True
+                break
+            add_asset(_asset_for_path(path, source="models_dir", allowed_bases=allowed_bases, warnings=warnings))
+
+    for folder in imported_folders:
+        if len(assets) >= limit:
+            scan_limited = True
+            break
+        folder_asset = _folder_asset_for_path(folder, allowed_bases=allowed_bases)
+        add_asset(folder_asset)
+        if len(assets) >= limit:
+            scan_limited = True
+            break
+        if folder_asset.resolved_path and not folder_asset.warnings:
+            for path in _iter_asset_files(Path(folder_asset.resolved_path), warnings, max(limit - len(assets), 0)):
+                if len(assets) >= limit:
+                    scan_limited = True
+                    break
+                add_asset(
+                    _asset_for_path(
+                        path,
+                        source="imported_folder",
+                        allowed_bases=allowed_bases,
+                        warnings=warnings,
+                    )
+                )
+
+    assets.sort(
+        key=lambda asset: (
+            _ASSET_SOURCE_ORDER.get(asset.source, 99),
+            _ASSET_KIND_ORDER.get(asset.kind, 99),
+            asset.display_name.lower(),
+            asset.resolved_path or asset.path,
+        )
+    )
+    return LlamaCppAssetsResponse(assets=assets, warnings=warnings, scan_limited=scan_limited)
 
 
 def scan_inventory(config_state: dict[str, Any] | None = None, limit: int = 500) -> LlamaCppInventoryResponse:
@@ -191,6 +276,139 @@ def _has_scannable_gguf(models_dir: Path, warnings: list[str]) -> bool:
     return False
 
 
+def _iter_asset_files(root_dir: Path, warnings: list[str], limit: int):
+    if limit <= 0:
+        return
+
+    visited = 0
+    max_visited = max(limit * 20, 1000)
+
+    def _on_error(error: OSError) -> None:
+        warnings.append(f"Could not scan '{error.filename}': {error.strerror or error.__class__.__name__}.")
+
+    for root, dirs, files in os.walk(root_dir, topdown=True, onerror=_on_error):
+        dirs.sort()
+        files.sort()
+        visited += len(dirs) + len(files)
+        if visited > max_visited:
+            warnings.append("Asset inventory scan reached the traversal limit.")
+            return
+        for filename in files:
+            if filename.lower().endswith(".gguf"):
+                yield Path(root) / filename
+
+
+def _asset_for_path(
+    path: Path,
+    *,
+    source: str,
+    allowed_bases: list[Path],
+    warnings: list[str] | None = None,
+) -> LlamaCppAsset | None:
+    try:
+        canonical = _canonical_path(path, "Asset")
+    except ServerError:
+        if warnings is not None:
+            warnings.append("Could not inspect an asset inventory path because it could not be resolved.")
+        return None
+
+    basename = canonical.name
+    kind = _asset_kind_for_path(canonical)
+    item_warnings: list[str] = []
+    size_bytes: int | None = None
+    modified_at: str | None = None
+
+    if kind == "unknown":
+        item_warnings.append("Registered asset path does not reference a recognized GGUF or mmproj file.")
+    elif kind == "gguf":
+        item_warnings.append("Asset capability is unknown until inspected or selected in a profile.")
+
+    if not canonical.exists():
+        item_warnings.append("Registered asset path is missing.")
+    elif not canonical.is_file():
+        item_warnings.append("Registered asset path is not a file.")
+    else:
+        try:
+            stat_result = canonical.stat()
+            size_bytes = stat_result.st_size
+            modified_at = datetime.fromtimestamp(stat_result.st_mtime, UTC).isoformat()
+        except PermissionError:
+            item_warnings.append("Registered asset path is not readable.")
+        except OSError:
+            item_warnings.append("Could not read registered asset metadata.")
+
+    if allowed_bases and not handler_utils.is_path_allowed(canonical, allowed_bases):
+        item_warnings.append("Asset path is outside allowed llama.cpp paths and cannot be used until allowed_paths is updated.")
+
+    return LlamaCppAsset(
+        asset_id=asset_id_for_path(canonical, kind),
+        kind=kind,
+        identity_basis="resolved_path",
+        path=str(path.expanduser()),
+        resolved_path=str(canonical),
+        display_name=_display_name(basename),
+        source=source,
+        size_bytes=size_bytes,
+        modified_at=modified_at,
+        metadata=_asset_metadata_from_filename(basename),
+        capabilities=_capabilities_for_asset(kind),
+        warnings=item_warnings,
+    )
+
+
+def _folder_asset_for_path(path: Path, *, allowed_bases: list[Path]) -> LlamaCppAsset:
+    canonical = _canonical_path(path, "Imported asset folder")
+    warnings: list[str] = []
+    modified_at: str | None = None
+
+    if not canonical.exists():
+        warnings.append("Imported asset folder is missing.")
+    elif not canonical.is_dir():
+        warnings.append("Imported asset path is not a folder.")
+    else:
+        try:
+            modified_at = datetime.fromtimestamp(canonical.stat().st_mtime, UTC).isoformat()
+        except PermissionError:
+            warnings.append("Imported asset folder is not readable.")
+        except OSError:
+            warnings.append("Could not read imported folder metadata.")
+
+    if allowed_bases and not handler_utils.is_path_allowed(canonical, allowed_bases):
+        warnings.append("Imported asset folder is outside allowed llama.cpp paths and cannot be scanned until allowed_paths is updated.")
+
+    return LlamaCppAsset(
+        asset_id=asset_id_for_path(canonical, "folder"),
+        kind="folder",
+        identity_basis="resolved_path",
+        path=str(path.expanduser()),
+        resolved_path=str(canonical),
+        display_name=canonical.name or str(canonical),
+        source="imported_folder",
+        modified_at=modified_at,
+        metadata=LlamaCppAssetMetadata(),
+        capabilities=["asset_folder"],
+        warnings=warnings,
+    )
+
+
+def _asset_kind_for_path(path: Path) -> str:
+    lowered_name = path.name.lower()
+    if not lowered_name.endswith(".gguf"):
+        return "unknown"
+    stem = lowered_name[:-5]
+    if "mmproj" in stem or "projector" in stem:
+        return "mmproj"
+    return "gguf"
+
+
+def _capabilities_for_asset(kind: str) -> list[str]:
+    if kind == "mmproj":
+        return ["vision_projector"]
+    if kind == "gguf":
+        return ["unknown"]
+    return []
+
+
 def _item_for_path(
     path: Path,
     *,
@@ -264,6 +482,19 @@ def _metadata_from_filename(filename: str) -> LlamaCppModelMetadata:
     )
 
 
+def _asset_metadata_from_filename(filename: str) -> LlamaCppAssetMetadata:
+    quant_match = _QUANT_RE.search(filename)
+    param_match = _PARAM_RE.search(filename)
+    ctx_match = _CTX_RE.search(filename)
+    family_hint = _display_name(filename).replace("_", " ").replace("-", " ").strip() or None
+    return LlamaCppAssetMetadata(
+        quantization=quant_match.group(1).upper() if quant_match else None,
+        parameter_hint=param_match.group(1).upper() if param_match else None,
+        context_hint=int(ctx_match.group(1)) if ctx_match else None,
+        family_hint=family_hint,
+    )
+
+
 def _display_name(filename: str) -> str:
     return filename[:-5] if filename.lower().endswith(".gguf") else filename
 
@@ -284,11 +515,12 @@ def _read_saved_config() -> dict[str, Any]:
     parser = load_comprehensive_config()
     section = parser["LlamaCpp"] if parser and parser.has_section("LlamaCpp") else None
     if section is None:
-        return {"allowed_paths": [], "registered_model_paths": []}
+        return {"allowed_paths": [], "registered_model_paths": [], "imported_asset_folders": []}
     return {
         "models_dir": _str_or_none(section.get("models_dir", fallback=None)),
         "allowed_paths": _split_list(section.get("allowed_paths", fallback="")),
         "registered_model_paths": _split_list(section.get("registered_model_paths", fallback="")),
+        "imported_asset_folders": _split_list(section.get("imported_asset_folders", fallback="")),
     }
 
 

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
@@ -38,3 +38,51 @@ def test_config_state_reads_imported_asset_folders(monkeypatch, tmp_path: Path):
     state = llamacpp_config_service.get_config_state(llm_manager=object())
 
     assert state["saved_config"]["imported_asset_folders"] == [str(imported)]
+
+
+@pytest.mark.unit
+def test_scan_assets_discovers_gguf_mmproj_and_folder(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    (models_dir / "Llama-3-8B-Q4_K_M.gguf").write_text("base")
+    (models_dir / "mmproj-Llama-3-vision-f16.gguf").write_text("projector")
+    (imported / "notes.txt").write_text("not a model")
+
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, allowed_paths=str(imported), imported_asset_folders=str(imported)),
+    )
+
+    result = llamacpp_inventory_service.scan_assets(limit=500)
+
+    by_kind = {asset.kind: asset for asset in result.assets}
+    assert by_kind["gguf"].asset_id.startswith("gguf:")
+    assert by_kind["mmproj"].asset_id.startswith("mmproj:")
+    assert by_kind["folder"].asset_id.startswith("folder:")
+    assert "vision_projector" in by_kind["mmproj"].capabilities
+    assert by_kind["folder"].source == "imported_folder"
+
+
+@pytest.mark.unit
+def test_scan_assets_reports_stale_imported_folder_without_failing(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    missing = tmp_path / "missing"
+    models_dir.mkdir()
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, imported_asset_folders=str(missing)),
+    )
+
+    result = llamacpp_inventory_service.scan_assets(limit=500)
+
+    folder = next(asset for asset in result.assets if asset.kind == "folder")
+    assert folder.resolved_path == str(missing)
+    assert any("missing" in warning.lower() for warning in folder.warnings)

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from configparser import ConfigParser
+from pathlib import Path
+
+import pytest
+
+
+def _llamacpp_parser(models_dir: Path, **overrides: str) -> ConfigParser:
+    parser = ConfigParser()
+    parser.add_section("LlamaCpp")
+    values = {
+        "enabled": "true",
+        "models_dir": str(models_dir),
+        "allowed_paths": "",
+        "registered_model_paths": "",
+        "imported_asset_folders": "",
+    }
+    values.update(overrides)
+    parser["LlamaCpp"] = values
+    return parser
+
+
+@pytest.mark.unit
+def test_config_state_reads_imported_asset_folders(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_config_service
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "external"
+    models_dir.mkdir()
+    imported.mkdir()
+    monkeypatch.setattr(
+        llamacpp_config_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, imported_asset_folders=str(imported)),
+    )
+
+    state = llamacpp_config_service.get_config_state(llm_manager=object())
+
+    assert state["saved_config"]["imported_asset_folders"] == [str(imported)]

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
@@ -86,3 +86,28 @@ def test_scan_assets_reports_stale_imported_folder_without_failing(monkeypatch, 
     folder = next(asset for asset in result.assets if asset.kind == "folder")
     assert folder.resolved_path == str(missing)
     assert any("missing" in warning.lower() for warning in folder.warnings)
+
+
+@pytest.mark.unit
+def test_scan_assets_adds_inferred_mmproj_candidates_with_warnings(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "llava-7b-Q4_K_M.gguf"
+    projector = models_dir / "mmproj-llava-7b-f16.gguf"
+    base.write_text("base")
+    projector.write_text("projector")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+
+    result = llamacpp_inventory_service.scan_assets(limit=500)
+
+    base_asset = next(asset for asset in result.assets if asset.kind == "gguf")
+    projector_asset = next(asset for asset in result.assets if asset.kind == "mmproj")
+    assert projector_asset.asset_id in base_asset.mmproj_asset_ids
+    assert base_asset.asset_id in projector_asset.base_model_asset_ids
+    assert any("inferred" in warning.lower() for warning in base_asset.warnings)

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
@@ -293,6 +293,44 @@ def test_import_folder_persists_allowlisted_folder_and_returns_folder_asset(monk
 
 
 @pytest.mark.unit
+def test_legacy_inventory_excludes_mmproj_assets_after_asset_v2(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "chat.gguf").write_text("base")
+    (models_dir / "mmproj-chat.gguf").write_text("projector")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+
+    inventory = llamacpp_inventory_service.scan_inventory(limit=500)
+
+    assert [item.basename for item in inventory.models] == ["chat.gguf"]
+
+
+@pytest.mark.unit
+def test_resolve_model_id_rejects_mmproj_asset_id(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    projector = models_dir / "mmproj-chat.gguf"
+    projector.write_text("projector")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+
+    with pytest.raises(ModelNotFoundError):
+        llamacpp_inventory_service.resolve_model_id(llamacpp_inventory_service.asset_id_for_path(projector, "mmproj"))
+
+
+@pytest.mark.unit
 def test_register_path_persists_and_returns_inventory_item(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
 

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
@@ -243,6 +243,56 @@ def test_inventory_model_ids_are_stable_for_canonical_path(monkeypatch, tmp_path
 
 
 @pytest.mark.unit
+def test_assets_endpoint_lists_gguf_and_mmproj(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "chat.Q4_K_M.gguf").write_text("base")
+    (models_dir / "mmproj-chat-f16.gguf").write_text("projector")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+    monkeypatch.setattr(lp.llamacpp_config_service, "get_config_state", lambda llm_manager: _config_state(models_dir))
+    app = _make_app_with_manager(_Manager())
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/llamacpp/assets")
+
+    assert response.status_code == 200, response.text
+    kinds = {asset["kind"] for asset in response.json()["assets"]}
+    assert {"gguf", "mmproj"} <= kinds
+
+
+@pytest.mark.unit
+def test_import_folder_persists_allowlisted_folder_and_returns_folder_asset(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    updates: list[dict[str, dict[str, str]]] = []
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, allowed_paths=str(imported), imported_asset_folders=""),
+    )
+    monkeypatch.setattr(llamacpp_inventory_service.setup_manager, "update_config", updates.append)
+    monkeypatch.setattr(llamacpp_inventory_service, "refresh_config_cache", lambda: None)
+    app = _make_app_with_manager(_Manager())
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/llamacpp/assets/import-folder", json={"path": str(imported)})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["kind"] == "folder"
+    assert updates[-1]["LlamaCpp"]["imported_asset_folders"] == str(imported)
+
+
+@pytest.mark.unit
 def test_register_path_persists_and_returns_inventory_item(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
 

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
@@ -154,6 +154,7 @@ def test_inventory_recursively_scans_gguf_and_skips_mmproj(monkeypatch, tmp_path
     model = nested / "Llama-3-8B-Q4_K_M.gguf"
     model.write_text("fake model")
     (nested / "mmproj-model-f16.gguf").write_text("projector")
+    (nested / "projector-Llama-3-f16.gguf").write_text("projector")
 
     monkeypatch.setattr(
         llamacpp_inventory_service,
@@ -293,6 +294,82 @@ def test_import_folder_persists_allowlisted_folder_and_returns_folder_asset(monk
 
 
 @pytest.mark.unit
+def test_asset_endpoints_offload_blocking_inventory_work_to_threadpool(monkeypatch):
+    calls: list[tuple[Any, tuple[Any, ...], dict[str, Any]]] = []
+    config_state = {
+        "saved_config": {
+            "models_dir": None,
+            "allowed_paths": [],
+            "registered_model_paths": [],
+            "imported_asset_folders": [],
+        },
+        "active_config": {"handler_configured": True},
+        "restart_required": False,
+        "restart_reasons": [],
+        "env_overrides": {},
+        "warnings": [],
+    }
+    asset_payload = {
+        "asset_id": "folder:fake",
+        "kind": "folder",
+        "identity_basis": "resolved_path",
+        "path": "/models",
+        "resolved_path": "/models",
+        "display_name": "models",
+        "source": "imported_folder",
+        "size_bytes": None,
+        "modified_at": None,
+        "metadata": {},
+        "capabilities": ["asset_folder"],
+        "mmproj_asset_ids": [],
+        "base_model_asset_ids": [],
+        "warnings": [],
+    }
+
+    def fake_get_config_state(llm_manager: Any) -> dict[str, Any]:
+        assert isinstance(llm_manager, _Manager)
+        return config_state
+
+    def fake_scan_assets(received_config_state: dict[str, Any]) -> dict[str, Any]:
+        assert received_config_state is config_state
+        return {"assets": [], "warnings": [], "scan_limited": False}
+
+    def fake_register_asset_path(path: Path) -> dict[str, Any]:
+        assert path == Path("/models/base.gguf")
+        return asset_payload
+
+    def fake_import_asset_folder(path: Path) -> dict[str, Any]:
+        assert path == Path("/models")
+        return asset_payload
+
+    async def fake_run_in_threadpool(func: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(lp, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(lp.llamacpp_config_service, "get_config_state", fake_get_config_state)
+    monkeypatch.setattr(lp.llamacpp_inventory_service, "scan_assets", fake_scan_assets)
+    monkeypatch.setattr(lp.llamacpp_inventory_service, "register_asset_path", fake_register_asset_path)
+    monkeypatch.setattr(lp.llamacpp_inventory_service, "import_asset_folder", fake_import_asset_folder)
+    app = _make_app_with_manager(_Manager())
+
+    with TestClient(app) as client:
+        list_response = client.get("/api/v1/llamacpp/assets")
+        register_response = client.post("/api/v1/llamacpp/assets/register-path", json={"path": "/models/base.gguf"})
+        import_response = client.post("/api/v1/llamacpp/assets/import-folder", json={"path": "/models"})
+
+    assert list_response.status_code == 200, list_response.text
+    assert register_response.status_code == 200, register_response.text
+    assert import_response.status_code == 200, import_response.text
+    assert [call[0] for call in calls] == [
+        fake_get_config_state,
+        fake_scan_assets,
+        fake_register_asset_path,
+        fake_import_asset_folder,
+    ]
+
+
+@pytest.mark.unit
 def test_legacy_inventory_excludes_mmproj_assets_after_asset_v2(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
 
@@ -309,6 +386,34 @@ def test_legacy_inventory_excludes_mmproj_assets_after_asset_v2(monkeypatch, tmp
     inventory = llamacpp_inventory_service.scan_inventory(limit=500)
 
     assert [item.basename for item in inventory.models] == ["chat.gguf"]
+
+
+@pytest.mark.unit
+def test_legacy_inventory_excludes_registered_mmproj_and_projector_paths(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "chat.gguf"
+    mmproj = models_dir / "mmproj-chat.gguf"
+    projector = models_dir / "projector-chat.gguf"
+    base.write_text("base")
+    mmproj.write_text("projector")
+    projector.write_text("projector")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, registered_model_paths=f"{base}, {mmproj}, {projector}"),
+    )
+
+    inventory = llamacpp_inventory_service.scan_inventory(limit=500)
+
+    assert [item.basename for item in inventory.models] == ["chat.gguf"]
+    with pytest.raises(ModelNotFoundError):
+        llamacpp_inventory_service.resolve_model_id(llamacpp_inventory_service.model_id_for_path(mmproj))
+    with pytest.raises(ModelNotFoundError):
+        llamacpp_inventory_service.resolve_model_id(llamacpp_inventory_service.model_id_for_path(projector))
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add llama.cpp Asset Inventory V2 backend contracts, scanning, inferred mmproj candidate metadata, and admin-only asset list/register/import endpoints.
- Preserve legacy `/llamacpp/inventory` and start-by-model behavior while exposing mmproj/folder/unknown assets through the new `/llamacpp/assets` surface.
- Add WebUI asset types/client methods plus a minimal Admin assets panel with grouped assets, warnings, register path, and import folder workflows.

## Change summary
Maintainer to fill in before merge: this PR is materially AI-authored and requires a human-written explanation of what changed and why these implementation choices were made.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py -v`
- [x] `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppInventoryPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_config_service.py tldw_Server_API/app/api/v1/endpoints/llamacpp.py -f json -o /tmp/bandit_llamacpp_asset_inventory_v2.json`
- [x] `git diff --check`

## Notes
- Deferred by design: remote downloads, model-family routing, automatic profile mutation, and automatic mmproj pairing.
- `bunx tsc --noEmit --pretty false` could not run inside the sandbox because Bun could not write to its tempdir; an escalated rerun was rejected by the approval reviewer. Focused Vitest coverage was run instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements llama.cpp Asset Inventory V2 with unified local asset scanning (GGUF, mmproj, folders), admin APIs, and an Admin UI panel to view/manage assets. Legacy `/llamacpp/inventory` remains GGUF-only, and asset endpoints now offload blocking work to the threadpool.

- **New Features**
  - Backend: asset schemas and config parsing for `imported_asset_folders`; scans `models_dir`, registered paths, and imported folders; returns GGUF/mmproj/folder/unknown assets with stable `asset_id`, metadata hints, inferred mmproj candidates, and warnings.
  - Backend APIs: `GET /llamacpp/assets`, `POST /llamacpp/assets/register-path`, `POST /llamacpp/assets/import-folder`; legacy inventory and model-id resolution strictly GGUF-only.
  - WebUI: TypeScript asset types and client methods; new `LlamacppAssetsPanel.tsx` integrated into `LlamacppAdminPage.tsx` with grouped lists, inferred candidates, warnings, and Rescan/Register/Import actions.

- **Bug Fixes**
  - Assets endpoints run scans/mutations via threadpool to avoid blocking the event loop.
  - Exclude `mmproj`/projector files from legacy inventory and reject mmproj IDs in model resolution.
  - Admin assets panel shows API errors without hiding the legacy inventory; Ant `List` rows keyed by `asset_id`.

<sup>Written for commit 2b6532316fac0551ff029755a6548029467d20a6. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1764?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

