### PR TITLE
Make llama.cpp acquisition plan commands portable

### DIFF
--- a/Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** FastAPI, Pydantic v2, existing llama.cpp Admin schemas/endpoints, `llamacpp_inventory_service`, core Jobs `JobManager`/`WorkerSDK`, pytest/TestClient, React/Ant Design shared UI, Vitest/testing-library, Bandit.
 
+**Command note:** Run Python verification commands after activating the project virtual environment from the repository root, for example `source .venv/bin/activate`.
+
 ---
 
 ## References
@@ -159,7 +161,7 @@ Also cover:
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py \
   -k "import_asset_folder_preview" -v
 ```
@@ -257,7 +259,7 @@ async def preview_llamacpp_asset_folder_endpoint(
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py \
   tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -v
@@ -307,7 +309,7 @@ Cover:
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py -v
 ```
 
@@ -396,7 +398,7 @@ Use `get_job_manager` from `API_Deps.jobs_deps`.
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py \
   tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -v
@@ -444,7 +446,7 @@ Use a local aiohttp/httpx test server or a monkeypatched stream adapter. Cover:
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py -v
 ```
 
@@ -500,7 +502,7 @@ Use the existing worker inventory registration helper so shutdown diagnostics se
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py \
   tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -v
 ```
@@ -646,7 +648,7 @@ Do not require real remote downloads in E2E.
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+python -m pytest \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py \
   tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py \
@@ -685,7 +687,7 @@ If the suite requires a running backend/frontend server, start the established d
 Run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
+python -m bandit \
   -r tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py \
      tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py \
      tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_jobs.py \

--- a/backlog/tasks/task-417 - Fix-llama.cpp-acquisition-plan-portable-verification-commands.md
+++ b/backlog/tasks/task-417 - Fix-llama.cpp-acquisition-plan-portable-verification-commands.md
@@ -1,0 +1,50 @@
+---
+id: TASK-417
+title: Fix llama.cpp acquisition plan portable verification commands
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 03:11'
+labels:
+  - llamacpp
+  - docs
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1810'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address review feedback after PR #1810 merged: remove developer-specific absolute virtualenv paths from the llama.cpp model acquisition/import workflow plan verification snippets so examples are copy/pasteable across machines.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Verification snippets use portable python -m pytest / python -m bandit commands with a clear note to activate the project virtual environment first.
+- [x] #2 Docs-only validation confirms no hardcoded local path remains in the plan and the diff is clean.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified the finding on current origin/dev after PR #1810 merged: the plan contained seven absolute pytest invocations and one absolute Bandit invocation.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced all developer-specific absolute Python invocations in the llama.cpp acquisition/import workflow plan with portable python -m pytest and python -m bandit commands, and added a command note to activate the project virtual environment from the repository root. Validation: rg found no local absolute path or absolute virtualenv invocation references in the plan/task, git diff --check passed, and the docs-only change skipped Bandit as not applicable.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replaces machine-specific Python verification paths in the llama.cpp model acquisition/import workflow plan with portable `python -m pytest` / `python -m bandit` snippets.
- Adds a command note to activate the project virtual environment from the repository root before running verification snippets.
- Adds TASK-417 to track the review-fix work after PR #1810 merged.

## Verification
- `rg -n "/Users/macbook-dev|\.venv/bin/python" Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md backlog/tasks/task-417\ -\ Fix-llama.cpp-acquisition-plan-portable-verification-commands.md` returned no matches.
- `git diff --check`
- `git diff --cached --check`
- `rg -nP "[^\x00-\x7F]" Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md backlog/tasks/task-417\ -\ Fix-llama.cpp-acquisition-plan-portable-verification-commands.md` returned no matches.
- Bandit skipped: docs/task metadata only; no Python code touched.

## Change summary

_Human maintainer: before marking this PR ready, replace this placeholder with your own summary of what changed and why._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced machine-specific Python paths in the llama.cpp acquisition/import plan with portable `python -m pytest` and `python -m bandit` commands, and added a note to activate the virtual environment from the repository root. Addresses TASK-417 by making verification snippets copy/pasteable across machines and validating that no hardcoded local paths remain (docs-only change).

<sup>Written for commit eee62d26da55db04632c0d8ef3622daf570ad203. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1812?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

