### PR TITLE
Add llama.cpp Admin saved profile editor

### DIFF
--- a/Docs/superpowers/plans/2026-05-16-llamacpp-admin-profile-editor-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-admin-profile-editor-plan.md
@@ -386,7 +386,7 @@ git add "backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-edit
 git commit -m "docs: close out llama.cpp profile editor task"
 ```
 
-- [ ] **Step 7: Prepare PR**
+- [x] **Step 7: Prepare PR**
 
 Check status and diff:
 

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-admin-profile-editor-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-admin-profile-editor-plan.md
@@ -1,0 +1,399 @@
+# llama.cpp Admin Saved Profile Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a focused `/admin/llamacpp` profile editor so admins can create, edit, duplicate, and delete durable saved llama.cpp launch profiles from the WebUI.
+
+**Architecture:** Reuse the existing backend-owned profile APIs and `LlamacppProfile` TypeScript contract. Add one focused `LlamacppProfilesPanel` component that owns form state and payload shaping, then wire it into `LlamacppAdminPage` so saves refresh profiles and runtimes without auto-starting or auto-wiring Chat. Keep remote downloads, catalogs, and full advanced routing out of this slice.
+
+**Tech Stack:** React, Ant Design, lucide-react, shared design-system Alert primitive, existing `tldwClient` llama.cpp profile methods, Vitest, Testing Library.
+
+---
+
+## Scope Check
+
+This plan implements the next usability slice after the merged multi-instance
+backend, Asset Inventory V2, mmproj launch wiring, metadata, and runtime
+visibility work.
+
+In scope:
+
+- profile list/editor panel on `/admin/llamacpp`;
+- create profile from discovered GGUF assets;
+- optional mmproj selection for vision profiles;
+- edit, duplicate, and delete saved profiles;
+- payload shaping for known profile fields;
+- warnings/errors surfaced inside the panel;
+- focused Vitest coverage.
+
+Out of scope:
+
+- remote model downloads or catalog search;
+- upload/copy/move model files;
+- auto-start after profile save;
+- auto-wire Chat after profile save;
+- backend API changes unless a current client/server mismatch is discovered;
+- full advanced args browser redesign.
+
+## File Structure
+
+Create:
+
+- `apps/packages/ui/src/components/Option/Admin/LlamacppProfilesPanel.tsx`
+  - List saved profiles, render compact metadata, open create/edit/duplicate
+    form, validate JSON fields, and call parent callbacks.
+- `apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx`
+  - Unit coverage for create/edit/duplicate/delete payloads and JSON validation.
+
+Modify:
+
+- `apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx`
+  - Reorder the llama.cpp console to render Assets, then Profiles, then
+    Runtime so users move from files to saved services to process state.
+  - Add profile action handlers that call existing `tldwClient` methods.
+  - Refresh `listLlamacppProfiles()` and `listLlamacppInstances()` after
+    profile mutations.
+- `apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx`
+  - Mock the new panel and assert page-level profile action routing.
+- `backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md`
+  - Record acceptance criteria, notes, verification, and closeout.
+
+Do not modify:
+
+- `tldw_Server_API` backend profile APIs;
+- llama.cpp supervisor or process runner behavior;
+- `/api/v1/llm/models/metadata`;
+- Chat or Knowledge routing.
+
+## Task 1: Profile Panel Component
+
+**Files:**
+
+- Create: `apps/packages/ui/src/components/Option/Admin/LlamacppProfilesPanel.tsx`
+- Create: `apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx`
+
+- [x] **Step 1: Write failing create/edit/duplicate/delete tests**
+
+Add component tests with local fixtures:
+
+```tsx
+const ggufAsset = {
+  asset_id: "gguf:toy",
+  kind: "gguf" as const,
+  display_name: "Toy 7B",
+  path: "/models/toy.gguf",
+  resolved_path: "/models/toy.gguf",
+  identity_basis: "resolved_path" as const,
+  source: "models_dir" as const,
+  metadata: {},
+  capabilities: ["unknown"],
+  mmproj_asset_ids: ["mmproj:toy"],
+  base_model_asset_ids: [],
+  warnings: []
+}
+const mmprojAsset = {
+  ...ggufAsset,
+  asset_id: "mmproj:toy",
+  kind: "mmproj" as const,
+  display_name: "Toy projector",
+  path: "/models/mmproj-toy.gguf",
+  resolved_path: "/models/mmproj-toy.gguf",
+  capabilities: ["vision_projector"],
+  mmproj_asset_ids: [],
+  base_model_asset_ids: ["gguf:toy"]
+}
+```
+
+Cover:
+
+- create opens a form, selects model/mode/port, and calls `onCreate()` with
+  `name`, `mode`, `model_id`, `host`, `port`, `port_policy`, `enabled`,
+  `autostart`, `server_args`, and `tags`;
+- edit opens an existing profile and calls `onUpdate(profile_id, payload)`;
+- duplicate opens an existing profile as a new profile with a copied name and
+  calls `onCreate()` instead of `onUpdate()`;
+- delete requires confirmation and calls `onDelete(profile_id)`;
+- invalid server args JSON shows an inline error and does not call a mutation.
+
+- [x] **Step 2: Run panel tests to verify failure**
+
+Run:
+
+```bash
+./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx
+```
+
+Expected: FAIL because `LlamacppProfilesPanel` does not exist.
+
+- [x] **Step 3: Implement `LlamacppProfilesPanel`**
+
+Implement props:
+
+```ts
+interface LlamacppProfilesPanelProps {
+  profiles: LlamacppProfile[]
+  assets: LlamacppAssetsResponse | null
+  loading?: boolean
+  savingProfileId?: string | null
+  error?: string | null
+  onRefresh: () => void
+  onCreate: (payload: LlamacppProfileCreateRequest) => Promise<boolean> | boolean
+  onUpdate: (
+    profileId: string,
+    payload: LlamacppProfileUpdateRequest
+  ) => Promise<boolean> | boolean
+  onDelete: (profileId: string) => Promise<boolean> | boolean
+}
+```
+
+Use a `Card` titled `Profiles`, a `List` for existing profiles, and a `Modal`
+for the form.
+
+Form fields:
+
+- name: `Input`
+- enabled: `Switch`
+- mode: `Select` for `chat`, `vision`, `embedding`, `rerank`, `server_generic`
+- model: `Select` populated from `assets.assets.filter(kind === "gguf")`
+- mmproj: optional `Select` populated from `assets.assets.filter(kind === "mmproj")`
+- host: `Input`
+- port: `InputNumber`
+- port policy: `Select` for `explicit` and `autoselect`
+- autostart: `Switch`
+- provider alias: `Input`
+- tags: comma-separated `Input`
+- server args: JSON `TextArea`
+
+Payload rules:
+
+- trim strings before submit;
+- `profile_id` is omitted for create unless the form later adds an explicit ID;
+- empty `mmproj_model_id` and `provider_alias` become `null`;
+- tags split on commas, trimmed, and empty values removed;
+- `server_args` must parse to an object, otherwise show `Invalid server args JSON.`;
+- duplicate mode appends ` copy` to the profile name and clears no runtime state.
+
+Do not auto-start, auto-stop, or auto-wire Chat from this panel.
+
+- [x] **Step 4: Run panel tests**
+
+Run:
+
+```bash
+./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Commit panel component**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/Admin/LlamacppProfilesPanel.tsx \
+  apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx
+git commit -m "feat: add llama.cpp profile editor panel"
+```
+
+## Task 2: Admin Page Wiring
+
+**Files:**
+
+- Modify: `apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx`
+
+- [x] **Step 1: Write failing page wiring tests**
+
+In `LlamacppAdminPage.test.tsx`:
+
+- add `createLlamacppProfile`, `updateLlamacppProfile`, and
+  `deleteLlamacppProfile` to `apiMock`;
+- mock `LlamacppProfilesPanel` with buttons that call `onCreate`, `onUpdate`,
+  and `onDelete`;
+- assert create calls `tldwClient.createLlamacppProfile(payload)`;
+- assert edit calls `tldwClient.updateLlamacppProfile(profile_id, payload)`;
+- assert delete calls `tldwClient.deleteLlamacppProfile(profile_id)`;
+- assert each successful mutation reloads profile/runtime data without calling
+  start or use-in-chat methods.
+
+- [x] **Step 2: Run page wiring tests to verify failure**
+
+Run:
+
+```bash
+./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+```
+
+Expected: FAIL because the page does not render or wire a profiles panel yet.
+
+- [x] **Step 3: Wire panel into `LlamacppAdminPage`**
+
+Add import:
+
+```ts
+import { LlamacppProfilesPanel } from "./LlamacppProfilesPanel"
+```
+
+Add state:
+
+```ts
+const [profileActionId, setProfileActionId] = React.useState<string | null>(null)
+const [profileError, setProfileError] = React.useState<string | null>(null)
+```
+
+Add helper:
+
+```ts
+const refreshProfilesAndRuntimes = React.useCallback(
+  () => loadRuntimePlane(),
+  [loadRuntimePlane]
+)
+```
+
+Add handlers:
+
+```ts
+const handleCreateProfile = async (payload: LlamacppProfileCreateRequest) => {
+  try {
+    setProfileActionId("__create__")
+    setProfileError(null)
+    await tldwClient.createLlamacppProfile(payload)
+    await refreshProfilesAndRuntimes()
+    return true
+  } catch (error: unknown) {
+    setProfileError(sanitizeAdminErrorMessage(error, "Failed to create llama.cpp profile."))
+    markAdminGuardFromError(error)
+    return false
+  } finally {
+    setProfileActionId(null)
+  }
+}
+```
+
+Repeat the same pattern for update/delete. Use `profileId` as the action ID for
+update/delete.
+
+Render:
+
+```tsx
+<LlamacppProfilesPanel
+  profiles={runtimeProfiles}
+  assets={assets}
+  loading={loadingRuntimes}
+  savingProfileId={profileActionId}
+  error={profileError}
+  onRefresh={loadRuntimePlane}
+  onCreate={handleCreateProfile}
+  onUpdate={handleUpdateProfile}
+  onDelete={handleDeleteProfile}
+/>
+```
+
+Move `LlamacppRuntimePanel` below `LlamacppProfilesPanel` so the page reads
+Readiness → Assets → Profiles → Runtime → legacy Inventory/Launch. Keep the
+existing Runtime panel behavior unchanged.
+
+- [x] **Step 4: Run page wiring tests**
+
+Run:
+
+```bash
+./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Run combined frontend tests**
+
+Run:
+
+```bash
+./node_modules/.bin/vitest run \
+  src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx \
+  src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx \
+  src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx \
+  src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+```
+
+Expected: PASS.
+
+- [x] **Step 6: Commit page wiring**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx \
+  apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+git commit -m "feat: wire llama.cpp profile editor into admin"
+```
+
+## Task 3: Verification And Closeout
+
+**Files:**
+
+- Modify: `backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md`
+
+- [x] **Step 1: Run focused Admin llama.cpp tests**
+
+Run:
+
+```bash
+./node_modules/.bin/vitest run \
+  src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx \
+  src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx \
+  src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx \
+  src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run touched-scope TypeScript check if feasible**
+
+Run:
+
+```bash
+./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false
+```
+
+Expected: The package may still fail on known repo-wide baseline type debt. If
+it fails, confirm whether any errors reference the touched llama.cpp files and
+record that distinction in the Backlog task.
+
+- [x] **Step 3: Run diff checks**
+
+From repo root:
+
+```bash
+git diff --check
+git diff --check origin/dev...HEAD
+```
+
+Expected: PASS.
+
+- [x] **Step 4: Record Bandit disposition**
+
+No Python files should be touched in this UI-only slice. Record Bandit as not
+applicable in the Backlog task. If backend files become necessary, run Bandit
+on the touched Python paths before closeout.
+
+- [x] **Step 5: Update Backlog task**
+
+Use Backlog MCP to mark `TASK-397.8` Done, fill acceptance criteria, append
+verification notes, and add a final summary.
+
+- [x] **Step 6: Commit closeout notes**
+
+```bash
+git add "backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md"
+git commit -m "docs: close out llama.cpp profile editor task"
+```
+
+- [ ] **Step 7: Prepare PR**
+
+Check status and diff:
+
+```bash
+git status --short --branch
+git log --oneline origin/dev..HEAD
+```
+
+Then push and open a draft PR against `dev` with a human-owned `Change summary`
+placeholder.

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
@@ -10,6 +10,8 @@ import type {
   LlamacppHardwareSnapshotResponse,
   LlamacppInventoryResponse,
   LlamacppProfile,
+  LlamacppProfileCreateRequest,
+  LlamacppProfileUpdateRequest,
   LlamacppRuntime
 } from "@/types/llamacpp-admin"
 import {
@@ -26,6 +28,7 @@ import {
 import { LlamacppAssetsPanel } from "./LlamacppAssetsPanel"
 import { LlamacppInventoryPanel } from "./LlamacppInventoryPanel"
 import { LlamacppLaunchPanel } from "./LlamacppLaunchPanel"
+import { LlamacppProfilesPanel } from "./LlamacppProfilesPanel"
 import { LlamacppReadinessPanel } from "./LlamacppReadinessPanel"
 import { LlamacppRuntimePanel } from "./LlamacppRuntimePanel"
 
@@ -150,6 +153,8 @@ export const LlamacppAdminPage: React.FC = () => {
   const [chatActionLoading, setChatActionLoading] = React.useState(false)
   const [chatNotice, setChatNotice] = React.useState<string | null>(null)
   const [chatWarnings, setChatWarnings] = React.useState<string[]>([])
+  const [profileActionId, setProfileActionId] = React.useState<string | null>(null)
+  const [profileError, setProfileError] = React.useState<string | null>(null)
   const [runtimeActionProfileId, setRuntimeActionProfileId] = React.useState<string | null>(null)
 
   const markAdminGuardFromError = React.useCallback((error: unknown) => {
@@ -377,6 +382,65 @@ export const LlamacppAdminPage: React.FC = () => {
       return false
     } finally {
       setImportingAssetFolder(false)
+    }
+  }
+
+  const handleCreateProfile = async (
+    payload: LlamacppProfileCreateRequest
+  ): Promise<boolean> => {
+    try {
+      setProfileActionId("__create__")
+      setProfileError(null)
+      await tldwClient.createLlamacppProfile(payload)
+      await loadRuntimePlane()
+      return true
+    } catch (error: unknown) {
+      setProfileError(
+        sanitizeAdminErrorMessage(error, "Failed to create llama.cpp profile.")
+      )
+      markAdminGuardFromError(error)
+      return false
+    } finally {
+      setProfileActionId(null)
+    }
+  }
+
+  const handleUpdateProfile = async (
+    profileId: string,
+    payload: LlamacppProfileUpdateRequest
+  ): Promise<boolean> => {
+    try {
+      setProfileActionId(profileId)
+      setProfileError(null)
+      await tldwClient.updateLlamacppProfile(profileId, payload)
+      await loadRuntimePlane()
+      return true
+    } catch (error: unknown) {
+      setProfileError(
+        sanitizeAdminErrorMessage(error, "Failed to update llama.cpp profile.")
+      )
+      markAdminGuardFromError(error)
+      return false
+    } finally {
+      setProfileActionId(null)
+    }
+  }
+
+  const handleDeleteProfile = async (profileId: string): Promise<boolean> => {
+    try {
+      setProfileActionId(profileId)
+      setProfileError(null)
+      await tldwClient.deleteLlamacppProfile(profileId)
+      await loadRuntimePlane()
+      return true
+    } catch (error: unknown) {
+      setProfileError(
+        sanitizeAdminErrorMessage(error, "Failed to delete llama.cpp profile.")
+      )
+      markAdminGuardFromError(error)
+      return false
+    } finally {
+      setProfileActionId(null)
     }
   }
 
@@ -671,24 +735,6 @@ export const LlamacppAdminPage: React.FC = () => {
               loading={loadingConfig}
             />
 
-            {!runtimeUnsupported && (
-              <LlamacppRuntimePanel
-                profiles={runtimeProfiles}
-                runtimes={runtimeInstances}
-                loading={loadingRuntimes}
-                error={runtimeError}
-                actionProfileId={runtimeActionProfileId}
-                onRefresh={loadRuntimePlane}
-                onStart={handleStartProfile}
-                onStop={handleStopProfile}
-                onPause={handlePauseProfile}
-                onResume={handleResumeProfile}
-                onUseInChat={(profileId) => {
-                  void handleUseProfileInChat(profileId)
-                }}
-              />
-            )}
-
             <LlamacppAssetsPanel
               assets={assets}
               loading={loadingAssets}
@@ -699,6 +745,38 @@ export const LlamacppAdminPage: React.FC = () => {
               onImportFolder={handleImportAssetFolder}
               onReload={loadAssets}
             />
+
+            {!runtimeUnsupported && (
+              <>
+                <LlamacppProfilesPanel
+                  profiles={runtimeProfiles}
+                  assets={assets}
+                  loading={loadingRuntimes}
+                  savingProfileId={profileActionId}
+                  error={profileError}
+                  onRefresh={loadRuntimePlane}
+                  onCreate={handleCreateProfile}
+                  onUpdate={handleUpdateProfile}
+                  onDelete={handleDeleteProfile}
+                />
+
+                <LlamacppRuntimePanel
+                  profiles={runtimeProfiles}
+                  runtimes={runtimeInstances}
+                  loading={loadingRuntimes}
+                  error={runtimeError}
+                  actionProfileId={runtimeActionProfileId}
+                  onRefresh={loadRuntimePlane}
+                  onStart={handleStartProfile}
+                  onStop={handleStopProfile}
+                  onPause={handlePauseProfile}
+                  onResume={handleResumeProfile}
+                  onUseInChat={(profileId) => {
+                    void handleUseProfileInChat(profileId)
+                  }}
+                />
+              </>
+            )}
 
             <LlamacppInventoryPanel
               inventory={inventory}

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppProfilesPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppProfilesPanel.tsx
@@ -1,0 +1,503 @@
+import React from "react"
+import {
+  Button,
+  Card,
+  Empty,
+  Input,
+  InputNumber,
+  List,
+  Modal,
+  Select,
+  Space,
+  Switch,
+  Tag,
+  Typography
+} from "antd"
+import { Copy, Edit3, Plus, RefreshCw, Trash2 } from "lucide-react"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
+import type {
+  LlamacppAsset,
+  LlamacppAssetsResponse,
+  LlamacppPortPolicy,
+  LlamacppProfile,
+  LlamacppProfileCreateRequest,
+  LlamacppProfileMode,
+  LlamacppProfileUpdateRequest
+} from "@/types/llamacpp-admin"
+
+const { Text } = Typography
+const { TextArea } = Input
+
+const PROFILE_MODES: LlamacppProfileMode[] = [
+  "chat",
+  "vision",
+  "embedding",
+  "rerank",
+  "server_generic"
+]
+
+const PORT_POLICIES: LlamacppPortPolicy[] = ["explicit", "autoselect"]
+
+type FormMode = "create" | "edit" | "duplicate"
+
+interface LlamacppProfilesPanelProps {
+  profiles: LlamacppProfile[]
+  assets: LlamacppAssetsResponse | null
+  loading?: boolean
+  savingProfileId?: string | null
+  error?: string | null
+  onRefresh: () => void
+  onCreate: (payload: LlamacppProfileCreateRequest) => Promise<boolean> | boolean
+  onUpdate: (
+    profileId: string,
+    payload: LlamacppProfileUpdateRequest
+  ) => Promise<boolean> | boolean
+  onDelete: (profileId: string) => Promise<boolean> | boolean
+}
+
+interface ProfileFormState {
+  name: string
+  enabled: boolean
+  mode: LlamacppProfileMode
+  modelId: string
+  modelPath: string
+  mmprojModelId: string
+  host: string
+  port: number
+  portPolicy: LlamacppPortPolicy
+  autostart: boolean
+  providerAlias: string
+  tagsText: string
+  serverArgsText: string
+  restartPolicy: Record<string, unknown>
+}
+
+interface ActiveForm {
+  mode: FormMode
+  profile?: LlamacppProfile
+}
+
+const safeJsonStringify = (value: unknown) => {
+  try {
+    return JSON.stringify(value || {}, null, 2)
+  } catch {
+    return "{}"
+  }
+}
+
+const firstAssetId = (assets: LlamacppAsset[], kind: LlamacppAsset["kind"]) =>
+  assets.find((asset) => asset.kind === kind)?.asset_id || ""
+
+const formFromProfile = (
+  profile: LlamacppProfile | undefined,
+  assets: LlamacppAsset[],
+  mode: FormMode
+): ProfileFormState => ({
+  name:
+    mode === "duplicate" && profile
+      ? `${profile.name} copy`
+      : profile?.name || "",
+  enabled: profile?.enabled ?? true,
+  mode: profile?.mode || "chat",
+  modelId: profile?.model_id || firstAssetId(assets, "gguf"),
+  modelPath: profile?.model_path || "",
+  mmprojModelId: profile?.mmproj_model_id || "",
+  host: profile?.host || "127.0.0.1",
+  port: profile?.port || 8080,
+  portPolicy: profile?.port_policy || "explicit",
+  autostart: profile?.autostart ?? false,
+  providerAlias: profile?.provider_alias || "",
+  tagsText: (profile?.tags || []).join(", "),
+  serverArgsText: safeJsonStringify(profile?.server_args),
+  restartPolicy: profile?.restart_policy || {}
+})
+
+const parseTags = (value: string) =>
+  value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+
+const profileEndpoint = (profile: LlamacppProfile) => `${profile.host}:${profile.port}`
+
+const assetOptions = (
+  assets: LlamacppAsset[],
+  kind: LlamacppAsset["kind"],
+  selectedId?: string | null
+) => {
+  const options = assets
+    .filter((asset) => asset.kind === kind)
+    .map((asset) => ({
+      label: `${asset.display_name} (${asset.asset_id})`,
+      value: asset.asset_id
+    }))
+
+  if (selectedId && !options.some((option) => option.value === selectedId)) {
+    options.push({ label: selectedId, value: selectedId })
+  }
+
+  return options
+}
+
+export const LlamacppProfilesPanel: React.FC<LlamacppProfilesPanelProps> = ({
+  profiles,
+  assets,
+  loading = false,
+  savingProfileId = null,
+  error,
+  onRefresh,
+  onCreate,
+  onUpdate,
+  onDelete
+}) => {
+  const assetList = assets?.assets || []
+  const [activeForm, setActiveForm] = React.useState<ActiveForm | null>(null)
+  const [form, setForm] = React.useState<ProfileFormState>(() =>
+    formFromProfile(undefined, assetList, "create")
+  )
+  const [formError, setFormError] = React.useState<string | null>(null)
+
+  const openForm = (mode: FormMode, profile?: LlamacppProfile) => {
+    setActiveForm({ mode, profile })
+    setForm(formFromProfile(profile, assetList, mode))
+    setFormError(null)
+  }
+
+  const closeForm = () => {
+    setActiveForm(null)
+    setFormError(null)
+  }
+
+  const updateForm = <K extends keyof ProfileFormState>(
+    key: K,
+    value: ProfileFormState[K]
+  ) => {
+    setForm((current) => ({ ...current, [key]: value }))
+  }
+
+  const buildPayload = () => {
+    const name = form.name.trim()
+    if (!name) {
+      setFormError("Profile name is required.")
+      return null
+    }
+
+    let serverArgs: Record<string, unknown>
+    try {
+      const parsed = JSON.parse(form.serverArgsText || "{}")
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error("Server args must be an object.")
+      }
+      serverArgs = parsed as Record<string, unknown>
+    } catch {
+      setFormError("Invalid server args JSON.")
+      return null
+    }
+
+    return {
+      name,
+      enabled: form.enabled,
+      mode: form.mode,
+      model_id: form.modelId.trim() || null,
+      model_path: form.modelPath.trim() || null,
+      mmproj_model_id: form.mmprojModelId.trim() || null,
+      host: form.host.trim() || "127.0.0.1",
+      port: form.port,
+      port_policy: form.portPolicy,
+      server_args: serverArgs,
+      autostart: form.autostart,
+      restart_policy: form.restartPolicy,
+      provider_alias: form.providerAlias.trim() || null,
+      tags: parseTags(form.tagsText)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!activeForm) return
+    const payload = buildPayload()
+    if (!payload) return
+
+    const saved =
+      activeForm.mode === "edit" && activeForm.profile
+        ? await onUpdate(activeForm.profile.profile_id, payload)
+        : await onCreate(payload)
+
+    if (saved) {
+      closeForm()
+    }
+  }
+
+  const handleDelete = async (profile: LlamacppProfile) => {
+    const confirmed = window.confirm(`Delete llama.cpp profile "${profile.name}"?`)
+    if (!confirmed) return
+    await onDelete(profile.profile_id)
+  }
+
+  return (
+    <Card
+      title="Profiles"
+      loading={loading}
+      extra={
+        <Space>
+          <Button size="small" icon={<RefreshCw size={14} />} onClick={onRefresh}>
+            Refresh
+          </Button>
+          <Button
+            size="small"
+            type="primary"
+            icon={<Plus size={14} />}
+            onClick={() => openForm("create")}
+          >
+            New profile
+          </Button>
+        </Space>
+      }
+      aria-label="Profiles"
+    >
+      <Space orientation="vertical" size="middle" className="w-full">
+        {error && <DesignSystemAlert variant="error" title={error} />}
+
+        {profiles.length === 0 ? (
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description="No saved llama.cpp profiles are available."
+          />
+        ) : (
+          <List
+            size="small"
+            bordered
+            rowKey="profile_id"
+            dataSource={profiles}
+            renderItem={(profile) => (
+              <List.Item
+                actions={[
+                  <Button
+                    key="edit"
+                    size="small"
+                    icon={<Edit3 size={14} />}
+                    onClick={() => openForm("edit", profile)}
+                    loading={savingProfileId === profile.profile_id}
+                    aria-label={`Edit ${profile.name}`}
+                  >
+                    Edit
+                  </Button>,
+                  <Button
+                    key="duplicate"
+                    size="small"
+                    icon={<Copy size={14} />}
+                    onClick={() => openForm("duplicate", profile)}
+                    aria-label={`Duplicate ${profile.name}`}
+                  >
+                    Duplicate
+                  </Button>,
+                  <Button
+                    key="delete"
+                    size="small"
+                    danger
+                    icon={<Trash2 size={14} />}
+                    onClick={() => {
+                      void handleDelete(profile)
+                    }}
+                    loading={savingProfileId === profile.profile_id}
+                    aria-label={`Delete ${profile.name}`}
+                  >
+                    Delete
+                  </Button>
+                ]}
+              >
+                <Space orientation="vertical" size={4} className="w-full">
+                  <Space wrap size="small">
+                    <Text strong>{profile.name}</Text>
+                    <Tag>{profile.mode}</Tag>
+                    <Tag color={profile.enabled ? "green" : "default"}>
+                      {profile.enabled ? "enabled" : "disabled"}
+                    </Tag>
+                    {profile.autostart && <Tag color="blue">autostart</Tag>}
+                    <Tag>{profile.port_policy}</Tag>
+                  </Space>
+                  <Space wrap size="small">
+                    <Text code>{profile.profile_id}</Text>
+                    <Text type="secondary">{profileEndpoint(profile)}</Text>
+                    {profile.model_id && <Text type="secondary">{profile.model_id}</Text>}
+                    {profile.mmproj_model_id && (
+                      <Text type="secondary">{profile.mmproj_model_id}</Text>
+                    )}
+                  </Space>
+                  {profile.tags.length > 0 && (
+                    <Space wrap size="small">
+                      {profile.tags.map((tag) => (
+                        <Tag key={tag}>{tag}</Tag>
+                      ))}
+                    </Space>
+                  )}
+                </Space>
+              </List.Item>
+            )}
+          />
+        )}
+      </Space>
+
+      <Modal
+        open={Boolean(activeForm)}
+        title={
+          activeForm?.mode === "edit"
+            ? "Edit profile"
+            : activeForm?.mode === "duplicate"
+              ? "Duplicate profile"
+              : "New profile"
+        }
+        okText="Save profile"
+        onOk={() => {
+          void handleSave()
+        }}
+        onCancel={closeForm}
+        confirmLoading={
+          savingProfileId === "__create__" ||
+          Boolean(activeForm?.profile && savingProfileId === activeForm.profile.profile_id)
+        }
+        destroyOnHidden
+      >
+        <Space orientation="vertical" size="middle" className="w-full">
+          {formError && <DesignSystemAlert variant="error" title={formError} />}
+
+          <div>
+            <Text>Name</Text>
+            <Input
+              aria-label="Profile name"
+              value={form.name}
+              onChange={(event) => updateForm("name", event.target.value)}
+              placeholder="Vision runtime"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <Text>Mode</Text>
+              <Select
+                aria-label="Profile mode"
+                value={form.mode}
+                onChange={(value) => updateForm("mode", value)}
+                options={PROFILE_MODES.map((value) => ({ label: value, value }))}
+                style={{ width: "100%", marginTop: 4 }}
+              />
+            </div>
+
+            <div>
+              <Text>Port policy</Text>
+              <Select
+                aria-label="Profile port policy"
+                value={form.portPolicy}
+                onChange={(value) => updateForm("portPolicy", value)}
+                options={PORT_POLICIES.map((value) => ({ label: value, value }))}
+                style={{ width: "100%", marginTop: 4 }}
+              />
+            </div>
+
+            <div>
+              <Text>Host</Text>
+              <Input
+                aria-label="Profile host"
+                value={form.host}
+                onChange={(event) => updateForm("host", event.target.value)}
+              />
+            </div>
+
+            <div>
+              <Text>Port</Text>
+              <InputNumber
+                aria-label="Profile port"
+                value={form.port}
+                min={1}
+                max={65535}
+                onChange={(value) => updateForm("port", value ?? 8080)}
+                style={{ width: "100%", marginTop: 4 }}
+              />
+            </div>
+          </div>
+
+          <div>
+            <Text>Model asset</Text>
+            <Select
+              aria-label="Profile model"
+              value={form.modelId || undefined}
+              onChange={(value) => updateForm("modelId", value || "")}
+              options={assetOptions(assetList, "gguf", form.modelId)}
+              placeholder="Select a GGUF asset"
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              style={{ width: "100%", marginTop: 4 }}
+            />
+          </div>
+
+          <div>
+            <Text>mmproj asset</Text>
+            <Select
+              aria-label="Profile mmproj"
+              value={form.mmprojModelId || undefined}
+              onChange={(value) => updateForm("mmprojModelId", value || "")}
+              options={assetOptions(assetList, "mmproj", form.mmprojModelId)}
+              placeholder="Optional projector asset"
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              style={{ width: "100%", marginTop: 4 }}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div className="flex items-center justify-between">
+              <Text>Enabled</Text>
+              <Switch
+                aria-label="Profile enabled"
+                checked={form.enabled}
+                onChange={(checked) => updateForm("enabled", checked)}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Text>Autostart</Text>
+              <Switch
+                aria-label="Profile autostart"
+                checked={form.autostart}
+                onChange={(checked) => updateForm("autostart", checked)}
+              />
+            </div>
+          </div>
+
+          <div>
+            <Text>Provider alias</Text>
+            <Input
+              aria-label="Profile provider alias"
+              value={form.providerAlias}
+              onChange={(event) => updateForm("providerAlias", event.target.value)}
+              placeholder="optional local provider alias"
+            />
+          </div>
+
+          <div>
+            <Text>Tags</Text>
+            <Input
+              aria-label="Profile tags"
+              value={form.tagsText}
+              onChange={(event) => updateForm("tagsText", event.target.value)}
+              placeholder="local, vision"
+            />
+          </div>
+
+          <div>
+            <Text>Server args JSON</Text>
+            <TextArea
+              aria-label="Profile server args JSON"
+              value={form.serverArgsText}
+              onChange={(event) => updateForm("serverArgsText", event.target.value)}
+              rows={5}
+            />
+          </div>
+        </Space>
+      </Modal>
+    </Card>
+  )
+}
+
+export default LlamacppProfilesPanel

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppProfilesPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppProfilesPanel.tsx
@@ -37,6 +37,8 @@ const PROFILE_MODES: LlamacppProfileMode[] = [
 ]
 
 const PORT_POLICIES: LlamacppPortPolicy[] = ["explicit", "autoselect"]
+const SERVER_ARGS_SERIALIZATION_ERROR =
+  "Saved server args could not be displayed. Re-enter server args before saving."
 
 type FormMode = "create" | "edit" | "duplicate"
 
@@ -69,6 +71,7 @@ interface ProfileFormState {
   providerAlias: string
   tagsText: string
   serverArgsText: string
+  serverArgsSerializationError: string | null
   restartPolicy: Record<string, unknown>
 }
 
@@ -77,11 +80,18 @@ interface ActiveForm {
   profile?: LlamacppProfile
 }
 
-const safeJsonStringify = (value: unknown) => {
+const serializeServerArgsForForm = (value: unknown) => {
   try {
-    return JSON.stringify(value || {}, null, 2)
-  } catch {
-    return "{}"
+    return {
+      text: JSON.stringify(value ?? {}, null, 2),
+      error: null
+    }
+  } catch (error) {
+    console.warn("[LlamacppProfilesPanel] Failed to serialize saved server_args", error)
+    return {
+      text: "{}",
+      error: SERVER_ARGS_SERIALIZATION_ERROR
+    }
   }
 }
 
@@ -92,25 +102,30 @@ const formFromProfile = (
   profile: LlamacppProfile | undefined,
   assets: LlamacppAsset[],
   mode: FormMode
-): ProfileFormState => ({
-  name:
-    mode === "duplicate" && profile
-      ? `${profile.name} copy`
-      : profile?.name || "",
-  enabled: profile?.enabled ?? true,
-  mode: profile?.mode || "chat",
-  modelId: profile?.model_id || firstAssetId(assets, "gguf"),
-  modelPath: profile?.model_path || "",
-  mmprojModelId: profile?.mmproj_model_id || "",
-  host: profile?.host || "127.0.0.1",
-  port: profile?.port || 8080,
-  portPolicy: profile?.port_policy || "explicit",
-  autostart: profile?.autostart ?? false,
-  providerAlias: profile?.provider_alias || "",
-  tagsText: (profile?.tags || []).join(", "),
-  serverArgsText: safeJsonStringify(profile?.server_args),
-  restartPolicy: profile?.restart_policy || {}
-})
+): ProfileFormState => {
+  const serializedServerArgs = serializeServerArgsForForm(profile?.server_args)
+
+  return {
+    name:
+      mode === "duplicate" && profile
+        ? `${profile.name} copy`
+        : profile?.name || "",
+    enabled: profile?.enabled ?? true,
+    mode: profile?.mode || "chat",
+    modelId: profile?.model_id || firstAssetId(assets, "gguf"),
+    modelPath: profile?.model_path || "",
+    mmprojModelId: profile?.mmproj_model_id || "",
+    host: profile?.host || "127.0.0.1",
+    port: profile?.port || 8080,
+    portPolicy: profile?.port_policy || "explicit",
+    autostart: profile?.autostart ?? false,
+    providerAlias: profile?.provider_alias || "",
+    tagsText: (profile?.tags || []).join(", "),
+    serverArgsText: serializedServerArgs.text,
+    serverArgsSerializationError: serializedServerArgs.error,
+    restartPolicy: profile?.restart_policy || {}
+  }
+}
 
 const parseTags = (value: string) =>
   value
@@ -175,10 +190,31 @@ export const LlamacppProfilesPanel: React.FC<LlamacppProfilesPanelProps> = ({
     setForm((current) => ({ ...current, [key]: value }))
   }
 
+  const updateServerArgsText = (value: string) => {
+    setFormError(null)
+    setForm((current) => ({
+      ...current,
+      serverArgsText: value,
+      serverArgsSerializationError: null
+    }))
+  }
+
   const buildPayload = () => {
     const name = form.name.trim()
     if (!name) {
       setFormError("Profile name is required.")
+      return null
+    }
+
+    const modelId = form.modelId.trim()
+    const modelPath = form.modelPath.trim()
+    if (!modelId && !modelPath) {
+      setFormError("Model asset or model path is required.")
+      return null
+    }
+
+    if (form.serverArgsSerializationError) {
+      setFormError(form.serverArgsSerializationError)
       return null
     }
 
@@ -194,13 +230,33 @@ export const LlamacppProfilesPanel: React.FC<LlamacppProfilesPanelProps> = ({
       return null
     }
 
+    const mmprojModelId = form.mmprojModelId.trim()
+    const manualMmproj = serverArgs.mmproj
+    if (
+      mmprojModelId &&
+      manualMmproj !== undefined &&
+      manualMmproj !== null &&
+      manualMmproj !== ""
+    ) {
+      const selectedMmproj = assetList.find(
+        (asset) => asset.kind === "mmproj" && asset.asset_id === mmprojModelId
+      )
+      const selectedPaths = [selectedMmproj?.resolved_path, selectedMmproj?.path].filter(
+        Boolean
+      )
+      if (selectedPaths.length > 0 && !selectedPaths.includes(String(manualMmproj))) {
+        setFormError("mmproj asset conflicts with server args mmproj path.")
+        return null
+      }
+    }
+
     return {
       name,
       enabled: form.enabled,
       mode: form.mode,
-      model_id: form.modelId.trim() || null,
-      model_path: form.modelPath.trim() || null,
-      mmproj_model_id: form.mmprojModelId.trim() || null,
+      model_id: modelId || null,
+      model_path: modelPath || null,
+      mmproj_model_id: mmprojModelId || null,
       host: form.host.trim() || "127.0.0.1",
       port: form.port,
       port_policy: form.portPolicy,
@@ -359,6 +415,9 @@ export const LlamacppProfilesPanel: React.FC<LlamacppProfilesPanelProps> = ({
       >
         <Space orientation="vertical" size="middle" className="w-full">
           {formError && <DesignSystemAlert variant="error" title={formError} />}
+          {form.serverArgsSerializationError && (
+            <DesignSystemAlert variant="error" title={form.serverArgsSerializationError} />
+          )}
 
           <div>
             <Text>Name</Text>
@@ -490,7 +549,7 @@ export const LlamacppProfilesPanel: React.FC<LlamacppProfilesPanelProps> = ({
             <TextArea
               aria-label="Profile server args JSON"
               value={form.serverArgsText}
-              onChange={(event) => updateForm("serverArgsText", event.target.value)}
+              onChange={(event) => updateServerArgsText(event.target.value)}
               rows={5}
             />
           </div>

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
@@ -17,6 +17,9 @@ const apiMock = vi.hoisted(() => ({
   pauseLlamacppProfile: vi.fn(),
   resumeLlamacppProfile: vi.fn(),
   useLlamacppProfileInChat: vi.fn(),
+  createLlamacppProfile: vi.fn(),
+  updateLlamacppProfile: vi.fn(),
+  deleteLlamacppProfile: vi.fn(),
   startLlamacppModel: vi.fn(),
   startLlamacppServer: vi.fn(),
   stopLlamacppServer: vi.fn(),
@@ -183,6 +186,63 @@ vi.mock("../LlamacppRuntimePanel", async () => {
   return {
     LlamacppRuntimePanel,
     default: LlamacppRuntimePanel
+  }
+})
+
+vi.mock("../LlamacppProfilesPanel", async () => {
+  const React = await import("react")
+
+  interface ProfilesPanelProps {
+    onCreate: (payload: any) => void
+    onUpdate: (profileId: string, payload: any) => void
+    onDelete: (profileId: string) => void
+  }
+
+  const LlamacppProfilesPanel = ({
+    onCreate,
+    onUpdate,
+    onDelete
+  }: ProfilesPanelProps) =>
+    React.createElement(
+      "section",
+      { "aria-label": "Profiles" },
+      React.createElement(
+        "button",
+        {
+          onClick: () =>
+            onCreate({
+              name: "Created profile",
+              model_id: "gguf:toy-model-id",
+              host: "127.0.0.1",
+              port: 8190,
+              port_policy: "explicit",
+              server_args: {}
+            })
+        },
+        "Create saved profile"
+      ),
+      React.createElement(
+        "button",
+        {
+          onClick: () =>
+            onUpdate("analysis", {
+              name: "Edited profile",
+              port: 8191,
+              server_args: { ctx_size: 8192 }
+            })
+        },
+        "Update saved profile"
+      ),
+      React.createElement(
+        "button",
+        { onClick: () => onDelete("analysis") },
+        "Delete saved profile"
+      )
+    )
+
+  return {
+    LlamacppProfilesPanel,
+    default: LlamacppProfilesPanel
   }
 })
 
@@ -448,6 +508,12 @@ describe("LlamacppAdminPage", () => {
       effective: true,
       warnings: []
     })
+    apiMock.createLlamacppProfile.mockResolvedValue(mockProfiles.profiles[0])
+    apiMock.updateLlamacppProfile.mockResolvedValue(mockProfiles.profiles[1])
+    apiMock.deleteLlamacppProfile.mockResolvedValue({
+      profile_id: "analysis",
+      deleted: true
+    })
     apiMock.startLlamacppModel.mockResolvedValue({
       status: "started",
       model_id: "gguf:toy-model-id"
@@ -556,6 +622,63 @@ describe("LlamacppAdminPage", () => {
       expect(apiMock.startLlamacppProfile).toHaveBeenCalledWith("analysis")
       expect(apiMock.useLlamacppProfileInChat).toHaveBeenCalledWith("default")
     })
+  })
+
+  it("routes saved profile mutations without lifecycle side effects", async () => {
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByLabelText("Profiles")).toBeTruthy()
+
+    apiMock.listLlamacppProfiles.mockClear()
+    apiMock.listLlamacppInstances.mockClear()
+    apiMock.startLlamacppProfile.mockClear()
+    apiMock.useLlamacppProfileInChat.mockClear()
+    apiMock.startLlamacppModel.mockClear()
+
+    fireEvent.click(screen.getByRole("button", { name: "Create saved profile" }))
+
+    await waitFor(() => {
+      expect(apiMock.createLlamacppProfile).toHaveBeenCalledWith({
+        name: "Created profile",
+        model_id: "gguf:toy-model-id",
+        host: "127.0.0.1",
+        port: 8190,
+        port_policy: "explicit",
+        server_args: {}
+      })
+      expect(apiMock.listLlamacppProfiles).toHaveBeenCalledTimes(1)
+      expect(apiMock.listLlamacppInstances).toHaveBeenCalledTimes(1)
+    })
+
+    apiMock.listLlamacppProfiles.mockClear()
+    apiMock.listLlamacppInstances.mockClear()
+
+    fireEvent.click(screen.getByRole("button", { name: "Update saved profile" }))
+
+    await waitFor(() => {
+      expect(apiMock.updateLlamacppProfile).toHaveBeenCalledWith("analysis", {
+        name: "Edited profile",
+        port: 8191,
+        server_args: { ctx_size: 8192 }
+      })
+      expect(apiMock.listLlamacppProfiles).toHaveBeenCalledTimes(1)
+      expect(apiMock.listLlamacppInstances).toHaveBeenCalledTimes(1)
+    })
+
+    apiMock.listLlamacppProfiles.mockClear()
+    apiMock.listLlamacppInstances.mockClear()
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete saved profile" }))
+
+    await waitFor(() => {
+      expect(apiMock.deleteLlamacppProfile).toHaveBeenCalledWith("analysis")
+      expect(apiMock.listLlamacppProfiles).toHaveBeenCalledTimes(1)
+      expect(apiMock.listLlamacppInstances).toHaveBeenCalledTimes(1)
+    })
+
+    expect(apiMock.startLlamacppProfile).not.toHaveBeenCalled()
+    expect(apiMock.useLlamacppProfileInChat).not.toHaveBeenCalled()
+    expect(apiMock.startLlamacppModel).not.toHaveBeenCalled()
   })
 
   it("keeps single-server controls when runtime instance APIs are unavailable", async () => {

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx
@@ -203,4 +203,74 @@ describe("LlamacppProfilesPanel", () => {
     expect(await screen.findByText("Invalid server args JSON.")).toBeTruthy()
     expect(onCreate).not.toHaveBeenCalled()
   })
+
+  it("blocks saving when no model asset or model path is available", async () => {
+    const { onCreate } = renderPanel({
+      assets: { assets: [], warnings: [], scan_limited: false }
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "New profile" }))
+    fireEvent.change(screen.getByLabelText("Profile name"), {
+      target: { value: "No model" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }))
+
+    expect(await screen.findByText("Model asset or model path is required.")).toBeTruthy()
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it("blocks conflicting mmproj asset and server args projector settings", async () => {
+    const { onUpdate } = renderPanel({
+      profiles: [
+        {
+          ...profiles[0],
+          profile_id: "vision",
+          name: "Vision runtime",
+          mmproj_model_id: "mmproj:toy"
+        }
+      ]
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Vision runtime" }))
+    fireEvent.change(screen.getByLabelText("Profile server args JSON"), {
+      target: { value: '{ "mmproj": "/models/other-projector.gguf" }' }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }))
+
+    expect(
+      await screen.findByText("mmproj asset conflicts with server args mmproj path.")
+    ).toBeTruthy()
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it("surfaces unserializable saved server args instead of silently replacing them", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const circularArgs: Record<string, unknown> = {}
+    circularArgs.self = circularArgs
+    const { onUpdate } = renderPanel({
+      profiles: [
+        {
+          ...profiles[0],
+          profile_id: "circular",
+          name: "Circular args",
+          server_args: circularArgs
+        }
+      ]
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Circular args" }))
+
+    expect(
+      await screen.findByText("Saved server args could not be displayed. Re-enter server args before saving.")
+    ).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }))
+
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[LlamacppProfilesPanel] Failed to serialize saved server_args",
+      expect.any(TypeError)
+    )
+    warnSpy.mockRestore()
+  })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx
@@ -1,0 +1,206 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { LlamacppProfilesPanel } from "../LlamacppProfilesPanel"
+import type {
+  LlamacppAsset,
+  LlamacppProfile
+} from "@/types/llamacpp-admin"
+
+const ggufAsset: LlamacppAsset = {
+  asset_id: "gguf:toy",
+  kind: "gguf",
+  identity_basis: "resolved_path",
+  path: "/models/toy.gguf",
+  resolved_path: "/models/toy.gguf",
+  display_name: "Toy 7B",
+  source: "models_dir",
+  size_bytes: 4_200_000_000,
+  modified_at: null,
+  metadata: {},
+  capabilities: ["unknown"],
+  mmproj_asset_ids: ["mmproj:toy"],
+  base_model_asset_ids: [],
+  warnings: []
+}
+
+const mmprojAsset: LlamacppAsset = {
+  ...ggufAsset,
+  asset_id: "mmproj:toy",
+  kind: "mmproj",
+  path: "/models/mmproj-toy.gguf",
+  resolved_path: "/models/mmproj-toy.gguf",
+  display_name: "Toy projector",
+  size_bytes: 50_000_000,
+  capabilities: ["vision_projector"],
+  mmproj_asset_ids: [],
+  base_model_asset_ids: ["gguf:toy"]
+}
+
+const profiles: LlamacppProfile[] = [
+  {
+    profile_id: "default",
+    name: "Default runtime",
+    enabled: true,
+    mode: "chat",
+    model_id: "gguf:toy",
+    model_path: "/models/toy.gguf",
+    host: "127.0.0.1",
+    port: 8181,
+    port_policy: "explicit",
+    server_args: {},
+    autostart: false,
+    restart_policy: {},
+    provider_alias: null,
+    tags: ["default"]
+  },
+  {
+    profile_id: "analysis",
+    name: "Analysis runtime",
+    enabled: true,
+    mode: "chat",
+    model_id: "gguf:analysis",
+    model_path: "/models/analysis.gguf",
+    host: "127.0.0.1",
+    port: 8182,
+    port_policy: "explicit",
+    server_args: { ctx_size: 8192 },
+    autostart: true,
+    restart_policy: {},
+    provider_alias: "analysis-local",
+    tags: ["analysis"]
+  }
+]
+
+const renderPanel = (overrides = {}) => {
+  const onCreate = vi.fn().mockResolvedValue(true)
+  const onUpdate = vi.fn().mockResolvedValue(true)
+  const onDelete = vi.fn().mockResolvedValue(true)
+
+  render(
+    <LlamacppProfilesPanel
+      profiles={profiles}
+      assets={{ assets: [ggufAsset, mmprojAsset], warnings: [], scan_limited: false }}
+      loading={false}
+      savingProfileId={null}
+      error={null}
+      onRefresh={vi.fn()}
+      onCreate={onCreate}
+      onUpdate={onUpdate}
+      onDelete={onDelete}
+      {...overrides}
+    />
+  )
+
+  return { onCreate, onUpdate, onDelete }
+}
+
+describe("LlamacppProfilesPanel", () => {
+  it("creates a saved launch profile from local assets", async () => {
+    const { onCreate } = renderPanel()
+
+    fireEvent.click(screen.getByRole("button", { name: "New profile" }))
+    fireEvent.change(screen.getByLabelText("Profile name"), {
+      target: { value: "Vision runtime" }
+    })
+    fireEvent.change(screen.getByLabelText("Profile port"), {
+      target: { value: "8190" }
+    })
+    fireEvent.change(screen.getByLabelText("Profile tags"), {
+      target: { value: "vision, local" }
+    })
+    fireEvent.change(screen.getByLabelText("Profile server args JSON"), {
+      target: { value: '{ "ctx_size": 4096 }' }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }))
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Vision runtime",
+          mode: "chat",
+          model_id: "gguf:toy",
+          host: "127.0.0.1",
+          port: 8190,
+          port_policy: "explicit",
+          enabled: true,
+          autostart: false,
+          server_args: { ctx_size: 4096 },
+          tags: ["vision", "local"]
+        })
+      )
+    })
+  })
+
+  it("updates an existing profile without changing runtime state", async () => {
+    const { onUpdate } = renderPanel()
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Analysis runtime" }))
+    fireEvent.change(screen.getByLabelText("Profile name"), {
+      target: { value: "Analysis edited" }
+    })
+    fireEvent.change(screen.getByLabelText("Profile server args JSON"), {
+      target: { value: '{ "ctx_size": 16384 }' }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }))
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(
+        "analysis",
+        expect.objectContaining({
+          name: "Analysis edited",
+          server_args: { ctx_size: 16384 }
+        })
+      )
+    })
+  })
+
+  it("duplicates an existing profile as a create request", async () => {
+    const { onCreate, onUpdate } = renderPanel()
+
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate Default runtime" }))
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }))
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Default runtime copy",
+          model_id: "gguf:toy",
+          port: 8181,
+          tags: ["default"]
+        })
+      )
+    })
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it("confirms before deleting a profile", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true)
+    const { onDelete } = renderPanel()
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Analysis runtime" }))
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("analysis")
+    })
+    expect(confirmSpy).toHaveBeenCalled()
+
+    confirmSpy.mockRestore()
+  })
+
+  it("keeps the form open when server args JSON is invalid", async () => {
+    const { onCreate } = renderPanel()
+
+    fireEvent.click(screen.getByRole("button", { name: "New profile" }))
+    fireEvent.change(screen.getByLabelText("Profile name"), {
+      target: { value: "Broken args" }
+    })
+    fireEvent.change(screen.getByLabelText("Profile server args JSON"), {
+      target: { value: "{" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save profile" }))
+
+    expect(await screen.findByText("Invalid server args JSON.")).toBeTruthy()
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+})

--- a/backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md
+++ b/backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md
@@ -1,0 +1,56 @@
+---
+id: TASK-397.8
+title: Implement llama.cpp Admin saved profile editor
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 22:14'
+labels:
+  - llamacpp
+  - webui
+  - admin
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+parent_task_id: TASK-397
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a focused Admin WebUI profile editor slice for saved llama.cpp launch profiles. The slice should let admins create, edit, duplicate, and delete durable profiles using the existing backend profile APIs, while preserving explicit start/use-in-chat behavior and deferring remote downloads/catalog workflows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Profiles panel lets admins create, edit, duplicate, and delete saved llama.cpp profiles using existing backend API payloads.
+- [x] #2 Admin page wires profile create, update, and delete actions to tldwClient and refreshes profile/runtime state after successful mutations.
+- [x] #3 Profile saves do not auto-start llama.cpp instances or auto-wire Chat; those remain explicit runtime actions.
+- [x] #4 Focused Admin llama.cpp Vitest coverage covers the profile editor and still passes.
+- [x] #5 Verification recorded; Bandit is not applicable because this slice touched only TypeScript/Markdown/Backlog files.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started from fresh origin/dev worktree codex/llamacpp-admin-profile-editor. Current inspection shows backend profile CRUD client methods already exist in apps/packages/ui/src/services/tldw/domains/models-audio.ts, so this slice can focus on a WebUI profile editor panel plus Admin page wiring and focused Vitest coverage.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a UI-only saved profile editor on /admin/llamacpp. Added LlamacppProfilesPanel for create/edit/duplicate/delete flows, model/mmproj selection, tags, port policy, autostart, provider alias, and server_args JSON validation. Reordered the Admin console to Assets -> Profiles -> Runtime, wired profile mutations to existing tldwClient profile APIs, and refreshes profiles/runtimes without auto-starting or auto-wiring Chat. Focused Vitest suite passes: LlamacppProfilesPanel, LlamacppRuntimePanel, LlamacppAssetsPanel, and LlamacppAdminPage: 30 tests. Full UI TypeScript check still fails on existing repo-wide baseline errors outside the touched llama.cpp profile editor files. git diff --check passed before closeout; rerun planned after this task update. Bandit is not applicable because no Python code was touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md
+++ b/backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md
@@ -4,12 +4,14 @@ title: Implement llama.cpp Admin saved profile editor
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 22:14'
+updated_date: '2026-05-16 22:17'
 labels:
   - llamacpp
   - webui
   - admin
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1804'
 documentation:
   - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
 parent_task_id: TASK-397
@@ -42,7 +44,7 @@ Started from fresh origin/dev worktree codex/llamacpp-admin-profile-editor. Curr
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented a UI-only saved profile editor on /admin/llamacpp. Added LlamacppProfilesPanel for create/edit/duplicate/delete flows, model/mmproj selection, tags, port policy, autostart, provider alias, and server_args JSON validation. Reordered the Admin console to Assets -> Profiles -> Runtime, wired profile mutations to existing tldwClient profile APIs, and refreshes profiles/runtimes without auto-starting or auto-wiring Chat. Focused Vitest suite passes: LlamacppProfilesPanel, LlamacppRuntimePanel, LlamacppAssetsPanel, and LlamacppAdminPage: 30 tests. Full UI TypeScript check still fails on existing repo-wide baseline errors outside the touched llama.cpp profile editor files. git diff --check passed before closeout; rerun planned after this task update. Bandit is not applicable because no Python code was touched.
+Implemented a UI-only saved profile editor on /admin/llamacpp. Added LlamacppProfilesPanel for create/edit/duplicate/delete flows, model/mmproj selection, tags, port policy, autostart, provider alias, and server_args JSON validation. Reordered the Admin console to Assets -> Profiles -> Runtime, wired profile mutations to existing tldwClient profile APIs, and refreshes profiles/runtimes without auto-starting or auto-wiring Chat. Focused Vitest suite passes: LlamacppProfilesPanel, LlamacppRuntimePanel, LlamacppAssetsPanel, and LlamacppAdminPage: 30 tests. Full UI TypeScript check still fails on existing repo-wide baseline errors outside the touched llama.cpp profile editor files. Diff whitespace checks passed during closeout. Bandit is not applicable because no Python code was touched. Draft PR: https://github.com/rmusser01/tldw_server/pull/1804
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md
+++ b/backlog/tasks/task-397.8 - Implement-llama.cpp-Admin-saved-profile-editor.md
@@ -4,7 +4,7 @@ title: Implement llama.cpp Admin saved profile editor
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 22:17'
+updated_date: '2026-05-16 22:29'
 labels:
   - llamacpp
   - webui
@@ -12,6 +12,9 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/1804'
+  - 'https://github.com/rmusser01/tldw_server/pull/1804#discussion_r3253657615'
+  - 'https://github.com/rmusser01/tldw_server/pull/1804#discussion_r3253657616'
+  - 'https://github.com/rmusser01/tldw_server/pull/1804#discussion_r3253657617'
 documentation:
   - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
 parent_task_id: TASK-397
@@ -44,7 +47,7 @@ Started from fresh origin/dev worktree codex/llamacpp-admin-profile-editor. Curr
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented a UI-only saved profile editor on /admin/llamacpp. Added LlamacppProfilesPanel for create/edit/duplicate/delete flows, model/mmproj selection, tags, port policy, autostart, provider alias, and server_args JSON validation. Reordered the Admin console to Assets -> Profiles -> Runtime, wired profile mutations to existing tldwClient profile APIs, and refreshes profiles/runtimes without auto-starting or auto-wiring Chat. Focused Vitest suite passes: LlamacppProfilesPanel, LlamacppRuntimePanel, LlamacppAssetsPanel, and LlamacppAdminPage: 30 tests. Full UI TypeScript check still fails on existing repo-wide baseline errors outside the touched llama.cpp profile editor files. Diff whitespace checks passed during closeout. Bandit is not applicable because no Python code was touched. Draft PR: https://github.com/rmusser01/tldw_server/pull/1804
+Addressed PR #1804 Qodo inline review feedback. Verified all three findings against current code: safeJsonStringify silently hid serialization failures, model-less profile saves were possible when no GGUF asset/model path was present, and mmproj_model_id could conflict with server_args.mmproj. Added focused regressions and patched LlamacppProfilesPanel to surface unserializable saved server args, block model-less saves, and block known mmproj path conflicts before save. Focused Admin llama.cpp Vitest suite now passes: LlamacppProfilesPanel, LlamacppRuntimePanel, LlamacppAssetsPanel, and LlamacppAdminPage: 33 tests. Full UI TypeScript check still fails on existing repo-wide baseline errors outside touched llama.cpp profile editor files. Diff whitespace checks passed. Bandit is not applicable because no Python code was touched.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Adds a llama.cpp Admin Profiles panel for creating, editing, duplicating, and deleting saved launch profiles with existing profile APIs.
- Wires profile mutations into `/admin/llamacpp` and refreshes profile/runtime state without auto-starting or auto-wiring Chat.
- Adds focused Vitest coverage for profile editor payloads and Admin page routing.

## Verification
- `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx` -> 30 passed
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false` -> existing repo-wide baseline failures outside touched llama.cpp profile editor files
- `git diff --check`
- `git diff --check origin/dev...HEAD`
- Bandit not applicable; no Python touched

## Change summary
Human-written summary required before merge:
- [ ] Explain what changed.
- [ ] Explain why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a llama.cpp Admin Profiles editor to create, edit, duplicate, and delete saved launch profiles in `/admin/llamacpp`. Saves refresh profiles and runtimes without auto-starting or wiring Chat.

- **New Features**
  - Added `LlamacppProfilesPanel` with model/mmproj selection, port policy, tags, provider alias, and `server_args` JSON; supports create/edit/duplicate/delete.
  - Wired profile mutations to existing profile APIs on the Admin page, reordered UI to Assets → Profiles → Runtime, and refresh profile/runtime state after successful changes with no lifecycle side effects.

- **Bug Fixes**
  - Hardened validation in the profile editor: block invalid or unserializable `server_args`, require a name and a model asset or path, and prevent conflicts between selected `mmproj` and `server_args.mmproj` (with focused Vitest regressions).

<sup>Written for commit e4d8a54307bc5a16e9ca07ea8f21cdcfde551f62. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1804?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

