### PR TITLE
Add Buddy pipeline import-preview diagnostics

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -108,6 +108,17 @@ stored with `status: "blocked"` and includes `commit_eligible: false`,
 is still a review-only path: no asset rows or pack rows are committed, no pack is
 activated, no runtime renderer is loaded, and no MCP provider behavior is added.
 
+For V1 `sprite_frames` archives, import preview also exposes lightweight packet
+diagnostics in `bundle_summary`. `manifest_asset_references` lists source asset
+IDs referenced by timed manifest animations, and each `bundle_summary.assets[]`
+entry includes `manifest_referenced`. When an archive asset declares a known
+Buddy pipeline `asset_group`, such as `neutral_anchor`, `static_talking_sheet`,
+`static_reaction_sheet`, `animation_strips`, or `animation_atlas`, preview
+returns that group for review. Unknown groups are returned as null, so arbitrary
+archive metadata does not become a support claim. This lets review surfaces
+distinguish source sheets and neutral anchors from runtime strip or atlas outputs
+without committing or activating the archive.
+
 ### Sprite Atlas Frames
 ## Sprite Atlas Packs
 

--- a/backlog/tasks/task-412 - Add-Buddy-animation-pipeline-packet-import-preview-fixtures.md
+++ b/backlog/tasks/task-412 - Add-Buddy-animation-pipeline-packet-import-preview-fixtures.md
@@ -51,6 +51,17 @@ Verification:
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py` passed.
 - `git diff --check` passed.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py -f json -o /tmp/bandit_persona_visual_pipeline.json` passed with 0 findings.
