### PR TITLE
Polish chat composer control grouping

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
@@ -594,6 +594,46 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
   const formattingGuideToggleClass = appendFormattingGuidePrompt
     ? "bg-primary/10 text-primaryStrong"
     : "text-text-muted"
+  const casualModeContextGroupLabel = t(
+    "playground:composer.groups.modeAndContext",
+    "Mode and context controls"
+  ) as string
+  const runInputGroupLabel = t(
+    "playground:composer.groups.runInput",
+    "Run input controls"
+  ) as string
+  const mobileModeModelGroupLabel = t(
+    "playground:composer.groups.mobileModeAndModel",
+    "Mobile mode and model controls"
+  ) as string
+  const mobileContextGroupLabel = t(
+    "playground:composer.groups.mobileContext",
+    "Mobile context controls"
+  ) as string
+  const mobileRunInputGroupLabel = t(
+    "playground:composer.groups.mobileRunInput",
+    "Mobile run input controls"
+  ) as string
+  const proContextPanelLabel = t(
+    "playground:composer.groups.contextSetupControls",
+    "Context setup controls"
+  ) as string
+  const proContextPanelHeading = t(
+    "playground:composer.groups.contextSetup",
+    "Context setup"
+  ) as string
+  const proGenerationPanelLabel = t(
+    "playground:composer.groups.modelToolsRunControls",
+    "Model, tools, and run controls"
+  ) as string
+  const proGenerationPanelHeading = t(
+    "playground:composer.groups.modelToolsRun",
+    "Model, tools, and run"
+  ) as string
+  const advancedControlsGroupLabel = t(
+    "playground:composer.groups.advancedComposerControls",
+    "Advanced composer controls"
+  ) as string
   const formattingGuideControl = (
     <button
       type="button"
@@ -623,6 +663,7 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
       }
       aria-expanded={casualAdvancedControlsOpen}
       aria-pressed={casualAdvancedControlsOpen}
