### PR TITLE
Add Persona Visual provider archive handoff

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -350,6 +350,14 @@ local generation: provider asset handles are intake placeholders until the
 server validates metadata, copies bytes through approved storage paths, and
 assigns real asset ids.
 
+The provider archive handoff helper,
+`build_provider_archive_import_preview_handoff()`, validates a normalized
+portable archive envelope into an MCP resource retrieval descriptor. It is still
+pre-persistence: it does not download MCP resources, create preview rows,
+enqueue import-preview Jobs, write archives, commit imports, or activate packs.
+The existing import-preview job contract remains local-archive-path based after
+a future retrieval adapter materializes the archive.
+
 Provider provenance is metadata only. It must not override user ownership,
 persona scope, activation state, or personal-library source references. The
 server must sanitize provenance before storage and reject secrets, API keys,

--- a/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
+++ b/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
@@ -120,6 +120,14 @@ activation. The helper is review-only: it returns sanitized metadata and
 machine-readable blockers or warnings, but it does not execute providers or
 persist provider output.
 
+Portable archive results then pass through
+`build_provider_archive_import_preview_handoff()`. That handoff validates the
+normalized archive metadata and returns an MCP resource retrieval descriptor for
+the next intake step. It does not create preview rows, write archive files,
+enqueue Jobs, commit imports, or activate packs; a later resource-retrieval
+adapter must materialize a local archive path before using the existing
+import-preview job payload.
+
 ```json
 {
   "contract_version": 1,
@@ -389,13 +397,16 @@ Recommended sequence:
 1. Contract docs and examples: this slice.
 2. Provider discovery/intake adapter: list provider offers and normalize result
    envelopes without persisting assets.
-3. Portable archive intake: retrieve a provider archive resource and enqueue the
-   existing import-preview job.
-4. Generated-candidate intake: retrieve provider assets, validate metadata, and
+3. Portable archive handoff: validate a normalized provider archive descriptor
+   into an MCP resource retrieval request without writing assets or enqueueing
+   Jobs.
+4. Portable archive intake: retrieve a provider archive resource and enqueue the
+   existing import-preview job after a local archive path exists.
+5. Generated-candidate intake: retrieve provider assets, validate metadata, and
    create a reviewed candidate for an existing draft.
-5. Persona Garden provider review UI: show provider offers, diagnostics,
+6. Persona Garden provider review UI: show provider offers, diagnostics,
    provenance, and handoff actions.
-6. Optional Live2D provider fixture only after the Live2D runtime spike has its
+7. Optional Live2D provider fixture only after the Live2D runtime spike has its
    own feature gate and fallback rules.
 
 ## Non-Goals

--- a/backlog/tasks/task-411 - Implement-Persona-Visual-provider-archive-handoff.md
+++ b/backlog/tasks/task-411 - Implement-Persona-Visual-provider-archive-handoff.md
@@ -1,0 +1,71 @@
+---
+id: TASK-411
+title: Implement Persona Visual provider archive handoff
+status: Done
+labels:
+- persona
+- persona-visual
+- mcp
+- backend
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1510
+documentation:
+- Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+modified_files:
+- tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py
+- tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py
+- Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next backend-only Persona Visual external-provider slice: convert a normalized portable_archive provider envelope into the existing import-preview Jobs handoff contract without executing providers, retrieving MCP resources, writing assets, committing imports, activating packs, changing renderer support, adding Persona Garden UI, or touching Buddy animation/VN behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Provider portable_archive envelopes can be validated into a deterministic import-preview handoff request using the existing provider envelope normalizer.
+- [x] #2 The handoff fails closed for blocked/non-eligible envelopes, missing or unsafe mcp_resource_uri, unsupported result types, activation attempts, and missing archive payload metadata.
+- [x] #3 The helper reuses existing Persona Visual import-preview job payload conventions where practical and does not retrieve provider resources, write DB rows/assets, enqueue Jobs directly, commit imports, or activate packs.
+- [x] #4 Focused backend tests cover valid portable archive handoff and fail-closed invalid/blocked cases.
+- [x] #5 Docs or task notes record the boundary and follow-up slices enabled by this handoff.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused RED tests for provider portable-archive handoff construction and fail-closed invalid inputs.
+2. Add a pure provider-envelope helper that validates normalized portable_archive metadata into an MCP resource retrieval descriptor without persistence, Jobs enqueue, archive writes, imports, activation, runtime renderer changes, UI, Buddy animation, or VN behavior.
+3. Update provider contract/code docs and Backlog notes with the handoff boundary and follow-up retrieval slice.
+4. Run focused pytest, py_compile, diff check, and Bandit on touched Python scope.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented `build_provider_archive_import_preview_handoff()` in `provider_envelope.py`. The helper normalizes raw provider output, validates portable_archive MCP resource metadata, returns a deterministic import-preview handoff descriptor, and fails closed with machine-readable blockers. It intentionally does not retrieve MCP resources, create preview rows, write archive files/assets, enqueue Jobs, commit imports, activate packs, change renderer support, add UI, or touch Buddy animation/VN behavior.
+
+RED verification: focused provider-envelope pytest failed on missing `build_provider_archive_import_preview_handoff` import before implementation.
+
+GREEN verification: focused provider-envelope pytest passed with 33 tests; Persona Visual jobs pytest passed with 8 tests; py_compile passed for the touched helper/test; git diff --check passed; Bandit on `provider_envelope.py` wrote `/tmp/bandit_persona_provider_archive_handoff.json` with zero findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the backend-only Persona Visual provider archive handoff helper. Normalized portable_archive provider envelopes now produce a review-only MCP resource retrieval descriptor for a future import-preview retrieval adapter, with fail-closed blockers for invalid result types, activation attempts, missing MCP resource handles, invalid checksums, and unsafe normalized envelopes. Documentation now records that this remains pre-persistence and does not enqueue import-preview Jobs until a local archive path exists.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched Python code or documented non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-411 - Implement-Persona-Visual-provider-archive-handoff.md
+++ b/backlog/tasks/task-411 - Implement-Persona-Visual-provider-archive-handoff.md
@@ -52,6 +52,8 @@ Implemented `build_provider_archive_import_preview_handoff()` in `provider_envel
 RED verification: focused provider-envelope pytest failed on missing `build_provider_archive_import_preview_handoff` import before implementation.
 
 GREEN verification: focused provider-envelope pytest passed with 33 tests; Persona Visual jobs pytest passed with 8 tests; py_compile passed for the touched helper/test; git diff --check passed; Bandit on `provider_envelope.py` wrote `/tmp/bandit_persona_provider_archive_handoff.json` with zero findings.
