### PR TITLE
Expose managed llama.cpp profile metadata

### DIFF
--- a/backlog/tasks/task-397.6 - Implement-llama.cpp-managed-profile-model-metadata.md
+++ b/backlog/tasks/task-397.6 - Implement-llama.cpp-managed-profile-model-metadata.md
@@ -3,8 +3,8 @@ id: TASK-397.6
 title: Implement llama.cpp managed profile model metadata
 status: Done
 assignee: []
-created_date: ''
-updated_date: '2026-05-16 19:44'
+created_date: '2026-05-16 19:34'
+updated_date: '2026-05-16 20:00'
 labels:
   - llamacpp
   - backend
@@ -35,17 +35,13 @@ Implement Task 3 from the llama.cpp model-family/mmproj profile wiring plan: exp
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented Task 3 managed profile metadata for /api/v1/llm/models/metadata. Added a public metadata builder backed by the existing llama.cpp profile capability resolver, appended supervisor-managed profile entries through the existing llm_manager path, preserved existing catalog filters, kept stale asset failures as bounded capability warnings, and documented disabled profiles as visible with is_configured=false.
+Implemented Task 3 managed profile metadata for /api/v1/llm/models/metadata. Added a public metadata builder backed by the existing llama.cpp profile capability resolver, appended supervisor-managed profile entries through the existing llm_manager path, preserved existing catalog filters, kept stale asset failures as bounded capability warnings, and documented disabled profiles as visible with is_configured=false. PR review fixes offloaded managed profile metadata collection from the async endpoint, bounded Local_LLM scan failures, added scan-truncation warnings, and expanded output_modality test coverage.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Managed llama.cpp profiles now appear in /api/v1/llm/models/metadata with profile IDs, aliases, type, capabilities, modalities, and warning metadata. Verification recorded: 24 metadata/provider tests passed, 75 focused llama.cpp backend tests passed, Bandit on touched backend files reported zero findings, and git diff --check was clean.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Managed llama.cpp profiles now appear in /api/v1/llm/models/metadata with profile IDs, aliases, type, capabilities, modalities, and warning metadata. Review fixes addressed async offload, bounded scan errors, scan-limited warnings, request typing, output_modality coverage, and task metadata cleanup. Verification recorded: 15 metadata/provider tests passed, 77 focused llama.cpp backend tests passed, Bandit on touched backend files reported zero findings, and git diff --check was clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-397.6 - Implement-llama.cpp-managed-profile-model-metadata.md
+++ b/backlog/tasks/task-397.6 - Implement-llama.cpp-managed-profile-model-metadata.md
@@ -1,0 +1,59 @@
+---
+id: TASK-397.6
+title: Implement llama.cpp managed profile model metadata
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 19:44'
+labels:
+  - llamacpp
+  - backend
+  - metadata
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md
+parent_task_id: TASK-397
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 3 from the llama.cpp model-family/mmproj profile wiring plan: expose managed llama.cpp profiles through /api/v1/llm/models/metadata with capability and modality metadata while preserving bounded failure behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /api/v1/llm/models/metadata includes managed llama.cpp profile entries with profile IDs, aliases, capability metadata, and modality metadata.
+- [x] #2 Metadata type and input_modality filters include or exclude managed profile entries consistently with existing catalog filtering.
+- [x] #3 Invalid or stale managed profile assets produce bounded warning metadata instead of failing the entire endpoint.
+- [x] #4 Focused metadata/runtime tests, Bandit on touched backend code, and git diff checks are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Task 3 managed profile metadata for /api/v1/llm/models/metadata. Added a public metadata builder backed by the existing llama.cpp profile capability resolver, appended supervisor-managed profile entries through the existing llm_manager path, preserved existing catalog filters, kept stale asset failures as bounded capability warnings, and documented disabled profiles as visible with is_configured=false.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Managed llama.cpp profiles now appear in /api/v1/llm/models/metadata with profile IDs, aliases, type, capabilities, modalities, and warning metadata. Verification recorded: 24 metadata/provider tests passed, 75 focused llama.cpp backend tests passed, Bandit on touched backend files reported zero findings, and git diff --check was clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
@@ -26,6 +26,7 @@ from tldw_Server_API.app.core.http_client import RetryPolicy as _RetryPolicy
 from tldw_Server_API.app.core.http_client import fetch as _http_fetch
 from tldw_Server_API.app.core.Image_Generation.listing import list_image_models_for_catalog
 from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import LLMInferenceLibError
 from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import (
     managed_profile_model_metadata,
 )
