### PR TITLE
Harden Persona Visual MCP runtime triggers

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -234,6 +234,16 @@ Runtime state triggers are transient session behavior; library reuse is a
 durable draft-creation action that must preserve review and explicit activation
 semantics.
 
+`persona_visuals.trigger_state` accepts built-in visual states and safe custom
+state IDs declared by the persona's active pack. Custom runtime IDs must use the
+same bounded `state_catalog` ID grammar as manifests and must have a matching
+entry in the active pack's `states` map before the backend emits a
+`visual_state_override` event. The WebUI stores safe custom override candidates,
+but Persona Buddy only resolves them when the currently loaded active pack
+declares the state; otherwise it falls back to normal live/tool state resolution.
+This keeps direct MCP triggers compatible with large custom state catalogs
+without allowing arbitrary runtime state strings to become renderable states.
+
 ## Bundled Starter Catalog Scaffolds
 
 Bundled starter catalog entries are immutable server fixtures for first-run or

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -20,7 +20,10 @@ import type {
   PersonaBuddyRenderContext,
   PersonaBuddySummary
 } from "@/types/persona-buddy"
-import { PERSONA_VISUAL_PACK_ACTIVATED_EVENT } from "@/types/persona-visuals"
+import {
+  isPersonaVisualCustomStateIdText,
+  PERSONA_VISUAL_PACK_ACTIVATED_EVENT
+} from "@/types/persona-visuals"
 import type { PersonaVisualPack } from "@/types/persona-visuals"
 
 import { useBuddyShellRenderContext } from "./BuddyShellRenderContext"
@@ -394,6 +397,15 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
       runtimeOverride.sessionId === renderContext.live_session_id)
       ? runtimeOverride
       : null
+  const runtimeStateIds = React.useMemo(() => {
+    const states = visualPack?.manifest?.states
+    const stateCatalog = visualPack?.manifest?.state_catalog
+    if (!states || !stateCatalog) return []
+    return Object.keys(states).filter((stateId) =>
+      Object.prototype.hasOwnProperty.call(stateCatalog, stateId) &&
+      isPersonaVisualCustomStateIdText(stateId)
+    )
+  }, [visualPack])
   const visualState =
     renderContext.visual_state ??
     resolvePersonaVisualState({
@@ -405,6 +417,7 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
         Boolean(renderContext.recovery_mode) &&
         renderContext.recovery_mode !== "none",
       runtimeOverride: applicableRuntimeOverride,
+      runtimeStateIds,
       authoredTriggers: visualPack?.manifest?.authored_triggers,
       mcpRuntimeReason: applicableRuntimeOverride?.reason
     })

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -845,6 +845,80 @@ describe("BuddyShellHost", () => {
     )
   })
 