+
+PR #1792 review follow-up: addressed still-valid CodeRabbit/Gemini/Qodo comments by skipping archive metadata parsing for non-portable_archive handoffs, tightening the SHA-256 regex to lowercase after normalization, removing the redundant commit_eligible branch, replacing the hardcoded test job type with `PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE`, wrapping newly added long test/helper lines, and adding a regression that non-archive handoffs do not get archive_payload_missing blockers. Validation: provider-envelope pytest passed with 34 tests; Persona Visual jobs pytest passed with 8 tests; py_compile passed; git diff --check passed; Bandit wrote `/tmp/bandit_persona_provider_archive_handoff_review.json` with zero findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py
@@ -45,7 +45,7 @@ _SECRET_VALUE_RE = re.compile(
     r"bearer\s+[A-Za-z0-9._-]{8,}|api[_-]?key|secret|token|session[_-]?cookie)",
     re.IGNORECASE,
 )
-_SHA256_RE = re.compile(r"^[a-fA-F0-9]{64}$")
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _UNSAFE_PATH_RE = re.compile(
     r"(^/|^[A-Za-z]:[\\/]|\.\.|~[/\\]|file://|localhost|127\.0\.0\.1|::1)",
     re.IGNORECASE,
@@ -165,7 +165,7 @@ def build_provider_archive_import_preview_handoff(
     """
     normalized = normalize_provider_result_envelope(raw)
     blockers = list(normalized["blockers"])
-    archive = _provider_archive_from_normalized_envelope(normalized, blockers)
+    archive = None
 
     if normalized.get("result_type") != "portable_archive":
         blockers.append(
@@ -174,12 +174,17 @@ def build_provider_archive_import_preview_handoff(
                 "Only portable archive provider output can be handed to import preview.",
             )
         )
-    if not normalized.get("commit_eligible"):
-        archive = None
+    else:
+        archive = _provider_archive_from_normalized_envelope(normalized, blockers)
     if blockers:
         archive = None
 
     normalized_blockers = _dedupe_diagnostics(blockers)
+    safe_target_persona_id = (
+        _safe_text(target_persona_id, max_length=128)
+        if target_persona_id
+        else None
+    )
     return {
         "ready": not normalized_blockers,
         "operation": "import_preview",
@@ -188,7 +193,7 @@ def build_provider_archive_import_preview_handoff(
             "user_id": _safe_text(user_id, max_length=128),
             "preview_id": _safe_text(preview_id, max_length=128),
             "request_id": _safe_text(request_id, max_length=128),
-            "target_persona_id": _safe_text(target_persona_id, max_length=128) if target_persona_id else None,
+            "target_persona_id": safe_target_persona_id,
         },
         "archive": archive,
         "provider": normalized.get("provider"),
@@ -249,9 +254,19 @@ def _provider_archive_from_normalized_envelope(
     media_type = _safe_text(archive.get("media_type"), max_length=120)
 
     if not resource_uri or not resource_uri.startswith(_ALLOWED_URI_SCHEME_PREFIXES):
-        blockers.append(_diagnostic("archive_resource_uri_missing", "Portable archive MCP resource URI is required."))
+        blockers.append(
+            _diagnostic(
+                "archive_resource_uri_missing",
+                "Portable archive MCP resource URI is required.",
+            )
+        )
     if not _SHA256_RE.fullmatch(archive_sha256):
-        blockers.append(_diagnostic("archive_sha256_invalid", "Portable archive SHA-256 checksum is required."))
+        blockers.append(
+            _diagnostic(
+                "archive_sha256_invalid",
+                "Portable archive SHA-256 checksum is required.",
+            )
+        )
     if media_type not in COMPATIBLE_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPES:
         blockers.append(
             _diagnostic(

--- a/tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py
@@ -14,6 +14,8 @@ from collections.abc import Mapping, Sequence
 from itertools import islice
 from typing import Any
 
+from tldw_Server_API.app.core.Persona.visual_jobs import PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE
+
 
 PROVIDER_CONTRACT_VERSION = 1
 CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE = "application/vnd.tldw.persona.visual-pack+zip"
@@ -43,6 +45,7 @@ _SECRET_VALUE_RE = re.compile(
     r"bearer\s+[A-Za-z0-9._-]{8,}|api[_-]?key|secret|token|session[_-]?cookie)",
     re.IGNORECASE,
 )
+_SHA256_RE = re.compile(r"^[a-fA-F0-9]{64}$")
 _UNSAFE_PATH_RE = re.compile(
     r"(^/|^[A-Za-z]:[\\/]|\.\.|~[/\\]|file://|localhost|127\.0\.0\.1|::1)",
     re.IGNORECASE,
@@ -146,6 +149,61 @@ def normalize_provider_result_envelope(raw: Any) -> dict[str, Any]:
     return normalized
 
 
+def build_provider_archive_import_preview_handoff(
+    raw: Any,
+    *,
+    user_id: str,
+    request_id: str,
+    preview_id: str,
+    target_persona_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a review-only MCP resource handoff for portable archive import preview.
+
+    The returned object is intentionally not a Jobs payload: provider archives
+    still need an authenticated MCP resource retrieval step that materializes a
+    local archive path before the existing import-preview worker can run.
+    """
+    normalized = normalize_provider_result_envelope(raw)
+    blockers = list(normalized["blockers"])
+    archive = _provider_archive_from_normalized_envelope(normalized, blockers)
+
+    if normalized.get("result_type") != "portable_archive":
+        blockers.append(
+            _diagnostic(
+                "unsupported_archive_handoff_result_type",
+                "Only portable archive provider output can be handed to import preview.",
+            )
+        )
+    if not normalized.get("commit_eligible"):
+        archive = None
+    if blockers:
+        archive = None
+
+    normalized_blockers = _dedupe_diagnostics(blockers)
+    return {
+        "ready": not normalized_blockers,
+        "operation": "import_preview",
+        "job_type": PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+        "request": {
+            "user_id": _safe_text(user_id, max_length=128),
+            "preview_id": _safe_text(preview_id, max_length=128),
+            "request_id": _safe_text(request_id, max_length=128),
+            "target_persona_id": _safe_text(target_persona_id, max_length=128) if target_persona_id else None,
+        },
+        "archive": archive,
+        "provider": normalized.get("provider"),
+        "pack": normalized.get("pack"),
+        "provenance": normalized.get("provenance"),
+        "diagnostics": {
+            "status": "ready_for_import_preview_handoff" if not normalized_blockers else "blocked",
+            "blockers": normalized_blockers,
+            "warnings": list(normalized.get("warnings") or []),
+        },
+        "blockers": normalized_blockers,
+        "warnings": list(normalized.get("warnings") or []),
+    }
+
+
 def _validate_portable_archive_payload(
     *,
     payload: Any,
@@ -170,6 +228,45 @@ def _validate_portable_archive_payload(
                 "Portable archive media type must be a supported zip payload type.",
             )
         )
+
+
+def _provider_archive_from_normalized_envelope(
+    normalized: Mapping[str, Any],
+    blockers: list[dict[str, str]],
+) -> dict[str, str] | None:
+    """Return safe portable archive source metadata from a normalized envelope."""
+    payload = normalized.get("payload")
+    if not isinstance(payload, Mapping):
+        blockers.append(_diagnostic("archive_payload_missing", "Portable archive payload is required."))
+        return None
+    archive = payload.get("archive")
+    if not isinstance(archive, Mapping):
+        blockers.append(_diagnostic("archive_payload_missing", "Portable archive payload is required."))
+        return None
+
+    resource_uri = _safe_text(archive.get("mcp_resource_uri"), max_length=500)
+    archive_sha256 = _safe_text(archive.get("sha256"), max_length=80).lower()
+    media_type = _safe_text(archive.get("media_type"), max_length=120)
+
+    if not resource_uri or not resource_uri.startswith(_ALLOWED_URI_SCHEME_PREFIXES):
+        blockers.append(_diagnostic("archive_resource_uri_missing", "Portable archive MCP resource URI is required."))
+    if not _SHA256_RE.fullmatch(archive_sha256):
+        blockers.append(_diagnostic("archive_sha256_invalid", "Portable archive SHA-256 checksum is required."))
+    if media_type not in COMPATIBLE_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPES:
+        blockers.append(
+            _diagnostic(
+                "unsupported_archive_media_type",
+                "Portable archive media type must be a supported zip payload type.",
+            )
+        )
+    if blockers:
+        return None
+    return {
+        "source_type": "mcp_resource",
+        "mcp_resource_uri": resource_uri,
+        "sha256": archive_sha256,
+        "media_type": media_type,
+    }
 
 
 def _normalize_diagnostics(value: Any) -> tuple[dict[str, Any], bool]:

--- a/tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
+from typing import Callable
 
 import pytest
 
+from tldw_Server_API.app.core.Persona.visual_jobs import (
+    PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+)
 from tldw_Server_API.app.core.Persona.visual_portability.provider_envelope import (
     CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
     build_provider_archive_import_preview_handoff,
@@ -355,7 +359,7 @@ def test_build_provider_archive_import_preview_handoff_accepts_valid_portable_ar
 
     assert handoff["ready"] is True
     assert handoff["operation"] == "import_preview"
-    assert handoff["job_type"] == "persona_visual_pack_import_preview"
+    assert handoff["job_type"] == PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE
     assert handoff["request"] == {
         "user_id": "user-1",
         "preview_id": "preview-1",
@@ -368,7 +372,9 @@ def test_build_provider_archive_import_preview_handoff_accepts_valid_portable_ar
             "mcp://local-sprite-pose-maker/resources/"
             "expr-pack-2026-05-13.tldw-persona-vpack"
         ),
-        "sha256": "2f3a6c2c4b0b0c7f9f7ad3e2c0f9f95543e3013d6a45b69822ad0f01f54415be",
+        "sha256": (
+            "2f3a6c2c4b0b0c7f9f7ad3e2c0f9f95543e3013d6a45b69822ad0f01f54415be"
+        ),
         "media_type": CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
     }
     assert handoff["diagnostics"]["blockers"] == []
@@ -376,28 +382,49 @@ def test_build_provider_archive_import_preview_handoff_accepts_valid_portable_ar
     assert "activation_allowed" not in str(handoff["archive"])
 
 
+def _set_provider_result_type_generated_candidate(raw: dict[str, object]) -> None:
+    raw["result_type"] = "generated_candidate"
+
+
+def _allow_provider_activation(raw: dict[str, object]) -> None:
+    raw["activation_allowed"] = True
+
+
+def _remove_provider_archive_resource_uri(raw: dict[str, object]) -> None:
+    payload = raw["payload"]
+    assert isinstance(payload, dict)
+    archive = payload["archive"]
+    assert isinstance(archive, dict)
+    archive.pop("mcp_resource_uri")
+
+
+def _set_invalid_provider_archive_sha(raw: dict[str, object]) -> None:
+    payload = raw["payload"]
+    assert isinstance(payload, dict)
+    archive = payload["archive"]
+    assert isinstance(archive, dict)
+    archive["sha256"] = "not-a-sha"
+
+
 @pytest.mark.parametrize(
     ("mutator", "expected_code"),
     [
-        (lambda raw: raw.update({"result_type": "generated_candidate"}), "unsupported_archive_handoff_result_type"),
-        (lambda raw: raw.update({"activation_allowed": True}), "activation_not_allowed"),
         (
-            lambda raw: raw["payload"]["archive"].pop("mcp_resource_uri"),  # type: ignore[index]
-            "archive_resource_uri_missing",
+            _set_provider_result_type_generated_candidate,
+            "unsupported_archive_handoff_result_type",
         ),
-        (
-            lambda raw: raw["payload"]["archive"].update({"sha256": "not-a-sha"}),  # type: ignore[index]
-            "archive_sha256_invalid",
-        ),
+        (_allow_provider_activation, "activation_not_allowed"),
+        (_remove_provider_archive_resource_uri, "archive_resource_uri_missing"),
+        (_set_invalid_provider_archive_sha, "archive_sha256_invalid"),
     ],
 )
 def test_build_provider_archive_import_preview_handoff_fails_closed_for_invalid_inputs(
-    mutator: object,
+    mutator: Callable[[dict[str, object]], object],
     expected_code: str,
 ) -> None:
     """Return deterministic blockers without enqueueing or materializing provider output."""
     raw = _valid_portable_archive_envelope()
-    mutator(raw)  # type: ignore[operator]
+    mutator(raw)
 
     handoff = build_provider_archive_import_preview_handoff(
         raw,
@@ -408,4 +435,23 @@ def test_build_provider_archive_import_preview_handoff_fails_closed_for_invalid_
 
     assert handoff["ready"] is False
     assert expected_code in _blocker_codes(handoff)
+    assert handoff["archive"] is None
+
+
+def test_provider_archive_handoff_skips_archive_parse_for_non_archives() -> None:
+    """Avoid archive-payload diagnostics for provider result types that are not archives."""
+    raw = _valid_portable_archive_envelope()
+    raw["result_type"] = "generated_candidate"
+    raw["payload"] = None
+
+    handoff = build_provider_archive_import_preview_handoff(
+        raw,
+        user_id="user-1",
+        request_id="request-1",
+        preview_id="preview-1",
+    )
+
+    codes = _blocker_codes(handoff)
+    assert "unsupported_archive_handoff_result_type" in codes
+    assert "archive_payload_missing" not in codes
     assert handoff["archive"] is None

--- a/tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py
@@ -8,6 +8,7 @@ import pytest
 
 from tldw_Server_API.app.core.Persona.visual_portability.provider_envelope import (
     CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
+    build_provider_archive_import_preview_handoff,
     normalize_provider_result_envelope,
 )
 
@@ -340,3 +341,71 @@ def test_normalize_provider_result_envelope_rejects_remote_or_embedded_resource_
     assert normalized["commit_eligible"] is False
     assert "unsafe_provider_metadata" in _blocker_codes(normalized)
     assert resource_uri not in str(normalized)
+
+
+def test_build_provider_archive_import_preview_handoff_accepts_valid_portable_archive() -> None:
+    """Build a review-only MCP resource handoff for a portable archive result."""
+    handoff = build_provider_archive_import_preview_handoff(
+        _valid_portable_archive_envelope(),
+        user_id="user-1",
+        request_id="request-1",
+        preview_id="preview-1",
+        target_persona_id="persona-1",
+    )
+
+    assert handoff["ready"] is True
+    assert handoff["operation"] == "import_preview"
+    assert handoff["job_type"] == "persona_visual_pack_import_preview"
+    assert handoff["request"] == {
+        "user_id": "user-1",
+        "preview_id": "preview-1",
+        "request_id": "request-1",
+        "target_persona_id": "persona-1",
+    }
+    assert handoff["archive"] == {
+        "source_type": "mcp_resource",
+        "mcp_resource_uri": (
+            "mcp://local-sprite-pose-maker/resources/"
+            "expr-pack-2026-05-13.tldw-persona-vpack"
+        ),
+        "sha256": "2f3a6c2c4b0b0c7f9f7ad3e2c0f9f95543e3013d6a45b69822ad0f01f54415be",
+        "media_type": CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
+    }
+    assert handoff["diagnostics"]["blockers"] == []
+    assert "archive_path" not in str(handoff)
+    assert "activation_allowed" not in str(handoff["archive"])
+
+
+@pytest.mark.parametrize(
+    ("mutator", "expected_code"),
+    [
+        (lambda raw: raw.update({"result_type": "generated_candidate"}), "unsupported_archive_handoff_result_type"),
+        (lambda raw: raw.update({"activation_allowed": True}), "activation_not_allowed"),
+        (
+            lambda raw: raw["payload"]["archive"].pop("mcp_resource_uri"),  # type: ignore[index]
+            "archive_resource_uri_missing",
+        ),
+        (
+            lambda raw: raw["payload"]["archive"].update({"sha256": "not-a-sha"}),  # type: ignore[index]
+            "archive_sha256_invalid",
+        ),
+    ],
+)
+def test_build_provider_archive_import_preview_handoff_fails_closed_for_invalid_inputs(
+    mutator: object,
+    expected_code: str,
+) -> None:
+    """Return deterministic blockers without enqueueing or materializing provider output."""
+    raw = _valid_portable_archive_envelope()
+    mutator(raw)  # type: ignore[operator]
+
+    handoff = build_provider_archive_import_preview_handoff(
+        raw,
+        user_id="user-1",
+        request_id="request-1",
+        preview_id="preview-1",
+    )
+
+    assert handoff["ready"] is False
+    assert expected_code in _blocker_codes(handoff)
+    assert handoff["archive"] is None


### PR DESCRIPTION
## Change summary
TODO: human-owned summary required by the AI-generated PR merge gate.

## What changed
- Added a pure backend Persona Visual helper that converts normalized external-provider `portable_archive` output into a review-only import-preview handoff descriptor.
- Added fail-closed validation for unsupported result types, activation attempts, missing MCP resource handles, invalid archive checksums, and unsafe normalized envelopes.
- Documented that this handoff remains pre-persistence: no MCP retrieval, archive writes, preview rows, Jobs enqueue, import commit, activation, renderer changes, UI, Buddy animation, or VN behavior.

## Validation
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py -q --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_jobs.py -q --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py -f json -o /tmp/bandit_persona_provider_archive_handoff.json`

## Risk & rollback
- Low risk: pure helper plus docs/tests only.
- Rollback by reverting this PR; no schema, persistence, endpoint, worker, runtime, or UI behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend-only helper that converts normalized `portable_archive` provider results into a review-only MCP resource retrieval descriptor for import preview. It doesn’t persist data or enqueue jobs, and it blocks unsafe inputs.

- **New Features**
  - Added `build_provider_archive_import_preview_handoff()` in `tldw_Server_API/app/core/Persona/visual_portability/provider_envelope.py` to produce an MCP resource descriptor (job type `PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE`) for import preview without downloading, writing, enqueuing, or activating.
  - Fail-closed validation for unsupported result types, activation attempts, missing/unsafe `mcp_resource_uri`, invalid `sha256`, unsupported media types, and unsafe envelopes.
  - Updated docs to define the handoff boundary; added focused tests for valid and blocked cases.

- **Bug Fixes**
  - Use `PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE` instead of a hardcoded string, skip archive parsing for non-`portable_archive` results, and tighten SHA-256 validation.

<sup>Written for commit 5de241e4aeaed774362e5179419ccd509552bb70. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1792?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

