### PR TITLE
Harden Buddy starter animation recipe metadata

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -265,16 +265,16 @@ scaffolds from final authored default assets:
 2. `production_status` is currently `scaffold` for all bundled starters.
 3. `neutral_anchor_required` is true when the final authored pack should begin
    from a neutral identity anchor.
-4. `expected_asset_groups` lists the authored inputs expected before a scaffold
-   becomes production artwork, such as `identity_brief`, `neutral_anchor`,
-   `static_talking_reaction_sheet`, `animation_strips`, or
-   `animation_atlas`.
+4. `expected_asset_groups` lists the authored inputs and outputs expected
+   before a scaffold becomes production artwork, such as `identity_brief`,
+   `neutral_anchor`, `static_talking_reaction_sheet`,
+   `required_state_loops`, `animation_strips`, or `animation_atlas`.
 5. `animation_coverage_notes` are bounded notes for reviewers and future
    generation jobs. They describe the missing neutral-anchor-derived animation
    work and do not grant runtime support by themselves.
 6. `production_recipe` is structured handoff metadata for authored assets. It
    includes an `identity_brief`, `neutral_anchor` guidance, `static_sheet`
-   guidance, expected `animation_outputs`, and `review_checks`.
+   guidance, timed runtime `animation_outputs`, and `review_checks`.
 
 The neutral-anchor pipeline remains: identity brief, neutral anchor, optional
 static talking/reaction sheet, animation strips or atlas regions, review, then
@@ -289,6 +289,14 @@ variants. Intricate starters add animation strips or atlas regions on top of the
 same neutral anchor. These recipes are not prompts that the server executes and
 are not proof that finished animation assets exist; they are bounded metadata
 for reviewers, future generation jobs, and custom provider handoffs.
+
+Static talking/reaction sheets are source material, not timed animation outputs.
+They may appear in `expected_asset_groups` and in the recipe `static_sheet`
+guidance, but they must not appear in `production_recipe.animation_outputs`.
+Those outputs name runtime artifacts that can be mapped into manifest
+`animations`, such as `required_state_loops`, `animation_strips`,
+`animation_atlas`, or `custom_state_variants`. A static sheet becomes animation
+only after its cells are explicitly mapped as timed manifest frames.
 
 Copying a bundled starter pack creates a normal user-owned draft pack attached
 to the selected target persona. The copy path validates the fixture manifest and

--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -267,7 +267,7 @@ scaffolds from final authored default assets:
    from a neutral identity anchor.
 4. `expected_asset_groups` lists the authored inputs and outputs expected
    before a scaffold becomes production artwork, such as `identity_brief`,
-   `neutral_anchor`, `static_talking_reaction_sheet`,
+   `neutral_anchor`, `static_talking_sheet`, `static_reaction_sheet`,
    `required_state_loops`, `animation_strips`, or `animation_atlas`.
 5. `animation_coverage_notes` are bounded notes for reviewers and future
    generation jobs. They describe the missing neutral-anchor-derived animation
@@ -277,20 +277,20 @@ scaffolds from final authored default assets:
    guidance, timed runtime `animation_outputs`, and `review_checks`.
 
 The neutral-anchor pipeline remains: identity brief, neutral anchor, optional
-static talking/reaction sheet, animation strips or atlas regions, review, then
-copy/import into an inactive draft with separate activation. The production
+static talking and reaction sheets, animation strips or atlas regions, review,
+then copy/import into an inactive draft with separate activation. The production
 metadata is catalog guidance for that pipeline; it does not create final art,
 run image generation, activate a pack, or change renderer support.
 
 Production recipes make the scaffold-to-art handoff explicit. Basic starters
 usually expect only required-state loops derived from a single neutral anchor.
-Intermediate starters add a static talking/reaction sheet and custom-state
+Intermediate starters add separate static talking and reaction sheets and custom-state
 variants. Intricate starters add animation strips or atlas regions on top of the
 same neutral anchor. These recipes are not prompts that the server executes and
 are not proof that finished animation assets exist; they are bounded metadata
 for reviewers, future generation jobs, and custom provider handoffs.
 
-Static talking/reaction sheets are source material, not timed animation outputs.
+Static talking sheets and static reaction sheets are source material, not timed animation outputs.
 They may appear in `expected_asset_groups` and in the recipe `static_sheet`
 guidance, but they must not appear in `production_recipe.animation_outputs`.
 Those outputs name runtime artifacts that can be mapped into manifest

--- a/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
@@ -38,11 +38,16 @@ Do not generate final Buddy images in this slice. Do not change runtime renderin
   - Owns service-level starter fixture validation.
   - Reject recipe `animation_outputs` that are static/source asset groups before
     invalid fixture metadata reaches API response construction.
+  - Reject recipe `animation_outputs` that are not declared as expected asset
+    groups for the same starter, so a fixture cannot advertise a production
+    output that the catalog does not claim to collect.
 
 - Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
   - Owns API response validation for starter production recipes.
   - Reuse the shared taxonomy to validate that recipe `animation_outputs` use
     supported timed-output IDs and do not include static asset groups.
+  - Reuse the shared taxonomy to validate starter `expected_asset_groups` at the
+    API response boundary as a backstop against catalog drift.
 
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
   - Owns focused starter catalog fixture/service validation.
@@ -57,11 +62,23 @@ Do not generate final Buddy images in this slice. Do not change runtime renderin
   - Owns generated-candidate job and provenance coverage.
   - Update any invalid recipe-output fixtures that use static sheet outputs.
 
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py`
+  - Owns generated-candidate provenance sanitization coverage.
+  - Keep `static_sheet` as guidance metadata, but do not use static sheet labels
+    as recipe output IDs.
+
+- Modify: `tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py`
+  - Owns DB-level candidate provenance persistence coverage.
+  - Keep historical/static-sheet text sanitization coverage while using a valid
+    timed recipe output ID.
+
 - Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
   - Owns durable technical documentation for Persona/Buddy visual packs.
   - Clarify that static talking/reaction sheets are expected asset groups and source material, not timed animation outputs.
 
-- Modify: `backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md`
+- Modify: implementation Backlog task for this slice.
+  - Use `TASK-411` if present: `backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md`.
+  - Fall back to `TASK-410` only if `TASK-411` does not exist in the worktree.
   - Record the plan path, touched files, verification, and known Bandit/doc-only details.
 
 ## Task 1: Add Pipeline Taxonomy Tests
@@ -100,6 +117,7 @@ def test_default_starter_production_recipes_use_pipeline_taxonomy(
         assert expected_groups <= BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
         assert animation_outputs <= BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
         assert not (animation_outputs & BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS)
+        assert animation_outputs <= expected_groups
 ```
 
 Add this test to prove intermediate/intricate starters still ask for static source material, but not as animation outputs:
@@ -243,6 +261,8 @@ animation_outputs=(
 ```
 
 Do not remove `static_talking_reaction_sheet` from `_INTERMEDIATE_EXPECTED_ASSET_GROUPS` or `_INTRICATE_EXPECTED_ASSET_GROUPS`.
+Add `required_state_loops` to `_INTRICATE_EXPECTED_ASSET_GROUPS` so every
+recipe `animation_outputs` value is also declared as an expected asset group.
 
 - [ ] **Step 2: Update existing catalog expectations**
 
@@ -329,6 +349,32 @@ def test_list_starter_packs_rejects_static_source_animation_outputs(
     assert exc_info.value.details["field_name"] == "production_recipe.animation_outputs"
 ```
 
+Add a sibling service-level test proving a timed output is still rejected when
+the starter does not declare the corresponding expected asset group:
+
+```python
+def test_list_starter_packs_rejects_recipe_outputs_missing_expected_groups(
+    db_instance: CharactersRAGDB,
+) -> None:
+    malformed = replace(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0],
+        production_recipe=PersonaVisualStarterProductionRecipe(
+            identity_brief="Identity",
+            neutral_anchor="Neutral anchor",
+            static_sheet="Static sheet",
+            animation_outputs=("custom_state_variants",),
+        ),
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.list_starter_packs()
+
+    assert exc_info.value.code == "invalid_starter_fixture"
+    assert exc_info.value.details["field_name"] == "production_recipe.animation_outputs"
+    assert exc_info.value.details["invalid_outputs"] == ["custom_state_variants"]
+```
+
 Add a test near `test_production_recipe_response_enforces_catalog_bounds`:
 
 ```python
@@ -352,6 +398,24 @@ def test_production_recipe_response_rejects_non_animation_outputs(
         PersonaVisualStarterProductionRecipeResponse.model_validate(payload)
 ```
 
+Also import `PersonaVisualStarterPackResponse` and add a response-boundary test
+for unknown expected asset groups:
+
+```python
+def test_starter_pack_response_rejects_unknown_expected_asset_groups() -> None:
+    payload = {
+        "id": "starter-with-bad-group",
+        "title": "Starter With Bad Group",
+        "description": "Invalid starter metadata.",
+        "renderer_type": "sprite_frames",
+        "expected_asset_groups": ["neutral_anchor", "unknown_group"],
+        "production_recipe": _valid_recipe_payload(),
+    }
+
+    with pytest.raises(ValidationError):
+        PersonaVisualStarterPackResponse.model_validate(payload)
+```
+
 - [ ] **Step 2: Run tests and verify they fail**
 
 Run:
@@ -360,6 +424,8 @@ Run:
 /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
   tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_list_starter_packs_rejects_static_source_animation_outputs \
   tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_production_recipe_response_rejects_non_animation_outputs \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_list_starter_packs_rejects_recipe_outputs_missing_expected_groups \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_starter_pack_response_rejects_unknown_expected_asset_groups \
   -v
 ```
 
@@ -373,10 +439,33 @@ In `tldw_Server_API/app/core/Persona/visual_starter_catalog.py`, import:
 ```python
 from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
     BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
+    BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
 )
 ```
 
-After `animation_outputs` is normalized in `_starter_production_recipe()`, add:
+In `_validate_starter_fixture()`, after `expected_asset_groups` is normalized,
+reject unknown expected asset groups:
+
+```python
+        invalid_expected_groups = sorted(
+            group
+            for group in expected_asset_groups
+            if group not in BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
+        )
+        if invalid_expected_groups:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter expected_asset_groups must use supported pipeline group ids.",
+                details={
+                    "starter_pack_id": starter.id,
+                    "field_name": "expected_asset_groups",
+                    "invalid_groups": invalid_expected_groups,
+                },
+            )
+```
+
+After `animation_outputs` is normalized in `_starter_production_recipe()`, reject
+unknown or static/source outputs:
 
 ```python
         invalid_outputs = sorted(
@@ -396,6 +485,34 @@ After `animation_outputs` is normalized in `_starter_production_recipe()`, add:
             )
 ```
 
+Then, back in `_validate_starter_fixture()`, after normalizing the production
+recipe, reject timed outputs that are not also declared in `expected_asset_groups`:
+
+```python
+        production_recipe = PersonaVisualStarterCatalogService._starter_production_recipe(
+            starter.production_recipe,
+            starter_id=starter.id,
+        )
+        missing_expected_outputs = sorted(
+            output
+            for output in production_recipe["animation_outputs"]
+            if output not in expected_asset_groups
+        )
+        if missing_expected_outputs:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production recipe outputs must be declared expected asset groups.",
+                details={
+                    "starter_pack_id": starter.id,
+                    "field_name": "production_recipe.animation_outputs",
+                    "invalid_outputs": missing_expected_outputs,
+                },
+            )
+```
+
+Avoid calling `_starter_production_recipe()` twice in the same validation path;
+reuse the normalized value for the consistency check.
+
 - [ ] **Step 4: Add schema validator using the shared taxonomy**
 
 In `tldw_Server_API/app/api/v1/schemas/persona.py`, import:
@@ -403,6 +520,7 @@ In `tldw_Server_API/app/api/v1/schemas/persona.py`, import:
 ```python
 from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
     BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
+    BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
 )
 ```
 
@@ -419,6 +537,20 @@ Add a validator to `PersonaVisualStarterProductionRecipeResponse`:
             raise ValueError(
                 "animation_outputs must contain timed animation output ids only"
             )
+        return value
+```
+
+Add a validator to `PersonaVisualStarterPackResponse`:
+
+```python
+    @field_validator("expected_asset_groups")
+    @classmethod
+    def validate_expected_asset_groups(cls, value: list[str]) -> list[str]:
+        invalid = sorted(
+            group for group in value if group not in BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
+        )
+        if invalid:
+            raise ValueError("expected_asset_groups must contain supported pipeline group ids")
         return value
 ```
 
@@ -449,11 +581,13 @@ git add tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py \
 git commit -m "fix: bound buddy starter recipe animation outputs"
 ```
 
-## Task 4: Update API And Job Tests For Valid Recipe Outputs
+## Task 4: Update API, Job, And Provenance Tests For Valid Recipe Outputs
 
 **Files:**
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visual_jobs.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py`
+- Modify: `tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py`
 
 - [ ] **Step 1: Find stale static recipe-output assumptions**
 
@@ -462,7 +596,9 @@ Run:
 ```bash
 rg -n '"static_sheet"|"static_talking_reaction_sheet"|recipe_output' \
   tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
-  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
 ```
 
 Expected: identify any test fixtures that use `recipe_output: "static_sheet"` or expect `static_talking_reaction_sheet` as an animation output.
@@ -489,6 +625,8 @@ Run:
 /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
   tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
   tldw_Server_API/tests/Persona/test_persona_visual_jobs.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py \
   -v
 ```
 
@@ -500,7 +638,9 @@ Run:
 
 ```bash
 git add tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
-  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
 git commit -m "test: align buddy recipe output consumers"
 ```
 
@@ -508,7 +648,8 @@ git commit -m "test: align buddy recipe output consumers"
 
 **Files:**
 - Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
-- Modify: `backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md`
+- Modify: implementation Backlog task for this slice (`TASK-411` when present,
+  otherwise `TASK-410`)
 
 - [ ] **Step 1: Patch Persona Visual Packs documentation**
 
@@ -532,7 +673,7 @@ If there is no existing docs test for this exact file, do not add a new broad do
 
 - [ ] **Step 3: Update Backlog task metadata**
 
-Use the Backlog MCP task edit tool to add:
+Use the Backlog MCP task edit tool to add to the implementation task:
 
 - plan path: `Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md`
 - touched files from this implementation slice,
@@ -545,9 +686,12 @@ Run:
 
 ```bash
 git add Docs/Code_Documentation/Persona_Visual_Packs.md \