+  it("renders custom visual states from active-pack runtime overrides", async () => {
+    const basePack = buildVisualPack("persona-1")
+    const customState = asPersonaVisualCustomStateId("tool.notes_search")
+    const visualPack = {
+      ...basePack,
+      manifest: {
+        ...basePack.manifest,
+        state_catalog: {
+          [customState]: {
+            label: "Searching notes",
+            kind: "tool_variant"
+          }
+        },
+        states: {
+          ...basePack.manifest.states,
+          [customState]: { animation_id: "tool-notes-search" }
+        },
+        animations: {
+          ...basePack.manifest.animations,
+          "tool-notes-search": {
+            frames: [{ asset_id: "tool-notes-search-asset", duration_ms: 100 }]
+          }
+        }
+      },
+      assets_by_id: {
+        ...basePack.assets_by_id,
+        "tool-notes-search-asset": {
+          id: "tool-notes-search-asset",
+          url: "/assets/tool-notes-search.png",
+          mime_type: "image/png",
+          asset_role: "frame",
+          width: 24,
+          height: 24
+        }
+      }
+    }
+    visualMocks.listPersonaVisualPacks.mockResolvedValue({
+      packs: [visualPack],
+      active_pack: visualPack
+    })
+    usePersonaVisualRuntimeStore.getState().setOverride({
+      personaId: "persona-1",
+      sessionId: "session-1",
+      state: customState,
+      reason: "mcp_runtime.notes.search",
+      expiresAt: Date.now() + 10_000
+    })
+
+    renderHost({
+      context: {
+        surface_id: "persona-garden",
+        surface_active: true,
+        active_persona_id: "persona-1",
+        live_session_id: "session-1",
+        position_bucket: "sidepanel-desktop",
+        persona_source: "route-local",
+        buddy_summary: buildBuddySummary("persona-1"),
+        live_voice_state: "thinking"
+      },
+      root: "sidepanel"
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-visual-frame")).toHaveAttribute(
+        "data-visual-state",
+        "tool.notes_search"
+      )
+    })
+    expect(screen.getByTestId("persona-visual-frame")).toHaveAttribute(
+      "src",
+      expect.stringContaining("/assets/tool-notes-search.png")
+    )
+  })
+
   it("keeps derived buddy text when active visual pack loading fails", async () => {
     visualMocks.listPersonaVisualPacks.mockRejectedValue(new Error("offline"))
 

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts
@@ -38,6 +38,40 @@ describe("resolvePersonaVisualState", () => {
     ).toBe("approval_needed")
   })
 
+  it("uses custom runtime overrides declared by the active visual pack", () => {
+    const customState = asPersonaVisualCustomStateId("tool.notes_search")
+
+    expect(
+      resolvePersonaVisualState({
+        liveVoiceState: "speaking",
+        runtimeOverride: {
+          state: customState,
+          reason: "mcp_runtime.notes.search",
+          expiresAt: 2000
+        },
+        runtimeStateIds: [customState],
+        now: 1000
+      })
+    ).toBe("tool.notes_search")
+  })
+
+  it("ignores custom runtime overrides missing from the active visual pack", () => {
+    const customState = asPersonaVisualCustomStateId("tool.notes_search")
+
+    expect(
+      resolvePersonaVisualState({
+        liveVoiceState: "speaking",
+        runtimeOverride: {
+          state: customState,
+          reason: "mcp_runtime.notes.search",
+          expiresAt: 2000
+        },
+        runtimeStateIds: [],
+        now: 1000
+      })
+    ).toBe("speaking")
+  })
+
   it("ignores expired runtime overrides", () => {
     expect(
       resolvePersonaVisualState({

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
@@ -9,7 +9,7 @@ import {
 } from "@/types/persona-visuals"
 
 export type PersonaVisualRuntimeOverride = {
-  state: PersonaVisualBuiltinStateId
+  state: PersonaVisualStateId
   reason?: string | null
   expiresAt: number
 }
@@ -20,6 +20,7 @@ export type ResolvePersonaVisualStateInput = {
   recovering?: boolean
   approvalNeeded?: boolean
   runtimeOverride?: PersonaVisualRuntimeOverride | null
+  runtimeStateIds?: Iterable<string> | null
   authoredTriggers?: PersonaVisualAuthoredTrigger[] | null
   activeToolName?: string | null
   activeToolStatus?: string | null
@@ -100,6 +101,21 @@ const triggerMatches = (
   return false
 }
 
+const runtimeOverrideStateAllowed = (
+  state: PersonaVisualStateId,
+  runtimeStateIds: Iterable<string> | null | undefined
+): boolean => {
+  if (BUILTIN_VISUAL_STATES.has(state as PersonaVisualBuiltinStateId)) {
+    return true
+  }
+  for (const candidate of runtimeStateIds || []) {
+    if (String(candidate) === state) {
+      return true
+    }
+  }
+  return false
+}
+
 const resolveAuthoredTriggerState = (
   input: ResolvePersonaVisualStateInput,
   liveState: PersonaVisualBuiltinStateId | null
@@ -121,7 +137,10 @@ export const resolvePersonaVisualState = (
   if (
     input.runtimeOverride &&
     input.runtimeOverride.expiresAt > now &&
-    BUILTIN_VISUAL_STATES.has(input.runtimeOverride.state)
+    runtimeOverrideStateAllowed(
+      input.runtimeOverride.state,
+      input.runtimeStateIds
+    )
   ) {
     return input.runtimeOverride.state
   }

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
@@ -109,7 +109,7 @@ const runtimeOverrideStateAllowed = (
     return true
   }
   for (const candidate of runtimeStateIds || []) {
-    if (String(candidate) === state) {
+    if (candidate === state) {
       return true
     }
   }

--- a/apps/packages/ui/src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx
+++ b/apps/packages/ui/src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx
@@ -82,4 +82,68 @@ describe("usePersonaIncomingPayload visual state overrides", () => {
       expiresAt: 1_750
     })
   })
+
+  it("stores safe custom visual_state_override payloads for active-pack resolution", () => {
+    const liveVoiceController = { handlePayload: vi.fn() }
+    const { result } = renderHook(() => {
+      const [approvedStepMap, setApprovedStepMap] = React.useState<Record<number, boolean>>({})
+      const [pendingApprovals, setPendingApprovals] = React.useState<any[]>([])
+      const [pendingPlan, setPendingPlan] = React.useState<any>(null)
+      const [resolvedApprovalSnapshot, setResolvedApprovalSnapshot] =
+        React.useState<{ key: string; toolName: string } | null>(null)
+      const [setupTestOutcome, setSetupTestOutcome] = React.useState<any>(null)
+      const [setupLiveDetour, setSetupLiveDetour] = React.useState<any>(null)
+      const [setupTestResumeNote, setSetupTestResumeNote] = React.useState<string | null>(null)
+
+      void approvedStepMap
+      void pendingApprovals
+      void pendingPlan
+      void resolvedApprovalSnapshot
+      void setupTestOutcome
+      void setupLiveDetour
+      void setupTestResumeNote
+
+      return usePersonaIncomingPayload({
+        appendLog: vi.fn(),
+        clearResolvedApprovalFadeTimer: vi.fn(),
+        consumeSetupHandoffAction: vi.fn(),
+        emitSetupAnalyticsEvent: vi.fn(),
+        liveVoiceController,
+        personaId: "persona-1",
+        personaSetupWizardCurrentStep: "test",
+        personaSetupWizardIsSetupRequired: false,
+        resolvedApprovalSnapshot,
+        sessionId: "session-1",
+        setApprovedStepMap,
+        setPendingApprovals,
+        setPendingPlan,
+        setResolvedApprovalSnapshot,
+        setSetupTestOutcome,
+        setSetupLiveDetour,
+        setSetupTestResumeNote,
+        setupLiveDetourRef: React.useRef(null),
+        setupHandoffRef: React.useRef(null),
+        activeTabRef: React.useRef("live"),
+        setupWizardAwaitingLiveResponseRef: React.useRef(false),
+        setupWizardLastLiveTextRef: React.useRef("")
+      })
+    })
+
+    act(() => {
+      result.current({
+        type: "visual_state_override",
+        state: "tool.notes_search",
+        duration_ms: 1250,
+        reason: "mcp_runtime.notes.search"
+      })
+    })
+
+    expect(usePersonaVisualRuntimeStore.getState().override).toEqual({
+      personaId: "persona-1",
+      sessionId: "session-1",
+      state: "tool.notes_search",
+      reason: "mcp_runtime.notes.search",
+      expiresAt: 2_250
+    })
+  })
 })

--- a/apps/packages/ui/src/routes/hooks/usePersonaIncomingPayload.ts
+++ b/apps/packages/ui/src/routes/hooks/usePersonaIncomingPayload.ts
@@ -2,10 +2,9 @@ import React from "react"
 import type { PersonaSetupStep } from "@/hooks/usePersonaSetupWizard"
 import type { SetupTestOutcome } from "@/components/PersonaGarden/SetupTestAndFinishStep"
 import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
-import type { PersonaVisualBuiltinStateId } from "@/types/persona-visuals"
 import {
-  isPersonaVisualBuiltinStateId,
-  PERSONA_VISUAL_BUILTIN_STATES
+  asPersonaVisualStateId,
+  isPersonaVisualStateIdText
 } from "@/types/persona-visuals"
 import {
   coerceGovernanceContext as _coerceGovernanceContext,
@@ -91,10 +90,7 @@ export const usePersonaIncomingPayload = ({
 
       if (eventType === "visual_state_override") {
         const state = String(payload?.state || payload?.visual_state || "").trim()
-        const allowedStates = new Set<PersonaVisualBuiltinStateId>(
-          PERSONA_VISUAL_BUILTIN_STATES
-        )
-        if (!isPersonaVisualBuiltinStateId(state) || !allowedStates.has(state)) return
+        if (!isPersonaVisualStateIdText(state)) return
         const durationMsRaw =
           typeof payload?.duration_ms === "number"
             ? payload.duration_ms
@@ -102,6 +98,11 @@ export const usePersonaIncomingPayload = ({
         const durationMs = Number.isFinite(durationMsRaw)
           ? Math.max(250, Math.min(durationMsRaw, 30_000))
           : 1500
+        const reason = String(payload?.reason || "")
+          .split(/\s+/)
+          .filter(Boolean)
+          .join(" ")
+          .slice(0, 200)
         setVisualRuntimeOverride({
           personaId: String(payload?.persona_id || personaId || ""),
           sessionId: payload?.session_id
@@ -109,8 +110,8 @@ export const usePersonaIncomingPayload = ({
             : sessionId
               ? String(sessionId)
               : null,
-          state,
-          reason: payload?.reason ? String(payload.reason) : null,
+          state: asPersonaVisualStateId(state),
+          reason: reason || null,
           expiresAt: Date.now() + durationMs
         })
         return

--- a/apps/packages/ui/src/store/persona-visual-runtime.ts
+++ b/apps/packages/ui/src/store/persona-visual-runtime.ts
@@ -2,14 +2,13 @@ import { create } from "zustand"
 
 import type { PersonaVisualDiagnostic } from "@/components/Common/PersonaBuddy/personaVisualDiagnostics"
 import type {
-  PersonaVisualBuiltinStateId,
   PersonaVisualStateId
 } from "@/types/persona-visuals"
 
 export interface PersonaVisualRuntimeOverride {
   personaId: string
   sessionId: string | null
-  state: PersonaVisualBuiltinStateId
+  state: PersonaVisualStateId
   reason: string | null
   expiresAt: number
 }

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -13,6 +13,35 @@ export const PERSONA_VISUAL_BUILTIN_STATES = [
 export type PersonaVisualBuiltinStateId =
   (typeof PERSONA_VISUAL_BUILTIN_STATES)[number]
 
+export const PERSONA_VISUAL_CUSTOM_STATE_ID_PATTERN =
+  /^[a-z][a-z0-9_.:-]{0,95}$/
+
+const PERSONA_VISUAL_UNSAFE_CUSTOM_STATE_MARKERS = [
+  "access_token",
+  "api_key",
+  "apikey",
+  "auth_token",
+  "authorization",
+  "bearer_token",
+  "client_secret",
+  "password",
+  "passwd",
+  "private_key",
+  "refresh_token",
+  "secret",
+  "secret_key"
+] as const
+
+const PERSONA_VISUAL_UNSAFE_CUSTOM_STATE_PREFIXES = [
+  "env:",
+  "file:",
+  "ftp:",
+  "http:",
+  "https:",
+  "proc:",
+  "ssh:"
+] as const
+
 declare const personaVisualCustomStateIdBrand: unique symbol
 export type PersonaVisualCustomStateId = string & {
   readonly [personaVisualCustomStateIdBrand]: "PersonaVisualCustomStateId"
@@ -29,6 +58,29 @@ export const isPersonaVisualBuiltinStateId = (
   value: string
 ): value is PersonaVisualBuiltinStateId =>
   (PERSONA_VISUAL_BUILTIN_STATES as readonly string[]).includes(value)
+
+export const isPersonaVisualCustomStateIdText = (
+  value: string
+): value is PersonaVisualCustomStateId => {
+  if (!PERSONA_VISUAL_CUSTOM_STATE_ID_PATTERN.test(value)) return false
+  const lowered = value.toLowerCase()
+  if (
+    PERSONA_VISUAL_UNSAFE_CUSTOM_STATE_PREFIXES.some((prefix) =>
+      lowered.startsWith(prefix)
+    )
+  ) {
+    return false
+  }
+  const compact = lowered.replace(/[._:-]+/g, "_")
+  return !PERSONA_VISUAL_UNSAFE_CUSTOM_STATE_MARKERS.some((marker) =>
+    compact.includes(marker)
+  )
+}
+
+export const isPersonaVisualStateIdText = (
+  value: string
+): value is PersonaVisualStateId =>
+  isPersonaVisualBuiltinStateId(value) || isPersonaVisualCustomStateIdText(value)
 
 export const asPersonaVisualCustomStateId = (
   value: string

--- a/backlog/tasks/task-413 - Harden-Persona-Visual-MCP-trigger-state-runtime-contract.md
+++ b/backlog/tasks/task-413 - Harden-Persona-Visual-MCP-trigger-state-runtime-contract.md
@@ -1,0 +1,79 @@
+---
+id: TASK-413
+title: Harden Persona Visual MCP trigger-state runtime contract
+status: Done
+labels:
+- persona
+- buddy
+- visual-packs
+- mcp
+- runtime
+- issue-1787
+references:
+- https://github.com/rmusser01/tldw_server/issues/1787
+- https://github.com/rmusser01/tldw_server/pull/1717
+- https://github.com/rmusser01/tldw_server/pull/1794
+- https://github.com/rmusser01/tldw_server/pull/1798
+modified_files:
+- Docs/Code_Documentation/Persona_Visual_Packs.md
+- apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+- apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+- apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts
+- apps/packages/ui/src/components/Common/PersonaBuddy/personaVisualState.ts
+- apps/packages/ui/src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx
+- apps/packages/ui/src/routes/hooks/usePersonaIncomingPayload.ts
+- apps/packages/ui/src/store/persona-visual-runtime.ts
+- apps/packages/ui/src/types/persona-visuals.ts
+- tldw_Server_API/app/api/v1/endpoints/persona.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
+- tldw_Server_API/app/core/Persona/visuals.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next issue #1787 Buddy animation pipeline slice after the import-preview fixture work: harden the direct MCP/runtime persona_visuals.trigger_state path for exact tool/custom-state variants. Scope is limited to Persona Visual/Buddy runtime trigger behavior and excludes generation jobs, final art production, Persona Garden UX, VN/CYOA, and unrelated Persona backend work.
+
+Acceptance criteria:
+- Backend direct persona_visuals.trigger_state handling validates/bounds emitted runtime state identifiers and reasons rather than passing arbitrary unsafe values through.
+- Direct trigger payloads can target declared custom state IDs while rejecting or ignoring unsafe/unknown states at the right boundary.
+- Frontend runtime override handling remains aligned with the current pack/custom-state contract and does not bypass existing built-in/manual override restrictions.
+- Focused backend/frontend tests cover accepted custom state IDs plus ignored unsafe/unknown values.
+- Verification includes focused tests, syntax/type checks as applicable, git diff --check, and Bandit for touched Python paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Persona Visual MCP trigger-state runtime contract for the Buddy animation pipeline. Direct MCP triggers can now target safe custom state IDs declared by the active visual pack, capabilities exposes active custom runtime states, and the WebUI resolves custom runtime overrides only when the currently loaded active pack exposes the state. Added backend/frontend regression coverage and documented the contract.
+
+Verification:
+- Red tests first: backend custom trigger tests failed on built-in-only behavior; frontend custom override tests failed on rejected custom state/resolver fallback.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q` -> 13 passed, 3 warnings.
+- `bunx vitest run -c vitest.config.ts src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx` -> 3 files passed, 38 tests passed; existing i18next warning only.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile` on touched Python files -> passed.
+- `git diff --check` -> passed.
+- Bandit on touched Python paths -> 0 findings in `/tmp/bandit_persona_visual_mcp_trigger.json`.
+- `bunx tsc --noEmit -p tsconfig.json` in `apps/packages/ui` remains blocked by unrelated repo baseline errors outside touched Persona Visual files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-413 - Harden-Persona-Visual-MCP-trigger-state-runtime-contract.md
+++ b/backlog/tasks/task-413 - Harden-Persona-Visual-MCP-trigger-state-runtime-contract.md
@@ -56,13 +56,13 @@ Acceptance criteria:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened the Persona Visual MCP trigger-state runtime contract for the Buddy animation pipeline. Direct MCP triggers can now target safe custom state IDs declared by the active visual pack, capabilities exposes active custom runtime states, and the WebUI resolves custom runtime overrides only when the currently loaded active pack exposes the state. Added backend/frontend regression coverage and documented the contract.
+Hardened the Persona Visual MCP trigger-state runtime contract for the Buddy animation pipeline. Direct MCP triggers can now target safe custom state IDs declared by the active visual pack, capabilities expose active custom runtime states, and the WebUI resolves custom runtime overrides only when the currently loaded active pack exposes the state. Added backend/frontend regression coverage and documented the contract.
 
 Verification:
 - Red tests first: backend custom trigger tests failed on built-in-only behavior; frontend custom override tests failed on rejected custom state/resolver fallback.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q` -> 13 passed, 3 warnings.
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q` -> 13 passed, 3 warnings.
 - `bunx vitest run -c vitest.config.ts src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx` -> 3 files passed, 38 tests passed; existing i18next warning only.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile` on touched Python files -> passed.
+- `python -m py_compile` on touched Python files -> passed.
 - `git diff --check` -> passed.
 - Bandit on touched Python paths -> 0 findings in `/tmp/bandit_persona_visual_mcp_trigger.json`.
 - `bunx tsc --noEmit -p tsconfig.json` in `apps/packages/ui` remains blocked by unrelated repo baseline errors outside touched Persona Visual files.
@@ -70,10 +70,10 @@ Verification:
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -181,6 +181,7 @@ from tldw_Server_API.app.core.Persona.visuals import (
     MAX_TRIGGER_DURATION_MS,
     MIN_TRIGGER_DURATION_MS,
     VISUAL_STATE_IDS,
+    custom_visual_state_id_error,
 )
 from tldw_Server_API.app.core.Persona.visual_service import (
     MAX_VISUAL_UPLOAD_BYTES,
@@ -2116,8 +2117,10 @@ def _persona_visual_override_payload_from_tool_result(
     if not isinstance(payload, dict) or payload.get("type") != "visual_state_override":
         return None
 
-    state = str(payload.get("state") or payload.get("visual_state") or "").strip()
-    if state not in VISUAL_STATE_IDS:
+    state = _safe_persona_visual_override_state(
+        payload.get("state") or payload.get("visual_state")
+    )
+    if state is None:
         return None
 
     try:
@@ -2131,16 +2134,38 @@ def _persona_visual_override_payload_from_tool_result(
     if not resolved_persona_id or not resolved_session_id:
         return None
 
-    reason = str(payload.get("reason") or "persona_visuals.trigger_state").strip()
+    reason = _safe_persona_visual_override_reason(payload.get("reason"))
     return {
         "type": "visual_state_override",
         "persona_id": resolved_persona_id,
         "session_id": resolved_session_id,
         "state": state,
         "duration_ms": duration_ms,
-        "reason": reason or "persona_visuals.trigger_state",
+        "reason": reason,
         "tool": "persona_visuals.trigger_state",
     }
+
+
+def _safe_persona_visual_override_state(value: Any) -> str | None:
+    """Return a built-in or safe custom visual state ID for runtime payloads."""
+    state = str(value or "").strip()
+    if not state:
+        return None
+    if state in VISUAL_STATE_IDS:
+        return state
+    if custom_visual_state_id_error(state) is None:
+        return state
+    return None
+
+
+def _safe_persona_visual_override_reason(value: Any) -> str:
+    """Return a bounded, single-line reason for trace-safe runtime payloads."""
+    if value is not None and not isinstance(value, str):
+        return "persona_visuals.trigger_state"
+    reason = " ".join(str(value or "persona_visuals.trigger_state").split())
+    if not reason:
+        return "persona_visuals.trigger_state"
+    return reason[:200]
 
 
 def _persona_visual_pack_to_response(

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
@@ -225,8 +225,8 @@ class PersonaVisualsModule(BaseModule):
             if arguments.get("duration_ms") is not None:
                 int(arguments["duration_ms"])
             self._validate_optional_string(arguments, "reason")
-            if len(str(arguments.get("reason") or "")) > _MAX_TRIGGER_REASON_LENGTH:
-                raise ValueError(f"reason must be <= {_MAX_TRIGGER_REASON_LENGTH} chars")
+            if "reason" in arguments:
+                arguments["reason"] = self._safe_trigger_reason(arguments.get("reason"))
             return
         if tool_name == "persona_visuals.create_draft_pack":
             self._validate_optional_string(arguments, "persona_id")
@@ -688,6 +688,8 @@ class PersonaVisualsModule(BaseModule):
         active_pack: dict[str, Any] | None,
         state: str,
     ) -> bool:
+        if state in VISUAL_STATE_IDS:
+            return True
         return state in PersonaVisualsModule._runtime_visual_state_ids(active_pack)
 
     @staticmethod

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/persona_visuals_module.py
@@ -1,3 +1,5 @@
+"""MCP tools for Persona Visual packs and Buddy runtime state triggers."""
+
 from __future__ import annotations
 
 import asyncio
@@ -17,6 +19,7 @@ from tldw_Server_API.app.core.Persona.visuals import (
     MAX_TRIGGER_DURATION_MS,
     MIN_TRIGGER_DURATION_MS,
     VISUAL_STATE_IDS,
+    custom_visual_state_id_error,
 )
 
 from ..base import BaseModule, create_tool_definition
@@ -42,6 +45,7 @@ _PERSONA_VISUALS_NONCRITICAL_EXCEPTIONS = (
 )
 
 _MAX_LIBRARY_ITEMS_OFFSET = 1_000_000
+_MAX_TRIGGER_REASON_LENGTH = 200
 
 
 class PersonaVisualsModule(BaseModule):
@@ -94,7 +98,15 @@ class PersonaVisualsModule(BaseModule):
                 parameters={
                     "properties": {
                         "persona_id": {"type": "string"},
-                        "state": {"type": "string", "enum": sorted(VISUAL_STATE_IDS)},
+                        "state": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 96,
+                            "description": (
+                                "Built-in visual state or custom state declared by the "
+                                "active Persona Visual pack."
+                            ),
+                        },
                         "duration_ms": {
                             "type": "integer",
                             "minimum": MIN_TRIGGER_DURATION_MS,
@@ -209,14 +221,12 @@ class PersonaVisualsModule(BaseModule):
             return
         if tool_name == "persona_visuals.trigger_state":
             self._validate_optional_string(arguments, "persona_id")
-            state = str(arguments.get("state") or "").strip()
-            if not state:
-                raise ValueError("state is required")
-            if state not in VISUAL_STATE_IDS:
-                raise ValueError(f"Unknown visual state: {state}")
+            self._normalize_visual_state_id(arguments.get("state"))
             if arguments.get("duration_ms") is not None:
                 int(arguments["duration_ms"])
             self._validate_optional_string(arguments, "reason")
+            if len(str(arguments.get("reason") or "")) > _MAX_TRIGGER_REASON_LENGTH:
+                raise ValueError(f"reason must be <= {_MAX_TRIGGER_REASON_LENGTH} chars")
             return
         if tool_name == "persona_visuals.create_draft_pack":
             self._validate_optional_string(arguments, "persona_id")
@@ -286,7 +296,7 @@ class PersonaVisualsModule(BaseModule):
             draft_packs = [pack for pack in packs if str(pack.get("status") or "") == "draft"]
             return {
                 "persona_id": persona_id,
-                "states": sorted(VISUAL_STATE_IDS),
+                "states": sorted(self._runtime_visual_state_ids(active_pack)),
                 "active_pack": self._pack_summary(db, active_pack, persona_id=persona_id, user_id=user_id)
                 if active_pack
                 else None,
@@ -324,14 +334,17 @@ class PersonaVisualsModule(BaseModule):
     def _trigger_state_sync(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
         user_id = self._resolve_user_id(context)
         persona_id = self._resolve_persona_id(args, context)
-        state = str(args.get("state") or "").strip()
-        if state not in VISUAL_STATE_IDS:
-            raise ValueError(f"Unknown visual state: {state}")
+        state = self._normalize_visual_state_id(args.get("state"))
         duration_ms = self._clamp_duration(args.get("duration_ms", 1500))
         session_id = str(getattr(context, "session_id", "") or "").strip() or None
         db = self._open_db(context)
         try:
             self._require_persona(db, persona_id=persona_id, user_id=user_id)
+            active_pack = db.get_active_persona_visual_pack(persona_id=persona_id, user_id=user_id)
+            if not self._visual_state_available_for_runtime(active_pack, state):
+                raise ValueError(
+                    f"Custom visual state {state} is not available in the active Persona Visual pack"
+                )
         finally:
             self._close_db(db)
         return {
@@ -340,7 +353,7 @@ class PersonaVisualsModule(BaseModule):
             "session_id": session_id,
             "state": state,
             "duration_ms": duration_ms,
-            "reason": str(args.get("reason") or "mcp_runtime").strip() or "mcp_runtime",
+            "reason": self._safe_trigger_reason(args.get("reason")),
         }
 
     def _create_draft_pack_sync(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
@@ -657,6 +670,51 @@ class PersonaVisualsModule(BaseModule):
     def _validate_optional_string(arguments: dict[str, Any], key: str) -> None:
         if arguments.get(key) is not None and not isinstance(arguments.get(key), str):
             raise ValueError(f"{key} must be a string")
+
+    @staticmethod
+    def _normalize_visual_state_id(value: Any) -> str:
+        state = str(value or "").strip()
+        if not state:
+            raise ValueError("state is required")
+        if state in VISUAL_STATE_IDS:
+            return state
+        custom_error = custom_visual_state_id_error(state)
+        if custom_error:
+            raise ValueError(custom_error)
+        return state
+
+    @staticmethod
+    def _visual_state_available_for_runtime(
+        active_pack: dict[str, Any] | None,
+        state: str,
+    ) -> bool:
+        return state in PersonaVisualsModule._runtime_visual_state_ids(active_pack)
+
+    @staticmethod
+    def _runtime_visual_state_ids(active_pack: dict[str, Any] | None) -> set[str]:
+        state_ids = set(VISUAL_STATE_IDS)
+        manifest = active_pack.get("manifest") if isinstance(active_pack, dict) else None
+        if not isinstance(manifest, dict):
+            return state_ids
+        states = manifest.get("states")
+        state_catalog = manifest.get("state_catalog")
+        if not isinstance(states, dict) or not isinstance(state_catalog, dict):
+            return state_ids
+        state_ids.update(
+            state
+            for state in states
+            if state in state_catalog and custom_visual_state_id_error(state) is None
+        )
+        return state_ids
+
+    @staticmethod
+    def _safe_trigger_reason(value: Any) -> str:
+        if value is not None and not isinstance(value, str):
+            return "mcp_runtime"
+        reason = " ".join(str(value or "mcp_runtime").split())
+        if not reason:
+            return "mcp_runtime"
+        return reason[:_MAX_TRIGGER_REASON_LENGTH]
 
 
 __all__ = ["PersonaVisualsModule"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
@@ -305,6 +305,16 @@ async def test_trigger_state_requires_context_rejects_unknown_states_and_clamps_
     )
     assert minimum["duration_ms"] == 100
 
+    long_reason = "  " + ("reason detail " * 30) + "\nextra"
+    long_reason_payload = await module.execute_tool(
+        "persona_visuals.trigger_state",
+        {"state": "speaking", "reason": long_reason},
+        context=_context(db_path, persona_id),
+    )
+    assert long_reason_payload["reason"] == " ".join(long_reason.split())[:200]
+    assert len(long_reason_payload["reason"]) == 200
+    assert "\n" not in long_reason_payload["reason"]
+
     with pytest.raises(ValueError, match="not available in the active Persona Visual pack"):
         await module.execute_tool(
             "persona_visuals.trigger_state",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py
@@ -54,6 +54,29 @@ def _create_persona(db: CharactersRAGDB, *, user_id: str = "1", name: str = "Vis
     return db.create_persona_profile({"user_id": user_id, "name": name})
 
 
+def _custom_visual_state_manifest() -> dict[str, Any]:
+    return {
+        "manifest_version": 1,
+        "renderer_type": "sprite_frames",
+        "state_catalog": {
+            "tool.notes_search": {
+                "label": "Searching notes",
+                "kind": "tool_variant",
+            },
+        },
+        "states": {
+            "idle": {"animation_id": "idle"},
+            "tool.notes_search": {"animation_id": "tool-notes-search"},
+        },
+        "animations": {
+            "idle": {"frames": [{"asset_id": "idle-asset", "duration_ms": 100}]},
+            "tool-notes-search": {
+                "frames": [{"asset_id": "tool-notes-search-asset", "duration_ms": 100}]
+            },
+        },
+    }
+
+
 def test_visual_state_override_payload_helper_clamps_and_labels_tool() -> None:
     payload = _persona_visual_override_payload_from_tool_result(
         tool_name="persona_visuals.trigger_state",
@@ -92,6 +115,50 @@ def test_visual_state_override_payload_helper_clamps_and_labels_tool() -> None:
     )
 
 
+def test_visual_state_override_payload_helper_accepts_safe_custom_states() -> None:
+    payload = _persona_visual_override_payload_from_tool_result(
+        tool_name="persona_visuals.trigger_state",
+        result={
+            "ok": True,
+            "output": {
+                "type": "visual_state_override",
+                "persona_id": "persona-1",
+                "session_id": "session-1",
+                "state": "tool.notes_search",
+                "duration_ms": 1200,
+                "reason": "mcp_runtime.notes.search",
+            },
+        },
+        persona_id="persona-1",
+        session_id="session-1",
+    )
+
+    assert payload == {
+        "type": "visual_state_override",
+        "persona_id": "persona-1",
+        "session_id": "session-1",
+        "state": "tool.notes_search",
+        "duration_ms": 1200,
+        "reason": "mcp_runtime.notes.search",
+        "tool": "persona_visuals.trigger_state",
+    }
+    assert (
+        _persona_visual_override_payload_from_tool_result(
+            tool_name="persona_visuals.trigger_state",
+            result={
+                "ok": True,
+                "output": {
+                    "type": "visual_state_override",
+                    "state": "file:/tmp/secret",
+                },
+            },
+            persona_id="persona-1",
+            session_id="session-1",
+        )
+        is None
+    )
+
+
 def test_persona_visuals_module_config_is_present_and_disabled() -> None:
     repo_root = Path(__file__).resolve().parents[5]
     config_path = repo_root / "tldw_Server_API" / "Config_Files" / "mcp_modules.yaml"
@@ -118,7 +185,7 @@ async def test_capabilities_returns_active_and_draft_pack_summaries(chacha_db) -
         persona_id=persona_id,
         user_id="1",
         title="Active Pack",
-        manifest={"manifest_version": 1, "renderer_type": "sprite_frames"},
+        manifest=_custom_visual_state_manifest(),
         status="active",
     )
     draft = db.create_persona_visual_pack(
@@ -153,6 +220,7 @@ async def test_capabilities_returns_active_and_draft_pack_summaries(chacha_db) -
     assert result["active_pack"]["assets_count"] == 1
     assert [pack["id"] for pack in result["draft_packs"]] == [draft["id"]]
     assert "thinking" in result["states"]
+    assert "tool.notes_search" in result["states"]
 
 
 @pytest.mark.asyncio
@@ -237,7 +305,7 @@ async def test_trigger_state_requires_context_rejects_unknown_states_and_clamps_
     )
     assert minimum["duration_ms"] == 100
 
-    with pytest.raises(ValueError, match="Unknown visual state"):
+    with pytest.raises(ValueError, match="not available in the active Persona Visual pack"):
         await module.execute_tool(
             "persona_visuals.trigger_state",
             {"state": "dancing"},
@@ -260,6 +328,60 @@ async def test_trigger_state_requires_context_rejects_unknown_states_and_clamps_
                 db_paths={"chacha": str(db_path)},
                 metadata={},
             ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_trigger_state_accepts_custom_state_declared_by_active_pack(chacha_db) -> None:
+    db, db_path = chacha_db
+    persona_id = _create_persona(db)
+    db.create_persona_visual_pack(
+        persona_id=persona_id,
+        user_id="1",
+        title="Active Custom Pack",
+        manifest=_custom_visual_state_manifest(),
+        status="active",
+    )
+    module = PersonaVisualsModule(ModuleConfig(name="persona_visuals"))
+
+    payload = await module.execute_tool(
+        "persona_visuals.trigger_state",
+        {
+            "state": "tool.notes_search",
+            "duration_ms": 1200,
+            "reason": "mcp_runtime.notes.search",
+        },
+        context=_context(db_path, persona_id),
+    )
+
+    assert payload == {
+        "type": "visual_state_override",
+        "persona_id": persona_id,
+        "session_id": "session-visuals",
+        "state": "tool.notes_search",
+        "duration_ms": 1200,
+        "reason": "mcp_runtime.notes.search",
+    }
+
+
+@pytest.mark.asyncio
+async def test_trigger_state_rejects_custom_state_missing_from_active_pack(chacha_db) -> None:
+    db, db_path = chacha_db
+    persona_id = _create_persona(db)
+    db.create_persona_visual_pack(
+        persona_id=persona_id,
+        user_id="1",
+        title="Active Custom Pack",
+        manifest=_custom_visual_state_manifest(),
+        status="active",
+    )
+    module = PersonaVisualsModule(ModuleConfig(name="persona_visuals"))
+
+    with pytest.raises(ValueError, match="not available in the active Persona Visual pack"):
+        await module.execute_tool(
+            "persona_visuals.trigger_state",
+            {"state": "tool.other_search"},
+            context=_context(db_path, persona_id),
         )
 
 

--- a/tldw_Server_API/app/core/Persona/visuals.py
+++ b/tldw_Server_API/app/core/Persona/visuals.py
@@ -457,6 +457,11 @@ def _custom_state_id_error(state_id: Any) -> str | None:
     return None
 
 
+def custom_visual_state_id_error(state_id: Any) -> str | None:
+    """Return a validation error for a custom runtime visual state ID, if any."""
+    return _custom_state_id_error(state_id)
+
+
 def _contains_control_character(value: str) -> bool:
     """Return whether user-facing manifest text contains ASCII control codes."""
     return any(ord(character) < 32 or ord(character) == 127 for character in value)
@@ -598,5 +603,6 @@ __all__ = [
     "VISUAL_STATE_IDS",
     "PersonaVisualManifestError",
     "PersonaVisualManifestValidation",
+    "custom_visual_state_id_error",
     "validate_visual_manifest",
 ]


### PR DESCRIPTION
## Summary
- Allow persona_visuals.trigger_state to target safe custom state IDs declared by the active Persona Visual pack.
- Keep runtime override rendering active-pack scoped in the WebUI so unsafe or unknown custom states do not become renderable.
- Expose active custom runtime states through Persona Visual MCP capabilities and document the trigger contract.

## Change summary
Pending human-authored Change summary before merge, per the AI-generated PR merge gate.

## Verification
- Red tests first: backend custom trigger tests failed on built-in-only behavior; frontend custom override tests failed on rejected custom state/resolver fallback.
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_persona_visuals_module.py -q -> 13 passed, 3 warnings.
- bunx vitest run -c vitest.config.ts src/components/Common/PersonaBuddy/__tests__/personaVisualState.test.ts src/routes/hooks/__tests__/usePersonaIncomingPayload.visuals.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx -> 3 files passed, 38 tests passed; existing i18next warning only.
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile on touched Python files -> passed.
- git diff --check origin/dev..HEAD -> passed.
- Bandit on touched Python paths -> 0 findings in /tmp/bandit_persona_visual_mcp_trigger.json.
- Note: bunx tsc --noEmit -p tsconfig.json in apps/packages/ui remains blocked by unrelated repo baseline errors outside touched Persona Visual files.

Part of #1787.
Backlog: TASK-413.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Persona Visual MCP runtime triggers by accepting built-in or safe custom states, gating customs to the active pack, and sanitizing reasons. WebUI stores safe overrides and only resolves customs declared by the active pack. Part of #1787.

- **New Features**
  - Backend: `trigger_state` accepts built-in or safe custom `state` (validated grammar; rejects unsafe prefixes/secret markers); requires custom IDs in the active pack (`states` + `state_catalog`); clamps duration; normalizes `reason` to one line and 200 chars; capabilities return built-ins plus active custom states; tool schema now uses a bounded string for `state`.
  - WebUI: Allow custom `PersonaVisualStateId` in overrides; validate/sanitize payloads (bounded `reason`); compute `runtimeStateIds` from the active pack and gate the resolver on built-ins or `runtimeStateIds`.
  - Docs: Update `Persona_Visual_Packs.md` with the MCP trigger contract, ID grammar, and active-pack gating behavior.

<sup>Written for commit 836e91a436c1f2c748a3c6bc3d35936d880611a5. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1798?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

