### PR TITLE
Gate chat starter deck by intent

### DIFF
--- a/Docs/superpowers/plans/2026-05-16-chat-cockpit-intent-gated-starter-deck.md
+++ b/Docs/superpowers/plans/2026-05-16-chat-cockpit-intent-gated-starter-deck.md
@@ -1,0 +1,91 @@
+# Chat Cockpit Intent-Gated Starter Deck Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the main `/chat` starter deck only for a true blank state, then let the composer and transcript take priority once the user has chat intent.
+
+**Architecture:** Add a narrow intent signal around the existing Playground coordinator state instead of creating a new mode system. The parent `/chat` surface should decide whether the starter deck is allowed; `PlaygroundEmpty` remains the reusable deck component and does not learn about global chat state.
+
+**Tech Stack:** React, TypeScript, Vitest with Testing Library, Playwright real-server workflow for final browser proof if needed.
+
+---
+
+## Scope Guard
+
+This slice is limited to the main WebUI `/chat` cockpit. Do not touch browser-extension sidepanel/sidebar routes, settings pages, character library pages, backend APIs, MCP Hub, or unrelated cockpit work.
+
+The approved behavior is option 1, intent-gated collapse:
+
+- Show the full starter deck only when there are no messages/history, no active draft text, and no active conversation.
+- Hide the starter deck as soon as the composer has draft text.
+- Keep it hidden for existing or loaded conversations.
+- Allow it to reappear if the user clears the draft before any send.
+- Do not add a bottom bar or composer-adjacent replacement summary.
+
+## File Map
+
+- Modify: `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+  - Derive a `showStarterDeck` or equivalent from existing messages/history/session state plus current composer draft state.
+  - Render `PlaygroundEmpty` only when that signal is true.
+- Modify: `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+  - If needed, expose the current composer draft text to the parent through a focused callback.
+  - Keep existing composer controls and send behavior unchanged.
+- Modify or create focused tests under `apps/packages/ui/src/components/Option/Playground/__tests__/`
+  - Cover blank state, typed draft, existing conversation, and draft-cleared restoration.
+- Update: `backlog/tasks/task-412 - Implement-main-chat-intent-gated-starter-deck.md`
+  - Record plan, verification, and final state.
+
+## Stage 1: Lock The Intent Contract
+
+**Goal:** Add failing focused tests for the center starter deck visibility rules.
+**Success Criteria:** Tests fail on current `origin/dev` because the starter deck remains visible after a draft appears.
+**Tests:** `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx --config vitest.config.ts`
+**Status:** Complete
+
+- [x] Add a focused Playground test that renders a true blank state and expects `playground-empty-mode-deck` to be visible.
+- [x] Add a focused Playground test that simulates or injects composer draft text before send and expects `playground-empty-mode-deck` to be absent.
+- [x] Add a focused Playground test with existing messages/history/server chat state and expects the starter deck to stay absent.
+- [x] Add a focused Playground test that clears the draft before send and expects the starter deck to return.
+- [x] Run the focused tests and confirm the new draft-intent assertion fails for the current behavior.
+
+Red evidence: the focused cockpit-shell test failed on the draft, active conversation, and restored-draft assertions before the production wiring was added.
+
+## Stage 2: Implement Intent-Gated Rendering
+
+**Goal:** Hide the starter deck when the user has a draft or conversation intent without adding a new visible control.
+**Success Criteria:** Existing `/chat` state paths continue to work and the starter deck only renders for true blank state.
+**Tests:** Same focused Vitest command from Stage 1.
+**Status:** Complete
+
+- [x] Add a minimal parent-level draft intent signal in `Playground.tsx`.
+- [x] Wire the composer draft signal from `PlaygroundForm.tsx` only if no existing parent-readable draft state exists.
+- [x] Gate `PlaygroundEmpty` rendering on no messages/history, no active server/local conversation, and no draft text.
+- [x] Keep the transcript, composer, rails, and status strip rendering unchanged.
+- [x] Run the focused tests and confirm they pass.
+
+## Stage 3: Regression And Real-Server Proof
+
+**Goal:** Prove the slice does not regress cockpit rails, composer behavior, or real `/chat` operation.
+**Success Criteria:** Focused unit coverage passes; real-server proof either captures the starter-deck transition or records why browser proof was not useful for this state-only slice.
+**Tests:**
+
+- `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx --config vitest.config.ts`
+- `git diff --check`
+- Targeted ESLint/prettier if touched files require it.
+- Real-server Playwright only if it materially helps validate the visible transition.
+
+**Status:** Complete
+
+- [x] Run focused Vitest.
+- [x] Run `git diff --check`.
+- [x] Run formatting/lint checks for touched frontend files where available.
+- [x] Record Bandit skip because touched scope is frontend TypeScript and Backlog/plan Markdown only.
+- [x] Update TASK-412 with verification evidence and final summary.
+
+Verification evidence:
+
+- `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.signals.guard.test.ts --config vitest.config.ts` passed: 4 files, 22 tests.
+- `bunx tsc --noEmit --project tsconfig.json --pretty false` still fails on the existing UI baseline; filtering `/tmp/chat-cockpit-intent-starter-tsc.log` found no touched-file errors for `Playground.tsx`, `PlaygroundChat.tsx`, `PlaygroundForm.tsx`, `Playground.cockpit-shell.test.tsx`, or `PlaygroundChat.server-load-state.test.tsx`.
+- `git diff --check` passed.
+- Real-server browser proof was not captured because no tldw_server2 frontend/backend listener was running on the expected local ports; `lsof` only showed unrelated local services including tldw_chatbook on `8837` and llama-server on `9099`.
+- Bandit skipped: touched runtime code is frontend TypeScript and Markdown only.

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -198,7 +198,7 @@ export const Playground = () => {
     React.useState<ServerReadinessState>(null);
   const [composerDockMetrics, setComposerDockMetrics] =
     React.useState<ComposerDockLayoutMetrics | null>(null);
-  const [composerDraftMessage, setComposerDraftMessage] = React.useState("");
+  const [composerHasDraft, setComposerHasDraft] = React.useState(false);
   const { t } = useTranslation(["playground", "common"]);
   const navigate = useNavigate();
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
@@ -352,9 +352,9 @@ export const Playground = () => {
     },
     [],
   );