-  "backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md"
+  "backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md"
 git commit -m "docs: clarify buddy static sheet recipe semantics"
 ```
+
+If `TASK-411` is not present in the worktree, use the `TASK-410` design task
+path instead and note the fallback in the task update.
 
 ## Task 6: Final Verification
 
@@ -563,6 +707,8 @@ Run:
   tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py \
   tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
   tldw_Server_API/tests/Persona/test_persona_visual_jobs.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py \
   -v
 ```
 
@@ -632,9 +778,12 @@ Comment on GitHub issue #1787 with:
 If the Backlog task changed during final verification, commit it:
 
 ```bash
-git add "backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md"
+git add "backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md"
 git commit -m "chore: record buddy catalog metadata verification"
 ```
+
+If `TASK-411` is not present in the worktree, use the `TASK-410` design task
+path instead and note the fallback in the commit summary.
 
 ## Completion Criteria
 
@@ -645,7 +794,7 @@ This slice is complete when:
   groups in `animation_outputs`.
 - starter catalog/API/job tests pass.
 - docs explain the distinction clearly.
-- issue #1787 and the Backlog task record the verification.
+- issue #1787 and the implementation Backlog task record the verification.
 
 ## Out Of Scope For This Plan
 

--- a/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
@@ -24,15 +24,25 @@ Do not generate final Buddy images in this slice. Do not change runtime renderin
 
 ## Files And Responsibilities
 
+- Create: `tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py`
+  - Owns shared taxonomy constants for starter expected asset groups, static
+    source groups, and timed animation output IDs.
+  - Keeps fixture validation and API schema validation from drifting.
+
 - Modify: `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
   - Owns immutable bundled starter catalog fixture definitions and production recipes.
-  - Add explicit pipeline taxonomy constants.
   - Remove `static_talking_reaction_sheet` from `animation_outputs`.
   - Keep `static_talking_reaction_sheet` in `expected_asset_groups` where appropriate.
 
+- Modify: `tldw_Server_API/app/core/Persona/visual_starter_catalog.py`
+  - Owns service-level starter fixture validation.
+  - Reject recipe `animation_outputs` that are static/source asset groups before
+    invalid fixture metadata reaches API response construction.
+
 - Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
   - Owns API response validation for starter production recipes.
-  - Add validation that recipe `animation_outputs` use supported timed-output IDs and do not include static asset groups.
+  - Reuse the shared taxonomy to validate that recipe `animation_outputs` use
+    supported timed-output IDs and do not include static asset groups.
 
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
   - Owns focused starter catalog fixture/service validation.
@@ -57,15 +67,15 @@ Do not generate final Buddy images in this slice. Do not change runtime renderin
 ## Task 1: Add Pipeline Taxonomy Tests
 
 **Files:**
+- Create: `tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py`
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
-- Modify: `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
 
 - [ ] **Step 1: Write failing taxonomy tests**
 
-Add imports from `visual_starter_fixtures.py` for the new constants that will be implemented in Step 3:
+Add imports from the new taxonomy module for the constants that will be implemented in Step 3:
 
 ```python
-from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
+from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
     BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
     BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
     BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS,
@@ -133,13 +143,20 @@ Run:
   -v
 ```
 
-Expected: fail because the taxonomy constants do not exist and the current recipes include `static_talking_reaction_sheet` in some `animation_outputs`.
+Expected: fail because the taxonomy module/constants do not exist and the current recipes include `static_talking_reaction_sheet` in some `animation_outputs`.
 
-- [ ] **Step 3: Add taxonomy constants**
+- [ ] **Step 3: Add the shared taxonomy module**
 
-In `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`, add constants near the existing expected asset group constants:
+Create `tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py`:
 
 ```python
+"""Shared taxonomy for Persona Visual starter production recipes.
+
+The starter catalog exposes source asset groups and timed runtime animation
+outputs as separate concepts. Keeping the taxonomy in this small module avoids
+drift between immutable fixture validation and public API schema validation.
+"""
+
 BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS = frozenset(
     {
         "identity_brief",
@@ -170,9 +187,17 @@ BUDDY_VISUAL_ANIMATION_OUTPUT_IDS = frozenset(
         "custom_state_variants",
     }
 )
+
+__all__ = [
+    "BUDDY_VISUAL_ANIMATION_OUTPUT_IDS",
+    "BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS",
+    "BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS",
+]
 ```
 
-Add the three constants to `__all__`.
+`custom_state_variants` remains in `BUDDY_VISUAL_ANIMATION_OUTPUT_IDS` because
+it means timed runtime loops or frame mappings for declared custom states, not
+static source-sheet cells.
 
 - [ ] **Step 4: Run tests and verify the remaining semantic failure**
 
@@ -265,18 +290,44 @@ Expected: pass.
 Run:
 
 ```bash
-git add tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
+git add tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py \
+  tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
   tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
 git commit -m "test: separate buddy static sheets from animation outputs"
 ```
 
-## Task 3: Enforce Recipe Output Semantics At The API Schema Boundary
+## Task 3: Enforce Recipe Output Semantics At Catalog And API Boundaries
 
 **Files:**
+- Modify: `tldw_Server_API/app/core/Persona/visual_starter_catalog.py`
 - Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
 
-- [ ] **Step 1: Write failing schema validation tests**
+- [ ] **Step 1: Write failing service and schema validation tests**
+
+Add this service-level test near the malformed production metadata tests:
+
+```python
+def test_list_starter_packs_rejects_static_source_animation_outputs(
+    db_instance: CharactersRAGDB,
+) -> None:
+    malformed = replace(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0],
+        production_recipe=PersonaVisualStarterProductionRecipe(
+            identity_brief="Identity",
+            neutral_anchor="Neutral anchor",
+            static_sheet="Static sheet",
+            animation_outputs=("static_talking_reaction_sheet",),
+        ),
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.list_starter_packs()
+
+    assert exc_info.value.code == "invalid_starter_fixture"
+    assert exc_info.value.details["field_name"] == "production_recipe.animation_outputs"
+```
 
 Add a test near `test_production_recipe_response_enforces_catalog_bounds`:
 
@@ -301,30 +352,57 @@ def test_production_recipe_response_rejects_non_animation_outputs(
         PersonaVisualStarterProductionRecipeResponse.model_validate(payload)
 ```
 
-- [ ] **Step 2: Run test and verify it fails**
+- [ ] **Step 2: Run tests and verify they fail**
 
 Run:
 
 ```bash
 /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_list_starter_packs_rejects_static_source_animation_outputs \
   tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_production_recipe_response_rejects_non_animation_outputs \
   -v
 ```
 
-Expected: fail because the schema currently accepts any bounded non-empty recipe item.
+Expected: fail because the catalog service and schema currently accept any
+bounded non-empty recipe item.
 
-- [ ] **Step 3: Add schema constants and validator**
+- [ ] **Step 3: Add catalog service validation**
 
-In `tldw_Server_API/app/api/v1/schemas/persona.py`, add near the recipe type aliases:
+In `tldw_Server_API/app/core/Persona/visual_starter_catalog.py`, import:
 
 ```python
-_PERSONA_VISUAL_STARTER_ANIMATION_OUTPUTS = frozenset(
-    {
-        "required_state_loops",
-        "animation_strips",
-        "animation_atlas",
-        "custom_state_variants",
-    }
+from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
+    BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
+)
+```
+
+After `animation_outputs` is normalized in `_starter_production_recipe()`, add:
+
+```python
+        invalid_outputs = sorted(
+            output
+            for output in animation_outputs
+            if output not in BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
+        )
+        if invalid_outputs:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production recipe animation_outputs must be timed output ids.",
+                details={
+                    "starter_pack_id": starter_id,
+                    "field_name": "production_recipe.animation_outputs",
+                    "invalid_outputs": invalid_outputs,
+                },
+            )
+```
+
+- [ ] **Step 4: Add schema validator using the shared taxonomy**
+
+In `tldw_Server_API/app/api/v1/schemas/persona.py`, import:
+
+```python
+from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
+    BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
 )
 ```
 
@@ -335,7 +413,7 @@ Add a validator to `PersonaVisualStarterProductionRecipeResponse`:
     @classmethod
     def validate_animation_outputs(cls, value: list[str]) -> list[str]:
         invalid = sorted(
-            output for output in value if output not in _PERSONA_VISUAL_STARTER_ANIMATION_OUTPUTS
+            output for output in value if output not in BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
         )
         if invalid:
             raise ValueError(
@@ -344,9 +422,10 @@ Add a validator to `PersonaVisualStarterProductionRecipeResponse`:
         return value
 ```
 
-Keep this schema-local to avoid coupling public API schemas to the fixture module.
+Do not import from `visual_starter_fixtures.py`; the shared taxonomy module is
+the stable dependency.
 
-- [ ] **Step 4: Run focused schema/catalog tests**
+- [ ] **Step 5: Run focused schema/catalog tests**
 
 Run:
 
@@ -358,12 +437,14 @@ Run:
 
 Expected: pass.
 
-- [ ] **Step 5: Commit schema validation**
+- [ ] **Step 6: Commit catalog and schema validation**
 
 Run:
 
 ```bash
-git add tldw_Server_API/app/api/v1/schemas/persona.py \
+git add tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py \
+  tldw_Server_API/app/core/Persona/visual_starter_catalog.py \
+  tldw_Server_API/app/api/v1/schemas/persona.py \
   tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
 git commit -m "fix: bound buddy starter recipe animation outputs"
 ```
@@ -493,6 +574,8 @@ Run:
 
 ```bash
 /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile \
+  tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py \
+  tldw_Server_API/app/core/Persona/visual_starter_catalog.py \
   tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
   tldw_Server_API/app/api/v1/schemas/persona.py
 ```
@@ -505,7 +588,9 @@ Run:
 
 ```bash
 /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
-  -r tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
+  -r tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py \
+     tldw_Server_API/app/core/Persona/visual_starter_catalog.py \
+     tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
      tldw_Server_API/app/api/v1/schemas/persona.py \
   -f json -o /tmp/bandit_buddy_animation_catalog_metadata.json
 ```
@@ -556,7 +641,8 @@ git commit -m "chore: record buddy catalog metadata verification"
 This slice is complete when:
 
 - `static_talking_reaction_sheet` is present only as source/expected asset metadata, not as a recipe animation output.
-- API schema validation rejects static/source groups in `animation_outputs`.
+- catalog service validation and API schema validation reject static/source
+  groups in `animation_outputs`.
 - starter catalog/API/job tests pass.
 - docs explain the distinction clearly.
 - issue #1787 and the Backlog task record the verification.

