### PR TITLE
Design Persona Visual post-setup management UX

### DIFF
--- a/Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md
+++ b/Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md
@@ -159,7 +159,7 @@ type PersonaVisualManagementSummary = {
     failed: number
   }
   attentionCounts: {
-    invalidSelectedManifest: number
+    invalidPackCount: number
     reviewCandidates: number
     failedCandidates: number
     unavailableLibraryItems: number

--- a/Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md
+++ b/Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md
@@ -1,0 +1,257 @@
+# Persona Visual Post-Setup Management Design
+
+## Status
+
+Draft design for GitHub issue #1769 and Backlog TASK-406.
+
+## Purpose
+
+The Persona Visual setup path is now mostly present: users can start from bundled
+defaults, import archives, create draft packs, save packs to the personal
+library, duplicate packs to another persona, queue generation jobs, review
+generated candidates, and explicitly activate a pack. The remaining product gap
+is management after first setup. The current `VisualPackEditor` exposes the
+right operations, but the lifecycle is dense and action-oriented users have to
+infer which pack is live, which packs are drafts, which jobs need attention, and
+which recovery state matters next.
+
+This design defines a post-setup management UX for Persona Garden Visuals. It is
+parallel to PR #1767 and intentionally does not change the recipe-backed
+generation request or job-payload design.
+
+## Current System
+
+The existing Persona Visual system already provides:
+
+1. active and available pack listing via `listPersonaVisualPacks()`.
+2. draft creation, manifest editing, asset upload, activation, and deactivation.
+3. export jobs with status refresh and authenticated archive download.
+4. import-preview and import-commit jobs with conflict choices.
+5. same-user duplicate-to-persona draft creation.
+6. reference-backed personal-library save, edit, remove, and use flows.
+7. generated candidate review before manifest changes.
+8. generation readiness diagnostics before queueing generation jobs.
+9. Buddy runtime fallback and an `Open Visuals` entry point.
+
+The design should keep these backend/API semantics and improve how the existing
+Visuals tab frames and sequences them.
+
+## Goals
+
+1. Make the current live Buddy visual pack obvious.
+2. Separate post-setup management from first-run setup.
+3. Give users a lifecycle view of active, draft, review, archived, and failed
+   packs.
+4. Put outstanding work in one visible attention path: invalid manifests,
+   incomplete drafts, pending jobs, candidates awaiting review, unavailable
+   library sources, and failed import/export/generation jobs.
+5. Preserve review-first and explicit activation semantics.
+6. Keep the first implementation slice mostly frontend and documentation
+   oriented, using existing endpoints.
+
+## Non-Goals
+
+1. No overlap with #1765 / PR #1767 recipe-backed generation request fields,
+   prompt composition, idempotency, or job payloads.
+2. No backend generation orchestration changes.
+3. No final default buddy art production.
+4. No renderer expansion, Live2D/Rive/Spine adapter, or manifest version bump.
+5. No MCP provider execution or resource download.
+6. No marketplace, shared public library, or cross-user sharing.
+7. No VN/CYOA behavior.
+8. No automatic activation after import, duplicate, library use, or generation.
+
+## Recommended UX Model
+
+### Management Header
+
+The Visuals tab should open with a compact management header once setup is no
+longer the dominant state. The header should summarize:
+
+1. selected persona name.
+2. active pack title or "No active visual pack".
+3. active pack health: ready, invalid, unavailable, or fallback.
+4. counts for drafts, review candidates, failed items, and library items.
+5. primary action: open the active pack, activate a valid selected draft, or
+   start setup when no packs exist.
+
+This header should not duplicate the full editor. It should orient users before
+they choose a pack or task.
+
+### Pack Workspace
+
+The existing pack selector should become a clearer workspace with filtered
+sections:
+
+1. **Active**: the one pack Buddy renders now. Show deactivation and diagnostics
+   here, not buried near unrelated actions.
+2. **Drafts and Review**: editable packs, imported drafts, duplicated drafts,
+   and packs with generated candidates.
+3. **Archived/Inactive**: previously active or inactive packs that remain
+   available but are not rendered.
+4. **Failed/Needs Attention**: failed packs, invalid manifests, source-stale
+   library rows, and failed jobs.
+
+The first implementation does not need a new route or backend filter. It can
+derive these groups from the existing pack list, selected pack, candidate list,
+library list, and job state already loaded by `VisualPackEditor`.
+
+### Task Queue
+
+Post-setup users need a small "needs attention" queue before the lower-level
+editor controls:
+
+1. generated candidates awaiting accept/reject.
+2. import preview ready for conflict choices.
+3. import commit completed and ready for draft review.
+4. export completed and ready to download.
+5. generation unavailable because jobs/provider/backend are not configured.
+6. invalid manifest blocking activation.
+7. stale or unavailable personal-library sources.
+
+Each row should link or focus the existing control area. The first slice should
+use local state only; durable job history can remain future work.
+
+### Reuse Panel
+
+`VisualPackReusePanel` is the correct concept, but in post-setup management it
+should read as a management action row rather than first-run help:
+
+1. Start fresh: creates a draft.
+2. Personal library: opens reusable same-user references.
+3. Portable archive: opens import preview and export affordances.
+4. Another persona: duplicates selected pack to another persona as a draft.
+
+The copy should continue to emphasize draft-first review and explicit
+activation. It should not suggest that library entries are snapshots; the
+reference-backed model in `Persona_Visual_Packs.md` remains authoritative.
+
+### Editor Sections
+
+The lower-level manifest editor can stay mostly as-is, but should be grouped so
+users do not have to scan a long mixed surface:
+
+1. Pack basics and active status.
+2. Assets and animations.
+3. State mappings and fallbacks.
+4. Authored triggers.
+5. Validation and activation.
+6. Jobs and review.
+7. Reuse and portability.
+
+This grouping is also the likely implementation path for splitting
+`VisualPackEditor.tsx` into smaller components later.
+
+## State Model
+
+The UI should derive a small `PersonaVisualManagementSummary` view model from
+existing data:
+
+```ts
+type PersonaVisualManagementSummary = {
+  activePackId: string | null
+  activePackTitle: string | null
+  packCounts: {
+    active: number
+    draft: number
+    review: number
+    archived: number
+    failed: number
+  }
+  attentionCounts: {
+    invalidSelectedManifest: number
+    reviewCandidates: number
+    failedCandidates: number
+    unavailableLibraryItems: number
+    changedLibraryItems: number
+    pendingJobs: number
+    failedJobs: number
+  }
+}
+```
+
+The first implementation can keep this view model in shared UI code and test it
+with deterministic inputs. Backend persistence is not required for V1.
+
+## Error And Recovery Semantics
+
+The management surface should preserve current behavior:
+
+1. Failed pack list/detail loads fall back to derived Buddy behavior.
+2. Failed generation readiness checks block queueing and explain what is
+   unavailable.
+3. Import previews and commits remain explicit; completed commits create drafts.
+4. Library items with unavailable sources remain removable but unusable.
+5. Changed library sources remain usable but visibly stale.
+6. Activation is disabled until required states resolve.
+7. Deactivation does not delete packs.
+
+## Accessibility And Copy
+
+The first implementation should avoid a visual-only dashboard. Counts and
+statuses need text labels, keyboard-focusable actions, and test IDs for the
+attention rows. Labels should use existing localization patterns in
+`sidepanel:personaGarden.visuals.*`.
+
+Copy should be direct:
+
+1. "Rendered now" for the active pack.
+2. "Draft, not live" for editable inactive packs.
+3. "Review required" for candidates/imports.
+4. "Source unavailable" for stale library references.
+5. "Ready to activate" only when validation passes.
+
+## Implementation Slices
+
+### Slice 1: Management Summary And Attention Model
+
+Add a pure shared UI helper that derives the management summary and attention
+rows from existing pack, candidate, library, import/export job, and readiness
+state. Add focused tests. No visual rewrite is required yet.
+
+### Slice 2: Visuals Tab Management Header
+
+Render the summary at the top of `VisualPackEditor`, including active-pack
+status, counts, and the highest-priority attention item. Keep existing controls
+intact below it.
+
+### Slice 3: Sectioned Pack Workspace
+
+Refactor the editor into clearer grouped sections while preserving behavior and
+test coverage. This is the point to extract small components from
+`VisualPackEditor.tsx`.
+
+### Slice 4: Attention Navigation Polish
+
+Add focus/scroll links from attention rows to existing controls: candidate
+review, import preview, import commit, export download, validation, library, and
+generation readiness.
+
+## Testing Strategy
+
+Focused tests should cover:
+
+1. management summary derivation with no packs.
+2. active pack plus inactive drafts.
+3. invalid selected manifest blocking activation.
+4. generated candidates awaiting review.
+5. completed import commit with draft review copy.
+6. completed export with download affordance.
+7. unavailable and changed library sources.
+8. generation readiness unavailable states.
+9. keyboard-accessible attention actions.
+10. existing Visual Pack editor behavior remains covered.
+
+## Rollout
+
+Keep each slice behind existing Persona Garden Visuals behavior; do not add a
+new feature flag unless the rendered layout becomes large enough to risk user
+confusion. Slice 1 is non-rendering and low risk. Slices 2-4 should preserve all
+existing test IDs or add compatibility wrappers where tests rely on current
+controls.
+
+## Recommendation
+
+Implement Slice 1 first. A tested management-summary helper gives future UI work
+a stable contract and makes the next PR reviewable without touching backend
+behavior or PR #1767's recipe-backed generation design.

--- a/backlog/tasks/task-406 - Design-Persona-Visual-post-setup-management-UX.md
+++ b/backlog/tasks/task-406 - Design-Persona-Visual-post-setup-management-UX.md
@@ -38,6 +38,7 @@ Write a Persona/Buddy design spec for the post-setup Persona Visual management e
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Added `Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md`.
 - Created GitHub tracking issue #1769 under the Persona/Buddy epic #1510.
+- Review follow-up: renamed the aggregate attention model field from `invalidSelectedManifest` to `invalidPackCount` to match the rest of the count-based summary fields.
 - Verified with `git diff --check`.
 - Bandit skipped because this slice only changes documentation and Backlog task metadata.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
@@ -45,7 +46,7 @@ Write a Persona/Buddy design spec for the post-setup Persona Visual management e
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Design completed for a post-setup Persona Visual management UX centered on the existing Persona Garden Visuals surface. The spec keeps the work parallel to PR #1767 and recommends a first implementation slice for a pure shared UI management-summary/attention model.
+Design completed for a post-setup Persona Visual management UX centered on the existing Persona Garden Visuals surface. The spec keeps the work parallel to PR #1767 and recommends a first implementation slice for a pure shared UI management-summary/attention model with aggregate count naming for attention states.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-406 - Design-Persona-Visual-post-setup-management-UX.md
+++ b/backlog/tasks/task-406 - Design-Persona-Visual-post-setup-management-UX.md
@@ -1,0 +1,59 @@
+---
+id: TASK-406
+title: Design Persona Visual post-setup management UX
+status: Done
+labels:
+- persona
+- visual-packs
+- design
+- webui
+priority: medium
+ordinal: 398
+references:
+- https://github.com/rmusser01/tldw_server/issues/1769
+- https://github.com/rmusser01/tldw_server/issues/1510
+documentation:
+- Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md
+modified_files:
+- Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write a Persona/Buddy design spec for the post-setup Persona Visual management experience in Persona Garden Visuals. Scope is documentation/tracking only: define how users understand and manage active packs, drafts, imports, exports, generated candidates, personal-library entries, duplicate-to-persona drafts, and recovery states without changing backend semantics or overlapping PR #1767 recipe-backed generation work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design defines post-setup active/draft/review/archived/failed pack management without changing backend semantics.
+- [x] #2 Design identifies attention states for generated candidates, import/export jobs, invalid manifests, generation readiness, and stale library entries.
+- [x] #3 Design preserves review-first and explicit activation semantics.
+- [x] #4 Design explicitly excludes PR #1767 recipe-backed generation work and VN/CYOA scope.
+- [x] #5 Design proposes small implementation slices and focused verification.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md`.
+- Created GitHub tracking issue #1769 under the Persona/Buddy epic #1510.
+- Verified with `git diff --check`.
+- Bandit skipped because this slice only changes documentation and Backlog task metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Design completed for a post-setup Persona Visual management UX centered on the existing Persona Garden Visuals surface. The spec keeps the work parallel to PR #1767 and recommends a first implementation slice for a pure shared UI management-summary/attention model.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds a Persona/Buddy design spec for post-setup Persona Visual management in Persona Garden Visuals.
- Defines active/draft/review/archived/failed pack lifecycle framing, attention states, recovery copy, and frontend implementation slices.
- Tracks the parallel work with GitHub issue #1769 and Backlog TASK-406.

## Scope Boundaries
- No overlap with #1765 / PR #1767 recipe-backed generation request or job-payload design.
- No backend generation orchestration, final art production, renderer expansion, MCP provider execution, marketplace/shared-library behavior, VN/CYOA behavior, or automatic activation.

## Change summary
TODO (human): Explain what changed and why this post-setup management design is the right next Persona/Buddy UX slice before merge.

## Verification
- `git diff --check origin/dev...HEAD`

Closes #1769.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a design spec for post-setup management of Persona Visual packs so users can clearly see what’s live, what needs review, and what needs fixing while keeping review-first, explicit activation. It proposes a compact management header, a small attention queue, and a sectioned workspace that reuse `VisualPackEditor` and existing endpoints, plus a count-based `PersonaVisualManagementSummary` view model (including `invalidPackCount`) as the first pure shared-UI slice; excludes backend changes and PR #1767’s recipe-backed generation scope (aligns with issue #1769 and TASK-406).

<sup>Written for commit fd872cedef6cddce53943d217dd61b887764aed1. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1771?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

