### PR TITLE
Wire llama.cpp mmproj profiles into launch

### DIFF
--- a/backlog/tasks/task-410 - Implement-llama.cpp-supervisor-mmproj-launch-wiring.md
+++ b/backlog/tasks/task-410 - Implement-llama.cpp-supervisor-mmproj-launch-wiring.md
@@ -9,6 +9,7 @@ labels:
 modified_files:
 - tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
 - tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py
 - tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
 references:
 - https://github.com/rmusser01/tldw_server/pull/1788
@@ -39,15 +40,15 @@ Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-pl
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Supervisor starts now use the llama.cpp profile capability resolver, injecting resolved mmproj paths at launch time and rejecting invalid vision/mmproj configurations before process start. Added focused async supervisor coverage for valid mmproj injection, missing projector, wrong-kind projector asset, outside-allowlist manual mmproj, resolved_args propagation, and non-mutation of persisted profile server_args. Verification: RED check failed as expected before implementation; focused pytest passed with 41 tests; git diff --check passed; Bandit on touched backend files passed with zero findings.
+Supervisor starts now use the llama.cpp profile capability resolver, injecting resolved mmproj paths at launch time and rejecting invalid vision/mmproj configurations before process start. Review fixes for PR #1788 route inventory asset-ID paths through the injected path resolver, delegate supervisor launch path validation to the inventory service to avoid stale allowlist logic/private helper access, add docstrings for new helper contracts, configure supervisor tests with matching inventory saved config, and mark the Definition of Done checklist consistently. Verification: RED check failed as expected before implementation; review regression passed; focused pytest passed with 42 tests; git diff --check passed; Bandit on touched backend files passed with zero findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-410 - Implement-llama.cpp-supervisor-mmproj-launch-wiring.md
+++ b/backlog/tasks/task-410 - Implement-llama.cpp-supervisor-mmproj-launch-wiring.md
@@ -1,0 +1,53 @@
+---
+id: TASK-410
+title: Implement llama.cpp supervisor mmproj launch wiring
+status: Done
+labels:
+- llamacpp
+- backend
+- profiles
+modified_files:
+- tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
+- tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/1788
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 2 from Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md: resolve managed llama.cpp profiles at supervisor start time, inject resolved mmproj args without mutating persisted profiles, reject invalid vision/mmproj launches, and add focused supervisor/runtime API coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Supervisor starts now use the llama.cpp profile capability resolver, injecting resolved mmproj paths at launch time and rejecting invalid vision/mmproj configurations before process start. Added focused async supervisor coverage for valid mmproj injection, missing projector, wrong-kind projector asset, outside-allowlist manual mmproj, resolved_args propagation, and non-mutation of persisted profile server_args. Verification: RED check failed as expected before implementation; focused pytest passed with 41 tests; git diff --check passed; Bandit on touched backend files passed with zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
@@ -82,6 +82,13 @@ def _resolve_base_model_path(
     assets: list[LlamaCppAsset] | None,
     path_resolver: Callable[[str | Path, str, str], Path] | None,
 ) -> Path:
