### PR TITLE
Add Persona Visual management summary model

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  PersonaVisualCandidate,
+  PersonaVisualImportPreviewResponse,
+  PersonaVisualLibraryItem,
+  PersonaVisualManifest,
+  PersonaVisualPack,
+  PersonaVisualPackExportResponse,
+  PersonaVisualPortabilityJobResponse
+} from "@/types/persona-visuals"
+import type { PersonaVisualGenerationReadinessView } from "../personaVisualGenerationReadiness"
+import { buildPersonaVisualManagementSummary } from "../personaVisualManagementSummary"
+
+const baseManifest: PersonaVisualManifest = {
+  manifest_version: 1,
+  renderer_type: "sprite_frames",
+  states: {},
+  animations: {}
+}
+
+const makePack = (overrides: Partial<PersonaVisualPack>): PersonaVisualPack => ({
+  id: "pack-1",
+  persona_id: "persona-1",
+  title: "Visual pack",
+  renderer_type: "sprite_frames",
+  status: "draft",
+  manifest: baseManifest,
+  ...overrides
+})
+
+const makeCandidate = (
+  overrides: Partial<PersonaVisualCandidate>
+): PersonaVisualCandidate => ({
+  id: "candidate-1",
+  pack_id: "pack-1",
+  persona_id: "persona-1",
+  status: "review",
+  ...overrides
+})
+
+const makeLibraryItem = (
+  overrides: Partial<PersonaVisualLibraryItem>
+): PersonaVisualLibraryItem => ({
+  id: "library-1",
+  title: "Reusable pack",
+  tags: [],
+  source_available: true,
+  source_changed: false,
+  ...overrides
+})
+
+const makeImportPreview = (
+  overrides: Partial<PersonaVisualImportPreviewResponse>
+): PersonaVisualImportPreviewResponse => ({
+  preview_id: "preview-1",
+  job_id: "preview-job-1",
+  portability_job_id: "portability-preview-1",
+  operation: "import_preview",
+  status: "completed",
+  visual_status: "completed",
+  stage: "completed",
+  bundle_summary: {},
+  validation_warnings: [],
+  conflicts: [],
+  proposed_plan: {},
+  quota_estimate: {},
+  required_choices: [],
+  target_warnings: [],
+  ...overrides
+})
+
+const makeExportJob = (
+  overrides: Partial<PersonaVisualPackExportResponse>
+): PersonaVisualPackExportResponse => ({
+  job_id: "export-job-1",
+  portability_job_id: "portability-export-1",
+  operation: "export",
+  persona_id: "persona-1",
+  pack_id: "pack-1",
+  status: "completed",
+  stage: "completed",
+  download_url: "/archive.tldw-persona-vpack",
+  ...overrides
+})
+
+const makePortabilityJob = (
+  overrides: Partial<PersonaVisualPortabilityJobResponse>
+): PersonaVisualPortabilityJobResponse => ({
+  job_id: "job-1",
+  portability_job_id: "portability-job-1",
+  operation: "import_commit",
+  persona_id: "persona-1",
+  pack_id: "pack-1",
+  status: "processing",
+  visual_status: "processing",
+  stage: "processing",
+  progress: {},
+  warnings: [],
+  ...overrides
+})
+
+const blockedReadiness: PersonaVisualGenerationReadinessView = {
+  status: "jobs_unavailable",
+  canQueue: false,
+  blocking: true,
+  enabledBackends: [],
+  queue: "persona_visual_generation"
+}
+
+describe("buildPersonaVisualManagementSummary", () => {
+  it("returns an empty management state when no visual packs exist", () => {
+    const model = buildPersonaVisualManagementSummary({ packs: [] })
+
+    expect(model.summary).toEqual({
+      activePackId: null,
+      activePackTitle: null,
+      packCounts: {
+        active: 0,
+        draft: 0,
+        review: 0,
+        archived: 0,
+        failed: 0
+      },
+      attentionCounts: {
+        invalidPackCount: 0,
+        reviewCandidates: 0,
+        failedCandidates: 0,
+        unavailableLibraryItems: 0,
+        changedLibraryItems: 0,
+        pendingJobs: 0,
+        failedJobs: 0
+      }
+    })
+    expect(model.attentionRows).toEqual([])
+  })
+
+  it("deduplicates the active pack returned outside the pack list", () => {
+    const activePack = makePack({
+      id: "active-pack",
+      title: "Rendered now",
+      status: "active"
+    })
+
+    const model = buildPersonaVisualManagementSummary({
+      activePack,
+      packs: [
+        makePack({ id: "draft-pack", status: "draft" }),
+        makePack({ id: "review-pack", status: "review" }),
+        makePack({ id: "archived-pack", status: "archived" }),
+        makePack({ id: "failed-pack", status: "failed" })
+      ]
+    })
+
+    expect(model.summary.activePackId).toBe("active-pack")
+    expect(model.summary.activePackTitle).toBe("Rendered now")
+    expect(model.summary.packCounts).toEqual({
+      active: 1,
+      draft: 1,
+      review: 1,
+      archived: 1,
+      failed: 1
+    })
+    expect(model.attentionRows.map((row) => row.kind)).toEqual(["failed_pack"])
+  })
+
+  it("surfaces selected-pack validation and generated candidate review state", () => {
+    const model = buildPersonaVisualManagementSummary({
+      packs: [makePack({ id: "pack-1", status: "draft" })],
+      selectedPack: makePack({ id: "pack-1", status: "draft" }),
+      validationErrors: ["Missing required state: speaking"],
+      candidates: [
+        makeCandidate({ id: "candidate-review", status: "review" }),
+        makeCandidate({ id: "candidate-failed", status: "failed" }),
+        makeCandidate({ id: "candidate-rejected", status: "rejected" })
+      ]
+    })
+
+    expect(model.summary.attentionCounts.invalidPackCount).toBe(1)
+    expect(model.summary.attentionCounts.reviewCandidates).toBe(1)
+    expect(model.summary.attentionCounts.failedCandidates).toBe(1)
+    expect(model.attentionRows.map((row) => row.kind)).toEqual([
+      "invalid_manifest",
+      "generated_candidates_review",
+      "generated_candidates_failed"
+    ])
+  })
+
+  it("tracks import/export job attention without activating completed drafts", () => {
+    const model = buildPersonaVisualManagementSummary({
+      packs: [makePack({ id: "pack-1", status: "draft" })],
+      importPreview: makeImportPreview({ status: "completed" }),
+      importCommitJob: makePortabilityJob({
+        operation: "import_commit",
+        status: "completed",
+        visual_status: "completed",
+        stage: "completed",
+        pack_id: "imported-draft"
+      }),
+      exportJob: makeExportJob({ status: "completed" })
+    })
+
+    expect(model.summary.activePackId).toBeNull()
+    expect(model.summary.attentionCounts.pendingJobs).toBe(0)
+    expect(model.summary.attentionCounts.failedJobs).toBe(0)
+    expect(model.attentionRows.map((row) => row.kind)).toEqual([
+      "import_preview_ready",
+      "import_commit_completed",
+      "export_completed"
+    ])
+  })
+
+  it("tracks stale library sources, unavailable generation, and failed jobs", () => {
+    const model = buildPersonaVisualManagementSummary({
+      packs: [makePack({ id: "pack-1", status: "draft" })],
+      libraryItems: [
+        makeLibraryItem({
+          id: "unavailable-library-item",
+          source_available: false,
+          source_changed: false
+        }),
+        makeLibraryItem({
+          id: "changed-library-item",
+          source_available: true,
+          source_changed: true
+        })
+      ],
+      generationReadiness: blockedReadiness,
+      exportJob: makePortabilityJob({
+        operation: "export",
+        status: "failed",
+        visual_status: "failed",
+        stage: "failed"
+      }),
+      importCommitJob: makePortabilityJob({
+        operation: "import_commit",
+        status: "processing",
+        visual_status: "processing",
+        stage: "processing"
+      })
+    })
+
+    expect(model.summary.attentionCounts.unavailableLibraryItems).toBe(1)
+    expect(model.summary.attentionCounts.changedLibraryItems).toBe(1)
+    expect(model.summary.attentionCounts.pendingJobs).toBe(1)
+    expect(model.summary.attentionCounts.failedJobs).toBe(1)
+    expect(model.attentionRows.map((row) => row.kind)).toEqual([
+      "library_source_unavailable",
+      "library_source_changed",
+      "generation_unavailable",
+      "pending_job",
+      "failed_job"
+    ])
+  })
+})

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts
@@ -164,6 +164,33 @@ describe("buildPersonaVisualManagementSummary", () => {
     expect(model.attentionRows.map((row) => row.kind)).toEqual(["failed_pack"])
   })
 