-  const handleComposerDraftMessageChange = React.useCallback(
-    (message: string) => {
-      setComposerDraftMessage(message);
+  const handleComposerDraftPresenceChange = React.useCallback(
+    (hasDraft: boolean) => {
+      setComposerHasDraft(hasDraft);
     },
     [],
   );
@@ -391,7 +391,7 @@ export const Playground = () => {
     history.length === 0 &&
     !stableHistoryId &&
     !serverChatId &&
-    composerDraftMessage.trim().length === 0;
+    !composerHasDraft;
   const setRouteContext = useChatSurfaceCoordinatorStore(
     (state) => state.setRouteContext,
   );
@@ -2835,7 +2835,7 @@ export const Playground = () => {
               onSelectAttachedResearchContextHistory={
                 handleSelectAttachedResearchContextHistory
               }
-              onDraftMessageChange={handleComposerDraftMessageChange}
+              onDraftPresenceChange={handleComposerDraftPresenceChange}
             />
           </div>
           </div>

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -198,6 +198,7 @@ export const Playground = () => {
     React.useState<ServerReadinessState>(null);
   const [composerDockMetrics, setComposerDockMetrics] =
     React.useState<ComposerDockLayoutMetrics | null>(null);
+  const [composerDraftMessage, setComposerDraftMessage] = React.useState("");
   const { t } = useTranslation(["playground", "common"]);
   const navigate = useNavigate();
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
@@ -351,6 +352,12 @@ export const Playground = () => {
     },
     [],
   );
+  const handleComposerDraftMessageChange = React.useCallback(
+    (message: string) => {
+      setComposerDraftMessage(message);
+    },
+    [],
+  );
   const { containerRef, isAutoScrollToBottom, autoScrollToBottom } =
     useSmartScroll(messages, streaming, 120, {
       bottomOffsetPx: composerBottomOffsetPx,
@@ -379,6 +386,12 @@ export const Playground = () => {
   const initializePlaygroundRef = React.useRef(false);
   const previousThreadRef = React.useRef<string | null>(null);
   const stableHistoryId = historyId && historyId !== "temp" ? historyId : null;
+  const showStarterDeck =
+    messages.length === 0 &&
+    history.length === 0 &&
+    !stableHistoryId &&
+    !serverChatId &&
+    composerDraftMessage.trim().length === 0;
   const setRouteContext = useChatSurfaceCoordinatorStore(
     (state) => state.setRouteContext,
   );
@@ -2730,6 +2743,7 @@ export const Playground = () => {
             <div className="mx-auto w-full max-w-[64rem] pb-6">
               <ChatErrorBoundary>
                 <PlaygroundChat
+                  showStarterDeck={showStarterDeck}
                   searchQuery={threadSearchQuery.trim()}
                   matchedMessageIndices={threadSearchMatchSet}
                   activeSearchMessageIndex={threadSearchActiveMessageIndex}
@@ -2821,6 +2835,7 @@ export const Playground = () => {
               onSelectAttachedResearchContextHistory={
                 handleSelectAttachedResearchContextHistory
               }
+              onDraftMessageChange={handleComposerDraftMessageChange}
             />
           </div>
           </div>

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundChat.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundChat.tsx
@@ -81,6 +81,7 @@ const LazyChatGreetingPicker = React.lazy(() =>
 )
 
 type PlaygroundChatProps = {
+  showStarterDeck?: boolean
   searchQuery?: string
   matchedMessageIndices?: Set<number>
   activeSearchMessageIndex?: number | null
@@ -133,6 +134,7 @@ const buildBlocks = (messages: TimelineMessageShape[]): TimelineBlock[] => {
 }
 
 export const PlaygroundChat = ({
+  showStarterDeck = true,
   searchQuery,
   matchedMessageIndices,
   activeSearchMessageIndex = null,
@@ -423,6 +425,16 @@ export const PlaygroundChat = ({
       "playground:selectedServerChatLoadFailure",
       "Failed to load the selected conversation."
     ) as string)
+  const showNoProvidersNotice = isConnected && noProvidersConfigured
+  const showNoModelsNotice =
+    isConnected &&
+    !noProvidersConfigured &&
+    chatModelsFetched &&
+    chatModels.length === 0
+  const showEmptyStarterRegion =
+    messages.length === 0 &&
+    serverChatLoadState !== "loading" &&
+    (showStarterDeck || showNoProvidersNotice || showNoModelsNotice)
   const normalizedSearchQuery =
     typeof searchQuery === "string" ? searchQuery.trim() : ""
   const resolveSearchMatch = React.useCallback(
@@ -1030,9 +1042,9 @@ export const PlaygroundChat = ({
               {selectedServerChatLoadFailureMessage}
             </div>
           </div>
-        ) : messages.length === 0 && serverChatLoadState !== "loading" && (
+        ) : showEmptyStarterRegion && (
           <div className="mt-4 w-full">
-            {isConnected && noProvidersConfigured && (
+            {showNoProvidersNotice && (
               <NoProviderBanner
                 className="mb-4"
                 onRefresh={() => {
@@ -1042,7 +1054,7 @@ export const PlaygroundChat = ({
                 }}
               />
             )}
-            {isConnected && !noProvidersConfigured && chatModelsFetched && chatModels.length === 0 && (
+            {showNoModelsNotice && (
               <div className="mx-auto mb-4 max-w-xl rounded-xl border border-amber-500/30 bg-amber-500/5 px-5 py-4 text-center text-sm text-text">
                 <p className="font-medium">
                   {characterChatNoModelCopy
@@ -1074,7 +1086,7 @@ export const PlaygroundChat = ({
                 </p>
               </div>
             )}
-            <PlaygroundEmpty />
+            {showStarterDeck && <PlaygroundEmpty />}
           </div>
         )}
         <React.Suspense fallback={null}>

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -248,6 +248,7 @@ type Props = {
   onPrepareResearchFollowUp?: (target: ResearchFollowUpTarget) => void;
   stickyDockEnabled?: boolean;
   onComposerLayoutChange?: (metrics: ComposerDockLayoutMetrics) => void;
+  onDraftMessageChange?: (message: string) => void;
 };
 
 type DefaultCharacterPreferenceQueryResult = {
@@ -428,6 +429,7 @@ export const PlaygroundForm = ({
   onPrepareResearchFollowUp,
   stickyDockEnabled = false,
   onComposerLayoutChange,
+  onDraftMessageChange,
 }: Props) => {
   const { t: translate } = useTranslation(["playground", "common", "option"]);
   const t = React.useCallback(
@@ -1770,6 +1772,10 @@ export const PlaygroundForm = ({
     wrapComposerProfile,
     draftSaved,
   } = composerInput;
+
+  React.useEffect(() => {
+    onDraftMessageChange?.(form.values.message || "");
+  }, [form.values.message, onDraftMessageChange]);
 
   const { deferredInput: deferredComposerInput } = useDeferredComposerInput(
     form.values.message || "",

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -248,7 +248,7 @@ type Props = {
   onPrepareResearchFollowUp?: (target: ResearchFollowUpTarget) => void;
   stickyDockEnabled?: boolean;
   onComposerLayoutChange?: (metrics: ComposerDockLayoutMetrics) => void;
-  onDraftMessageChange?: (message: string) => void;
+  onDraftPresenceChange?: (hasDraft: boolean) => void;
 };
 
 type DefaultCharacterPreferenceQueryResult = {
@@ -412,6 +412,9 @@ const LazyPlaygroundMcpSettingsModal = React.lazy(() =>
   })),
 );
 
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
 export const PlaygroundForm = ({
   droppedFiles,
   attachedResearchContext = null,
@@ -429,7 +432,7 @@ export const PlaygroundForm = ({
   onPrepareResearchFollowUp,
   stickyDockEnabled = false,
   onComposerLayoutChange,
-  onDraftMessageChange,
+  onDraftPresenceChange,
 }: Props) => {
   const { t: translate } = useTranslation(["playground", "common", "option"]);
   const t = React.useCallback(
@@ -1773,9 +1776,10 @@ export const PlaygroundForm = ({
     draftSaved,
   } = composerInput;
 
-  React.useEffect(() => {
-    onDraftMessageChange?.(form.values.message || "");
-  }, [form.values.message, onDraftMessageChange]);
+  const hasDraft = (form.values.message || "").trim().length > 0;
+  useIsomorphicLayoutEffect(() => {
+    onDraftPresenceChange?.(hasDraft);
+  }, [hasDraft, onDraftPresenceChange]);
 
   const { deferredInput: deferredComposerInput } = useDeferredComposerInput(
     form.values.message || "",

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -65,6 +65,10 @@ const storageState = vi.hoisted(() => ({
   values: new Map<string, unknown>(),
 }));
 
+const chatSettingsState = vi.hoisted(() => ({
+  syncChatSettingsForServerChat: vi.fn(async (_params: unknown) => null),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, defaultValue?: string) => defaultValue || key,
@@ -72,11 +76,38 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
-  PlaygroundForm: () => <div data-testid="playground-form" />,
+  PlaygroundForm: ({
+    onDraftMessageChange,
+  }: {
+    onDraftMessageChange?: (message: string) => void;
+  }) => (
+    <div data-testid="playground-form">
+      <textarea
+        aria-label="Composer draft"
+        data-testid="composer-textarea"
+        onChange={(event) => onDraftMessageChange?.(event.currentTarget.value)}
+      />
+    </div>
+  ),
 }));
 
 vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
-  PlaygroundChat: () => <div data-testid="playground-chat" />,
+  PlaygroundChat: ({
+    showStarterDeck,
+  }: {
+    showStarterDeck?: boolean;
+  }) => {
+    const legacyWouldShowStarterDeck =
+      messageOptionState.value.messages.length === 0;
+
+    return (
+      <div data-testid="playground-chat">
+        {(showStarterDeck ?? legacyWouldShowStarterDeck) && (
+          <div data-testid="playground-empty-mode-deck" />
+        )}
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/components/Sidepanel/Chat/ArtifactsPanel", () => ({
@@ -97,6 +128,11 @@ vi.mock("@/hooks/playground-session-restore", () => ({
 
 vi.mock("@/services/app", () => ({
   webUIResumeLastChat: vi.fn(async () => false),
+}));
+
+vi.mock("@/services/chat-settings", () => ({
+  syncChatSettingsForServerChat: (params: unknown) =>
+    chatSettingsState.syncChatSettingsForServerChat(params),
 }));
 
 vi.mock("@/db/dexie/helpers", () => ({
@@ -229,6 +265,7 @@ describe("Playground cockpit shell", () => {
     messageOptionState.value.contextFiles = [];
     messageOptionState.value.regenerateLastMessage = vi.fn();
     sessionPersistenceState.value.sessionScopeReady = true;
+    chatSettingsState.syncChatSettingsForServerChat.mockClear();
   });
 
   it("renders the cockpit rails, main chat surface, and status strip by default", async () => {
@@ -251,6 +288,68 @@ describe("Playground cockpit shell", () => {
     ).toHaveTextContent("Context and runtime rails visible.");
     expect(screen.getByTestId("playground-chat")).toBeInTheDocument();
     expect(screen.getByTestId("playground-form")).toBeInTheDocument();
+  });
+
+  it("shows the starter deck for a true blank chat state", async () => {
+    render(<Playground />);
+
+    expect(
+      await screen.findByTestId("playground-empty-mode-deck"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the starter deck when the composer has unsent draft text", async () => {
+    render(<Playground />);
+
+    expect(
+      await screen.findByTestId("playground-empty-mode-deck"),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("composer-textarea"), {
+      target: { value: "Draft a cockpit-ready message" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("playground-empty-mode-deck")).toBeNull();
+    });
+  });
+
+  it("keeps the starter deck hidden for an active conversation without rendered messages", async () => {
+    messageOptionState.value.historyId = "local-history-1";
+    messageOptionState.value.serverChatId = "server-chat-1";
+
+    render(<Playground />);
+
+    await screen.findByTestId("playground-cockpit-shell");
+
+    expect(screen.queryByTestId("playground-empty-mode-deck")).toBeNull();
+  });
+
+  it("restores the starter deck when draft text is cleared before send", async () => {
+    render(<Playground />);
+
+    expect(
+      await screen.findByTestId("playground-empty-mode-deck"),
+    ).toBeInTheDocument();
+
+    const composer = screen.getByTestId("composer-textarea");
+    fireEvent.change(composer, {
+      target: { value: "Temporary draft" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("playground-empty-mode-deck")).toBeNull();
+    });
+
+    fireEvent.change(composer, {
+      target: { value: "" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("playground-empty-mode-deck"),
+      ).toBeInTheDocument();
+    });
   });
 
   it("keeps cockpit tooltip ids unique across multiple shell instances", async () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -69,6 +69,10 @@ const chatSettingsState = vi.hoisted(() => ({
   syncChatSettingsForServerChat: vi.fn(async (_params: unknown) => null),
 }));
 
+const cockpitChatRenderState = vi.hoisted(() => ({
+  starterDeckSignals: [] as Array<boolean | undefined>,
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, defaultValue?: string) => defaultValue || key,
@@ -77,15 +81,17 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
   PlaygroundForm: ({
-    onDraftMessageChange,
+    onDraftPresenceChange,
   }: {
-    onDraftMessageChange?: (message: string) => void;
+    onDraftPresenceChange?: (hasDraft: boolean) => void;
   }) => (
     <div data-testid="playground-form">
       <textarea
         aria-label="Composer draft"
         data-testid="composer-textarea"
-        onChange={(event) => onDraftMessageChange?.(event.currentTarget.value)}
+        onChange={(event) =>
+          onDraftPresenceChange?.(event.currentTarget.value.trim().length > 0)
+        }
       />
     </div>
   ),
@@ -97,6 +103,7 @@ vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
   }: {
     showStarterDeck?: boolean;
   }) => {
+    cockpitChatRenderState.starterDeckSignals.push(showStarterDeck);
     const legacyWouldShowStarterDeck =
       messageOptionState.value.messages.length === 0;
 
@@ -266,6 +273,7 @@ describe("Playground cockpit shell", () => {
     messageOptionState.value.regenerateLastMessage = vi.fn();
     sessionPersistenceState.value.sessionScopeReady = true;
     chatSettingsState.syncChatSettingsForServerChat.mockClear();
+    cockpitChatRenderState.starterDeckSignals = [];
   });
 
   it("renders the cockpit rails, main chat surface, and status strip by default", async () => {
@@ -349,6 +357,35 @@ describe("Playground cockpit shell", () => {
       expect(
         screen.getByTestId("playground-empty-mode-deck"),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("does not re-render the chat surface for draft edits that keep the same blankness", async () => {
+    render(<Playground />);
+
+    expect(
+      await screen.findByTestId("playground-empty-mode-deck"),
+    ).toBeInTheDocument();
+
+    const composer = screen.getByTestId("composer-textarea");
+    fireEvent.change(composer, {
+      target: { value: "First non-empty draft" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("playground-empty-mode-deck")).toBeNull();
+    });
+    const renderCountAfterIntentChange =
+      cockpitChatRenderState.starterDeckSignals.length;
+
+    fireEvent.change(composer, {
+      target: { value: "First non-empty draft with more text" },
+    });
+
+    await waitFor(() => {
+      expect(cockpitChatRenderState.starterDeckSignals).toHaveLength(
+        renderCountAfterIntentChange,
+      );
     });
   });
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx
@@ -119,6 +119,18 @@ describe("PlaygroundChat selected server chat load state", () => {
     expect(emptyState.parentElement?.parentElement).not.toHaveClass("pt-16")
   })
 
+  it("omits the starter deck when the parent chat surface disallows it", () => {
+    useMessageOptionState.value = {
+      ...useMessageOptionState.value,
+      serverChatLoadState: "idle",
+      serverChatLoadError: null
+    }
+
+    render(<PlaygroundChat showStarterDeck={false} />)
+
+    expect(screen.queryByTestId("playground-empty")).not.toBeInTheDocument()
+  })
+
   it("shows a selected-chat load failure state instead of the empty state", () => {
     useMessageOptionState.value = {
       ...useMessageOptionState.value,

--- a/backlog/tasks/task-412 - Implement-main-chat-intent-gated-starter-deck.md
+++ b/backlog/tasks/task-412 - Implement-main-chat-intent-gated-starter-deck.md
@@ -1,0 +1,62 @@
+---
+id: TASK-412
+title: Implement main chat intent-gated starter deck
+status: Done
+labels:
+- webui
+- chat
+- cockpit
+- ux
+- frontend
+priority: medium
+documentation:
+- Docs/superpowers/plans/2026-05-16-chat-cockpit-intent-gated-starter-deck.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved main WebUI /chat first-paint density slice. Keep the full starter deck only for a true blank state, collapse or omit it when the user has typed a draft or a conversation exists, and avoid bottom controls, extension sidepanel/sidebar scope, or unrelated pages.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Full /chat starter deck remains visible on true blank state with no draft and no conversation.
+- [x] #2 Starter deck hides or collapses when the composer has draft text before send.
+- [x] #3 Starter deck stays hidden for existing/loaded conversations.
+- [x] #4 Clearing the draft before any send can restore the starter deck.
+- [x] #5 No bottom bar or composer-adjacent replacement summary is introduced.
+- [x] #6 Focused tests cover blank, draft, existing conversation, and restored blank states.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created the implementation plan at Docs/superpowers/plans/2026-05-16-chat-cockpit-intent-gated-starter-deck.md. Scope is main WebUI /chat only, with no sidepanel/sidebar or bottom replacement summary.
+
+Implemented parent-owned starter deck visibility in `Playground.tsx`, a narrow composer draft callback in `PlaygroundForm.tsx`, and a `showStarterDeck` gate in `PlaygroundChat.tsx`. Provider/model availability warnings remain independent of the starter deck gate so chat feedback can still appear when relevant.
+
+Verification:
+- Red test: focused cockpit-shell suite failed before implementation on draft, active conversation, and restored-draft starter deck assertions.
+- Green tests: `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.signals.guard.test.ts --config vitest.config.ts` passed with 4 files and 22 tests.
+- TypeScript: `bunx tsc --noEmit --project tsconfig.json --pretty false` still fails on existing repo-wide baseline; filtered log found no touched-file errors for the Playground files/tests in this task.
+- Whitespace: `git diff --check` passed.
+- Browser proof: not captured because no tldw_server2 frontend/backend listener was running on the expected local ports. `lsof` showed unrelated tldw_chatbook on `8837` and llama-server on `9099`; no mocked data or alternate fake server was used.
+- Bandit skipped because touched runtime scope is frontend TypeScript plus Markdown task/plan files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Main `/chat` starter deck is now intent-gated for the first slice: visible only for true blank state, hidden after unsent draft text or active conversation identity, and restored when draft text is cleared before send. No bottom bar, composer replacement summary, extension sidepanel/sidebar, or unrelated page changes were introduced.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-412 - Implement-main-chat-intent-gated-starter-deck.md
+++ b/backlog/tasks/task-412 - Implement-main-chat-intent-gated-starter-deck.md
@@ -45,6 +45,14 @@ Verification:
 - Whitespace: `git diff --check` passed.
 - Browser proof: not captured because no tldw_server2 frontend/backend listener was running on the expected local ports. `lsof` showed unrelated tldw_chatbook on `8837` and llama-server on `9099`; no mocked data or alternate fake server was used.
 - Bandit skipped because touched runtime scope is frontend TypeScript plus Markdown task/plan files.
+
+Review fix:
+- Addressed Gemini/Qodo draft callback comments by changing the parent signal from full draft text to boolean draft presence.
+- `PlaygroundForm` now notifies with an isomorphic layout effect keyed on draft presence, avoiding per-keystroke parent re-renders and preventing a restored-draft starter-deck paint flash.
+- Added a regression assertion that non-empty-to-non-empty draft edits do not re-render the chat surface after the initial intent transition.
+- Re-ran focused tests: `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.signals.guard.test.ts --config vitest.config.ts` passed with 4 files and 23 tests.
+- Re-ran TypeScript baseline check; it still fails on existing repo-wide errors, with no touched-file matches in `/tmp/chat-cockpit-intent-starter-tsc-review.log`.
+- Re-ran `git diff --check`; passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-412 - Implement-main-chat-intent-gated-starter-deck.md
+++ b/backlog/tasks/task-412 - Implement-main-chat-intent-gated-starter-deck.md
@@ -11,6 +11,8 @@ labels:
 priority: medium
 documentation:
 - Docs/superpowers/plans/2026-05-16-chat-cockpit-intent-gated-starter-deck.md
+related:
+- https://github.com/rmusser01/tldw_server/pull/1795
 ---
 
 ## Description


### PR DESCRIPTION
## Summary
- Adds a parent-owned `/chat` starter deck visibility signal so the full deck only appears for true blank state.
- Reports only composer draft presence upward, not full draft text, so the large `Playground` coordinator does not re-render on every non-empty keystroke.
- Keeps provider/model availability warnings independent of the starter deck gate and adds focused coverage for blank, draft, active conversation, cleared-draft restoration, parent override, and non-rerender cases.

## Change summary
Pending human-written change summary before merge.

## UX Audit Checklist
- [x] Main WebUI `/chat` only.
- [x] No browser-extension sidepanel/sidebar changes.
- [x] No backend/API changes.
- [x] No bottom bar or composer-adjacent replacement summary added.
- [x] True blank state still shows the starter deck.
- [x] Draft text, active local conversation, and active server conversation hide the starter deck.
- [x] Clearing draft text before send restores the starter deck.
- [x] Provider/model availability warnings remain visible independently from the starter deck.
- [x] Focused tests cover the starter-deck intent states and the review-requested render behavior.

## Risk & Rollback
- Risk: Low to medium. The runtime change is limited to `/chat` Playground composition and starter-deck visibility, but it touches the large Playground coordinator.
- Rollback: Revert this PR to restore the prior always-render-empty-deck behavior. No migrations, backend changes, or persisted data changes are involved.

## Test Plan
- [x] `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/PlaygroundChat.server-load-state.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.signals.guard.test.ts --config vitest.config.ts`
- [x] `bunx tsc --noEmit --project tsconfig.json --pretty false` still fails on existing repo-wide baseline; filtered `/tmp/chat-cockpit-intent-starter-tsc-review.log` found no touched-file errors.
- [x] `git diff --check`
- [x] Real-server browser proof attempted/documented: no tldw_server2 frontend/backend listener was running on expected local ports, so no browser screenshot was captured. No mocked data or alternate fake server was used.

## Review Fixes
- Gemini performance thread: addressed by changing the parent signal from full draft text to boolean draft presence.
- Qodo restored-draft flash thread: addressed by notifying from an isomorphic layout effect keyed on draft presence.
- Both inline review threads were replied to and resolved.

## Scope
Main WebUI `/chat` only. No browser-extension sidepanel/sidebar changes, no backend/API changes, and no bottom bar or composer replacement summary.