--- a/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
@@ -1,0 +1,570 @@
+# Buddy Animation Pipeline Catalog Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the bundled Buddy starter catalog metadata enforce the neutral-anchor-first animation pipeline contract without claiming final default animation art exists.
+
+**Architecture:** Keep the current Persona Visual pack/runtime contract intact. The first implementation slice only tightens starter catalog recipe metadata, schema validation, documentation, and tests so static talking/reaction sheets remain separate from timed animation outputs. It does not add final art assets, new renderers, or activation behavior.
+
+**Tech Stack:** Python dataclasses and Pydantic schemas in `tldw_Server_API`, pytest unit tests, existing Persona Visual starter catalog service, existing Markdown docs.
+
+---
+
+## Scope Check
+
+The design spec covers several independent subsystems: catalog metadata, production packet fixtures, editor UX, runtime/MCP trigger hardening, and final asset production. This plan intentionally covers only the first concrete slice:
+
+- catalog production metadata alignment,
+- static-sheet versus animation-output separation,
+- recipe/schema tests,
+- documentation update,
+- Backlog/task metadata update.
+
+Do not generate final Buddy images in this slice. Do not change runtime rendering behavior. Do not change activation behavior.
+
+## Files And Responsibilities
+
+- Modify: `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
+  - Owns immutable bundled starter catalog fixture definitions and production recipes.
+  - Add explicit pipeline taxonomy constants.
+  - Remove `static_talking_reaction_sheet` from `animation_outputs`.
+  - Keep `static_talking_reaction_sheet` in `expected_asset_groups` where appropriate.
+
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+  - Owns API response validation for starter production recipes.
+  - Add validation that recipe `animation_outputs` use supported timed-output IDs and do not include static asset groups.
+
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
+  - Owns focused starter catalog fixture/service validation.
+  - Add tests for the pipeline taxonomy and static/animation separation.
+  - Update existing expectations that currently treat `static_talking_reaction_sheet` as an animation output.
+
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
+  - Owns API-level starter catalog and generation enqueue coverage.
+  - Add or adjust assertions so the API exposes static sheet guidance separately from `animation_outputs`.
+
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_jobs.py`
+  - Owns generated-candidate job and provenance coverage.
+  - Update any invalid recipe-output fixtures that use static sheet outputs.
+
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+  - Owns durable technical documentation for Persona/Buddy visual packs.
+  - Clarify that static talking/reaction sheets are expected asset groups and source material, not timed animation outputs.
+
+- Modify: `backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md`
+  - Record the plan path, touched files, verification, and known Bandit/doc-only details.
+
+## Task 1: Add Pipeline Taxonomy Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
+- Modify: `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
+
+- [ ] **Step 1: Write failing taxonomy tests**
+
+Add imports from `visual_starter_fixtures.py` for the new constants that will be implemented in Step 3:
+
+```python
+from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
+    BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
+    BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
+    BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS,
+)
+```
+
+Add this test near the production-readiness tests:
+
+```python
+def test_default_starter_production_recipes_use_pipeline_taxonomy(
+    db_instance: CharactersRAGDB,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    for detail in (
+        service.get_starter_pack(starter_id)
+        for starter_id in DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS
+    ):
+        expected_groups = set(detail["expected_asset_groups"])
+        animation_outputs = set(detail["production_recipe"]["animation_outputs"])
+
+        assert expected_groups <= BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
+        assert animation_outputs <= BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
+        assert not (animation_outputs & BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS)
+```
+
+Add this test to prove intermediate/intricate starters still ask for static source material, but not as animation outputs:
+
+```python
+@pytest.mark.parametrize(
+    "starter_pack_id",
+    (
+        "study-desk-intermediate",
+        "tool-helper-intermediate",
+        "object-creature-intermediate",
+        "lofi-study-intricate",
+        "action-guide-intricate",
+        "elaborate-persona-intricate",
+    ),
+)
+def test_static_talking_sheet_is_source_material_not_animation_output(
+    db_instance: CharactersRAGDB,
+    starter_pack_id: str,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    detail = service.get_starter_pack(starter_pack_id)
+
+    assert "static_talking_reaction_sheet" in detail["expected_asset_groups"]
+    assert "static" in detail["production_recipe"]["static_sheet"].lower()
+    assert (
+        "static_talking_reaction_sheet"
+        not in detail["production_recipe"]["animation_outputs"]
+    )
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_default_starter_production_recipes_use_pipeline_taxonomy \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_static_talking_sheet_is_source_material_not_animation_output \
+  -v
+```
+
+Expected: fail because the taxonomy constants do not exist and the current recipes include `static_talking_reaction_sheet` in some `animation_outputs`.
+
+- [ ] **Step 3: Add taxonomy constants**
+
+In `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`, add constants near the existing expected asset group constants:
+
+```python
+BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS = frozenset(
+    {
+        "identity_brief",
+        "neutral_anchor",
+        "preview_image",
+        "model_sheet",
+        "static_talking_reaction_sheet",
+        "required_state_loops",
+        "animation_strips",
+        "animation_atlas",
+        "custom_state_variants",
+    }
+)
+BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS = frozenset(
+    {
+        "identity_brief",
+        "neutral_anchor",
+        "preview_image",
+        "model_sheet",
+        "static_talking_reaction_sheet",
+    }
+)
+BUDDY_VISUAL_ANIMATION_OUTPUT_IDS = frozenset(
+    {
+        "required_state_loops",
+        "animation_strips",
+        "animation_atlas",
+        "custom_state_variants",
+    }
+)
+```
+
+Add the three constants to `__all__`.
+
+- [ ] **Step 4: Run tests and verify the remaining semantic failure**
+
+Run the same pytest command from Step 2.
+
+Expected: constants import, but the static-sheet separation test still fails until Task 2 updates recipe outputs.
+
+## Task 2: Separate Static Sheets From Animation Outputs
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
+
+- [ ] **Step 1: Update recipe outputs in fixtures**
+
+In `_multi_asset_pack()`, change `animation_outputs` so it no longer includes `static_talking_reaction_sheet`:
+
+```python
+animation_outputs=(
+    (
+        "required_state_loops",
+        "animation_strips",
+        "animation_atlas",
+        "custom_state_variants",
+    )
+    if complexity_tier == "intricate"
+    else (
+        "required_state_loops",
+        "custom_state_variants",
+    )
+),
+```
+
+In `_atlas_pack()`, remove `static_talking_reaction_sheet` from `animation_outputs`:
+
+```python
+animation_outputs=(
+    "required_state_loops",
+    "animation_strips",
+    "animation_atlas",
+    "custom_state_variants",
+),
+```
+
+Do not remove `static_talking_reaction_sheet` from `_INTERMEDIATE_EXPECTED_ASSET_GROUPS` or `_INTRICATE_EXPECTED_ASSET_GROUPS`.
+
+- [ ] **Step 2: Update existing catalog expectations**
+
+In `test_starter_pack_reports_production_readiness_metadata`, replace the current single `required_group` assertion with separate expected asset group and expected recipe output values.
+
+Use this parametrization:
+
+```python
+@pytest.mark.parametrize(
+    ("starter_pack_id", "complexity_tier", "required_group", "expected_output"),
+    (
+        ("research-buddy-basic", "basic", "required_state_loops", "required_state_loops"),
+        (
+            "study-desk-intermediate",
+            "intermediate",
+            "static_talking_reaction_sheet",
+            "required_state_loops",
+        ),
+        ("lofi-study-intricate", "intricate", "animation_atlas", "animation_atlas"),
+    ),
+)
+```
+
+Then assert:
+
+```python
+assert required_group in detail["expected_asset_groups"]
+_assert_recipe_shape(detail["production_recipe"], expected_output=expected_output)
+```
+
+- [ ] **Step 3: Run focused starter catalog tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py \
+  -v
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit the fixture/test separation**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+git commit -m "test: separate buddy static sheets from animation outputs"
+```
+
+## Task 3: Enforce Recipe Output Semantics At The API Schema Boundary
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
+
+- [ ] **Step 1: Write failing schema validation tests**
+
+Add a test near `test_production_recipe_response_enforces_catalog_bounds`:
+
+```python
+@pytest.mark.parametrize(
+    "animation_outputs",
+    (
+        ["static_talking_reaction_sheet"],
+        ["identity_brief"],
+        ["neutral_anchor"],
+        ["model_sheet"],
+        ["unknown_output"],
+    ),
+)
+def test_production_recipe_response_rejects_non_animation_outputs(
+    animation_outputs: list[str],
+) -> None:
+    payload = _valid_recipe_payload()
+    payload["animation_outputs"] = animation_outputs
+
+    with pytest.raises(ValidationError):
+        PersonaVisualStarterProductionRecipeResponse.model_validate(payload)
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py::test_production_recipe_response_rejects_non_animation_outputs \
+  -v
+```
+
+Expected: fail because the schema currently accepts any bounded non-empty recipe item.
+
+- [ ] **Step 3: Add schema constants and validator**
+
+In `tldw_Server_API/app/api/v1/schemas/persona.py`, add near the recipe type aliases:
+
+```python
+_PERSONA_VISUAL_STARTER_ANIMATION_OUTPUTS = frozenset(
+    {
+        "required_state_loops",
+        "animation_strips",
+        "animation_atlas",
+        "custom_state_variants",
+    }
+)
+```
+
+Add a validator to `PersonaVisualStarterProductionRecipeResponse`:
+
+```python
+    @field_validator("animation_outputs")
+    @classmethod
+    def validate_animation_outputs(cls, value: list[str]) -> list[str]:
+        invalid = sorted(
+            output for output in value if output not in _PERSONA_VISUAL_STARTER_ANIMATION_OUTPUTS
+        )
+        if invalid:
+            raise ValueError(
+                "animation_outputs must contain timed animation output ids only"
+            )
+        return value
+```
+
+Keep this schema-local to avoid coupling public API schemas to the fixture module.
+
+- [ ] **Step 4: Run focused schema/catalog tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py \
+  -v
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit schema validation**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/persona.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+git commit -m "fix: bound buddy starter recipe animation outputs"
+```
+
+## Task 4: Update API And Job Tests For Valid Recipe Outputs
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_visual_jobs.py`
+
+- [ ] **Step 1: Find stale static recipe-output assumptions**
+
+Run:
+
+```bash
+rg -n '"static_sheet"|"static_talking_reaction_sheet"|recipe_output' \
+  tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+```
+
+Expected: identify any test fixtures that use `recipe_output: "static_sheet"` or expect `static_talking_reaction_sheet` as an animation output.
+
+- [ ] **Step 2: Update invalid job/API fixtures**
+
+Replace invalid recipe outputs with a valid timed output such as `required_state_loops` unless the test specifically checks invalid-output rejection.
+
+If a test intentionally validates invalid recipe output handling, prefer `not_a_recipe_output` so the failure reason remains clearly invalid, not a now-static source group.
+
+For any API assertion that verifies static sheet availability, assert it through:
+
+```python
+assert "static_talking_reaction_sheet" in starter["expected_asset_groups"]
+assert "static" in starter["production_recipe"]["static_sheet"].lower()
+assert "static_talking_reaction_sheet" not in starter["production_recipe"]["animation_outputs"]
+```
+
+- [ ] **Step 3: Run focused API/job tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py \
+  -v
+```
+
+Expected: pass. If unrelated existing failures appear, record them in the Backlog task and rerun the narrow tests touched by this slice.
+
+- [ ] **Step 4: Commit API/job test alignment**
+
+Run:
+
+```bash
+git add tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+git commit -m "test: align buddy recipe output consumers"
+```
+
+## Task 5: Update Documentation
+
+**Files:**
+- Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
+- Modify: `backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md`
+
+- [ ] **Step 1: Patch Persona Visual Packs documentation**
+
+In the "Bundled Starter Catalog Scaffolds" section, update the production recipe explanation to state:
+
+- `expected_asset_groups` may include source groups such as `static_talking_reaction_sheet`.
+- `production_recipe.animation_outputs` only names timed runtime outputs.
+- Static talking/reaction sheets become animation only when cells are explicitly mapped into manifest `animations` frames.
+
+Keep wording explicit that current PNGs are scaffolds and not final animation packs.
+
+- [ ] **Step 2: Add documentation assertions if an existing docs test covers this file**
+
+Run:
+
+```bash
+rg -n "Persona_Visual_Packs|Bundled Starter Catalog|static_talking_reaction_sheet" tldw_Server_API/tests Docs
+```
+
+If there is no existing docs test for this exact file, do not add a new broad docs-test harness in this slice. The source and API tests are enough.
+
+- [ ] **Step 3: Update Backlog task metadata**
+
+Use the Backlog MCP task edit tool to add:
+
+- plan path: `Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md`
+- touched files from this implementation slice,
+- verification commands and results,
+- Bandit result or skip reason.
+
+- [ ] **Step 4: Commit docs and Backlog updates**
+
+Run:
+
+```bash
+git add Docs/Code_Documentation/Persona_Visual_Packs.md \
+  "backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md"
+git commit -m "docs: clarify buddy static sheet recipe semantics"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+- No new source files; validates the full touched scope.
+
+- [ ] **Step 1: Run focused pytest suite**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py \
+  tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
+  tldw_Server_API/tests/Persona/test_persona_visual_jobs.py \
+  -v
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run py_compile on touched Python modules**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile \
+  tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
+  tldw_Server_API/app/api/v1/schemas/persona.py
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Run Bandit on touched Python modules**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
+  -r tldw_Server_API/app/core/Persona/visual_starter_fixtures.py \
+     tldw_Server_API/app/api/v1/schemas/persona.py \
+  -f json -o /tmp/bandit_buddy_animation_catalog_metadata.json
+```
+
+Expected: no new findings in touched code. If Bandit is not installed in the venv, record the environment skip in the Backlog task.
+
+- [ ] **Step 4: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Inspect git history and status**
+
+Run:
+
+```bash
+git log --oneline origin/dev..HEAD
+git status --short --branch
+```
+
+Expected: branch contains the design commit and the implementation commits; working tree is clean.
+
+- [ ] **Step 6: Update issue #1787**
+
+Comment on GitHub issue #1787 with:
+
+- the committed implementation summary,
+- verification results,
+- any skipped checks and why,
+- remaining next slices.
+
+- [ ] **Step 7: Final commit if verification notes changed Backlog**
+
+If the Backlog task changed during final verification, commit it:
+
+```bash
+git add "backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md"
+git commit -m "chore: record buddy catalog metadata verification"
+```
+
+## Completion Criteria
+
+This slice is complete when:
+
+- `static_talking_reaction_sheet` is present only as source/expected asset metadata, not as a recipe animation output.
+- API schema validation rejects static/source groups in `animation_outputs`.
+- starter catalog/API/job tests pass.
+- docs explain the distinction clearly.
+- issue #1787 and the Backlog task record the verification.
+
+## Out Of Scope For This Plan
+
+- Generating the nine final Buddy art packs.
+- Adding UI for neutral-anchor upload or production packets.
+- Adding a new renderer.
+- Bumping wire-level `manifest_version` for `sprite_frames`.
+- Changing `BuddyShellHost` runtime state resolution.

--- a/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the bundled Buddy starter catalog metadata enforce the neutral-anchor-first animation pipeline contract without claiming final default animation art exists.
 
-**Architecture:** Keep the current Persona Visual pack/runtime contract intact. The first implementation slice only tightens starter catalog recipe metadata, schema validation, documentation, and tests so static talking/reaction sheets remain separate from timed animation outputs. It does not add final art assets, new renderers, or activation behavior.
+**Architecture:** Keep the current Persona Visual pack/runtime contract intact. The first implementation slice only tightens starter catalog recipe metadata, schema validation, documentation, and tests so static talking sheets and static reaction sheets remain separate from timed animation outputs. It does not add final art assets, new renderers, or activation behavior.
 
 **Tech Stack:** Python dataclasses and Pydantic schemas in `tldw_Server_API`, pytest unit tests, existing Persona Visual starter catalog service, existing Markdown docs.
 
@@ -31,8 +31,8 @@ Do not generate final Buddy images in this slice. Do not change runtime renderin
 
 - Modify: `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py`
   - Owns immutable bundled starter catalog fixture definitions and production recipes.
-  - Remove `static_talking_reaction_sheet` from `animation_outputs`.
-  - Keep `static_talking_reaction_sheet` in `expected_asset_groups` where appropriate.
+  - Remove static talking and reaction sheet groups from `animation_outputs`.
+  - Keep `static_talking_sheet` and `static_reaction_sheet` in `expected_asset_groups` where appropriate.
 
 - Modify: `tldw_Server_API/app/core/Persona/visual_starter_catalog.py`
   - Owns service-level starter fixture validation.
@@ -52,7 +52,7 @@ Do not generate final Buddy images in this slice. Do not change runtime renderin
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py`
   - Owns focused starter catalog fixture/service validation.
   - Add tests for the pipeline taxonomy and static/animation separation.
-  - Update existing expectations that currently treat `static_talking_reaction_sheet` as an animation output.
+  - Update existing expectations that currently treat static talking sheets and static reaction sheets as animation outputs.
 
 - Modify: `tldw_Server_API/tests/Persona/test_persona_visuals_api.py`
   - Owns API-level starter catalog and generation enqueue coverage.
@@ -74,7 +74,7 @@ Do not generate final Buddy images in this slice. Do not change runtime renderin
 
 - Modify: `Docs/Code_Documentation/Persona_Visual_Packs.md`
   - Owns durable technical documentation for Persona/Buddy visual packs.
-  - Clarify that static talking/reaction sheets are expected asset groups and source material, not timed animation outputs.
+  - Clarify that static talking sheets and static reaction sheets are expected asset groups and source material, not timed animation outputs.
 
 - Modify: implementation Backlog task for this slice.
   - Use `TASK-411` if present: `backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md`.
@@ -134,7 +134,7 @@ Add this test to prove intermediate/intricate starters still ask for static sour
         "elaborate-persona-intricate",
     ),
 )