+  it("deduplicates the same active pack when it also appears in the pack list", () => {
+    const sharedPack = makePack({
+      id: "shared-pack",
+      title: "Shared pack",
+      status: "active"
+    })
+
+    const model = buildPersonaVisualManagementSummary({
+      activePack: sharedPack,
+      packs: [
+        sharedPack,
+        makePack({ id: "draft-pack", status: "draft" }),
+        makePack({ id: "failed-pack", status: "failed" })
+      ]
+    })
+
+    expect(model.summary.activePackId).toBe("shared-pack")
+    expect(model.summary.packCounts).toEqual({
+      active: 1,
+      draft: 1,
+      review: 0,
+      archived: 0,
+      failed: 1
+    })
+    expect(model.attentionRows.map((row) => row.kind)).toEqual(["failed_pack"])
+  })
+
   it("surfaces selected-pack validation and generated candidate review state", () => {
     const model = buildPersonaVisualManagementSummary({
       packs: [makePack({ id: "pack-1", status: "draft" })],
@@ -208,6 +235,42 @@ describe("buildPersonaVisualManagementSummary", () => {
       "import_commit_completed",
       "export_completed"
     ])
+  })
+
+  it("treats deleted import previews as failed jobs, not preview-ready work", () => {
+    const model = buildPersonaVisualManagementSummary({
+      packs: [makePack({ id: "pack-1", status: "draft" })],
+      importPreview: makeImportPreview({
+        status: "deleted",
+        visual_status: "deleted",
+        stage: "deleted"
+      })
+    })
+
+    expect(model.summary.attentionCounts.failedJobs).toBe(1)
+    expect(model.attentionRows.map((row) => row.kind)).toEqual(["failed_job"])
+  })
+
+  it("uses failure precedence for conflicting job status fields", () => {
+    const model = buildPersonaVisualManagementSummary({
+      packs: [makePack({ id: "pack-1", status: "draft" })],
+      importCommitJob: makePortabilityJob({
+        operation: "import_commit",
+        status: "processing",
+        visual_status: "failed",
+        stage: "processing"
+      }),
+      exportJob: makePortabilityJob({
+        operation: "export",
+        status: "failed",
+        visual_status: "completed",
+        stage: "failed"
+      })
+    })
+
+    expect(model.summary.attentionCounts.pendingJobs).toBe(0)
+    expect(model.summary.attentionCounts.failedJobs).toBe(2)
+    expect(model.attentionRows.map((row) => row.kind)).toEqual(["failed_job"])
   })
 
   it("tracks stale library sources, unavailable generation, and failed jobs", () => {

--- a/apps/packages/ui/src/components/PersonaGarden/personaVisualManagementSummary.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaVisualManagementSummary.ts
@@ -1,0 +1,324 @@
+import type {
+  PersonaVisualCandidate,
+  PersonaVisualImportCommitStartResponse,
+  PersonaVisualImportPreviewResponse,
+  PersonaVisualImportPreviewStartResponse,
+  PersonaVisualLibraryItem,
+  PersonaVisualPack,
+  PersonaVisualPackExportResponse,
+  PersonaVisualPackStatus,
+  PersonaVisualPortabilityJobResponse
+} from "@/types/persona-visuals"
+import type { PersonaVisualGenerationReadinessView } from "./personaVisualGenerationReadiness"
+
+/**
+ * Derives post-setup Persona Visual management state from existing editor data.
+ *
+ * The helper is intentionally pure so the Visuals tab can render lifecycle
+ * headers and attention queues without introducing new backend state.
+ */
+
+export type PersonaVisualManagementAttentionKind =
+  | "failed_pack"
+  | "invalid_manifest"
+  | "generated_candidates_review"
+  | "generated_candidates_failed"
+  | "import_preview_ready"
+  | "import_commit_completed"
+  | "export_completed"
+  | "library_source_unavailable"
+  | "library_source_changed"
+  | "generation_unavailable"
+  | "pending_job"
+  | "failed_job"
+
+export type PersonaVisualManagementAttentionTarget =
+  | "packs"
+  | "validation"
+  | "candidates"
+  | "import"
+  | "export"
+  | "library"
+  | "generation"
+  | "jobs"
+
+export interface PersonaVisualManagementAttentionRow {
+  id: string
+  kind: PersonaVisualManagementAttentionKind
+  target: PersonaVisualManagementAttentionTarget
+  count: number
+}
+
+export interface PersonaVisualManagementSummary {
+  activePackId: string | null
+  activePackTitle: string | null
+  packCounts: Record<PersonaVisualPackStatus, number>
+  attentionCounts: {
+    invalidPackCount: number
+    reviewCandidates: number
+    failedCandidates: number
+    unavailableLibraryItems: number
+    changedLibraryItems: number
+    pendingJobs: number
+    failedJobs: number
+  }
+}
+
+type PersonaVisualImportPreviewStatus =
+  | PersonaVisualImportPreviewStartResponse
+  | PersonaVisualImportPreviewResponse
+
+type PersonaVisualImportCommitJob =
+  | PersonaVisualImportCommitStartResponse
+  | PersonaVisualPortabilityJobResponse
+
+type PersonaVisualExportJob =
+  | PersonaVisualPackExportResponse
+  | PersonaVisualPortabilityJobResponse
+
+type PersonaVisualManagementJob =
+  | PersonaVisualImportPreviewStatus
+  | PersonaVisualImportCommitJob
+  | PersonaVisualExportJob
+
+export interface PersonaVisualManagementSummaryInput {
+  packs?: readonly PersonaVisualPack[]
+  activePack?: PersonaVisualPack | null
+  selectedPack?: PersonaVisualPack | null
+  validationErrors?: readonly string[]
+  candidates?: readonly PersonaVisualCandidate[]
+  libraryItems?: readonly PersonaVisualLibraryItem[]
+  importPreview?: PersonaVisualImportPreviewStatus | null
+  importCommitJob?: PersonaVisualImportCommitJob | null
+  exportJob?: PersonaVisualExportJob | null
+  generationReadiness?: PersonaVisualGenerationReadinessView | null
+}
+
+export interface PersonaVisualManagementModel {
+  summary: PersonaVisualManagementSummary
+  attentionRows: PersonaVisualManagementAttentionRow[]
+}
+
+const PACK_STATUSES: PersonaVisualPackStatus[] = [
+  "active",
+  "draft",
+  "review",
+  "archived",
+  "failed"
+]
+
+const PENDING_JOB_STATUSES = new Set(["queued", "pending", "processing", "running"])
+const FAILED_JOB_STATUSES = new Set(["failed", "cancelled", "quarantined"])
+
+const normalizeStatus = (status: string | null | undefined): string =>
+  String(status || "").trim().toLowerCase()
+
+const dedupePacks = (
+  packs: readonly PersonaVisualPack[],
+  activePack: PersonaVisualPack | null | undefined
+): PersonaVisualPack[] => {
+  const byId = new Map<string, PersonaVisualPack>()
+  for (const pack of packs) {
+    byId.set(pack.id, pack)
+  }
+  if (activePack) {
+    byId.set(activePack.id, activePack)
+  }
+  return Array.from(byId.values())
+}
+
+const countByStatus = (
+  packs: readonly PersonaVisualPack[]
+): Record<PersonaVisualPackStatus, number> => {
+  const counts = PACK_STATUSES.reduce<Record<PersonaVisualPackStatus, number>>(
+    (nextCounts, status) => {
+      nextCounts[status] = 0
+      return nextCounts
+    },
+    {
+      active: 0,
+      draft: 0,
+      review: 0,
+      archived: 0,
+      failed: 0
+    }
+  )
+
+  for (const pack of packs) {
+    counts[pack.status] += 1
+  }
+  return counts
+}
+
+const getActivePack = (
+  packs: readonly PersonaVisualPack[],
+  activePack: PersonaVisualPack | null | undefined
+): PersonaVisualPack | null =>
+  activePack ?? packs.find((pack) => pack.status === "active") ?? null
+
+const getJobStatus = (job: PersonaVisualManagementJob | null | undefined): string =>
+  normalizeStatus(job?.status)
+
+const getJobVisualStatus = (
+  job: PersonaVisualManagementJob | null | undefined
+): string => {
+  if (!job || !("visual_status" in job)) return ""
+  return normalizeStatus(job.visual_status)
+}
+
+const isPendingJob = (job: PersonaVisualManagementJob | null | undefined): boolean =>
+  PENDING_JOB_STATUSES.has(getJobStatus(job)) ||
+  PENDING_JOB_STATUSES.has(getJobVisualStatus(job))
+
+const isFailedJob = (job: PersonaVisualManagementJob | null | undefined): boolean =>
+  FAILED_JOB_STATUSES.has(getJobStatus(job)) ||
+  FAILED_JOB_STATUSES.has(getJobVisualStatus(job))
+
+const isCompletedJob = (job: PersonaVisualManagementJob | null | undefined): boolean =>
+  getJobStatus(job) === "completed" || getJobVisualStatus(job) === "completed"
+
+const countJobs = (
+  jobs: readonly (PersonaVisualManagementJob | null | undefined)[],
+  predicate: (job: PersonaVisualManagementJob | null | undefined) => boolean
+): number => jobs.filter(predicate).length
+
+const isGenerationUnavailable = (
+  readiness: PersonaVisualGenerationReadinessView | null | undefined
+): boolean =>
+  Boolean(
+    readiness &&
+      readiness.blocking &&
+      readiness.status !== "loading" &&
+      readiness.status !== "ready"
+  )
+
+const addAttentionRow = (
+  rows: PersonaVisualManagementAttentionRow[],
+  row: PersonaVisualManagementAttentionRow
+): void => {
+  if (row.count > 0) rows.push(row)
+}
+
+export function buildPersonaVisualManagementSummary(
+  input: PersonaVisualManagementSummaryInput
+): PersonaVisualManagementModel {
+  const packs = dedupePacks(input.packs || [], input.activePack)
+  const activePack = getActivePack(packs, input.activePack)
+  const packCounts = countByStatus(packs)
+  const candidates = input.candidates || []
+  const libraryItems = input.libraryItems || []
+  const jobs = [input.importPreview, input.importCommitJob, input.exportJob]
+
+  const invalidPackCount =
+    input.selectedPack && (input.validationErrors || []).length > 0 ? 1 : 0
+  const reviewCandidates = candidates.filter(
+    (candidate) => candidate.status === "review"
+  ).length
+  const failedCandidates = candidates.filter(
+    (candidate) => candidate.status === "failed"
+  ).length
+  const unavailableLibraryItems = libraryItems.filter(
+    (item) => !item.source_available
+  ).length
+  const changedLibraryItems = libraryItems.filter(
+    (item) => item.source_available && item.source_changed
+  ).length
+  const pendingJobs = countJobs(jobs, isPendingJob)
+  const failedJobs = countJobs(jobs, isFailedJob)
+
+  const attentionRows: PersonaVisualManagementAttentionRow[] = []
+  addAttentionRow(attentionRows, {
+    id: "failed-pack",
+    kind: "failed_pack",
+    target: "packs",
+    count: packCounts.failed
+  })
+  addAttentionRow(attentionRows, {
+    id: "invalid-manifest",
+    kind: "invalid_manifest",
+    target: "validation",
+    count: invalidPackCount
+  })
+  addAttentionRow(attentionRows, {
+    id: "generated-candidates-review",
+    kind: "generated_candidates_review",
+    target: "candidates",
+    count: reviewCandidates
+  })
+  addAttentionRow(attentionRows, {
+    id: "generated-candidates-failed",
+    kind: "generated_candidates_failed",
+    target: "candidates",
+    count: failedCandidates
+  })
+  addAttentionRow(attentionRows, {
+    id: "import-preview-ready",
+    kind: "import_preview_ready",
+    target: "import",
+    count:
+      input.importPreview &&
+      ["blocked", "completed"].includes(getJobStatus(input.importPreview))
+        ? 1
+        : 0
+  })
+  addAttentionRow(attentionRows, {
+    id: "import-commit-completed",
+    kind: "import_commit_completed",
+    target: "import",
+    count: isCompletedJob(input.importCommitJob) ? 1 : 0
+  })
+  addAttentionRow(attentionRows, {
+    id: "export-completed",
+    kind: "export_completed",
+    target: "export",
+    count: isCompletedJob(input.exportJob) ? 1 : 0
+  })
+  addAttentionRow(attentionRows, {
+    id: "library-source-unavailable",
+    kind: "library_source_unavailable",
+    target: "library",
+    count: unavailableLibraryItems
+  })
+  addAttentionRow(attentionRows, {
+    id: "library-source-changed",
+    kind: "library_source_changed",
+    target: "library",
+    count: changedLibraryItems
+  })
+  addAttentionRow(attentionRows, {
+    id: "generation-unavailable",
+    kind: "generation_unavailable",
+    target: "generation",
+    count: isGenerationUnavailable(input.generationReadiness) ? 1 : 0
+  })
+  addAttentionRow(attentionRows, {
+    id: "pending-job",
+    kind: "pending_job",
+    target: "jobs",
+    count: pendingJobs
+  })
+  addAttentionRow(attentionRows, {
+    id: "failed-job",
+    kind: "failed_job",
+    target: "jobs",
+    count: failedJobs
+  })
+
+  return {
+    summary: {
+      activePackId: activePack?.id || null,
+      activePackTitle: activePack?.title || null,
+      packCounts,
+      attentionCounts: {
+        invalidPackCount,
+        reviewCandidates,
+        failedCandidates,
+        unavailableLibraryItems,
+        changedLibraryItems,
+        pendingJobs,
+        failedJobs
+      }
+    },
+    attentionRows
+  }
+}

--- a/apps/packages/ui/src/components/PersonaGarden/personaVisualManagementSummary.ts
+++ b/apps/packages/ui/src/components/PersonaGarden/personaVisualManagementSummary.ts
@@ -99,16 +99,13 @@ export interface PersonaVisualManagementModel {
   attentionRows: PersonaVisualManagementAttentionRow[]
 }
 
-const PACK_STATUSES: PersonaVisualPackStatus[] = [
-  "active",
-  "draft",
-  "review",
-  "archived",
-  "failed"
-]
-
 const PENDING_JOB_STATUSES = new Set(["queued", "pending", "processing", "running"])
-const FAILED_JOB_STATUSES = new Set(["failed", "cancelled", "quarantined"])
+const FAILED_JOB_STATUSES = new Set([
+  "failed",
+  "cancelled",
+  "deleted",
+  "quarantined"
+])
 
 const normalizeStatus = (status: string | null | undefined): string =>
   String(status || "").trim().toLowerCase()
@@ -130,19 +127,13 @@ const dedupePacks = (
 const countByStatus = (
   packs: readonly PersonaVisualPack[]
 ): Record<PersonaVisualPackStatus, number> => {
-  const counts = PACK_STATUSES.reduce<Record<PersonaVisualPackStatus, number>>(
-    (nextCounts, status) => {
-      nextCounts[status] = 0
-      return nextCounts
-    },
-    {
-      active: 0,
-      draft: 0,
-      review: 0,
-      archived: 0,
-      failed: 0
-    }
-  )
+  const counts: Record<PersonaVisualPackStatus, number> = {
+    active: 0,
+    draft: 0,
+    review: 0,
+    archived: 0,
+    failed: 0
+  }
 
   for (const pack of packs) {
     counts[pack.status] += 1
@@ -166,16 +157,24 @@ const getJobVisualStatus = (
   return normalizeStatus(job.visual_status)
 }
 
+const getCanonicalJobState = (
+  job: PersonaVisualManagementJob | null | undefined
+): string => {
+  const status = getJobStatus(job)
+  const visualStatus = getJobVisualStatus(job)
+  if (FAILED_JOB_STATUSES.has(status)) return status
+  if (FAILED_JOB_STATUSES.has(visualStatus)) return visualStatus
+  return status || visualStatus
+}
+
 const isPendingJob = (job: PersonaVisualManagementJob | null | undefined): boolean =>
-  PENDING_JOB_STATUSES.has(getJobStatus(job)) ||
-  PENDING_JOB_STATUSES.has(getJobVisualStatus(job))
+  PENDING_JOB_STATUSES.has(getCanonicalJobState(job))
 
 const isFailedJob = (job: PersonaVisualManagementJob | null | undefined): boolean =>
-  FAILED_JOB_STATUSES.has(getJobStatus(job)) ||
-  FAILED_JOB_STATUSES.has(getJobVisualStatus(job))
+  FAILED_JOB_STATUSES.has(getCanonicalJobState(job))
 
 const isCompletedJob = (job: PersonaVisualManagementJob | null | undefined): boolean =>
-  getJobStatus(job) === "completed" || getJobVisualStatus(job) === "completed"
+  getCanonicalJobState(job) === "completed"
 
 const countJobs = (
   jobs: readonly (PersonaVisualManagementJob | null | undefined)[],

--- a/backlog/tasks/task-408 - Implement-Persona-Visual-management-summary-model.md
+++ b/backlog/tasks/task-408 - Implement-Persona-Visual-management-summary-model.md
@@ -1,0 +1,54 @@
+---
+id: TASK-408
+title: Implement Persona Visual management summary model
+status: Done
+references:
+- https://github.com/rmusser01/tldw_server/issues/1510
+- https://github.com/rmusser01/tldw_server/issues/1769
+documentation:
+- Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md
+modified_files:
+- apps/packages/ui/src/components/PersonaGarden/personaVisualManagementSummary.ts
+- apps/packages/ui/src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts
+- backlog/tasks/task-408 - Implement-Persona-Visual-management-summary-model.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Slice 1 from the Persona Visual post-setup management design: add a pure shared UI helper that derives PersonaVisualManagementSummary and attention rows from existing Persona Garden visual pack, candidate, library, import/export job, and generation-readiness state. Keep this slice frontend-only with deterministic tests and no backend/API behavior changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Slice 1 of the Persona Visual post-setup management design. Added a pure shared UI helper that derives PersonaVisualManagementSummary plus attention rows from existing Persona Garden visual state: packs, active pack, selected validation errors, generated candidates, library items, import/export jobs, and generation readiness. Added deterministic Vitest coverage for empty state, active-pack dedupe, validation/candidate attention, import/export completion attention, library stale/unavailable state, generation unavailability, pending jobs, and failed jobs.
+
+Verification:
+- RED: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts failed because ../personaVisualManagementSummary did not exist.
+- GREEN: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts passed 5 tests.
+- Focused regression: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed 59 tests.
+- git diff --check passed.
+- Full package TypeScript check was attempted with bunx tsc --noEmit -p tsconfig.json and failed on existing unrelated repo-wide type debt outside this slice; no errors referenced the new Persona Visual helper files.
+- Bandit skipped because this slice only changes TypeScript frontend files and Backlog metadata, with no Python touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-408 - Implement-Persona-Visual-management-summary-model.md
+++ b/backlog/tasks/task-408 - Implement-Persona-Visual-management-summary-model.md
@@ -21,6 +21,10 @@ Implement Slice 1 from the Persona Visual post-setup management design: add a pu
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] Pure Persona Visual management summary model derives active-pack identity, pack lifecycle counts, and attention rows from existing Persona Garden editor state without backend or API changes.
+- [x] Attention model covers invalid selected manifests, generated candidate review/failure, stale or unavailable library sources, generation unavailability, import/export completion, pending jobs, and failed terminal jobs.
+- [x] Tests cover empty state, active-pack dedupe including duplicate active-pack inputs, validation/candidate attention, import/export completion, deleted import preview failure, conflicting job-state precedence, library source state, generation unavailability, pending jobs, and failed jobs.
+- [x] Focused Persona Garden visual regression tests pass and verification details are recorded in the Final Summary.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -32,12 +36,19 @@ Implement Slice 1 from the Persona Visual post-setup management design: add a pu
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented Slice 1 of the Persona Visual post-setup management design. Added a pure shared UI helper that derives PersonaVisualManagementSummary plus attention rows from existing Persona Garden visual state: packs, active pack, selected validation errors, generated candidates, library items, import/export jobs, and generation readiness. Added deterministic Vitest coverage for empty state, active-pack dedupe, validation/candidate attention, import/export completion attention, library stale/unavailable state, generation unavailability, pending jobs, and failed jobs.
+Implemented Slice 1 of the Persona Visual post-setup management design. Added a pure shared UI helper that derives PersonaVisualManagementSummary plus attention rows from existing Persona Garden visual state: packs, active pack, selected validation errors, generated candidates, library items, import/export jobs, and generation readiness. Added deterministic Vitest coverage for empty state, active-pack dedupe, validation/candidate attention, import/export completion attention, library stale/unavailable state, generation unavailability, pending jobs, failed jobs, deleted import preview failure, and conflicting job-state failure precedence.
+
+Review follow-up:
+- Verified and fixed the deleted import-preview terminal state so it contributes to failed job attention rather than disappearing from the management model.
+- Replaced OR-based job classification with canonical state precedence where failure terminal states win over pending/completed conflicts.
+- Added the missing actual dedupe regression where the same active pack is present in both active_pack and packs.
+- Simplified pack count initialization and completed the Backlog AC/DoD metadata.
 
 Verification:
-- RED: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts failed because ../personaVisualManagementSummary did not exist.
-- GREEN: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts passed 5 tests.
-- Focused regression: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed 59 tests.
+- RED: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts failed before the helper existed.
+- Review RED: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts failed on deleted preview and conflicting job status regressions before the review fixes.
+- GREEN: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts passed 8 tests.
+- Focused regression: bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx passed 62 tests.
 - git diff --check passed.
 - Full package TypeScript check was attempted with bunx tsc --noEmit -p tsconfig.json and failed on existing unrelated repo-wide type debt outside this slice; no errors referenced the new Persona Visual helper files.
 - Bandit skipped because this slice only changes TypeScript frontend files and Backlog metadata, with no Python touched.
@@ -45,10 +56,10 @@ Verification:
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds a pure Persona Visual management summary helper for post-setup lifecycle counts and attention rows.
- Covers active-pack dedupe, validation/candidate attention, import/export completion, stale library sources, generation unavailability, pending jobs, failed jobs, deleted import previews, and conflicting job-state precedence with focused Vitest tests.
- Records the implementation and review follow-up in Backlog TASK-408.

Refs #1510 and #1769.

## Review follow-up
- Added the missing actual active-pack dedupe regression.
- Classified deleted import previews as failed job attention.
- Switched job classification to canonical failure precedence so one job cannot be both pending/completed and failed.
- Simplified pack count initialization.
- Filled Backlog acceptance criteria and aligned the DoD checklist with the task status.

## Change summary
TODO: human-authored change summary required before merge.

## Verification
- RED: `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts` failed before the helper existed.
- Review RED: `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts` failed on deleted preview and conflicting job status regressions before the review fixes.
- GREEN: `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts` passed 8 tests.
- `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed 62 tests.
- `git diff --check` passed.
- `bunx tsc --noEmit -p tsconfig.json` was attempted and failed on existing unrelated package-wide type debt outside this slice; no emitted errors referenced the new Persona Visual helper files.
- Bandit skipped: frontend TypeScript-only slice, no Python touched.