### PR TITLE
Show llama.cpp profile capabilities in Admin

### DIFF
--- a/apps/packages/ui/src/components/Option/Admin/LlamacppRuntimePanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppRuntimePanel.tsx
@@ -98,7 +98,10 @@ const capabilityTags = (row: RuntimeRow, projector: string | null) => {
     ...(row.profile?.capabilities || {}),
     ...(row.runtime?.capabilities || {})
   }
-  const modalities = row.runtime?.modalities || row.profile?.modalities || {}
+  const modalities = {
+    ...(row.profile?.modalities || {}),
+    ...(row.runtime?.modalities || {})
+  }
   const inputModalities = modalities.input || []
   const outputModalities = modalities.output || []
   const mode = row.profile?.mode

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppRuntimePanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppRuntimePanel.tsx
@@ -75,6 +75,67 @@ const modelLabel = (row: RuntimeRow) =>
   row.profile?.model_id ||
   "No model selected"
 
+const uniqueStrings = (values: Array<string | null | undefined>) =>
+  Array.from(new Set(values.map((value) => value?.trim()).filter(Boolean) as string[]))
+
+const basename = (value?: string | null) => {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+  return trimmed.split(/[\\/]/).filter(Boolean).pop() || trimmed
+}
+
+const projectorLabel = (row: RuntimeRow) =>
+  row.runtime?.mmproj_display_name ||
+  row.profile?.mmproj_display_name ||
+  basename(row.runtime?.mmproj_path) ||
+  basename(row.profile?.mmproj_path) ||
+  row.runtime?.mmproj_model_id ||
+  row.profile?.mmproj_model_id ||
+  null
+
+const capabilityTags = (row: RuntimeRow, projector: string | null) => {
+  const capabilities = {
+    ...(row.profile?.capabilities || {}),
+    ...(row.runtime?.capabilities || {})
+  }
+  const modalities = row.runtime?.modalities || row.profile?.modalities || {}
+  const inputModalities = modalities.input || []
+  const outputModalities = modalities.output || []
+  const mode = row.profile?.mode
+  const tags: Array<{ label: string; color: string }> = []
+
+  if (
+    capabilities.vision ||
+    inputModalities.includes("image") ||
+    (mode === "vision" && projector)
+  ) {
+    tags.push({ label: "Vision input", color: "purple" })
+  }
+  if (
+    capabilities.embeddings ||
+    outputModalities.includes("embedding") ||
+    mode === "embedding"
+  ) {
+    tags.push({ label: "Embeddings", color: "geekblue" })
+  }
+  if (
+    capabilities.rerank ||
+    outputModalities.includes("score") ||
+    mode === "rerank"
+  ) {
+    tags.push({ label: "Rerank", color: "cyan" })
+  }
+
+  return tags
+}
+
+const capabilityWarnings = (row: RuntimeRow) =>
+  uniqueStrings([
+    ...(row.profile?.capability_warnings || []),
+    ...(row.runtime?.capability_warnings || []),
+    ...(row.runtime?.warnings || [])
+  ])
+
 export const LlamacppRuntimePanel: React.FC<LlamacppRuntimePanelProps> = ({
   profiles,
   runtimes,
@@ -145,7 +206,9 @@ export const LlamacppRuntimePanel: React.FC<LlamacppRuntimePanelProps> = ({
               const isStarting = state === "starting"
               const isPaused = state === "paused"
               const isBusy = actionProfileId === row.profileId
-              const warnings = row.runtime?.warnings || []
+              const projector = projectorLabel(row)
+              const warnings = capabilityWarnings(row)
+              const tags = capabilityTags(row, projector)
               const actions: React.ReactNode[] = []
 
               if (isRunning) {
@@ -232,6 +295,12 @@ export const LlamacppRuntimePanel: React.FC<LlamacppRuntimePanelProps> = ({
                       <Text strong>{label}</Text>
                       <Tag color={stateColor(state)}>{state}</Tag>
                       {row.profile?.mode && <Tag>{row.profile.mode}</Tag>}
+                      {tags.map((tag) => (
+                        <Tag key={tag.label} color={tag.color}>
+                          {tag.label}
+                        </Tag>
+                      ))}
+                      {projector && <Tag color="purple">mmproj</Tag>}
                       {row.profile?.enabled === false && <Tag color="orange">disabled</Tag>}
                       {row.runtime?.pid && <Tag>pid {row.runtime.pid}</Tag>}
                       {port && <Tag>{port}</Tag>}
@@ -247,6 +316,11 @@ export const LlamacppRuntimePanel: React.FC<LlamacppRuntimePanelProps> = ({
                       <Text type="secondary" className="break-all">
                         {modelLabel(row)}
                       </Text>
+                      {projector && (
+                        <Text type="secondary" className="break-all">
+                          {projector}
+                        </Text>
+                      )}
                     </Space>
 
                     {warnings.length > 0 && (

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx
@@ -138,6 +138,79 @@ describe("LlamacppRuntimePanel", () => {
     expect(onStart).not.toHaveBeenCalled()
   })
 
+  it("shows managed profile capability and projector state", () => {
+    render(
+      <LlamacppRuntimePanel
+        profiles={[
+          {
+            ...profiles[1],
+            enabled: true,
+            capabilities: {
+              chat: true,
+              vision: true,
+              embeddings: false,
+              rerank: false
+            },
+            modalities: {
+              input: ["text", "image"],
+              output: ["text"]
+            },
+            capability_warnings: ["Projector metadata is filename-derived."],
+            mmproj_display_name: "mmproj-chat.gguf"
+          },
+          {
+            ...profiles[0],
+            profile_id: "embed",
+            name: "Embedding runtime",
+            mode: "embedding" as const,
+            capabilities: {
+              chat: false,
+              vision: false,
+              embeddings: true,
+              rerank: false
+            },
+            modalities: {
+              input: ["text"],
+              output: ["embedding"]
+            }
+          },
+          {
+            ...profiles[0],
+            profile_id: "rerank",
+            name: "Rerank runtime",
+            mode: "rerank" as const,
+            capabilities: {
+              chat: false,
+              vision: false,
+              embeddings: false,
+              rerank: true
+            },
+            modalities: {
+              input: ["text"],
+              output: ["score"]
+            }
+          }
+        ]}
+        runtimes={[]}
+        loading={false}
+        actionProfileId={null}
+        onRefresh={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onUseInChat={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("vision")).toBeTruthy()
+    expect(screen.getByText("Vision input")).toBeTruthy()
+    expect(screen.getByText("mmproj-chat.gguf")).toBeTruthy()
+    expect(screen.getByText("Projector metadata is filename-derived.")).toBeTruthy()
+    expect(screen.getByText("Embeddings")).toBeTruthy()
+    expect(screen.getByText("Rerank")).toBeTruthy()
+  })
+
   it("renders runtime load errors through the design-system alert primitive", () => {
     render(
       <LlamacppRuntimePanel

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx
@@ -211,6 +211,44 @@ describe("LlamacppRuntimePanel", () => {
     expect(screen.getByText("Rerank")).toBeTruthy()
   })
 
+  it("uses profile modalities when runtime modalities are empty", () => {
+    render(
+      <LlamacppRuntimePanel
+        profiles={[
+          {
+            ...profiles[0],
+            profile_id: "profile-modalities",
+            name: "Profile modalities",
+            capabilities: {},
+            modalities: {
+              input: ["text", "image"],
+              output: ["text"]
+            }
+          }
+        ]}
+        runtimes={[
+          {
+            ...runtimes[0],
+            profile_id: "profile-modalities",
+            model_id: "gguf:profile-modalities",
+            model_path: "/models/profile-modalities.gguf",
+            modalities: {}
+          }
+        ]}
+        loading={false}
+        actionProfileId={null}
+        onRefresh={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onUseInChat={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Vision input")).toBeTruthy()
+  })
+
   it("renders runtime load errors through the design-system alert primitive", () => {
     render(
       <LlamacppRuntimePanel

--- a/apps/packages/ui/src/types/llamacpp-admin.ts
+++ b/apps/packages/ui/src/types/llamacpp-admin.ts
@@ -153,8 +153,10 @@ export type LlamacppProfileMode =
   | "rerank"
   | "server_generic"
 
-export type LlamacppCapabilityMap = Record<string, boolean>
-export type LlamacppModalities = Record<string, string[]>
+export type LlamacppCapabilityKey = "chat" | "vision" | "embeddings" | "rerank"
+export type LlamacppModalityDirection = "input" | "output"
+export type LlamacppCapabilityMap = Partial<Record<LlamacppCapabilityKey, boolean>>
+export type LlamacppModalities = Partial<Record<LlamacppModalityDirection, string[]>>
 
 export type LlamacppPortPolicy = "explicit" | "autoselect"
 

--- a/apps/packages/ui/src/types/llamacpp-admin.ts
+++ b/apps/packages/ui/src/types/llamacpp-admin.ts
@@ -153,6 +153,9 @@ export type LlamacppProfileMode =
   | "rerank"
   | "server_generic"
 
+export type LlamacppCapabilityMap = Record<string, boolean>
+export type LlamacppModalities = Record<string, string[]>
+
 export type LlamacppPortPolicy = "explicit" | "autoselect"
 
 export type LlamacppRuntimeState =
@@ -171,6 +174,11 @@ export interface LlamacppProfile {
   model_id?: string | null
   model_path?: string | null
   mmproj_model_id?: string | null
+  mmproj_path?: string | null
+  mmproj_display_name?: string | null
+  capabilities?: LlamacppCapabilityMap
+  modalities?: LlamacppModalities
+  capability_warnings?: string[]
   host: string
   port: number
   port_policy: LlamacppPortPolicy
@@ -182,7 +190,18 @@ export interface LlamacppProfile {
 }
 
 export type LlamacppProfileCreateRequest = Partial<
-  Omit<LlamacppProfile, "profile_id" | "server_args" | "restart_policy" | "tags">
+  Omit<
+    LlamacppProfile,
+    | "profile_id"
+    | "server_args"
+    | "restart_policy"
+    | "tags"
+    | "mmproj_path"
+    | "mmproj_display_name"
+    | "capabilities"
+    | "modalities"
+    | "capability_warnings"
+  >
 > & {
   profile_id?: string | null
   name: string
@@ -192,7 +211,15 @@ export type LlamacppProfileCreateRequest = Partial<
 }
 
 export type LlamacppProfileUpdateRequest = Partial<
-  Omit<LlamacppProfile, "profile_id">
+  Omit<
+    LlamacppProfile,
+    | "profile_id"
+    | "mmproj_path"
+    | "mmproj_display_name"
+    | "capabilities"
+    | "modalities"
+    | "capability_warnings"
+  >
 >
 
 export interface LlamacppProfileListResponse {
@@ -208,6 +235,12 @@ export interface LlamacppRuntime {
   endpoint?: string | null
   model_id?: string | null
   model_path?: string | null
+  mmproj_model_id?: string | null
+  mmproj_path?: string | null
+  mmproj_display_name?: string | null
+  capabilities?: LlamacppCapabilityMap
+  modalities?: LlamacppModalities
+  capability_warnings?: string[]
   resolved_args: string[]
   started_at?: string | null
   stopped_at?: string | null

--- a/backlog/tasks/task-397.7 - Implement-llama.cpp-WebUI-capability-visibility.md
+++ b/backlog/tasks/task-397.7 - Implement-llama.cpp-WebUI-capability-visibility.md
@@ -1,0 +1,55 @@
+---
+id: TASK-397.7
+title: Implement llama.cpp WebUI capability visibility
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 20:48'
+labels:
+  - llamacpp
+  - webui
+  - admin
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md
+parent_task_id: TASK-397
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 4 from the llama.cpp model-family/mmproj profile wiring plan: surface managed profile capabilities, multimodal projector state, and capability warnings in the llama.cpp Admin WebUI while keeping the slice display-only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Runtime panel shows managed profile capability/mode tags, mmproj display details, and capability warnings for profile/runtime payloads without adding editor controls.
+- [x] #2 Admin llama.cpp TypeScript types accept optional capability, modality, warning, and mmproj display fields while staying compatible with older servers.
+- [x] #3 Focused runtime/assets/admin page tests cover capability visibility and continue to pass.
+- [x] #4 Frontend verification and diff checks are recorded; Bandit is recorded as not applicable if no Python files are touched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the display-only WebUI capability visibility slice. Added optional response-only profile/runtime capability, modality, capability warning, and mmproj display fields to the llama.cpp admin TS types while excluding those response-only fields from create/update request types. Updated LlamacppRuntimePanel to render compact Vision input, Embeddings, Rerank, and mmproj tags from profile/runtime capability metadata, mmproj display/path/model IDs, and merged profile/runtime capability warnings with existing runtime warnings. Added regression coverage for managed profile capability and projector state visibility.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Llama.cpp Admin runtime rows now surface managed-profile capabilities and multimodal projector state without adding editor controls. Verification: watched the new runtime-panel test fail on missing Vision input display, then pass after implementation; final focused Vitest suite passed with 23 tests across runtime/assets/admin page specs; git diff --check passed. Package-wide tsc --noEmit still fails on existing unrelated baseline type debt and did not report touched llama.cpp runtime/type files. Bandit was not applicable because this slice only touched frontend TypeScript and Backlog task files. Attempted a temporary Vite/Playwright visual preview, but the preview harness hung before producing a useful screenshot; temporary files/processes were cleaned up.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-397.7 - Implement-llama.cpp-WebUI-capability-visibility.md
+++ b/backlog/tasks/task-397.7 - Implement-llama.cpp-WebUI-capability-visibility.md
@@ -4,16 +4,15 @@ title: Implement llama.cpp WebUI capability visibility
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 20:48'
+updated_date: 2026-05-16 21:45
 labels:
-  - llamacpp
-  - webui
-  - admin
+- llamacpp
+- webui
+- admin
 dependencies: []
 documentation:
-  - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
-  - >-
-    Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md
+- Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+- Docs/superpowers/plans/2026-05-16-llamacpp-model-family-mmproj-profile-wiring-plan.md
 parent_task_id: TASK-397
 priority: high
 ---
@@ -36,12 +35,17 @@ Implement Task 4 from the llama.cpp model-family/mmproj profile wiring plan: sur
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the display-only WebUI capability visibility slice. Added optional response-only profile/runtime capability, modality, capability warning, and mmproj display fields to the llama.cpp admin TS types while excluding those response-only fields from create/update request types. Updated LlamacppRuntimePanel to render compact Vision input, Embeddings, Rerank, and mmproj tags from profile/runtime capability metadata, mmproj display/path/model IDs, and merged profile/runtime capability warnings with existing runtime warnings. Added regression coverage for managed profile capability and projector state visibility.
+
+PR review follow-up: Qodo reported two actionable findings on PR #1799: narrow the capability/modalities map types to known optional keys, and merge runtime/profile modalities so an empty runtime modalities object does not suppress profile-derived capability tags. Reopening TASK-397.7 for the minimal review-fix patch.
+
+PR review fix complete: narrowed llama.cpp capability/modalities metadata to known optional keys and merged profile/runtime modalities so an empty runtime modalities object no longer suppresses profile-derived capability tags. Added focused regression coverage for the fallback case.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Llama.cpp Admin runtime rows now surface managed-profile capabilities and multimodal projector state without adding editor controls. Verification: watched the new runtime-panel test fail on missing Vision input display, then pass after implementation; final focused Vitest suite passed with 23 tests across runtime/assets/admin page specs; git diff --check passed. Package-wide tsc --noEmit still fails on existing unrelated baseline type debt and did not report touched llama.cpp runtime/type files. Bandit was not applicable because this slice only touched frontend TypeScript and Backlog task files. Attempted a temporary Vite/Playwright visual preview, but the preview harness hung before producing a useful screenshot; temporary files/processes were cleaned up.
+PR review update: addressed both Qodo findings on PR #1799. Verified the new runtime modality fallback test fails before the merge fix and passes after; focused Admin llama.cpp Vitest suite passes with 24 tests. Full UI tsc --noEmit still fails on existing baseline errors outside the touched llama.cpp files. PR-style git diff --check origin/dev...HEAD passes; two-dot origin/dev..HEAD reports unrelated base-drift whitespace in Watchlists history and is not representative of the PR diff. Bandit remains not applicable because this follow-up only touched frontend TypeScript and Backlog task metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Add optional response-only llama.cpp profile/runtime capability, modality, warning, and mmproj display fields to the Admin UI types while keeping create/update request types clean.
- Render compact Vision input, Embeddings, Rerank, and mmproj state in the llama.cpp runtime panel.
- Add focused runtime-panel regression coverage and Backlog tracking for TASK-397.7.

## Verification

- [x] `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx`
- [x] `git diff --check origin/dev..HEAD`
- [x] Bandit not applicable: frontend TypeScript and Backlog-only slice.
- [ ] Visual screenshot approval: attempted a temporary Vite/Playwright component preview, but the preview harness hung before producing a useful screenshot. Needs human visual check before merge.

## Type Check

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false` still fails on existing unrelated baseline type debt outside the touched llama.cpp runtime/type files.

## Change Summary

TODO (human-authored): replace before merge with a concise explanation of what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced llama.cpp profile capabilities and multimodal projector state in the Admin runtime panel to make modes and projector usage clear at a glance. Tightened capability metadata handling and added modality fallback; satisfies TASK-397.7.

- New Features
  - Tags for Vision input, Embeddings, and Rerank from combined profile/runtime capabilities and modalities (display-only).
  - `mmproj` tag and projector label from `mmproj_display_name`, path basename, or model ID.
  - Capability warnings merged from profile/runtime with existing runtime warnings.
  - Types extended with optional response-only capability/modality/warning/mmproj display fields; excluded from create/update.

- Bug Fixes
  - Narrow capability/modality maps to known keys and fallback to profile modalities when runtime modalities are empty; added focused tests.

<sup>Written for commit 3442e1fdb57d1758f574ab8ccf3899266c1442b8. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1799?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