-def test_static_talking_sheet_is_source_material_not_animation_output(
+def test_static_talking_and_reaction_sheets_are_source_material_not_animation_output(
     db_instance: CharactersRAGDB,
     starter_pack_id: str,
 ) -> None:
@@ -142,12 +142,11 @@ def test_static_talking_sheet_is_source_material_not_animation_output(
 
     detail = service.get_starter_pack(starter_pack_id)
 
-    assert "static_talking_reaction_sheet" in detail["expected_asset_groups"]
+    assert "static_talking_sheet" in detail["expected_asset_groups"]
+    assert "static_reaction_sheet" in detail["expected_asset_groups"]
     assert "static" in detail["production_recipe"]["static_sheet"].lower()
-    assert (
-        "static_talking_reaction_sheet"
-        not in detail["production_recipe"]["animation_outputs"]
-    )
+    assert "static_talking_sheet" not in detail["production_recipe"]["animation_outputs"]
+    assert "static_reaction_sheet" not in detail["production_recipe"]["animation_outputs"]
 ```
 
 - [ ] **Step 2: Run tests and verify they fail**
@@ -161,7 +160,7 @@ Run:
   -v
 ```
 
-Expected: fail because the taxonomy module/constants do not exist and the current recipes include `static_talking_reaction_sheet` in some `animation_outputs`.
+Expected: fail because the taxonomy module/constants do not exist and the current recipes include static talking or reaction sheet groups in some `animation_outputs`.
 
 - [ ] **Step 3: Add the shared taxonomy module**
 
@@ -181,7 +180,8 @@ BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS = frozenset(
         "neutral_anchor",
         "preview_image",
         "model_sheet",
-        "static_talking_reaction_sheet",
+        "static_talking_sheet",
+        "static_reaction_sheet",
         "required_state_loops",
         "animation_strips",
         "animation_atlas",
@@ -194,7 +194,8 @@ BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS = frozenset(
         "neutral_anchor",
         "preview_image",
         "model_sheet",
-        "static_talking_reaction_sheet",
+        "static_talking_sheet",
+        "static_reaction_sheet",
     }
 )
 BUDDY_VISUAL_ANIMATION_OUTPUT_IDS = frozenset(
@@ -231,7 +232,7 @@ Expected: constants import, but the static-sheet separation test still fails unt
 
 - [ ] **Step 1: Update recipe outputs in fixtures**
 
-In `_multi_asset_pack()`, change `animation_outputs` so it no longer includes `static_talking_reaction_sheet`:
+In `_multi_asset_pack()`, change `animation_outputs` so it no longer includes static talking or reaction sheet groups:
 
 ```python
 animation_outputs=(
@@ -249,7 +250,7 @@ animation_outputs=(
 ),
 ```
 
-In `_atlas_pack()`, remove `static_talking_reaction_sheet` from `animation_outputs`:
+In `_atlas_pack()`, remove static talking or reaction sheet groups from `animation_outputs`:
 
 ```python
 animation_outputs=(
@@ -260,7 +261,7 @@ animation_outputs=(
 ),
 ```
 
-Do not remove `static_talking_reaction_sheet` from `_INTERMEDIATE_EXPECTED_ASSET_GROUPS` or `_INTRICATE_EXPECTED_ASSET_GROUPS`.
+Do not remove `static_talking_sheet` or `static_reaction_sheet` from `_INTERMEDIATE_EXPECTED_ASSET_GROUPS` or `_INTRICATE_EXPECTED_ASSET_GROUPS`.
 Add `required_state_loops` to `_INTRICATE_EXPECTED_ASSET_GROUPS` so every
 recipe `animation_outputs` value is also declared as an expected asset group.
 
@@ -278,7 +279,7 @@ Use this parametrization:
         (
             "study-desk-intermediate",
             "intermediate",
-            "static_talking_reaction_sheet",
+            "static_talking_sheet",
             "required_state_loops",
         ),
         ("lofi-study-intricate", "intricate", "animation_atlas", "animation_atlas"),
@@ -337,7 +338,7 @@ def test_list_starter_packs_rejects_static_source_animation_outputs(
             identity_brief="Identity",
             neutral_anchor="Neutral anchor",
             static_sheet="Static sheet",
-            animation_outputs=("static_talking_reaction_sheet",),
+            animation_outputs=("static_talking_sheet",),
         ),
     )
     service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
@@ -381,7 +382,8 @@ Add a test near `test_production_recipe_response_enforces_catalog_bounds`:
 @pytest.mark.parametrize(
     "animation_outputs",
     (
-        ["static_talking_reaction_sheet"],
+        ["static_talking_sheet"],
+        ["static_reaction_sheet"],
         ["identity_brief"],
         ["neutral_anchor"],
         ["model_sheet"],
@@ -594,14 +596,14 @@ git commit -m "fix: bound buddy starter recipe animation outputs"
 Run:
 
 ```bash
-rg -n '"static_sheet"|"static_talking_reaction_sheet"|recipe_output' \
+rg -n '"static_sheet"|"static_talking_sheet"|"static_reaction_sheet"|recipe_output' \
   tldw_Server_API/tests/Persona/test_persona_visuals_api.py \
   tldw_Server_API/tests/Persona/test_persona_visual_jobs.py \
   tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py \
   tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
 ```
 
-Expected: identify any test fixtures that use `recipe_output: "static_sheet"` or expect `static_talking_reaction_sheet` as an animation output.
+Expected: identify any test fixtures that use `recipe_output: "static_sheet"` or expect static talking sheets or static reaction sheets as animation outputs.
 
 - [ ] **Step 2: Update invalid job/API fixtures**
 
@@ -612,9 +614,11 @@ If a test intentionally validates invalid recipe output handling, prefer `not_a_
 For any API assertion that verifies static sheet availability, assert it through:
 
 ```python
-assert "static_talking_reaction_sheet" in starter["expected_asset_groups"]
+assert "static_talking_sheet" in starter["expected_asset_groups"]
+assert "static_reaction_sheet" in starter["expected_asset_groups"]
 assert "static" in starter["production_recipe"]["static_sheet"].lower()
-assert "static_talking_reaction_sheet" not in starter["production_recipe"]["animation_outputs"]
+assert "static_talking_sheet" not in starter["production_recipe"]["animation_outputs"]
+assert "static_reaction_sheet" not in starter["production_recipe"]["animation_outputs"]
 ```
 
 - [ ] **Step 3: Run focused API/job tests**
@@ -655,9 +659,9 @@ git commit -m "test: align buddy recipe output consumers"
 
 In the "Bundled Starter Catalog Scaffolds" section, update the production recipe explanation to state:
 
-- `expected_asset_groups` may include source groups such as `static_talking_reaction_sheet`.
+- `expected_asset_groups` may include source groups such as `static_talking_sheet` and `static_reaction_sheet`.
 - `production_recipe.animation_outputs` only names timed runtime outputs.
-- Static talking/reaction sheets become animation only when cells are explicitly mapped into manifest `animations` frames.
+- Static talking sheets and static reaction sheets become animation only when cells are explicitly mapped into manifest `animations` frames.
 
 Keep wording explicit that current PNGs are scaffolds and not final animation packs.
 
@@ -666,7 +670,7 @@ Keep wording explicit that current PNGs are scaffolds and not final animation pa
 Run:
 
 ```bash
-rg -n "Persona_Visual_Packs|Bundled Starter Catalog|static_talking_reaction_sheet" tldw_Server_API/tests Docs
+rg -n "Persona_Visual_Packs|Bundled Starter Catalog|static_talking_sheet|static_reaction_sheet" tldw_Server_API/tests Docs
 ```
 
 If there is no existing docs test for this exact file, do not add a new broad docs-test harness in this slice. The source and API tests are enough.
@@ -789,7 +793,7 @@ path instead and note the fallback in the commit summary.
 
 This slice is complete when:
 
-- `static_talking_reaction_sheet` is present only as source/expected asset metadata, not as a recipe animation output.
+- `static_talking_sheet` and `static_reaction_sheet` are present only as source/expected asset metadata, not as recipe animation outputs.
 - catalog service validation and API schema validation reject static/source
   groups in `animation_outputs`.
 - starter catalog/API/job tests pass.

--- a/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
@@ -1,0 +1,512 @@
+# Buddy Animation Pipeline Design
+
+Date: 2026-05-16
+Status: Draft for review
+Backlog: TASK-410
+GitHub: https://github.com/rmusser01/tldw_server/issues/1787
+Parent epic: https://github.com/rmusser01/tldw_server/issues/1510
+
+## Summary
+
+This design defines the Buddy animation pipeline for Persona Visual Packs. It is
+scoped to the floating Persona Buddy and live Persona assistant surface, not VN
+assets or Persona backend management work.
+
+The key decision is to make final Buddy art a neutral-pose-first production
+workflow:
+
+1. establish one approved neutral identity anchor for a Buddy,
+2. optionally produce a static talking/reaction sheet from that anchor,
+3. generate timed animation strips or atlas regions from the same anchor,
+4. review generated candidates,
+5. import or copy the result into an inactive Persona Visual draft pack,
+6. activate only after explicit user review.
+
+The current starter catalog already contains nine scaffold IDs and the runtime
+already supports bounded custom visual states through `state_catalog` and
+`authored_triggers`. This spec turns those scaffolds into a production-ready
+asset pipeline without claiming that finished default animation packs already
+exist.
+
+## Current Foundations
+
+The current implementation already provides the foundations this pipeline should
+reuse:
+
+- `Docs/Code_Documentation/Persona_Visual_Packs.md` documents user-owned,
+  persona-attached, manifest-backed packs, explicit activation, import/export,
+  generated-candidate review, personal library reuse, and the nine starter
+  scaffold IDs.
+- `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py` defines the
+  nine immutable starter scaffolds, production recipe metadata, complexity
+  tiers, expected asset groups, and current scaffold status.
+- `tldw_Server_API/app/core/Persona/visuals.py` validates sprite-frame manifests,
+  frame timing, atlas regions, required states, custom state catalog entries,
+  authored triggers, fallbacks, and bounds such as 256 custom states and 512
+  triggers.
+- `apps/packages/ui/src/types/persona-visuals.ts` defines the shared frontend
+  manifest shape, including `state_catalog`, `authored_triggers`, custom state
+  IDs, and renderer capability metadata.
+- `apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts`
+  resolves live voice state, tool status, exact `tool_name` triggers, MCP
+  runtime reasons, and authored triggers before falling back to built-in states.
+- `SpriteFrameRenderer` and `BuddyShellHost` already render active sprite-frame
+  packs with fail-soft diagnostics instead of blocking Persona Live.
+
+The correct implementation path is therefore extension and hardening of this
+existing stack, not a new avatar runtime.
+
+## Goals
+
+1. Define the final-art production workflow for nine bundled default Buddies.
+2. Preserve the existing Persona Visual pack contract and explicit activation
+   model.
+3. Adapt the Puzzle Attack art pipeline pattern to Buddy assets: manifest-driven
+   production, neutral/model-sheet anchoring, generated strips, compilation,
+   review, and deterministic runtime export.
+4. Support simple and complex user-created Buddies without forcing every user
+   through an intricate art workflow.
+5. Support many custom states and per-tool animation variants while keeping IDs,
+   labels, triggers, and fallback chains bounded and safe.
+6. Keep static talking/reaction sheets distinct from timed animation frames.
+
+## Non-Goals
+
+1. Do not build a VN/CYOA asset workflow.
+2. Do not add executable visual plugins, arbitrary JavaScript, or untrusted
+   runtime renderer code.
+3. Do not treat the current scaffold PNG fixtures as final art.
+4. Do not activate generated, imported, or copied packs automatically.
+5. Do not require Live2D, Rive, Lottie, Spine, or another non-sprite renderer
+   for the first production Buddy pipeline.
+6. Do not use raw prompts, secrets, host-local paths, or provider payloads as
+   durable user-facing provenance.
+
+## Nine Default Buddies
+
+The bundled defaults are organized as three complexity tiers. The existing
+starter IDs stay stable; final art replaces scaffold assets behind those
+contracts.
+
+| Tier | Starter ID | Design intent | Production target |
+| --- | --- | --- | --- |
+| Basic | `research-buddy-basic` | Clean assistant mascot based on the original Buddy mockup direction. | One strong neutral anchor plus required-state loops. |
+| Basic | `migu-marker-basic` | Rough marker-line user-art feel inspired by the supplied Migu image. | Preserve hand-drawn charm; simple mouth and reaction changes. |
+| Basic | `minimal-helper-basic` | Geometric low-complexity helper. | Fast user-customizable baseline with few moving parts. |
+| Intermediate | `study-desk-intermediate` | Calm study companion in the Puzzle Attack clean anime/game-sprite style. | Neutral anchor, static talking sheet, separate required-state loops. |
+| Intermediate | `tool-helper-intermediate` | Utility-themed helper with exact tool variant support. | Required states plus at least one exact `tool_name` animation variant. |
+| Intermediate | `object-creature-intermediate` | Non-human expressive object companion. | Proves the format is not humanoid-only. |
+| Intricate | `lofi-study-intricate` | Original lofi-study companion, not a copyrighted character clone. | Full model sheet, talking/reaction sheet, atlas-backed loops, tool variants. |
+| Intricate | `action-guide-intricate` | High-motion guide with anticipation and success beats. | Rich reaction states and more expressive motion arcs. |
+| Intricate | `elaborate-persona-intricate` | High-detail fantasy/sci-fi assistant. | Multiple custom-state rows, atlas/strip compilation, richer review gates. |
+
+The lofi default must capture the broad product direction of a calm study
+companion in the same clean, readable game-art language as Puzzle Attack. It
+must not copy a protected character identity. The Migu default should preserve
+the user-art spirit of the reference image: playful proportions, visible marker
+quality, cyan twin-tail silhouette, and deliberately simple expression language.
+
+## Complexity Tiers
+
+### Basic
+
+Basic Buddies optimize for quick creation and low art burden. A user should be
+able to create a usable Buddy from one neutral pose plus a small number of
+derived loops.
+
+Required production assets:
+
+- identity brief
+- neutral anchor
+- preview image
+- required-state loops for `idle`, `listening`, `thinking`, `speaking`, and
+  `error`
+
+Optional assets:
+
+- tiny static mouth or expression sheet
+- one reaction loop
+
+Basic packs may reuse the same neutral anchor across several states if the
+manifest maps those states clearly and fallbacks remain valid.
+
+### Intermediate
+
+Intermediate Buddies add more expression without requiring a full atlas
+workflow.
+
+Required production assets:
+
+- identity brief
+- neutral anchor or simple model sheet
+- static talking/reaction sheet
+- separate required-state loops
+- one or more custom-state variants
+
+Intermediate packs should demonstrate at least one authored trigger or custom
+state category, such as `tool.notes_search` or `reaction.success`, with a clear
+fallback chain.
+
+### Intricate
+
+Intricate Buddies demonstrate the high ceiling of the format.
+
+Required production assets:
+
+- identity brief
+- approved neutral model sheet
+- static talking/reaction sheet
+- animation strips or atlas source
+- compiled runtime atlas or frame set
+- multiple custom-state variants
+
+Intricate packs should use the same neutral identity anchor for every generated
+strip. Their review checklist must include identity consistency, silhouette
+stability, frame registration, transparent background, atlas region validity,
+state/trigger alignment, and fallback behavior.
+
+## Neutral-Pose-First Workflow
+
+The production sequence is intentionally linear:
+
+```text
+identity brief
+  -> neutral identity anchor
+  -> optional static talking/reaction sheet
+  -> generated animation strips or atlas frames
+  -> validation and compilation
+  -> human review
+  -> inactive visual-pack draft
+  -> explicit activation
+```
+
+Rules:
+
+1. The neutral anchor is the identity source of truth for all downstream assets.
+2. Do not generate timed animation frames directly from text after the anchor is
+   approved.
+3. Static talking/reaction sheets are still images with semantic cells. They are
+   not animations until manifest `animations` map cells into timed frames.
+4. Animation outputs must be generated from the neutral anchor or a model sheet
+   using image-to-image continuity.
+5. Generated strips can be compiled into atlas-backed `sprite_frames` manifests
+   or separate frame assets.
+6. Review must happen before draft commit or candidate acceptance, and
+   activation remains separate.
+
+This mirrors the useful Puzzle Attack pattern: model-sheet-first production,
+manifest-driven asset IDs, generated strips, compile profiles, release exports,
+and review gates. It avoids the failure mode where a single sheet of expressions
+is mistaken for an animation set.
+
+## Animation Production Contract
+
+Animation generation should use strip-based production because it scales from
+simple to intricate packs.
+
+Recommended source units:
+
+- 4-frame horizontal strips for small loops or previews.
+- 16-frame loop targets for polished states, organized as four 4-frame strips.
+- Atlas compilation for intricate packs when multiple states share one image.
+
+Recommended runtime forms:
+
+- separate `frame` assets for simple packs.
+- one `sprite_sheet` atlas plus frame `region` entries for intricate packs.
+
+Recommended state loop shape:
+
+| State | Intent | Minimum frame behavior |
+| --- | --- | --- |
+| `idle` | neutral resting presence | soft hold, blink, breathing, or subtle body motion |
+| `listening` | attentive input state | lean, eye focus, ear/head cue, or device cue |
+| `thinking` | processing state | small loop with concentration or tool-use read |
+| `speaking` | output state | mouth/expression movement; can reuse static talking cells as timed frames |
+| `error` | recoverable problem | clear but non-alarming fault/retry read |
+| `tool_running` | generic tool work | fallback if no exact tool state exists |
+| `approval_needed` | waits for user decision | paused, expectant, or prompt-facing loop |
+| `wake_armed` | passive listening enabled | subtle readiness cue |
+| `offline` | unavailable/degraded | dimmed or inactive loop |
+
+For short-lived states, the first 3 to 4 frames must communicate the state
+clearly. Puzzle Attack's 16-frame design has the same concern: many runtime
+state durations show only early frames, so key visual meaning must be
+front-loaded.
+
+## Manifest State Catalog Semantics
+
+The current runtime already supports custom states through `state_catalog` and
+`authored_triggers`. The production design should treat this as the state-catalog
+V2 semantics for sprite-frame packs, whether it remains an additive
+`manifest_version: 1` extension or later becomes a wire-level manifest version
+bump.
+
+The compatibility rule is:
+
+- `manifest_version: 1` plus `renderer_type: "sprite_frames"` remains the only
+  activatable V1 Buddy renderer until a deliberate backend capability bump.
+- Custom visual states are declared in `state_catalog`.
+- `states` may map built-in states and declared custom states to animations.
+- `fallbacks` define how custom states degrade to built-in states.
+- `authored_triggers` map runtime signals to built-in or custom states.
+
+If a future implementation introduces `manifest_version: 2` for sprite-frame
+packs, the renderer capability endpoint must advertise both versions during
+migration and all import/export paths must preserve V1 compatibility.
+
+### Bounds
+
+The current backend bounds are acceptable for the first production version:
+
+- up to 256 custom state IDs per pack,
+- up to 512 authored triggers per pack,
+- up to 240 frames per animation,
+- up to 8 fallback-chain depth,
+- trigger duration between 100 and 30,000 ms,
+- state label up to 80 characters,
+- state description up to 280 characters,
+- up to 16 tags per custom state,
+- custom state ID pattern `^[a-z][a-z0-9_.:-]{0,95}$`.
+
+This is not literally unlimited, but it is large enough for a complex user's
+per-tool and per-response variants while staying safe for validation, editor UI,
+runtime lookup, and import/export.
+
+### Recommended Custom State ID Namespaces
+
+Use stable, lowercase namespaces:
+
+- `tool.<tool_id>` for exact tool variants.
+- `tool.<category>.<variant>` for category-level tool families.
+- `reaction.<name>` for short emotional or response beats.
+- `mood.<name>` for longer-lived presentation modes.
+- `live.<name>` for live-session variants beyond built-ins.
+- `pack.<name>` for pack-private states that should not imply global semantics.
+
+Examples:
+
+```json
+{
+  "state_catalog": {
+    "tool.notes_search": {
+      "label": "Searching notes",
+      "kind": "tool_variant",
+      "description": "Shown while the notes search tool runs.",
+      "tags": ["tool", "notes"]
+    },
+    "reaction.success": {
+      "label": "Success",
+      "kind": "reaction",
+      "description": "Short celebratory response after work completes.",
+      "tags": ["reaction"]
+    }
+  },
+  "fallbacks": {
+    "tool.notes_search": ["tool_running", "thinking", "idle"],
+    "reaction.success": ["speaking", "idle"]
+  },
+  "authored_triggers": [
+    {
+      "id": "notes-search-tool",
+      "source": "tool_name",
+      "match": "notes.search",
+      "state": "tool.notes_search",
+      "duration_ms": 2400,
+      "priority": 80
+    }
+  ]
+}
+```
+
+### Trigger Matching
+
+Trigger resolution should keep the current priority order:
+
+1. hard error or recovery state,
+2. approval needed,
+3. unexpired MCP runtime override,
+4. highest-priority matching authored trigger,
+5. generic tool running,
+6. wake armed,
+7. normalized live voice state,
+8. offline,
+9. idle.
+
+Exact `tool_name` triggers must match the structured active tool name, not a
+display string. `tool_category` can use status/category text as a lower-specific
+fallback. MCP runtime triggers should use bounded runtime reasons, not arbitrary
+payloads.
+
+## Asset Creation And Import
+
+Users should have three production paths:
+
+1. Start from a bundled default scaffold and generate or upload final assets.
+2. Upload their own neutral anchor and build a pack from it.
+3. Import a `.tldw-persona-vpack` or external MCP provider proposal into review.
+
+All three paths converge on the same draft and review model:
+
+- create or select a persona-attached draft pack,
+- add assets through bounded raster storage,
+- validate the manifest against available assets and dimensions,
+- show preview diagnostics,
+- activate only when the user explicitly chooses to activate.
+
+Background jobs are the right execution model for generation, compilation, and
+portable import/export because they need progress, retries, review state, and
+user-visible failure diagnostics.
+
+## Review Criteria
+
+A candidate Buddy pack is not production-ready until review confirms:
+
+- the final art matches the neutral identity anchor,
+- the same character/object is present in every frame,
+- transparent background is clean where required,
+- cells are sliceable and frame registration is stable,
+- no static expression sheet is mislabeled as animation,
+- required states resolve,
+- custom states are declared in `state_catalog`,
+- custom states have fallbacks,
+- exact tool variants use structured `tool_name` matches,
+- atlas regions fit inside source image dimensions,
+- first frames of short loops communicate state,
+- provenance is bounded and trace-safe.
+
+## Staged Implementation Plan
+
+### Stage 1: Spec and Tracker
+
+Goal: land this design, link it from the Backlog task, and create or update a
+GitHub issue under the live persona/buddy epic.
+
+Verification:
+
+- markdown link/path review,
+- `git diff --check`,
+- Backlog task records the spec path and non-code validation.
+
+### Stage 2: Catalog Metadata Alignment
+
+Goal: make starter catalog metadata match the final nine-default production
+intent without adding fake animation assets.
+
+Likely changes:
+
+- tighten production recipes for the nine IDs,
+- ensure final-art status stays `scaffold` until assets exist,
+- add doc/API tests proving the catalog is explicit about scaffold status.
+
+Verification:
+
+- focused Persona starter catalog tests,
+- schema validation tests,
+- no runtime activation claims for missing art.
+
+### Stage 3: Pipeline Contract Fixtures
+
+Goal: add small manifest/fixture examples for neutral anchor, static sheet,
+strip, atlas, and compiled runtime manifest outputs.
+
+Likely changes:
+
+- schema fixtures for production packet metadata,
+- import-preview examples,
+- docs for expected file names and state IDs,
+- no generated final art committed unless reviewed assets exist.
+
+Verification:
+
+- manifest validation tests,
+- import preview tests,
+- asset-reference remapping tests.
+
+### Stage 4: Editor UX For Production Packets
+
+Goal: help users create packs through the neutral-anchor-first workflow in
+Persona Garden.
+
+Likely changes:
+
+- visual distinction between neutral anchor, static sheet, generated strips,
+  atlas, and active runtime manifest,
+- starter catalog copy/generation choices,
+- custom-state and exact-tool-variant editing improvements,
+- review warnings when static sheets are not wired as timed animation frames.
+
+Verification:
+
+- focused `VisualPackEditor` tests,
+- Buddy shell render tests,
+- browser screenshot review before calling UI work complete.
+
+### Stage 5: Runtime And MCP Trigger Hardening
+
+Goal: make authored custom states reliable under live tool execution.
+
+Likely changes:
+
+- preserve exact `active_tool_name` propagation,
+- add diagnostics for missing custom-state animations,
+- ensure MCP runtime triggers stay transient and bounded,
+- document external MCP provider handoff for generated animation variants.
+
+Verification:
+
+- `personaVisualState` tests,
+- `BuddyShellHost` tests,
+- MCP module tests for review-first behavior.
+
+### Stage 6: Final Default Art Production
+
+Goal: produce the actual nine default Buddy animation packs.
+
+This is an asset-production effort, not a code-only patch. Each default should
+go through:
+
+1. identity brief,
+2. neutral anchor,
+3. static talking/reaction sheet if applicable,
+4. animation strip/atlas generation,
+5. machine validation,
+6. human visual review,
+7. inactive draft import/copy,
+8. explicit activation test.
+
+Verification:
+
+- visual review artifacts,
+- manifest validation,
+- runtime Buddy screenshot/video checks,
+- catalog status changes from `scaffold` to `art_ready` only for completed
+  defaults.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Static expression sheets are mistaken for animations. | Keep `static_sheet` and `animation_outputs` separate in recipes, docs, UI, and review checks. |
+| Starter scaffolds are treated as final art. | Preserve `production_status: scaffold` and explicit docs until reviewed assets exist. |
+| Custom state IDs become unsafe or unbounded. | Keep current ID regex, unsafe marker checks, and count limits. |
+| Per-tool variants become brittle. | Prefer exact structured `tool_name` matches, with `tool_category` only as fallback. |
+| Generated frames drift from the character identity. | Require neutral-anchor/image-to-image generation and identity consistency review. |
+| Atlas compilation produces partial or out-of-bounds output. | Fail closed when dependencies or regions are invalid. |
+| New pipeline duplicates existing Persona Visual behavior. | Reuse draft packs, generated candidates, import preview, personal library, and explicit activation. |
+
+## Open Decisions
+
+1. Whether to represent this as a wire-level `manifest_version: 2` for
+   `sprite_frames`, or as documented state-catalog V2 semantics within the
+   existing `manifest_version: 1` renderer.
+2. Whether final default art should be committed as bundled assets or shipped as
+   optional downloadable packs.
+3. Whether external MCP providers may submit production packets directly, or
+   only portable archives/generated candidates through the existing review
+   surfaces.
+
+The recommended first implementation target is to keep the current
+`manifest_version: 1` sprite-frame wire format, strengthen the documented
+state-catalog V2 semantics, and delay an actual manifest version bump until a
+non-compatible renderer or archive change requires one.

--- a/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
@@ -16,7 +16,7 @@ The key decision is to make final Buddy art a neutral-pose-first production
 workflow:
 
 1. establish one approved neutral identity anchor for a Buddy,
-2. optionally produce a static talking/reaction sheet from that anchor,
+2. optionally produce separate static talking and reaction sheets from that anchor,
 3. generate timed animation strips or atlas regions from the same anchor,
 4. review generated candidates,
 5. import or copy the result into an inactive Persona Visual draft pack,
@@ -68,7 +68,7 @@ existing stack, not a new avatar runtime.
    through an intricate art workflow.
 5. Support many custom states and per-tool animation variants while keeping IDs,
    labels, triggers, and fallback chains bounded and safe.
-6. Keep static talking/reaction sheets distinct from timed animation frames.
+6. Keep static talking sheets and static reaction sheets distinct from timed animation frames.
 
 ## Non-Goals
 
@@ -96,7 +96,7 @@ contracts.
 | Intermediate | `study-desk-intermediate` | Calm study companion in the Puzzle Attack clean anime/game-sprite style. | Neutral anchor, static talking sheet, separate required-state loops. |
 | Intermediate | `tool-helper-intermediate` | Utility-themed helper with exact tool variant support. | Required states plus at least one exact `tool_name` animation variant. |
 | Intermediate | `object-creature-intermediate` | Non-human expressive object companion. | Proves the format is not humanoid-only. |
-| Intricate | `lofi-study-intricate` | Original lofi-study companion, not a copyrighted character clone. | Full model sheet, talking/reaction sheet, atlas-backed loops, tool variants. |
+| Intricate | `lofi-study-intricate` | Original lofi-study companion, not a copyrighted character clone. | Full model sheet, separate talking and reaction sheets, atlas-backed loops, tool variants. |
 | Intricate | `action-guide-intricate` | High-motion guide with anticipation and success beats. | Rich reaction states and more expressive motion arcs. |
 | Intricate | `elaborate-persona-intricate` | High-detail fantasy/sci-fi assistant. | Multiple custom-state rows, atlas/strip compilation, richer review gates. |
 
@@ -139,7 +139,7 @@ Required production assets:
 
 - identity brief
 - neutral anchor or simple model sheet
-- static talking/reaction sheet
+- static talking and reaction sheets
 - separate required-state loops
 - one or more custom-state variants
 
@@ -155,7 +155,7 @@ Required production assets:
 
 - identity brief
 - approved neutral model sheet
-- static talking/reaction sheet
+- static talking and reaction sheets
 - animation strips or atlas source
 - compiled runtime atlas or frame set
 - multiple custom-state variants
@@ -172,7 +172,7 @@ The production sequence is intentionally linear:
 ```text
 identity brief
   -> neutral identity anchor
-  -> optional static talking/reaction sheet
+  -> optional static talking and reaction sheets
   -> generated animation strips or atlas frames
   -> validation and compilation
   -> human review
@@ -185,7 +185,7 @@ Rules:
 1. The neutral anchor is the identity source of truth for all downstream assets.
 2. Do not generate timed animation frames directly from text after the anchor is
    approved.
-3. Static talking/reaction sheets are still images with semantic cells. They are
+3. Static talking sheets and static reaction sheets are still images with semantic cells. They are
    not animations until manifest `animations` map cells into timed frames.
 4. Animation outputs must be generated from the neutral anchor or a model sheet
    using image-to-image continuity.
@@ -471,7 +471,7 @@ go through:
 
 1. identity brief,
 2. neutral anchor,
-3. static talking/reaction sheet if applicable,
+3. static talking and reaction sheets if applicable,
 4. animation strip/atlas generation,
 5. machine validation,
 6. human visual review,

--- a/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
@@ -237,10 +237,11 @@ front-loaded.
 ## Manifest State Catalog Semantics
 
 The current runtime already supports custom states through `state_catalog` and
-`authored_triggers`. The production design should treat this as the state-catalog
-V2 semantics for sprite-frame packs, whether it remains an additive
-`manifest_version: 1` extension or later becomes a wire-level manifest version
-bump.
+`authored_triggers`. The production design should treat this as the
+state-catalog V2 semantics for sprite-frame packs, but the immediate
+implementation should not bump the wire-level manifest version. In this slice,
+"V2 semantics" means a documented production contract over the existing
+`manifest_version: 1` sprite-frame renderer.
 
 The compatibility rule is:
 
@@ -250,6 +251,8 @@ The compatibility rule is:
 - `states` may map built-in states and declared custom states to animations.
 - `fallbacks` define how custom states degrade to built-in states.
 - `authored_triggers` map runtime signals to built-in or custom states.
+- `custom_state_variants` means timed runtime loops or frame mappings for
+  declared custom states, not static source-sheet cells by themselves.
 
 If a future implementation introduces `manifest_version: 2` for sprite-frame
 packs, the renderer capability endpoint must advertise both versions during

--- a/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
+++ b/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
@@ -1,0 +1,56 @@
+---
+id: TASK-410
+title: Design Persona Buddy default catalog and manifest v2 visual states
+status: In Progress
+labels:
+- persona
+- buddy
+- visual-packs
+- design
+priority: medium
+ordinal: 347
+documentation:
+- Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+modified_files:
+- Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+references:
+- https://github.com/rmusser01/tldw_server/issues/1787
+- https://github.com/rmusser01/tldw_server/issues/1510
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a repo-backed design spec for the Persona Buddy default visual catalog and user-facing asset creation workflow. The design must capture the approved 9-default catalog structure, the neutral-pose-first asset generation pipeline adapted from Puzzle Attack, and a manifest v2 extension for bounded custom state IDs and per-tool animation variants while preserving the existing Persona Visual pack/runtime contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Spec documents 9 bundled default buddies across basic, intermediate, and intricate complexity tiers.
+- [ ] #2 Spec defines the neutral identity anchor workflow and distinguishes static talking/reaction sheets from generated animation frames.
+- [ ] #3 Spec defines manifest v2 custom state catalog semantics, bounds, fallback behavior, trigger matching, and compatibility with existing required states.
+- [ ] #4 Spec outlines staged implementation slices for backend validation, MCP/runtime trigger handling, editor UX, starter catalog fixtures, and verification.
+- [ ] #5 Spec references the current Persona Visual pack contract and Puzzle Attack asset-generation process enough for future implementers to work without prior chat context.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Buddy animation pipeline design spec and GitHub tracker issue #1787 under epic #1510. The spec covers the nine default Buddy catalog tiers, neutral-anchor-first workflow, static sheet versus timed animation separation, state_catalog/authored_triggers custom-state semantics, staged implementation slices, and verification expectations. Validation so far is documentation-focused: git diff --check passed. Bandit is not applicable because this slice only changes Markdown/Backlog tracking.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
+++ b/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
@@ -11,8 +11,10 @@ priority: medium
 ordinal: 347
 documentation:
 - Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+- Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
 modified_files:
 - Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+- Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
 references:
 - https://github.com/rmusser01/tldw_server/issues/1787
 - https://github.com/rmusser01/tldw_server/issues/1510

--- a/backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md
+++ b/backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-411
 title: Separate Buddy static source sheets from animation outputs
-status: In Progress
+status: Done
 labels:
 - persona
 - visual-starter
@@ -41,7 +41,7 @@ Implement the first executable Buddy Animation Pipeline Catalog Metadata unit by
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implementation in progress. Completed committed slices: taxonomy/static sheet separation, recipe metadata bounds at catalog/API boundaries, and recipe-output consumer test alignment. Remaining: final docs/task closeout, full focused pytest, py_compile, Bandit, diff check, and issue #1787 update.
+Implemented the Buddy starter catalog metadata slice for static-sheet versus timed-animation semantics. Added shared taxonomy constants, removed static_talking_reaction_sheet from recipe animation_outputs while retaining it as expected source material, enforced taxonomy at catalog and API response boundaries, aligned API/job/DB provenance tests to use valid timed recipe_output IDs, and updated docs/plan tracking. Verification: focused pytest suite passed with 150 passed, 5 warnings; py_compile passed for touched production modules; Bandit passed with no findings on touched production modules; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md
+++ b/backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md
@@ -8,6 +8,7 @@ labels:
 - tests
 priority: medium
 modified_files:
+- Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
 - Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
 - tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py
 - tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -25,11 +26,16 @@ modified_files:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Implement the first executable Buddy Animation Pipeline Catalog Metadata unit by adding shared starter recipe taxonomy tests/constants and updating fixture recipe animation outputs so static talking reaction sheets remain expected source material, not timed animation outputs.
+Implement the first executable Buddy Animation Pipeline Catalog Metadata unit by adding shared starter recipe taxonomy tests/constants and updating fixture recipe animation outputs so static talking sheets and static reaction sheets remain distinct expected source material, not timed animation outputs.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Shared taxonomy defines expected asset groups, static/source groups, and timed animation output IDs.
+- [x] #2 Static talking sheets and static reaction sheets are distinct source/expected groups and are excluded from `production_recipe.animation_outputs`.
+- [x] #3 Catalog and API schema validation reject unknown expected groups, non-timed animation outputs, and outputs missing from `expected_asset_groups`.
+- [x] #4 API/job/DB provenance tests use valid timed `recipe_output` IDs while retaining `static_sheet` guidance metadata.
+- [x] #5 Documentation and issue tracker record the static-source versus timed-output distinction.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -41,15 +47,15 @@ Implement the first executable Buddy Animation Pipeline Catalog Metadata unit by
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Buddy starter catalog metadata slice for static-sheet versus timed-animation semantics. Added shared taxonomy constants, removed static_talking_reaction_sheet from recipe animation_outputs while retaining it as expected source material, enforced taxonomy at catalog and API response boundaries, aligned API/job/DB provenance tests to use valid timed recipe_output IDs, and updated docs/plan tracking. Verification: focused pytest suite passed with 150 passed, 5 warnings; py_compile passed for touched production modules; Bandit passed with no findings on touched production modules; git diff --check passed.
+Implemented the Buddy starter catalog metadata slice for static-sheet versus timed-animation semantics. Added shared taxonomy constants, kept static_talking_sheet and static_reaction_sheet as distinct source/expected groups while excluding them from recipe animation_outputs, enforced taxonomy and expected-group subset checks at catalog and API response boundaries, aligned API/job/DB provenance tests to use valid timed recipe_output IDs, and updated docs/plan tracking. Verification: focused pytest suite passed with 152 passed, 5 warnings; py_compile passed for touched production modules; Bandit passed with no findings on touched production modules; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md
+++ b/backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md
@@ -1,0 +1,55 @@
+---
+id: TASK-411
+title: Separate Buddy static source sheets from animation outputs
+status: In Progress
+labels:
+- persona
+- visual-starter
+- tests
+priority: medium
+modified_files:
+- Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
+- tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py
+- tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+- tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+- tldw_Server_API/app/api/v1/schemas/persona.py
+- tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+- tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+- tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+- tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py
+- tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+- backlog/tasks/task-411 - Separate-Buddy-static-source-sheets-from-animation-outputs.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first executable Buddy Animation Pipeline Catalog Metadata unit by adding shared starter recipe taxonomy tests/constants and updating fixture recipe animation outputs so static talking reaction sheets remain expected source material, not timed animation outputs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implementation in progress. Completed committed slices: taxonomy/static sheet separation, recipe metadata bounds at catalog/API boundaries, and recipe-output consumer test alignment. Remaining: final docs/task closeout, full focused pytest, py_compile, Bandit, diff check, and issue #1787 update.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from tldw_Server_API.app.core.Persona.visual_renderer_capabilities import (
     PersonaVisualRendererSetupStatus,
@@ -361,6 +361,23 @@ class PersonaVisualStarterPackResponse(BaseModel):
                 f"Invalid: {invalid_group_list}"
             )
         return value
+
+    @model_validator(mode="after")
+    def validate_recipe_outputs_are_expected(self) -> "PersonaVisualStarterPackResponse":
+        expected_groups = set(self.expected_asset_groups)
+        missing_outputs = sorted(
+            output
+            for output in self.production_recipe.animation_outputs
+            if output not in expected_groups
+        )
+        if missing_outputs:
+            missing_output_list = ", ".join(missing_outputs)
+            raise ValueError(
+                "production_recipe.animation_outputs must be declared in "
+                "expected_asset_groups. "
+                f"Missing: {missing_output_list}"
+            )
+        return self
 
 
 class PersonaVisualStarterPackDetailResponse(PersonaVisualStarterPackResponse):

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -315,7 +315,11 @@ class PersonaVisualStarterProductionRecipeResponse(BaseModel):
             output for output in value if output not in BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
         ]
         if invalid_outputs:
-            raise ValueError("animation_outputs must use supported animation output ids")
+            invalid_output_list = ", ".join(sorted(set(invalid_outputs)))
+            raise ValueError(
+                "animation_outputs must use supported animation output ids. "
+                f"Invalid: {invalid_output_list}"
+            )
         return value
 
     @field_validator("review_checks")
@@ -351,7 +355,11 @@ class PersonaVisualStarterPackResponse(BaseModel):
             group for group in value if group not in BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
         ]
         if invalid_groups:
-            raise ValueError("expected_asset_groups must use supported asset group ids")
+            invalid_group_list = ", ".join(sorted(set(invalid_groups)))
+            raise ValueError(
+                "expected_asset_groups must use supported asset group ids. "
+                f"Invalid: {invalid_group_list}"
+            )
         return value
 
 

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -12,6 +12,10 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from tldw_Server_API.app.core.Persona.visual_renderer_capabilities import (
     PersonaVisualRendererSetupStatus,
 )
+from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
+    BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
+    BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
+)
 
 
 PersonaMode = Literal["session_scoped", "persistent_scoped"]
