### PR TITLE
Migrate Tldw connection auth alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2981,28 +2981,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Settings/TldwConnectionSettings.tsx:Alert#antd-alert-tldwconnectionsettings-type-info-line-180-u7hkt9",
-    "path": "src/components/Option/Settings/TldwConnectionSettings.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Settings/TldwConnectionSettings.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Settings/TldwConnectionSettings.tsx:Alert#antd-alert-tldwconnectionsettings-type-success-line-268-gzdflb",
-    "path": "src/components/Option/Settings/TldwConnectionSettings.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Settings/TldwConnectionSettings.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Settings/TTSModeSettings.tsx:Alert#antd-alert-ttsmodesettings-type-error-line-814-lmd0y2",
     "path": "src/components/Option/Settings/TTSModeSettings.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Settings/TldwConnectionSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/TldwConnectionSettings.tsx
@@ -177,15 +177,13 @@ export const TldwConnectionSettings = ({
 
       {authMode === 'multi-user' && !isLoggedIn && (
         <>
-          <DesignSystemAlert
+          <Alert
             title={t('settings:tldw.loginRequired.title', 'Login Required')}
             variant="info"
-            role="status"
-            aria-live="polite"
             className="mb-4"
           >
             {t('settings:tldw.loginRequired.description', 'Please login with your tldw_server credentials')}
-          </DesignSystemAlert>
+          </Alert>
           <Form.Item
             label={t('settings:tldw.loginMethod.label', 'Login Method')}
           >
@@ -267,11 +265,9 @@ export const TldwConnectionSettings = ({
       )}
 
       {authMode === 'multi-user' && isLoggedIn && (
-        <DesignSystemAlert
+        <Alert
           title={t('settings:tldw.loggedIn.title', 'Logged In')}
           variant="success"
-          role="status"
-          aria-live="polite"
           action={
             {
               label: t('settings:tldw.buttons.logout', 'Logout'),
@@ -282,7 +278,7 @@ export const TldwConnectionSettings = ({
           className="mb-4"
         >
           {t('settings:tldw.loggedIn.description', 'You are currently logged in to tldw_server')}
-        </DesignSystemAlert>
+        </Alert>
       )}
 
       <Space className="w-full justify-between">

--- a/apps/packages/ui/src/components/Option/Settings/TldwConnectionSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/TldwConnectionSettings.tsx
@@ -3,7 +3,6 @@ import {
   Segmented,
   Space,
   Input,
-  Alert,
   Form,
   Modal,
   Button,
@@ -13,6 +12,7 @@ import type { FormInstance } from "antd"
 import React from "react"
 import type { TFunction } from "i18next"
 import { isFirefoxTarget } from "@/config/platform"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import {
   getCoreStatusLabel,
   getRagStatusLabel,
@@ -177,13 +177,15 @@ export const TldwConnectionSettings = ({
 
       {authMode === 'multi-user' && !isLoggedIn && (
         <>
-          <Alert
+          <DesignSystemAlert
             title={t('settings:tldw.loginRequired.title', 'Login Required')}
-            description={t('settings:tldw.loginRequired.description', 'Please login with your tldw_server credentials')}
-            type="info"
-            showIcon
+            variant="info"
+            role="status"
+            aria-live="polite"
             className="mb-4"
-          />
+          >
+            {t('settings:tldw.loginRequired.description', 'Please login with your tldw_server credentials')}
+          </DesignSystemAlert>
           <Form.Item
             label={t('settings:tldw.loginMethod.label', 'Login Method')}
           >
@@ -265,18 +267,22 @@ export const TldwConnectionSettings = ({
       )}
 
       {authMode === 'multi-user' && isLoggedIn && (
-        <Alert
+        <DesignSystemAlert
           title={t('settings:tldw.loggedIn.title', 'Logged In')}
-          description={t('settings:tldw.loggedIn.description', 'You are currently logged in to tldw_server')}
-          type="success"
-          showIcon
+          variant="success"
+          role="status"
+          aria-live="polite"
           action={
-            <Button size="small" danger onClick={onLogout}>
-              {t('settings:tldw.buttons.logout', 'Logout')}
-            </Button>
+            {
+              label: t('settings:tldw.buttons.logout', 'Logout'),
+              onClick: onLogout,
+              variant: "danger",
+            }
           }
           className="mb-4"
-        />
+        >
+          {t('settings:tldw.loggedIn.description', 'You are currently logged in to tldw_server')}
+        </DesignSystemAlert>
       )}
 
       <Space className="w-full justify-between">

--- a/apps/packages/ui/src/components/Option/Settings/TldwConnectionSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/TldwConnectionSettings.tsx
@@ -12,7 +12,7 @@ import type { FormInstance } from "antd"
 import React from "react"
 import type { TFunction } from "i18next"
 import { isFirefoxTarget } from "@/config/platform"
-import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
+import { Alert } from "@/components/ui/primitives"
 import {
   getCoreStatusLabel,
   getRagStatusLabel,

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/tldw-review-comments.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/tldw-review-comments.test.tsx
@@ -3,7 +3,7 @@
 import React from "react"
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import type { TFunction } from "react-i18next"
+import type { TFunction } from "i18next"
 
 const {
   formItemSpy,
@@ -308,6 +308,44 @@ describe("settings PR review fixes", () => {
       name: undefined,
       rules: undefined
     })
+  })
+
+  it("renders the login-required notice through the design-system alert primitive", () => {
+    render(
+      <TldwConnectionSettings
+        {...createConnectionProps({
+          authMode: "multi-user",
+          isLoggedIn: false
+        })}
+      />
+    )
+
+    const loginRequiredTitle = screen.getByText(/Login Required/)
+    expect(
+      loginRequiredTitle.closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+  })
+
+  it("renders the logged-in notice through the design-system alert primitive and preserves logout", () => {
+    const onLogout = vi.fn()
+
+    render(
+      <TldwConnectionSettings
+        {...createConnectionProps({
+          authMode: "multi-user",
+          isLoggedIn: true,
+          onLogout
+        })}
+      />
+    )
+
+    const loggedInTitle = screen.getByText(/Logged In/)
+    expect(
+      loggedInTitle.closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Logout" }))
+    expect(onLogout).toHaveBeenCalledTimes(1)
   })
 
   it("formats invoice amounts using the invoice currency instead of a hardcoded dollar prefix", () => {

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/tldw-review-comments.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/tldw-review-comments.test.tsx
@@ -321,9 +321,10 @@ describe("settings PR review fixes", () => {
     )
 
     const loginRequiredTitle = screen.getByText(/Login Required/)
-    expect(
-      loginRequiredTitle.closest('[data-ds-component="Alert"]')
-    ).toBeInTheDocument()
+    const alert = loginRequiredTitle.closest('[data-ds-component="Alert"]')
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveAttribute("role", "status")
+    expect(alert).toHaveAttribute("aria-live", "polite")
   })
 
   it("renders the logged-in notice through the design-system alert primitive and preserves logout", () => {
@@ -340,9 +341,10 @@ describe("settings PR review fixes", () => {
     )
 
     const loggedInTitle = screen.getByText(/Logged In/)
-    expect(
-      loggedInTitle.closest('[data-ds-component="Alert"]')
-    ).toBeInTheDocument()
+    const alert = loggedInTitle.closest('[data-ds-component="Alert"]')
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveAttribute("role", "status")
+    expect(alert).toHaveAttribute("aria-live", "polite")
 
     fireEvent.click(screen.getByRole("button", { name: "Logout" }))
     expect(onLogout).toHaveBeenCalledTimes(1)

--- a/apps/packages/ui/src/components/ui/primitives/Alert.tsx
+++ b/apps/packages/ui/src/components/ui/primitives/Alert.tsx
@@ -20,6 +20,7 @@ export interface AlertProps {
     onClick: () => void
     loading?: boolean
     disabled?: boolean
+    variant?: React.ComponentProps<typeof Button>["variant"]
   }
   /** Secondary action (text link style) */
   secondaryAction?: {
@@ -144,6 +145,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
               {action && (
                 <Button
                   size="sm"
+                  variant={action.variant}
                   onClick={action.onClick}
                   loading={action.loading}
                   disabled={action.disabled}

--- a/apps/packages/ui/src/components/ui/primitives/Alert.tsx
+++ b/apps/packages/ui/src/components/ui/primitives/Alert.tsx
@@ -99,7 +99,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       dismissible = false,
       onDismiss,
       dismissLabel = "Dismiss",
-      role = "alert",
+      role,
       "aria-live": ariaLive,
       className,
       "data-testid": dataTestId,
@@ -109,6 +109,10 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     const config = variantConfig[variant]
     const DefaultIcon = config.icon
     const hasContent = React.Children.toArray(children).some((child) => child !== "")
+    const defaultsToStatus = variant === "info" || variant === "success"
+    const resolvedRole = role ?? (defaultsToStatus ? "status" : "alert")
+    const resolvedAriaLive =
+      ariaLive ?? (resolvedRole === "status" ? "polite" : undefined)
 
     return (
       <div
@@ -118,8 +122,8 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
           config.container,
           className
         )}
-        role={role}
-        aria-live={ariaLive}
+        role={resolvedRole}
+        aria-live={resolvedAriaLive}
         data-testid={dataTestId}
         data-ds-component="Alert"
       >

--- a/backlog/tasks/task-45.44.6 - Migrate-design-system-product-state-Settings-and-account-security.md
+++ b/backlog/tasks/task-45.44.6 - Migrate-design-system-product-state-Settings-and-account-security.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-45.44.6
 title: 'Migrate design-system product state: Settings and account/security'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
+updated_date: '2026-05-16 16:29'
 labels:
   - design-system
   - webui
@@ -15,6 +16,7 @@ references:
   - >-
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/1781'
 parent_task_id: TASK-45.44
 priority: medium
 ---
@@ -31,6 +33,12 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
 - [ ] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TASK-45.44.6.2 completed on codex/design-system-next-slice-8: migrated TldwConnectionSettings auth notices from AntD Alert to DesignSystemAlert. Baseline evidence: total product-state exceptions 400 -> 398; Settings/account-security exceptions 49 -> 47. PR: https://github.com/rmusser01/tldw_server/pull/1781.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-45.44.6.2 - Migrate-TldwConnectionSettings-auth-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.6.2 - Migrate-TldwConnectionSettings-auth-alerts-to-design-system-Alert.md
@@ -59,6 +59,8 @@ Verification: focused red test failed on missing data-ds-component marker before
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Migrated TldwConnectionSettings login-required and logged-in auth notices to the shared design-system Alert primitive, preserved logout behavior and danger action styling through a small Alert action variant extension, and removed the two resolved product-state baseline exceptions.
+
+PR #1781 review follow-up moved info/success polite status-region defaults into the Alert primitive, removed duplicate role/aria-live props from TldwConnectionSettings, renamed the local import to Alert, and verified that the logout action's danger variant is valid for the existing Button API.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.6.2 - Migrate-TldwConnectionSettings-auth-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.6.2 - Migrate-TldwConnectionSettings-auth-alerts-to-design-system-Alert.md
@@ -1,0 +1,72 @@
+---
+id: TASK-45.44.6.2
+title: Migrate TldwConnectionSettings auth alerts to design-system Alert
+status: Done
+assignee:
+- Codex
+created_date: ''
+updated_date: 2026-05-16 16:20
+labels:
+- design-system
+- webui
+- extension
+- product-state
+dependencies: []
+references:
+- apps/packages/ui/src/components/Option/Settings/TldwConnectionSettings.tsx
+- apps/packages/ui/src/components/Option/Settings/__tests__/tldw-review-comments.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1781
+documentation:
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+parent_task_id: TASK-45.44.6
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the remaining TldwConnectionSettings authentication status alerts from AntD Alert to the shared design-system Alert primitive while preserving login-required and logged-in copy, logout behavior, and product-state guard coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TldwConnectionSettings renders login-required and logged-in auth status messages through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Existing auth mode, magic-link, and logout behavior remain covered by focused tests.
+- [x] #3 The design-system product-state baseline no longer contains TldwConnectionSettings AntD Alert exceptions.
+- [x] #4 Focused tests, design-system verifier, git diff check, and TypeScript/Bandit applicability are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused tests proving login-required and logged-in auth notices render inside the design-system Alert primitive and that logged-in logout action still calls onLogout.
+2. Run the focused test before implementation to capture the expected failure while TldwConnectionSettings still uses AntD Alert.
+3. Replace the two AntD Alert auth notices with the shared design-system Alert primitive, mapping info/success variants and converting the logout action to the primitive action contract.
+4. Remove the two TldwConnectionSettings AntD Alert baseline entries.
+5. Verify focused tests, product-state verifier, git diff check, and document TypeScript/Bandit applicability.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented via TDD. Added failing coverage for the login-required and logged-in auth notices to require the shared design-system Alert marker and preserve the logged-in Logout action. Migrated both TldwConnectionSettings auth notices from AntD Alert to DesignSystemAlert with info/success variants and polite status regions. Extended the Alert primitive action contract with an optional Button variant so the logout action can keep danger styling while using the primitive action API. Removed the two TldwConnectionSettings AntD Alert baseline exceptions.
+
+Verification: focused red test failed on missing data-ds-component marker before implementation. After implementation, bunx vitest run src/components/Option/Settings/__tests__/tldw-review-comments.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 58 tests. bun run verify:design-system-state passed with baseline exceptions reduced from 400 to 398 and Settings exceptions at 47. Baseline JSON parse passed. git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide TypeScript debt; filtered output for TldwConnectionSettings, tldw-review-comments, components/ui/primitives/Alert, and the baseline file had no matches after fixing the touched test TFunction import. Bandit not run because this slice touches frontend TypeScript/JSON/backlog files only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated TldwConnectionSettings login-required and logged-in auth notices to the shared design-system Alert primitive, preserved logout behavior and danger action styling through a small Alert action variant extension, and removed the two resolved product-state baseline exceptions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates TldwConnectionSettings login-required and logged-in auth notices from AntD Alert to the shared design-system Alert primitive.
- Preserves logout behavior and danger action styling through a small Alert action variant extension.
- Removes the two resolved TldwConnectionSettings product-state baseline exceptions and records TASK-45.44.6.2 evidence.

## Test Plan
- bunx vitest run src/components/Option/Settings/__tests__/tldw-review-comments.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"
- git diff --check
- bunx tsc --noEmit --pretty false (expected existing repo-wide failures; filtered touched paths had no matches)

## Change summary
Maintainer-owned summary required before merge: TODO

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `TldwConnectionSettings` auth alerts from AntD to the design-system `Alert` to standardize UI and remove product-state exceptions. Addresses TASK-45.44.6.2 under TASK-45.44.6.

- **Refactors**
  - Replaced AntD `Alert` with design-system `Alert` for login-required and logged-in notices; uses info/success variants with default polite status region.
  - Extended design-system `Alert` action API to accept `variant` so the `Logout` action stays danger-styled.
  - Removed two product-state baseline exceptions and added focused tests asserting design-system `Alert` usage and preserved `Logout` behavior.

<sup>Written for commit a31f9bfc9c150618ceaceb6838168c7f37c7f390. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1781?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

