### PR TITLE
Migrate TimelineModal alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -4147,28 +4147,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Timeline/TimelineModal.tsx:Alert#antd-alert-timelinemodal-type-error-failed-to-load-timel-19ixoqo",
-    "path": "src/components/Timeline/TimelineModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Timeline/TimelineModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Timeline/TimelineModal.tsx:Alert#antd-alert-timelinemodal-type-info-no-conversation-data-80lj1f",
-    "path": "src/components/Timeline/TimelineModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Timeline/TimelineModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/WorkflowEditor/ExecutionPanel.tsx:Alert#antd-alert-executionpanel-type-error-execution-error-lin-14y38x7",
     "path": "src/components/WorkflowEditor/ExecutionPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Timeline/TimelineModal.tsx
+++ b/apps/packages/ui/src/components/Timeline/TimelineModal.tsx
@@ -6,8 +6,9 @@
  */
 
 import React, { useEffect, useCallback } from 'react'
-import { Modal, Spin, Alert } from 'antd'
+import { Modal, Spin } from 'antd'
 import { useTimelineStore } from '@/store/timeline'
+import { Alert } from '@/components/ui/primitives'
 import { GraphCanvas } from './GraphCanvas'
 import { TimelineToolbar } from './TimelineToolbar'
 import { NodeInfoPanel } from './NodeInfoPanel'