+    """Resolve and validate the profile's base GGUF path.
+
+    The base model can come from an inventory asset ID or a direct profile path.
+    Both forms pass through `_resolve_asset_path` so supervisor-provided launch
+    validation can enforce the same file, kind, and allowlist checks. Raises
+    `ModelNotFoundError` when the profile has no usable base model.
+    """
     if profile.model_id:
         asset = llamacpp_inventory_service.resolve_asset_id(
             profile.model_id,
@@ -93,7 +100,7 @@ def _resolve_base_model_path(
                 f"Model asset {profile.model_id} does not reference an "
                 "available local asset."
             )
-        return Path(asset.resolved_path)
+        return _resolve_asset_path(asset.resolved_path, "gguf", "Model", path_resolver)
     if profile.model_path:
         return _resolve_asset_path(profile.model_path, "gguf", "Model", path_resolver)
     raise ModelNotFoundError("Llama.cpp profile requires a model_id or model_path.")
@@ -105,6 +112,13 @@ def _resolve_mmproj_path(
     assets: list[LlamaCppAsset] | None,
     path_resolver: Callable[[str | Path, str, str], Path] | None,
 ) -> Path | None:
+    """Resolve and validate the optional mmproj path for a profile launch.
+
+    Projectors can be selected by inventory ID or supplied manually in
+    `server_args["mmproj"]`. When both are present they must resolve to the same
+    validated path. Raises `ModelNotFoundError` for missing/wrong-kind projector
+    assets and `ServerError` for conflicting projector selections.
+    """
     asset_path: Path | None = None
     if profile.mmproj_model_id:
         asset = llamacpp_inventory_service.resolve_asset_id(
@@ -117,7 +131,7 @@ def _resolve_mmproj_path(
                 f"mmproj asset {profile.mmproj_model_id} does not reference an "
                 "available local asset."
             )
-        asset_path = Path(asset.resolved_path)
+        asset_path = _resolve_asset_path(asset.resolved_path, "mmproj", "mmproj", path_resolver)
 
     manual_value = server_args.get("mmproj")
     if manual_value in (None, ""):
@@ -135,6 +149,13 @@ def _resolve_asset_path(
     label: str,
     path_resolver: Callable[[str | Path, str, str], Path] | None,
 ) -> Path:
+    """Validate an asset path through the launch resolver or inventory service.
+
+    The optional resolver lets the supervisor align launch-time validation with
+    its chosen source of configuration while plain metadata calls keep using the
+    inventory service's saved-config validation. Errors are intentionally
+    propagated from the selected resolver so endpoint mappings remain stable.
+    """
     if path_resolver is not None:
         return path_resolver(raw_path, expected_kind, label)
     return llamacpp_inventory_service.resolve_asset_path(raw_path, expected_kind=expected_kind, label=label)

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable
 
 from pydantic import BaseModel, Field
 
@@ -33,11 +34,12 @@ class LlamaCppResolvedProfileLaunch(BaseModel):
 def resolve_profile_launch(
     profile: LlamaCppProfile,
     assets: list[LlamaCppAsset] | None = None,
+    path_resolver: Callable[[str | Path, str, str], Path] | None = None,
 ) -> LlamaCppResolvedProfileLaunch:
     """Resolve a profile's model assets, launch args, and mode capabilities."""
-    model_path = _resolve_base_model_path(profile, assets)
+    model_path = _resolve_base_model_path(profile, assets, path_resolver)
     server_args = dict(profile.server_args)
-    mmproj_path = _resolve_mmproj_path(profile, server_args, assets)
+    mmproj_path = _resolve_mmproj_path(profile, server_args, assets, path_resolver)
 
     if profile.mode == LlamaCppProfileMode.VISION and mmproj_path is None:
         raise ServerError("Vision llama.cpp profiles require a valid mmproj asset.")
@@ -78,6 +80,7 @@ def profile_capability_metadata(
 def _resolve_base_model_path(
     profile: LlamaCppProfile,
     assets: list[LlamaCppAsset] | None,
+    path_resolver: Callable[[str | Path, str, str], Path] | None,
 ) -> Path:
     if profile.model_id:
         asset = llamacpp_inventory_service.resolve_asset_id(
@@ -92,11 +95,7 @@ def _resolve_base_model_path(
             )
         return Path(asset.resolved_path)
     if profile.model_path:
-        return llamacpp_inventory_service.resolve_asset_path(
-            profile.model_path,
-            expected_kind="gguf",
-            label="Model",
-        )
+        return _resolve_asset_path(profile.model_path, "gguf", "Model", path_resolver)
     raise ModelNotFoundError("Llama.cpp profile requires a model_id or model_path.")
 
 
@@ -104,6 +103,7 @@ def _resolve_mmproj_path(
     profile: LlamaCppProfile,
     server_args: dict[str, object],
     assets: list[LlamaCppAsset] | None,
+    path_resolver: Callable[[str | Path, str, str], Path] | None,
 ) -> Path | None:
     asset_path: Path | None = None
     if profile.mmproj_model_id:
@@ -123,14 +123,21 @@ def _resolve_mmproj_path(
     if manual_value in (None, ""):
         return asset_path
 
-    manual_path = llamacpp_inventory_service.resolve_asset_path(
-        str(manual_value),
-        expected_kind="mmproj",
-        label="mmproj",
-    )
+    manual_path = _resolve_asset_path(str(manual_value), "mmproj", "mmproj", path_resolver)
     if asset_path is not None and manual_path != asset_path:
         raise ServerError("Profile mmproj_model_id conflicts with server_args['mmproj'].")
     return asset_path or manual_path
+
+
+def _resolve_asset_path(
+    raw_path: str | Path,
+    expected_kind: str,
+    label: str,
+    path_resolver: Callable[[str | Path, str, str], Path] | None,
+) -> Path:
+    if path_resolver is not None:
+        return path_resolver(raw_path, expected_kind, label)
+    return llamacpp_inventory_service.resolve_asset_path(raw_path, expected_kind=expected_kind, label=label)
 
 
 def _capabilities_for_mode(

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Protocol
 from uuid import uuid4
 
 from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
-from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError, ServerError
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Schemas import LlamaCppConfig
 from tldw_Server_API.app.core.Local_LLM.llamacpp_process_runner import LlamaCppProcessRunner
 from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
@@ -431,26 +431,31 @@ class LlamaCppSupervisor:
         return profile
 
     def _profile_for_launch_resolution(self, profile: LlamaCppProfile) -> LlamaCppProfile:
+        """Return the profile shape used only for launch-time resolution.
+
+        The default-profile compatibility path persists both `model_id` and a
+        resolved `model_path` after `/start-by-model`. Clearing `model_id` here
+        keeps start-by-model/start-by-path bridge launches path-based without
+        mutating the stored profile. Other profiles keep their original asset
+        selection so invalid IDs still fail before runner spawn.
+        """
         if profile.profile_id == DEFAULT_PROFILE_ID and profile.model_path:
             return profile.model_copy(update={"model_id": None})
         return profile
 
     def _resolve_launch_asset_path(self, raw_path: str | Path, expected_kind: str, label: str) -> Path:
-        try:
-            path = Path(raw_path).expanduser().resolve()
-        except (OSError, RuntimeError, ValueError) as exc:
-            raise ServerError(f"{label} path could not be resolved.") from exc
-        if not path.is_file():
-            raise ModelNotFoundError(f"{label} path does not reference an available local file.")
-        if llamacpp_inventory_service._asset_kind_for_path(path) != expected_kind:
-            raise ModelNotFoundError(f"{label} path does not reference a {expected_kind} asset.")
-        allowed_paths = handler_utils.build_allowed_paths(
-            Path(self.config.models_dir),
-            getattr(self.config, "allowed_paths", None),
+        """Resolve a launch asset path using the inventory service contract.
+
+        The inventory service reads the current saved llama.cpp config for
+        canonicalization, asset-kind validation, and allowlist enforcement. This
+        avoids stale supervisor config snapshots and preserves the standard
+        `ModelNotFoundError`/`ServerError` behavior used by Admin endpoints.
+        """
+        return llamacpp_inventory_service.resolve_asset_path(
+            raw_path,
+            expected_kind=expected_kind,
+            label=label,
         )
-        if not handler_utils.is_path_allowed(path, allowed_paths):
-            raise ServerError(f"{label} path is outside allowed llama.cpp paths.")
-        return path
 
     def _validate_runtime_port_available(self, profile: LlamaCppProfile) -> None:
         if not profile.enabled or profile.port_policy != LlamaCppPortPolicy.EXPLICIT:

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
@@ -10,9 +10,10 @@ from typing import Any, Callable, Protocol
 from uuid import uuid4
 
 from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
-from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError, ServerError
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Schemas import LlamaCppConfig
 from tldw_Server_API.app.core.Local_LLM.llamacpp_process_runner import LlamaCppProcessRunner
+from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
 from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_store import (
     DEFAULT_PROFILE_ID,
     DEFAULT_PROFILE_NAME,
@@ -182,8 +183,13 @@ class LlamaCppSupervisor:
                     return status
                 await runner.stop()
             self._validate_runtime_port_available(profile)
-            model_path = self._resolve_profile_model_path(profile)
-            return await runner.start(model_path, profile)
+            resolution_profile = self._profile_for_launch_resolution(profile)
+            resolved = resolve_profile_launch(
+                resolution_profile,
+                path_resolver=self._resolve_launch_asset_path,
+            )
+            launch_profile = profile.model_copy(update={"server_args": resolved.server_args})
+            return await runner.start(resolved.model_path, launch_profile)
 
     async def stop_profile(self, profile_id: str, disable: bool = False) -> LlamaCppRuntime:
         async with self._lock_for(profile_id):
@@ -424,12 +430,27 @@ class LlamaCppSupervisor:
             raise LlamaCppProfileNotFoundError(f"Llama.cpp profile '{profile_id}' was not found.")
         return profile
 
-    def _resolve_profile_model_path(self, profile: LlamaCppProfile) -> Path:
-        if profile.model_path:
-            return Path(profile.model_path)
-        if profile.model_id:
-            return llamacpp_inventory_service.resolve_model_id(profile.model_id)
-        raise ServerError(f"Llama.cpp profile '{profile.profile_id}' does not have a model.")
+    def _profile_for_launch_resolution(self, profile: LlamaCppProfile) -> LlamaCppProfile:
+        if profile.profile_id == DEFAULT_PROFILE_ID and profile.model_path:
+            return profile.model_copy(update={"model_id": None})
+        return profile
+
+    def _resolve_launch_asset_path(self, raw_path: str | Path, expected_kind: str, label: str) -> Path:
+        try:
+            path = Path(raw_path).expanduser().resolve()
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ServerError(f"{label} path could not be resolved.") from exc
+        if not path.is_file():
+            raise ModelNotFoundError(f"{label} path does not reference an available local file.")
+        if llamacpp_inventory_service._asset_kind_for_path(path) != expected_kind:
+            raise ModelNotFoundError(f"{label} path does not reference a {expected_kind} asset.")
+        allowed_paths = handler_utils.build_allowed_paths(
+            Path(self.config.models_dir),
+            getattr(self.config, "allowed_paths", None),
+        )
+        if not handler_utils.is_path_allowed(path, allowed_paths):
+            raise ServerError(f"{label} path is outside allowed llama.cpp paths.")
+        return path
 
     def _validate_runtime_port_available(self, profile: LlamaCppProfile) -> None:
         if not profile.enabled or profile.port_policy != LlamaCppPortPolicy.EXPLICIT:

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py
@@ -118,6 +118,41 @@ def test_vision_profile_injects_resolved_mmproj(monkeypatch, tmp_path: Path):
 
 
 @pytest.mark.unit
+def test_asset_id_paths_pass_through_custom_path_resolver(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    base = models_dir / "llava.gguf"
+    projector = models_dir / "mmproj-llava.gguf"
+    base.write_text("base")
+    projector.write_text("projector")
+    _configure_assets(monkeypatch, models_dir)
+    calls: list[tuple[str, str, str]] = []
+
+    def path_resolver(raw_path: str | Path, expected_kind: str, label: str) -> Path:
+        calls.append((str(raw_path), expected_kind, label))
+        return Path(raw_path).resolve()
+
+    profile = LlamaCppProfile(
+        profile_id="vision",
+        name="Vision",
+        mode=LlamaCppProfileMode.VISION,
+        model_id=llamacpp_inventory_service.asset_id_for_path(base, "gguf"),
+        mmproj_model_id=llamacpp_inventory_service.asset_id_for_path(projector, "mmproj"),
+    )
+
+    resolved = resolve_profile_launch(profile, path_resolver=path_resolver)
+
+    assert resolved.model_path == base.resolve()
+    assert resolved.mmproj_path == projector.resolve()
+    assert calls == [
+        (str(base.resolve()), "gguf", "Model"),
+        (str(projector.resolve()), "mmproj", "mmproj"),
+    ]
+
+
+@pytest.mark.unit
 def test_vision_profile_rejects_conflicting_manual_mmproj(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
 

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+from configparser import ConfigParser
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +54,32 @@ def make_model(config: LlamaCppConfig, name: str = "model.gguf") -> Path:
     model_path = config.models_dir / name
     model_path.write_text("not really gguf", encoding="utf-8")
     return model_path
+
+
+def _llamacpp_parser(default_models_dir: Path, **overrides: str) -> ConfigParser:
+    parser = ConfigParser()
+    parser.add_section("LlamaCpp")
+    values = {
+        "enabled": "true",
+        "models_dir": str(default_models_dir),
+        "allowed_paths": "",
+        "registered_model_paths": "",
+        "imported_asset_folders": "",
+    }
+    values.update(overrides)
+    parser["LlamaCpp"] = values
+    return parser
+
+
+@pytest.fixture(autouse=True)
+def configure_inventory_for_supervisor_tests(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(tmp_path / "models"),
+    )
 
 
 def profile(
@@ -182,24 +209,17 @@ def configure_supervisor_assets(
     base_name: str = "llava.gguf",
     mmproj_name: str = "mmproj-llava.gguf",
 ) -> tuple[Path, Path, str, str]:
-    from configparser import ConfigParser
-
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
 
     base_path = make_model(config, base_name)
     mmproj_path = config.models_dir / mmproj_name
     mmproj_path.write_text("projector", encoding="utf-8")
 
-    parser = ConfigParser()
-    parser.add_section("LlamaCpp")
-    parser["LlamaCpp"] = {
-        "enabled": "true",
-        "models_dir": str(config.models_dir),
-        "allowed_paths": "",
-        "registered_model_paths": "",
-        "imported_asset_folders": "",
-    }
-    monkeypatch.setattr(llamacpp_inventory_service, "load_comprehensive_config", lambda: parser)
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(config.models_dir),
+    )
     return (
         base_path.resolve(),
         mmproj_path.resolve(),

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
@@ -12,13 +12,14 @@ from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppProfileCreateRequest,
     LlamaCppProfileUpdateRequest,
 )
-from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ModelNotFoundError, ServerError
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Schemas import LlamaCppConfig
 from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_store import JsonLlamaCppProfileStore
 from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
     LlamaCppPortPolicy,
     LlamaCppProfile,
     LlamaCppProfileConflictError,
+    LlamaCppProfileMode,
     LlamaCppRuntime,
     LlamaCppRuntimeState,
 )
@@ -80,12 +81,19 @@ class FakeRunner:
         self.profile_id = profile_id
         self.calls = calls
         self.runtime = LlamaCppRuntime(profile_id=profile_id, state=LlamaCppRuntimeState.DEFINED)
+        self.model_paths: list[Path] = []
+        self.starts: list[LlamaCppProfile] = []
         self.cleaned = False
         self.stop_calls = 0
 
     async def start(self, model_path: Path, profile: LlamaCppProfile) -> LlamaCppRuntime:
         self.calls[self.profile_id] = self.calls.get(self.profile_id, 0) + 1
+        self.model_paths.append(model_path)
+        self.starts.append(profile)
         await asyncio.sleep(0)
+        resolved_args: list[str] = []
+        if profile.server_args.get("mmproj"):
+            resolved_args = ["llama-server", "--mmproj", str(profile.server_args["mmproj"])]
         self.runtime = LlamaCppRuntime(
             profile_id=self.profile_id,
             state=LlamaCppRuntimeState.RUNNING,
@@ -95,6 +103,7 @@ class FakeRunner:
             endpoint=f"http://{profile.host}:{profile.port}",
             model_id=profile.model_id,
             model_path=str(model_path),
+            resolved_args=resolved_args,
         )
         return self.runtime
 
@@ -164,6 +173,140 @@ def make_supervisor(tmp_path: Path) -> tuple[LlamaCppSupervisor, LlamaCppConfig,
     factory = FakeRunnerFactory()
     supervisor = LlamaCppSupervisor(config=config, store=store, runner_factory=factory)
     return supervisor, config, factory
+
+
+def configure_supervisor_assets(
+    monkeypatch: pytest.MonkeyPatch,
+    config: LlamaCppConfig,
+    *,
+    base_name: str = "llava.gguf",
+    mmproj_name: str = "mmproj-llava.gguf",
+) -> tuple[Path, Path, str, str]:
+    from configparser import ConfigParser
+
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    base_path = make_model(config, base_name)
+    mmproj_path = config.models_dir / mmproj_name
+    mmproj_path.write_text("projector", encoding="utf-8")
+
+    parser = ConfigParser()
+    parser.add_section("LlamaCpp")
+    parser["LlamaCpp"] = {
+        "enabled": "true",
+        "models_dir": str(config.models_dir),
+        "allowed_paths": "",
+        "registered_model_paths": "",
+        "imported_asset_folders": "",
+    }
+    monkeypatch.setattr(llamacpp_inventory_service, "load_comprehensive_config", lambda: parser)
+    return (
+        base_path.resolve(),
+        mmproj_path.resolve(),
+        llamacpp_inventory_service.asset_id_for_path(base_path, "gguf"),
+        llamacpp_inventory_service.asset_id_for_path(mmproj_path, "mmproj"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_supervisor_starts_vision_profile_with_resolved_mmproj(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    supervisor, config, factory = make_supervisor(tmp_path)
+    base_path, mmproj_path, base_asset_id, mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(
+            profile_id="vision",
+            name="Vision",
+            mode=LlamaCppProfileMode.VISION,
+            model_id=base_asset_id,
+            mmproj_model_id=mmproj_asset_id,
+            server_args={"ctx_size": 4096},
+        )
+    )
+
+    runtime = await supervisor.start_profile("vision")
+
+    runner = factory.runners["vision"]
+    assert runtime.profile_id == "vision"
+    assert runner.model_paths == [base_path]
+    assert runner.starts[0].server_args["ctx_size"] == 4096
+    assert runner.starts[0].server_args["mmproj"] == str(mmproj_path)
+    assert runtime.resolved_args[-2:] == ["--mmproj", str(mmproj_path)]
+    assert supervisor.store.get("vision").server_args == {"ctx_size": 4096}
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_vision_profile_without_mmproj_before_runner_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    supervisor, config, factory = make_supervisor(tmp_path)
+    _base_path, _mmproj_path, base_asset_id, _mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(
+            profile_id="vision",
+            name="Vision",
+            mode=LlamaCppProfileMode.VISION,
+            model_id=base_asset_id,
+            server_args={"ctx_size": 4096},
+        )
+    )
+
+    with pytest.raises(ServerError, match="mmproj"):
+        await supervisor.start_profile("vision")
+
+    assert factory.runners["vision"].starts == []
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_wrong_kind_mmproj_asset_before_runner_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    supervisor, config, factory = make_supervisor(tmp_path)
+    _base_path, _mmproj_path, base_asset_id, _mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(
+            profile_id="vision",
+            name="Vision",
+            mode=LlamaCppProfileMode.VISION,
+            model_id=base_asset_id,
+            mmproj_model_id=base_asset_id,
+        )
+    )
+
+    with pytest.raises(ModelNotFoundError, match="mmproj"):
+        await supervisor.start_profile("vision")
+
+    assert factory.runners["vision"].starts == []
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_manual_mmproj_path_outside_allowlist_before_runner_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    supervisor, config, factory = make_supervisor(tmp_path)
+    _base_path, _mmproj_path, base_asset_id, _mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
+    outside = tmp_path / "outside" / "mmproj-other.gguf"
+    outside.parent.mkdir()
+    outside.write_text("outside projector", encoding="utf-8")
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(
+            profile_id="vision",
+            name="Vision",
+            mode=LlamaCppProfileMode.VISION,
+            model_id=base_asset_id,
+            server_args={"mmproj": str(outside)},
+        )
+    )
+
+    with pytest.raises(ServerError, match="outside allowed"):
+        await supervisor.start_profile("vision")
+
+    assert factory.runners["vision"].starts == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Route managed llama.cpp profile starts through the profile capability resolver.
- Inject resolved mmproj launch args into a transient profile copy without mutating persisted server_args.
- Add supervisor coverage for valid vision projector launch, missing/wrong projector assets, outside-allowlist manual mmproj paths, and resolved_args propagation.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py -v
- [x] git diff --check
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py -f json -o /tmp/bandit_task_410.json

## Change summary
Pending human-authored summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes llama.cpp vision/mmproj launches through the profile capability resolver and injects the resolved `--mmproj` at start without mutating stored profiles. Path validation now delegates to the inventory service so model and projector IDs or manual paths are checked for kind and allowed locations before the runner starts.

- **New Features**
  - Start profiles via `resolve_profile_launch` with a supervisor `path_resolver`; inject resolved `mmproj` into a transient profile copy.
  - Delegate launch-path checks to the inventory service (exists, kind, allowlist); validate both asset IDs and manual paths; reject conflicts between `mmproj_model_id` and `server_args.mmproj`.
  - Persisted `server_args` stay unchanged; only the launched profile gets `mmproj`, and resolved args are propagated to the runtime.
  - Added tests for valid vision launch with `--mmproj`, missing projector, wrong-kind projector, manual path outside allowlist, and asset-ID paths passing through the custom resolver.

<sup>Written for commit b22f5785d57baf2621bd7ecf040e22735288df17. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1788?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

