### PR TITLE
Add llama.cpp profile capability resolver

### DIFF
--- a/backlog/tasks/task-408 - Implement-llama.cpp-profile-capability-resolver.md
+++ b/backlog/tasks/task-408 - Implement-llama.cpp-profile-capability-resolver.md
@@ -9,6 +9,8 @@ labels:
 priority: high
 documentation:
 - Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/1777
 ---
 
 ## Description

--- a/backlog/tasks/task-408 - Implement-llama.cpp-profile-capability-resolver.md
+++ b/backlog/tasks/task-408 - Implement-llama.cpp-profile-capability-resolver.md
@@ -1,0 +1,55 @@
+---
+id: TASK-408
+title: Implement llama.cpp profile capability resolver
+status: Done
+labels:
+- llamacpp
+- backend
+- tests
+priority: high
+documentation:
+- Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 1 from the llama.cpp model-family/mmproj profile wiring plan: add a public local asset resolver and a profile capability/launch resolver that validates base GGUF and optional mmproj assets, derives mode capabilities/modalities, and normalizes launch args without changing supervisor or WebUI wiring yet.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 resolve_asset_id supports expected-kind filtering, missing IDs, stale paths, and optional pre-scanned assets without changing resolve_model_id compatibility.
+- [x] #2 resolve_profile_launch resolves base model paths, requires mmproj for vision mode, injects resolved mmproj args, rejects conflicting projector args, and derives mode capability/modalities.
+- [x] #3 Profile capability metadata returns bounded public metadata without raw path exposure.
+- [x] #4 Focused llama.cpp inventory/profile capability tests pass.
+- [x] #5 Bandit and git diff checks are recorded for touched code.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+RED: asset resolver tests failed with AttributeError because resolve_asset_id did not exist. RED: profile capability tests failed with ModuleNotFoundError because llamacpp_profile_capabilities did not exist. Additional RED: folder expected-kind resolver test failed until folder assets were accepted explicitly.
+
+GREEN: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py -v -> 36 passed, 5 warnings.
+
+Validation: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py -f json -o /tmp/bandit_llamacpp_profile_capability_resolver.json -> 0 findings. git diff --check -> exit 0.
+
+Known deferred work: supervisor startup wiring, /api/v1/llm/models/metadata integration, and WebUI display remain later tasks from the approved plan.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Task 1 backend resolver slice for llama.cpp managed profiles: public asset ID resolution in inventory service plus profile launch/capability metadata helpers for GGUF, mmproj, vision, embedding, rerank, and server_generic modes. Supervisor wiring, llm metadata endpoint integration, and WebUI display remain intentionally deferred to later plan tasks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation/task notes updated when relevant
+- [x] #4 Bandit run for touched code when applicable or documented skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-408 - Implement-llama.cpp-profile-capability-resolver.md
+++ b/backlog/tasks/task-408 - Implement-llama.cpp-profile-capability-resolver.md
@@ -33,17 +33,23 @@ Implement Task 1 from the llama.cpp model-family/mmproj profile wiring plan: add
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 RED: asset resolver tests failed with AttributeError because resolve_asset_id did not exist. RED: profile capability tests failed with ModuleNotFoundError because llamacpp_profile_capabilities did not exist. Additional RED: folder expected-kind resolver test failed until folder assets were accepted explicitly.
 
-GREEN: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py -v -> 36 passed, 5 warnings.
+PR #1777 review RED: python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py::test_resolve_asset_id_fails_closed_without_allowed_paths tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py::test_manual_profile_path_fails_closed_without_allowed_paths -v -> failed because current code did not raise ServerError for empty allowlists.
 
-Validation: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py -f json -o /tmp/bandit_llamacpp_profile_capability_resolver.json -> 0 findings. git diff --check -> exit 0.
+Final GREEN: python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py -v -> 38 passed, 5 warnings.
+
+Warnings investigated with python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py -o addopts='' -q -rw -> 36 passed, 5 warnings before review-fix tests were added. Warning details accepted as existing baseline outside this llama.cpp slice: PytestConfigWarning at .venv/lib/python3.11/site-packages/_pytest/config/__init__.py:1474, Unknown config option: import_mode; PytestConfigWarning at .venv/lib/python3.11/site-packages/_pytest/config/__init__.py:1474, Unknown config option: plugins; DeprecationWarning at .venv/lib/python3.11/site-packages/passlib/utils/__init__.py:854, crypt is deprecated and slated for removal in Python 3.13; UserWarning at .venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:198, Field name schema in ResponseFormatJsonSchemaSpec shadows an attribute in parent BaseModel; UserWarning at .venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:198, Field name schema in JSONValidateConfig shadows an attribute in parent BaseAdapterConfig.
+
+Validation: python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py -f json -> 0 findings. git diff --check -> exit 0.
 
 Known deferred work: supervisor startup wiring, /api/v1/llm/models/metadata integration, and WebUI display remain later tasks from the approved plan.
