### PR TITLE
Migrate TablePreview alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1617,28 +1617,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/DataTables/TablePreview.tsx:Alert#antd-alert-tablepreview-type-error-line-461-1wcr4it",
-    "path": "src/components/Option/DataTables/TablePreview.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/DataTables/TablePreview.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/DataTables/TablePreview.tsx:Alert#antd-alert-tablepreview-type-warning-line-494-1biqk4f",
-    "path": "src/components/Option/DataTables/TablePreview.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/DataTables/TablePreview.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx:Alert#antd-alert-dictionaryversionhistorymodal-type-error-vers-1pavdz5",
     "path": "src/components/Option/Dictionaries/DictionaryVersionHistoryModal.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/DataTables/TablePreview.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/TablePreview.tsx
@@ -3,7 +3,6 @@ import { DragDropProvider, type DragDropEvents } from "@dnd-kit/react"
 import { useSortable } from "@dnd-kit/react/sortable"
 import { closestCenter } from "@dnd-kit/collision"
 import {
-  Alert,
   Button,
   Empty,
   Popconfirm,
@@ -29,6 +28,7 @@ import { useDataTablesStore } from "@/store/data-tables"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { pollDataTableJob } from "@/utils/data-tables-jobs"
 import type { DataTableColumn, DataTableRow } from "@/types/data-tables"
+import { Alert } from "@/components/ui/primitives"
 import { EditableCell } from "./EditableCell"
 const AddColumnModal = React.lazy(() =>
   import("./AddColumnModal").then((module) => ({
@@ -459,11 +459,11 @@ export const TablePreview: React.FC = () => {
     return (
       <div className="space-y-4">
         <Alert
-          type="error"
+          variant="error"
           title={t("dataTables:generationFailed", "Generation Failed")}
-          description={generationError}
-          showIcon
-        />
+        >
+          {generationError}
+        </Alert>
         <div className="flex justify-center">
           <Button
             type="primary"
@@ -492,17 +492,15 @@ export const TablePreview: React.FC = () => {
       {/* Warnings */}
       {generationWarnings.length > 0 && (
         <Alert
-          type="warning"
+          variant="warning"
           title={t("dataTables:warnings", "Warnings")}
-          description={
-            <ul className="list-disc list-inside">
-              {generationWarnings.map((warning, index) => (
-                <li key={index}>{warning}</li>
-              ))}
-            </ul>
-          }
-          showIcon
-        />
+        >
+          <ul className="list-disc list-inside">
+            {generationWarnings.map((warning, index) => (
+              <li key={index}>{warning}</li>
+            ))}
+          </ul>
+        </Alert>
       )}
 
       {/* Toolbar */}

--- a/apps/packages/ui/src/components/Option/DataTables/__tests__/TablePreview.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/DataTables/__tests__/TablePreview.product-state.test.tsx
@@ -1,0 +1,237 @@
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { TablePreview } from "../TablePreview"
+import type { DataTable } from "@/types/data-tables"
+
+const { dataTablesState, generateDataTableMock } = vi.hoisted(() => ({
+  generateDataTableMock: vi.fn(),
+  dataTablesState: {
+    tableName: "Research notes",
+    prompt: "Extract claims",
+    selectedSources: [
+      {
+        type: "document",
+        id: "doc-1",
+        title: "Notes",
+        snippet: "A short source preview"
+      }
+    ],
+    columnHints: [],
+    selectedModel: null,
+    maxRows: 100,
+    generatedTable: null as DataTable | null,
+    generationError: null as string | null,
+    generationWarnings: [] as string[],
+    editingTable: null as DataTable | null,
+    editingRows: [] as Array<Record<string, unknown>>,
+    editingState: {
+      editingCellKey: null as string | null,
+      isDirty: false,
+      pendingChanges: []
+    },
+    setIsGenerating: vi.fn(),
+    setGeneratedTable: vi.fn(),
+    setGenerationError: vi.fn(),
+    setGenerationWarnings: vi.fn(),
+    startEditing: vi.fn(),
+    stopEditing: vi.fn(),
+    updateCell: vi.fn(),
+    addRow: vi.fn(),
+    deleteRow: vi.fn(),
+    addColumn: vi.fn(),
+    deleteColumn: vi.fn(),
+    reorderColumns: vi.fn(),
+    setEditingCellKey: vi.fn(),
+    discardChanges: vi.fn()
+  }
+}))
+
+const sampleTable: DataTable = {
+  id: "table-1",
+  name: "Research notes",
+  prompt: "Extract claims",
+  columns: [
+    {
+      id: "claim",
+      name: "Claim",
+      type: "text"
+    }
+  ],
+  rows: [
+    {
+      Claim: "The dataset includes one useful row"
+    }
+  ],
+  sources: [
+    {
+      type: "document",
+      id: "doc-1",
+      title: "Notes"
+    }
+  ],
+  created_at: "2026-05-16T00:00:00.000Z",
+  updated_at: "2026-05-16T00:00:00.000Z",
+  row_count: 1
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("@dnd-kit/react", () => ({
+  DragDropProvider: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="drag-drop-provider">{children}</div>
+  )
+}))
+
+vi.mock("@dnd-kit/react/sortable", () => ({
+  useSortable: () => ({
+    ref: vi.fn(),
+    handleRef: vi.fn(),
+    isDragging: false
+  })
+}))
+
+vi.mock("@dnd-kit/collision", () => ({
+  closestCenter: vi.fn()
+}))
+
+vi.mock("@/store/data-tables", () => ({
+  useDataTablesStore: (selector: (state: typeof dataTablesState) => unknown) =>
+    selector(dataTablesState)
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    generateDataTable: generateDataTableMock,
+    getDataTableJob: vi.fn(),
+    getDataTable: vi.fn()
+  }
+}))
+
+vi.mock("../EditableCell", () => ({
+  EditableCell: ({ value }: { value?: React.ReactNode }) => <span>{value}</span>
+}))
+
+vi.mock("../AddColumnModal", () => ({
+  AddColumnModal: () => null
+}))
+
+const renderPreview = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TablePreview />
+    </QueryClientProvider>
+  )
+}
+
+const expectInsideDesignSystemAlert = (text: string | RegExp) => {
+  const node = screen.getByText(text)
+  const alert = node.closest('[data-ds-component="Alert"]')
+  expect(alert).toHaveAttribute("data-ds-component", "Alert")
+  return alert
+}
+
+describe("TablePreview product states", () => {
+  const originalMatchMedia = window.matchMedia
+
+  beforeAll(() => {
+    if (typeof window.matchMedia !== "function") {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+
+    if (!(globalThis as any).ResizeObserver) {
+      ;(globalThis as any).ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    }
+  })
+
+  afterAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: originalMatchMedia
+    })
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dataTablesState.generatedTable = null
+    dataTablesState.generationError = null
+    dataTablesState.generationWarnings = []
+    dataTablesState.editingTable = null
+    dataTablesState.editingRows = []
+    dataTablesState.editingState.editingCellKey = null
+    dataTablesState.editingState.isDirty = false
+    dataTablesState.editingState.pendingChanges = []
+  })
+
+  it("renders generation failures through the design-system Alert primitive", () => {
+    dataTablesState.generationError = "The table generation job failed"
+
+    renderPreview()
+
+    const alert = expectInsideDesignSystemAlert("Generation Failed")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(screen.getByText("The table generation job failed")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument()
+  })
+
+  it("renders generation warnings through the design-system Alert primitive", () => {
+    dataTablesState.generatedTable = sampleTable
+    dataTablesState.editingTable = sampleTable
+    dataTablesState.editingRows = sampleTable.rows.map((row, index) => ({
+      ...row,
+      _id: `row-${index}`
+    }))
+    dataTablesState.generationWarnings = [
+      "Some source rows were skipped",
+      "The preview was limited to the first 100 rows"
+    ]
+
+    renderPreview()
+
+    const alert = expectInsideDesignSystemAlert("Warnings")
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(screen.getByText("Some source rows were skipped")).toBeInTheDocument()
+    expect(
+      screen.getByText("The preview was limited to the first 100 rows")
+    ).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.2 - Migrate-design-system-product-state-Ingestion-Library-and-media.md
+++ b/backlog/tasks/task-45.44.2 - Migrate-design-system-product-state-Ingestion-Library-and-media.md
@@ -36,6 +36,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - TASK-45.44.2.4 migrates TimelineModal error and empty product-state alerts from AntD Alert to the shared design-system Alert primitive, reducing the baseline from 398 to 396 total exceptions and the Ingestion/Library/media area by 2. PR: https://github.com/rmusser01/tldw_server/pull/1785
+- TASK-45.44.2.5 migrates TablePreview generation error and warning product-state alerts from AntD Alert to the shared design-system Alert primitive, reducing the baseline from 396 to 394 total exceptions and the Ingestion/Library/media area by 2. PR: https://github.com/rmusser01/tldw_server/pull/1786
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.2.5 - Migrate-TablePreview-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.2.5 - Migrate-TablePreview-alerts-to-design-system-Alert.md
@@ -1,0 +1,64 @@
+---
+id: TASK-45.44.2.5
+title: Migrate TablePreview alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.2
+references:
+- apps/packages/ui/src/components/Option/DataTables/TablePreview.tsx
+- apps/packages/ui/src/components/Option/DataTables/__tests__/TablePreview.product-state.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1659
+- https://github.com/rmusser01/tldw_server/pull/1786
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Ingestion/Library/media product-state migration by replacing TablePreview generation error and warning AntD Alerts with the shared design-system Alert primitive, then remove the matching baseline exceptions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TablePreview generation error alert renders through the shared design-system Alert primitive while preserving copy and retry behavior.
+- [x] #2 TablePreview generation warning alert renders through the shared design-system Alert primitive while preserving the warning list content.
+- [x] #3 The two TablePreview AntD Alert baseline entries are removed without introducing new guard findings.
+- [x] #4 Focused Vitest, design-system guard verification, TypeScript touched-scope check, and diff whitespace checks are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Scope intentionally stayed limited to TablePreview generation error/warning alerts, their focused DOM regression test, and the matching guard baseline entries.
+- PR: https://github.com/rmusser01/tldw_server/pull/1786
+- The initial focused Vitest run failed as expected because the current AntD Alert markup did not provide `data-ds-component="Alert"`.
+- Verification:
+  - `bunx vitest run src/components/Option/DataTables/__tests__/TablePreview.product-state.test.tsx --maxWorkers=1 --no-file-parallelism` passed, 2 tests.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism` passed, 52 tests.
+  - `bun run verify:design-system-state` passed and reported 394 baseline exceptions.
+  - `node -e "const data=require('./apps/packages/ui/scripts/design-system-product-state-baseline.json'); console.log(data.length); console.log(JSON.stringify(data.filter(e=>e.path==='src/components/Option/DataTables/TablePreview.tsx'), null, 2));"` reported `394` and `[]`.
+  - `git diff --check` passed.
+  - `bunx tsc --noEmit --pretty false` still exits 2 on existing unrelated repo TypeScript errors; filtered output for `TablePreview`, the baseline file, and this task file had no matches.
+  - Bandit skipped because the touched implementation files are UI TypeScript/JSON/Backlog task files only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated TablePreview generation error and warning product-state alerts from direct AntD Alert usage to the shared design-system Alert primitive, added focused DOM coverage for both branches, and removed the two matching TablePreview product-state baseline exceptions. Baseline count moved from 396 to 394 total exceptions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates DataTables `TablePreview` generation error and warning alerts from direct AntD `Alert` usage to the shared design-system `Alert` primitive.
- Adds focused DOM regression coverage for both product-state branches.
- Removes the two matching `TablePreview` product-state baseline entries, moving the baseline from 396 to 394.

## Test Plan
- RED: `bunx vitest run src/components/Option/DataTables/__tests__/TablePreview.product-state.test.tsx --maxWorkers=1 --no-file-parallelism` failed before implementation because no enclosing `data-ds-component="Alert"` existed.
- `bunx vitest run src/components/Option/DataTables/__tests__/TablePreview.product-state.test.tsx --maxWorkers=1 --no-file-parallelism` passed, 2 tests.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism` passed, 52 tests.
- `bun run verify:design-system-state` passed and reported 394 baseline exceptions.
- `node -e "const data=require('./apps/packages/ui/scripts/design-system-product-state-baseline.json'); console.log(data.length); console.log(JSON.stringify(data.filter(e=>e.path==='src/components/Option/DataTables/TablePreview.tsx'), null, 2));"` reported `394` and `[]`.
- `git diff --check` passed.
- `bunx tsc --noEmit --pretty false` still exits 2 on existing unrelated repo TypeScript errors; filtering `/tmp/ds-datatables-table-preview-tsc.log` for `TablePreview`, `design-system-product-state-baseline`, and `task-45.44.2.5` returned no matches.
- Bandit skipped because the touched implementation files are UI TypeScript/JSON/Backlog task files only.

## Change summary
Human-owned merge summary required before merge: TODO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates DataTables `TablePreview` error and warning alerts from AntD to the shared design-system `Alert` to standardize UI and satisfy product-state guards. Adds focused tests and removes two legacy baseline exceptions, reducing the baseline from 396 to 394.

- **Refactors**
  - Replace AntD `Alert` with design-system `Alert` (from `@/components/ui/primitives`) in `TablePreview` for generation errors and warnings; preserve titles, content, and the retry button.
  - Add focused tests asserting the design-system Alert via `data-ds-component="Alert"` and remove the two `TablePreview` baseline exceptions (baseline 396 → 394).

<sup>Written for commit 0e82d2c1dc72d395ab36d1116bde334b63d1c1d7. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1786?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