+
+Review follow-up:
+
+- Addressed Gemini's null manifest-section review thread with a regression test
+  for V2 renderer-preview archives where `states` and `animations` are null.
+- Addressed Qodo's helper-docstring review thread by documenting
+  `_bundle_asset_summary()` and `_known_asset_group()`.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py -q` passed with 15 tests.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py` passed.
+- `git diff --check` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py -f json -o /tmp/bandit_persona_visual_pipeline_review_fixes.json` passed with 0 findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-412 - Add-Buddy-animation-pipeline-packet-import-preview-fixtures.md
+++ b/backlog/tasks/task-412 - Add-Buddy-animation-pipeline-packet-import-preview-fixtures.md
@@ -1,0 +1,70 @@
+---
+id: TASK-412
+title: Add Buddy animation pipeline packet import-preview fixtures
+status: Done
+labels:
+- persona
+- buddy
+- visual-packs
+- backend
+- issue-1787
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1787
+- https://github.com/rmusser01/tldw_server/issues/1510
+modified_files:
+- tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+- tldw_Server_API/app/core/Persona/visual_portability/preview.py
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next backend-first slice for GitHub issue #1787: add deterministic Persona/Buddy animation pipeline packet fixtures and focused import-preview coverage for neutral anchors, distinct static talking/reaction sheets, animation strips/atlas outputs, and compiled manifests. Reuse the existing Persona Visual portability/import-preview path and preserve draft/review-before-activation semantics. Scope excludes WebUI changes, final art generation, automatic activation, new renderer support, MCP provider execution/resource download, marketplace/shared-library behavior, and VN/CYOA behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Deterministic test fixture represents a Buddy pipeline packet with neutral anchor, static_talking_sheet, static_reaction_sheet, strips/atlas outputs, and a compiled manifest using current Persona Visual contracts.
+- [x] #2 Import-preview validation accepts the packet as a previewable Persona Visual archive without activating or mutating packs.
+- [x] #3 Preview diagnostics expose enough staged asset/manifest information to distinguish source sheets from timed runtime animation outputs.
+- [x] #4 Existing malformed archive/import-preview tests continue to pass without loosening manifest validation.
+- [x] #5 Focused pytest, py_compile, git diff --check, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added a deterministic Buddy pipeline portable archive fixture covering
+`neutral_anchor`, `static_talking_sheet`, `static_reaction_sheet`,
+`animation_strips`, `animation_atlas`, custom state catalog entries, exact tool
+triggers, and timed sprite-frame manifest output. Import preview now reports
+`manifest_asset_references` and per-asset `asset_group` / `manifest_referenced`
+diagnostics so review surfaces can distinguish source sheets from runtime
+outputs without committing or activating the archive.
+
+Verification:
+
+- RED focused test failed with `KeyError: 'manifest_asset_references'` before implementation.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py -q` passed with 14 tests.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py` passed.
+- `git diff --check` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py -f json -o /tmp/bandit_persona_visual_pipeline.json` passed with 0 findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Buddy animation pipeline packet import-preview coverage and lightweight preview diagnostics for source-vs-runtime assets. The preview remains review-only and uses the existing Persona Visual portable archive path.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Persona/visual_portability/preview.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/preview.py
@@ -338,6 +338,8 @@ def _bundle_summary(
     if not isinstance(visual_manifest, Mapping):
         visual_manifest = {}
     manifest_asset_references = collect_visual_manifest_asset_ids(dict(visual_manifest))
+    states = visual_manifest.get("states")
+    animations = visual_manifest.get("animations")
     return {
         "pack_title": pack.get("title") or manifest.get("pack_title"),
         "renderer_type": pack.get("renderer_type") or manifest.get("renderer_type"),
@@ -345,8 +347,8 @@ def _bundle_summary(
         "asset_count": len(assets),
         "assets_with_bytes": asset_summary["present_asset_items"],
         "missing_asset_items": asset_summary["missing_asset_items"],
-        "state_count": len(visual_manifest.get("states", {})),
-        "animation_count": len(visual_manifest.get("animations", {})),
+        "state_count": len(states) if isinstance(states, Mapping) else 0,
+        "animation_count": len(animations) if isinstance(animations, Mapping) else 0,
         "resolved_required_states": dict(resolved_required_states),
         "manifest_asset_references": sorted(manifest_asset_references),
         "assets": [
@@ -364,6 +366,8 @@ def _bundle_asset_summary(
     *,
     manifest_asset_references: set[str],
 ) -> dict[str, Any]:
+    """Return review-safe asset diagnostics for an import-preview bundle."""
+
     source_asset_id = str(asset.get("source_asset_id") or "").strip()
     return {
         "source_asset_id": asset.get("source_asset_id"),
@@ -380,6 +384,8 @@ def _bundle_asset_summary(
 
 
 def _known_asset_group(value: Any) -> str | None:
+    """Return a recognized Buddy pipeline asset group, if the archive declared one."""
+
     if not isinstance(value, str):
         return None
     normalized = value.strip()

--- a/tldw_Server_API/app/core/Persona/visual_portability/preview.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/preview.py
@@ -12,6 +12,12 @@ from typing import Any
 from tldw_Server_API.app.core.Persona.visual_import_preview_validators import (
     preview_renderer_import,
 )
+from tldw_Server_API.app.core.Persona.visual_manifest_assets import (
+    collect_visual_manifest_asset_ids,
+)
+from tldw_Server_API.app.core.Persona.visual_starter_recipe_taxonomy import (
+    BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS,
+)
 from tldw_Server_API.app.core.Persona.visuals import (
     PersonaVisualManifestError,
     validate_visual_manifest,
@@ -328,6 +334,10 @@ def _bundle_summary(
     asset_summary: Mapping[str, int],
     resolved_required_states: Mapping[str, str],
 ) -> dict[str, Any]:
+    visual_manifest = pack.get("visual_manifest")
+    if not isinstance(visual_manifest, Mapping):
+        visual_manifest = {}
+    manifest_asset_references = collect_visual_manifest_asset_ids(dict(visual_manifest))
     return {
         "pack_title": pack.get("title") or manifest.get("pack_title"),
         "renderer_type": pack.get("renderer_type") or manifest.get("renderer_type"),
@@ -335,21 +345,47 @@ def _bundle_summary(
         "asset_count": len(assets),
         "assets_with_bytes": asset_summary["present_asset_items"],
         "missing_asset_items": asset_summary["missing_asset_items"],
-        "state_count": len((pack.get("visual_manifest") or {}).get("states", {})),
-        "animation_count": len((pack.get("visual_manifest") or {}).get("animations", {})),
+        "state_count": len(visual_manifest.get("states", {})),
+        "animation_count": len(visual_manifest.get("animations", {})),
         "resolved_required_states": dict(resolved_required_states),
+        "manifest_asset_references": sorted(manifest_asset_references),
         "assets": [
-            {
-                "source_asset_id": asset.get("source_asset_id"),
-                "asset_role": asset.get("asset_role"),
-                "asset_bytes_status": asset.get("asset_bytes_status"),
-                "mime_type": asset.get("mime_type"),
-                "width": asset.get("width"),
-                "height": asset.get("height"),
-            }
+            _bundle_asset_summary(
+                asset,
+                manifest_asset_references=manifest_asset_references,
+            )
             for asset in assets
         ],
     }
+
+
+def _bundle_asset_summary(
+    asset: Mapping[str, Any],
+    *,
+    manifest_asset_references: set[str],
+) -> dict[str, Any]:
+    source_asset_id = str(asset.get("source_asset_id") or "").strip()
+    return {
+        "source_asset_id": asset.get("source_asset_id"),
+        "asset_role": asset.get("asset_role"),
+        "asset_group": _known_asset_group(asset.get("asset_group")),
+        "asset_bytes_status": asset.get("asset_bytes_status"),
+        "mime_type": asset.get("mime_type"),
+        "width": asset.get("width"),
+        "height": asset.get("height"),
+        "manifest_referenced": bool(
+            source_asset_id and source_asset_id in manifest_asset_references
+        ),
+    }
+
+
+def _known_asset_group(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if normalized in BUDDY_VISUAL_EXPECTED_ASSET_GROUP_IDS:
+        return normalized
+    return None
 
 
 def _validation_warnings(assets: list[Mapping[str, Any]]) -> list[str]:

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -99,6 +99,157 @@ def _live2d_v2_manifest() -> dict[str, object]:
     }
 
 
+def _buddy_pipeline_manifest() -> dict[str, object]:
+    return {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "state_catalog": {
+            "tool.notes_search": {
+                "label": "Notes search",
+                "kind": "tool_variant",
+                "description": "Used when the notes search tool is running.",
+                "tags": ["tool", "search"],
+            },
+            "reaction.cheer": {
+                "label": "Cheer",
+                "kind": "reaction",
+                "description": "Short positive response animation.",
+                "tags": ["reaction"],
+            },
+        },
+        "states": {
+            "idle": {"animation_id": "idle-loop"},
+            "listening": {"animation_id": "listening-loop"},
+            "thinking": {"animation_id": "thinking-loop"},
+            "speaking": {"animation_id": "speaking-loop"},
+            "error": {"animation_id": "error-loop"},
+            "tool.notes_search": {"animation_id": "tool-notes-search-loop"},
+            "reaction.cheer": {"animation_id": "reaction-cheer-loop"},
+        },
+        "fallbacks": {
+            "tool.notes_search": ["tool_running", "thinking", "idle"],
+            "reaction.cheer": ["speaking", "idle"],
+        },
+        "authored_triggers": [
+            {
+                "id": "notes-search-exact-tool",
+                "source": "tool_name",
+                "match": "notes.search",
+                "state": "tool.notes_search",
+                "duration_ms": 2400,
+                "priority": 80,
+            },
+            {
+                "id": "cheer-reaction",
+                "source": "live_state",
+                "match": "positive_response",
+                "state": "reaction.cheer",
+                "duration_ms": 1200,
+                "priority": 40,
+            },
+        ],
+        "animations": {
+            "idle-loop": {
+                "frames": [
+                    {
+                        "asset_id": "buddy-animation-atlas",
+                        "region": {"x": 0, "y": 0, "width": 4, "height": 4},
+                        "duration_ms": 180,
+                    },
+                    {
+                        "asset_id": "buddy-animation-atlas",
+                        "region": {"x": 4, "y": 0, "width": 4, "height": 4},
+                        "duration_ms": 180,
+                    },
+                ],
+                "frame_rate": 6,
+                "preview_frame": 0,
+            },
+            "listening-loop": {
+                "frames": [
+                    {
+                        "asset_id": "buddy-animation-atlas",
+                        "region": {"x": 0, "y": 4, "width": 4, "height": 4},
+                        "duration_ms": 120,
+                    },
+                ],
+                "frame_rate": 8,
+                "preview_frame": 0,
+            },
+            "thinking-loop": {
+                "frames": [
+                    {
+                        "asset_id": "buddy-strip-required",
+                        "region": {"x": 0, "y": 0, "width": 4, "height": 4},
+                        "duration_ms": 160,
+                    },
+                    {
+                        "asset_id": "buddy-strip-required",
+                        "region": {"x": 4, "y": 0, "width": 4, "height": 4},
+                        "duration_ms": 160,
+                    },
+                ],
+                "frame_rate": 6,
+                "preview_frame": 0,
+            },
+            "speaking-loop": {
+                "frames": [
+                    {
+                        "asset_id": "buddy-strip-required",
+                        "region": {"x": 0, "y": 0, "width": 4, "height": 4},
+                        "duration_ms": 90,
+                    },
+                    {
+                        "asset_id": "buddy-strip-required",
+                        "region": {"x": 4, "y": 0, "width": 4, "height": 4},
+                        "duration_ms": 90,
+                    },
+                ],
+                "frame_rate": 12,
+                "preview_frame": 1,
+            },
+            "error-loop": {
+                "frames": [
+                    {
+                        "asset_id": "buddy-animation-atlas",
+                        "region": {"x": 4, "y": 4, "width": 4, "height": 4},
+                        "duration_ms": 300,
+                    },
+                ],
+                "frame_rate": 4,
+                "preview_frame": 0,
+            },
+            "tool-notes-search-loop": {
+                "frames": [
+                    {
+                        "asset_id": "buddy-animation-atlas",
+                        "region": {"x": 0, "y": 4, "width": 4, "height": 4},
+                        "duration_ms": 140,
+                    },
+                    {
+                        "asset_id": "buddy-animation-atlas",
+                        "region": {"x": 4, "y": 4, "width": 4, "height": 4},
+                        "duration_ms": 140,
+                    },
+                ],
+                "frame_rate": 10,
+                "preview_frame": 0,
+            },
+            "reaction-cheer-loop": {
+                "frames": [
+                    {
+                        "asset_id": "buddy-animation-atlas",
+                        "region": {"x": 4, "y": 0, "width": 4, "height": 4},
+                        "duration_ms": 120,
+                    },
+                ],
+                "frame_rate": 8,
+                "preview_frame": 0,
+            },
+        },
+    }
+
+
 def _renderer_preview_archive(
     tmp_path: Path,
     *,
@@ -147,6 +298,68 @@ def _renderer_preview_archive(
         for member_path, member_bytes in entries.items():
             archive.writestr(member_path, member_bytes)
     return archive_path
+
+
+def _buddy_pipeline_assets() -> tuple[list[dict[str, object]], dict[str, bytes]]:
+    asset_specs = [
+        (
+            "buddy-neutral-anchor",
+            "still_pose",
+            "neutral_anchor",
+            "neutral.png",
+            _png_bytes(width=4, height=4),
+        ),
+        (
+            "buddy-static-talking-sheet",
+            "sprite_sheet",
+            "static_talking_sheet",
+            "static-talking.png",
+            _png_bytes(width=8, height=4),
+        ),
+        (
+            "buddy-static-reaction-sheet",
+            "sprite_sheet",
+            "static_reaction_sheet",
+            "static-reactions.png",
+            _png_bytes(width=8, height=4),
+        ),
+        (
+            "buddy-strip-required",
+            "sprite_sheet",
+            "animation_strips",
+            "required-state-strip.png",
+            _png_bytes(width=8, height=4),
+        ),
+        (
+            "buddy-animation-atlas",
+            "sprite_sheet",
+            "animation_atlas",
+            "animation-atlas.png",
+            _png_bytes(width=8, height=8),
+        ),
+    ]
+    assets: list[dict[str, object]] = []
+    asset_files: dict[str, bytes] = {}
+    for source_asset_id, asset_role, asset_group, filename, content in asset_specs:
+        asset_path = f"assets/persona_visuals/{filename}"
+        with Image.open(io.BytesIO(content)) as image:
+            width, height = image.size
+        assets.append(
+            {
+                "source_asset_id": source_asset_id,
+                "asset_role": asset_role,
+                "asset_group": asset_group,
+                "asset_bytes_status": ASSET_BYTES_STATUS_PRESENT,
+                "asset_path": asset_path,
+                "asset_sha256": sha256_bytes(content),
+                "mime_type": "image/png",
+                "width": width,
+                "height": height,
+                "original_filename": filename,
+            }
+        )
+        asset_files[asset_path] = content
+    return assets, asset_files
 
 
 def _live2d_preview_assets(
@@ -267,8 +480,8 @@ def test_validate_archive_members_allows_zip_directory_entries(tmp_path: Path) -
 
     members = validate_archive_members(archive_path)
 
-    assert REQUIRED_MEMBERS <= set(members)
-    assert "metadata/" not in members
+    assert REQUIRED_MEMBERS <= set(members)  # nosec B101
+    assert "metadata/" not in members  # nosec B101
 
 
 def test_export_pack_writes_manifest_metadata_checksums_and_asset_bytes(
@@ -505,6 +718,52 @@ def test_import_preview_reports_missing_asset_bytes_as_warning(
     ]
     exported_assets = preview["bundle_summary"]["assets"]
     assert exported_assets[0]["asset_bytes_status"] == ASSET_BYTES_STATUS_MISSING  # nosec B101
+
+
+def test_import_preview_accepts_buddy_pipeline_packet_with_source_sheet_diagnostics(
+    tmp_path: Path,
+) -> None:
+    assets, asset_files = _buddy_pipeline_assets()
+    archive_path = _renderer_preview_archive(
+        tmp_path,
+        title="Buddy Pipeline Packet",
+        visual_manifest=_buddy_pipeline_manifest(),
+        assets=assets,
+        asset_files=asset_files,
+    )
+
+    preview = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=archive_path,
+        owner_user_id="user-1",
+        target_persona_id="target-persona",
+    )
+
+    summary = preview["bundle_summary"]
+    assets_by_id = {
+        asset["source_asset_id"]: asset
+        for asset in summary["assets"]
+    }
+    assert preview["status"] == "completed"  # nosec B101
+    assert summary["renderer_type"] == "sprite_frames"  # nosec B101
+    assert summary["asset_count"] == 5  # nosec B101
+    assert summary["state_count"] == 7  # nosec B101
+    assert summary["animation_count"] == 7  # nosec B101
+    assert summary["manifest_asset_references"] == [  # nosec B101
+        "buddy-animation-atlas",
+        "buddy-strip-required",
+    ]
+    assert assets_by_id["buddy-neutral-anchor"]["asset_group"] == "neutral_anchor"  # nosec B101
+    assert assets_by_id["buddy-neutral-anchor"]["manifest_referenced"] is False  # nosec B101
+    assert assets_by_id["buddy-static-talking-sheet"]["asset_group"] == "static_talking_sheet"  # nosec B101
+    assert assets_by_id["buddy-static-talking-sheet"]["manifest_referenced"] is False  # nosec B101
+    assert assets_by_id["buddy-static-reaction-sheet"]["asset_group"] == "static_reaction_sheet"  # nosec B101
+    assert assets_by_id["buddy-static-reaction-sheet"]["manifest_referenced"] is False  # nosec B101
+    assert assets_by_id["buddy-strip-required"]["asset_group"] == "animation_strips"  # nosec B101
+    assert assets_by_id["buddy-strip-required"]["manifest_referenced"] is True  # nosec B101
+    assert assets_by_id["buddy-animation-atlas"]["asset_group"] == "animation_atlas"  # nosec B101
+    assert assets_by_id["buddy-animation-atlas"]["manifest_referenced"] is True  # nosec B101
+    assert preview["proposed_plan"]["review_before_commit"] is True  # nosec B101
+    assert preview["validation_warnings"] == []  # nosec B101
 
 
 def test_import_preview_reports_v2_live2d_renderer_diagnostics_without_activation(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -890,6 +890,32 @@ def test_import_preview_reports_v2_unknown_renderer_safely(
     assert "\n" not in renderer_preview["blockers"][0]  # nosec B101
 
 
+def test_import_preview_counts_null_v2_manifest_sections_as_empty(
+    tmp_path: Path,
+) -> None:
+    assets, asset_files = _live2d_preview_assets()
+    visual_manifest = _live2d_v2_manifest()
+    visual_manifest["states"] = None
+    visual_manifest["animations"] = None
+    archive_path = _renderer_preview_archive(
+        tmp_path,
+        title="Live2D Null Sections",
+        visual_manifest=visual_manifest,
+        assets=assets,
+        asset_files=asset_files,
+    )
+
+    preview = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=archive_path,
+        owner_user_id="user-1",
+        target_persona_id="target-persona",
+    )
+
+    assert preview["status"] == "blocked"  # nosec B101
+    assert preview["bundle_summary"]["state_count"] == 0  # nosec B101
+    assert preview["bundle_summary"]["animation_count"] == 0  # nosec B101
+
+
 def test_import_preview_rejects_unsupported_renderer_type_in_visual_manifest(
     db_instance: CharactersRAGDB,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Adds deterministic Buddy pipeline packet import-preview coverage for neutral anchors, static talking/reaction sheets, runtime strips, atlas outputs, custom states, and exact tool triggers.
- Extends import preview bundle summaries with manifest asset references plus per-asset asset_group and manifest_referenced diagnostics.
- Documents the preview-only diagnostics and records TASK-412 verification.

## Change summary
Human-authored summary required before merge.

## Verification
- RED focused test failed before implementation with KeyError for missing manifest_asset_references.
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/tests/Persona/test_persona_visual_portability.py -f json -o /tmp/bandit_persona_visual_pipeline.json

Refs #1787
Backlog: TASK-412

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Buddy pipeline import-preview diagnostics for `sprite_frames` to show which assets the manifest references and each asset’s group. Addresses TASK-412 and #1787 by letting reviewers distinguish source sheets and neutral anchors from runtime strips/atlas outputs without activation.

- New Features
  - Import preview now returns bundle_summary.manifest_asset_references.
  - Each asset includes asset_group (only known Buddy groups) and a manifest_referenced flag.
  - Preview supports Buddy state catalog entries and exact tool triggers.
  - Docs updated and deterministic tests added; preview remains review-only.

- Bug Fixes
  - Treats null V2 `states`/`animations` as empty in summaries.

<sup>Written for commit a8c5e568d179c4a9abfe2e6950b18baf56ce5761. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1794?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