+
+Review disposition: fixed the Qodo allowlist finding by making asset/profile path validation fail closed when no allowed bases are configured. Fixed Qodo line-length comments in the touched regions. Fixed CodeRabbit Backlog command portability and warning-detail comments. Gemini redundant-validation/private-helper comments were addressed where valid by returning validated resolved asset paths directly and moving manual path validation into a public inventory helper; the remaining asset-kind recheck in resolve_asset_id is intentionally retained because callers can pass pre-scanned assets and the resolver should validate the actual path as well as the supplied asset metadata.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Task 1 backend resolver slice for llama.cpp managed profiles: public asset ID resolution in inventory service plus profile launch/capability metadata helpers for GGUF, mmproj, vision, embedding, rerank, and server_generic modes. Supervisor wiring, llm metadata endpoint integration, and WebUI display remain intentionally deferred to later plan tasks.
+Implemented the Task 1 backend resolver slice for llama.cpp managed profiles and addressed PR #1777 review feedback. Asset and manual profile path validation now fails closed when no allowed bases are configured, manual profile-path validation reuses a public inventory helper, resolved asset IDs return canonical paths, and the Backlog task records portable commands plus warning details. Supervisor wiring, llm metadata endpoint integration, and WebUI display remain intentionally deferred to later plan tasks.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -333,6 +333,42 @@ def resolve_model_id(model_id: str) -> Path:
     raise ModelNotFoundError(f"Model ID {wanted} was not found in the llama.cpp inventory.")
 
 
+def resolve_asset_id(
+    asset_id: str,
+    expected_kind: str | None = None,
+    assets: list[LlamaCppAsset] | None = None,
+) -> LlamaCppAsset:
+    """Resolve a stable asset inventory ID to an available local asset."""
+    wanted = str(asset_id or "").strip()
+    if not wanted:
+        raise ModelNotFoundError("Asset ID is required.")
+    normalized_kind = str(expected_kind or "").strip().lower() or None
+    search_pool = assets if assets is not None else scan_assets().assets
+    saved_config = _read_saved_config()
+    allowed_bases = _allowed_bases_for_config(saved_config)
+
+    for asset in search_pool:
+        if asset.asset_id != wanted:
+            continue
+        if normalized_kind and asset.kind != normalized_kind:
+            raise ModelNotFoundError(f"Asset ID {wanted} does not reference a {normalized_kind} asset.")
+        if not asset.resolved_path:
+            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
+        path = _canonical_path(Path(asset.resolved_path), "Asset")
+        if not path.exists():
+            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
+        if asset.kind in {"gguf", "mmproj"} and not path.is_file():
+            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
+        if asset.kind == "folder" and not path.is_dir():
+            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
+        if normalized_kind in {"gguf", "mmproj"} and _asset_kind_for_path(path) != normalized_kind:
+            raise ModelNotFoundError(f"Asset ID {wanted} does not reference a {normalized_kind} asset.")
+        if allowed_bases and not handler_utils.is_path_allowed(path, allowed_bases):
+            raise ServerError("Asset path is outside allowed llama.cpp paths.")
+        return asset
+    raise ModelNotFoundError(f"Asset ID {wanted} was not found.")
+
+
 def _iter_gguf_models(models_dir: Path, warnings: list[str], limit: int):
     if limit <= 0:
         return

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -351,22 +351,72 @@ def resolve_asset_id(
         if asset.asset_id != wanted:
             continue
         if normalized_kind and asset.kind != normalized_kind:
-            raise ModelNotFoundError(f"Asset ID {wanted} does not reference a {normalized_kind} asset.")
+            raise ModelNotFoundError(
+                f"Asset ID {wanted} does not reference a {normalized_kind} asset."
+            )
         if not asset.resolved_path:
-            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
+            raise ModelNotFoundError(
+                f"Asset ID {wanted} does not reference an available local asset."
+            )
         path = _canonical_path(Path(asset.resolved_path), "Asset")
         if not path.exists():
-            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
+            raise ModelNotFoundError(
+                f"Asset ID {wanted} does not reference an available local asset."
+            )
         if asset.kind in {"gguf", "mmproj"} and not path.is_file():
-            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
+            raise ModelNotFoundError(
+                f"Asset ID {wanted} does not reference an available local asset."
+            )
         if asset.kind == "folder" and not path.is_dir():
-            raise ModelNotFoundError(f"Asset ID {wanted} does not reference an available local asset.")
-        if normalized_kind in {"gguf", "mmproj"} and _asset_kind_for_path(path) != normalized_kind:
-            raise ModelNotFoundError(f"Asset ID {wanted} does not reference a {normalized_kind} asset.")
-        if allowed_bases and not handler_utils.is_path_allowed(path, allowed_bases):
-            raise ServerError("Asset path is outside allowed llama.cpp paths.")
-        return asset
+            raise ModelNotFoundError(
+                f"Asset ID {wanted} does not reference an available local asset."
+            )
+        if (
+            normalized_kind in {"gguf", "mmproj"}
+            and _asset_kind_for_path(path) != normalized_kind
+        ):
+            raise ModelNotFoundError(
+                f"Asset ID {wanted} does not reference a {normalized_kind} asset."
+            )
+        _validate_allowed_asset_path(path, allowed_bases, "Asset path")
+        return asset.model_copy(update={"resolved_path": str(path)})
     raise ModelNotFoundError(f"Asset ID {wanted} was not found.")
+
+
+def resolve_asset_path(
+    raw_path: str | Path,
+    expected_kind: str,
+    *,
+    label: str = "Asset",
+) -> Path:
+    """Resolve and validate a local llama.cpp asset path."""
+    normalized_kind = str(expected_kind or "").strip().lower()
+    path = _canonical_path(Path(raw_path), label)
+    if not normalized_kind:
+        raise ModelNotFoundError(f"{label} path requires an expected asset kind.")
+    if normalized_kind == "folder":
+        if not path.is_dir():
+            raise ModelNotFoundError(
+                f"{label} path does not reference an available folder."
+            )
+    else:
+        if not path.is_file():
+            raise ModelNotFoundError(
+                f"{label} path does not reference an available local file."
+            )
+        if _asset_kind_for_path(path) != normalized_kind:
+            raise ModelNotFoundError(
+                f"{label} path does not reference a {normalized_kind} asset."
+            )
+
+    allowed_bases = _allowed_bases_for_config(_read_saved_config())
+    _validate_allowed_asset_path(path, allowed_bases, f"{label} path")
+    return path
+
+
+def _validate_allowed_asset_path(path: Path, allowed_bases: list[Path], label: str) -> None:
+    if not allowed_bases or not handler_utils.is_path_allowed(path, allowed_bases):
+        raise ServerError(f"{label} is outside allowed llama.cpp paths.")
 
 
 def _iter_gguf_models(models_dir: Path, warnings: list[str], limit: int):

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
@@ -7,9 +7,15 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAsset
-from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
-from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError, ServerError
-from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import LlamaCppProfile, LlamaCppProfileMode
+from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import (
+    ModelNotFoundError,
+    ServerError,
+)
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
+    LlamaCppProfile,
+    LlamaCppProfileMode,
+)
 
 
 class LlamaCppResolvedProfileLaunch(BaseModel):