+      aria-controls="composer-casual-advanced-controls-row"
       data-testid="composer-casual-advanced-chip"
       className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:bg-surface2 ${advancedChipClass}`}>
       <span>{t("playground:composer.advancedControls", "Advanced controls")}</span>
@@ -707,6 +748,7 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
           type="button"
           onClick={() => setAdvancedControlsOpen(!advancedControlsOpen)}
           aria-expanded={advancedControlsOpen}
+          aria-controls="composer-pro-advanced-controls-row"
           data-testid="composer-advanced-toggle"
           className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-xs font-medium text-text-muted transition hover:bg-surface2 hover:text-text">
           <span>
@@ -721,6 +763,9 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
         </button>
         {advancedControlsOpen && (
           <div
+            id="composer-pro-advanced-controls-row"
+            role="group"
+            aria-label={advancedControlsGroupLabel}
             data-playground-toolbar-row="advanced"
             className="mt-2 flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-2">
@@ -745,6 +790,8 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
   const mobileToolbarLayout = (
     <div className="flex flex-col gap-2">
       <div
+        role="group"
+        aria-label={mobileModeModelGroupLabel}
         data-playground-toolbar-row="primary"
         className="flex flex-wrap items-center gap-2">
         {modeLauncherButton}
@@ -757,12 +804,18 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
       <div
         data-playground-toolbar-row="actions"
         className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
+        <div
+          role="group"
+          aria-label={mobileContextGroupLabel}
+          className="flex items-center gap-2">
           {ephemeralToggle}
           {searchContextButton}
           {webSearchButton}
         </div>
-        <div className="flex items-center gap-2">
+        <div
+          role="group"
+          aria-label={mobileRunInputGroupLabel}
+          className="flex items-center gap-2">
           {modelUsageBadge}
           <ComposerToolbarOverflow
             isProMode={isProMode}
@@ -800,14 +853,20 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
       <div
         data-playground-toolbar-row="actions"
         className="flex flex-nowrap items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <div className="flex flex-nowrap items-center gap-2 text-text-muted">
+        <div
+          role="group"
+          aria-label={casualModeContextGroupLabel}
+          className="flex flex-nowrap items-center gap-2 text-text-muted">
           {modeLauncherButton}
           {mcpControl}
           {searchContextButton}
           {promptSelectControl}
           {characterSelectControl}
         </div>
-        <div className="ml-auto flex flex-nowrap items-center gap-2">
+        <div
+          role="group"
+          aria-label={runInputGroupLabel}
+          className="ml-auto flex flex-nowrap items-center gap-2">
           {compareControl}
           {dictationButton}
           {researchLaunchButton}
@@ -823,9 +882,12 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
   const casualAdvancedControlsPanel =
     casualAdvancedControlsOpen && !isMobile && !isProMode ? (
       <div
+        role="group"
+        aria-label={advancedControlsGroupLabel}
         data-playground-toolbar-row="advanced"
         className="rounded-md border border-border/60 bg-surface2/60 p-2">
         <div
+          id="composer-casual-advanced-controls-row"
           data-testid="composer-casual-advanced-controls-row"
           className="flex flex-nowrap items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <ConnectionStatus showLabel={false} className="px-1 py-0.5" />
@@ -844,8 +906,13 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
       className="flex flex-col gap-2">
       <div className="grid gap-2 lg:grid-cols-2">
         <section
+          role="group"
+          aria-label={proContextPanelLabel}
           data-testid="composer-pro-context-panel"
           className="rounded-md border border-border/60 bg-surface2/60 p-2">
+          <div className="mb-2 text-[11px] font-semibold text-text-muted">
+            {proContextPanelHeading}
+          </div>
           <div
             data-playground-toolbar-row="primary"
             className="flex flex-wrap items-center gap-2">
@@ -865,8 +932,13 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
           </div>
         </section>
         <section
+          role="group"
+          aria-label={proGenerationPanelLabel}
           data-testid="composer-pro-generation-panel"
           className="rounded-md border border-border/60 bg-surface2/60 p-2">
+          <div className="mb-2 text-[11px] font-semibold text-text-muted">
+            {proGenerationPanelHeading}
+          </div>
           <div className="flex flex-wrap items-center gap-2">
             <ConnectionStatus showLabel={false} className="px-1 py-0.5" />
             {mcpControl}

--- a/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
@@ -614,17 +614,9 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
     "playground:composer.groups.mobileRunInput",
     "Mobile run input controls"
   ) as string
-  const proContextPanelLabel = t(
-    "playground:composer.groups.contextSetupControls",
-    "Context setup controls"
-  ) as string
   const proContextPanelHeading = t(
     "playground:composer.groups.contextSetup",
     "Context setup"
-  ) as string
-  const proGenerationPanelLabel = t(
-    "playground:composer.groups.modelToolsRunControls",
-    "Model, tools, and run controls"
   ) as string
   const proGenerationPanelHeading = t(
     "playground:composer.groups.modelToolsRun",
@@ -634,6 +626,10 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
     "playground:composer.groups.advancedComposerControls",
     "Advanced composer controls"
   ) as string
+  const casualAdvancedControlsId = "composer-casual-advanced-controls-row"
+  const proAdvancedControlsId = "composer-pro-advanced-controls-row"
+  const proContextHeadingId = "composer-pro-context-heading"
+  const proGenerationHeadingId = "composer-pro-generation-heading"
   const formattingGuideControl = (
     <button
       type="button"
@@ -663,7 +659,7 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
       }
       aria-expanded={casualAdvancedControlsOpen}
       aria-pressed={casualAdvancedControlsOpen}
-      aria-controls="composer-casual-advanced-controls-row"
+      aria-controls={casualAdvancedControlsOpen ? casualAdvancedControlsId : undefined}
       data-testid="composer-casual-advanced-chip"
       className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:bg-surface2 ${advancedChipClass}`}>
       <span>{t("playground:composer.advancedControls", "Advanced controls")}</span>