@@ -304,6 +308,16 @@ class PersonaVisualStarterProductionRecipeResponse(BaseModel):
     animation_outputs: PersonaVisualStarterRecipeItems
     review_checks: PersonaVisualStarterRecipeItems
 
+    @field_validator("animation_outputs")
+    @classmethod
+    def validate_animation_outputs(cls, value: list[str]) -> list[str]:
+        invalid_outputs = [
+            output for output in value if output not in BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
+        ]
+        if invalid_outputs:
+            raise ValueError("animation_outputs must use supported animation output ids")
+        return value
+
     @field_validator("review_checks")
     @classmethod
     def validate_review_checks(cls, value: list[str]) -> list[str]:
@@ -329,6 +343,16 @@ class PersonaVisualStarterPackResponse(BaseModel):
     expected_asset_groups: list[str] = Field(default_factory=list)
     animation_coverage_notes: list[str] = Field(default_factory=list)
     production_recipe: PersonaVisualStarterProductionRecipeResponse
+
+    @field_validator("expected_asset_groups")
+    @classmethod
+    def validate_expected_asset_groups(cls, value: list[str]) -> list[str]:
+        invalid_groups = [
+            group for group in value if group not in BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
+        ]
+        if invalid_groups:
+            raise ValueError("expected_asset_groups must use supported asset group ids")
+        return value
 
 
 class PersonaVisualStarterPackDetailResponse(PersonaVisualStarterPackResponse):