@@ -106,11 +107,11 @@ export const TimelineModal: React.FC = () => {
           {error && !isLoading && (
             <div className="timeline-error">
               <Alert
-                type="error"
+                variant="error"
                 title="Failed to load timeline"
-                description={error}
-                showIcon
-              />
+              >
+                {error}
+              </Alert>
             </div>
           )}
 
@@ -123,11 +124,11 @@ export const TimelineModal: React.FC = () => {
           {!graph && !isLoading && !error && (
             <div className="timeline-empty">
               <Alert
-                type="info"
+                variant="info"
                 title="No conversation data"
-                description="This conversation doesn't have any messages yet."
-                showIcon
-              />
+              >
+                This conversation doesn't have any messages yet.
+              </Alert>
             </div>
           )}
         </div>

--- a/apps/packages/ui/src/components/Timeline/__tests__/TimelineModal.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Timeline/__tests__/TimelineModal.product-state.test.tsx
@@ -1,0 +1,123 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TimelineModal } from "../TimelineModal"
+
+const timelineState = vi.hoisted(() => ({
+  isOpen: true,
+  isLoading: false,
+  error: null as string | null,
+  graph: null as { nodes: unknown[]; edges: unknown[] } | null,
+  selectedNodeId: null as string | null,
+  closeTimeline: vi.fn(),
+  selectNode: vi.fn(),
+  settings: {
+    showLegend: false,
+    userNodeColor: "rgb(59 130 246)",
+    assistantNodeColor: "rgb(255 255 255)",
+    systemNodeColor: "rgb(107 114 128)",
+  },
+}))
+
+vi.mock("antd", () => ({
+  Modal: ({
+    children,
+    onCancel,
+    open,
+  }: {
+    children?: React.ReactNode
+    onCancel?: () => void
+    open?: boolean
+  }) =>
+    open ? (
+      <div role="dialog">
+        <button type="button" onClick={onCancel}>
+          Close modal
+        </button>
+        {children}
+      </div>
+    ) : null,
+  Spin: ({ tip }: { tip?: React.ReactNode }) => <div role="status">{tip}</div>,
+}))
+
+vi.mock("../GraphCanvas", () => ({
+  GraphCanvas: () => <div data-testid="timeline-graph" />,
+}))
+
+vi.mock("../NodeInfoPanel", () => ({
+  NodeInfoPanel: () => <aside data-testid="timeline-node-info" />,
+}))
+
+vi.mock("../TimelineToolbar", () => ({
+  TimelineToolbar: () => <nav data-testid="timeline-toolbar" />,
+}))
+
+vi.mock("@/store/timeline", () => ({
+  useTimelineStore: () => timelineState,
+}))
+
+describe("TimelineModal product states", () => {
+  beforeEach(() => {
+    timelineState.isOpen = true
+    timelineState.isLoading = false
+    timelineState.error = null
+    timelineState.graph = null
+    timelineState.selectedNodeId = null
+    timelineState.settings.showLegend = false
+    timelineState.closeTimeline.mockClear()
+    timelineState.selectNode.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("renders loading state without timeline alerts", () => {
+    timelineState.isLoading = true
+
+    render(<TimelineModal />)
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Building conversation tree..."
+    )
+    expect(screen.queryByText("Failed to load timeline")).not.toBeInTheDocument()
+    expect(screen.queryByText("No conversation data")).not.toBeInTheDocument()
+  })
+
+  it("renders the timeline error through the design-system Alert primitive", () => {
+    timelineState.error = "Graph build failed"
+
+    render(<TimelineModal />)
+
+    const title = screen.getByText("Failed to load timeline")
+    const alert = title.closest('[data-ds-component="Alert"]')
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(screen.getByText("Graph build failed")).toBeInTheDocument()
+  })
+
+  it("renders the empty timeline through the design-system Alert primitive", () => {
+    render(<TimelineModal />)
+
+    const title = screen.getByText("No conversation data")
+    const alert = title.closest('[data-ds-component="Alert"]')
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveAttribute("role", "status")
+    expect(alert).toHaveAttribute("aria-live", "polite")
+    expect(
+      screen.getByText("This conversation doesn't have any messages yet.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders the graph state and preserves close behavior", () => {
+    timelineState.graph = { nodes: [], edges: [] }
+
+    render(<TimelineModal />)
+
+    expect(screen.getByTestId("timeline-graph")).toBeInTheDocument()
+    expect(screen.queryByText("No conversation data")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Close modal" }))
+    expect(timelineState.closeTimeline).toHaveBeenCalledTimes(1)
+  })
+})

--- a/backlog/tasks/task-45.44.2 - Migrate-design-system-product-state-Ingestion-Library-and-media.md
+++ b/backlog/tasks/task-45.44.2 - Migrate-design-system-product-state-Ingestion-Library-and-media.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.2
 title: 'Migrate design-system product state: Ingestion, Library, and media'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
 labels:
@@ -31,6 +31,12 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
 - [ ] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- TASK-45.44.2.4 migrates TimelineModal error and empty product-state alerts from AntD Alert to the shared design-system Alert primitive, reducing the baseline from 398 to 396 total exceptions and the Ingestion/Library/media area by 2. PR: https://github.com/rmusser01/tldw_server/pull/1785
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-45.44.2.4 - Migrate-TimelineModal-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.2.4 - Migrate-TimelineModal-alerts-to-design-system-Alert.md
@@ -1,0 +1,73 @@
+---
+id: TASK-45.44.2.4
+title: Migrate TimelineModal alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- timeline
+priority: medium
+parent_task_id: TASK-45.44.2
+references:
+- apps/packages/ui/src/components/Timeline/TimelineModal.tsx
+- apps/packages/ui/src/components/Timeline/__tests__/TimelineModal.product-state.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1785
+documentation:
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Ingestion, Library, and media design-system migration by replacing TimelineModal's remaining AntD Alert product-state usage with the shared design-system Alert primitive while preserving loading, error, and empty timeline behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TimelineModal renders error and empty timeline product-state messages through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Existing loading, graph, error, empty, and close behavior remain covered by focused tests.
+- [x] #3 The product-state baseline no longer contains TimelineModal AntD Alert exceptions.
+- [x] #4 Focused Vitest, design-system verifier, git diff check, and TypeScript/Bandit applicability are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused TimelineModal coverage proving error and empty states render through the design-system Alert primitive while loading and graph states remain distinct.
+2. Run the focused test before implementation to capture the missing design-system Alert marker while TimelineModal still uses AntD Alert.
+3. Replace the two AntD Alert usages with the shared Alert primitive, mapping error to variant="error" and empty to variant="info".
+4. Remove the two TimelineModal AntD Alert baseline exceptions.
+5. Verify focused Vitest, product-state guard/verifier, git diff check, and TypeScript/Bandit applicability.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented via TDD. The focused TimelineModal product-state test failed first on the missing design-system Alert marker for the error and empty states while loading and graph states already passed. TimelineModal now imports the shared Alert primitive for the two product-state messages, maps error to variant="error" and empty to variant="info", and keeps the existing AntD Modal and Spin mechanics unchanged. Removed the two TimelineModal AntD Alert baseline exceptions.
+
+PR opened against dev: https://github.com/rmusser01/tldw_server/pull/1785
+
+PR review follow-up: removed the now-redundant AntD Alert mock from the TimelineModal product-state test after the component migrated to the design-system Alert primitive. Focused TimelineModal plus product-state guard Vitest remained green.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated TimelineModal error and empty product-state alerts from AntD Alert to the shared design-system Alert primitive, added focused coverage for loading, error, empty, graph, and close behavior, and reduced the product-state baseline from 398 to 396 exceptions.
+
+Verification: RED focused Vitest failed on missing design-system Alert markers for error and empty states; GREEN focused TimelineModal plus product-state guard Vitest passed 56 tests; bun run verify:design-system-state passed with 396 allowed legacy exceptions; baseline JSON parse passed; git diff --check passed. bunx tsc --noEmit --pretty false still exits 2 on existing repo-wide TypeScript debt, with no touched-file matches for TimelineModal, TimelineModal.product-state, or design-system-product-state-baseline. Bandit skipped because this slice touches frontend TypeScript, JSON baseline data, and Backlog metadata only.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates TimelineModal error and empty product-state messages from AntD Alert to the shared design-system Alert primitive.
- Adds focused TimelineModal coverage for loading, error, empty, graph, and close behavior.
- Removes the two TimelineModal product-state baseline exceptions, reducing the baseline from 398 to 396.

## Test Plan
- [x] `bunx vitest run src/components/Timeline/__tests__/TimelineModal.product-state.test.tsx src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- [x] `bun run verify:design-system-state`
- [x] `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"`
- [x] `git diff --check`
- [x] `bunx tsc --noEmit --pretty false` exits 2 on existing repo-wide TypeScript debt; filtered output has no touched-file matches.

## Change summary
Human-owned merge summary required before merge: TODO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `TimelineModal` error and empty states from `antd` `Alert` to the design-system `Alert`, mapping `type="error/info"` to `variant="error/info"`, moving `description` to children, and keeping `Modal`/`Spin` unchanged. Reduced product-state baseline exceptions by 2 (398 → 396) and added focused tests for loading, error, empty, graph, and close (TASK-45.44.2).

<sup>Written for commit 53b5888b2e6f537f3b55758bc9d0081bd06d97f0. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1785?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