@@ -748,7 +744,7 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
           type="button"
           onClick={() => setAdvancedControlsOpen(!advancedControlsOpen)}
           aria-expanded={advancedControlsOpen}
-          aria-controls="composer-pro-advanced-controls-row"
+          aria-controls={advancedControlsOpen ? proAdvancedControlsId : undefined}
           data-testid="composer-advanced-toggle"
           className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-xs font-medium text-text-muted transition hover:bg-surface2 hover:text-text">
           <span>
@@ -763,7 +759,7 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
         </button>
         {advancedControlsOpen && (
           <div
-            id="composer-pro-advanced-controls-row"
+            id={proAdvancedControlsId}
             role="group"
             aria-label={advancedControlsGroupLabel}
             data-playground-toolbar-row="advanced"
@@ -882,12 +878,12 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
   const casualAdvancedControlsPanel =
     casualAdvancedControlsOpen && !isMobile && !isProMode ? (
       <div
+        id={casualAdvancedControlsId}
         role="group"
         aria-label={advancedControlsGroupLabel}
         data-playground-toolbar-row="advanced"
         className="rounded-md border border-border/60 bg-surface2/60 p-2">
         <div
-          id="composer-casual-advanced-controls-row"
           data-testid="composer-casual-advanced-controls-row"
           className="flex flex-nowrap items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <ConnectionStatus showLabel={false} className="px-1 py-0.5" />
@@ -907,12 +903,14 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
       <div className="grid gap-2 lg:grid-cols-2">
         <section
           role="group"
-          aria-label={proContextPanelLabel}
+          aria-labelledby={proContextHeadingId}
           data-testid="composer-pro-context-panel"
           className="rounded-md border border-border/60 bg-surface2/60 p-2">
-          <div className="mb-2 text-[11px] font-semibold text-text-muted">
+          <h3
+            id={proContextHeadingId}
+            className="mb-2 text-[11px] font-semibold text-text-muted">
             {proContextPanelHeading}
-          </div>
+          </h3>
           <div
             data-playground-toolbar-row="primary"
             className="flex flex-wrap items-center gap-2">
@@ -933,12 +931,14 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
         </section>
         <section
           role="group"
-          aria-label={proGenerationPanelLabel}
+          aria-labelledby={proGenerationHeadingId}
           data-testid="composer-pro-generation-panel"
           className="rounded-md border border-border/60 bg-surface2/60 p-2">
-          <div className="mb-2 text-[11px] font-semibold text-text-muted">
+          <h3
+            id={proGenerationHeadingId}
+            className="mb-2 text-[11px] font-semibold text-text-muted">
             {proGenerationPanelHeading}
-          </div>
+          </h3>
           <div className="flex flex-wrap items-center gap-2">
             <ConnectionStatus showLabel={false} className="px-1 py-0.5" />
             {mcpControl}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
@@ -186,6 +186,40 @@ describe("ComposerToolbar web search", () => {
     expect(screen.getByTestId("character-select")).toBeInTheDocument()
   })
 
+  it("labels casual composer control groups for scanning and keyboard focus", () => {
+    render(
+      <ComposerToolbar
+        {...createProps({
+          modeLauncherButton: <button type="button">Modes</button>,
+          voiceChatButton: <button type="button">Start voice chat</button>
+        })}
+      />
+    )
+
+    const contextGroup = screen.getByRole("group", {
+      name: "Mode and context controls"
+    })
+    const runGroup = screen.getByRole("group", {
+      name: "Run input controls"
+    })
+
+    expect(contextGroup).toContainElement(
+      screen.getByRole("button", { name: "Modes" })
+    )
+    expect(contextGroup).toContainElement(
+      screen.getByRole("button", { name: "MCP" })
+    )
+    expect(runGroup).toContainElement(
+      screen.getByRole("button", { name: "Start voice chat" })
+    )
+    expect(runGroup).toContainElement(
+      screen.getByRole("button", { name: "Chat Settings" })
+    )
+    expect(runGroup).toContainElement(
+      screen.getByRole("button", { name: "Send" })
+    )
+  })
+
   it("places token usage in the casual bottom context chip row", () => {
     render(
       <ComposerToolbar
@@ -412,6 +446,81 @@ describe("ComposerToolbar web search", () => {
     expect(
       screen.getByTestId("composer-formatting-guide-toggle")
     ).toBeInTheDocument()
+  })
+
+  it("labels pro cockpit panels by task area without hiding existing controls", () => {
+    render(
+      <ComposerToolbar
+        {...createProps({
+          isProMode: true,
+          modeLauncherButton: <button type="button">Modes</button>,
+          compareControl: <button type="button">Compare</button>,
+          researchLaunchButton: <button type="button">Deep Research</button>
+        })}
+      />
+    )
+
+    const contextPanel = screen.getByRole("group", {
+      name: "Context setup controls"
+    })
+    const generationPanel = screen.getByRole("group", {
+      name: "Model, tools, and run controls"
+    })
+
+    expect(screen.getByText("Context setup")).toBeInTheDocument()
+    expect(screen.getByText("Model, tools, and run")).toBeInTheDocument()
+    expect(contextPanel).toContainElement(
+      screen.getByRole("button", { name: "Modes" })
+    )
+    expect(contextPanel).toContainElement(
+      screen.getByRole("button", { name: "Compare" })
+    )
+    expect(generationPanel).toContainElement(
+      screen.getByRole("button", { name: "MCP" })
+    )
+    expect(generationPanel).toContainElement(
+      screen.getByRole("button", { name: "Deep Research" })
+    )
+    expect(generationPanel).toContainElement(
+      screen.getByRole("button", { name: "Send" })
+    )
+  })
+
+  it("labels mobile composer groups without moving controls into a bottom bar", () => {
+    render(
+      <ComposerToolbar
+        {...createProps({
+          isMobile: true,
+          modeLauncherButton: <button type="button">Modes</button>
+        })}
+      />
+    )
+
+    const primaryGroup = screen.getByRole("group", {
+      name: "Mobile mode and model controls"
+    })
+    const contextGroup = screen.getByRole("group", {
+      name: "Mobile context controls"
+    })
+    const runGroup = screen.getByRole("group", {
+      name: "Mobile run input controls"
+    })
+
+    expect(primaryGroup).toContainElement(
+      screen.getByRole("button", { name: "Modes" })
+    )
+    expect(primaryGroup).toContainElement(screen.getByText("Model selector"))
+    expect(contextGroup).toContainElement(
+      screen.getByRole("button", { name: "Saved" })
+    )
+    expect(contextGroup).toContainElement(
+      screen.getByRole("button", { name: "Search & Context" })
+    )
+    expect(runGroup).toContainElement(screen.getByTestId("toolbar-overflow"))
+    expect(runGroup).toContainElement(
+      screen.getByRole("button", { name: "Attach" })
+    )
+    expect(screen.queryByTestId("composer-bottom-bar")).toBeNull()
   })
 
   it("invokes toggle callback when web search button is clicked", () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
@@ -220,6 +220,23 @@ describe("ComposerToolbar web search", () => {
     )
   })
 
+  it("only exposes casual advanced aria-controls when the controlled group is mounted", () => {
+    render(<ComposerToolbar {...createProps()} />)
+
+    const toggle = screen.getByTestId("composer-casual-advanced-chip")
+    expect(toggle).not.toHaveAttribute("aria-controls")
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute(
+      "aria-controls",
+      "composer-casual-advanced-controls-row"
+    )
+    expect(
+      screen.getByRole("group", { name: "Advanced composer controls" })
+    ).toHaveAttribute("id", "composer-casual-advanced-controls-row")
+  })
+
   it("places token usage in the casual bottom context chip row", () => {
     render(
       <ComposerToolbar
@@ -448,6 +465,23 @@ describe("ComposerToolbar web search", () => {
     ).toBeInTheDocument()
   })
 
+  it("only exposes pro advanced aria-controls when the controlled group is mounted", () => {
+    render(<ComposerToolbar {...createProps({ isProMode: true })} />)
+
+    const toggle = screen.getByTestId("composer-advanced-toggle")
+    expect(toggle).not.toHaveAttribute("aria-controls")
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute(
+      "aria-controls",
+      "composer-pro-advanced-controls-row"
+    )
+    expect(
+      screen.getByRole("group", { name: "Advanced composer controls" })
+    ).toHaveAttribute("id", "composer-pro-advanced-controls-row")
+  })
+
   it("labels pro cockpit panels by task area without hiding existing controls", () => {
     render(
       <ComposerToolbar
@@ -461,14 +495,18 @@ describe("ComposerToolbar web search", () => {
     )
 
     const contextPanel = screen.getByRole("group", {
-      name: "Context setup controls"
+      name: "Context setup"
     })
     const generationPanel = screen.getByRole("group", {
-      name: "Model, tools, and run controls"
+      name: "Model, tools, and run"
     })
 
-    expect(screen.getByText("Context setup")).toBeInTheDocument()
-    expect(screen.getByText("Model, tools, and run")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Context setup" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Model, tools, and run" })
+    ).toBeInTheDocument()
     expect(contextPanel).toContainElement(
       screen.getByRole("button", { name: "Modes" })
     )

--- a/backlog/tasks/task-415 - Polish-main-chat-cockpit-composer-control-grouping.md
+++ b/backlog/tasks/task-415 - Polish-main-chat-cockpit-composer-control-grouping.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-415
 title: Polish main chat cockpit composer control grouping
-status: In Progress
+status: Ready for Review
 dependencies:
 - TASK-406
 - TASK-414
@@ -27,34 +27,34 @@ Implement a narrow main WebUI /chat cockpit UX follow-up for power-user composer
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Main /chat composer power-user controls are visually grouped for scanning without removing existing controls or changing send behavior.
-- [ ] #2 Icon-only composer/cockpit controls expose clear hover/focus names using existing UI patterns or accessible labels.
-- [ ] #3 Keyboard/focus behavior remains intact for grouped controls and existing popovers/dialogs.
-- [ ] #4 Focused Vitest coverage proves grouping labels and no behavior regression for the composer/cockpit surface.
-- [ ] #5 Verification records focused tests, git diff check, and Bandit applicability; real-server/browser proof is added only if it materially helps this UI slice.
+- [x] #1 Main /chat composer power-user controls are visually grouped for scanning without removing existing controls or changing send behavior.
+- [x] #2 Icon-only composer/cockpit controls expose clear hover/focus names using existing UI patterns or accessible labels.
+- [x] #3 Keyboard/focus behavior remains intact for grouped controls and existing popovers/dialogs.
+- [x] #4 Focused Vitest coverage proves grouping labels and no behavior regression for the composer/cockpit surface.
+- [x] #5 Verification records focused tests, git diff check, and Bandit applicability; real-server/browser proof is added only if it materially helps this UI slice.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Implemented narrow main /chat ComposerToolbar grouping labels for casual, pro, and mobile layouts. Added aria-labeled role=group regions, aria-controls wiring for advanced controls, and compact pro cockpit panel headings without moving controls or adding any bottom bar.
-- Verification: `bunx vitest run src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx src/components/Option/Playground/__tests__/ComposerToolbar.layout.guard.test.ts src/components/Option/Playground/__tests__/PlaygroundForm.composer-options.guard.test.ts --config vitest.config.ts` passed: 3 files, 29 tests. `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx --config vitest.config.ts` passed: 2 files, 24 tests; existing mocked-test stderr still reports `tldw server not configured`. `git diff --check` passed.
-- Real-server visual proof: started local WebUI from this worktree at `http://127.0.0.1:3100` and used the real API server at `http://127.0.0.1:8000` with the API key loaded from the project `.env` into the browser context. Screenshot: `/private/tmp/chat-cockpit-composer-grouping-real-auth.png`. Browser evidence showed `/chat` loaded, group labels existed, and `data-testid="composer-bottom-bar"` was absent.
+- Verification: `bunx vitest run src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx src/components/Option/Playground/__tests__/ComposerToolbar.layout.guard.test.ts src/components/Option/Playground/__tests__/PlaygroundForm.composer-options.guard.test.ts --config vitest.config.ts` passed: 3 files, 31 tests. `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx --config vitest.config.ts` passed: 2 files, 24 tests; existing mocked-test stderr still reports `tldw server not configured`. `git diff --check` passed.
+- Real-server visual proof: started local WebUI from this worktree at `http://127.0.0.1:3100` and used the real API server at `http://127.0.0.1:8000` with the API key loaded from the project `.env` into the browser context. The screenshot was shown to the requester in the Codex thread as local visual-approval evidence; no bitmap artifact is committed in this code PR. Browser evidence showed `/chat` loaded, group labels existed, and `data-testid="composer-bottom-bar"` was absent. Recapture the same real-server view before final visual approval if a fresh shared artifact is needed.
 - Known verification caveat: `bun run verify:design-system-state` exits 1 on unrelated existing product-state baseline/stale-entry findings under Watchlists and other non-/chat areas. No touched files are listed in that failure. Bandit is not applicable because this slice only changes TypeScript/React frontend files. Pending external gate: rendered screenshot still needs user visual approval before treating the visible UI work as fully done.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+This slice tightens the main `/chat` cockpit composer grouping without changing chat behavior or moving controls. It adds accessible grouped regions across casual, pro, and mobile layouts, makes the pro cockpit panel labels semantic headings, prevents advanced-control toggles from pointing at unmounted regions, and adds focused regression tests for those states. No migration is required. The code is ready for review, but the PR remains blocked on requester visual approval, the required human-owned PR Change summary, and final GitHub check completion.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-415 - Polish-main-chat-cockpit-composer-control-grouping.md
+++ b/backlog/tasks/task-415 - Polish-main-chat-cockpit-composer-control-grouping.md
@@ -1,0 +1,60 @@
+---
+id: TASK-415
+title: Polish main chat cockpit composer control grouping
+status: In Progress
+dependencies:
+- TASK-406
+- TASK-414
+labels:
+- chat
+- webui
+- cockpit
+- ux
+- frontend
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
+references:
+- https://github.com/rmusser01/tldw_server/pull/1809
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement a narrow main WebUI /chat cockpit UX follow-up for power-user composer controls. Scope is strictly the main /chat Playground composer/cockpit surface: improve scan grouping and hover/focus names for dense advanced composer controls without changing chat behavior, adding bottom UI, touching extension sidepanel/sidebar routes, or broadening into unrelated pages.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Main /chat composer power-user controls are visually grouped for scanning without removing existing controls or changing send behavior.
+- [ ] #2 Icon-only composer/cockpit controls expose clear hover/focus names using existing UI patterns or accessible labels.
+- [ ] #3 Keyboard/focus behavior remains intact for grouped controls and existing popovers/dialogs.
+- [ ] #4 Focused Vitest coverage proves grouping labels and no behavior regression for the composer/cockpit surface.
+- [ ] #5 Verification records focused tests, git diff check, and Bandit applicability; real-server/browser proof is added only if it materially helps this UI slice.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Implemented narrow main /chat ComposerToolbar grouping labels for casual, pro, and mobile layouts. Added aria-labeled role=group regions, aria-controls wiring for advanced controls, and compact pro cockpit panel headings without moving controls or adding any bottom bar.
+- Verification: `bunx vitest run src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx src/components/Option/Playground/__tests__/ComposerToolbar.layout.guard.test.ts src/components/Option/Playground/__tests__/PlaygroundForm.composer-options.guard.test.ts --config vitest.config.ts` passed: 3 files, 29 tests. `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx --config vitest.config.ts` passed: 2 files, 24 tests; existing mocked-test stderr still reports `tldw server not configured`. `git diff --check` passed.
+- Real-server visual proof: started local WebUI from this worktree at `http://127.0.0.1:3100` and used the real API server at `http://127.0.0.1:8000` with the API key loaded from the project `.env` into the browser context. Screenshot: `/private/tmp/chat-cockpit-composer-grouping-real-auth.png`. Browser evidence showed `/chat` loaded, group labels existed, and `data-testid="composer-bottom-bar"` was absent.
+- Known verification caveat: `bun run verify:design-system-state` exits 1 on unrelated existing product-state baseline/stale-entry findings under Watchlists and other non-/chat areas. No touched files are listed in that failure. Bandit is not applicable because this slice only changes TypeScript/React frontend files. Pending external gate: rendered screenshot still needs user visual approval before treating the visible UI work as fully done.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Tightened the main `/chat` ComposerToolbar grouping across casual, pro, and mobile layouts without moving controls or adding a bottom bar.
- Made the pro cockpit panels semantic headings linked through `aria-labelledby`.
- Only expose advanced-toggle `aria-controls` while the controlled advanced group is mounted, and point the casual relationship at the labeled outer group.
- Updated TASK-415 status, acceptance criteria, Definition of Done, final summary, and visual-evidence notes.

## Validation Checklist
- [x] `bunx vitest run src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx src/components/Option/Playground/__tests__/ComposerToolbar.layout.guard.test.ts src/components/Option/Playground/__tests__/PlaygroundForm.composer-options.guard.test.ts --config vitest.config.ts` passed: 3 files, 31 tests.
- [x] `bunx vitest run src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-maturity.test.tsx --config vitest.config.ts` passed: 2 files, 24 tests. Existing mocked-test stderr still reports `tldw server not configured`.
- [x] `git diff --check` passed.
- [x] Bandit not applicable: TypeScript/React frontend-only slice.
- [ ] GitHub Actions are still pending for the latest commit.
- [ ] Requester visual approval is still pending before this visible UI slice should be treated as merge-ready.

## UX Audit Checklist
- [x] Scope is only the main WebUI `/chat` cockpit composer surface.
- [x] Existing controls remain in the composer/cockpit layout; no bottom bar was introduced.
- [x] Casual, pro, and mobile control areas expose accessible grouped regions for scanning and keyboard/focus navigation.
- [x] Pro cockpit section labels are semantic headings and group names.
- [x] Advanced-control toggles avoid dangling `aria-controls` relationships when collapsed.
- [ ] A fresh real-server screenshot can be recaptured before final visual approval if a shared artifact is needed.

## Risk & Rollback
- Risk is limited to main `/chat` ComposerToolbar semantics and visual grouping; send behavior and control ownership are unchanged.
- Rollback is a straight revert of this PR if the grouping treatment is rejected during visual review.

## Visual Evidence / Artifact Plan
- Real-server visual proof was captured during the Codex review against the local WebUI from this worktree and the real API server at `http://127.0.0.1:8000`; no mocked server data or request interception was used.
- The screenshot was shown in the Codex thread as local visual-approval evidence. No temp-path screenshot is relied on in this PR and no bitmap artifact is committed.
- Recapture an up-to-date real-server `/chat` screenshot before moving from draft to ready if final visual approval requires a shareable artifact.

## Change Summary
Human-authored summary required before merge.