--- a/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_catalog.py
@@ -26,6 +26,10 @@ from tldw_Server_API.app.core.Persona.visual_service import (
     PersonaVisualService,
     PersonaVisualServiceError,
 )
+from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
+    BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
+    BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
+)
 from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
     DEFAULT_PERSONA_VISUAL_STARTER_PACK_ID,
     DEFAULT_PERSONA_VISUAL_STARTER_PACKS,
@@ -402,6 +406,21 @@ class PersonaVisualStarterCatalogService:
             field_name="expected_asset_groups",
             starter_id=starter.id,
         )
+        invalid_expected_groups = [
+            group
+            for group in expected_asset_groups
+            if group not in BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
+        ]
+        if invalid_expected_groups:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter expected asset groups must use the shared taxonomy.",
+                details={
+                    "starter_pack_id": starter.id,
+                    "field_name": "expected_asset_groups",
+                    "invalid_groups": invalid_expected_groups,
+                },
+            )
         neutral_anchor_required = PersonaVisualStarterCatalogService._starter_metadata_bool(
             starter.neutral_anchor_required,
             field_name="neutral_anchor_required",
@@ -427,10 +446,25 @@ class PersonaVisualStarterCatalogService:
                 "Bundled starter animation coverage notes are required.",
                 details={"starter_pack_id": starter.id},
             )
