### PR TITLE
Add Persona Visual candidate provenance metadata

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -33,6 +33,21 @@ it. Generated or imported assets do not become live just because a job finished.
 Deactivation clears the active visual pack for that persona while leaving
 available packs in place for later editing or activation.
 
+## Generated Candidate Provenance
+
+Generated candidates are review artifacts. Their persisted
+`generation_provenance` metadata is intentionally bounded and trace-safe so a
+review surface can explain why a candidate exists without echoing raw prompts,
+provider secrets, local paths, or arbitrary job payloads.
+
+The V1 provenance shape stores `schema_version`, `generation_mode`,
+`request_id`, `job_id`, `backend`, and `target_state` when present. Recipe-backed
+jobs may also include a `recipe` summary with `starter_pack_id`,
+`recipe_output`, `correlation_id`, `identity_brief`, `neutral_anchor`,
+`static_sheet`, bounded `review_checks`, and a boolean
+`user_prompt_included`. The raw effective prompt remains outside provenance, and
+unknown provenance keys are dropped during candidate row normalization.
+
 ## Manifest-Backed Pack Format
 
 Packs are stored as manifests with referenced assets. The V1 renderer uses

--- a/Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provenance.md
+++ b/Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provenance.md
@@ -1,0 +1,141 @@
+# Persona Visual Candidate Provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist and return bounded, trace-safe provenance metadata for Persona Visual generated candidates so review screens can explain where a candidate came from without exposing raw prompts or provider secrets.
+
+**Architecture:** Add one bounded provenance helper in the Persona core layer, store normalized JSON on `persona_visual_candidates`, and return it through the existing candidate response contract. Keep generation review-gated; do not activate packs automatically, add renderer behavior, or introduce MCP provider execution.
+
+**Tech Stack:** Python, FastAPI/Pydantic, SQLite/PostgreSQL schema migrations, existing ChaChaNotesDB Persona state store, pytest.
+
+---
+
+### Task 1: Add Candidate Provenance Storage Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Persona/visual_candidate_provenance.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py`
+- Test: `tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py`
+
+- [x] **Step 1: Write failing DB round-trip tests**
+
+Add a test that creates a candidate with `generation_provenance`, fetches it back through `list_persona_visual_candidates`, and asserts the returned dict includes bounded normalized provenance.
+
+Add a second assertion that unsafe/unbounded text in provenance is redacted or truncated and the raw unsafe string is not returned.
+
+- [x] **Step 2: Run focused DB test to verify RED**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py::test_candidate_generation_provenance_round_trip -q --tb=short --disable-warnings`
+
+Expected: FAIL because `generation_provenance` is not accepted or returned yet.
+
+- [x] **Step 3: Implement schema v47 and store normalization**
+
+Add `generation_provenance_json TEXT NOT NULL DEFAULT '{}'` to `persona_visual_candidates` for fresh SQLite/PostgreSQL schemas, add v46-to-v47 migrations, wire both migration paths, and bump `_CURRENT_SCHEMA_VERSION`.
+
+Add a Persona core helper that normalizes allowed provenance keys and omits or redacts unsafe text. Use it before insert and when decoding candidate rows.
+
+- [x] **Step 4: Run focused DB test to verify GREEN**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py::test_candidate_generation_provenance_round_trip -q --tb=short --disable-warnings`
+
+Expected: PASS.
+
+### Task 2: Capture Generation Job Provenance
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Persona/visual_jobs_worker.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visual_jobs.py`
+
+- [x] **Step 1: Write failing worker test**
+
+Extend the generated-candidate worker test so a recipe-backed job stores provenance with:
+- `schema_version`
+- `generation_mode`
+- `request_id`
+- `job_id`
+- `backend`
+- `target_state`
+- recipe summary fields such as `starter_pack_id`, `recipe_output`, `correlation_id`, and review checks
+
+Assert raw prompt/user prompt text is not copied into `generation_provenance`.
+
+- [x] **Step 2: Run focused worker test to verify RED**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_jobs.py::test_generation_worker_stores_generated_asset_and_candidate -q --tb=short --disable-warnings`
+
+Expected: FAIL because stored candidates have no provenance yet.
+
+- [x] **Step 3: Build provenance in the worker**
+
+Use the new helper to build provenance from safe job payload fields and recipe intent. Pass it to `create_persona_visual_candidate` when `_persist_generated_candidate` stores the review candidate.
+
+- [x] **Step 4: Run focused worker test to verify GREEN**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_jobs.py::test_generation_worker_stores_generated_asset_and_candidate -q --tb=short --disable-warnings`
+
+Expected: PASS.
+
+### Task 3: Return Provenance Through API And Docs
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+- Test: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
+
+- [x] **Step 1: Write failing API response test**
+
+Extend generated-candidate list/detail coverage to create a candidate with provenance and assert the serialized response includes `generation_provenance` without raw unsafe metadata.
+
+- [x] **Step 2: Run focused API test to verify RED**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_list_generated_candidates_returns_preview_asset_urls -q --tb=short --disable-warnings`
+
+Expected: FAIL because `PersonaVisualCandidateResponse` does not include the field yet.
+
+- [x] **Step 3: Expose the response field and document it**
+
+Add `generation_provenance` to `PersonaVisualCandidateResponse`, populate it in `_persona_visual_candidate_to_response`, and update the Persona Visual Packs documentation with the trace-safe provenance contract.
+
+- [x] **Step 4: Run focused API test to verify GREEN**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_list_generated_candidates_returns_preview_asset_urls -q --tb=short --disable-warnings`
+
+Expected: PASS.
+
+### Task 4: Verification And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-409 - Add-Persona-Visual-generated-candidate-provenance-review-metadata.md`
+
+- [x] **Step 1: Run focused Persona Visual regression tests**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py tldw_Server_API/tests/Persona/test_persona_visual_jobs.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short --disable-warnings`
+
+Expected: PASS.
+
+- [x] **Step 2: Run syntax, whitespace, and Bandit checks**
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_candidate_provenance.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py`
+
+Run:
+`git diff --check`
+
+Run:
+`/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_candidate_provenance.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_persona_visual_candidate_provenance.json`
+
+Expected: all commands exit 0 with no new findings in touched code.
+
+- [x] **Step 3: Update task and commit**
+
+Update `TASK-409` with touched files, verification results, and the PR/issue relationship. Commit the implementation with a message that references #1782.

