### PR TITLE
Add Persona Visual provider archive retrieval adapter

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -371,11 +371,15 @@ assigns real asset ids.
 
 The provider archive handoff helper,
 `build_provider_archive_import_preview_handoff()`, validates a normalized
-portable archive envelope into an MCP resource retrieval descriptor. It is still
-pre-persistence: it does not download MCP resources, create preview rows,
-enqueue import-preview Jobs, write archives, commit imports, or activate packs.
-The existing import-preview job contract remains local-archive-path based after
-a future retrieval adapter materializes the archive.
+portable archive envelope into an MCP resource retrieval descriptor. The
+retrieval materializer,
+`materialize_provider_archive_import_preview_handoff()`, accepts that ready
+descriptor plus an injected resource reader, writes bounded bytes to the local
+import-preview staging area, verifies the provider SHA-256 checksum, and returns
+the existing local-archive-path import-preview job payload. Both helpers remain
+pre-commit and non-activating: they do not create preview rows, enqueue Jobs,
+commit imports, activate packs, change renderer support, or expose raw provider
+payloads in diagnostics.
 
 Provider provenance is metadata only. It must not override user ownership,
 persona scope, activation state, or personal-library source references. The

--- a/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
+++ b/Docs/Design/2026-05-13-persona-visual-external-mcp-provider-contract.md
@@ -123,10 +123,13 @@ persist provider output.
 Portable archive results then pass through
 `build_provider_archive_import_preview_handoff()`. That handoff validates the
 normalized archive metadata and returns an MCP resource retrieval descriptor for