-        PersonaVisualStarterCatalogService._starter_production_recipe(
+        production_recipe = PersonaVisualStarterCatalogService._starter_production_recipe(
             starter.production_recipe,
             starter_id=starter.id,
         )
+        invalid_recipe_outputs = [
+            output
+            for output in production_recipe["animation_outputs"]
+            if output not in expected_asset_groups
+        ]
+        if invalid_recipe_outputs:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter recipe outputs must be declared by expected asset groups.",
+                details={
+                    "starter_pack_id": starter.id,
+                    "field_name": "production_recipe.animation_outputs",
+                    "invalid_outputs": invalid_recipe_outputs,
+                },
+            )
 
         asset_keys: set[str] = set()
         for asset in starter.assets:
@@ -585,6 +619,21 @@ class PersonaVisualStarterCatalogService:
             field_name="production_recipe.animation_outputs",
             starter_id=starter_id,
         )
+        invalid_animation_outputs = [
+            output
+            for output in animation_outputs
+            if output not in BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
+        ]
+        if invalid_animation_outputs:
+            raise PersonaVisualStarterCatalogError(
+                "invalid_starter_fixture",
+                "Bundled starter production recipe outputs must be runtime animation ids.",
+                details={
+                    "starter_pack_id": starter_id,
+                    "field_name": "production_recipe.animation_outputs",
+                    "invalid_outputs": invalid_animation_outputs,
+                },
+            )
         review_checks = PersonaVisualStarterCatalogService._starter_recipe_tuple(
             value.review_checks,
             field_name="production_recipe.review_checks",

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -49,6 +49,7 @@ _INTRICATE_EXPECTED_ASSET_GROUPS = (
     "neutral_anchor",
     "model_sheet",
     "static_talking_reaction_sheet",
+    "required_state_loops",
     "animation_strips",
     "animation_atlas",
     "custom_state_variants",

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -429,7 +429,6 @@ def _multi_asset_pack(
             animation_outputs=(
                 (
                     "required_state_loops",
-                    "static_talking_reaction_sheet",
                     "animation_strips",
                     "animation_atlas",
                     "custom_state_variants",
@@ -437,7 +436,6 @@ def _multi_asset_pack(
                 if complexity_tier == "intricate"
                 else (
                     "required_state_loops",
-                    "static_talking_reaction_sheet",
                     "custom_state_variants",
                 )
             ),
@@ -484,12 +482,11 @@ def _atlas_pack(
                 "Author a full neutral model sheet before generating atlas-backed loops."
             ),
             static_sheet=(
-                "Create a separate talking/reaction sheet for expression choices before "
-                "compiling timed atlas regions."
+                "Create a separate static talking/reaction sheet for expression choices "
+                "before compiling timed atlas regions."
             ),
             animation_outputs=(
                 "required_state_loops",
-                "static_talking_reaction_sheet",
                 "animation_strips",
                 "animation_atlas",
                 "custom_state_variants",

--- a/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_fixtures.py
@@ -40,7 +40,8 @@ _BASIC_EXPECTED_ASSET_GROUPS = (
 _INTERMEDIATE_EXPECTED_ASSET_GROUPS = (
     "identity_brief",
     "neutral_anchor",
-    "static_talking_reaction_sheet",
+    "static_talking_sheet",
+    "static_reaction_sheet",
     "required_state_loops",
     "custom_state_variants",
 )
@@ -48,7 +49,8 @@ _INTRICATE_EXPECTED_ASSET_GROUPS = (
     "identity_brief",
     "neutral_anchor",
     "model_sheet",
-    "static_talking_reaction_sheet",
+    "static_talking_sheet",
+    "static_reaction_sheet",
     "required_state_loops",
     "animation_strips",
     "animation_atlas",
@@ -60,7 +62,7 @@ _BASIC_ANIMATION_NOTES = (
 )
 _INTERMEDIATE_ANIMATION_NOTES = (
     "Scaffold fixture only: final intermediate art should add a neutral model "
-    "sheet, talking/reaction sheet, and short custom-state loops.",
+    "sheet, separate talking and reaction sheets, and short custom-state loops.",
 )
 _INTRICATE_ANIMATION_NOTES = (
     "Scaffold fixture only: final intricate art should compile reviewed "
@@ -424,8 +426,8 @@ def _multi_asset_pack(
                 "Author a neutral model sheet or pose set before generating state frames."
             ),
             static_sheet=(
-                "Create a static talking/reaction sheet for mouth, face, and small pose "
-                "changes before compiling timed animation loops."
+                "Create separate static talking and reaction sheets for mouth, face, "
+                "and small pose changes before compiling timed animation loops."
             ),
             animation_outputs=(
                 (
@@ -483,8 +485,8 @@ def _atlas_pack(
                 "Author a full neutral model sheet before generating atlas-backed loops."
             ),
             static_sheet=(
-                "Create a separate static talking/reaction sheet for expression choices "
-                "before compiling timed atlas regions."
+                "Create separate static talking and reaction sheets for expression "
+                "choices before compiling timed atlas regions."
             ),
             animation_outputs=(
                 "required_state_loops",

--- a/tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py
@@ -1,0 +1,43 @@
+"""Shared taxonomy for Persona Visual starter production recipes.
+
+The starter catalog exposes source asset groups and timed runtime animation
+outputs as separate concepts. Keeping the taxonomy in this small module avoids
+drift between immutable fixture validation and public API schema validation.
+"""
+
+BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS = frozenset(
+    {
+        "identity_brief",
+        "neutral_anchor",
+        "preview_image",
+        "model_sheet",
+        "static_talking_reaction_sheet",
+        "required_state_loops",
+        "animation_strips",
+        "animation_atlas",
+        "custom_state_variants",
+    }
+)
+BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS = frozenset(
+    {
+        "identity_brief",
+        "neutral_anchor",
+        "preview_image",
+        "model_sheet",
+        "static_talking_reaction_sheet",
+    }
+)
+BUDDY_VISUAL_ANIMATION_OUTPUT_IDS = frozenset(
+    {
+        "required_state_loops",
+        "animation_strips",
+        "animation_atlas",
+        "custom_state_variants",
+    }
+)
+
+__all__ = [
+    "BUDDY_VISUAL_ANIMATION_OUTPUT_IDS",
+    "BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS",
+    "BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS",
+]

--- a/tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py
+++ b/tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py
@@ -11,7 +11,8 @@ BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS = frozenset(
         "neutral_anchor",
         "preview_image",
         "model_sheet",
-        "static_talking_reaction_sheet",
+        "static_talking_sheet",
+        "static_reaction_sheet",
         "required_state_loops",
         "animation_strips",
         "animation_atlas",
@@ -24,7 +25,8 @@ BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS = frozenset(
         "neutral_anchor",
         "preview_image",
         "model_sheet",
-        "static_talking_reaction_sheet",
+        "static_talking_sheet",
+        "static_reaction_sheet",
     }
 )
 BUDDY_VISUAL_ANIMATION_OUTPUT_IDS = frozenset(

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
@@ -345,7 +345,7 @@ def test_candidate_generation_provenance_round_trip(db_instance: CharactersRAGDB
             "target_state": "thinking",
             "recipe": {
                 "starter_pack_id": "starter-basic",
-                "recipe_output": "static_sheet",
+                "recipe_output": "required_state_loops",
                 "correlation_id": "corr-1",
                 "identity_brief": "friendly buddy",
                 "neutral_anchor": "api_key=secret\n/Users/macbook-dev/private",
@@ -373,7 +373,7 @@ def test_candidate_generation_provenance_round_trip(db_instance: CharactersRAGDB
     assert provenance["backend"] == "fake provider"
     assert provenance["target_state"] == "thinking"
     assert provenance["recipe"]["starter_pack_id"] == "starter-basic"
-    assert provenance["recipe"]["recipe_output"] == "static_sheet"
+    assert provenance["recipe"]["recipe_output"] == "required_state_loops"
     assert provenance["recipe"]["correlation_id"] == "corr-1"
     assert provenance["recipe"]["identity_brief"] == "friendly buddy"
     assert provenance["recipe"]["neutral_anchor"] == "[redacted]"

--- a/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_jobs.py
@@ -487,7 +487,7 @@ async def test_generation_worker_stores_generated_asset_and_candidate(
                 "request_id": "request-worker-1",
                 "recipe_intent": {
                     "starter_pack_id": "starter-basic",
-                    "recipe_output": "static_sheet",
+                    "recipe_output": "required_state_loops",
                     "correlation_id": "corr-worker-1",
                     "identity_brief": "small helpful buddy",
                     "neutral_anchor": "front-facing neutral pose",
@@ -526,7 +526,7 @@ async def test_generation_worker_stores_generated_asset_and_candidate(
     assert provenance["backend"] == "fake"
     assert provenance["target_state"] == "thinking"
     assert provenance["recipe"]["starter_pack_id"] == "starter-basic"
-    assert provenance["recipe"]["recipe_output"] == "static_sheet"
+    assert provenance["recipe"]["recipe_output"] == "required_state_loops"
     assert provenance["recipe"]["correlation_id"] == "corr-worker-1"
     assert provenance["recipe"]["review_checks"] == [
         "consistent silhouette",

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -10,7 +10,10 @@ import pytest
 from PIL import Image
 from pydantic import ValidationError
 
-from tldw_Server_API.app.api.v1.schemas.persona import PersonaVisualStarterProductionRecipeResponse
+from tldw_Server_API.app.api.v1.schemas.persona import (
+    PersonaVisualStarterPackResponse,
+    PersonaVisualStarterProductionRecipeResponse,
+)
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
@@ -220,6 +223,47 @@ def test_default_starter_production_recipes_use_pipeline_taxonomy(
         assert not (animation_outputs & BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS)
 
 
+def test_list_starter_packs_rejects_static_source_animation_outputs(
+    db_instance: CharactersRAGDB,
+) -> None:
+    malformed_recipe = replace(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0].production_recipe,
+        animation_outputs=("static_talking_reaction_sheet",),
+    )
+    malformed = replace(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0],
+        production_recipe=malformed_recipe,
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.list_starter_packs()
+
+    assert exc_info.value.code == "invalid_starter_fixture"
+    assert exc_info.value.details["field_name"] == "production_recipe.animation_outputs"
+
+
+def test_list_starter_packs_rejects_recipe_outputs_missing_expected_groups(
+    db_instance: CharactersRAGDB,
+) -> None:
+    malformed_recipe = replace(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0].production_recipe,
+        animation_outputs=("custom_state_variants",),
+    )
+    malformed = replace(
+        DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0],
+        production_recipe=malformed_recipe,
+    )
+    service = PersonaVisualStarterCatalogService(db_instance, starter_packs=(malformed,))
+
+    with pytest.raises(PersonaVisualStarterCatalogError) as exc_info:
+        service.list_starter_packs()
+
+    assert exc_info.value.code == "invalid_starter_fixture"
+    assert exc_info.value.details["field_name"] == "production_recipe.animation_outputs"
+    assert exc_info.value.details["invalid_outputs"] == ["custom_state_variants"]
+
+
 @pytest.mark.parametrize(
     "starter_pack_id",
     (
@@ -317,6 +361,40 @@ def test_production_recipe_response_enforces_catalog_bounds(patch: dict[str, obj
 
     with pytest.raises(ValidationError):
         PersonaVisualStarterProductionRecipeResponse.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "animation_outputs",
+    (
+        ["static_talking_reaction_sheet"],
+        ["identity_brief"],
+        ["neutral_anchor"],
+        ["model_sheet"],
+        ["unknown_output"],
+    ),
+)
+def test_production_recipe_response_rejects_non_animation_outputs(
+    animation_outputs: list[str],
+) -> None:
+    payload = _valid_recipe_payload()
+    payload["animation_outputs"] = animation_outputs
+
+    with pytest.raises(ValidationError):
+        PersonaVisualStarterProductionRecipeResponse.model_validate(payload)
+
+
+def test_starter_pack_response_rejects_unknown_expected_asset_groups() -> None:
+    with pytest.raises(ValidationError):
+        PersonaVisualStarterPackResponse.model_validate(
+            {
+                "id": "starter",
+                "title": "Starter",
+                "description": "Starter fixture",
+                "renderer_type": "sprite_frames",
+                "expected_asset_groups": ["neutral_anchor", "unknown_group"],
+                "production_recipe": _valid_recipe_payload(),
+            }
+        )
 
 
 def test_get_starter_pack_accepts_legacy_research_buddy_alias(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -216,6 +216,7 @@ def test_default_starter_production_recipes_use_pipeline_taxonomy(
 
         assert expected_groups <= BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
         assert animation_outputs <= BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
+        assert animation_outputs <= expected_groups
         assert not (animation_outputs & BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS)
 
 

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -180,7 +180,7 @@ def test_get_starter_pack_returns_isolated_manifest_preview(
         (
             "study-desk-intermediate",
             "intermediate",
-            "static_talking_reaction_sheet",
+            "static_talking_sheet",
             "required_state_loops",
         ),
         ("lofi-study-intricate", "intricate", "animation_atlas", "animation_atlas"),
@@ -228,7 +228,7 @@ def test_list_starter_packs_rejects_static_source_animation_outputs(
 ) -> None:
     malformed_recipe = replace(
         DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0].production_recipe,
-        animation_outputs=("static_talking_reaction_sheet",),
+        animation_outputs=("static_talking_sheet",),
     )
     malformed = replace(
         DEFAULT_PERSONA_VISUAL_STARTER_PACKS[0],
@@ -275,7 +275,7 @@ def test_list_starter_packs_rejects_recipe_outputs_missing_expected_groups(
         "elaborate-persona-intricate",
     ),
 )
-def test_static_talking_sheet_is_source_material_not_animation_output(
+def test_static_talking_and_reaction_sheets_are_source_material_not_animation_output(
     db_instance: CharactersRAGDB,
     starter_pack_id: str,
 ) -> None:
@@ -283,12 +283,11 @@ def test_static_talking_sheet_is_source_material_not_animation_output(
 
     detail = service.get_starter_pack(starter_pack_id)
 
-    assert "static_talking_reaction_sheet" in detail["expected_asset_groups"]
+    assert "static_talking_sheet" in detail["expected_asset_groups"]
+    assert "static_reaction_sheet" in detail["expected_asset_groups"]
     assert "static" in detail["production_recipe"]["static_sheet"].lower()
-    assert (
-        "static_talking_reaction_sheet"
-        not in detail["production_recipe"]["animation_outputs"]
-    )
+    assert "static_talking_sheet" not in detail["production_recipe"]["animation_outputs"]
+    assert "static_reaction_sheet" not in detail["production_recipe"]["animation_outputs"]
 
 
 @pytest.mark.parametrize(
@@ -366,7 +365,8 @@ def test_production_recipe_response_enforces_catalog_bounds(patch: dict[str, obj
 @pytest.mark.parametrize(
     "animation_outputs",
     (
-        ["static_talking_reaction_sheet"],
+        ["static_talking_sheet"],
+        ["static_reaction_sheet"],
         ["identity_brief"],
         ["neutral_anchor"],
         ["model_sheet"],
@@ -401,6 +401,25 @@ def test_starter_pack_response_rejects_unknown_expected_asset_groups() -> None:
         )
 
     assert "unknown_group" in str(exc_info.value)
+
+
+def test_starter_pack_response_rejects_recipe_outputs_missing_expected_groups() -> None:
+    payload = {
+        "id": "starter",
+        "title": "Starter",
+        "description": "Starter fixture",
+        "renderer_type": "sprite_frames",
+        "expected_asset_groups": ["neutral_anchor", "required_state_loops"],
+        "production_recipe": {
+            **_valid_recipe_payload(),
+            "animation_outputs": ["required_state_loops", "custom_state_variants"],
+        },
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PersonaVisualStarterPackResponse.model_validate(payload)
+
+    assert "custom_state_variants" in str(exc_info.value)
 
 
 def test_get_starter_pack_accepts_legacy_research_buddy_alias(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -29,6 +29,11 @@ from tldw_Server_API.app.core.Persona.visual_starter_fixtures import (
     PersonaVisualStarterPack,
     PersonaVisualStarterProductionRecipe,
 )
+from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
+    BUDDY_VISUAL_ANIMATION_OUTPUT_IDS,
+    BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
+    BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -166,11 +171,16 @@ def test_get_starter_pack_returns_isolated_manifest_preview(
 
 
 @pytest.mark.parametrize(
-    ("starter_pack_id", "complexity_tier", "required_group"),
+    ("starter_pack_id", "complexity_tier", "required_group", "expected_output"),
     (
-        ("research-buddy-basic", "basic", "required_state_loops"),
-        ("study-desk-intermediate", "intermediate", "static_talking_reaction_sheet"),
-        ("lofi-study-intricate", "intricate", "animation_atlas"),
+        ("research-buddy-basic", "basic", "required_state_loops", "required_state_loops"),
+        (
+            "study-desk-intermediate",
+            "intermediate",
+            "static_talking_reaction_sheet",
+            "required_state_loops",
+        ),
+        ("lofi-study-intricate", "intricate", "animation_atlas", "animation_atlas"),
     ),
 )
 def test_starter_pack_reports_production_readiness_metadata(
@@ -178,6 +188,7 @@ def test_starter_pack_reports_production_readiness_metadata(
     starter_pack_id: str,
     complexity_tier: str,
     required_group: str,
+    expected_output: str,
 ) -> None:
     service = PersonaVisualStarterCatalogService(db_instance)
 
@@ -188,7 +199,51 @@ def test_starter_pack_reports_production_readiness_metadata(
     assert detail["neutral_anchor_required"] is True
     assert required_group in detail["expected_asset_groups"]
     assert all("scaffold" in note.lower() for note in detail["animation_coverage_notes"])
-    _assert_recipe_shape(detail["production_recipe"], expected_output=required_group)
+    _assert_recipe_shape(detail["production_recipe"], expected_output=expected_output)
+
+
+def test_default_starter_production_recipes_use_pipeline_taxonomy(
+    db_instance: CharactersRAGDB,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    for detail in (
+        service.get_starter_pack(starter_id)
+        for starter_id in DEFAULT_PERSONA_VISUAL_STARTER_PACK_IDS
+    ):
+        expected_groups = set(detail["expected_asset_groups"])
+        animation_outputs = set(detail["production_recipe"]["animation_outputs"])
+
+        assert expected_groups <= BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS
+        assert animation_outputs <= BUDDY_VISUAL_ANIMATION_OUTPUT_IDS
+        assert not (animation_outputs & BUDDY_VISUAL_STATIC_SOURCE_ASSET_GROUP_IDS)
+
+
+@pytest.mark.parametrize(
+    "starter_pack_id",
+    (
+        "study-desk-intermediate",
+        "tool-helper-intermediate",
+        "object-creature-intermediate",
+        "lofi-study-intricate",
+        "action-guide-intricate",
+        "elaborate-persona-intricate",
+    ),
+)
+def test_static_talking_sheet_is_source_material_not_animation_output(
+    db_instance: CharactersRAGDB,
+    starter_pack_id: str,
+) -> None:
+    service = PersonaVisualStarterCatalogService(db_instance)
+
+    detail = service.get_starter_pack(starter_pack_id)
+
+    assert "static_talking_reaction_sheet" in detail["expected_asset_groups"]
+    assert "static" in detail["production_recipe"]["static_sheet"].lower()
+    assert (
+        "static_talking_reaction_sheet"
+        not in detail["production_recipe"]["animation_outputs"]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py
@@ -379,12 +379,16 @@ def test_production_recipe_response_rejects_non_animation_outputs(
     payload = _valid_recipe_payload()
     payload["animation_outputs"] = animation_outputs
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         PersonaVisualStarterProductionRecipeResponse.model_validate(payload)
+
+    error_message = str(exc_info.value)
+    for animation_output in animation_outputs:
+        assert animation_output in error_message
 
 
 def test_starter_pack_response_rejects_unknown_expected_asset_groups() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         PersonaVisualStarterPackResponse.model_validate(
             {
                 "id": "starter",
@@ -395,6 +399,8 @@ def test_starter_pack_response_rejects_unknown_expected_asset_groups() -> None:
                 "production_recipe": _valid_recipe_payload(),
             }
         )
+
+    assert "unknown_group" in str(exc_info.value)
 
 
 def test_get_starter_pack_accepts_legacy_research_buddy_alias(

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -210,6 +210,24 @@ def test_get_persona_visual_starter_pack_detail(persona_db: CharactersRAGDB) -> 
     assert payload["assets"][0]["mime_type"] == "image/png"
 
 
+def test_get_persona_visual_starter_pack_detail_exposes_static_sheet_source_group(
+    persona_db: CharactersRAGDB,
+) -> None:
+    with _client_for_user(1, persona_db) as client:
+        response = client.get(
+            "/api/v1/persona/visual-starter-packs/study-desk-intermediate"
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "static_talking_reaction_sheet" in payload["expected_asset_groups"]
+    assert "static" in payload["production_recipe"]["static_sheet"].lower()
+    assert (
+        "static_talking_reaction_sheet"
+        not in payload["production_recipe"]["animation_outputs"]
+    )
+
+
 def _upload_png(client: TestClient, persona_id: str, pack_id: str) -> dict:
     response = client.post(
         f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack_id}/assets",
@@ -392,6 +410,20 @@ def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
     assert "neutral_anchor" in starter["expected_asset_groups"]
     assert starter["production_recipe"]["identity_brief"]
     assert "required_state_loops" in starter["production_recipe"]["animation_outputs"]
+    static_sheet_starter = next(
+        item
+        for item in payload["starter_packs"]
+        if item["id"] == "study-desk-intermediate"
+    )
+    assert (
+        "static_talking_reaction_sheet"
+        in static_sheet_starter["expected_asset_groups"]
+    )
+    assert "static" in static_sheet_starter["production_recipe"]["static_sheet"].lower()
+    assert (
+        "static_talking_reaction_sheet"
+        not in static_sheet_starter["production_recipe"]["animation_outputs"]
+    )
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(
         set(starter["states_offered"])
     )

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -220,12 +220,11 @@ def test_get_persona_visual_starter_pack_detail_exposes_static_sheet_source_grou
 
     assert response.status_code == 200
     payload = response.json()
-    assert "static_talking_reaction_sheet" in payload["expected_asset_groups"]
+    assert "static_talking_sheet" in payload["expected_asset_groups"]
+    assert "static_reaction_sheet" in payload["expected_asset_groups"]
     assert "static" in payload["production_recipe"]["static_sheet"].lower()
-    assert (
-        "static_talking_reaction_sheet"
-        not in payload["production_recipe"]["animation_outputs"]
-    )
+    assert "static_talking_sheet" not in payload["production_recipe"]["animation_outputs"]
+    assert "static_reaction_sheet" not in payload["production_recipe"]["animation_outputs"]
 
 
 def _upload_png(client: TestClient, persona_id: str, pack_id: str) -> dict:
@@ -415,13 +414,15 @@ def test_list_persona_visual_starter_packs(persona_db: CharactersRAGDB) -> None:
         for item in payload["starter_packs"]
         if item["id"] == "study-desk-intermediate"
     )
-    assert (
-        "static_talking_reaction_sheet"
-        in static_sheet_starter["expected_asset_groups"]
-    )
+    assert "static_talking_sheet" in static_sheet_starter["expected_asset_groups"]
+    assert "static_reaction_sheet" in static_sheet_starter["expected_asset_groups"]
     assert "static" in static_sheet_starter["production_recipe"]["static_sheet"].lower()
     assert (
-        "static_talking_reaction_sheet"
+        "static_talking_sheet"
+        not in static_sheet_starter["production_recipe"]["animation_outputs"]
+    )
+    assert (
+        "static_reaction_sheet"
         not in static_sheet_starter["production_recipe"]["animation_outputs"]
     )
     assert {"idle", "listening", "thinking", "speaking", "error"}.issubset(


### PR DESCRIPTION
## Summary
- Add a shared Buddy starter recipe taxonomy for expected asset groups, static/source groups, and timed animation output IDs.
- Keep `static_talking_reaction_sheet` as source material while removing it from `production_recipe.animation_outputs`.
- Enforce catalog/API schema bounds for expected groups and recipe outputs, and align API/job/provenance tests.
- Update Persona Visual Pack docs, the implementation plan, TASK-411, and issue #1787 tracking.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_visual_jobs.py tldw_Server_API/tests/Persona/test_persona_visual_candidate_provenance.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py -v` (`150 passed, 5 warnings`)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/api/v1/schemas/persona.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_starter_recipe_taxonomy.py tldw_Server_API/app/core/Persona/visual_starter_catalog.py tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_buddy_animation_catalog_metadata_rebased.json` (no findings)
- [x] `git diff --check`

## Change summary
Human-owned merge gate: maintainer to fill in before marking this PR ready for review/merge.

## Tracking
Refs #1787 and #1510.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates static talking and reaction sheets from timed animation outputs and enforces a shared Buddy starter recipe taxonomy across fixtures, the catalog service, and API schemas. Adds stricter validation with clearer error details; no runtime behavior changes.

- **New Features**
  - Added shared taxonomy for expected groups, static/source groups, and timed animation outputs.
  - Validated `production_recipe.animation_outputs` to allow only timed outputs and require they are declared in `expected_asset_groups`.
  - Validated `expected_asset_groups` against the taxonomy.
  - Updated docs to state static talking/reaction sheets are source material, not animation outputs.

- **Refactors**
  - Split `static_talking_reaction_sheet` into `static_talking_sheet` and `static_reaction_sheet`; removed both from `animation_outputs` while keeping them in `expected_asset_groups`.
  - Aligned fixtures, catalog service, API schemas, and API/job/DB tests to use valid timed outputs (e.g., `required_state_loops`) and surface invalid IDs in errors.
  - Added plan/spec documents for the Buddy animation pipeline.

<sup>Written for commit bc0d62f6a684c025f4c93206f4f896cd0e2a56e4. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1790?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