@@ -69,14 +75,28 @@ def profile_capability_metadata(
     }
 
 
-def _resolve_base_model_path(profile: LlamaCppProfile, assets: list[LlamaCppAsset] | None) -> Path:
+def _resolve_base_model_path(
+    profile: LlamaCppProfile,
+    assets: list[LlamaCppAsset] | None,
+) -> Path:
     if profile.model_id:
-        asset = llamacpp_inventory_service.resolve_asset_id(profile.model_id, expected_kind="gguf", assets=assets)
+        asset = llamacpp_inventory_service.resolve_asset_id(
+            profile.model_id,
+            expected_kind="gguf",
+            assets=assets,
+        )
         if not asset.resolved_path:
-            raise ModelNotFoundError(f"Model asset {profile.model_id} does not reference an available local asset.")
-        return _resolve_manual_asset_path(asset.resolved_path, expected_kind="gguf", label="Model")
+            raise ModelNotFoundError(
+                f"Model asset {profile.model_id} does not reference an "
+                "available local asset."
+            )
+        return Path(asset.resolved_path)
     if profile.model_path:
-        return _resolve_manual_asset_path(profile.model_path, expected_kind="gguf", label="Model")
+        return llamacpp_inventory_service.resolve_asset_path(
+            profile.model_path,
+            expected_kind="gguf",
+            label="Model",
+        )
     raise ModelNotFoundError("Llama.cpp profile requires a model_id or model_path.")
 
 
@@ -93,36 +113,24 @@ def _resolve_mmproj_path(
             assets=assets,
         )
         if not asset.resolved_path:
-            raise ModelNotFoundError(f"mmproj asset {profile.mmproj_model_id} does not reference an available local asset.")
-        asset_path = _resolve_manual_asset_path(asset.resolved_path, expected_kind="mmproj", label="mmproj")
+            raise ModelNotFoundError(
+                f"mmproj asset {profile.mmproj_model_id} does not reference an "
+                "available local asset."
+            )
+        asset_path = Path(asset.resolved_path)
 
     manual_value = server_args.get("mmproj")
     if manual_value in (None, ""):
         return asset_path
 