-the next intake step. It does not create preview rows, write archive files,
-enqueue Jobs, commit imports, or activate packs; a later resource-retrieval
-adapter must materialize a local archive path before using the existing
-import-preview job payload.
+the next intake step. `materialize_provider_archive_import_preview_handoff()`
+then accepts the ready descriptor plus an injected authenticated resource
+reader, writes bounded bytes into the local import-preview staging area,
+verifies the provider checksum, and returns the existing local-archive-path
+import-preview job payload. These helpers do not create preview rows, enqueue
+Jobs, commit imports, activate packs, change renderer support, or expose raw
+provider payloads in diagnostics.
 
 ```json
 {
@@ -204,13 +207,16 @@ Use this when the provider can produce a `.tldw-persona-vpack` archive.
 
 Handoff:
 
-1. tldw retrieves the MCP resource through an authenticated MCP client path.
-2. tldw runs the existing archive import preview flow.
-3. Preview records warnings, blockers, conflicts, quota estimates, renderer
+1. tldw builds a review-only handoff descriptor from the normalized provider
+   envelope.
+2. tldw materializes the MCP resource through an authenticated injected reader
+   into local import-preview staging, enforcing size and checksum validation.
+3. tldw runs the existing archive import preview flow.
+4. Preview records warnings, blockers, conflicts, quota estimates, renderer
    diagnostics, and proposed commit plan.
-4. Commit creates or replaces a reviewed draft only when the preview is
+5. Commit creates or replaces a reviewed draft only when the preview is
    eligible and required choices are supplied.
-5. Activation remains separate.
+6. Activation remains separate.
 
 ### Generated Candidate
 
@@ -401,7 +407,9 @@ Recommended sequence:
    into an MCP resource retrieval request without writing assets or enqueueing
    Jobs.
 4. Portable archive intake: retrieve a provider archive resource and enqueue the
-   existing import-preview job after a local archive path exists.
+   existing import-preview job after a local archive path exists. The backend
+   materialization helper for this path exists, but endpoint/worker orchestration
+   remains a separate slice.
 5. Generated-candidate intake: retrieve provider assets, validate metadata, and
    create a reviewed candidate for an existing draft.
 6. Persona Garden provider review UI: show provider offers, diagnostics,

--- a/backlog/tasks/task-413 - Implement-Persona-Visual-provider-archive-retrieval-adapter.md
+++ b/backlog/tasks/task-413 - Implement-Persona-Visual-provider-archive-retrieval-adapter.md
@@ -59,6 +59,16 @@ passed for the new module/test. git diff --check passed. Bandit wrote
 `/tmp/bandit_persona_provider_archive_retrieval.json` with zero findings after
 replacing assert statements with casts.
 
+PR #1797 review follow-up: addressed still-valid Gemini, CodeRabbit, and Qodo
+comments by allowing bytearray chunks, making media type validation
+case-insensitive, deriving the private retrieval error from the project
+`DownloadError`, using pathlib cleanup, removing redundant Path wrapping, and
+redacting upstream diagnostic messages while preserving diagnostic codes.
+Validation: focused provider archive retrieval/provider envelope/visual jobs
+pytest passed with 53 tests; py_compile passed; git diff --check passed; Bandit
+wrote `/tmp/bandit_persona_provider_archive_retrieval_review.json` with zero
+findings.
+
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-413 - Implement-Persona-Visual-provider-archive-retrieval-adapter.md
+++ b/backlog/tasks/task-413 - Implement-Persona-Visual-provider-archive-retrieval-adapter.md
@@ -1,0 +1,78 @@
+---
+id: TASK-413
+title: Implement Persona Visual provider archive retrieval adapter
+status: Done
+labels:
+- persona
+- persona-visual
+- mcp
+- backend
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1796
+- https://github.com/rmusser01/tldw_server/pull/1792
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the backend-only Persona Visual provider archive retrieval/materialization slice tracked by GitHub issue #1796. Convert validated provider archive handoff descriptors from PR #1792 into local archive import-preview job input through a bounded retrieval adapter, without committing imports, activating packs, changing renderers, adding WebUI, or touching Buddy animation/VN behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Provider archive handoff descriptors can be materialized into a local archive input without committing or activating packs.
+- [x] #2 The adapter fails closed for missing resource handles, unsupported media types, oversized payloads, checksum mismatch, unsafe paths/URIs, and retrieval failures.
+- [x] #3 Existing import-preview job payload conventions remain the source of truth after materialization.
+- [x] #4 Trace/log/output data remains bounded and does not expose raw provider payloads, local temp paths, secrets, or archive contents.
+- [x] #5 Focused backend tests cover valid materialization and fail-closed cases.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect merged provider handoff helper and existing Persona Visual import-preview job payload conventions.
+2. Add focused RED tests for valid materialization and fail-closed retrieval/checksum/size/media/path cases.
+3. Implement a bounded pure retrieval/materialization adapter around an injectable resource fetcher/writer abstraction.
+4. Update docs/task notes with boundary and validation results.
+5. Run focused pytest, py_compile, git diff --check, and Bandit on touched Python scope.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented `materialize_provider_archive_import_preview_handoff()` in
+`provider_archive_retrieval.py`. The helper accepts a ready provider archive
+handoff plus an injected resource reader, writes bounded byte chunks into local
+import-preview staging, validates MCP resource handles/media type/checksum/size,
+deletes partial files on failure, and returns the existing
+`build_visual_pack_import_preview_payload()` shape without creating preview
+rows, enqueueing Jobs, committing imports, activating packs, changing renderers,
+or exposing raw provider payloads in diagnostics.
+
+RED verification: provider archive retrieval pytest failed on missing module
+before implementation.
+
+GREEN verification: provider archive retrieval pytest passed; focused provider
+envelope and visual jobs regressions passed with 50 total tests. py_compile
+passed for the new module/test. git diff --check passed. Bandit wrote
+`/tmp/bandit_persona_provider_archive_retrieval.json` with zero findings after
+replacing assert statements with casts.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the backend-only Persona Visual provider archive retrieval/materialization adapter. Ready provider archive handoff descriptors can now be converted into local archive import-preview job payloads through an injected resource reader with fail-closed validation for blocked handoffs, unsafe resource handles, invalid media/checksum metadata, non-byte resources, oversized resources, checksum mismatch, retrieval failures, and staging write failures. Docs now record that endpoint/worker orchestration remains a separate follow-up slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Persona/visual_portability/provider_archive_retrieval.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/provider_archive_retrieval.py
@@ -1,0 +1,394 @@
+"""Materialize Persona Visual provider archive handoffs for import preview.
+
+Provider envelope normalization and handoff construction intentionally stop at
+an MCP resource descriptor. This module implements the next backend-only bridge:
+given a ready handoff and an injected resource reader, it writes bounded archive
+bytes into local import-preview staging, verifies the provider checksum, and
+returns the existing Persona Visual import-preview Jobs payload shape. It does
+not execute providers, create preview rows, enqueue Jobs, commit imports,
+activate packs, change renderers, or expose raw provider content in diagnostics.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any, Callable, cast
+
+from tldw_Server_API.app.core.Persona.visual_jobs import (
+    PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+    build_visual_pack_import_preview_payload,
+)
+
+from .archive import DEFAULT_MAX_ARCHIVE_SIZE_BYTES
+from .constants import PERSONA_VISUAL_PACK_EXTENSION
+from .provider_envelope import COMPATIBLE_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPES
+
+
+ProviderArchiveResourceReader = Callable[[str], bytes | bytearray | Iterable[bytes]]
+
+_SHA256_HEX_LENGTH = 64
+_SAFE_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:-")
+_MAX_ID_LENGTH = 128
+
+
+def materialize_provider_archive_import_preview_handoff(
+    handoff: Mapping[str, Any],
+    *,
+    resource_reader: ProviderArchiveResourceReader,
+    staging_root: Path,
+    max_archive_size_bytes: int = DEFAULT_MAX_ARCHIVE_SIZE_BYTES,
+) -> dict[str, Any]:
+    """Fetch a ready provider archive handoff into an import-preview job payload."""
+    blockers: list[dict[str, str]] = []
+    warnings = _diagnostics_list(handoff.get("warnings"))
+    request = _mapping(handoff.get("request"))
+    archive = _mapping(handoff.get("archive"))
+
+    if handoff.get("ready") is not True:
+        blockers.append(_diagnostic("handoff_not_ready", "Provider archive handoff is not ready."))
+    if handoff.get("operation") != "import_preview":
+        blockers.append(
+            _diagnostic(
+                "unsupported_archive_handoff_operation",
+                "Provider archive handoff must target import preview.",
+            )
+        )
+    if handoff.get("job_type") != PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE:
+        blockers.append(
+            _diagnostic(
+                "unsupported_archive_handoff_job_type",
+                "Provider archive handoff uses an unsupported job type.",
+            )
+        )
+    blockers.extend(_diagnostics_list(handoff.get("blockers")))
+
+    user_id = _safe_identifier(request.get("user_id") if request else None)
+    preview_id = _safe_identifier(request.get("preview_id") if request else None)
+    request_id = _safe_identifier(request.get("request_id") if request else None)
+    target_persona_id = _safe_identifier(request.get("target_persona_id") if request else None)
+    if not user_id or not preview_id or not request_id:
+        blockers.append(
+            _diagnostic(
+                "invalid_handoff_request",
+                "Provider archive handoff request identifiers are required.",
+            )
+        )
+
+    resource_uri = _safe_resource_uri(archive.get("mcp_resource_uri") if archive else None)
+    expected_sha256 = _safe_sha256(archive.get("sha256") if archive else None)
+    media_type = _safe_text(archive.get("media_type") if archive else None, max_length=120)
+    if not archive or archive.get("source_type") != "mcp_resource" or not resource_uri:
+        blockers.append(
+            _diagnostic(
+                "archive_resource_uri_missing",
+                "Portable archive MCP resource URI is required.",
+            )
+        )
+    if not expected_sha256:
+        blockers.append(
+            _diagnostic(
+                "archive_sha256_invalid",
+                "Portable archive SHA-256 checksum is required.",
+            )
+        )
+    if media_type not in COMPATIBLE_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPES:
+        blockers.append(
+            _diagnostic(
+                "unsupported_archive_media_type",
+                "Portable archive media type must be a supported zip payload type.",
+            )
+        )
+
+    if blockers:
+        return _blocked_result(blockers=blockers, warnings=warnings)
+
+    user_id = cast(str, user_id)
+    preview_id = cast(str, preview_id)
+    request_id = cast(str, request_id)
+    resource_uri = cast(str, resource_uri)
+    expected_sha256 = cast(str, expected_sha256)
+
+    archive_path = _materialized_archive_path(
+        staging_root=Path(staging_root),
+        user_id=user_id,
+        preview_id=preview_id,
+        request_id=request_id,
+        resource_uri=resource_uri,
+    )
+    try:
+        size_bytes, actual_sha256 = _write_resource_archive(
+            archive_path=archive_path,
+            resource_reader=resource_reader,
+            resource_uri=resource_uri,
+            max_archive_size_bytes=max_archive_size_bytes,
+        )
+    except _ProviderArchiveRetrievalError as exc:
+        _remove_file(archive_path)
+        return _blocked_result(blockers=[_diagnostic(exc.code, exc.message)], warnings=warnings)
+
+    if actual_sha256 != expected_sha256:
+        _remove_file(archive_path)
+        return _blocked_result(
+            blockers=[
+                _diagnostic(
+                    "archive_sha256_mismatch",
+                    "Retrieved archive checksum does not match provider metadata.",
+                )
+            ],
+            warnings=warnings,
+        )
+
+    job_payload = build_visual_pack_import_preview_payload(
+        user_id=user_id,
+        preview_id=preview_id,
+        archive_path=str(archive_path),
+        request_id=request_id,
+        target_persona_id=target_persona_id,
+    )
+    return {
+        "ready": True,
+        "operation": "import_preview",
+        "job_type": PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+        "job_payload": job_payload,
+        "archive": {
+            "source_type": "mcp_resource",
+            "media_type": media_type,
+            "sha256": actual_sha256,
+            "size_bytes": size_bytes,
+        },
+        "diagnostics": {
+            "status": "ready_for_import_preview_job",
+            "blockers": [],
+            "warnings": warnings,
+        },
+        "blockers": [],
+        "warnings": warnings,
+    }
+
+
+class _ProviderArchiveRetrievalError(Exception):
+    """Trace-safe retrieval failure with a stable diagnostic code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(code)
+        self.code = code
+        self.message = message
+
+
+def _write_resource_archive(
+    *,
+    archive_path: Path,
+    resource_reader: ProviderArchiveResourceReader,
+    resource_uri: str,
+    max_archive_size_bytes: int,
+) -> tuple[int, str]:
+    """Write resource chunks to disk while enforcing size and checksum accounting."""
+    if max_archive_size_bytes <= 0:
+        raise _ProviderArchiveRetrievalError(
+            "archive_too_large",
+            "Retrieved archive exceeds size limits.",
+        )
+
+    try:
+        resource = resource_reader(resource_uri)
+        chunks = _resource_chunks(resource)
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        digest = hashlib.sha256()
+        size_bytes = 0
+        with archive_path.open("wb") as file_obj:
+            for chunk in chunks:
+                if not isinstance(chunk, bytes):
+                    raise _ProviderArchiveRetrievalError(
+                        "archive_resource_invalid",
+                        "Retrieved archive resource must yield bytes.",
+                    )
+                size_bytes += len(chunk)
+                if size_bytes > max_archive_size_bytes:
+                    raise _ProviderArchiveRetrievalError(
+                        "archive_too_large",
+                        "Retrieved archive exceeds size limits.",
+                    )
+                digest.update(chunk)
+                file_obj.write(chunk)
+    except _ProviderArchiveRetrievalError:
+        raise
+    except OSError as exc:
+        raise _ProviderArchiveRetrievalError(
+            "archive_materialization_failed",
+            "Retrieved archive could not be written to staging.",
+        ) from exc
+    except Exception as exc:
+        raise _ProviderArchiveRetrievalError(
+            "archive_retrieval_failed",
+            "Provider archive resource retrieval failed.",
+        ) from exc
+
+    return size_bytes, digest.hexdigest()
+
+
+def _resource_chunks(value: bytes | bytearray | Iterable[bytes]) -> Iterable[bytes]:
+    """Return byte chunks from a reader result or raise a trace-safe error."""
+    if isinstance(value, bytes):
+        return (value,)
+    if isinstance(value, bytearray):
+        return (bytes(value),)
+    if isinstance(value, (str, Mapping)):
+        raise _ProviderArchiveRetrievalError(
+            "archive_resource_invalid",
+            "Retrieved archive resource must be bytes.",
+        )
+    if isinstance(value, Iterable):
+        return value
+    raise _ProviderArchiveRetrievalError(
+        "archive_resource_invalid",
+        "Retrieved archive resource must be bytes.",
+    )
+
+
+def _materialized_archive_path(
+    *,
+    staging_root: Path,
+    user_id: str,
+    preview_id: str,
+    request_id: str,
+    resource_uri: str,
+) -> Path:
+    """Return a deterministic local archive path without embedding provider URI text."""
+    fingerprint = hashlib.sha256(
+        f"{user_id}\0{preview_id}\0{request_id}\0{resource_uri}".encode("utf-8")
+    ).hexdigest()[:24]
+    filename = f"{fingerprint}{PERSONA_VISUAL_PACK_EXTENSION}"
+    return Path(staging_root).resolve(strict=False) / filename
+
+
+def _blocked_result(
+    *,
+    blockers: list[dict[str, str]],
+    warnings: list[dict[str, str]],
+) -> dict[str, Any]:
+    """Return a trace-safe blocked materialization result."""
+    return {
+        "ready": False,
+        "operation": "import_preview",
+        "job_type": PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+        "job_payload": None,
+        "archive": None,
+        "diagnostics": {
+            "status": "blocked",
+            "blockers": _dedupe_diagnostics(blockers),
+            "warnings": warnings,
+        },
+        "blockers": _dedupe_diagnostics(blockers),
+        "warnings": warnings,
+    }
+
+
+def _mapping(value: Any) -> Mapping[str, Any] | None:
+    """Return mappings only, preserving read-only access for caller-owned data."""
+    return value if isinstance(value, Mapping) else None
+
+
+def _diagnostics_list(value: Any) -> list[dict[str, str]]:
+    """Copy bounded diagnostic code/message objects without leaking arbitrary payloads."""
+    if not isinstance(value, list):
+        return []
+    diagnostics: list[dict[str, str]] = []
+    for item in value[:64]:
+        if not isinstance(item, Mapping):
+            continue
+        code = _safe_code(item.get("code"))
+        message = _safe_text(item.get("message"), max_length=300)
+        if code and message:
+            diagnostics.append(_diagnostic(code, message))
+    return diagnostics
+
+
+def _dedupe_diagnostics(items: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Return diagnostics in first-seen order without duplicate codes."""
+    seen: set[str] = set()
+    out: list[dict[str, str]] = []
+    for item in items:
+        code = _safe_code(item.get("code"))
+        if not code or code in seen:
+            continue
+        seen.add(code)
+        out.append(_diagnostic(code, item.get("message", "")))
+    return out
+
+
+def _diagnostic(code: str, message: str) -> dict[str, str]:
+    """Build a stable machine-readable diagnostic object."""
+    return {
+        "code": _safe_code(code) or "archive_materialization_failed",
+        "message": (
+            _safe_text(message, max_length=300)
+            or "Provider archive materialization failed."
+        ),
+    }
+
+
+def _safe_identifier(value: Any) -> str | None:
+    """Return a bounded identifier for job payload fields."""
+    text = _safe_text(value, max_length=_MAX_ID_LENGTH)
+    if not text:
+        return None
+    if any(char not in _SAFE_ID_CHARS for char in text):
+        return None
+    return text
+
+
+def _safe_resource_uri(value: Any) -> str | None:
+    """Return an MCP resource URI handle without accepting paths or remote URLs."""
+    text = _safe_text(value, max_length=500)
+    if not text or not text.startswith("mcp://"):
+        return None
+    if any(part in text for part in ("\n", "\r", "\x00", "\\", "../", "/..")):
+        return None
+    return text
+
+
+def _safe_sha256(value: Any) -> str | None:
+    """Return a lowercase SHA-256 digest when it is syntactically valid."""
+    text = _safe_text(value, max_length=80).lower()
+    if len(text) != _SHA256_HEX_LENGTH:
+        return None
+    if any(char not in "0123456789abcdef" for char in text):
+        return None
+    return text
+
+
+def _safe_code(value: Any) -> str:
+    """Return a bounded diagnostic code."""
+    text = _safe_text(value, max_length=80)
+    if not text:
+        return ""
+    if not text[0].isalpha():
+        return ""
+    if any(char not in "abcdefghijklmnopqrstuvwxyz0123456789_:-" for char in text):
+        return ""
+    return text
+
+
+def _safe_text(value: Any, *, max_length: int) -> str:
+    """Return stripped scalar text without path expansion or newlines."""
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if len(text) > max_length:
+        return ""
+    if any(char in text for char in ("\n", "\r", "\x00")):
+        return ""
+    return text
+
+
+def _remove_file(path: Path) -> None:
+    """Remove a partial materialized archive without surfacing filesystem details."""
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        return
+    except OSError:
+        return

--- a/tldw_Server_API/app/core/Persona/visual_portability/provider_archive_retrieval.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/provider_archive_retrieval.py
@@ -12,11 +12,11 @@ activate packs, change renderers, or expose raw provider content in diagnostics.
 from __future__ import annotations
 
 import hashlib
-import os
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any, Callable, cast
 
+from tldw_Server_API.app.core.exceptions import DownloadError
 from tldw_Server_API.app.core.Persona.visual_jobs import (
     PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
     build_visual_pack_import_preview_payload,
@@ -27,11 +27,19 @@ from .constants import PERSONA_VISUAL_PACK_EXTENSION
 from .provider_envelope import COMPATIBLE_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPES
 
 
-ProviderArchiveResourceReader = Callable[[str], bytes | bytearray | Iterable[bytes]]
+ProviderArchiveResourceReader = Callable[
+    [str],
+    bytes | bytearray | Iterable[bytes | bytearray],
+]
 
 _SHA256_HEX_LENGTH = 64
 _SAFE_ID_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:-")
 _MAX_ID_LENGTH = 128
+_COMPATIBLE_ARCHIVE_MEDIA_TYPES = {
+    media_type.lower()
+    for media_type in COMPATIBLE_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPES
+}
+_UPSTREAM_DIAGNOSTIC_MESSAGE = "Provider archive handoff reported a diagnostic."
 
 
 def materialize_provider_archive_import_preview_handoff(
@@ -79,7 +87,10 @@ def materialize_provider_archive_import_preview_handoff(
 
     resource_uri = _safe_resource_uri(archive.get("mcp_resource_uri") if archive else None)
     expected_sha256 = _safe_sha256(archive.get("sha256") if archive else None)
-    media_type = _safe_text(archive.get("media_type") if archive else None, max_length=120)
+    media_type = _safe_text(
+        archive.get("media_type") if archive else None,
+        max_length=120,
+    ).lower()
     if not archive or archive.get("source_type") != "mcp_resource" or not resource_uri:
         blockers.append(
             _diagnostic(
@@ -94,7 +105,7 @@ def materialize_provider_archive_import_preview_handoff(
                 "Portable archive SHA-256 checksum is required.",
             )
         )
-    if media_type not in COMPATIBLE_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPES:
+    if media_type not in _COMPATIBLE_ARCHIVE_MEDIA_TYPES:
         blockers.append(
             _diagnostic(
                 "unsupported_archive_media_type",
@@ -112,7 +123,7 @@ def materialize_provider_archive_import_preview_handoff(
     expected_sha256 = cast(str, expected_sha256)
 
     archive_path = _materialized_archive_path(
-        staging_root=Path(staging_root),
+        staging_root=staging_root,
         user_id=user_id,
         preview_id=preview_id,
         request_id=request_id,
@@ -169,7 +180,7 @@ def materialize_provider_archive_import_preview_handoff(
     }
 
 
-class _ProviderArchiveRetrievalError(Exception):
+class _ProviderArchiveRetrievalError(DownloadError):
     """Trace-safe retrieval failure with a stable diagnostic code."""
 
     def __init__(self, code: str, message: str) -> None:
@@ -200,7 +211,7 @@ def _write_resource_archive(
         size_bytes = 0
         with archive_path.open("wb") as file_obj:
             for chunk in chunks:
-                if not isinstance(chunk, bytes):
+                if not isinstance(chunk, (bytes, bytearray)):
                     raise _ProviderArchiveRetrievalError(
                         "archive_resource_invalid",
                         "Retrieved archive resource must yield bytes.",
@@ -229,7 +240,9 @@ def _write_resource_archive(
     return size_bytes, digest.hexdigest()
 
 
-def _resource_chunks(value: bytes | bytearray | Iterable[bytes]) -> Iterable[bytes]:
+def _resource_chunks(
+    value: bytes | bytearray | Iterable[bytes | bytearray],
+) -> Iterable[bytes | bytearray]:
     """Return byte chunks from a reader result or raise a trace-safe error."""
     if isinstance(value, bytes):
         return (value,)
@@ -261,7 +274,7 @@ def _materialized_archive_path(
         f"{user_id}\0{preview_id}\0{request_id}\0{resource_uri}".encode("utf-8")
     ).hexdigest()[:24]
     filename = f"{fingerprint}{PERSONA_VISUAL_PACK_EXTENSION}"
-    return Path(staging_root).resolve(strict=False) / filename
+    return staging_root.resolve(strict=False) / filename
 
 
 def _blocked_result(
@@ -300,9 +313,8 @@ def _diagnostics_list(value: Any) -> list[dict[str, str]]:
         if not isinstance(item, Mapping):
             continue
         code = _safe_code(item.get("code"))
-        message = _safe_text(item.get("message"), max_length=300)
-        if code and message:
-            diagnostics.append(_diagnostic(code, message))
+        if code:
+            diagnostics.append(_diagnostic(code, _UPSTREAM_DIAGNOSTIC_MESSAGE))
     return diagnostics
 
 
@@ -387,8 +399,6 @@ def _safe_text(value: Any, *, max_length: int) -> str:
 def _remove_file(path: Path) -> None:
     """Remove a partial materialized archive without surfacing filesystem details."""
     try:
-        os.remove(path)
-    except FileNotFoundError:
-        return
+        path.unlink(missing_ok=True)
     except OSError:
         return

--- a/tldw_Server_API/tests/Persona/test_persona_visual_provider_archive_retrieval.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_provider_archive_retrieval.py
@@ -22,6 +22,7 @@ def _ready_handoff(
     *,
     archive_sha256: str,
     resource_uri: str = "mcp://provider/resources/pack",
+    media_type: str = CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
 ) -> dict[str, object]:
     return {
         "ready": True,
@@ -37,7 +38,7 @@ def _ready_handoff(
             "source_type": "mcp_resource",
             "mcp_resource_uri": resource_uri,
             "sha256": archive_sha256,
-            "media_type": CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
+            "media_type": media_type,
         },
         "diagnostics": {"blockers": [], "warnings": []},
         "blockers": [],
@@ -91,6 +92,42 @@ def test_materialize_provider_archive_import_preview_handoff_writes_job_payload(
     assert str(archive_path) not in str(result["diagnostics"])
 
 
+def test_materialize_provider_archive_import_preview_handoff_accepts_case_insensitive_media_type(
+    tmp_path: Path,
+) -> None:
+    """Treat compatible archive media types as case-insensitive metadata."""
+    archive_bytes = b"portable persona visual archive"
+
+    result = materialize_provider_archive_import_preview_handoff(
+        _ready_handoff(
+            archive_sha256=sha256_bytes(archive_bytes),
+            media_type=CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE.upper(),
+        ),
+        resource_reader=lambda uri: archive_bytes,
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is True
+    assert result["archive"]["media_type"] == CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE
+
+
+def test_materialize_provider_archive_import_preview_handoff_accepts_bytearray_chunks(
+    tmp_path: Path,
+) -> None:
+    """Allow bytearray chunks from resource readers because they are bytes-like."""
+    archive_bytes = b"portable persona visual archive"
+
+    result = materialize_provider_archive_import_preview_handoff(
+        _ready_handoff(archive_sha256=sha256_bytes(archive_bytes)),
+        resource_reader=lambda uri: [bytearray(archive_bytes[:8]), bytearray(archive_bytes[8:])],
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is True
+    archive_path = Path(str(result["job_payload"]["archive_path"]))
+    assert archive_path.read_bytes() == archive_bytes
+
+
 def test_materialize_provider_archive_import_preview_handoff_fails_closed_for_blocked_handoff(
     tmp_path: Path,
 ) -> None:
@@ -111,6 +148,40 @@ def test_materialize_provider_archive_import_preview_handoff_fails_closed_for_bl
     assert result["ready"] is False
     assert "handoff_not_ready" in _codes(result)
     assert list(tmp_path.iterdir()) == []
+
+
+def test_materialize_provider_archive_import_preview_handoff_redacts_upstream_diagnostics(
+    tmp_path: Path,
+) -> None:
+    """Keep upstream diagnostic codes without reflecting caller-provided messages."""
+    handoff = _ready_handoff(archive_sha256=sha256_bytes(b"archive"))
+    handoff["ready"] = False
+    handoff["blockers"] = [
+        {
+            "code": "provider_failed",
+            "message": "file:///Users/alice/secret-pack token=abc123",
+        }
+    ]
+    handoff["warnings"] = [
+        {
+            "code": "provider_warning",
+            "message": "mcp://provider/resources/private-pack",
+        }
+    ]
+
+    result = materialize_provider_archive_import_preview_handoff(
+        handoff,
+        resource_reader=lambda uri: b"archive",
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is False
+    assert "provider_failed" in _codes(result)
+    serialized = str(result)
+    assert "file:///Users/alice" not in serialized
+    assert "token=abc123" not in serialized
+    assert "mcp://provider/resources/private-pack" not in serialized
+    assert "Provider archive handoff reported a diagnostic." in serialized
 
 
 def test_materialize_provider_archive_import_preview_handoff_rejects_checksum_mismatch(

--- a/tldw_Server_API/tests/Persona/test_persona_visual_provider_archive_retrieval.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_provider_archive_retrieval.py
@@ -1,0 +1,190 @@
+"""Tests for Persona Visual provider archive retrieval materialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Persona.visual_jobs import (
+    PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+)
+from tldw_Server_API.app.core.Persona.visual_portability.fingerprints import sha256_bytes
+from tldw_Server_API.app.core.Persona.visual_portability.provider_archive_retrieval import (
+    materialize_provider_archive_import_preview_handoff,
+)
+from tldw_Server_API.app.core.Persona.visual_portability.provider_envelope import (
+    CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
+)
+
+
+def _ready_handoff(
+    *,
+    archive_sha256: str,
+    resource_uri: str = "mcp://provider/resources/pack",
+) -> dict[str, object]:
+    return {
+        "ready": True,
+        "operation": "import_preview",
+        "job_type": PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE,
+        "request": {
+            "user_id": "user-1",
+            "preview_id": "preview-1",
+            "request_id": "request-1",
+            "target_persona_id": "persona-1",
+        },
+        "archive": {
+            "source_type": "mcp_resource",
+            "mcp_resource_uri": resource_uri,
+            "sha256": archive_sha256,
+            "media_type": CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
+        },
+        "diagnostics": {"blockers": [], "warnings": []},
+        "blockers": [],
+        "warnings": [],
+    }
+
+
+def _codes(result: dict[str, object]) -> list[str]:
+    diagnostics = result.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+    blockers = diagnostics.get("blockers")
+    assert isinstance(blockers, list)
+    return [str(item.get("code")) for item in blockers if isinstance(item, dict)]
+
+
+def test_materialize_provider_archive_import_preview_handoff_writes_job_payload(
+    tmp_path: Path,
+) -> None:
+    """Materialize a ready MCP resource handoff into the existing import-preview payload shape."""
+    archive_bytes = b"portable persona visual archive"
+    handoff = _ready_handoff(archive_sha256=sha256_bytes(archive_bytes))
+
+    result = materialize_provider_archive_import_preview_handoff(
+        handoff,
+        resource_reader=lambda uri: [archive_bytes[:9], archive_bytes[9:]],
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is True
+    assert result["operation"] == "import_preview"
+    assert result["job_type"] == PERSONA_VISUAL_PACK_IMPORT_PREVIEW_JOB_TYPE
+    payload = result["job_payload"]
+    assert payload == {
+        "user_id": "user-1",
+        "preview_id": "preview-1",
+        "archive_path": payload["archive_path"],
+        "request_id": "request-1",
+        "target_persona_id": "persona-1",
+    }
+    archive_path = Path(str(payload["archive_path"]))
+    assert archive_path.parent == tmp_path
+    assert archive_path.suffix == ".tldw-persona-vpack"
+    assert archive_path.read_bytes() == archive_bytes
+    assert result["archive"] == {
+        "source_type": "mcp_resource",
+        "media_type": CANONICAL_PERSONA_VISUAL_ARCHIVE_MEDIA_TYPE,
+        "sha256": sha256_bytes(archive_bytes),
+        "size_bytes": len(archive_bytes),
+    }
+    assert "mcp://provider/resources/pack" not in str(result["diagnostics"])
+    assert str(archive_path) not in str(result["diagnostics"])
+
+
+def test_materialize_provider_archive_import_preview_handoff_fails_closed_for_blocked_handoff(
+    tmp_path: Path,
+) -> None:
+    """Do not read or write archives when the provider handoff is not ready."""
+    handoff = _ready_handoff(archive_sha256=sha256_bytes(b"archive"))
+    handoff["ready"] = False
+    handoff["blockers"] = [{"code": "archive_sha256_invalid", "message": "bad sha"}]
+
+    def _reader(_uri: str) -> bytes:
+        raise AssertionError("blocked handoff should not retrieve resources")
+
+    result = materialize_provider_archive_import_preview_handoff(
+        handoff,
+        resource_reader=_reader,
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is False
+    assert "handoff_not_ready" in _codes(result)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_materialize_provider_archive_import_preview_handoff_rejects_checksum_mismatch(
+    tmp_path: Path,
+) -> None:
+    """Delete materialized bytes when the fetched resource checksum does not match."""
+    result = materialize_provider_archive_import_preview_handoff(
+        _ready_handoff(archive_sha256=sha256_bytes(b"expected")),
+        resource_reader=lambda uri: b"actual",
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is False
+    assert "archive_sha256_mismatch" in _codes(result)
+    assert list(tmp_path.iterdir()) == []
+    assert "actual" not in str(result)
+
+
+def test_materialize_provider_archive_import_preview_handoff_rejects_oversized_resource(
+    tmp_path: Path,
+) -> None:
+    """Stop writing and clean up when the fetched resource exceeds the configured byte cap."""
+    archive_bytes = b"0123456789"
+
+    result = materialize_provider_archive_import_preview_handoff(
+        _ready_handoff(archive_sha256=sha256_bytes(archive_bytes)),
+        resource_reader=lambda uri: [b"01234", b"56789"],
+        staging_root=tmp_path,
+        max_archive_size_bytes=8,
+    )
+
+    assert result["ready"] is False
+    assert "archive_too_large" in _codes(result)
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "not bytes",
+        {"bytes": b"archive"},
+        [b"ok", "not bytes"],
+    ],
+)
+def test_materialize_provider_archive_import_preview_handoff_rejects_non_byte_resources(
+    tmp_path: Path,
+    bad_value: object,
+) -> None:
+    """Require readers to return bytes or byte chunks so text/object data cannot leak."""
+    result = materialize_provider_archive_import_preview_handoff(
+        _ready_handoff(archive_sha256=sha256_bytes(b"archive")),
+        resource_reader=lambda uri: bad_value,
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is False
+    assert "archive_resource_invalid" in _codes(result)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_materialize_provider_archive_import_preview_handoff_rejects_unsafe_resource_uri(
+    tmp_path: Path,
+) -> None:
+    """Only MCP resource handles are accepted for provider archive retrieval."""
+    result = materialize_provider_archive_import_preview_handoff(
+        _ready_handoff(
+            archive_sha256=sha256_bytes(b"archive"),
+            resource_uri="file:///Users/alice/archive.tldw-persona-vpack",
+        ),
+        resource_reader=lambda uri: b"archive",
+        staging_root=tmp_path,
+    )
+
+    assert result["ready"] is False
+    assert "archive_resource_uri_missing" in _codes(result)
+    assert "file:///Users/alice" not in str(result)
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Change summary
TODO: human-owned summary required by the AI-generated PR merge gate.

## What changed
- Added a backend-only Persona Visual provider archive materializer that accepts ready provider archive handoff descriptors and an injected resource reader.
- Streams bounded resource bytes into local import-preview staging, validates MCP resource handles/media type/SHA-256/size, cleans up partial files on failure, and returns the existing `persona_visual_pack_import_preview` job payload shape.
- Added focused tests for valid materialization, blocked handoffs, unsafe resource handles, checksum mismatch, oversized resources, and non-byte resource output.
- Updated Persona Visual provider docs to record that endpoint/worker orchestration remains a separate follow-up slice.

## Scope boundaries
- No preview row creation.
- No Jobs enqueue.
- No import commit or activation.
- No renderer expansion.
- No WebUI or extension changes.
- No Buddy animation runtime or VN/CYOA behavior.

## Validation
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_provider_archive_retrieval.py tldw_Server_API/tests/Persona/test_persona_visual_provider_envelope.py tldw_Server_API/tests/Persona/test_persona_visual_jobs.py -q --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Persona/visual_portability/provider_archive_retrieval.py tldw_Server_API/tests/Persona/test_persona_visual_provider_archive_retrieval.py`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/provider_archive_retrieval.py -f json -o /tmp/bandit_persona_provider_archive_retrieval.json`

## Risk & rollback
- Low risk: new pure helper, docs, tests, and task tracking only.
- Rollback by reverting this PR; no schema, endpoint, worker, renderer, runtime, or UI behavior changes.

Refs #1796
Parent #1510

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend-only adapter that materializes Persona Visual provider archive handoffs into local import-preview inputs. It streams bytes via an injected reader, validates MCP handle/media type/size/SHA-256, cleans up on failure, and returns the existing import-preview job payload (addresses #1796).

- **New Features**
  - Introduces `materialize_provider_archive_import_preview_handoff()` to convert a validated provider handoff into a staged local archive via an injected resource reader.
  - Enforces MCP URI/media-type checks, size caps, and SHA-256 verification; removes partial files on error; keeps diagnostics trace-safe.
  - Adds focused tests for success and fail-closed cases; updates Persona Visual provider docs. Endpoint/worker orchestration is a follow-up.

- **Refactors**
  - Accepts `bytearray` chunks and treats archive media types case-insensitively.
  - Uses a retrieval error that derives from `DownloadError`, improves cleanup via `pathlib`, and redacts upstream diagnostic messages while preserving diagnostic codes.

<sup>Written for commit b851a2198445840cd14896f7d2e0669af95f7f66. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1797?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

