### PR TITLE
Add collapsible chat cockpit rails and simplify status strip

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/playground.json
+++ b/apps/packages/ui/src/assets/locale/en/playground.json
@@ -926,6 +926,8 @@
     "runtime": "Runtime",
     "focus": "Focus",
     "cockpit": "Cockpit",
+    "collapseRailSection": "Collapse {{title}}",
+    "expandRailSection": "Expand {{title}}",
     "contextLandmark": "Chat cockpit context",
     "runtimeLandmark": "Chat cockpit runtime",
     "conversationContext": "Conversation context",

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -2324,6 +2324,7 @@ export const Playground = () => {
       messageCount={cockpitMessageCount}
       sessionLabel={sessionLabel}
       sessionTitle={sessionSummary.title}
+      sessionStatus={sessionSummary.status}
       sessionStatusLabel={sessionSummary.statusLabel}
       sessionDetail={sessionSummary.detail}
       sessionError={sessionSummary.error}

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundCompositionPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundCompositionPreview.tsx
@@ -174,7 +174,6 @@ export const PlaygroundCompositionPreview = ({
             aria-label={sectionToggleLabel}
             aria-expanded={sectionOpen}
             aria-controls={bodyId}
-            title={sectionToggleLabel}
             onClick={() => setSectionOpen((value) => !value)}
           >
             {sectionOpen ? (
@@ -186,7 +185,11 @@ export const PlaygroundCompositionPreview = ({
         </div>
       </div>
 
-      <div id={bodyId} hidden={!sectionOpen}>
+      <div
+        id={bodyId}
+        aria-hidden={!sectionOpen}
+        className={sectionOpen ? undefined : "hidden"}
+      >
         <ul className="mt-2 divide-y divide-border/60">
           {summary.entries.map((entry) => (
             <PreviewRow key={entry.id} entry={entry} />

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundCompositionPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundCompositionPreview.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronRight, ChevronUp } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { getDesignSystemState } from "@/design-system";
 import { cockpitRailStyles } from "./playground-cockpit-rail-styles";
@@ -110,8 +110,17 @@ export const PlaygroundCompositionPreview = ({
   summary,
 }: PlaygroundCompositionPreviewProps) => {
   const { t } = useTranslation("playground");
+  const [sectionOpen, setSectionOpen] = React.useState(true);
   const [open, setOpen] = React.useState(false);
+  const bodyId = React.useId();
   const panelId = React.useId();
+  const sectionToggleLabel = sectionOpen
+    ? t("cockpit.collapseRailSection", "Collapse Composition", {
+        title: t("cockpit.composition", "Composition"),
+      })
+    : t("cockpit.expandRailSection", "Expand Composition", {
+        title: t("cockpit.composition", "Composition"),
+      });
   const detailButtonLabel = open
     ? t("cockpit.hideCompositionDetails", "Hide composition details")
     : t("cockpit.showCompositionDetails", "Show composition details");
@@ -151,71 +160,90 @@ export const PlaygroundCompositionPreview = ({
             </p>
           ) : null}
         </div>
-        <span
-          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${stateClass(
-            summary.overallState === "ready" ? "active" : summary.overallState,
-          )}`}
-        >
-          {overallLabel(summary.overallState, t)}
-        </span>
+        <div className="flex shrink-0 items-start gap-2">
+          <span
+            className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${stateClass(
+              summary.overallState === "ready" ? "active" : summary.overallState,
+            )}`}
+          >
+            {overallLabel(summary.overallState, t)}
+          </span>
+          <button
+            type="button"
+            className={cockpitRailStyles.collapseAction}
+            aria-label={sectionToggleLabel}
+            aria-expanded={sectionOpen}
+            aria-controls={bodyId}
+            title={sectionToggleLabel}
+            onClick={() => setSectionOpen((value) => !value)}
+          >
+            {sectionOpen ? (
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+          </button>
+        </div>
       </div>
 
-      <ul className="mt-2 divide-y divide-border/60">
-        {summary.entries.map((entry) => (
-          <PreviewRow key={entry.id} entry={entry} />
-        ))}
-      </ul>
+      <div id={bodyId} hidden={!sectionOpen}>
+        <ul className="mt-2 divide-y divide-border/60">
+          {summary.entries.map((entry) => (
+            <PreviewRow key={entry.id} entry={entry} />
+          ))}
+        </ul>
 
-      <button
-        type="button"
-        className={`mt-2 gap-1 ${cockpitRailStyles.action}`}
-        aria-expanded={open}
-        aria-controls={panelId}
-        onClick={() => setOpen((value) => !value)}
-      >
+        <button
+          type="button"
+          className={`mt-2 gap-1 ${cockpitRailStyles.action}`}
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={() => setOpen((value) => !value)}
+        >
+          {open ? (
+            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          {detailButtonLabel}
+        </button>
+
         {open ? (
-          <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
-        ) : (
-          <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-        )}
-        {detailButtonLabel}
-      </button>
-
-      {open ? (
-        <div id={panelId} className="mt-3 space-y-3">
-          <div>
-            <p className="text-[10px] font-semibold uppercase text-text-muted">
-              {t("cockpit.contextStack", "Context stack")}
-            </p>
-            {summary.contextStack.length > 0 ? (
-              <ul className="mt-1 divide-y divide-border/60">
-                {summary.contextStack.map((entry) => (
-                  <PreviewRow key={`stack-${entry.id}`} entry={entry} />
+          <div id={panelId} className="mt-3 space-y-3">
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-text-muted">
+                {t("cockpit.contextStack", "Context stack")}
+              </p>
+              {summary.contextStack.length > 0 ? (
+                <ul className="mt-1 divide-y divide-border/60">
+                  {summary.contextStack.map((entry) => (
+                    <PreviewRow key={`stack-${entry.id}`} entry={entry} />
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-1 text-xs text-text-muted">
+                  {t("cockpit.noContextStack", "No context sources active.")}
+                </p>
+              )}
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase text-text-muted">
+                {t("cockpit.contextFootprint", "Context footprint")}
+              </p>
+              <ul className="mt-1 flex flex-wrap gap-1.5 text-xs text-text-muted">
+                {footprintItems.map((item) => (
+                  <li
+                    key={item}
+                    className={cockpitRailStyles.tag}
+                  >
+                    {item}
+                  </li>
                 ))}
               </ul>
-            ) : (
-              <p className="mt-1 text-xs text-text-muted">
-                {t("cockpit.noContextStack", "No context sources active.")}
-              </p>
-            )}
+            </div>
           </div>
-          <div>
-            <p className="text-[10px] font-semibold uppercase text-text-muted">
-              {t("cockpit.contextFootprint", "Context footprint")}
-            </p>
-            <ul className="mt-1 flex flex-wrap gap-1.5 text-xs text-text-muted">
-              {footprintItems.map((item) => (
-                <li
-                  key={item}
-                  className={cockpitRailStyles.tag}
-                >
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      ) : null}
+        ) : null}
+      </div>
     </section>
   );
 };

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
@@ -17,6 +17,7 @@ import {
   cockpitRailStyles,
   cockpitRailToneClass,
 } from "./playground-cockpit-rail-styles";
+import { PlaygroundRailSection } from "./PlaygroundRailSection";
 
 const railActionClass = cockpitRailStyles.action;
 const PROMPT_SELECT_TRIGGER_SELECTOR = "[data-cockpit-prompt-select-trigger]";
@@ -286,13 +287,10 @@ export const PlaygroundContextRail = ({
         </div>
       ) : null}
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.contextStack", "Context stack")}
+      <PlaygroundRailSection
+        label={t("cockpit.contextStack", "Context stack")}
+        title={t("cockpit.contextStack", "Context stack")}
       >
-        <h2 className={cockpitRailStyles.heading}>
-          {t("cockpit.contextStack", "Context stack")}
-        </h2>
         <div className="mt-1 flex items-start justify-between gap-2">
           <div className="min-w-0">
             <p className={cockpitRailStyles.value}>
@@ -424,13 +422,12 @@ export const PlaygroundContextRail = ({
             )}
           </div>
         )}
-      </section>
+      </PlaygroundRailSection>
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.promptManagement", "Prompt management")}
+      <PlaygroundRailSection
+        label={t("cockpit.promptManagement", "Prompt management")}
+        title={t("cockpit.prompt", "Prompt")}
       >
-        <h2 className={cockpitRailStyles.heading}>{t("cockpit.prompt", "Prompt")}</h2>
         <div className="mt-1 flex items-start justify-between gap-2">
           <div className="min-w-0">
             <p className={cockpitRailStyles.value}>{promptManagementLabel}</p>
@@ -461,15 +458,12 @@ export const PlaygroundContextRail = ({
             </button>
           ) : null}
         </div>
-      </section>
+      </PlaygroundRailSection>
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.searchAndSources", "Search & sources")}
+      <PlaygroundRailSection
+        label={t("cockpit.searchAndSources", "Search & sources")}
+        title={t("cockpit.searchAndSources", "Search & sources")}
       >
-        <h2 className={cockpitRailStyles.heading}>
-          {t("cockpit.searchAndSources", "Search & sources")}
-        </h2>
         <p className={cockpitRailStyles.muted}>
           {t(
             "cockpit.searchSourcesDetail",
@@ -530,13 +524,12 @@ export const PlaygroundContextRail = ({
             {t("cockpit.searchContext", "Search & Context")}
           </button>
         </div>
-      </section>
+      </PlaygroundRailSection>
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.conversationSession", "Conversation session")}
+      <PlaygroundRailSection
+        label={t("cockpit.conversationSession", "Conversation session")}
+        title={t("cockpit.session", "Session")}
       >
-        <h2 className={cockpitRailStyles.heading}>{t("cockpit.session", "Session")}</h2>
         <div className="mt-1 flex items-start justify-between gap-2">
           <div className="min-w-0">
             <p className={cockpitRailStyles.value}>{sessionLabel}</p>
@@ -582,7 +575,7 @@ export const PlaygroundContextRail = ({
             ? t("cockpit.saveConversation", "Save conversation")
             : t("cockpit.useTemporaryChat", "Use temporary chat")}
         </button>
-      </section>
+      </PlaygroundRailSection>
     </div>
   );
 };

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundRailSection.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundRailSection.tsx
@@ -39,7 +39,6 @@ export const PlaygroundRailSection = ({
           aria-label={toggleLabel}
           aria-expanded={open}
           aria-controls={panelId}
-          title={toggleLabel}
           onClick={() => setOpen((value) => !value)}
         >
           {open ? (
@@ -49,7 +48,11 @@ export const PlaygroundRailSection = ({
           )}
         </button>
       </div>
-      <div id={panelId} hidden={!open}>
+      <div
+        id={panelId}
+        aria-hidden={!open}
+        className={open ? undefined : "hidden"}
+      >
         {children}
       </div>
     </section>

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundRailSection.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundRailSection.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cockpitRailStyles } from "./playground-cockpit-rail-styles";
+
+export type PlaygroundRailSectionProps = {
+  label: string;
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+};
+
+export const PlaygroundRailSection = ({
+  label,
+  title,
+  children,
+  defaultOpen = true,
+}: PlaygroundRailSectionProps) => {
+  const { t } = useTranslation("playground");
+  const [open, setOpen] = React.useState(defaultOpen);
+  const headingId = React.useId();
+  const panelId = React.useId();
+  const toggleLabel = open
+    ? t("cockpit.collapseRailSection", `Collapse ${title}`, { title })
+    : t("cockpit.expandRailSection", `Expand ${title}`, { title });
+
+  return (
+    <section
+      className={cockpitRailStyles.section}
+      aria-label={label}
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <h2 id={headingId} className={cockpitRailStyles.heading}>
+          {title}
+        </h2>
+        <button
+          type="button"
+          className={cockpitRailStyles.collapseAction}
+          aria-label={toggleLabel}
+          aria-expanded={open}
+          aria-controls={panelId}
+          title={toggleLabel}
+          onClick={() => setOpen((value) => !value)}
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+      <div id={panelId} hidden={!open}>
+        {children}
+      </div>
+    </section>
+  );
+};

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundRuntimeInspector.tsx
@@ -22,6 +22,7 @@ import {
   cockpitRailStyles,
   cockpitRailToneClass,
 } from "./playground-cockpit-rail-styles";
+import { PlaygroundRailSection } from "./PlaygroundRailSection";
 
 export type RuntimeSettingSummary = {
   label: string;
@@ -228,11 +229,10 @@ export const PlaygroundRuntimeInspector = ({
       data-message-count={effectiveMessageCount}
       className={cockpitRailStyles.stack}
     >
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.runtimeState", "Runtime state")}
+      <PlaygroundRailSection
+        label={t("cockpit.runtimeState", "Runtime state")}
+        title={t("cockpit.runtime", "Runtime")}
       >
-        <h2 className={cockpitRailStyles.heading}>{t("cockpit.runtime", "Runtime")}</h2>
         <div className="mt-1 flex items-start justify-between gap-2">
           <div className="min-w-0">
             <p className={cockpitRailStyles.value}>{statusLabel}</p>
@@ -272,15 +272,12 @@ export const PlaygroundRuntimeInspector = ({
             </p>
           </div>
         ) : null}
-      </section>
+      </PlaygroundRailSection>
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.modelRoute", "Model route")}
+      <PlaygroundRailSection
+        label={t("cockpit.modelRoute", "Model route")}
+        title={t("cockpit.modelRoute", "Model route")}
       >
-        <h2 className={cockpitRailStyles.heading}>
-          {t("cockpit.modelRoute", "Model route")}
-        </h2>
         <div className="mt-2 flex flex-col gap-2">
           <button
             type="button"
@@ -330,15 +327,12 @@ export const PlaygroundRuntimeInspector = ({
             </p>
           )}
         </div>
-      </section>
+      </PlaygroundRailSection>
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.assistant", "Assistant")}
+      <PlaygroundRailSection
+        label={t("cockpit.assistant", "Assistant")}
+        title={t("cockpit.assistant", "Assistant")}
       >
-        <h2 className={cockpitRailStyles.heading}>
-          {t("cockpit.assistant", "Assistant")}
-        </h2>
         <div className="mt-1 flex items-start justify-between gap-2">
           <div className="min-w-0">
             <p className={cockpitRailStyles.value}>{assistantLabel}</p>
@@ -409,13 +403,12 @@ export const PlaygroundRuntimeInspector = ({
             )}
           </p>
         ) : null}
-      </section>
+      </PlaygroundRailSection>
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={mcpToolsLabel}
+      <PlaygroundRailSection
+        label={mcpToolsLabel}
+        title={mcpToolsLabel}
       >
-        <h2 className={cockpitRailStyles.heading}>{mcpToolsLabel}</h2>
         {toolSummary ? (
           <div className={`mt-2 ${cockpitRailStyles.inset}`}>
             <div className="flex items-start gap-2">
@@ -507,15 +500,12 @@ export const PlaygroundRuntimeInspector = ({
             )}
           </p>
         )}
-      </section>
+      </PlaygroundRailSection>
 
-      <section
-        className={cockpitRailStyles.section}
-        aria-label={t("cockpit.runControls", "Run controls")}
+      <PlaygroundRailSection
+        label={t("cockpit.runControls", "Run controls")}
+        title={t("cockpit.runControls", "Run controls")}
       >
-        <h2 className={cockpitRailStyles.heading}>
-          {t("cockpit.runControls", "Run controls")}
-        </h2>
         {emptyAssistantResponse && !streaming ? (
           <div
             role="status"
@@ -594,7 +584,7 @@ export const PlaygroundRuntimeInspector = ({
               : t("cockpit.searchClosed", "Search closed")}
           </p>
         </div>
-      </section>
+      </PlaygroundRailSection>
     </div>
   );
 };

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
@@ -64,7 +64,6 @@ const actionClass =
   "inline-flex min-h-[26px] items-center gap-1 rounded-md border border-border bg-surface2 px-2 text-xs font-medium text-text hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus";
 
 export const PlaygroundStatusStrip = ({
-  mode,
   streaming,
   selectedProvider,
   selectedModel,
@@ -75,8 +74,6 @@ export const PlaygroundStatusStrip = ({
   sessionDetail,
   sessionError,
   hasContext,
-  contextSummary = [],
-  temporaryChat,
   degraded = false,
   degradedChecks = [],
   errorMessage,
@@ -173,6 +170,7 @@ export const PlaygroundStatusStrip = ({
       normalizedSessionStatusLabel !== READY_STATE_LABEL &&
       normalizedSessionStatusLabel !== t("cockpit.idle", "Idle"),
   );
+  const hasCriticalSessionState = showSessionStatusLabel || Boolean(sessionDetailLabel);
 
   return (
     <footer
@@ -209,46 +207,28 @@ export const PlaygroundStatusStrip = ({
           )}
           {runtimeLabel}
         </span>
-        <span className={pillClass}>
-          {mode === "focus"
-            ? t("cockpit.focus", "Focus")
-            : t("cockpit.cockpit", "Cockpit")}
-        </span>
-        <span className={pillClass}>{sessionLabel}</span>
-        {normalizedSessionTitle ? (
-          <span className={pillClass}>{normalizedSessionTitle}</span>
+        {hasCriticalSessionState ? (
+          <>
+            <span className={pillClass}>{sessionLabel}</span>
+            {normalizedSessionTitle ? (
+              <span className={pillClass}>{normalizedSessionTitle}</span>
+            ) : null}
+            {showSessionStatusLabel ? (
+              <span className={pillClass}>{normalizedSessionStatusLabel}</span>
+            ) : null}
+            {sessionDetailLabel ? (
+              <span
+                className={`${pillClass} ${
+                  normalizedSessionError
+                    ? "border-error/40 bg-error/10 text-error"
+                    : ""
+                }`}
+              >
+                {sessionDetailLabel}
+              </span>
+            ) : null}
+          </>
         ) : null}
-        {showSessionStatusLabel ? (
-          <span className={pillClass}>{normalizedSessionStatusLabel}</span>
-        ) : null}
-        {typeof temporaryChat === "boolean" ? (
-          <span className={pillClass}>
-            {temporaryChat
-              ? t("cockpit.temporary", "Temporary")
-              : t("cockpit.saved", "Saved")}
-          </span>
-        ) : null}
-        {sessionDetailLabel ? (
-          <span
-            className={`${pillClass} ${
-              normalizedSessionError
-                ? "border-error/40 bg-error/10 text-error"
-                : ""
-            }`}
-          >
-            {sessionDetailLabel}
-          </span>
-        ) : null}
-        {hasContext ? (
-          <span className={pillClass}>
-            {t("cockpit.contextActive", "Context active")}
-          </span>
-        ) : null}
-        {contextSummary.map((item, index) => (
-          <span className={pillClass} key={`context-${index}-${item}`}>
-            {item}
-          </span>
-        ))}
         {errorMessage ? (
           <span className={pillClass}>{errorMessage}</span>
         ) : (

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
@@ -34,6 +34,12 @@ type PlaygroundStatusStripRuntimeState =
   | "degraded"
   | "ready";
 
+type PlaygroundStatusStripSessionStatus =
+  | "idle"
+  | "loading"
+  | "loaded"
+  | "failed";
+
 export type PlaygroundStatusStripProps = {
   mode: PlaygroundCockpitMode;
   streaming: boolean;
@@ -42,6 +48,7 @@ export type PlaygroundStatusStripProps = {
   messageCount: number;
   sessionLabel: string;
   sessionTitle?: string | null;
+  sessionStatus?: PlaygroundStatusStripSessionStatus | null;
   sessionStatusLabel?: string | null;
   sessionDetail?: string | null;
   sessionError?: string | null;
@@ -70,6 +77,7 @@ export const PlaygroundStatusStrip = ({
   messageCount,
   sessionLabel,
   sessionTitle,
+  sessionStatus,
   sessionStatusLabel,
   sessionDetail,
   sessionError,
@@ -161,11 +169,14 @@ export const PlaygroundStatusStrip = ({
   const hasSessionDetail =
     Boolean(normalizedSessionDetail) &&
     normalizedSessionDetail !== normalizedSessionStatusLabel;
+  const isCriticalSessionStatus =
+    sessionStatus === "loading" || sessionStatus === "failed";
   const sessionDetailLabel =
     normalizedSessionError ||
-    (hasSessionDetail ? normalizedSessionDetail : null);
+    (isCriticalSessionStatus && hasSessionDetail ? normalizedSessionDetail : null);
   const showSessionStatusLabel = Boolean(
-    normalizedSessionStatusLabel &&
+    isCriticalSessionStatus &&
+      normalizedSessionStatusLabel &&
       normalizedSessionStatusLabel !== sessionLabel &&
       normalizedSessionStatusLabel !== READY_STATE_LABEL &&
       normalizedSessionStatusLabel !== t("cockpit.idle", "Idle"),

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx
@@ -237,8 +237,10 @@ describe("Playground cockpit accessibility", () => {
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveAttribute("aria-atomic", "false");
     expect(status).toHaveTextContent("Streaming");
-    expect(status).toHaveTextContent("Focus");
-    expect(status).toHaveTextContent("Context active");
+    expect(status).toHaveTextContent("anthropic:claude-sonnet-4");
+    expect(status).toHaveTextContent("2 messages");
+    expect(status).not.toHaveTextContent("Focus");
+    expect(status).not.toHaveTextContent("Context active");
   });
 
   it("keeps model catalog controls labeled in the rendered DOM", () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx
@@ -222,6 +222,7 @@ describe("Playground mature cockpit surfaces", () => {
             messageCount={2}
             sessionLabel="Server chat"
             sessionTitle="Archived investigation"
+            sessionStatus="failed"
             sessionStatusLabel="Load failed"
             sessionError="Conversation no longer exists"
             hasContext={false}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx
@@ -192,7 +192,7 @@ describe("Playground mature cockpit surfaces", () => {
     const status = screen.getByRole("status", { name: "Chat status" })
     expect(within(status).getByText("Streaming")).toBeInTheDocument()
     expect(within(status).getByText("openai:gpt-4.1-mini")).toBeInTheDocument()
-    expect(within(status).getByText("Context active")).toBeInTheDocument()
+    expect(within(status).queryByText("Context active")).toBeNull()
 
     fireEvent.click(
       within(status).getByRole("button", { name: "Stop generation" })

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx
@@ -211,6 +211,64 @@ describe("PlaygroundContextRail first-slice controls", () => {
     ).toBeInTheDocument();
   });
 
+  it("lets each left rail section collapse without removing the rail", () => {
+    renderRail({
+      compositionPreviewSummary: compositionSummary(),
+      hasContext: false,
+      contextSummary: [],
+      promptSelectControl: (
+        <button type="button" aria-label="Select a prompt">
+          Select prompt
+        </button>
+      ),
+    });
+
+    const rail = screen.getByTestId("playground-context-rail");
+    const collapseContext = within(rail).getByRole("button", {
+      name: "Collapse Context stack",
+    });
+    const contextPanelId = collapseContext.getAttribute("aria-controls");
+    const contextPanel = contextPanelId
+      ? document.getElementById(contextPanelId)
+      : null;
+
+    expect(collapseContext).toHaveAttribute("aria-expanded", "true");
+    expect(contextPanel).not.toBeNull();
+    expect(contextPanel).not.toHaveAttribute("hidden");
+
+    fireEvent.click(collapseContext);
+
+    expect(rail).toBeInTheDocument();
+    expect(collapseContext).toHaveAttribute("aria-expanded", "false");
+    expect(contextPanel).toHaveAttribute("hidden");
+    expect(
+      within(rail).getByRole("button", { name: "Expand Context stack" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(rail).getByRole("button", { name: "Collapse Composition" }),
+    );
+    fireEvent.click(
+      within(rail).getByRole("button", { name: "Collapse Prompt" }),
+    );
+    fireEvent.click(
+      within(rail).getByRole("button", {
+        name: "Collapse Search & sources",
+      }),
+    );
+    fireEvent.click(
+      within(rail).getByRole("button", { name: "Collapse Session" }),
+    );
+
+    expect(screen.getByRole("heading", { name: "Composition" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Context stack" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Prompt" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Search & sources" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Session" })).toBeInTheDocument();
+  });
+
   it("preserves existing left rail actions after regrouping", () => {
     const props = renderRail({
       compositionPreviewSummary: compositionSummary(),

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx
@@ -234,13 +234,15 @@ describe("PlaygroundContextRail first-slice controls", () => {
 
     expect(collapseContext).toHaveAttribute("aria-expanded", "true");
     expect(contextPanel).not.toBeNull();
-    expect(contextPanel).not.toHaveAttribute("hidden");
+    expect(contextPanel).toHaveAttribute("aria-hidden", "false");
+    expect(contextPanel).not.toHaveClass("hidden");
 
     fireEvent.click(collapseContext);
 
     expect(rail).toBeInTheDocument();
     expect(collapseContext).toHaveAttribute("aria-expanded", "false");
-    expect(contextPanel).toHaveAttribute("hidden");
+    expect(contextPanel).toHaveAttribute("aria-hidden", "true");
+    expect(contextPanel).toHaveClass("hidden");
     expect(
       within(rail).getByRole("button", { name: "Expand Context stack" }),
     ).toBeInTheDocument();

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
@@ -158,13 +158,15 @@ describe("PlaygroundRuntimeInspector first-slice controls", () => {
 
     expect(collapseRuntime).toHaveAttribute("aria-expanded", "true");
     expect(runtimePanel).not.toBeNull();
-    expect(runtimePanel).not.toHaveAttribute("hidden");
+    expect(runtimePanel).toHaveAttribute("aria-hidden", "false");
+    expect(runtimePanel).not.toHaveClass("hidden");
 
     fireEvent.click(collapseRuntime);
 
     expect(rail).toBeInTheDocument();
     expect(collapseRuntime).toHaveAttribute("aria-expanded", "false");
-    expect(runtimePanel).toHaveAttribute("hidden");
+    expect(runtimePanel).toHaveAttribute("aria-hidden", "true");
+    expect(runtimePanel).toHaveClass("hidden");
     expect(
       within(rail).getByRole("button", { name: "Expand Runtime" }),
     ).toBeInTheDocument();

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx
@@ -137,6 +137,58 @@ describe("PlaygroundRuntimeInspector first-slice controls", () => {
     ).toBeInTheDocument();
   });
 
+  it("lets each right rail section collapse without replacing the side rail", () => {
+    renderInspector({
+      settingSummaries: [{ label: "Temperature", value: "0.7" }],
+      toolSummary: {
+        state: "available",
+        label: "MCP tools",
+        detail: "3 chat tools enabled",
+      },
+    });
+
+    const rail = screen.getByTestId("playground-runtime-inspector");
+    const collapseRuntime = within(rail).getByRole("button", {
+      name: "Collapse Runtime",
+    });
+    const runtimePanelId = collapseRuntime.getAttribute("aria-controls");
+    const runtimePanel = runtimePanelId
+      ? document.getElementById(runtimePanelId)
+      : null;
+
+    expect(collapseRuntime).toHaveAttribute("aria-expanded", "true");
+    expect(runtimePanel).not.toBeNull();
+    expect(runtimePanel).not.toHaveAttribute("hidden");
+
+    fireEvent.click(collapseRuntime);
+
+    expect(rail).toBeInTheDocument();
+    expect(collapseRuntime).toHaveAttribute("aria-expanded", "false");
+    expect(runtimePanel).toHaveAttribute("hidden");
+    expect(
+      within(rail).getByRole("button", { name: "Expand Runtime" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(rail).getByRole("button", { name: "Collapse Model route" }),
+    );
+    fireEvent.click(
+      within(rail).getByRole("button", { name: "Collapse Assistant" }),
+    );
+    fireEvent.click(
+      within(rail).getByRole("button", { name: "Collapse MCP tools" }),
+    );
+    fireEvent.click(
+      within(rail).getByRole("button", { name: "Collapse Run controls" }),
+    );
+
+    expect(screen.getByRole("heading", { name: "Runtime" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Model route" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Assistant" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "MCP tools" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Run controls" })).toBeInTheDocument();
+  });
+
   it("preserves existing right rail actions after regrouping", () => {
     const props = renderInspector({
       streaming: true,

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
@@ -21,6 +21,9 @@ describe("PlaygroundStatusStrip first-slice state", () => {
         selectedModel="gpt-4.1-mini"
         messageCount={3}
         sessionLabel="Server chat"
+        sessionStatus="loaded"
+        sessionStatusLabel="Local history"
+        sessionDetail="History linked"
         hasContext
         contextSummary={["Web search on", "2 files"]}
         temporaryChat={false}
@@ -35,10 +38,41 @@ describe("PlaygroundStatusStrip first-slice state", () => {
     expect(status).toHaveTextContent("3 messages");
     expect(status).not.toHaveTextContent("Cockpit");
     expect(status).not.toHaveTextContent("Server chat");
+    expect(status).not.toHaveTextContent("Local history");
+    expect(status).not.toHaveTextContent("History linked");
     expect(status).not.toHaveTextContent("Saved");
     expect(status).not.toHaveTextContent("Context active");
     expect(status).not.toHaveTextContent("Web search on");
     expect(status).not.toHaveTextContent("2 files");
+  });
+
+  it("does not treat routine temporary-session labels as critical status", () => {
+    render(
+      <PlaygroundStatusStrip
+        mode="cockpit"
+        streaming={false}
+        selectedProvider="openai"
+        selectedModel="gpt-4.1-mini"
+        messageCount={1}
+        sessionLabel="Temporary chat"
+        sessionStatus="idle"
+        sessionStatusLabel="Local only"
+        sessionDetail="Not saved"
+        hasContext={false}
+        contextSummary={[]}
+        temporaryChat
+        degradedChecks={[]}
+        errorMessage={null}
+      />,
+    );
+
+    const status = screen.getByRole("status", { name: "Chat status" });
+    expect(status).toHaveTextContent("Ready");
+    expect(status).toHaveTextContent("openai:gpt-4.1-mini");
+    expect(status).toHaveTextContent("1 message");
+    expect(status).not.toHaveTextContent("Temporary chat");
+    expect(status).not.toHaveTextContent("Local only");
+    expect(status).not.toHaveTextContent("Not saved");
   });
 
   it("renders degraded checks as warning-only status", () => {
@@ -209,6 +243,7 @@ describe("PlaygroundStatusStrip first-slice state", () => {
         messageCount={5}
         sessionLabel="Server chat"
         sessionTitle="Archived investigation"
+        sessionStatus="failed"
         sessionStatusLabel="Load failed"
         sessionDetail="Failed to load conversation"
         sessionError="Conversation no longer exists"

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
@@ -12,7 +12,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 describe("PlaygroundStatusStrip first-slice state", () => {
-  it("renders model, provider, context, persistence, and message state together", () => {
+  it("keeps the ready status strip limited to critical route and count state", () => {
     render(
       <PlaygroundStatusStrip
         mode="cockpit"
@@ -31,15 +31,14 @@ describe("PlaygroundStatusStrip first-slice state", () => {
 
     const status = screen.getByRole("status", { name: "Chat status" });
     expect(status).toHaveTextContent("Ready");
-    expect(status).toHaveTextContent("Cockpit");
-    expect(status).toHaveTextContent("Server chat");
-    expect(status).toHaveTextContent("Saved");
-    expect(status).toHaveTextContent("Context active");
-    expect(status).toHaveTextContent("Web search on");
-    expect(status).toHaveTextContent("2 files");
-    expect(status).toHaveTextContent("openai");
-    expect(status).toHaveTextContent("gpt-4.1-mini");
+    expect(status).toHaveTextContent("openai:gpt-4.1-mini");
     expect(status).toHaveTextContent("3 messages");
+    expect(status).not.toHaveTextContent("Cockpit");
+    expect(status).not.toHaveTextContent("Server chat");
+    expect(status).not.toHaveTextContent("Saved");
+    expect(status).not.toHaveTextContent("Context active");
+    expect(status).not.toHaveTextContent("Web search on");
+    expect(status).not.toHaveTextContent("2 files");
   });
 
   it("renders degraded checks as warning-only status", () => {
@@ -63,7 +62,7 @@ describe("PlaygroundStatusStrip first-slice state", () => {
     expect(status).toHaveTextContent("Degraded");
     expect(status).toHaveTextContent("Embeddings unavailable");
     expect(status).toHaveTextContent("Chat remains available.");
-    expect(status).toHaveTextContent("Temporary");
+    expect(status).not.toHaveTextContent("Temporary");
   });
 
   it("keeps active streaming primary while degraded health remains warning-only", () => {

--- a/apps/packages/ui/src/components/Option/Playground/playground-cockpit-rail-styles.ts
+++ b/apps/packages/ui/src/components/Option/Playground/playground-cockpit-rail-styles.ts
@@ -16,6 +16,8 @@ export const cockpitRailStyles = {
     "inline-flex min-h-[30px] items-center rounded-md border border-border/70 bg-surface2 px-2.5 py-1 text-xs font-medium text-text hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus",
   clearAction:
     "inline-flex shrink-0 items-center rounded border border-border/70 bg-surface2 px-1.5 py-0.5 text-[10px] font-medium text-text hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus",
+  collapseAction:
+    "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-border/70 bg-surface2 text-text-muted hover:bg-surface hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus",
   inset: "rounded-md border border-border/60 bg-bg/70 px-2.5 py-2",
   compactInset: "rounded-md border border-border/60 bg-bg/70 px-2 py-1.5",
   emptyInset:

--- a/apps/packages/ui/src/public/_locales/en/playground.json
+++ b/apps/packages/ui/src/public/_locales/en/playground.json
@@ -2463,7 +2463,7 @@
     "message": "Loading prompt details..."
   },
   "cockpit_noPromptContext": {
-    "message": "No prompt context will be added."
+    "message": "No system prompt will be added."
   },
   "cockpit_noPromptSelected": {
     "message": "No prompt selected"
@@ -2790,7 +2790,7 @@
     "message": "Scoped settings"
   },
   "cockpit_settingsDefault": {
-    "message": "Using default settings for this provider:model."
+    "message": "Default settings for this provider:model."
   },
   "cockpit_settingInherited": {
     "message": "Inherited"
@@ -2832,9 +2832,48 @@
     "message": "Open tools"
   },
   "cockpit_toolsComposerManaged": {
-    "message": "Open composer tool controls to inspect availability."
+    "message": "Use composer MCP controls to inspect availability."
   },
   "cockpit_mobilePanelTabs": {
     "message": "Mobile cockpit panels"
+  },
+  "cockpit_collapseRailSection": {
+    "message": "Collapse {{title}}"
+  },
+  "cockpit_expandRailSection": {
+    "message": "Expand {{title}}"
+  },
+  "cockpit_searchAndSources": {
+    "message": "Search & sources"
+  },
+  "cockpit_searchSourcesDetail": {
+    "message": "Manage web, files, knowledge, media, and research context."
+  },
+  "cockpit_promptManagement": {
+    "message": "Prompt management"
+  },
+  "cockpit_prompt": {
+    "message": "Prompt"
+  },
+  "cockpit_reviewModelSettings": {
+    "message": "Review model settings"
+  },
+  "cockpit_modelRoute": {
+    "message": "Model route"
+  },
+  "cockpit_noAssistantDetail": {
+    "message": "No persona or character will shape replies."
+  },
+  "cockpit_providerModelSettings": {
+    "message": "Provider:model settings"
+  },
+  "cockpit_chatToolAccess": {
+    "message": "Chat tool access"
+  },
+  "cockpit_configureMcpTools": {
+    "message": "Configure MCP tools"
+  },
+  "cockpit_empty": {
+    "message": "Empty"
   }
 }

--- a/backlog/tasks/task-414 - Simplify-chat-cockpit-status-strip-and-collapsible-rail-sections.md
+++ b/backlog/tasks/task-414 - Simplify-chat-cockpit-status-strip-and-collapsible-rail-sections.md
@@ -41,7 +41,7 @@ Implemented a shared PlaygroundRailSection primitive for in-place collapsible co
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed the main /chat cockpit status/sidechannel polish slice and opened draft PR #1801. Focused Vitest coverage proves compact critical status behavior, rail-section collapse semantics, and adjacent cockpit accessibility/composition behavior. Verification run: bunx vitest run PlaygroundStatusStrip.first-slice, PlaygroundContextRail.first-slice, PlaygroundRuntimeInspector.first-slice, Playground.cockpit-maturity, Playground.cockpit-a11y, PlaygroundCompositionPreview; bun run verify:design-system-state; git diff --check. Bandit skipped because this touched frontend TypeScript/TSX and Backlog markdown only. Live browser verification was not run because no local /chat WebUI/API listener was discoverable at the common checked ports and /api/v1/health on 127.0.0.1:18001 was unavailable.
+Completed the main /chat cockpit status/sidechannel polish slice and PR #1801 review fixes. Focused Vitest coverage now proves compact critical status behavior, realistic routine session labels staying hidden from the ready/degraded strip, rail-section collapse semantics, adjacent cockpit accessibility/composition behavior, and locale mirroring. Verification run: bunx vitest run PlaygroundStatusStrip.first-slice, PlaygroundContextRail.first-slice, PlaygroundRuntimeInspector.first-slice, Playground.cockpit-maturity, Playground.cockpit-a11y, PlaygroundCompositionPreview, playground-locale-mirror; bun run verify:design-system-state; git diff --check. Bandit skipped because this touched frontend TypeScript/TSX, locale JSON, and Backlog markdown only. Live browser verification was not run in this review-fix pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -53,3 +53,9 @@ Completed the main /chat cockpit status/sidechannel polish slice and opened draf
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented PR #1801 review fixes for the main /chat cockpit slice. Added structured sessionStatus wiring so routine loaded/idle local-history and temporary-session labels stay out of the simplified status strip while loading/failed/session-error states remain visible. Removed redundant collapse-toggle title attributes, replaced HTML hidden collapse bodies with CSS hiding plus aria-hidden, and added the missing collapse/expand rail-section locale keys with the public locale mirror synced by the repo script. Review-fix verification: bunx vitest run PlaygroundStatusStrip.first-slice, PlaygroundContextRail.first-slice, PlaygroundRuntimeInspector.first-slice, Playground.cockpit-maturity, Playground.cockpit-a11y, PlaygroundCompositionPreview, playground-locale-mirror (66 tests); bun run verify:design-system-state; git diff --check. Bandit skipped because touched code is frontend TS/TSX/JSON plus Backlog markdown only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-414 - Simplify-chat-cockpit-status-strip-and-collapsible-rail-sections.md
+++ b/backlog/tasks/task-414 - Simplify-chat-cockpit-status-strip-and-collapsible-rail-sections.md
@@ -1,0 +1,55 @@
+---
+id: TASK-414
+title: Simplify chat cockpit status strip and collapsible rail sections
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-16 21:02
+labels:
+- chat
+- webui
+- cockpit
+- ux
+- frontend
+dependencies: []
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/1801
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Tighten the main /chat cockpit UI by reducing the existing status strip to critical state/action information and making each main chat sidechannel rail section collapsible in place. Scope is limited to the WebUI /chat cockpit rails and status strip; no bottom rail replacement, no mocked data, no extension sidepanel/sidebar work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Ready-state status strip avoids duplicating routine session, persistence, and context summary chips already visible in cockpit rails.
+- [x] #2 Critical states remain visible in the status strip, including degraded chat-available warnings, streaming stop, missing model recovery, server-blocked state, loading-context state, and session failures.
+- [x] #3 Each existing main /chat sidechannel rail section can collapse and expand its body content without removing the rail or moving controls to the bottom of the page.
+- [x] #4 Rail section collapse controls are keyboard-accessible and expose aria-expanded/aria-controls semantics.
+- [x] #5 Focused Vitest coverage proves the status strip and collapsible rail behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a shared PlaygroundRailSection primitive for in-place collapsible cockpit rail sections. Wired it into the main /chat context rail and runtime rail, and added a top-level collapse control to the composition preview box. Simplified PlaygroundStatusStrip so normal Ready/Degraded state no longer repeats routine mode, session, persistence, and context-summary chips already visible in the rails, while critical session/runtime recovery state remains visible.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the main /chat cockpit status/sidechannel polish slice and opened draft PR #1801. Focused Vitest coverage proves compact critical status behavior, rail-section collapse semantics, and adjacent cockpit accessibility/composition behavior. Verification run: bunx vitest run PlaygroundStatusStrip.first-slice, PlaygroundContextRail.first-slice, PlaygroundRuntimeInspector.first-slice, Playground.cockpit-maturity, Playground.cockpit-a11y, PlaygroundCompositionPreview; bun run verify:design-system-state; git diff --check. Bandit skipped because this touched frontend TypeScript/TSX and Backlog markdown only. Live browser verification was not run because no local /chat WebUI/API listener was discoverable at the common checked ports and /api/v1/health on 127.0.0.1:18001 was unavailable.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Reduces the main `/chat` cockpit status strip so normal ready/degraded states stop duplicating routine mode, session, persistence, and context-summary chips already visible in the rails.
- Adds in-place collapsible controls for the main chat cockpit sidechannel sections, including context, prompt, search/sources, session, runtime, model route, assistant, MCP tools, run controls, and the composition preview box.
- Tracks the slice in `TASK-414` with focused regression coverage.

## Test Plan
- [x] `bunx vitest run src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx src/components/Option/Playground/__tests__/PlaygroundRuntimeInspector.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/PlaygroundCompositionPreview.test.tsx --config vitest.config.ts`
- [x] `bun run verify:design-system-state`
- [x] `git diff --check`
- [ ] Live `/chat` browser visual QA. Blocked in this session because no local WebUI/API listener was discoverable on the common checked ports, and `http://127.0.0.1:18001/api/v1/health` was unavailable.

## Change summary
Human reviewer must complete this section before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Backlog
- TASK-414

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the `/chat` cockpit status strip to show only critical route and count info, and adds in-place collapsible sections with keyboard/a11y semantics across both side rails and the composition preview. Addresses TASK-414.

- New Features
  - Status strip now focuses on `provider:model` and message count; shows session label/title/state only when loading or failed; keeps streaming/health warnings; removes mode, persistence, and context chips.
  - Reusable collapsible rail section with aria-expanded/aria-controls applied to Context, Prompt, Search & sources, Session, Runtime, Model route, Assistant, MCP tools, and Run controls; Composition preview gets a header-level collapse.
  - Adds a compact collapse-action style and localized collapse/expand labels (locale mirror updated); Vitest covers rail collapse semantics, composition preview, status strip expectations, and a11y.

<sup>Written for commit 184e0f1051ab72886b0ce4706477797d218aaa2d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1801?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