@@ -75,6 +76,9 @@ _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS = (
     EgressPolicyError,
     NetworkError,
     RetryExhaustedError,
+)
+_LLAMACPP_METADATA_EXCEPTIONS = _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS + (
+    LLMInferenceLibError,
 )
 
 # ----------------------------------------------------------------------------------
@@ -2050,31 +2054,38 @@ def _managed_llamacpp_profile_metadata_entries(supervisor: Any | None) -> list[d
         return []
     try:
         profiles = supervisor.list_profiles()
-    except _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS:
+    except _LLAMACPP_METADATA_EXCEPTIONS:
         logger.debug("Failed to list managed llama.cpp profiles for model metadata", exc_info=True)
         return []
     if not profiles:
         return []
 
-    asset_scan_warning: str | None = None
+    asset_scan_warnings: list[str] = []
     try:
-        assets = llamacpp_inventory_service.scan_assets().assets
-    except _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS:
+        asset_scan = llamacpp_inventory_service.scan_assets()
+        assets = asset_scan.assets
+        if asset_scan.scan_limited:
+            asset_scan_warnings.append(
+                "Managed llama.cpp asset inventory scan was truncated; capability metadata may be incomplete."
+            )
+    except _LLAMACPP_METADATA_EXCEPTIONS:
         logger.debug("Failed to scan llama.cpp assets for model metadata", exc_info=True)
         assets = []
-        asset_scan_warning = "Managed llama.cpp asset scan failed; capability metadata may be incomplete."
+        asset_scan_warnings.append("Managed llama.cpp asset scan failed; capability metadata may be incomplete.")
 
     entries: list[dict[str, Any]] = []
     for profile in profiles:
         try:
             entry = managed_profile_model_metadata(profile, assets=assets)
-        except _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS:
+        except _LLAMACPP_METADATA_EXCEPTIONS:
             logger.debug("Failed to build managed llama.cpp profile metadata", exc_info=True)
             continue
-        if asset_scan_warning:
+        if asset_scan_warnings:
             warnings = entry.setdefault("capability_warnings", [])
             if isinstance(warnings, list):
-                warnings.append(asset_scan_warning)
+                warnings.extend(asset_scan_warnings)
+            else:
+                entry["capability_warnings"] = list(asset_scan_warnings)
         entries.append(entry)
     return entries
 
@@ -2166,7 +2177,7 @@ async def get_llm_providers(include_deprecated: bool = False):
     ),
     response_model=dict[str, Any])
 async def get_models_metadata(
-    request: Request = None,
+    request: Request,
     include_deprecated: bool = False,
     refresh_openrouter: bool = Query(
         False,
@@ -2217,9 +2228,11 @@ async def get_models_metadata(
                 ):
                     continue
                 flattened.append(entry)
-        for entry in _managed_llamacpp_profile_metadata_entries(
-            _llamacpp_supervisor_from_request(request)
-        ):
+        managed_entries = await asyncio.to_thread(
+            _managed_llamacpp_profile_metadata_entries,
+            _llamacpp_supervisor_from_request(request),
+        )
+        for entry in managed_entries:
             if not _model_matches_filters(
                 entry,
                 type_filters=type_filters,

--- a/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
@@ -7,7 +7,7 @@ from functools import partial
 from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from loguru import logger
 
 import tldw_Server_API.app.core.LLM_Calls.adapter_registry as llm_adapter_registry
@@ -25,6 +25,10 @@ from tldw_Server_API.app.core.exceptions import (
 from tldw_Server_API.app.core.http_client import RetryPolicy as _RetryPolicy
 from tldw_Server_API.app.core.http_client import fetch as _http_fetch
 from tldw_Server_API.app.core.Image_Generation.listing import list_image_models_for_catalog
+from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import (
+    managed_profile_model_metadata,
+)
 from tldw_Server_API.app.core.LLM_Calls.provider_metadata import (
     PROVIDER_CAPABILITIES,
     provider_requires_api_key,
@@ -2039,6 +2043,49 @@ def _model_matches_filters(
         return False
     return not (output_filters and not set(output_mods).intersection(output_filters))
 
+
+def _managed_llamacpp_profile_metadata_entries(supervisor: Any | None) -> list[dict[str, Any]]:
+    """Return bounded model metadata entries for managed llama.cpp profiles."""
+    if supervisor is None:
+        return []
+    try:
+        profiles = supervisor.list_profiles()
+    except _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("Failed to list managed llama.cpp profiles for model metadata", exc_info=True)
+        return []
+    if not profiles:
+        return []
+
+    asset_scan_warning: str | None = None
+    try:
+        assets = llamacpp_inventory_service.scan_assets().assets
+    except _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("Failed to scan llama.cpp assets for model metadata", exc_info=True)
+        assets = []
+        asset_scan_warning = "Managed llama.cpp asset scan failed; capability metadata may be incomplete."
+
+    entries: list[dict[str, Any]] = []
+    for profile in profiles:
+        try:
+            entry = managed_profile_model_metadata(profile, assets=assets)
+        except _LLM_PROVIDERS_NONCRITICAL_EXCEPTIONS:
+            logger.debug("Failed to build managed llama.cpp profile metadata", exc_info=True)
+            continue
+        if asset_scan_warning:
+            warnings = entry.setdefault("capability_warnings", [])
+            if isinstance(warnings, list):
+                warnings.append(asset_scan_warning)
+        entries.append(entry)
+    return entries
+
+
+def _llamacpp_supervisor_from_request(request: Request | None) -> Any | None:
+    """Return the managed llama.cpp supervisor attached to the app, if present."""
+    if request is None:
+        return None
+    manager = getattr(request.app.state, "llm_manager", None)
+    return getattr(manager, "llamacpp_supervisor", None)
+
 #######################################################################################################################
 #
 # Endpoints:
@@ -2119,6 +2166,7 @@ async def get_llm_providers(include_deprecated: bool = False):
     ),
     response_model=dict[str, Any])
 async def get_models_metadata(
+    request: Request = None,
     include_deprecated: bool = False,
     refresh_openrouter: bool = Query(
         False,
@@ -2169,6 +2217,17 @@ async def get_models_metadata(
                 ):
                     continue
                 flattened.append(entry)
+        for entry in _managed_llamacpp_profile_metadata_entries(
+            _llamacpp_supervisor_from_request(request)
+        ):
+            if not _model_matches_filters(
+                entry,
+                type_filters=type_filters,
+                input_filters=input_filters,
+                output_filters=output_filters,
+            ):
+                continue
+            flattened.append(entry)
         # Append image generation backends to the catalog
         try:
             image_models = list_image_models_for_catalog()

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py
@@ -77,6 +77,27 @@ def profile_capability_metadata(
     }
 
 
+def managed_profile_model_metadata(
+    profile: LlamaCppProfile,
+    assets: list[LlamaCppAsset] | None = None,
+) -> dict[str, object]:
+    """Build public model-catalog metadata for one managed llama.cpp profile."""
+    alias = profile.provider_alias or f"llamacpp:{profile.profile_id}"
+    capabilities = profile_capability_metadata(profile, assets=assets)
+    return {
+        "provider": "llama.cpp",
+        "model": alias,
+        "name": profile.name,
+        "type": _type_for_mode(profile.mode),
+        "llamacpp_profile_id": profile.profile_id,
+        "source": "managed_llamacpp_profile",
+        "provider_is_configured": profile.enabled,
+        "is_configured": profile.enabled,
+        "catalog_only": False,
+        **capabilities,
+    }
+
+
 def _resolve_base_model_path(
     profile: LlamaCppProfile,
     assets: list[LlamaCppAsset] | None,
@@ -190,8 +211,20 @@ def _modalities_for_mode(
     return {"input": ["text"], "output": ["text"]}
 
 
+def _type_for_mode(mode: LlamaCppProfileMode) -> str:
+    """Map managed profile modes onto the public model catalog type vocabulary."""
+    if mode in {LlamaCppProfileMode.CHAT, LlamaCppProfileMode.VISION}:
+        return "chat"
+    if mode == LlamaCppProfileMode.EMBEDDING:
+        return "embedding"
+    if mode == LlamaCppProfileMode.RERANK:
+        return "rerank"
+    return "other"
+
+
 __all__ = [
     "LlamaCppResolvedProfileLaunch",
+    "managed_profile_model_metadata",
     "profile_capability_metadata",
     "resolve_profile_launch",
 ]

--- a/tldw_Server_API/tests/LLM_Adapters/unit/test_llm_openrouter_models_refresh.py
+++ b/tldw_Server_API/tests/LLM_Adapters/unit/test_llm_openrouter_models_refresh.py
@@ -51,6 +51,7 @@ def test_llm_models_metadata_refresh_openrouter_includes_live_models(monkeypatch
 
     refreshed = asyncio.run(
         llm_providers.get_models_metadata(
+            request=None,
             refresh_openrouter=True,
             model_type=None,
             input_modality=None,
@@ -63,6 +64,7 @@ def test_llm_models_metadata_refresh_openrouter_includes_live_models(monkeypatch
 
     cached = asyncio.run(
         llm_providers.get_models_metadata(
+            request=None,
             refresh_openrouter=False,
             model_type=None,
             input_modality=None,

--- a/tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_error_mapping.py
+++ b/tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_error_mapping.py
@@ -165,6 +165,7 @@ async def test_get_models_metadata_sanitizes_generic_failure(monkeypatch):
 
     with pytest.raises(HTTPException) as exc_info:
         await llm_endpoints.get_models_metadata(
+            request=None,
             refresh_openrouter=False,
             model_type=None,
             input_modality=None,
@@ -191,6 +192,7 @@ async def test_get_models_metadata_sanitizes_image_model_warning(monkeypatch):
     monkeypatch.setattr(llm_endpoints, "list_image_models_for_catalog", boom)
 
     result = await llm_endpoints.get_models_metadata(
+        request=None,
         refresh_openrouter=False,
         model_type=None,
         input_modality=None,

--- a/tldw_Server_API/tests/LLM_Local/test_llm_models_metadata_llamacpp_profiles.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llm_models_metadata_llamacpp_profiles.py
@@ -12,6 +12,7 @@ from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppAssetsResponse,
 )
 from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
 from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
     LlamaCppProfile,
     LlamaCppProfileMode,
@@ -45,6 +46,7 @@ def _client_for_profiles(
     *,
     profiles: list[LlamaCppProfile],
     assets: list[LlamaCppAsset],
+    scan_assets_response: LlamaCppAssetsResponse | BaseException | None = None,
 ) -> TestClient:
     allowed_roots = [
         Path(asset.resolved_path).parent
@@ -58,11 +60,14 @@ def _client_for_profiles(
     monkeypatch.setattr(llm_providers, "get_configured_providers_async", _configured_providers)
     monkeypatch.setattr(llm_providers, "apply_llm_provider_overrides_to_listing", lambda result: result)
     monkeypatch.setattr(llm_providers, "list_image_models_for_catalog", lambda: [])
-    monkeypatch.setattr(
-        llamacpp_inventory_service,
-        "scan_assets",
-        lambda: LlamaCppAssetsResponse(assets=assets, warnings=[]),
-    )
+    response_or_error = scan_assets_response or LlamaCppAssetsResponse(assets=assets, warnings=[])
+
+    def _scan_assets(*_args, **_kwargs):
+        if isinstance(response_or_error, BaseException):
+            raise response_or_error
+        return response_or_error
+
+    monkeypatch.setattr(llamacpp_inventory_service, "scan_assets", _scan_assets)
     monkeypatch.setattr(
         llamacpp_inventory_service,
         "resolve_asset_path",
@@ -153,8 +158,12 @@ def test_models_metadata_filters_managed_llamacpp_profiles(monkeypatch, tmp_path
     )
 
     with _client_for_profiles(monkeypatch, profiles=[vision, embedding], assets=[base, mmproj]) as client:
-        image_response = client.get("/api/v1/llm/models/metadata?type=chat&input_modality=image")
-        embedding_response = client.get("/api/v1/llm/models/metadata?type=embedding")
+        image_response = client.get(
+            "/api/v1/llm/models/metadata?type=chat&input_modality=image&output_modality=text"
+        )
+        embedding_response = client.get(
+            "/api/v1/llm/models/metadata?type=embedding&output_modality=embedding"
+        )
 
     assert image_response.status_code == 200, image_response.text
     image_profile_ids = {
@@ -193,3 +202,57 @@ def test_models_metadata_keeps_stale_llamacpp_profile_as_warning_entry(monkeypat
     assert entry["capabilities"]["vision"] is False
     assert entry["capability_warnings"]
     assert "gguf:missing" in entry["capability_warnings"][0]
+
+
+def test_models_metadata_keeps_scan_server_error_as_warning_entry(monkeypatch):
+    profile = LlamaCppProfile(
+        profile_id="scan-error",
+        name="Scan error profile",
+        mode=LlamaCppProfileMode.CHAT,
+        model_id="gguf:missing",
+        provider_alias="llamacpp-scan-error",
+    )
+
+    with _client_for_profiles(
+        monkeypatch,
+        profiles=[profile],
+        assets=[],
+        scan_assets_response=ServerError("imported folder path could not be resolved"),
+    ) as client:
+        response = client.get("/api/v1/llm/models/metadata")
+
+    assert response.status_code == 200, response.text
+    models = response.json()["models"]
+    entry = next(item for item in models if item["llamacpp_profile_id"] == "scan-error")
+    assert entry["model"] == "llamacpp-scan-error"
+    assert any(
+        "asset scan failed" in warning
+        for warning in entry["capability_warnings"]
+    )
+
+
+def test_models_metadata_marks_scan_limited_warning(monkeypatch):
+    profile = LlamaCppProfile(
+        profile_id="truncated",
+        name="Truncated inventory profile",
+        mode=LlamaCppProfileMode.CHAT,
+        model_id="gguf:not-in-limited-scan",
+        provider_alias="llamacpp-truncated",
+    )
+
+    with _client_for_profiles(
+        monkeypatch,
+        profiles=[profile],
+        assets=[],
+        scan_assets_response=LlamaCppAssetsResponse(assets=[], warnings=[], scan_limited=True),
+    ) as client:
+        response = client.get("/api/v1/llm/models/metadata")
+
+    assert response.status_code == 200, response.text
+    models = response.json()["models"]
+    entry = next(item for item in models if item["llamacpp_profile_id"] == "truncated")
+    assert entry["model"] == "llamacpp-truncated"
+    assert any(
+        "inventory scan was truncated" in warning
+        for warning in entry["capability_warnings"]
+    )

--- a/tldw_Server_API/tests/LLM_Local/test_llm_models_metadata_llamacpp_profiles.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llm_models_metadata_llamacpp_profiles.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints import llm_providers
+from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
+    LlamaCppAsset,
+    LlamaCppAssetsResponse,
+)
+from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
+    LlamaCppProfile,
+    LlamaCppProfileMode,
+)
+
+
+class _SupervisorStub:
+    def __init__(self, profiles: list[LlamaCppProfile]) -> None:
+        self._profiles = profiles
+
+    def list_profiles(self) -> list[LlamaCppProfile]:
+        return list(self._profiles)
+
+
+def _asset(asset_id: str, kind: str, path: Path) -> LlamaCppAsset:
+    path.write_text(kind)
+    return LlamaCppAsset(
+        asset_id=asset_id,
+        kind=kind,
+        identity_basis="resolved_path",
+        path=str(path),
+        resolved_path=str(path.resolve()),
+        display_name=path.name,
+        source="models_dir",
+        size_bytes=path.stat().st_size,
+    )
+
+
+def _client_for_profiles(
+    monkeypatch,
+    *,
+    profiles: list[LlamaCppProfile],
+    assets: list[LlamaCppAsset],
+) -> TestClient:
+    allowed_roots = [
+        Path(asset.resolved_path).parent
+        for asset in assets
+        if asset.resolved_path
+    ]
+
+    async def _configured_providers(*_args, **_kwargs):
+        return {"providers": [], "default_provider": None, "total_configured": 0}
+
+    monkeypatch.setattr(llm_providers, "get_configured_providers_async", _configured_providers)
+    monkeypatch.setattr(llm_providers, "apply_llm_provider_overrides_to_listing", lambda result: result)
+    monkeypatch.setattr(llm_providers, "list_image_models_for_catalog", lambda: [])
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "scan_assets",
+        lambda: LlamaCppAssetsResponse(assets=assets, warnings=[]),
+    )
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "resolve_asset_path",
+        lambda raw_path, **_kwargs: Path(raw_path).resolve(),
+    )
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "_allowed_bases_for_config",
+        lambda _config: allowed_roots,
+    )
+
+    app = FastAPI()
+    app.include_router(llm_providers.router, prefix="/api/v1")
+    app.state.llm_manager = SimpleNamespace(llamacpp_supervisor=_SupervisorStub(profiles))
+    return TestClient(app)
+
+
+def test_models_metadata_includes_managed_llamacpp_profiles(monkeypatch, tmp_path):
+    base = _asset("gguf:base", "gguf", tmp_path / "qwen-vl.gguf")
+    mmproj = _asset("mmproj:projector", "mmproj", tmp_path / "mmproj-qwen-vl.gguf")
+    profile = LlamaCppProfile(
+        profile_id="vision",
+        name="Vision profile",
+        mode=LlamaCppProfileMode.VISION,
+        model_id=base.asset_id,
+        mmproj_model_id=mmproj.asset_id,
+        provider_alias="llamacpp-vision",
+    )
+
+    with _client_for_profiles(monkeypatch, profiles=[profile], assets=[base, mmproj]) as client:
+        response = client.get("/api/v1/llm/models/metadata")
+
+    assert response.status_code == 200, response.text
+    models = response.json()["models"]
+    entry = next(item for item in models if item["llamacpp_profile_id"] == "vision")
+    assert entry["provider"] == "llama.cpp"
+    assert entry["model"] == "llamacpp-vision"
+    assert entry["name"] == "Vision profile"
+    assert entry["type"] == "chat"
+    assert entry["source"] == "managed_llamacpp_profile"
+    assert entry["capabilities"]["vision"] is True
+    assert entry["modalities"]["input"] == ["text", "image"]
+    assert entry["modalities"]["output"] == ["text"]
+    assert entry["is_configured"] is True
+    assert entry["catalog_only"] is False
+
+
+def test_models_metadata_includes_disabled_profile_as_unconfigured(monkeypatch, tmp_path):
+    base = _asset("gguf:base", "gguf", tmp_path / "disabled.gguf")
+    profile = LlamaCppProfile(
+        profile_id="disabled",
+        name="Disabled profile",
+        enabled=False,
+        mode=LlamaCppProfileMode.CHAT,
+        model_id=base.asset_id,
+        provider_alias="llamacpp-disabled",
+    )
+
+    with _client_for_profiles(monkeypatch, profiles=[profile], assets=[base]) as client:
+        response = client.get("/api/v1/llm/models/metadata")
+
+    assert response.status_code == 200, response.text
+    models = response.json()["models"]
+    entry = next(item for item in models if item["llamacpp_profile_id"] == "disabled")
+    assert entry["model"] == "llamacpp-disabled"
+    assert entry["is_configured"] is False
+    assert entry["provider_is_configured"] is False
+    assert entry["catalog_only"] is False
+
+
+def test_models_metadata_filters_managed_llamacpp_profiles(monkeypatch, tmp_path):
+    base = _asset("gguf:base", "gguf", tmp_path / "chat.gguf")
+    mmproj = _asset("mmproj:projector", "mmproj", tmp_path / "mmproj-chat.gguf")
+    vision = LlamaCppProfile(
+        profile_id="vision",
+        name="Vision",
+        mode=LlamaCppProfileMode.VISION,
+        model_id=base.asset_id,
+        mmproj_model_id=mmproj.asset_id,
+        provider_alias="llamacpp-vision",
+    )
+    embedding = LlamaCppProfile(
+        profile_id="embeddings",
+        name="Embeddings",
+        mode=LlamaCppProfileMode.EMBEDDING,
+        model_id=base.asset_id,
+        provider_alias="llamacpp-embeddings",
+    )
+
+    with _client_for_profiles(monkeypatch, profiles=[vision, embedding], assets=[base, mmproj]) as client:
+        image_response = client.get("/api/v1/llm/models/metadata?type=chat&input_modality=image")
+        embedding_response = client.get("/api/v1/llm/models/metadata?type=embedding")
+
+    assert image_response.status_code == 200, image_response.text
+    image_profile_ids = {
+        item.get("llamacpp_profile_id")
+        for item in image_response.json()["models"]
+        if item.get("source") == "managed_llamacpp_profile"
+    }
+    assert image_profile_ids == {"vision"}
+
+    assert embedding_response.status_code == 200, embedding_response.text
+    embedding_profile_ids = {
+        item.get("llamacpp_profile_id")
+        for item in embedding_response.json()["models"]
+        if item.get("source") == "managed_llamacpp_profile"
+    }
+    assert embedding_profile_ids == {"embeddings"}
+
+
+def test_models_metadata_keeps_stale_llamacpp_profile_as_warning_entry(monkeypatch):
+    profile = LlamaCppProfile(
+        profile_id="stale",
+        name="Stale local profile",
+        mode=LlamaCppProfileMode.VISION,
+        model_id="gguf:missing",
+        mmproj_model_id="mmproj:missing",
+        provider_alias="llamacpp-stale",
+    )
+
+    with _client_for_profiles(monkeypatch, profiles=[profile], assets=[]) as client:
+        response = client.get("/api/v1/llm/models/metadata")
+
+    assert response.status_code == 200, response.text
+    models = response.json()["models"]
+    entry = next(item for item in models if item["llamacpp_profile_id"] == "stale")
+    assert entry["model"] == "llamacpp-stale"
+    assert entry["capabilities"]["vision"] is False
+    assert entry["capability_warnings"]
+    assert "gguf:missing" in entry["capability_warnings"][0]


### PR DESCRIPTION
## Summary

- Exposes supervisor-managed llama.cpp profiles in `/api/v1/llm/models/metadata` with profile IDs, aliases, types, capabilities, modalities, and bounded warnings.
- Adds reusable model-catalog metadata shaping on top of the existing llama.cpp profile capability resolver.
- Adds regression coverage for active, disabled, filtered, and stale managed profile metadata entries, and records the slice in `TASK-397.6`.

## Tests

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llm_models_metadata_llamacpp_profiles.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py tldw_Server_API/tests/LLM_Adapters/unit/test_llm_models_filters.py tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_error_mapping.py::test_get_models_metadata_sanitizes_generic_failure tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_error_mapping.py::test_get_models_metadata_sanitizes_image_model_warning tldw_Server_API/tests/LLM_Adapters/unit/test_llm_openrouter_models_refresh.py -v`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py tldw_Server_API/tests/LLM_Local/test_llm_models_metadata_llamacpp_profiles.py -v`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py tldw_Server_API/app/api/v1/endpoints/llm_providers.py -f json -o /tmp/bandit_llamacpp_profile_metadata.json`
- `git diff --check HEAD~1..HEAD`

## Change summary

Human-owned summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose supervisor-managed `llama.cpp` profiles in `/api/v1/llm/models/metadata` so clients can discover local profiles with IDs, aliases, types, capabilities, modalities, and bounded warnings. Adds safe asset scanning with clear warnings for truncated or failed scans. Satisfies TASK-397.6.

- **New Features**
  - Append managed profile entries via the app’s `llm_manager.llamacpp_supervisor`.
  - Preserve catalog filters (`type`, `input_modality`, `output_modality`) for these entries.
  - Show disabled profiles as unconfigured (`is_configured=false`) instead of hiding them.
  - Keep capability warnings for stale/missing assets and asset-scan issues (failure or truncation) without failing the endpoint; tests cover active, disabled, filtered, stale, scan-failed, and scan-truncated cases.

<sup>Written for commit 022a431661e6e67967a0167d781da59850a80c8f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1793?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