-    manual_path = _resolve_manual_asset_path(str(manual_value), expected_kind="mmproj", label="mmproj")
+    manual_path = llamacpp_inventory_service.resolve_asset_path(
+        str(manual_value),
+        expected_kind="mmproj",
+        label="mmproj",
+    )
     if asset_path is not None and manual_path != asset_path:
         raise ServerError("Profile mmproj_model_id conflicts with server_args['mmproj'].")
     return asset_path or manual_path
-
-
-def _resolve_manual_asset_path(raw_path: str, *, expected_kind: str, label: str) -> Path:
-    path = _canonical_path(Path(raw_path), label)
-    if not path.is_file():
-        raise ModelNotFoundError(f"{label} path does not reference an available local file.")
-    if llamacpp_inventory_service._asset_kind_for_path(path) != expected_kind:
-        raise ModelNotFoundError(f"{label} path does not reference a {expected_kind} asset.")
-    allowed_bases = llamacpp_inventory_service._allowed_bases_for_config(llamacpp_inventory_service._read_saved_config())
-    if allowed_bases and not handler_utils.is_path_allowed(path, allowed_bases):
-        raise ServerError(f"{label} path is outside allowed llama.cpp paths.")
-    return path
-
-
-def _canonical_path(path: Path, label: str) -> Path:
-    try:
-        return path.expanduser().resolve()
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise ServerError(f"{label} path could not be resolved.") from exc
 
 
 def _capabilities_for_mode(

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
@@ -1,0 +1,161 @@
+"""Capability and launch resolution helpers for managed llama.cpp profiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAsset
+from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError, ServerError
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import LlamaCppProfile, LlamaCppProfileMode
+
+
+class LlamaCppResolvedProfileLaunch(BaseModel):
+    """Resolved launch contract for one managed llama.cpp profile."""
+
+    profile: LlamaCppProfile
+    model_path: Path
+    mmproj_path: Path | None = None
+    server_args: dict[str, object]
+    capabilities: dict[str, bool]
+    modalities: dict[str, list[str]]
+    warnings: list[str] = Field(default_factory=list)
+
+
+def resolve_profile_launch(
+    profile: LlamaCppProfile,
+    assets: list[LlamaCppAsset] | None = None,
+) -> LlamaCppResolvedProfileLaunch:
+    """Resolve a profile's model assets, launch args, and mode capabilities."""
+    model_path = _resolve_base_model_path(profile, assets)
+    server_args = dict(profile.server_args)
+    mmproj_path = _resolve_mmproj_path(profile, server_args, assets)
+
+    if profile.mode == LlamaCppProfileMode.VISION and mmproj_path is None:
+        raise ServerError("Vision llama.cpp profiles require a valid mmproj asset.")
+    if mmproj_path is not None:
+        server_args["mmproj"] = str(mmproj_path)
+
+    return LlamaCppResolvedProfileLaunch(
+        profile=profile,
+        model_path=model_path,
+        mmproj_path=mmproj_path,
+        server_args=server_args,
+        capabilities=_capabilities_for_mode(profile.mode, mmproj_path=mmproj_path),
+        modalities=_modalities_for_mode(profile.mode, mmproj_path=mmproj_path),
+        warnings=[],
+    )
+
+
+def profile_capability_metadata(
+    profile: LlamaCppProfile,
+    assets: list[LlamaCppAsset] | None = None,
+) -> dict[str, object]:
+    """Return bounded public capability metadata for a managed profile."""
+    try:
+        resolved = resolve_profile_launch(profile, assets=assets)
+    except (ModelNotFoundError, ServerError) as exc:
+        return {
+            "capabilities": _capabilities_for_mode(profile.mode, mmproj_path=None, validated=False),
+            "modalities": _modalities_for_mode(profile.mode, mmproj_path=None, validated=False),
+            "capability_warnings": [str(exc)],
+        }
+    return {
+        "capabilities": resolved.capabilities,
+        "modalities": resolved.modalities,
+        "capability_warnings": list(resolved.warnings),
+    }
+
+
+def _resolve_base_model_path(profile: LlamaCppProfile, assets: list[LlamaCppAsset] | None) -> Path:
+    if profile.model_id:
+        asset = llamacpp_inventory_service.resolve_asset_id(profile.model_id, expected_kind="gguf", assets=assets)
+        if not asset.resolved_path:
+            raise ModelNotFoundError(f"Model asset {profile.model_id} does not reference an available local asset.")
+        return _resolve_manual_asset_path(asset.resolved_path, expected_kind="gguf", label="Model")
+    if profile.model_path:
+        return _resolve_manual_asset_path(profile.model_path, expected_kind="gguf", label="Model")
+    raise ModelNotFoundError("Llama.cpp profile requires a model_id or model_path.")
+
+
+def _resolve_mmproj_path(
+    profile: LlamaCppProfile,
+    server_args: dict[str, object],
+    assets: list[LlamaCppAsset] | None,
+) -> Path | None:
+    asset_path: Path | None = None
+    if profile.mmproj_model_id:
+        asset = llamacpp_inventory_service.resolve_asset_id(
+            profile.mmproj_model_id,
+            expected_kind="mmproj",
+            assets=assets,
+        )
+        if not asset.resolved_path:
+            raise ModelNotFoundError(f"mmproj asset {profile.mmproj_model_id} does not reference an available local asset.")
+        asset_path = _resolve_manual_asset_path(asset.resolved_path, expected_kind="mmproj", label="mmproj")
+
+    manual_value = server_args.get("mmproj")
+    if manual_value in (None, ""):
+        return asset_path
+
+    manual_path = _resolve_manual_asset_path(str(manual_value), expected_kind="mmproj", label="mmproj")
+    if asset_path is not None and manual_path != asset_path:
+        raise ServerError("Profile mmproj_model_id conflicts with server_args['mmproj'].")
+    return asset_path or manual_path
+
+
+def _resolve_manual_asset_path(raw_path: str, *, expected_kind: str, label: str) -> Path:
+    path = _canonical_path(Path(raw_path), label)
+    if not path.is_file():
+        raise ModelNotFoundError(f"{label} path does not reference an available local file.")
+    if llamacpp_inventory_service._asset_kind_for_path(path) != expected_kind:
+        raise ModelNotFoundError(f"{label} path does not reference a {expected_kind} asset.")
+    allowed_bases = llamacpp_inventory_service._allowed_bases_for_config(llamacpp_inventory_service._read_saved_config())
+    if allowed_bases and not handler_utils.is_path_allowed(path, allowed_bases):
+        raise ServerError(f"{label} path is outside allowed llama.cpp paths.")
+    return path
+
+
+def _canonical_path(path: Path, label: str) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ServerError(f"{label} path could not be resolved.") from exc
+
+
+def _capabilities_for_mode(
+    mode: LlamaCppProfileMode,
+    *,
+    mmproj_path: Path | None,
+    validated: bool = True,
+) -> dict[str, bool]:
+    return {
+        "chat": validated and mode in {LlamaCppProfileMode.CHAT, LlamaCppProfileMode.VISION},
+        "vision": validated and mode == LlamaCppProfileMode.VISION and mmproj_path is not None,
+        "embeddings": validated and mode == LlamaCppProfileMode.EMBEDDING,
+        "rerank": validated and mode == LlamaCppProfileMode.RERANK,
+    }
+
+
+def _modalities_for_mode(
+    mode: LlamaCppProfileMode,
+    *,
+    mmproj_path: Path | None,
+    validated: bool = True,
+) -> dict[str, list[str]]:
+    if validated and mode == LlamaCppProfileMode.VISION and mmproj_path is not None:
+        return {"input": ["text", "image"], "output": ["text"]}
+    if validated and mode == LlamaCppProfileMode.EMBEDDING:
+        return {"input": ["text"], "output": ["embedding"]}
+    if validated and mode == LlamaCppProfileMode.RERANK:
+        return {"input": ["text"], "output": ["score"]}
+    return {"input": ["text"], "output": ["text"]}
+
+
+__all__ = [
+    "LlamaCppResolvedProfileLaunch",
+    "profile_capability_metadata",
+    "resolve_profile_launch",
+]

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
@@ -6,12 +6,12 @@ from pathlib import Path
 import pytest
 
 
-def _llamacpp_parser(models_dir: Path, **overrides: str) -> ConfigParser:
+def _llamacpp_parser(default_models_dir: Path, **overrides: str) -> ConfigParser:
     parser = ConfigParser()
     parser.add_section("LlamaCpp")
     values = {
         "enabled": "true",
-        "models_dir": str(models_dir),
+        "models_dir": str(default_models_dir),
         "allowed_paths": "",
         "registered_model_paths": "",
         "imported_asset_folders": "",
@@ -55,7 +55,11 @@ def test_scan_assets_discovers_gguf_mmproj_and_folder(monkeypatch, tmp_path: Pat
     monkeypatch.setattr(
         llamacpp_inventory_service,
         "load_comprehensive_config",
-        lambda: _llamacpp_parser(models_dir, allowed_paths=str(imported), imported_asset_folders=str(imported)),
+        lambda: _llamacpp_parser(
+            models_dir,
+            allowed_paths=str(imported),
+            imported_asset_folders=str(imported),
+        ),
     )
 
     result = llamacpp_inventory_service.scan_assets(limit=500)
@@ -226,3 +230,27 @@ def test_resolve_asset_id_accepts_folder_expected_kind(monkeypatch, tmp_path: Pa
 
     assert resolved.kind == "folder"
     assert resolved.resolved_path == str(imported.resolve())
+
+
+@pytest.mark.unit
+def test_resolve_asset_id_fails_closed_without_allowed_paths(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+
+    base = tmp_path / "chat.gguf"
+    base.write_text("base")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(
+            Path(""),
+            models_dir="",
+            registered_model_paths=str(base),
+        ),
+    )
+
+    with pytest.raises(ServerError, match="outside allowed"):
+        llamacpp_inventory_service.resolve_asset_id(
+            llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+            expected_kind="gguf",
+        )

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
@@ -111,3 +111,118 @@ def test_scan_assets_adds_inferred_mmproj_candidates_with_warnings(monkeypatch, 
     assert projector_asset.asset_id in base_asset.mmproj_asset_ids
     assert base_asset.asset_id in projector_asset.base_model_asset_ids
     assert any("inferred" in warning.lower() for warning in base_asset.warnings)
+
+
+@pytest.mark.unit
+def test_resolve_asset_id_rejects_wrong_kind(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "chat.gguf"
+    projector = models_dir / "mmproj-chat.gguf"
+    base.write_text("base")
+    projector.write_text("projector")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+
+    base_id = llamacpp_inventory_service.asset_id_for_path(base, "gguf")
+
+    with pytest.raises(ModelNotFoundError, match="mmproj"):
+        llamacpp_inventory_service.resolve_asset_id(base_id, expected_kind="mmproj")
+
+
+@pytest.mark.unit
+def test_resolve_asset_id_rejects_missing_asset_id(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+
+    with pytest.raises(ModelNotFoundError, match="was not found"):
+        llamacpp_inventory_service.resolve_asset_id("gguf:missing")
+
+
+@pytest.mark.unit
+def test_resolve_asset_id_rejects_stale_registered_asset(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    stale = models_dir / "stale.gguf"
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, registered_model_paths=str(stale)),
+    )
+
+    stale_id = llamacpp_inventory_service.asset_id_for_path(stale, "gguf")
+
+    with pytest.raises(ModelNotFoundError, match="available local asset"):
+        llamacpp_inventory_service.resolve_asset_id(stale_id, expected_kind="gguf")
+
+
+@pytest.mark.unit
+def test_resolve_asset_id_accepts_pre_scanned_assets(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "chat.gguf"
+    base.write_text("base")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+
+    assets = llamacpp_inventory_service.scan_assets(limit=500).assets
+
+    def fail_scan_assets(*_args, **_kwargs):
+        raise AssertionError("resolve_asset_id should use the provided pre-scanned assets")
+
+    monkeypatch.setattr(llamacpp_inventory_service, "scan_assets", fail_scan_assets)
+
+    resolved = llamacpp_inventory_service.resolve_asset_id(
+        llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+        expected_kind="gguf",
+        assets=assets,
+    )
+
+    assert resolved.resolved_path == str(base.resolve())
+
+
+@pytest.mark.unit
+def test_resolve_asset_id_accepts_folder_expected_kind(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(
+            models_dir,
+            allowed_paths=str(imported),
+            imported_asset_folders=str(imported),
+        ),
+    )
+    folder_id = llamacpp_inventory_service.asset_id_for_path(imported, "folder")
+
+    resolved = llamacpp_inventory_service.resolve_asset_id(folder_id, expected_kind="folder")
+
+    assert resolved.kind == "folder"
+    assert resolved.resolved_path == str(imported.resolve())

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py
@@ -6,15 +6,22 @@ from pathlib import Path
 import pytest
 
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
-from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import LlamaCppProfile, LlamaCppProfileMode
+from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import (
+    profile_capability_metadata,
+    resolve_profile_launch,
+)
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
+    LlamaCppProfile,
+    LlamaCppProfileMode,
+)
 
 
-def _llamacpp_parser(models_dir: Path, **overrides: str) -> ConfigParser:
+def _llamacpp_parser(default_models_dir: Path, **overrides: str) -> ConfigParser:
     parser = ConfigParser()
     parser.add_section("LlamaCpp")
     values = {
         "enabled": "true",
-        "models_dir": str(models_dir),
+        "models_dir": str(default_models_dir),
         "allowed_paths": "",
         "registered_model_paths": "",
         "imported_asset_folders": "",
@@ -37,7 +44,6 @@ def _configure_assets(monkeypatch: pytest.MonkeyPatch, models_dir: Path) -> None
 @pytest.mark.unit
 def test_chat_profile_resolves_base_model_without_mmproj(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -63,7 +69,6 @@ def test_chat_profile_resolves_base_model_without_mmproj(monkeypatch, tmp_path: 
 @pytest.mark.unit
 def test_vision_profile_requires_mmproj_asset(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -84,7 +89,6 @@ def test_vision_profile_requires_mmproj_asset(monkeypatch, tmp_path: Path):
 @pytest.mark.unit
 def test_vision_profile_injects_resolved_mmproj(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -116,7 +120,6 @@ def test_vision_profile_injects_resolved_mmproj(monkeypatch, tmp_path: Path):
 @pytest.mark.unit
 def test_vision_profile_rejects_conflicting_manual_mmproj(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -143,7 +146,6 @@ def test_vision_profile_rejects_conflicting_manual_mmproj(monkeypatch, tmp_path:
 @pytest.mark.unit
 def test_embedding_profile_derives_text_vector_capability(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -167,7 +169,6 @@ def test_embedding_profile_derives_text_vector_capability(monkeypatch, tmp_path:
 @pytest.mark.unit
 def test_rerank_profile_derives_text_score_capability(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -191,7 +192,6 @@ def test_rerank_profile_derives_text_score_capability(monkeypatch, tmp_path: Pat
 @pytest.mark.unit
 def test_server_generic_profile_makes_no_specialized_capability_claim(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -217,7 +217,6 @@ def test_server_generic_profile_makes_no_specialized_capability_claim(monkeypatc
 @pytest.mark.unit
 def test_profile_capability_metadata_is_bounded(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
-    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import profile_capability_metadata
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
@@ -236,3 +235,29 @@ def test_profile_capability_metadata_is_bounded(monkeypatch, tmp_path: Path):
     assert metadata["capabilities"]["chat"] is True
     assert metadata["modalities"] == {"input": ["text"], "output": ["text"]}
     assert str(base.resolve()) not in repr(metadata)
+
+
+@pytest.mark.unit
+def test_manual_profile_path_fails_closed_without_allowed_paths(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    base = tmp_path / "manual.gguf"
+    base.write_text("base")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(
+            Path(""),
+            models_dir="",
+            allowed_paths="",
+        ),
+    )
+    profile = LlamaCppProfile(
+        profile_id="manual",
+        name="Manual",
+        mode=LlamaCppProfileMode.CHAT,
+        model_path=str(base),
+    )
+
+    with pytest.raises(ServerError, match="outside allowed"):
+        resolve_profile_launch(profile)

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from configparser import ConfigParser
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import LlamaCppProfile, LlamaCppProfileMode
+
+
+def _llamacpp_parser(models_dir: Path, **overrides: str) -> ConfigParser:
+    parser = ConfigParser()
+    parser.add_section("LlamaCpp")
+    values = {
+        "enabled": "true",
+        "models_dir": str(models_dir),
+        "allowed_paths": "",
+        "registered_model_paths": "",
+        "imported_asset_folders": "",
+    }
+    values.update(overrides)
+    parser["LlamaCpp"] = values
+    return parser
+
+
+def _configure_assets(monkeypatch: pytest.MonkeyPatch, models_dir: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+
+
+@pytest.mark.unit
+def test_chat_profile_resolves_base_model_without_mmproj(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "chat.gguf"
+    base.write_text("base")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="chat",
+        name="Chat",
+        mode=LlamaCppProfileMode.CHAT,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+    )
+
+    resolved = resolve_profile_launch(profile)
+
+    assert resolved.model_path == base.resolve()
+    assert "mmproj" not in resolved.server_args
+    assert resolved.capabilities["chat"] is True
+    assert resolved.capabilities["vision"] is False
+    assert resolved.modalities == {"input": ["text"], "output": ["text"]}
+
+
+@pytest.mark.unit
+def test_vision_profile_requires_mmproj_asset(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "vision.gguf"
+    base.write_text("base")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="vision",
+        name="Vision",
+        mode=LlamaCppProfileMode.VISION,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+    )
+
+    with pytest.raises(ServerError, match="mmproj"):
+        resolve_profile_launch(profile)
+
+
+@pytest.mark.unit
+def test_vision_profile_injects_resolved_mmproj(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "llava.gguf"
+    projector = models_dir / "mmproj-llava.gguf"
+    base.write_text("base")
+    projector.write_text("projector")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="vision",
+        name="Vision",
+        mode=LlamaCppProfileMode.VISION,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+        mmproj_model_id=llamacpp_inventory_service.asset_id_for_path(projector, "mmproj"),
+        server_args={"ctx_size": 4096},
+    )
+
+    resolved = resolve_profile_launch(profile)
+
+    assert resolved.model_path == base.resolve()
+    assert resolved.mmproj_path == projector.resolve()
+    assert resolved.server_args["ctx_size"] == 4096
+    assert resolved.server_args["mmproj"] == str(projector.resolve())
+    assert resolved.capabilities["chat"] is True
+    assert resolved.capabilities["vision"] is True
+    assert resolved.modalities == {"input": ["text", "image"], "output": ["text"]}
+
+
+@pytest.mark.unit
+def test_vision_profile_rejects_conflicting_manual_mmproj(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "llava.gguf"
+    projector = models_dir / "mmproj-llava.gguf"
+    other_projector = models_dir / "mmproj-other.gguf"
+    base.write_text("base")
+    projector.write_text("projector")
+    other_projector.write_text("other projector")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="vision",
+        name="Vision",
+        mode=LlamaCppProfileMode.VISION,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+        mmproj_model_id=llamacpp_inventory_service.asset_id_for_path(projector, "mmproj"),
+        server_args={"mmproj": str(other_projector)},
+    )
+
+    with pytest.raises(ServerError, match="conflict"):
+        resolve_profile_launch(profile)
+
+
+@pytest.mark.unit
+def test_embedding_profile_derives_text_vector_capability(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "embedding.gguf"
+    base.write_text("base")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="embedding",
+        name="Embedding",
+        mode=LlamaCppProfileMode.EMBEDDING,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+    )
+
+    resolved = resolve_profile_launch(profile)
+
+    assert resolved.capabilities["chat"] is False
+    assert resolved.capabilities["embeddings"] is True
+    assert resolved.modalities == {"input": ["text"], "output": ["embedding"]}
+
+
+@pytest.mark.unit
+def test_rerank_profile_derives_text_score_capability(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "rerank.gguf"
+    base.write_text("base")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="rerank",
+        name="Rerank",
+        mode=LlamaCppProfileMode.RERANK,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+    )
+
+    resolved = resolve_profile_launch(profile)
+
+    assert resolved.capabilities["chat"] is False
+    assert resolved.capabilities["rerank"] is True
+    assert resolved.modalities == {"input": ["text"], "output": ["score"]}
+
+
+@pytest.mark.unit
+def test_server_generic_profile_makes_no_specialized_capability_claim(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "server.gguf"
+    base.write_text("base")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="server",
+        name="Server",
+        mode=LlamaCppProfileMode.SERVER_GENERIC,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+    )
+
+    resolved = resolve_profile_launch(profile)
+
+    assert resolved.capabilities["chat"] is False
+    assert resolved.capabilities["vision"] is False
+    assert resolved.capabilities["embeddings"] is False
+    assert resolved.capabilities["rerank"] is False
+    assert resolved.modalities == {"input": ["text"], "output": ["text"]}
+
+
+@pytest.mark.unit
+def test_profile_capability_metadata_is_bounded(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import profile_capability_metadata
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "chat.gguf"
+    base.write_text("base")
+    _configure_assets(monkeypatch, models_dir)
+    profile = LlamaCppProfile(
+        profile_id="chat",
+        name="Chat",
+        mode=LlamaCppProfileMode.CHAT,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+    )
+
+    metadata = profile_capability_metadata(profile)
+
+    assert metadata["capabilities"]["chat"] is True
+    assert metadata["modalities"] == {"input": ["text"], "output": ["text"]}
+    assert str(base.resolve()) not in repr(metadata)


### PR DESCRIPTION
## Summary
- Adds a public llama.cpp `resolve_asset_id` helper for GGUF, mmproj, folder, missing, stale, and pre-scanned asset cases.
- Adds profile launch/capability resolution for base GGUF paths, mmproj wiring, vision validation, embeddings, rerank, and server_generic metadata.
- Adds focused unit/API-adjacent coverage plus TASK-408 closeout notes.

## Change summary
Human-owned change summary required before merge: TODO by maintainer.

## Test plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py -v` -> 36 passed, 5 warnings
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py -f json -o /tmp/bandit_llamacpp_profile_capability_resolver.json` -> 0 findings
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `llama.cpp` profile capability and launch resolution to validate GGUF/mmproj assets, derive capabilities/modalities, and normalize server args for chat, vision, embeddings, and rerank. Implements TASK-408 backend slice with fail-closed allowlist enforcement; task notes updated; no supervisor/WebUI changes.

- **New Features**
  - Public `resolve_asset_id` and `resolve_asset_path` for GGUF, mmproj, and folder; expected-kind checks, missing/stale IDs, manual-path validation, and support for pre-scanned assets.
  - `resolve_profile_launch` and `profile_capability_metadata` resolve base model paths, require mmproj for vision, inject `mmproj` arg, reject conflicting args, and return bounded capability/modalities.
  - Canonical path + allowed-path enforcement that fails closed when no allowlist; blocks invalid/out-of-scope assets. Focused tests added; Bandit reports 0 findings.

<sup>Written for commit 3ed9e65356a48ea4c44a1fd9350a7350ab25e07c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1777?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

