### PR TITLE
Surface Buddy production packet review diagnostics

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -54,6 +54,8 @@ import type {
   PersonaVisualAssetRole,
   PersonaVisualAuthoredTrigger,
   PersonaVisualBuiltinStateId,
+  PersonaVisualImportBundleAssetGroup,
+  PersonaVisualImportBundleAssetSummary,
   PersonaVisualCandidate,
   PersonaVisualDuplicateTarget,
   PersonaVisualLibraryItem,
@@ -784,6 +786,127 @@ const previewRoleCategories = (
   )
   return Object.keys(categories).length ? categories : undefined
 }
+
+const BUDDY_PIPELINE_ASSET_GROUP_LABELS: Record<
+  PersonaVisualImportBundleAssetGroup,
+  string
+> = {
+  neutral_anchor: "Neutral anchor",
+  static_talking_sheet: "Static talking sheet",
+  static_reaction_sheet: "Static reaction sheet",
+  animation_strips: "Animation strips",
+  animation_atlas: "Animation atlas"
+}
+
+const BUDDY_PIPELINE_SOURCE_GROUPS = new Set<PersonaVisualImportBundleAssetGroup>([
+  "neutral_anchor",
+  "static_talking_sheet",
+  "static_reaction_sheet"
+])
+
+const BUDDY_PIPELINE_RUNTIME_GROUPS = new Set<PersonaVisualImportBundleAssetGroup>([
+  "animation_strips",
+  "animation_atlas"
+])
+
+type BuddyPipelineAssetKind = "source" | "runtime"
+
+interface BuddyPipelinePacketAssetDiagnostic {
+  sourceAssetId: string | null
+  assetRole: string | null
+  assetGroup: PersonaVisualImportBundleAssetGroup
+  assetKind: BuddyPipelineAssetKind
+  assetBytesStatus: string | null
+  mimeType: string | null
+  dimensions: string | null
+  manifestReferenced: boolean
+}
+
+interface BuddyPipelinePacketDiagnostics {
+  assets: BuddyPipelinePacketAssetDiagnostic[]
+  manifestAssetReferences: string[]
+}
+
+const getBuddyPipelineAssetGroup = (
+  value: unknown
+): PersonaVisualImportBundleAssetGroup | null => {
+  const group = previewString(value)
+  if (!group) return null
+  return Object.prototype.hasOwnProperty.call(
+    BUDDY_PIPELINE_ASSET_GROUP_LABELS,
+    group
+  )
+    ? (group as PersonaVisualImportBundleAssetGroup)
+    : null
+}
+
+const getBuddyPipelineAssetKind = (
+  group: PersonaVisualImportBundleAssetGroup
+): BuddyPipelineAssetKind =>
+  BUDDY_PIPELINE_SOURCE_GROUPS.has(group) &&
+  !BUDDY_PIPELINE_RUNTIME_GROUPS.has(group)
+    ? "source"
+    : "runtime"
+
+const getBuddyPipelineAssetDimensions = (
+  asset: PersonaVisualImportBundleAssetSummary
+): string | null => {
+  const width = previewNumber(asset.width)
+  const height = previewNumber(asset.height)
+  return width && height ? `${width}x${height}` : null
+}
+
+const getBuddyPipelinePacketDiagnostics = (
+  preview: PersonaVisualImportPreviewResponse | null
+): BuddyPipelinePacketDiagnostics | null => {
+  const summary = preview?.bundle_summary
+  if (!summary) return null
+  const manifestAssetReferences = previewStringList(
+    summary.manifest_asset_references
+  )
+  const manifestReferenceSet = new Set(manifestAssetReferences)
+  const rawAssets = Array.isArray(summary.assets) ? summary.assets : []
+  const assets = rawAssets.reduce<BuddyPipelinePacketAssetDiagnostic[]>(
+    (nextAssets, rawAsset) => {
+      if (!isRecord(rawAsset)) return nextAssets
+      const asset = rawAsset as PersonaVisualImportBundleAssetSummary
+      const assetGroup = getBuddyPipelineAssetGroup(asset.asset_group)
+      if (!assetGroup) return nextAssets
+      const sourceAssetId = previewString(asset.source_asset_id)
+      const manifestReferenced =
+        previewBoolean(asset.manifest_referenced) === true ||
+        Boolean(sourceAssetId && manifestReferenceSet.has(sourceAssetId))
+      nextAssets.push({
+        sourceAssetId,
+        assetRole: previewString(asset.asset_role),
+        assetGroup,
+        assetKind: getBuddyPipelineAssetKind(assetGroup),
+        assetBytesStatus: previewString(asset.asset_bytes_status),
+        mimeType: previewString(asset.mime_type),
+        dimensions: getBuddyPipelineAssetDimensions(asset),
+        manifestReferenced
+      })
+      return nextAssets
+    },
+    []
+  )
+  return assets.length ? { assets, manifestAssetReferences } : null
+}
+
+const getBuddyPipelineAssetDetailText = (
+  asset: BuddyPipelinePacketAssetDiagnostic,
+  manifestReferencedLabel: string
+): string =>
+  [
+    asset.sourceAssetId,
+    asset.assetRole,
+    asset.assetBytesStatus,
+    asset.mimeType,
+    asset.dimensions,
+    asset.manifestReferenced ? manifestReferencedLabel : null
+  ]
+    .filter(Boolean)
+    .join(" / ")
 
 const getRendererImportPreview = (
   preview: PersonaVisualImportPreviewResponse | null
@@ -2820,6 +2943,16 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const rendererImportPreview = getRendererImportPreview(fullImportPreview)
   const rendererImportRoleSummary =
     getRendererImportPreviewRoleSummary(rendererImportPreview)
+  const buddyPipelinePacketDiagnostics =
+    getBuddyPipelinePacketDiagnostics(fullImportPreview)
+  const buddyPipelineSourceAssets =
+    buddyPipelinePacketDiagnostics?.assets.filter(
+      (asset) => asset.assetKind === "source"
+    ) || []
+  const buddyPipelineRuntimeAssets =
+    buddyPipelinePacketDiagnostics?.assets.filter(
+      (asset) => asset.assetKind === "runtime"
+    ) || []
   const importCommitBlockers = getImportCommitBlockers(
     fullImportPreview,
     rendererImportPreview
@@ -2946,6 +3079,101 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           {importPreviewJobCopy ? (
             <div data-testid="persona-visual-import-preview-job-copy">
               {importPreviewJobCopy}
+            </div>
+          ) : null}
+          {buddyPipelinePacketDiagnostics ? (
+            <div
+              data-testid="persona-visual-import-buddy-packet-diagnostics"
+              className="rounded border border-border bg-bg p-2"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium text-text">
+                  {t("sidepanel:personaGarden.visuals.buddyPipelinePacketTitle", {
+                    defaultValue: "Buddy pipeline packet"
+                  })}
+                </span>
+                <Tag>
+                  {t("sidepanel:personaGarden.visuals.buddyPipelineAssetCount", {
+                    defaultValue: "{{count}} assets",
+                    count: buddyPipelinePacketDiagnostics.assets.length
+                  })}
+                </Tag>
+              </div>
+              {buddyPipelinePacketDiagnostics.manifestAssetReferences.length ? (
+                <div className="mt-1">
+                  {t("sidepanel:personaGarden.visuals.buddyPipelineManifestReferences", {
+                    defaultValue: "Manifest references"
+                  })}
+                  :{" "}
+                  {buddyPipelinePacketDiagnostics.manifestAssetReferences.join(
+                    ", "
+                  )}
+                </div>
+              ) : null}
+              {buddyPipelineSourceAssets.length ? (
+                <div className="mt-2">
+                  <div className="font-medium text-text">
+                    {t("sidepanel:personaGarden.visuals.buddyPipelineSourceMaterial", {
+                      defaultValue: "Source material"
+                    })}
+                  </div>
+                  <ul className="mt-1 list-disc space-y-1 pl-5">
+                    {buddyPipelineSourceAssets.map((asset, index) => (
+                      <li key={`${asset.assetGroup}-${asset.sourceAssetId || index}`}>
+                        <span className="text-text">
+                          {t(
+                            `sidepanel:personaGarden.visuals.buddyPipelineAssetGroup.${asset.assetGroup}`,
+                            {
+                              defaultValue:
+                                BUDDY_PIPELINE_ASSET_GROUP_LABELS[asset.assetGroup]
+                            }
+                          )}
+                        </span>
+                        {": "}
+                        {getBuddyPipelineAssetDetailText(
+                          asset,
+                          t(
+                            "sidepanel:personaGarden.visuals.buddyPipelineManifestReferenced",
+                            { defaultValue: "manifest referenced" }
+                          )
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {buddyPipelineRuntimeAssets.length ? (
+                <div className="mt-2">
+                  <div className="font-medium text-text">
+                    {t("sidepanel:personaGarden.visuals.buddyPipelineRuntimeOutput", {
+                      defaultValue: "Runtime output"
+                    })}
+                  </div>
+                  <ul className="mt-1 list-disc space-y-1 pl-5">
+                    {buddyPipelineRuntimeAssets.map((asset, index) => (
+                      <li key={`${asset.assetGroup}-${asset.sourceAssetId || index}`}>
+                        <span className="text-text">
+                          {t(
+                            `sidepanel:personaGarden.visuals.buddyPipelineAssetGroup.${asset.assetGroup}`,
+                            {
+                              defaultValue:
+                                BUDDY_PIPELINE_ASSET_GROUP_LABELS[asset.assetGroup]
+                            }
+                          )}
+                        </span>
+                        {": "}
+                        {getBuddyPipelineAssetDetailText(
+                          asset,
+                          t(
+                            "sidepanel:personaGarden.visuals.buddyPipelineManifestReferenced",
+                            { defaultValue: "manifest referenced" }
+                          )
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
             </div>
           ) : null}
           {importPreviewWarnings.length ? (

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -798,18 +798,15 @@ const BUDDY_PIPELINE_ASSET_GROUP_LABELS: Record<
   animation_atlas: "Animation atlas"
 }
 
-const BUDDY_PIPELINE_SOURCE_GROUPS = new Set<PersonaVisualImportBundleAssetGroup>([
-  "neutral_anchor",
-  "static_talking_sheet",
-  "static_reaction_sheet"
-])
-
-const BUDDY_PIPELINE_RUNTIME_GROUPS = new Set<PersonaVisualImportBundleAssetGroup>([
-  "animation_strips",
-  "animation_atlas"
-])
-
 type BuddyPipelineAssetKind = "source" | "runtime"
+
+const BUDDY_PIPELINE_ASSET_KIND = {
+  neutral_anchor: "source",
+  static_talking_sheet: "source",
+  static_reaction_sheet: "source",
+  animation_strips: "runtime",
+  animation_atlas: "runtime"
+} satisfies Record<PersonaVisualImportBundleAssetGroup, BuddyPipelineAssetKind>
 
 interface BuddyPipelinePacketAssetDiagnostic {
   sourceAssetId: string | null
@@ -843,17 +840,14 @@ const getBuddyPipelineAssetGroup = (
 const getBuddyPipelineAssetKind = (
   group: PersonaVisualImportBundleAssetGroup
 ): BuddyPipelineAssetKind =>
-  BUDDY_PIPELINE_SOURCE_GROUPS.has(group) &&
-  !BUDDY_PIPELINE_RUNTIME_GROUPS.has(group)
-    ? "source"
-    : "runtime"
+  BUDDY_PIPELINE_ASSET_KIND[group]
 
 const getBuddyPipelineAssetDimensions = (
   asset: PersonaVisualImportBundleAssetSummary
 ): string | null => {
   const width = previewNumber(asset.width)
   const height = previewNumber(asset.height)
-  return width && height ? `${width}x${height}` : null
+  return width !== null && height !== null ? `${width}x${height}` : null
 }
 
 const getBuddyPipelinePacketDiagnostics = (
@@ -3119,7 +3113,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                   </div>
                   <ul className="mt-1 list-disc space-y-1 pl-5">
                     {buddyPipelineSourceAssets.map((asset, index) => (
-                      <li key={`${asset.assetGroup}-${asset.sourceAssetId || index}`}>
+                      <li
+                        key={`${asset.assetGroup}-${asset.sourceAssetId ?? "unknown"}-${index}`}
+                      >
                         <span className="text-text">
                           {t(
                             `sidepanel:personaGarden.visuals.buddyPipelineAssetGroup.${asset.assetGroup}`,
@@ -3151,7 +3147,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                   </div>
                   <ul className="mt-1 list-disc space-y-1 pl-5">
                     {buddyPipelineRuntimeAssets.map((asset, index) => (
-                      <li key={`${asset.assetGroup}-${asset.sourceAssetId || index}`}>
+                      <li
+                        key={`${asset.assetGroup}-${asset.sourceAssetId ?? "unknown"}-${index}`}
+                      >
                         <span className="text-text">
                           {t(
                             `sidepanel:personaGarden.visuals.buddyPipelineAssetGroup.${asset.assetGroup}`,

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -4112,6 +4112,222 @@ describe("VisualPackEditor", () => {
     ).toBe(false)
   })
 
+  it("surfaces Buddy production packet asset diagnostics during import review", async () => {
+    const calls: string[] = []
+    const pack = makeVisualPack()
+    let importCommitStarts = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      calls.push(`${method} ${path}`)
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse([pack])
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/pack-1/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-buddy-packet",
+          job_id: "preview-job-buddy-packet",
+          portability_job_id: "portability-preview-buddy-packet",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-buddy-packet" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-buddy-packet",
+          job_id: "preview-job-buddy-packet",
+          portability_job_id: "portability-preview-buddy-packet",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          archive_sha256: "sha-buddy-packet",
+          canonical_payload_fingerprint: "fingerprint-buddy-packet",
+          schema_version: "persona_visual_pack.v1",
+          bundle_summary: {
+            pack_title: "Buddy Pipeline Packet",
+            asset_count: 6,
+            assets_with_bytes: 6,
+            manifest_asset_references: [
+              "buddy-animation-atlas",
+              "buddy-strip-required"
+            ],
+            assets: [
+              {
+                source_asset_id: "buddy-neutral-anchor",
+                asset_role: "preview",
+                asset_group: "neutral_anchor",
+                asset_bytes_status: "present",
+                mime_type: "image/png",
+                width: 512,
+                height: 512,
+                manifest_referenced: false
+              },
+              {
+                source_asset_id: "buddy-static-talking-sheet",
+                asset_role: "still_pose",
+                asset_group: "static_talking_sheet",
+                asset_bytes_status: "present",
+                mime_type: "image/png",
+                width: 1024,
+                height: 512,
+                manifest_referenced: false
+              },
+              {
+                source_asset_id: "buddy-static-reaction-sheet",
+                asset_role: "still_pose",
+                asset_group: "static_reaction_sheet",
+                asset_bytes_status: "present",
+                mime_type: "image/png",
+                width: 1024,
+                height: 512,
+                manifest_referenced: false
+              },
+              {
+                source_asset_id: "buddy-strip-required",
+                asset_role: "sprite_sheet",
+                asset_group: "animation_strips",
+                asset_bytes_status: "present",
+                mime_type: "image/png",
+                width: 1024,
+                height: 256,
+                manifest_referenced: true
+              },
+              {
+                source_asset_id: "buddy-animation-atlas",
+                asset_role: "sprite_sheet",
+                asset_group: "animation_atlas",
+                asset_bytes_status: "present",
+                mime_type: "image/png",
+                width: 1024,
+                height: 1024,
+                manifest_referenced: true
+              },
+              {
+                source_asset_id: "mystery-source",
+                asset_role: "frame",
+                asset_group: null,
+                asset_bytes_status: "present",
+                mime_type: "image/png",
+                width: 128,
+                height: 128,
+                manifest_referenced: false
+              }
+            ]
+          },
+          validation_warnings: [],
+          conflicts: [],
+          proposed_plan: { target_mode: "create_new" },
+          quota_estimate: { asset_bytes: 4096 },
+          required_choices: [],
+          target_warnings: []
+        })
+      }
+      if (
+        path ===
+          "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-buddy-packet/commit" &&
+        method === "POST"
+      ) {
+        importCommitStarts += 1
+        expect(parseJsonBody(init?.body)).toMatchObject({
+          trust_mode: "untrusted_import",
+          target_mode: "create_new"
+        })
+        return okResponse({
+          job_id: "import-job-buddy-packet",
+          portability_job_id: "portability-import-buddy-packet",
+          operation: "import_commit",
+          preview_id: "preview-buddy-packet",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-pack-status")).toHaveTextContent(
+        "draft"
+      )
+    )
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(screen.getByTestId("persona-visual-import-preview-input"), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "completed"
+      )
+    )
+
+    const diagnostics = screen.getByTestId(
+      "persona-visual-import-buddy-packet-diagnostics"
+    )
+    expect(diagnostics).toHaveTextContent("Buddy pipeline packet")
+    expect(diagnostics).toHaveTextContent("Neutral anchor")
+    expect(diagnostics).toHaveTextContent("Static talking sheet")
+    expect(diagnostics).toHaveTextContent("Static reaction sheet")
+    expect(diagnostics).toHaveTextContent("Animation strips")
+    expect(diagnostics).toHaveTextContent("Animation atlas")
+    expect(diagnostics).toHaveTextContent("Source material")
+    expect(diagnostics).toHaveTextContent("Runtime output")
+    expect(diagnostics).toHaveTextContent("Manifest references")
+    expect(diagnostics).toHaveTextContent("buddy-animation-atlas")
+    expect(diagnostics).toHaveTextContent("buddy-strip-required")
+    expect(diagnostics).not.toHaveTextContent("mystery-source")
+
+    const commitButton = screen.getByTestId("persona-visual-import-commit-button")
+    expect(commitButton).toBeEnabled()
+    fireEvent.click(commitButton)
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-commit-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+    expect(importCommitStarts).toBe(1)
+    expect(calls.some((call) => call.includes("/activate"))).toBe(false)
+  })
+
   it("rejects unsupported visual import archive filenames before upload", async () => {
     const calls: string[] = []
     const pack = {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -4175,7 +4175,7 @@ describe("VisualPackEditor", () => {
                 asset_group: "neutral_anchor",
                 asset_bytes_status: "present",
                 mime_type: "image/png",
-                width: 512,
+                width: 0,
                 height: 512,
                 manifest_referenced: false
               },
@@ -4312,6 +4312,7 @@ describe("VisualPackEditor", () => {
     expect(diagnostics).toHaveTextContent("Source material")
     expect(diagnostics).toHaveTextContent("Runtime output")
     expect(diagnostics).toHaveTextContent("Manifest references")
+    expect(diagnostics).toHaveTextContent("0x512")
     expect(diagnostics).toHaveTextContent("buddy-animation-atlas")
     expect(diagnostics).toHaveTextContent("buddy-strip-required")
     expect(diagnostics).not.toHaveTextContent("mystery-source")

--- a/apps/packages/ui/src/types/persona-visuals.ts
+++ b/apps/packages/ui/src/types/persona-visuals.ts
@@ -519,6 +519,33 @@ export interface PersonaVisualImportProposedPlan extends Record<string, unknown>
   renderer_import_preview?: PersonaVisualRendererImportPreview
 }
 
+export type PersonaVisualImportBundleAssetGroup =
+  | "neutral_anchor"
+  | "static_talking_sheet"
+  | "static_reaction_sheet"
+  | "animation_strips"
+  | "animation_atlas"
+
+export interface PersonaVisualImportBundleAssetSummary
+  extends Record<string, unknown> {
+  source_asset_id?: string | null
+  asset_role?: PersonaVisualAssetRole | string | null
+  asset_group?: PersonaVisualImportBundleAssetGroup | string | null
+  asset_bytes_status?: string | null
+  mime_type?: string | null
+  width?: number | null
+  height?: number | null
+  manifest_referenced?: boolean | null
+}
+
+export interface PersonaVisualImportBundleSummary extends Record<string, unknown> {
+  pack_title?: string | null
+  asset_count?: number | null
+  assets_with_bytes?: number | null
+  manifest_asset_references?: string[]
+  assets?: PersonaVisualImportBundleAssetSummary[]
+}
+
 export interface PersonaVisualImportPreviewResponse {
   preview_id: string
   job_id: string
@@ -531,7 +558,7 @@ export interface PersonaVisualImportPreviewResponse {
   archive_sha256?: string | null
   canonical_payload_fingerprint?: string | null
   schema_version?: string | null
-  bundle_summary: Record<string, unknown>
+  bundle_summary: PersonaVisualImportBundleSummary
   validation_warnings: unknown[]
   conflicts: PersonaVisualImportConflict[]
   proposed_plan: PersonaVisualImportProposedPlan

--- a/backlog/tasks/task-410.1 - Surface-Buddy-production-packet-review-diagnostics.md
+++ b/backlog/tasks/task-410.1 - Surface-Buddy-production-packet-review-diagnostics.md
@@ -4,7 +4,7 @@ title: Surface Buddy production packet review diagnostics
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 21:18'
+updated_date: '2026-05-16 21:56'
 labels:
   - persona
   - buddy
@@ -39,6 +39,8 @@ Implement the Persona Garden review surface for Buddy animation pipeline packet 
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented a Persona Garden import-preview diagnostics panel for recognized Buddy production packet asset groups. The panel reads the existing bundle_summary asset diagnostics, distinguishes source material from runtime outputs, shows manifest references, and ignores unknown/null asset groups. Import commit and activation behavior are unchanged.
+
+PR #1802 review fix sweep: verified and fixed the zero-dimension rendering guard, collision-safe diagnostic row keys, and exhaustive Buddy asset-kind classification map. Qodo/CodeRabbit findings were still valid against the PR code.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -47,6 +49,8 @@ Implemented a Persona Garden import-preview diagnostics panel for recognized Bud
 Persona Garden now surfaces Buddy production packet diagnostics during import review, backed by typed bundle_summary fields and focused Vitest coverage. Validation: red/green focused test, full VisualPackEditor Vitest file, git diff --check. Typecheck was attempted with tsc --noEmit -p apps/packages/ui/tsconfig.json and failed on existing repo-wide baseline errors outside this slice. Bandit skipped because this change only touches TypeScript/UI and Backlog metadata.
 
 A filtered tsc output check for VisualPackEditor/persona-visuals produced no touched-file type errors.
+
+Review fix validation: focused Buddy packet regression test passed, full VisualPackEditor Vitest file passed, git diff --check passed, and filtered tsc output for VisualPackEditor/persona-visuals stayed empty despite repo-wide baseline typecheck failures.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-410.1 - Surface-Buddy-production-packet-review-diagnostics.md
+++ b/backlog/tasks/task-410.1 - Surface-Buddy-production-packet-review-diagnostics.md
@@ -1,0 +1,60 @@
+---
+id: TASK-410.1
+title: Surface Buddy production packet review diagnostics
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 21:18'
+labels:
+  - persona
+  - buddy
+  - visual-packs
+  - webui
+  - issue-1800
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1800'
+  - 'https://github.com/rmusser01/tldw_server/issues/1787'
+  - 'https://github.com/rmusser01/tldw_server/issues/1510'
+parent_task_id: TASK-410
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Persona Garden review surface for Buddy animation pipeline packet import-preview diagnostics. Show neutral anchors, static talking/reaction source sheets, animation strips/atlas outputs, and manifest-referenced runtime assets from the existing bundle_summary without changing commit, activation, backend endpoints, renderer support, provider execution, VN/CYOA behavior, or Buddy runtime behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona Garden import-preview review shows Buddy packet asset group diagnostics when present.
+- [x] #2 Source sheets and neutral anchors are distinguished from manifest-referenced runtime outputs.
+- [x] #3 Unknown or absent asset groups remain harmless and do not become support claims.
+- [x] #4 Commit/import behavior remains unchanged and still creates an inactive draft only after user review.
+- [x] #5 Focused Persona Garden/service tests cover the new display and existing commit action preservation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a Persona Garden import-preview diagnostics panel for recognized Buddy production packet asset groups. The panel reads the existing bundle_summary asset diagnostics, distinguishes source material from runtime outputs, shows manifest references, and ignores unknown/null asset groups. Import commit and activation behavior are unchanged.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Persona Garden now surfaces Buddy production packet diagnostics during import review, backed by typed bundle_summary fields and focused Vitest coverage. Validation: red/green focused test, full VisualPackEditor Vitest file, git diff --check. Typecheck was attempted with tsc --noEmit -p apps/packages/ui/tsconfig.json and failed on existing repo-wide baseline errors outside this slice. Bandit skipped because this change only touches TypeScript/UI and Backlog metadata.
+
+A filtered tsc output check for VisualPackEditor/persona-visuals produced no touched-file type errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Adds typed `bundle_summary` asset diagnostics for Persona Visual import previews.
- Surfaces recognized Buddy production packet groups in Persona Garden, split between source material and runtime output.
- Keeps import commit behavior unchanged: reviewed imports still create draft packs and activation remains separate.
- Adds focused coverage that ignores unknown asset groups and preserves the commit action.

## Scope

- No backend endpoint changes.
- No renderer/runtime expansion.
- No provider execution or asset generation.
- No VN/CYOA behavior changes.
- No automatic activation.

## Validation

- RED: focused Buddy packet test first failed because `persona-visual-import-buddy-packet-diagnostics` did not exist.
- `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "surfaces Buddy production packet asset diagnostics during import review" --maxWorkers=1 --no-file-parallelism`
- `./node_modules/.bin/vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx --maxWorkers=1 --no-file-parallelism`
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` was attempted and fails on existing repo-wide baseline errors outside this slice; a filtered compiler-output check for `VisualPackEditor` / `persona-visuals` produced no touched-file type errors.
- Bandit skipped because this change only touches TypeScript/UI and Backlog metadata.

## Tracking

- Closes #1800.
- Contributes to #1787 and #1510.
- Backlog: `TASK-410.1`

## Change summary

TODO: Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a diagnostics panel to the Persona Garden import review that shows Buddy pipeline packet assets, split into Source material and Runtime output. Uses typed `bundle_summary` and includes manifest references and per-asset details.

- **New Features**
  - Typed `bundle_summary` models in `persona-visuals.ts` for Buddy asset groups and asset summaries.
  - Diagnostics panel in `VisualPackEditor` listing recognized groups with labels and details (id, role, bytes, mime, dimensions), grouped by source vs runtime.
  - Ignores unknown groups; commit behavior unchanged (no auto-activation).

- **Bug Fixes**
  - Shows manifest reference list and an assets count tag.
  - Handles zero-dimension assets, uses collision-safe list keys, and completes group→kind mapping.

<sup>Written for commit 2072eee7bdfd6143ddcf014431582a9bc2d21c65. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1802?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