--- a/backlog/tasks/task-409 - Add-Persona-Visual-generated-candidate-provenance-review-metadata.md
+++ b/backlog/tasks/task-409 - Add-Persona-Visual-generated-candidate-provenance-review-metadata.md
@@ -4,7 +4,7 @@ title: Add Persona Visual generated-candidate provenance review metadata
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 17:12'
+updated_date: '2026-05-16 17:18'
 labels:
   - persona
   - buddy
@@ -15,6 +15,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1782'
   - 'https://github.com/rmusser01/tldw_server/issues/1510'
+  - 'https://github.com/rmusser01/tldw_server/pull/1784'
 documentation:
   - Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provenance.md
 ---
@@ -43,9 +44,7 @@ Plan saved at Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provena
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Verification recorded: focused Persona Visual DB/worker/API suite passed (78 passed); py_compile passed; git diff --check passed; Bandit passed with empty results array in `/tmp/bandit_persona_visual_candidate_provenance.json`.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Verification recorded: focused Persona Visual DB/worker/API suite passed (78 passed); py_compile passed; git diff --check passed; Bandit passed with empty results array in /tmp/bandit_persona_visual_candidate_provenance.json. Draft PR: https://github.com/rmusser01/tldw_server/pull/1784
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-409 - Add-Persona-Visual-generated-candidate-provenance-review-metadata.md
+++ b/backlog/tasks/task-409 - Add-Persona-Visual-generated-candidate-provenance-review-metadata.md
@@ -4,20 +4,20 @@ title: Add Persona Visual generated-candidate provenance review metadata
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 17:18'
+updated_date: 2026-05-16 17:32
 labels:
-  - persona
-  - buddy
-  - visual-packs
-  - backend
-  - issue-1782
+- persona
+- buddy
+- visual-packs
+- backend
+- issue-1782
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1782'
-  - 'https://github.com/rmusser01/tldw_server/issues/1510'
-  - 'https://github.com/rmusser01/tldw_server/pull/1784'
+- https://github.com/rmusser01/tldw_server/issues/1782
+- https://github.com/rmusser01/tldw_server/issues/1510
+- https://github.com/rmusser01/tldw_server/pull/1784
 documentation:
-  - Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provenance.md
+- Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provenance.md
 ---
 
 ## Description
@@ -45,6 +45,10 @@ Plan saved at Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provena
 
 <!-- SECTION:NOTES:BEGIN -->
 Verification recorded: focused Persona Visual DB/worker/API suite passed (78 passed); py_compile passed; git diff --check passed; Bandit passed with empty results array in /tmp/bandit_persona_visual_candidate_provenance.json. Draft PR: https://github.com/rmusser01/tldw_server/pull/1784
+
+Review fix pass for PR #1784: verify and address unresolved comments on secret/path redaction specificity and Postgres v45/v47 migration drift.
+
+Review fix verification for PR #1784: tightened Persona Visual candidate provenance redaction to match concrete secret/path shapes while preserving normal art-description words; removed generation_provenance_json from the Postgres v44->v45 migration while keeping the v46->v47 addition; added focused sanitizer and migration-drift regression tests. Fresh validation: focused Persona Visual DB/worker/API/provenance suite passed (90 passed); py_compile passed for touched backend modules; git diff --check passed; Bandit passed with empty results array in /tmp/bandit_persona_visual_candidate_provenance.json.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-409 - Add-Persona-Visual-generated-candidate-provenance-review-metadata.md
+++ b/backlog/tasks/task-409 - Add-Persona-Visual-generated-candidate-provenance-review-metadata.md
@@ -1,0 +1,65 @@
+---
+id: TASK-409
+title: Add Persona Visual generated-candidate provenance review metadata
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 17:12'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - backend
+  - issue-1782
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1782'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+documentation:
+  - Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provenance.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1782 as a narrow backend/API Persona Visual review metadata slice. Persist and expose trace-safe generated-candidate provenance for recipe-backed generation jobs, keep prompt-only behavior backward-compatible, add focused tests for bounded/unsafe metadata handling, update docs, and preserve review-gated/no-auto-activation semantics. Scope excludes WebUI redesign, final art generation, MCP provider execution/resource download, renderer expansion, marketplace/shared-library behavior, VN/CYOA behavior, and automatic activation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Candidate rows persist and return bounded generation_provenance metadata without exposing raw unsafe strings.
+- [x] #2 Generation workers store recipe-backed provenance fields from request, job, backend, target state, and recipe summary context while omitting raw prompts.
+- [x] #3 Generated-candidate list and detail API responses include generation_provenance for review use.
+- [x] #4 Persona Visual documentation describes the trace-safe provenance contract and review-gated boundary.
+- [x] #5 Focused DB, worker, API, syntax, diff, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan saved at Docs/superpowers/plans/2026-05-16-persona-visual-candidate-provenance.md. Acceptance checks: persist bounded generation_provenance on persona_visual_candidates; worker stores recipe-backed provenance without raw prompts; API list/detail responses include provenance; docs describe trace-safe review metadata; focused tests, syntax, diff, and Bandit verification recorded.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification recorded: focused Persona Visual DB/worker/API suite passed (78 passed); py_compile passed; git diff --check passed; Bandit passed with empty results array in `/tmp/bandit_persona_visual_candidate_provenance.json`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added trace-safe generated-candidate provenance for Persona Visual review workflows. Candidates now persist bounded provenance metadata, recipe-backed generation jobs store review-relevant context without raw prompts, and API list/detail responses expose the normalized metadata for review screens. Documentation describes the V1 provenance shape and explicitly keeps it review-gated.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2212,6 +2212,11 @@ def _persona_visual_candidate_to_response(
             _persona_visual_asset_to_response(asset)
             for asset in (generated_assets or [])
         ],
+        generation_provenance=(
+            candidate.get("generation_provenance")
+            if isinstance(candidate.get("generation_provenance"), dict)
+            else {}
+        ),
         prompt=candidate.get("prompt"),
         failure_reason=candidate.get("failure_reason"),
         created_at=str(candidate.get("created_at") or _utc_now_iso()),

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -522,6 +522,7 @@ class PersonaVisualCandidateResponse(BaseModel):
     proposed_manifest_patch: dict[str, Any] = Field(default_factory=dict)
     generated_asset_ids: list[str] = Field(default_factory=list)
     generated_assets: list[PersonaVisualAssetResponse] = Field(default_factory=list)
+    generation_provenance: dict[str, Any] = Field(default_factory=dict)
     prompt: str | None = None
     failure_reason: str | None = None
     created_at: str

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -5254,7 +5254,6 @@ CREATE TABLE IF NOT EXISTS persona_visual_candidates (
                                CHECK(status IN ('review','accepted','rejected','failed')),
   proposed_manifest_patch_json TEXT NOT NULL DEFAULT '{}',
   generated_asset_ids_json     TEXT NOT NULL DEFAULT '[]',
-  generation_provenance_json   TEXT NOT NULL DEFAULT '{}',
   prompt                       TEXT,
   failure_reason               TEXT,
   created_at                   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -581,7 +581,7 @@ class CharactersRAGDB:
         is_memory_db (bool): True if the database is in-memory.
         db_path_str (str): String representation of the database path for SQLite connection.
     """
-    _CURRENT_SCHEMA_VERSION = 46  # Schema v46 adds persona visual library items
+    _CURRENT_SCHEMA_VERSION = 47  # Schema v47 adds persona visual candidate provenance
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES: tuple[str, ...] = ("in-progress", "resolved", "backlog", "non-viable")
     _ALLOWED_CONVERSATION_CHARACTER_SCOPES: tuple[str, ...] = ("all", "character", "non_character")
@@ -5254,6 +5254,7 @@ CREATE TABLE IF NOT EXISTS persona_visual_candidates (
                                CHECK(status IN ('review','accepted','rejected','failed')),
   proposed_manifest_patch_json TEXT NOT NULL DEFAULT '{}',
   generated_asset_ids_json     TEXT NOT NULL DEFAULT '[]',
+  generation_provenance_json   TEXT NOT NULL DEFAULT '{}',
   prompt                       TEXT,
   failure_reason               TEXT,
   created_at                   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -5336,6 +5337,20 @@ UPDATE db_schema_version
    SET version = 46
  WHERE schema_name = 'rag_char_chat_schema'
    AND version < 46;
+"""
+
+    _MIGRATION_SQL_V46_TO_V47_POSTGRES = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 47 — Persona visual candidate provenance (2026-05-16) [Postgres]
+───────────────────────────────────────────────────────────────*/
+
+ALTER TABLE persona_visual_candidates
+  ADD COLUMN IF NOT EXISTS generation_provenance_json TEXT NOT NULL DEFAULT '{}';
+
+UPDATE db_schema_version
+   SET version = 47
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 47;
 """
 
     _MIGRATION_SQL_V10_TO_V11_POSTGRES = """
@@ -7440,6 +7455,39 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V45->V46: {e}", exc_info=True)
             raise SchemaError(f"Unexpected error migrating to V46 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
 
+    def _migrate_from_v46_to_v47(self, conn: sqlite3.Connection) -> None:
+        """Migrate schema from V46 to V47 (persona visual candidate provenance)."""
+        logger.info(f"Migrating '{self._SCHEMA_NAME}' schema from V46 to V47 for DB: {self.db_path_str}...")
+        try:
+            candidate_cols = {
+                str(row[1])
+                for row in conn.execute("PRAGMA table_info('persona_visual_candidates')").fetchall()
+            }
+            if "generation_provenance_json" not in candidate_cols:
+                conn.execute(
+                    "ALTER TABLE persona_visual_candidates "
+                    "ADD COLUMN generation_provenance_json TEXT NOT NULL DEFAULT '{}'"
+                )
+            conn.execute(
+                "UPDATE db_schema_version SET version = 47 "
+                "WHERE schema_name = ? AND version < 47",
+                (self._SCHEMA_NAME,),
+            )
+            final_version = self._get_db_version(conn)
+            if final_version != 47:
+                raise SchemaError(  # noqa: TRY003, TRY301
+                    f"[{self._SCHEMA_NAME}] Migration V46->V47 failed version check. Expected 47, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME}] Migration to V47 completed.")
+        except sqlite3.Error as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Migration V46->V47 failed: {e}", exc_info=True)
+            raise SchemaError(f"Migration V46->V47 failed for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+        except SchemaError:
+            raise
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V46->V47: {e}", exc_info=True)
+            raise SchemaError(f"Unexpected error migrating to V47 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+
     def _ensure_recent_persona_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Backfill recent persona schema columns after version-number collisions."""
         profile_cols = {row[1] for row in conn.execute("PRAGMA table_info('persona_profiles')").fetchall()}
@@ -8924,6 +8972,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     if target_version >= 46 and current_db_version == 45:
                         self._migrate_from_v45_to_v46(conn)
                         current_db_version = self._get_db_version(conn)
+                    if target_version >= 47 and current_db_version == 46:
+                        self._migrate_from_v46_to_v47(conn)
+                        current_db_version = self._get_db_version(conn)
                 # Ensure helpful indexes that may have been introduced post-creation
                 try:
                     conn.execute("CREATE INDEX IF NOT EXISTS idx_flashcards_created_at ON flashcards(created_at)")
@@ -9271,6 +9322,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                 self._migrate_from_v44_to_v45(conn)
                             elif fallback_version == 45:
                                 self._migrate_from_v45_to_v46(conn)
+                            elif fallback_version == 46:
+                                self._migrate_from_v46_to_v47(conn)
                             else:
                                 raise SchemaError(  # noqa: TRY003, TRY301
                                     f"Migration path undefined for '{self._SCHEMA_NAME}' from version {current_initial_version} to {target_version}. "
@@ -9384,6 +9437,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     current_db_version = self._get_db_version(conn)
                 if target_version >= 46 and current_db_version == 45:
                     self._migrate_from_v45_to_v46(conn)
+                    current_db_version = self._get_db_version(conn)
+                if target_version >= 47 and current_db_version == 46:
+                    self._migrate_from_v46_to_v47(conn)
                     current_db_version = self._get_db_version(conn)
 
                 self._ensure_recent_persona_schema_sqlite(conn)
@@ -13204,6 +13260,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             if current_version < 46:
                 self._apply_postgres_migration_script(self._MIGRATION_SQL_V45_TO_V46_POSTGRES, conn, expected_version=46)
                 current_version = 46
+            if current_version < 47:
+                self._apply_postgres_migration_script(self._MIGRATION_SQL_V46_TO_V47_POSTGRES, conn, expected_version=47)
+                current_version = 47
 
             if current_version > target_version:
                 raise SchemaError(  # noqa: TRY003

--- a/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
@@ -18,6 +18,9 @@ from tldw_Server_API.app.core.DB_Management.backends.base import (
 )
 from tldw_Server_API.app.core.DB_Management.chacha import exemplar_normalization
 from tldw_Server_API.app.core.Persona.buddy import resolve_persona_buddy_profile
+from tldw_Server_API.app.core.Persona.visual_candidate_provenance import (
+    normalize_persona_visual_candidate_provenance,
+)
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
@@ -956,6 +959,13 @@ class PersonaStateStore:
             item.get("generated_asset_ids_json"),
             field_name="generated_asset_ids_json",
             context_label=f"persona visual candidate {candidate_label}",
+        )
+        item["generation_provenance"] = normalize_persona_visual_candidate_provenance(
+            self._decode_persona_json_object(
+                item.get("generation_provenance_json"),
+                field_name="generation_provenance_json",
+                context_label=f"persona visual candidate {candidate_label}",
+            )
         )
         item["deleted"] = self._as_bool(item.get("deleted"))
         return item
@@ -3210,6 +3220,7 @@ class PersonaStateStore:
         job_id: str | None,
         proposed_manifest_patch: dict[str, Any] | None,
         generated_asset_ids: list[str] | None,
+        generation_provenance: dict[str, Any] | None = None,
         prompt: str | None = None,
         status: str = "review",
         candidate_id: str | None = None,
@@ -3226,14 +3237,18 @@ class PersonaStateStore:
             for asset_id in (generated_asset_ids or [])
             if str(asset_id).strip()
         ]
+        generation_provenance_value = normalize_persona_visual_candidate_provenance(
+            generation_provenance
+        )
         candidate_id_value = str(candidate_id or self._generate_uuid()).strip()
         now = self._get_current_utc_timestamp_iso()
         bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
         query = (
             "INSERT INTO persona_visual_candidates("
             "id, pack_id, persona_id, user_id, job_id, status, proposed_manifest_patch_json, "
-            "generated_asset_ids_json, prompt, failure_reason, created_at, last_modified, deleted, version"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            "generated_asset_ids_json, generation_provenance_json, prompt, failure_reason, "
+            "created_at, last_modified, deleted, version"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         params = (
             candidate_id_value,
@@ -3244,6 +3259,7 @@ class PersonaStateStore:
             status_value,
             self._ensure_json_string(manifest_patch_value) or "{}",
             self._ensure_json_string(generated_asset_ids_value) or "[]",
+            self._ensure_json_string(generation_provenance_value) or "{}",
             self._normalize_nullable_text(prompt),
             None,
             now,

--- a/tldw_Server_API/app/core/Persona/visual_candidate_provenance.py
+++ b/tldw_Server_API/app/core/Persona/visual_candidate_provenance.py
@@ -9,6 +9,7 @@ unknown keys are intentionally excluded.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -20,23 +21,23 @@ PERSONA_VISUAL_CANDIDATE_PROVENANCE_REVIEW_CHECK_LIMIT = 12
 PERSONA_VISUAL_CANDIDATE_PROVENANCE_REVIEW_CHECK_TEXT_LIMIT = 120
 
 _ALLOWED_GENERATION_MODES = frozenset({"prompt_only", "recipe_backed"})
-_SECRET_MARKERS = (
-    "api_key",
-    "apikey",
-    "authorization",
-    "bearer ",
-    "password",
-    "secret",
-    "sk-",
-    "token",
-    "x-api-key",
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"\bBearer\b(?:\s*[:=]\s*\S+|\s+[A-Za-z0-9+/_=-]{12,})"),
+    re.compile(r"\bauthorization\b\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"\bx\s*[-_ ]?\s*api\s*[-_ ]?\s*key\b\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"\bapi\s*[-_ ]?\s*key\b\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"\b(?:access|refresh|id|auth)\s*[-_ ]?\s*token\b\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"\bclient\s*[-_ ]?\s*secret\b\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"\bsecret\s*[-_ ]?\s*(?:key|token)\b\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"\bpassword\b\s*[:=]\s*\S+", re.IGNORECASE),
+    re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]{7,}\b"),
 )
-_PATH_MARKERS = (
-    "/home/",
-    "/private/",
-    "/users/",
-    "\\",
+_PATH_PATTERNS = (
+    re.compile(r"(?:^|\s)/(?:home|private|users)/\S+", re.IGNORECASE),
+    re.compile(r"\b[A-Za-z]:\\\S+"),
+    re.compile(r"\\\\[^\s\\]+\\\S+"),
 )
+_TOKENISH_VALUE_PATTERN = re.compile(r"^[A-Za-z0-9+/_=-]{40,}$")
 _TOP_LEVEL_TEXT_FIELDS = {
     "request_id": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
     "job_id": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
@@ -158,12 +159,29 @@ def _safe_provenance_text(value: Any, *, max_length: int) -> str | None:
     text = str(value).strip()
     if not text:
         return None
-    lower_text = text.lower()
-    if any(marker in lower_text for marker in _SECRET_MARKERS):
-        return "[redacted]"
-    if any(marker in lower_text for marker in _PATH_MARKERS):
-        return "[redacted]"
     collapsed = " ".join(text.split())
+    if _contains_secret_value(text, collapsed):
+        return "[redacted]"
+    if any(pattern.search(collapsed) for pattern in _PATH_PATTERNS):
+        return "[redacted]"
     if len(collapsed) > max_length:
         return collapsed[:max_length]
     return collapsed
+
+
+def _contains_secret_value(text: str, collapsed: str) -> bool:
+    if any(pattern.search(text) or pattern.search(collapsed) for pattern in _SECRET_VALUE_PATTERNS):
+        return True
+    return _looks_like_single_token_secret(collapsed)
+
+
+def _looks_like_single_token_secret(value: str) -> bool:
+    if not _TOKENISH_VALUE_PATTERN.fullmatch(value):
+        return False
+    character_classes = (
+        any(char.islower() for char in value),
+        any(char.isupper() for char in value),
+        any(char.isdigit() for char in value),
+        any(char in "+/_=-" for char in value),
+    )
+    return sum(character_classes) >= 3 and len(set(value)) >= 16

--- a/tldw_Server_API/app/core/Persona/visual_candidate_provenance.py
+++ b/tldw_Server_API/app/core/Persona/visual_candidate_provenance.py
@@ -1,0 +1,169 @@
+"""Trace-safe provenance metadata for Persona Visual generated candidates.
+
+Generation jobs may carry prompt, provider, recipe, and request metadata that is
+useful during human review but unsafe to echo directly. This module builds and
+normalizes the small candidate provenance payload stored with review candidates:
+stable IDs, bounded labels, and recipe summary fields only. Raw prompts and
+unknown keys are intentionally excluded.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+PERSONA_VISUAL_CANDIDATE_PROVENANCE_SCHEMA_VERSION = 1
+PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT = 128
+PERSONA_VISUAL_CANDIDATE_PROVENANCE_SUMMARY_TEXT_LIMIT = 240
+PERSONA_VISUAL_CANDIDATE_PROVENANCE_REVIEW_CHECK_LIMIT = 12
+PERSONA_VISUAL_CANDIDATE_PROVENANCE_REVIEW_CHECK_TEXT_LIMIT = 120
+
+_ALLOWED_GENERATION_MODES = frozenset({"prompt_only", "recipe_backed"})
+_SECRET_MARKERS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer ",
+    "password",
+    "secret",
+    "sk-",
+    "token",
+    "x-api-key",
+)
+_PATH_MARKERS = (
+    "/home/",
+    "/private/",
+    "/users/",
+    "\\",
+)
+_TOP_LEVEL_TEXT_FIELDS = {
+    "request_id": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
+    "job_id": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
+    "backend": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
+    "target_state": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
+}
+_RECIPE_TEXT_FIELDS = {
+    "starter_pack_id": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
+    "recipe_output": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
+    "correlation_id": PERSONA_VISUAL_CANDIDATE_PROVENANCE_ID_TEXT_LIMIT,
+    "identity_brief": PERSONA_VISUAL_CANDIDATE_PROVENANCE_SUMMARY_TEXT_LIMIT,
+    "neutral_anchor": PERSONA_VISUAL_CANDIDATE_PROVENANCE_SUMMARY_TEXT_LIMIT,
+    "static_sheet": PERSONA_VISUAL_CANDIDATE_PROVENANCE_SUMMARY_TEXT_LIMIT,
+}
+
+
+def build_persona_visual_candidate_provenance(
+    *,
+    request_id: str | None,
+    job_id: str | int | None,
+    backend: str | None,
+    target_state: str | None,
+    recipe_intent: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build normalized provenance for a generated Persona Visual candidate."""
+    recipe_payload = dict(recipe_intent) if isinstance(recipe_intent, Mapping) else None
+    raw_provenance: dict[str, Any] = {
+        "generation_mode": "recipe_backed" if recipe_payload else "prompt_only",
+        "request_id": request_id,
+        "job_id": job_id,
+        "backend": backend,
+        "target_state": target_state,
+    }
+    if recipe_payload:
+        user_prompt = str(recipe_payload.get("user_prompt") or "").strip()
+        raw_provenance["recipe"] = {
+            "starter_pack_id": recipe_payload.get("starter_pack_id"),
+            "recipe_output": recipe_payload.get("recipe_output"),
+            "correlation_id": recipe_payload.get("correlation_id") or request_id,
+            "identity_brief": recipe_payload.get("identity_brief"),
+            "neutral_anchor": recipe_payload.get("neutral_anchor"),
+            "static_sheet": recipe_payload.get("static_sheet"),
+            "review_checks": recipe_payload.get("review_checks"),
+            "user_prompt_included": bool(user_prompt),
+        }
+    return normalize_persona_visual_candidate_provenance(raw_provenance)
+
+
+def normalize_persona_visual_candidate_provenance(value: Any) -> dict[str, Any]:
+    """Return bounded candidate provenance with only review-safe keys."""
+    if not isinstance(value, Mapping):
+        return {}
+
+    normalized: dict[str, Any] = {}
+    mode = _normalize_generation_mode(value.get("generation_mode"), value.get("recipe"))
+    if mode:
+        normalized["generation_mode"] = mode
+
+    for field_name, text_limit in _TOP_LEVEL_TEXT_FIELDS.items():
+        text_value = _safe_provenance_text(value.get(field_name), max_length=text_limit)
+        if text_value is not None:
+            normalized[field_name] = text_value
+
+    recipe = _normalize_recipe_provenance(value.get("recipe"))
+    if recipe:
+        normalized["recipe"] = recipe
+        normalized.setdefault("generation_mode", "recipe_backed")
+
+    if not normalized:
+        return {}
+    return {
+        "schema_version": PERSONA_VISUAL_CANDIDATE_PROVENANCE_SCHEMA_VERSION,
+        **normalized,
+    }
+
+
+def _normalize_generation_mode(value: Any, recipe: Any) -> str | None:
+    mode = str(value or "").strip()
+    if mode in _ALLOWED_GENERATION_MODES:
+        return mode
+    if isinstance(recipe, Mapping) and recipe:
+        return "recipe_backed"
+    return None
+
+
+def _normalize_recipe_provenance(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    recipe: dict[str, Any] = {}
+    for field_name, text_limit in _RECIPE_TEXT_FIELDS.items():
+        text_value = _safe_provenance_text(value.get(field_name), max_length=text_limit)
+        if text_value is not None:
+            recipe[field_name] = text_value
+    review_checks = _normalize_review_checks(value.get("review_checks"))
+    if review_checks:
+        recipe["review_checks"] = review_checks
+    if "user_prompt_included" in value:
+        recipe["user_prompt_included"] = bool(value.get("user_prompt_included"))
+    return recipe
+
+
+def _normalize_review_checks(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    checks: list[str] = []
+    for item in value[:PERSONA_VISUAL_CANDIDATE_PROVENANCE_REVIEW_CHECK_LIMIT]:
+        text_value = _safe_provenance_text(
+            item,
+            max_length=PERSONA_VISUAL_CANDIDATE_PROVENANCE_REVIEW_CHECK_TEXT_LIMIT,
+        )
+        if text_value is not None:
+            checks.append(text_value)
+    return checks
+
+
+def _safe_provenance_text(value: Any, *, max_length: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    lower_text = text.lower()
+    if any(marker in lower_text for marker in _SECRET_MARKERS):
+        return "[redacted]"
+    if any(marker in lower_text for marker in _PATH_MARKERS):
+        return "[redacted]"
+    collapsed = " ".join(text.split())
+    if len(collapsed) > max_length:
+        return collapsed[:max_length]
+    return collapsed

--- a/tldw_Server_API/app/core/Persona/visual_candidate_provenance.py
+++ b/tldw_Server_API/app/core/Persona/visual_candidate_provenance.py
@@ -115,6 +115,7 @@ def normalize_persona_visual_candidate_provenance(value: Any) -> dict[str, Any]:
 
 
 def _normalize_generation_mode(value: Any, recipe: Any) -> str | None:
+    """Return a supported generation mode, inferring recipe-backed when needed."""
     mode = str(value or "").strip()
     if mode in _ALLOWED_GENERATION_MODES:
         return mode
@@ -124,6 +125,7 @@ def _normalize_generation_mode(value: Any, recipe: Any) -> str | None:
 
 
 def _normalize_recipe_provenance(value: Any) -> dict[str, Any]:
+    """Normalize the recipe subsection to the bounded review-safe fields."""
     if not isinstance(value, Mapping):
         return {}
     recipe: dict[str, Any] = {}
@@ -140,6 +142,7 @@ def _normalize_recipe_provenance(value: Any) -> dict[str, Any]:
 
 
 def _normalize_review_checks(value: Any) -> list[str]:
+    """Return bounded review-check strings after safety normalization."""
     if not isinstance(value, list):
         return []
     checks: list[str] = []
@@ -154,6 +157,7 @@ def _normalize_review_checks(value: Any) -> list[str]:
 
 
 def _safe_provenance_text(value: Any, *, max_length: int) -> str | None:
+    """Return normalized text or a redaction marker for unsafe provenance values."""
     if value is None:
         return None
     text = str(value).strip()
@@ -170,12 +174,14 @@ def _safe_provenance_text(value: Any, *, max_length: int) -> str | None:
 
 
 def _contains_secret_value(text: str, collapsed: str) -> bool:
+    """Detect explicit auth-key shapes and high-entropy standalone tokens."""
     if any(pattern.search(text) or pattern.search(collapsed) for pattern in _SECRET_VALUE_PATTERNS):
         return True
     return _looks_like_single_token_secret(collapsed)
 
 
 def _looks_like_single_token_secret(value: str) -> bool:
+    """Return true for long standalone values that resemble opaque credentials."""
     if not _TOKENISH_VALUE_PATTERN.fullmatch(value):
         return False
     character_classes = (

--- a/tldw_Server_API/app/core/Persona/visual_jobs_worker.py
+++ b/tldw_Server_API/app/core/Persona/visual_jobs_worker.py
@@ -28,6 +28,9 @@ from tldw_Server_API.app.core.Persona.visual_jobs import (
     persona_visual_generation_queue,
     persona_visual_portability_queue,
 )
+from tldw_Server_API.app.core.Persona.visual_candidate_provenance import (
+    build_persona_visual_candidate_provenance,
+)
 from tldw_Server_API.app.core.Persona.visual_portability.exporter import (
     PersonaVisualPackExporter,
 )
@@ -105,6 +108,13 @@ class PersonaVisualGenerationWorker:
             request_id=f"persona_visuals:{persona_id}:{pack_id}:{request_id or job_id}",
         )
         result = await asyncio.to_thread(adapter.generate, request)
+        generation_provenance = build_persona_visual_candidate_provenance(
+            request_id=request_id or None,
+            job_id=job_id or None,
+            backend=backend,
+            target_state=target_state,
+            recipe_intent=recipe_intent,
+        )
 
         asset, candidate = await asyncio.to_thread(
             self._persist_generated_candidate,
@@ -117,6 +127,7 @@ class PersonaVisualGenerationWorker:
             target_state=target_state,
             job_id=job_id,
             prompt=prompt,
+            generation_provenance=generation_provenance,
         )
         asset_id = str(asset["id"])
         if recipe_intent:
@@ -148,6 +159,7 @@ class PersonaVisualGenerationWorker:
         target_state: str | None,
         job_id: str,
         prompt: str,
+        generation_provenance: dict[str, Any],
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         service = PersonaVisualService(self._db)
         asset = service.create_generated_asset(
@@ -183,6 +195,7 @@ class PersonaVisualGenerationWorker:
             job_id=job_id,
             proposed_manifest_patch=proposed_patch,
             generated_asset_ids=[asset_id],
+            generation_provenance=generation_provenance,
             prompt=prompt,
         )
         return asset, candidate

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
@@ -83,6 +83,11 @@ def test_migration_v44_to_latest_creates_persona_visual_tables(db_path: Path) ->
     migrated.close_connection()
 
 
+def test_postgres_v45_migration_does_not_define_candidate_provenance_column() -> None:
+    assert "generation_provenance_json" not in CharactersRAGDB._MIGRATION_SQL_V44_TO_V45_POSTGRES
+    assert "generation_provenance_json" in CharactersRAGDB._MIGRATION_SQL_V46_TO_V47_POSTGRES
+
+
 def test_create_and_list_visual_pack_for_persona(db_instance: CharactersRAGDB) -> None:
     persona_id = db_instance.create_persona_profile(
         {"user_id": "user-1", "name": "Visual Persona"}

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
@@ -309,3 +310,72 @@ def test_candidate_accept_reject_round_trip(db_instance: CharactersRAGDB) -> Non
     assert rejected_after is not None
     assert rejected_after["status"] == "rejected"
     assert rejected_after["failure_reason"] == "not useful"
+
+
+def test_candidate_generation_provenance_round_trip(db_instance: CharactersRAGDB) -> None:
+    persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Candidate Provenance Persona"}
+    )
+    pack = db_instance.create_persona_visual_pack(
+        persona_id=persona_id,
+        user_id="user-1",
+        title="Generated Provenance Pack",
+        manifest={"manifest_version": 1, "renderer_type": "sprite_frames"},
+    )
+
+    candidate = db_instance.create_persona_visual_candidate(
+        pack_id=pack["id"],
+        persona_id=persona_id,
+        user_id="user-1",
+        job_id="job-1",
+        proposed_manifest_patch={"states": {"thinking": {"animation_id": "think"}}},
+        generated_asset_ids=["asset-1"],
+        prompt="make a thinking pose",
+        generation_provenance={
+            "schema_version": 999,
+            "generation_mode": "recipe_backed",
+            "request_id": "request-1",
+            "job_id": "job-1",
+            "backend": "fake\nprovider",
+            "target_state": "thinking",
+            "recipe": {
+                "starter_pack_id": "starter-basic",
+                "recipe_output": "static_sheet",
+                "correlation_id": "corr-1",
+                "identity_brief": "friendly buddy",
+                "neutral_anchor": "api_key=secret\n/Users/macbook-dev/private",
+                "static_sheet": "x" * 400,
+                "review_checks": ["consistent silhouette", "token secret leak"],
+                "user_prompt_included": True,
+                "user_prompt": "raw user prompt should not be returned",
+            },
+            "prompt": "raw generation prompt should not be returned",
+        },
+    )
+
+    listed = db_instance.list_persona_visual_candidates(
+        pack_id=pack["id"],
+        persona_id=persona_id,
+        user_id="user-1",
+    )
+    listed_candidate = next(item for item in listed if item["id"] == candidate["id"])
+    provenance = listed_candidate["generation_provenance"]
+
+    assert provenance["schema_version"] == 1
+    assert provenance["generation_mode"] == "recipe_backed"
+    assert provenance["request_id"] == "request-1"
+    assert provenance["job_id"] == "job-1"
+    assert provenance["backend"] == "fake provider"
+    assert provenance["target_state"] == "thinking"
+    assert provenance["recipe"]["starter_pack_id"] == "starter-basic"
+    assert provenance["recipe"]["recipe_output"] == "static_sheet"
+    assert provenance["recipe"]["correlation_id"] == "corr-1"
+    assert provenance["recipe"]["identity_brief"] == "friendly buddy"
+    assert provenance["recipe"]["neutral_anchor"] == "[redacted]"
+    assert len(provenance["recipe"]["static_sheet"]) <= 240
+    assert provenance["recipe"]["user_prompt_included"] is True
+    serialized = json.dumps(provenance)
+    assert "api_key" not in serialized
+    assert "/Users/macbook-dev/private" not in serialized
+    assert "raw user prompt should not be returned" not in serialized
+    assert "raw generation prompt should not be returned" not in serialized

--- a/tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py
@@ -1,0 +1,83 @@
+"""Tests for Persona Visual candidate provenance normalization safety rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Persona.visual_candidate_provenance import (
+    normalize_persona_visual_candidate_provenance,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _normalize_recipe_provenance(recipe: dict[str, object]) -> dict[str, object]:
+    provenance = normalize_persona_visual_candidate_provenance(
+        {
+            "generation_mode": "recipe_backed",
+            "request_id": "request-1",
+            "recipe": recipe,
+        }
+    )
+    return provenance["recipe"]
+
+
+@pytest.mark.parametrize(
+    "unsafe_value",
+    [
+        "Bearer:\tabcdefghijkl",
+        "authorization = Bearer abcdefghijkl",
+        "api key: abcdefghijkl",
+        "x-api-key=abcdefghijkl",
+        "client-secret: abcdefghijkl",
+        "sk-live-abcdefghijkl",
+    ],
+)
+def test_normalize_provenance_redacts_common_secret_variants(
+    unsafe_value: str,
+) -> None:
+    recipe = _normalize_recipe_provenance({"neutral_anchor": unsafe_value})
+
+    assert recipe["neutral_anchor"] == "[redacted]"
+
+
+def test_normalize_provenance_keeps_legitimate_secret_and_token_words() -> None:
+    recipe = _normalize_recipe_provenance(
+        {
+            "identity_brief": "secret agent character holding a brass token and authorization scroll",
+            "review_checks": [
+                "token charm stays visible",
+                "secret-agent pose reads clearly",
+                "standard Bearer character stays visible",
+                "api key display label is omitted",
+            ],
+            "static_sheet": "pose guide uses \\alpha label markup",
+        }
+    )
+
+    assert recipe["identity_brief"] == (
+        "secret agent character holding a brass token and authorization scroll"
+    )
+    assert recipe["review_checks"] == [
+        "token charm stays visible",
+        "secret-agent pose reads clearly",
+        "standard Bearer character stays visible",
+        "api key display label is omitted",
+    ]
+    assert recipe["static_sheet"] == "pose guide uses \\alpha label markup"
+
+
+@pytest.mark.parametrize(
+    "path_value",
+    [
+        "/Users/macbook-dev/private/reference.png",
+        "/home/persona/reference.png",
+        "C:\\Users\\persona\\reference.png",
+        "\\\\fileserver\\persona\\reference.png",
+    ],
+)
+def test_normalize_provenance_redacts_specific_path_shapes(path_value: str) -> None:
+    recipe = _normalize_recipe_provenance({"neutral_anchor": path_value})
+
+    assert recipe["neutral_anchor"] == "[redacted]"

--- a/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -483,6 +484,17 @@ async def test_generation_worker_stores_generated_asset_and_candidate(
                 "prompt": "make a thinking pose",
                 "target_state": "thinking",
                 "backend": "fake",
+                "request_id": "request-worker-1",
+                "recipe_intent": {
+                    "starter_pack_id": "starter-basic",
+                    "recipe_output": "static_sheet",
+                    "correlation_id": "corr-worker-1",
+                    "identity_brief": "small helpful buddy",
+                    "neutral_anchor": "front-facing neutral pose",
+                    "static_sheet": "static talking variants",
+                    "review_checks": ["consistent silhouette", "transparent background"],
+                    "user_prompt": "raw user direction should not be copied",
+                },
             },
         }
     )
@@ -506,5 +518,23 @@ async def test_generation_worker_stores_generated_asset_and_candidate(
     assert candidates[0]["job_id"] == "101"
     assert candidates[0]["generated_asset_ids"] == [assets[0]["id"]]
     assert candidates[0]["proposed_manifest_patch"]["states"]["thinking"]["animation_id"]
+    provenance = candidates[0]["generation_provenance"]
+    assert provenance["schema_version"] == 1
+    assert provenance["generation_mode"] == "recipe_backed"
+    assert provenance["request_id"] == "request-worker-1"
+    assert provenance["job_id"] == "101"
+    assert provenance["backend"] == "fake"
+    assert provenance["target_state"] == "thinking"
+    assert provenance["recipe"]["starter_pack_id"] == "starter-basic"
+    assert provenance["recipe"]["recipe_output"] == "static_sheet"
+    assert provenance["recipe"]["correlation_id"] == "corr-worker-1"
+    assert provenance["recipe"]["review_checks"] == [
+        "consistent silhouette",
+        "transparent background",
+    ]
+    assert provenance["recipe"]["user_prompt_included"] is True
+    serialized_provenance = json.dumps(provenance)
+    assert "make a thinking pose" not in serialized_provenance
+    assert "raw user direction should not be copied" not in serialized_provenance
     assert {"get_persona_visual_pack", "generate"} <= set(offloaded_call_names)
     assert any(name == "_persist_generated_candidate" for name in offloaded_call_names)

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -1,3 +1,4 @@
+import json
 from io import BytesIO
 from pathlib import Path
 
@@ -846,6 +847,15 @@ def test_list_generated_candidates_returns_preview_asset_urls(persona_db: Charac
             proposed_manifest_patch={},
             generated_asset_ids=[asset["id"]],
             prompt="make preview",
+            generation_provenance={
+                "schema_version": 1,
+                "generation_mode": "prompt_only",
+                "request_id": "request-api-1",
+                "job_id": "job-preview",
+                "backend": "fake",
+                "target_state": "idle",
+                "recipe": {"user_prompt": "raw prompt should not be serialized"},
+            },
         )
 
         response = client.get(
@@ -855,6 +865,7 @@ def test_list_generated_candidates_returns_preview_asset_urls(persona_db: Charac
         assert response.status_code == 200, response.text
         payload = response.json()
         assert payload["candidates"][0]["id"] == candidate["id"]
+        assert payload["candidates"][0]["generation_provenance"]["request_id"] == "request-api-1"
         assert payload["candidates"][0]["generated_assets"][0]["id"] == asset["id"]
         assert payload["candidates"][0]["generated_assets"][0]["url"].endswith(
             f"/visual-packs/{pack['id']}/assets/{asset['id']}/content"
@@ -864,6 +875,10 @@ def test_list_generated_candidates_returns_preview_asset_urls(persona_db: Charac
         )
         assert detail.status_code == 200, detail.text
         assert detail.json()["generated_assets"][0]["id"] == asset["id"]
+        assert detail.json()["generation_provenance"]["target_state"] == "idle"
+        assert "raw prompt should not be serialized" not in json.dumps(
+            detail.json()["generation_provenance"]
+        )
 
 
 def test_create_generation_job_for_visual_pack(persona_db: CharactersRAGDB) -> None:


### PR DESCRIPTION
## Summary
- Add schema v47 storage for normalized Persona Visual generated-candidate provenance.
- Store bounded recipe/request/backend/target metadata from generation jobs without copying raw prompts.
- Expose generation_provenance through generated-candidate API responses and document the review-safe contract.
- Tighten provenance redaction after review so concrete secret/path shapes are redacted without hiding normal art-description words.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py tldw_Server_API/tests/Persona/test_persona_visual_jobs.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py -q --tb=short --disable-warnings
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_candidate_provenance.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py
- [x] git diff --check
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_candidate_provenance.py tldw_Server_API/app/core/Persona/visual_jobs_worker.py tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_persona_visual_candidate_provenance.json

## Validation Checklist
- [x] Generated-candidate provenance remains trace-safe: raw prompts are not persisted, unknown keys are dropped, long values are bounded, and secret/path-shaped values redact to `[redacted]`.
- [x] Legitimate Persona Visual art-description words such as `secret`, `token`, `authorization`, `Bearer`, and LaTeX-style backslashes are preserved when they are not concrete secret/path shapes.
- [x] Postgres schema evolution is version-consistent: `generation_provenance_json` is introduced in v47, not duplicated in the v44-to-v45 migration.
- [x] Backlog tracking is updated in TASK-409 with review-fix verification.

## UX Audit Checklist
- [x] No user-facing WebUI layout, copy, or interaction changed in this slice.
- [x] Review-gated Persona Visual candidate behavior is preserved; provenance is review metadata only and does not auto-activate generated assets.
- [x] API response additions are backward-compatible because `generation_provenance` defaults to an empty object for older/prompt-only candidates.

## Risk & Rollback
- Risk is limited to Persona Visual generated-candidate review metadata and ChaChaNotes schema migration definitions.
- Main regression risks are over-redacting review metadata, under-redacting unsafe provenance values, or drifting Postgres migration version boundaries; focused tests cover those cases.
- Rollback is to revert this PR before deploying migrations. After migration, the added v47 JSON column is additive and defaults to `{}`, so readers can ignore it while code is rolled back.

## Change summary
Human-authored change summary required before merge per project policy.

Refs #1782
Refs #1510

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trace-safe provenance for Persona Visual generated candidates. Stores normalized metadata in schema v47 and returns it via the candidate API so reviewers can see why a candidate exists without exposing raw prompts or secrets. Tightens redaction rules to avoid false positives. Addresses #1782.

- New Features
  - Persist bounded `generation_provenance` on `persona_visual_candidates` (schema v47).
  - Worker builds provenance from safe job/recipe fields and stores it with the candidate.
  - API includes `generation_provenance` in candidate responses.
  - Normalization helper drops unknown keys, redacts secrets and common path shapes, truncates long fields, and keeps legitimate words. Docs describe the V1 shape and review-safe rules.

- Migration
  - Schema v47 adds `generation_provenance_json` to `persona_visual_candidates` with SQLite/Postgres migrations; Postgres adds the column only in v47 (drift fixed).
  - No breaking changes; new field defaults to `{}`. Run DB migrations and redeploy.

<sup>Written for commit 92909b7d1f743c64478e42886c17b20fd42104f5. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1784?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

