### PR TITLE
Add bulk conference ingest workflow support

### DIFF
--- a/Docs/User_Guides/Bulk_Conference_Playlist_Ingest.md
+++ b/Docs/User_Guides/Bulk_Conference_Playlist_Ingest.md
@@ -1,0 +1,126 @@
+# Bulk Conference Playlist Ingest
+
+This guide covers the WebUI and browser-extension workflow for ingesting many related conference talks from one playlist, then reviewing them as one collection.
+
+## When To Use This
+
+Use this workflow when you have a playlist of related videos, such as a conference, course, workshop, or event track, and you want:
+
+- one collection for the whole event
+- shared metadata applied once
+- per-talk corrections when needed
+- durable progress tracking
+- clear recovery for duplicates, failed downloads, and retries
+- a review page ordered like the playlist
+
+## Start From The WebUI
+
+1. Open **Media** and choose **Quick Ingest**.
+2. Paste the playlist URL into the URL input.
+3. If the server advertises playlist preflight support, Quick Ingest shows **Playlist detected**.
+4. Select **Preview**.
+
+Preflight is metadata-only. It should not create media rows, collections, ingest jobs, or downloaded files. It reads the playlist structure, normalizes item URLs, and marks duplicate items before you commit to ingesting anything.
+
+## Start From The Extension
+
+When the active browser tab is a supported playlist URL, the extension can open Quick Ingest with the playlist already seeded. The same shared Quick Ingest preflight panel is used; the extension should not parse the playlist itself.
+
+If the extension opens Quick Ingest but no preview appears, check that:
+
+- the active tab URL contains a playlist id
+- the WebUI is connected to a tldw server
+- the server advertises playlist preflight capability
+
+## Review The Playlist Preflight
+
+The preview shows:
+
+- playlist title
+- total item count
+- selected item count
+- duplicate count
+- ordered talk list
+- item source URLs
+
+Review the selected items before continuing. For large conference playlists, deselect trailers, intro videos, duplicates, or talks you do not want to process.
+
+Duplicate policies:
+
+| Policy | What happens |
+|---|---|
+| Skip duplicates | Duplicate items are not selected for processing. |
+| Include existing | Existing duplicate items are included in the collection but are not reprocessed. |
+| Update metadata only | Existing duplicate items are kept as collection members with metadata updated where supported. |
+| Overwrite | Duplicate items are submitted with overwrite enabled. |
+
+## Add Conference Metadata Once
+
+After adding previewed items, fill the conference batch section:
+
+- Collection name: the review collection name, for example `Conference 2010 Review`
+- Conference name: the event name
+- Event year or date: used for inherited item metadata
+- Shared tags: tags applied to each planned item
+
+Use per-item overrides for talk title, speaker, track, talk date, or extra tags when the playlist metadata is incomplete.
+
+## Durable And Degraded Modes
+
+Durable mode is available when the server supports media collections and ingest jobs. In this mode, Quick Ingest creates a collection and planned collection items before submitting jobs. This gives you stable progress, retry metadata, and a collection review target even when some jobs fail.
+
+Degraded mode is used when the server does not support the durable collection or job path. Quick Ingest can still process items, but recovery is weaker because run state is local to the browser session.
+
+## Monitor Processing
+
+The processing step shows:
+
+- queued, processing, completed, failed, and cancelled item counts
+- durable collection tracking when available
+- collection id, planned item count, job count, and batch count
+- failed item export when failures are present
+- cancel controls for active runs
+
+If you minimize the wizard, the floating progress widget summarizes the collection name and mixed outcomes such as succeeded, skipped, and failed counts. It does not claim the collection is searchable until readiness is confirmed in the results or review surfaces.
+
+## Recover From Problems
+
+Use the results step for recovery:
+
+- **Skipped existing**: duplicates that were included but not reprocessed.
+- **Not submitted**: an item failed before a job was accepted.
+- **Failed during processing**: a job was accepted but the ingest process failed.
+- **Export failed list**: copies or downloads failed source URLs, collection item ids, retry attempt, and error summaries.
+- **Retry All**: retries durable, retryable failures using collection item ids and new idempotency keys.
+
+For private or removed videos, retrying may not help until the source is accessible. Export the failed list before closing if you need to inspect source URLs externally.
+
+## Review The Collection
+
+Open the collection from the results step. The collection review page shows:
+
+- conference collection name
+- total talk count
+- ready talk count
+- in-progress count
+- items needing attention
+- ordered talk navigation
+- status badges per talk
+- summary and transcript excerpt areas when available
+- compare checkboxes for reviewing multiple talks side by side
+
+Ready talks are completed items and skipped-existing items that have a resolved media id. Failed, cancelled, planned, or processing items are visible but not counted as ready for scoped QA.
+
+## Scoped Knowledge QA Readiness
+
+The **Ask this collection** action should only be enabled when at least one talk is ready and the server advertises backend-enforced collection scope. Scoped QA must be enforced by the backend using the collection id or resolved media ids, not by a frontend-only tag filter.
+
+If the button is disabled, wait for more talks to complete or retry failed items. If the button is missing, verify that the server advertises scoped Knowledge QA support.
+
+## Common Mistakes
+
+- Previewing a playlist is not ingestion. You still need to add selected items and start processing.
+- Skipped duplicates may still be useful collection members if they point to existing media.
+- A completed ingest job does not always mean the talk is ready for QA; readiness depends on resolved media ids and available transcripts/chunks.
+- Closing the wizard before exporting failed items is safe in durable mode, but export is useful when debugging unavailable videos.
+- Using tags alone is not enough for conference QA scope; use the collection review or scoped QA handoff.

--- a/Docs/User_Guides/index.md
+++ b/Docs/User_Guides/index.md
@@ -60,6 +60,7 @@ This section is organized by product surface so you can quickly find the right d
 - [TTS Providers Getting Started](WebUI_Extension/TTS_Getting_Started.md)
 - [TTS Setup Guide (Runbook Index)](WebUI_Extension/TTS-SETUP-GUIDE.md)
 - [PocketTTS Voice Cloning Guide](WebUI_Extension/PocketTTS_Voice_Cloning_Guide.md)
+- [Bulk Conference Playlist Ingest](Bulk_Conference_Playlist_Ingest.md)
 - [EPUB Reader Guide](WebUI_Extension/EPUB_Reader_Guide.md)
 - [Image Generation Setup](WebUI_Extension/Image_Generation_Setup.md)
 

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
@@ -1,0 +1,101 @@
+# Bulk Conference Contract Inventory
+
+Date: 2026-05-16
+Backlog: TASK-400
+Parent plan: `Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md`
+
+## Purpose
+
+This inventory resolves the source-of-truth question before implementing playlist preflight, durable conference collections, retry behavior, and collection-scoped review. The target workflow is a first-time user ingesting 34 related conference videos as one durable collection, not 34 independent URLs.
+
+## Candidate Stores
+
+| Candidate | Supports stable collection ID | Supports ordered membership | Supports planned items | Supports media resolution | Collision risk | Decision |
+|---|---:|---:|---:|---:|---|---|
+| Media DB item metadata/keywords | No | No | No | Yes | Medium: tags/metadata can conflate unrelated media and cannot represent unprocessed rows | Reject as collection source of truth; keep as canonical ingested media store |
+| Existing `CollectionsDatabase.content_items` only | No | No | Weak | Yes | High: `upsert_content_item()` selects existing rows by `canonical_url`, `content_hash`, or `url`, so planned playlist rows can collide with resolved content or each other | Reject as sole collection model; keep as resolved searchable item index |
+| Existing `collection_tags`/`content_item_tags` | Weak | No | No | Indirect | High: tag names are global labels, not collection instances, and cannot carry run/order/status metadata | Reject for conference grouping; keep for user-visible labels |
+| JobManager `batch_id` and media ingest job payloads | Weak | No | Only after submit | Yes after terminal result | Medium: batch IDs model a processing run, not a durable conference collection or later review object | Use only as run/execution state linked from collection items |
+| WebUI `media:collections:v1` localStorage | Browser-local only | Yes | No | Yes for existing IDs | High: not server-owned, not extension/WebUI durable, not recoverable across clients | Reject as durable source; keep as legacy/manual review convenience with optional migration |
+| Extend `content_items` with collection fields | Possible | Possible | Weak | Yes | High: mixes pending source rows with resolved content and inherits URL/hash upsert ambiguity | Reject for planned rows; only add bridges/filters if needed for resolved review |
+| New narrow media collection tables inside `CollectionsDatabase` | Yes | Yes | Yes | Yes via `media_id`/`content_item_id` after completion | Low: collection item identity and idempotency are separate from URL/hash content dedupe | Select |
+| Vector-store/RAG collection names | No | No | No | Partial | High: retrieval grouping is not an ingestion workflow contract | Reject; derive RAG scope from durable media collection membership |
+
+## Selected Contract
+
+Add a narrow durable media collection layer in `tldw_Server_API/app/core/DB_Management/Collections_DB.py`, adjacent to but separate from `content_items`.
+
+Minimum tables:
+
+- `media_collections`
+  - Owner-scoped stable collection entity.
+  - Stores user-facing name, collection kind, description, source playlist URL, conference-level metadata, default tags, created/updated timestamps, and soft-delete state if consistent with nearby tables.
+- `media_collection_items`
+  - Planned and resolved membership rows.
+  - Stores `collection_id`, `ordinal`, `source_url`, `normalized_source_id`, `source_kind`, title/speaker/date/track/tag overrides, duplicate status, current ingestion status, `media_id`, `content_item_id`, latest `job_id`, latest `collection_run_id`, idempotency key, retry count, terminal error/warnings, and timestamps.
+  - Represents the user's intended 34-item conference list before any download/transcription starts.
+- `media_collection_runs`
+  - One ingestion attempt across selected collection items.
+  - Stores `collection_id`, `batch_id`, run status, requested/queued/processing/completed/failed/skipped/cancelled counts, safe ingest options, started/completed timestamps, and terminal summary.
+
+The collection item row is the stable unit for retry, cancellation, duplicate marking, per-talk metadata edits, and later review navigation. `content_items` remains the resolved searchable/reviewable item after successful ingestion, linked by `content_item_id` and `media_id`.
+
+## Evidence From Current Code
+
+- `CollectionsDatabase.content_items` already includes `media_id`, `job_id`, and `run_id` fields and supports list filters for `job_id`, `run_id`, tags, origin, status, and FTS search.
+- `CollectionsDatabase.upsert_content_item()` looks up existing rows by `canonical_url`, `content_hash`, and `url`, then updates the matched row. That is useful for deduped resolved content, but unsafe for planned playlist rows where the product needs stable membership and retry state even before media exists.
+- `/api/v1/items` first queries `CollectionsDatabase.list_content_items()` and falls back to Media DB only when the collections layer has no rows. It is a unified content item list, not a collection/run orchestration endpoint.
+- `/api/v1/media/ingest/jobs` already creates one job per URL/file, returns a `batch_id`, lists by `batch_id`, streams SSE by `batch_id`, and supports batch cancellation. It does not store collection identity, planned item IDs, or inherited conference metadata in a first-class contract.
+- `media_ingest_jobs_worker.py` processes one job payload source and returns `media_id`/`media_uuid`/warnings/errors. It does not currently update collection item state after terminal job status.
+- `sync_media_add_results_to_collections()` dual-writes successful synchronous `/media/add` results into `content_items` with a canonical `media://{media_id}` URL and source metadata. This is the right bridge from ingested media into the review/search layer.
+- `apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts` stores manual media collections in `media:collections:v1` localStorage. Those collections have browser-local IDs, names, and `itemIds`, but no server identity, run state, planned source rows, inherited metadata, or extension/WebUI durability.
+- `apps/packages/ui/src/services/tldw/domains/collections.ts` exposes `/api/v1/items` list and bulk update wrappers. It has no durable collection CRUD or item membership API.
+- `apps/packages/ui/src/services/tldw/domains/media.ts` exposes `/api/v1/media/add` and `/api/v1/media/ingest/jobs` wrappers. It has no playlist preflight or durable collection/run API.
+
+## Rejected Alternatives
+
+Do not use only tags to group a conference. A tag such as `pycon-2010` is useful for search and filtering, but it cannot represent playlist order, planned-but-not-yet-ingested talks, retries, duplicate state, or collection-level metadata.
+
+Do not create planned playlist rows directly in `content_items`. The current upsert contract is designed for deduped content, not intended membership. A repeated URL, a content hash collision, or a later successful ingest could overwrite the planned row and lose the distinction between "this source is part of the conference plan" and "this media item exists."
+
+Do not treat `batch_id` as the collection ID. A batch is an execution run. The same conference collection needs multiple runs for retry, partial selection, cancellation/resume, and later review after the original batch is gone from the user's immediate task.
+
+Do not depend on `media:collections:v1` for durability. It should remain a legacy/manual client-side convenience until a migration affordance exists, but it cannot support extension-to-WebUI continuity or server-side review/RAG scope.
+
+Do not expose collection-scoped Knowledge QA from frontend-only filtering. The backend must resolve the selected collection to authorized `media_id` values and constrain retrieval there before the UI offers scoped QA.
+
+## API Placement
+
+Use the media API namespace for playlist and conference workflow primitives:
+
+- `POST /api/v1/media/playlists/preflight`
+  - Metadata-only playlist inspection.
+  - Returns normalized source IDs, proposed item rows, duplicate-in-batch flags, warnings, and safe playlist metadata.
+  - Does not download media or persist browser cookies, auth headers, videos, audio, or secrets.
+- `/api/v1/media/collections`
+  - Collection create/list/get/update.
+  - Item create/update/reorder/select/status operations.
+  - Run creation, run status, retry failed/skipped items, cancel active run, and export failed sources.
+- Existing `/api/v1/media/ingest/jobs`
+  - Stays the low-level execution mechanism.
+  - Accepts optional `collection_id`, `collection_item_id`, `collection_run_id`, and idempotency metadata when jobs come from a durable collection run.
+  - Continues to support plain one-off URL/file ingestion without collection metadata.
+- Existing `/api/v1/items`
+  - Remains the resolved content-item list/bulk-update API.
+  - May later gain collection filters only as a review/query convenience, not as the owner of run orchestration.
+- Knowledge/RAG endpoints
+  - Accept collection scope only after backend authorization and media-ID resolution are implemented.
+
+Capability discovery should expose playlist preflight, durable media collections, ingest jobs endpoint, ingest worker availability, job SSE, and collection-scoped Knowledge QA as separate booleans. Endpoint existence and worker availability must remain separate states.
+
+## Migration/Bridge Notes
+
+- Successful synchronous `/media/add` and async ingest jobs should continue to write or update resolved `content_items`; media collection items should link to those resolved rows after completion.
+- Planned collection items should not require a `content_items` row. They become reviewable content only after successful ingestion or an explicit duplicate-existing resolution.
+- Duplicate detection should be layered:
+  - preflight duplicate-in-batch by normalized source ID,
+  - duplicate-existing by source URL/media/content item lookup,
+  - optional content hash dedupe after media processing.
+- Retry should reuse the same `media_collection_items.id` and create a new `media_collection_runs` row or update latest run/job references. The user's row identity and edited metadata must survive failed attempts.
+- Existing localStorage collections can be offered an explicit migration path into backend media collections, but migration is not required before bulk conference ingest. Local collections without source URLs should migrate as manual resolved-media collections, not playlist ingestion plans.
+- The extension and WebUI should submit the same collection/run payloads through shared services so a playlist detected in the sidepanel can be continued and reviewed in the WebUI.

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
@@ -100,3 +100,12 @@ Capability discovery should expose playlist preflight, durable media collections
 - Existing localStorage collections can be offered an explicit migration path into backend media collections, but migration is not required before bulk conference ingest. Local collections without source URLs should migrate as manual resolved-media collections, not playlist ingestion plans.
 - Task 2 decision: `media:collections:v1` in `apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts` remains a local-only manual review collection store. Durable playlist/conference ingestion now uses `/api/v1/media/collections`; migration or side-by-side labeling of local review collections is deferred to a later UX slice.
 - The extension and WebUI should submit the same collection/run payloads through shared services so a playlist detected in the sidepanel can be continued and reviewed in the WebUI.
+
+## Task 6 RAG Scope Inventory
+
+- `UnifiedRAGRequest` already supported `include_media_ids`, and the standard retrieval path already passed those IDs into `execute_retrieval_phase()` as `allowed_media_ids`.
+- `MediaDBRetriever` and `MultiDatabaseRetriever` already enforce `allowed_media_ids`, so collection-scoped QA should map a backend-owned `collection_id` to ready media IDs server-side instead of filtering results in the client.
+- Ready conference items are `completed` or `skipped_existing` rows with a positive `media_id`. Other statuses are excluded from scoped QA.
+- If a collection has no ready media IDs, the backend must fail closed by sending a sentinel media-ID scope that returns no matches rather than silently broadening the search.
+- The agentic RAG fallback path must receive the same resolved media-ID scope as standard retrieval.
+- The WebUI may pass `collection_id` in Knowledge QA options only after `hasKnowledgeQaMediaScope` is true; request construction should not depend on client-side media-ID lists for durable conference collections.

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
@@ -98,4 +98,5 @@ Capability discovery should expose playlist preflight, durable media collections
   - optional content hash dedupe after media processing.
 - Retry should reuse the same `media_collection_items.id` and create a new `media_collection_runs` row or update latest run/job references. The user's row identity and edited metadata must survive failed attempts.
 - Existing localStorage collections can be offered an explicit migration path into backend media collections, but migration is not required before bulk conference ingest. Local collections without source URLs should migrate as manual resolved-media collections, not playlist ingestion plans.
+- Task 2 decision: `media:collections:v1` in `apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts` remains a local-only manual review collection store. Durable playlist/conference ingestion now uses `/api/v1/media/collections`; migration or side-by-side labeling of local review collections is deferred to a later UX slice.
 - The extension and WebUI should submit the same collection/run payloads through shared services so a playlist detected in the sidepanel can be continued and reviewed in the WebUI.

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -443,7 +443,7 @@ git commit -m "feat: add playlist preflight for quick ingest"
 - Test: `tldw_Server_API/tests/Collections/test_conference_media_collections.py`
 - Test: `apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts`
 
-- [ ] **Step 1: Write failing collection contract tests**
+- [x] **Step 1: Write failing collection contract tests**
 
 Start from the selected contract in Task 0. Minimum backend tests:
 
@@ -471,7 +471,7 @@ def test_conference_collection_persists_planned_and_resolved_items(collections_d
 
 Add tests that planned/source items do not overwrite unrelated `content_items` with matching URL/hash unless the selected contract intentionally reuses those rows with a safe namespace.
 
-- [ ] **Step 2: Run failing collection tests**
+- [x] **Step 2: Run failing collection tests**
 
 ```bash
 source .venv/bin/activate && python -m pytest \
@@ -481,7 +481,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: FAIL due missing collection APIs/storage helpers.
 
-- [ ] **Step 3: Implement the selected durable storage contract**
+- [x] **Step 3: Implement the selected durable storage contract**
 
 If reusing `CollectionsDatabase`, prefer narrow methods rather than exposing raw SQL:
 
@@ -557,7 +557,7 @@ CONFERENCE_ITEM_STATUSES = {
 }
 ```
 
-- [ ] **Step 4: Implement API and frontend client**
+- [x] **Step 4: Implement API and frontend client**
 
 Expose stable collection operations. If using `/api/v1/media/collections`, add:
 
@@ -572,7 +572,7 @@ PATCH /api/v1/media/collections/{collection_id}/items/{item_id}
 
 Add typed client wrappers and normalize collection item status/counts in `conference-collections.ts`.
 
-- [ ] **Step 5: Preserve localStorage collection boundary**
+- [x] **Step 5: Preserve localStorage collection boundary**
 
 Read `useMediaSelection.ts` and make one explicit choice:
 
@@ -582,7 +582,7 @@ Read `useMediaSelection.ts` and make one explicit choice:
 
 Record the choice in the inventory artifact.
 
-- [ ] **Step 6: Run focused verification**
+- [x] **Step 6: Run focused verification**
 
 ```bash
 source .venv/bin/activate && python -m pytest \
@@ -596,7 +596,7 @@ bunx vitest run \
 git diff --check
 ```
 
-- [ ] **Step 7: Run Bandit**
+- [x] **Step 7: Run Bandit**
 
 ```bash
 source .venv/bin/activate && python -m bandit \
@@ -607,7 +607,7 @@ source .venv/bin/activate && python -m bandit \
 
 Expected: no new high/medium findings in touched code.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -981,7 +981,7 @@ Completion notes:
 - Test: `tldw_Server_API/tests/RAG/test_conference_collection_scope.py`
 - Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/conference-scope.test.tsx`
 
-- [ ] **Step 1: Inventory current Knowledge QA/RAG scope contract**
+- [x] **Step 1: Inventory current Knowledge QA/RAG scope contract**
 
 Search:
 
@@ -995,7 +995,7 @@ rg -n "media_ids|source_ids|filters|selection|rag/search|KnowledgeQA" \
 
 Record the actual contract in Task 0's inventory or a new short note before modifying RAG.
 
-- [ ] **Step 2: Write failing backend scoped retrieval test**
+- [x] **Step 2: Write failing backend scoped retrieval test**
 
 ```python
 def test_conference_collection_scope_limits_rag_to_ready_media(client, seeded_collection):
@@ -1011,15 +1011,15 @@ def test_conference_collection_scope_limits_rag_to_ready_media(client, seeded_co
     assert {hit["media_id"] for hit in response.json()["results"]} <= seeded_collection.ready_media_ids
 ```
 
-- [ ] **Step 3: Implement or reuse backend-enforced scope**
+- [x] **Step 3: Implement or reuse backend-enforced scope**
 
 If existing RAG selection filters support media IDs, map collection ID to ready media IDs server-side. If not, add a minimal request field and retrieval filter. Do not rely on client-only filtering.
 
-- [ ] **Step 4: Write failing review UI test**
+- [x] **Step 4: Write failing review UI test**
 
 Assert talk list, transcript readiness counts, next/previous navigation, compare selected, and disabled QA when no items are ready.
 
-- [ ] **Step 5: Implement collection review UI**
+- [x] **Step 5: Implement collection review UI**
 
 Minimum V1:
 
@@ -1030,7 +1030,7 @@ Minimum V1:
 - selected-talk comparison using metadata plus available summaries/excerpts
 - scoped QA CTA with readiness copy
 
-- [ ] **Step 6: Run verification**
+- [x] **Step 6: Run verification**
 
 ```bash
 source .venv/bin/activate && python -m pytest \
@@ -1044,7 +1044,7 @@ bunx vitest run \
 git diff --check
 ```
 
-- [ ] **Step 7: Bandit**
+- [x] **Step 7: Bandit**
 
 ```bash
 source .venv/bin/activate && python -m bandit \
@@ -1055,7 +1055,7 @@ source .venv/bin/activate && python -m bandit \
 
 Review only findings in touched RAG/API files.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -1169,7 +1169,7 @@ git commit -m "feat: add extension playlist quick ingest handoff"
 - Test: `apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts`
 - Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx`
 
-- [ ] **Step 1: Write failing duplicate policy tests**
+- [x] **Step 1: Write failing duplicate policy tests**
 
 Policies:
 
@@ -1180,7 +1180,7 @@ Policies:
 
 Assert each policy produces expected planned item status and job submission behavior.
 
-- [ ] **Step 2: Write failing failure taxonomy tests**
+- [x] **Step 2: Write failing failure taxonomy tests**
 
 Classify conservative failure types:
 
@@ -1190,15 +1190,15 @@ expect(classifyConferenceIngestFailure("HTTP Error 404")).toBe("unavailable")
 expect(classifyConferenceIngestFailure("timed out")).toBe("timeout")
 ```
 
-- [ ] **Step 3: Implement duplicate policy UI and payloads**
+- [x] **Step 3: Implement duplicate policy UI and payloads**
 
 Expose policy choice in preflight/results only when duplicates exist. Default should avoid surprise overwrite.
 
-- [ ] **Step 4: Implement selected-subset retry**
+- [x] **Step 4: Implement selected-subset retry**
 
 Retry selected applies only to retryable `submit_failed`, `failed`, or `cancelled` items. It must use collection item ID plus retry attempt/idempotency key and must skip completed items.
 
-- [ ] **Step 5: Run verification**
+- [x] **Step 5: Run verification**
 
 ```bash
 source .venv/bin/activate && python -m pytest \
@@ -1213,7 +1213,7 @@ bunx vitest run \
 git diff --check
 ```
 
-- [ ] **Step 6: Bandit**
+- [x] **Step 6: Bandit**
 
 ```bash
 source .venv/bin/activate && python -m bandit \
@@ -1222,6 +1222,16 @@ source .venv/bin/activate && python -m bandit \
      tldw_Server_API/app/services/media_ingest_jobs_worker.py \
   -f json -o /tmp/bandit_bulk_conference_recovery.json
 ```
+
+Task 8 verification note: focused backend tests passed for
+`test_playlist_preflight.py` and `test_media_ingest_jobs_worker.py`; focused
+Vitest passed for conference collection helpers, playlist preflight panel,
+wizard results retry/navigation, and direct quick-ingest batch orchestration.
+`git diff --check` passed. Bandit on the touched backend playlist preflight
+module produced zero findings in `/tmp/bandit_task408.json`. Full frontend
+`tsc --noEmit` still fails only on the existing baseline files outside this
+slice: `EmbeddingsModelSelectionConfig.tsx`, `persona-visuals.ts`, and
+`lib/api/vnPlay.ts`.
 
 - [ ] **Step 7: Commit**
 

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -1233,7 +1233,7 @@ module produced zero findings in `/tmp/bandit_task408.json`. Full frontend
 slice: `EmbeddingsModelSelectionConfig.tsx`, `persona-visuals.ts`, and
 `lib/api/vnPlay.ts`.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add \
@@ -1251,6 +1251,8 @@ git add \
 git commit -m "feat: recover duplicate and failed playlist items"
 ```
 
+Committed as `60f40c127 feat: recover duplicate and failed playlist items`.
+
 ## Task 9: Notifications, Full-Path QA, And Documentation
 
 **Files:**
@@ -1261,11 +1263,11 @@ git commit -m "feat: recover duplicate and failed playlist items"
 - Modify if needed: `Docs/API-related/Media_Ingest_Jobs_API.md`
 - Test fixtures as needed under existing frontend/backend test fixture directories.
 
-- [ ] **Step 1: Add mocked 34-item playlist fixture**
+- [x] **Step 1: Add mocked 34-item playlist fixture**
 
 Create a deterministic fixture with 34 metadata-only items, duplicates, and failure permutations. Do not depend on real YouTube or downloads in automated tests.
 
-- [ ] **Step 2: Write full-path WebUI test**
+- [x] **Step 2: Write full-path WebUI test**
 
 Test:
 
@@ -1278,15 +1280,15 @@ Test:
 7. open collection
 8. see readiness counts
 
-- [ ] **Step 3: Write extension handoff test**
+- [x] **Step 3: Write extension handoff test**
 
 Assert active-tab playlist context opens the same preflight state as WebUI paste.
 
-- [ ] **Step 4: Add completion notification**
+- [x] **Step 4: Add completion notification**
 
 Use existing WebUI/extension notification/message patterns. Notification should include collection name and mixed success counts; it should not claim all searchable until readiness counts confirm it.
 
-- [ ] **Step 5: Write user documentation**
+- [x] **Step 5: Write user documentation**
 
 Document:
 
@@ -1297,7 +1299,7 @@ Document:
 - collection review
 - scoped Knowledge QA readiness
 
-- [ ] **Step 6: Run full verification**
+- [x] **Step 6: Run full verification**
 
 ```bash
 source .venv/bin/activate && python -m pytest \
@@ -1320,7 +1322,16 @@ npx playwright test apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
 git diff --check
 ```
 
-- [ ] **Step 7: Final Bandit touched backend sweep**
+Task 9 verification note:
+
+- Backend focused pytest passed: `46 passed, 9 warnings`.
+- Frontend focused Vitest passed: `7 files passed`, `68 tests passed`.
+- Focused Playwright conference workflow passed: `2 passed` for the mocked 34-talk WebUI flow and extension handoff using the webpack dev server.
+- Full `media-ingest.spec.ts` Playwright file was run with the webpack dev server and ended with `15 passed`, `12 skipped`, `3 failed`; the failures were existing broader-file drift outside the new conference workflow: missing legacy media search textbox, missing legacy empty-state "open quick ingest" trigger, and an unstable legacy review-route link click.
+- `./node_modules/.bin/tsc --noEmit` still fails only on known baseline files outside this slice: `EmbeddingsModelSelectionConfig.tsx`, `persona-visuals.ts`, and `lib/api/vnPlay.ts`.
+- `git diff --check` passed.
+
+- [x] **Step 7: Final Bandit touched backend sweep**
 
 ```bash
 source .venv/bin/activate && python -m bandit \
@@ -1331,7 +1342,9 @@ source .venv/bin/activate && python -m bandit \
   -f json -o /tmp/bandit_bulk_conference_final.json
 ```
 
-- [ ] **Step 8: Commit**
+Bandit reported zero findings in `/tmp/bandit_bulk_conference_final.json`.
+
+- [x] **Step 8: Commit**
 
 ```bash
 git add \
@@ -1345,16 +1358,16 @@ git commit -m "test: verify bulk conference ingest workflow"
 
 ## Cross-Stage Review Checklist
 
-- [ ] Preflight remains read-only: no jobs, no media rows, no collection mutation.
-- [ ] Server capabilities distinguish endpoint presence, worker availability, SSE, durable collection support, playlist preflight, and scoped QA.
-- [ ] Collection identity is stable and not tag-only.
-- [ ] Planned, processing, completed, skipped_existing, `submit_failed`, failed, and cancelled item states are represented.
-- [ ] Submit failures keep source URL, metadata, error, and export/retry path.
-- [ ] Retry is idempotent by collection item and retry attempt.
-- [ ] Synchronous fallback preserves metadata and clearly communicates weaker recovery.
-- [ ] Extension capture hands off to shared preflight and does not duplicate playlist parsing.
-- [ ] Scoped QA is backend-enforced and shows ready/not-ready counts.
-- [ ] One-off Quick Ingest remains unchanged.
+- [x] Preflight remains read-only: no jobs, no media rows, no collection mutation.
+- [x] Server capabilities distinguish endpoint presence, worker availability, SSE, durable collection support, playlist preflight, and scoped QA.
+- [x] Collection identity is stable and not tag-only.
+- [x] Planned, processing, completed, skipped_existing, `submit_failed`, failed, and cancelled item states are represented.
+- [x] Submit failures keep source URL, metadata, error, and export/retry path.
+- [x] Retry is idempotent by collection item and retry attempt.
+- [x] Synchronous fallback preserves metadata and clearly communicates weaker recovery.
+- [x] Extension capture hands off to shared preflight and does not duplicate playlist parsing.
+- [x] Scoped QA is backend-enforced and shows ready/not-ready counts.
+- [x] One-off Quick Ingest remains unchanged.
 
 ## Execution Notes
 

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -1079,7 +1079,7 @@ git commit -m "feat: review conference collections with scoped qa"
 - Test: `apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts`
 - Test as available: `apps/tldw-frontend/extension/__tests__/*`
 
-- [ ] **Step 1: Write failing context-handoff tests**
+- [x] **Step 1: Write failing context-handoff tests**
 
 Add a test that `requestQuickIngestOpen` accepts:
 
@@ -1094,7 +1094,7 @@ requestQuickIngestOpen({
 
 And that Sidepanel passes this detail to the modal/open request.
 
-- [ ] **Step 2: Run failing tests**
+- [x] **Step 2: Run failing tests**
 
 ```bash
 bunx vitest run \
@@ -1102,7 +1102,7 @@ bunx vitest run \
   apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts
 ```
 
-- [ ] **Step 3: Add typed Quick Ingest open detail**
+- [x] **Step 3: Add typed Quick Ingest open detail**
 
 In `quick-ingest-open.ts`:
 
@@ -1117,15 +1117,15 @@ export type QuickIngestOpenDetail =
     }
 ```
 
-- [ ] **Step 4: Detect active-tab playlist context**
+- [x] **Step 4: Detect active-tab playlist context**
 
 Use active-tab URL or existing sidepanel context, not content-script parsing. Show "Import playlist to tldw" only when the URL has a YouTube playlist/list context and extension readiness allows it.
 
-- [ ] **Step 5: Seed shared preflight**
+- [x] **Step 5: Seed shared preflight**
 
 Quick Ingest should consume the open detail and start the same preflight path as paste-from-WebUI.
 
-- [ ] **Step 6: Run verification**
+- [x] **Step 6: Run verification**
 
 ```bash
 bunx vitest run \
@@ -1135,7 +1135,14 @@ bunx vitest run \
 git diff --check
 ```
 
-- [ ] **Step 7: Commit**
+- Verification run:
+  - `./node_modules/.bin/vitest run -c vitest.config.ts ../../apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts ../../apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx ../../apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx`
+  - `./node_modules/.bin/vitest run -c vitest.config.ts ../../apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts`
+  - `./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false` still fails only on unrelated baseline files: `EmbeddingsModelSelectionConfig.tsx`, `persona-visuals.ts`, and `lib/api/vnPlay.ts`.
+  - `git diff --check`
+- Implementation note: `background.ts` did not need changes for this slice because the active-tab URL is resolved in `ControlRow.tsx` at the point of user action, and the existing background quick-ingest runtime already carries playlist metadata from prior tasks.
+
+- [x] **Step 7: Commit**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -884,9 +884,10 @@ Completion notes:
 - Modify: `apps/packages/ui/src/components/Common/QuickIngest/types.ts`
 - Modify: `apps/packages/ui/src/services/tldw/conference-collections.ts`
 - Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx`
 - Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx`
 
-- [ ] **Step 1: Write failing grouped-results test**
+- [x] **Step 1: Write failing grouped-results test**
 
 ```tsx
 render(<WizardResultsStep results={[
@@ -903,7 +904,7 @@ expect(screen.getByText(/Submit failed/i)).toBeInTheDocument()
 expect(screen.getByRole("button", { name: /Open collection/i })).toBeEnabled()
 ```
 
-- [ ] **Step 2: Run failing UI tests**
+- [x] **Step 2: Run failing UI tests**
 
 ```bash
 bunx vitest run \
@@ -911,7 +912,7 @@ bunx vitest run \
   apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
 ```
 
-- [ ] **Step 3: Implement grouped result model and CTAs**
+- [x] **Step 3: Implement grouped result model and CTAs**
 
 Primary CTA: open conference collection.
 
@@ -923,7 +924,7 @@ Secondary CTAs:
 - ingest more
 - ask this collection only when `hasKnowledgeQaMediaScope` is true and collection readiness is nonzero
 
-- [ ] **Step 4: Separate submit failures from processing failures**
+- [x] **Step 4: Separate submit failures from processing failures**
 
 Use distinct outcome/status copy:
 
@@ -936,12 +937,13 @@ const RESULT_GROUP_LABELS = {
 
 Export should include source URL, title, collection item ID, status, error summary, and retry attempt.
 
-- [ ] **Step 5: Run verification**
+- [x] **Step 5: Run verification**
 
 ```bash
 bunx vitest run \
   apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx \
   apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx \
   apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
 
 git diff --check
@@ -956,9 +958,17 @@ git add \
   apps/packages/ui/src/components/Common/QuickIngest/types.ts \
   apps/packages/ui/src/services/tldw/conference-collections.ts \
   apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx \
   apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
 git commit -m "feat: hand off bulk ingest results to collections"
 ```
+
+Completion notes:
+
+- Results now group succeeded, skipped existing, not submitted, failed during processing, and cancelled items separately.
+- Durable conference collections now remain the primary handoff CTA even when all items fail, and collection-scoped QA is gated on `hasKnowledgeQaMediaScope` plus at least one ready completed/skipped media item.
+- Failed export rows now include source URL, title, collection item ID, status, error summary, and retry attempt where available.
+- Verification run: focused Vitest suite `40 passed`, `git diff --check` passed. Frontend `tsc --noEmit` remains blocked by pre-existing unrelated type errors in `EmbeddingsModelSelectionConfig.tsx`, `persona-visuals.ts`, and `lib/api/vnPlay.ts`.
 
 ## Task 6: Conference Collection Review And Scoped QA
 

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -639,7 +639,7 @@ git commit -m "feat: add durable conference media collections"
 - Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx`
 - Test: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
 
-- [ ] **Step 1: Write failing UI tests for inherited metadata**
+- [x] **Step 1: Write failing UI tests for inherited metadata**
 
 Add a Quick Ingest integration test:
 
@@ -656,7 +656,7 @@ expect(screen.getByText(/34 selected/i)).toBeInTheDocument()
 
 Add an item override test for one speaker/title.
 
-- [ ] **Step 2: Run failing UI tests**
+- [x] **Step 2: Run failing UI tests**
 
 ```bash
 bunx vitest run \
@@ -666,7 +666,7 @@ bunx vitest run \
 
 Expected: FAIL because batch metadata controls and persisted session fields do not exist.
 
-- [ ] **Step 3: Add metadata types and helpers**
+- [x] **Step 3: Add metadata types and helpers**
 
 Add types:
 
@@ -692,11 +692,11 @@ export type ConferenceItemMetadataOverride = {
 
 Add pure merge helpers in `conference-collections.ts`.
 
-- [ ] **Step 4: Implement batch metadata panel and item table**
+- [x] **Step 4: Implement batch metadata panel and item table**
 
 Use compact forms and progressive disclosure. Batch fields are visible; per-item overrides live in a table/drawer and are optional.
 
-- [ ] **Step 5: Submit metadata before or atomically with jobs**
+- [x] **Step 5: Submit metadata before or atomically with jobs**
 
 Update quick-ingest submission so selected preflight items create planned collection items before jobs are submitted. If the API supports atomic create+submit, use that. Otherwise:
 
@@ -705,11 +705,11 @@ Update quick-ingest submission so selected preflight items create planned collec
 3. Submit jobs with planned item IDs/idempotency keys.
 4. Mark item `submit_failed` if submission fails.
 
-- [ ] **Step 6: Mirror extension runtime payload**
+- [x] **Step 6: Mirror extension runtime payload**
 
 Apply the same fields in `apps/packages/ui/src/entries/background.ts` so extension-runtime Quick Ingest does not drop collection metadata.
 
-- [ ] **Step 7: Run verification**
+- [x] **Step 7: Run verification**
 
 ```bash
 bunx vitest run \
@@ -721,7 +721,7 @@ bunx vitest run \
 git diff --check
 ```
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -1,0 +1,1329 @@
+# Bulk Conference Ingest Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a durable WebUI and extension workflow for ingesting, organizing, tracking, recovering, and reviewing a many-video conference playlist as one coherent collection.
+
+**Architecture:** Extend the existing shared Quick Ingest, media ingest jobs, Collections DB item layer, Media review, Knowledge QA, and extension sidepanel surfaces instead of creating a separate conference-ingest product. The backend owns playlist metadata preflight, duplicate lookup, durable collection/run state, and scoped retrieval enforcement; the shared frontend owns the preflight/review UI, batch metadata editing, run progress, and WebUI/extension handoff.
+
+**Tech Stack:** FastAPI, Pydantic, yt-dlp metadata extraction, existing Jobs/JobManager media ingest jobs, SQLite/Postgres-backed `CollectionsDatabase`, Next.js/shared React UI under `apps/packages/ui`, Ant Design, Zustand/session stores, WXT/browser-extension runtime messaging, Vitest, React Testing Library, pytest, Playwright, Backlog.md.
+
+---
+
+## Inputs
+
+- Design spec: `Docs/superpowers/specs/2026-05-16-bulk-conference-ingest-workflow-design.md`
+- Backlog task: `TASK-399`
+- Current media ingest jobs API docs: `Docs/API-related/Media_Ingest_Jobs_API.md`
+- Existing quick-ingest resume plan for adjacent context: `Docs/superpowers/plans/2026-03-24-quick-ingest-resume-and-e2e-implementation-plan.md`
+- Existing quick-ingest UX remediation plan for active wizard paths: `Docs/superpowers/plans/2026-05-16-quick-ingest-ux-remediation-implementation-plan.md`
+
+## Scope Rules
+
+- Preserve ordinary one-file and one-URL Quick Ingest behavior in every stage.
+- Keep shared WebUI/extension behavior under `apps/packages/ui/src` unless platform-specific extension APIs are required.
+- Do not parse playlists in the frontend. The server provides metadata-only preflight.
+- Do not depend on `media:collections:v1` localStorage as durable source of truth.
+- Do not expose scoped Knowledge QA until backend retrieval is actually constrained by media IDs or collection ID.
+- Do not store browser cookies, auth headers, downloaded video/audio, or secrets in preflight records or job payloads.
+- Treat worker availability separately from endpoint existence.
+- Each task below is intended as a reviewable PR or small sequence of commits.
+
+## Program File Map
+
+### Backend playlist preflight and capabilities
+
+- Create: `tldw_Server_API/app/api/v1/schemas/media_playlist_preflight.py`
+  - Pydantic request/response models for metadata-only playlist preflight.
+- Create: `tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py`
+  - Pure playlist URL classification, metadata normalization, duplicate-in-batch detection, and yt-dlp metadata extraction wrappers.
+- Create: `tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py`
+  - `POST /api/v1/media/playlists/preflight`, owner-scoped read-only endpoint.
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/__init__.py`
+  - Append `playlist_preflight` to `_MEDIA_ENDPOINT_MODULES`.
+- Modify: `tldw_Server_API/app/api/v1/endpoints/config_info.py`
+  - Add granular capability keys for playlist preflight, media jobs endpoint, worker availability, job SSE, durable media collections, and scoped Knowledge QA.
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py`
+- Test: `tldw_Server_API/tests/Config/test_docs_info_capabilities.py`
+
+### Backend durable conference collections and run binding
+
+- Modify: `tldw_Server_API/app/core/DB_Management/Collections_DB.py`
+  - Prefer a small extension of the existing `content_items` layer with collection/group identity only if the inventory proves it fits; otherwise add a narrow media collection table here.
+- Create if needed: `tldw_Server_API/app/api/v1/schemas/media_collections.py`
+  - Stable conference collection, collection item, run, and retry request/response models.
+- Create if needed: `tldw_Server_API/app/api/v1/endpoints/media/collections.py`
+  - Media collection list/get/create/update and collection item status endpoints under `/api/v1/media/collections`.
+- Modify if using a new media subrouter: `tldw_Server_API/app/api/v1/endpoints/media/__init__.py`
+  - Append `collections` to `_MEDIA_ENDPOINT_MODULES`.
+- Modify if reusing `/api/v1/items`: `tldw_Server_API/app/api/v1/endpoints/items.py`
+  - Add collection filters/metadata only where needed; do not make `/items` own run orchestration.
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py`
+  - Accept optional planned collection item IDs/idempotency keys and surface them in job payload/status.
+- Modify: `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
+  - Resolve planned collection items to completed/skipped/failed/cancelled status after job terminal state.
+- Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py`
+  - Preserve collection metadata in the existing `sync_media_add_results_to_collections` path for synchronous fallback.
+- Test: `tldw_Server_API/tests/Collections/test_conference_media_collections.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_conference_collection.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_ingest_jobs_conference_collection.py`
+
+### Backend scoped Knowledge QA
+
+- Read first: `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`, `tldw_Server_API/app/api/v1/endpoints/rag_health.py`, `tldw_Server_API/app/core/RAG/`, and `tldw_Server_API/tests/RAG/test_rag_selection_filters.py`
+- Modify only after confirming current contract: RAG search/generation schema and endpoint files that already support selection/media filters.
+- Test: `tldw_Server_API/tests/RAG/test_conference_collection_scope.py`
+
+### Shared frontend services, types, and capability detection
+
+- Modify: `apps/packages/ui/src/services/tldw/server-capabilities.ts`
+  - Add granular booleans:
+    - `hasMediaPlaylistPreflight`
+    - `hasMediaIngestJobs`
+    - `hasMediaIngestJobEvents`
+    - `hasMediaIngestWorker`
+    - `hasDurableMediaCollections`
+    - `hasKnowledgeQaMediaScope`
+- Modify: `apps/packages/ui/src/services/tldw/domains/media.ts`
+  - Add `preflightPlaylist`, collection create/get/update, run status/retry/cancel methods if the API lives under `/media`.
+- Modify if collection APIs remain under `/items`: `apps/packages/ui/src/services/tldw/domains/collections.ts`
+  - Add typed wrappers for conference collection and collection item operations.
+- Create: `apps/packages/ui/src/services/tldw/playlist-preflight.ts`
+  - Pure client normalizers for server preflight payloads and UI state.
+- Create: `apps/packages/ui/src/services/tldw/conference-collections.ts`
+  - Pure helpers for inherited metadata, planned item payloads, retryability, grouped result counts.
+- Modify: `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`
+  - Carry collection/run metadata, planned item IDs, idempotency keys, and retry metadata through direct WebUI submission.
+- Modify: `apps/packages/ui/src/entries/background.ts`
+  - Mirror shared metadata submission for extension-runtime batch handling.
+- Test: `apps/packages/ui/src/services/__tests__/server-capabilities.test.ts`
+- Test: `apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts`
+- Test: `apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts`
+- Test: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+
+### Shared Quick Ingest UI
+
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/types.ts`
+  - Add playlist preflight, batch metadata, collection/run, item override, and retry status types.
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx`
+  - Detect playlist-capable URLs and offer preflight before adding a single opaque row.
+- Create: `apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx`
+  - Expanded playlist preview with count, duplicate state, selection, warnings, and partial/expired states.
+- Create: `apps/packages/ui/src/components/Common/QuickIngest/BatchMetadataPanel.tsx`
+  - Conference-level metadata fields and shared tags.
+- Create: `apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx`
+  - Per-item title/speaker/date/track/tag overrides and selection.
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx`
+  - Persist playlist/batch/collection/run state in wizard/session state.
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx`
+  - Show conference metadata and selected item count before submission.
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/ProcessingStep.tsx`
+  - Show durable/degraded mode, collection/run counts, cancel, retry-all, and export-failed affordances as stages become available.
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx`
+  - Group results and provide collection handoff.
+- Test: existing Quick Ingest tests under `apps/packages/ui/src/components/Common/QuickIngest/__tests__/`.
+
+### Media/collection review and Knowledge QA UI
+
+- Read first: `apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts`
+  - Current local collection key: `media:collections:v1`.
+- Modify or create in Review area after route inventory:
+  - Collection route/page component for conference collection detail.
+  - Talk list, status badges, next/previous navigation, compare selected, scoped QA CTA.
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx`
+  - Accept collection/media-ID scope only after backend support is present.
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/` or closest existing KnowledgeQA test folder.
+- Test: `apps/packages/ui/src/components/Review/__tests__/conference-collection-review.test.tsx`
+
+### Extension handoff
+
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx`
+  - Add or refine playlist-aware quick action when active-tab context exists.
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
+  - Pass playlist URL/context into the shared Quick Ingest modal via `requestQuickIngestOpen`.
+- Modify: `apps/packages/ui/src/utils/quick-ingest-open.ts`
+  - Add typed `detail` payload for playlist preflight seed.
+- Modify: `apps/packages/ui/src/entries/background.ts`
+  - Add active-tab URL/context handoff if not already available.
+- Test: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx`
+- Test: `apps/packages/ui/src/routes/__tests__/sidepanel-chat.*.test.tsx`
+- Test: extension/WXT tests as available under `apps/tldw-frontend/extension/__tests__` or `apps/extension`.
+
+### Browser and e2e QA
+
+- Modify/add: `apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts`
+- Modify/add: `tldw_Server_API/tests/frontend_e2e/test_quick_ingest_media_workflow.py`
+- Add fixtures: mocked 34-item playlist metadata, mocked jobs event stream, duplicate/failure permutations.
+
+## Task 0: Contract Inventory And Slice Boundaries
+
+**Files:**
+- Create: `Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md`
+- Read: `tldw_Server_API/app/core/DB_Management/Collections_DB.py`
+- Read: `tldw_Server_API/app/api/v1/endpoints/items.py`
+- Read: `tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py`
+- Read: `tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py`
+- Read: `apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts`
+- Read: `apps/packages/ui/src/services/tldw/domains/collections.ts`
+- Read: `apps/packages/ui/src/services/tldw/domains/media.ts`
+
+- [x] **Step 1: Write the inventory artifact**
+
+Create `Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md` with:
+
+```markdown
+# Bulk Conference Contract Inventory
+
+Date: 2026-05-16
+Backlog: TASK-399
+
+## Candidate Stores
+
+| Candidate | Supports stable collection ID | Supports ordered membership | Supports planned items | Supports media resolution | Collision risk | Decision |
+|---|---:|---:|---:|---:|---|---|
+
+## Selected Contract
+
+## Rejected Alternatives
+
+## API Placement
+
+## Migration/Bridge Notes
+```
+
+- [x] **Step 2: Verify the artifact names a selected source of truth**
+
+Run:
+
+```bash
+rg -n "Selected Contract|Rejected Alternatives|API Placement" Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+```
+
+Expected: all headings present, with a concrete selection before Task 2 starts.
+
+- [x] **Step 3: Commit**
+
+```bash
+git add Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+git commit -m "docs: inventory bulk conference collection contracts"
+```
+
+## Task 1: Playlist Preflight And Basic Dedupe
+
+**Files:**
+- Create: `tldw_Server_API/app/api/v1/schemas/media_playlist_preflight.py`
+- Create: `tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py`
+- Create: `tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/__init__.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/config_info.py`
+- Modify: `apps/packages/ui/src/services/tldw/server-capabilities.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/media.ts`
+- Create: `apps/packages/ui/src/services/tldw/playlist-preflight.ts`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/types.ts`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx`
+- Create: `apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py`
+- Test: `tldw_Server_API/tests/Config/test_docs_info_capabilities.py`
+- Test: `apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/AddContentStep.url-detection.test.ts`
+
+- [x] **Step 1: Write failing backend classification tests**
+
+Add tests like:
+
+```python
+def test_youtube_watch_list_url_detects_playlist_context():
+    parsed = classify_playlist_url(
+        "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B"
+    )
+
+    assert parsed.source_kind == "youtube_watch_playlist"
+    assert parsed.playlist_id == "PL0065D9B288E6804B"
+    assert parsed.video_id == "PrNmmN6qBiw"
+```
+
+Also test:
+
+```python
+def test_preflight_duplicate_in_batch_uses_normalized_source_id():
+    items = normalize_preflight_items([
+        {"source_url": "https://youtu.be/abc123", "title": "A"},
+        {"source_url": "https://www.youtube.com/watch?v=abc123", "title": "A duplicate"},
+    ])
+
+    assert [item.duplicate_status for item in items] == [
+        "new",
+        "duplicate_in_batch",
+    ]
+```
+
+- [x] **Step 2: Run failing backend tests**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py \
+  -v
+```
+
+Expected: FAIL because the new module does not exist.
+
+- [x] **Step 3: Implement pure preflight helpers**
+
+Implement `playlist_preflight.py` with small pure functions first:
+
+```python
+@dataclass(frozen=True)
+class PlaylistUrlClassification:
+    source_kind: str
+    playlist_id: str | None
+    video_id: str | None
+    normalized_source_id: str | None
+
+
+def classify_playlist_url(raw_url: str) -> PlaylistUrlClassification:
+    return _classify_youtube_playlist_url(raw_url)
+
+
+def normalize_preflight_items(raw_items: list[dict[str, Any]]) -> list[PlaylistPreflightItemData]:
+    return _mark_duplicate_source_ids(_coerce_preflight_items(raw_items))
+```
+
+Keep yt-dlp access behind an injectable function so tests can mock metadata extraction without network.
+
+- [x] **Step 4: Write failing endpoint read-only tests**
+
+Use dependency overrides and a fake extractor. Assert:
+
+```python
+def test_playlist_preflight_does_not_create_jobs_or_media(client, monkeypatch):
+    response = client.post(
+        "/api/v1/media/playlists/preflight",
+        json={"url": "https://www.youtube.com/playlist?list=PLx"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["item_count"] == 2
+    assert fake_job_manager.created_jobs == []
+    assert fake_media_db.created_rows == []
+```
+
+Add explicit tests for partial/timeout/unsupported URL responses.
+
+- [x] **Step 5: Implement endpoint and schemas**
+
+Add request/response models:
+
+```python
+class PlaylistPreflightRequest(BaseModel):
+    url: HttpUrl
+    max_items: int = Field(default=100, ge=1, le=500)
+    timeout_seconds: int = Field(default=20, ge=1, le=60)
+
+
+class PlaylistPreflightItem(BaseModel):
+    source_url: str
+    normalized_source_id: str | None = None
+    position: int | None = None
+    title: str | None = None
+    duration_seconds: int | None = None
+    thumbnail_url: str | None = None
+    channel_or_uploader: str | None = None
+    published_at: str | None = None
+    existing_media_id: int | None = None
+    duplicate_status: Literal["new", "existing", "duplicate_in_batch", "unknown"]
+    selected: bool = True
+    warnings: list[str] = Field(default_factory=list)
+```
+
+Wire the router in `media/__init__.py`.
+
+- [x] **Step 6: Add granular capabilities**
+
+In `config_info.py`, expose at least:
+
+```python
+caps["hasMediaPlaylistPreflight"] = bool(config_mod.route_enabled("media", default_stable=True))
+caps["hasMediaIngestJobs"] = bool(config_mod.route_enabled("media", default_stable=True))
+caps["hasMediaIngestJobEvents"] = bool(config_mod.route_enabled("media", default_stable=True))
+caps["hasMediaIngestWorker"] = worker_path_enabled(
+    "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+    "media-ingest-jobs",
+    default_stable=False,
+    test_mode=False,
+)
+```
+
+In `server-capabilities.ts`, add matching fields, fallback spec paths, OpenAPI detection, and docs-info gate application.
+
+- [x] **Step 7: Add frontend normalizer and preflight client**
+
+Add `preflightPlaylist` to `domains/media.ts` and normalize payloads in `playlist-preflight.ts`:
+
+```ts
+export const normalizePlaylistPreflight = (payload: unknown): PlaylistPreflight => ({
+  preflightId: String((payload as any)?.preflight_id || ""),
+  sourceUrl: String((payload as any)?.source_url || ""),
+  status: normalizePreflightStatus((payload as any)?.status),
+  items: Array.isArray((payload as any)?.items)
+    ? (payload as any).items.map(normalizePlaylistPreflightItem)
+    : [],
+  warnings: normalizeStringList((payload as any)?.warnings)
+})
+```
+
+- [x] **Step 8: Add Quick Ingest preflight UI**
+
+In `AddContentStep.tsx`, when a URL is playlist-capable and `hasMediaPlaylistPreflight` is true, call preflight and render `PlaylistPreflightPanel`. The panel must support loading, ready, partial, failed, and expired states, plus deselection.
+
+- [x] **Step 9: Run focused verification**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py \
+  tldw_Server_API/tests/Config/test_docs_info_capabilities.py \
+  -v
+
+bunx vitest run \
+  apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/AddContentStep.url-detection.test.ts
+
+git diff --check
+```
+
+Expected: all focused tests pass; diff check has no whitespace errors.
+
+- [x] **Step 10: Run Bandit on touched backend scope**
+
+```bash
+source .venv/bin/activate && python -m bandit \
+  -r tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py \
+     tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py \
+  -f json -o /tmp/bandit_bulk_conference_playlist_preflight.json
+```
+
+Expected: no new high/medium findings in touched code.
+
+- [x] **Step 11: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/schemas/media_playlist_preflight.py \
+  tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py \
+  tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py \
+  tldw_Server_API/app/api/v1/endpoints/media/__init__.py \
+  tldw_Server_API/app/api/v1/endpoints/config_info.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py \
+  tldw_Server_API/tests/Config/test_docs_info_capabilities.py \
+  apps/packages/ui/src/services/tldw/server-capabilities.ts \
+  apps/packages/ui/src/services/tldw/domains/media.ts \
+  apps/packages/ui/src/services/tldw/playlist-preflight.ts \
+  apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/types.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/AddContentStep.url-detection.test.ts
+git commit -m "feat: add playlist preflight for quick ingest"
+```
+
+## Task 2: Durable Conference Collection Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Collections_DB.py`
+- Create if selected by inventory: `tldw_Server_API/app/api/v1/schemas/media_collections.py`
+- Create if selected by inventory: `tldw_Server_API/app/api/v1/endpoints/media/collections.py`
+- Modify if using media subrouter: `tldw_Server_API/app/api/v1/endpoints/media/__init__.py`
+- Modify if extending unified items: `tldw_Server_API/app/api/v1/endpoints/items.py`
+- Modify: `apps/packages/ui/src/services/tldw/server-capabilities.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/media.ts`
+- Create: `apps/packages/ui/src/services/tldw/conference-collections.ts`
+- Test: `tldw_Server_API/tests/Collections/test_conference_media_collections.py`
+- Test: `apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts`
+
+- [ ] **Step 1: Write failing collection contract tests**
+
+Start from the selected contract in Task 0. Minimum backend tests:
+
+```python
+def test_conference_collection_persists_planned_and_resolved_items(collections_db):
+    collection = collections_db.create_media_collection(
+        name="PyCon 2026",
+        kind="conference",
+        metadata={"conference_name": "PyCon", "event_year": "2026"},
+    )
+    planned = collections_db.add_media_collection_item(
+        collection_id=collection.id,
+        source_url="https://www.youtube.com/watch?v=a",
+        normalized_source_id="youtube:a",
+        status="planned",
+        metadata={"speaker": "Ada"},
+    )
+
+    collections_db.resolve_media_collection_item(planned.id, media_id=123, status="completed")
+
+    loaded = collections_db.get_media_collection(collection.id)
+    assert loaded.items[0].media_id == 123
+    assert loaded.items[0].metadata["speaker"] == "Ada"
+```
+
+Add tests that planned/source items do not overwrite unrelated `content_items` with matching URL/hash unless the selected contract intentionally reuses those rows with a safe namespace.
+
+- [ ] **Step 2: Run failing collection tests**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Collections/test_conference_media_collections.py \
+  -v
+```
+
+Expected: FAIL due missing collection APIs/storage helpers.
+
+- [ ] **Step 3: Implement the selected durable storage contract**
+
+If reusing `CollectionsDatabase`, prefer narrow methods rather than exposing raw SQL:
+
+```python
+def create_media_collection(
+    self,
+    *,
+    name: str,
+    kind: str,
+    metadata: dict[str, Any] | None = None,
+) -> MediaCollectionRow:
+    """Create a stable, user-owned media collection."""
+
+
+def add_media_collection_item(
+    self,
+    *,
+    collection_id: int,
+    source_url: str,
+    normalized_source_id: str | None,
+    status: str,
+    position: int | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> MediaCollectionItemRow:
+    """Add an unresolved planned/source item to a media collection."""
+
+
+def update_media_collection_item_status(
+    self,
+    item_id: int,
+    *,
+    status: str,
+    error_summary: str | None = None,
+) -> MediaCollectionItemRow:
+    """Update processing status without losing source metadata."""
+
+
+def resolve_media_collection_item(
+    self,
+    item_id: int,
+    *,
+    media_id: int,
+    status: str = "completed",
+) -> MediaCollectionItemRow:
+    """Resolve a planned item to an existing or newly created media row."""
+
+
+def get_media_collection(self, collection_id: int) -> MediaCollectionRow:
+    """Return collection metadata plus ordered membership."""
+
+
+def list_media_collections(
+    self,
+    *,
+    kind: str | None = None,
+    page: int = 1,
+    size: int = 20,
+) -> tuple[list[MediaCollectionRow], int]:
+    """List durable media collections for the current user."""
+```
+
+Supported statuses:
+
+```python
+CONFERENCE_ITEM_STATUSES = {
+    "planned",
+    "processing",
+    "completed",
+    "skipped_existing",
+    "submit_failed",
+    "failed",
+    "cancelled",
+}
+```
+
+- [ ] **Step 4: Implement API and frontend client**
+
+Expose stable collection operations. If using `/api/v1/media/collections`, add:
+
+```text
+POST /api/v1/media/collections
+GET /api/v1/media/collections
+GET /api/v1/media/collections/{collection_id}
+PATCH /api/v1/media/collections/{collection_id}
+POST /api/v1/media/collections/{collection_id}/items
+PATCH /api/v1/media/collections/{collection_id}/items/{item_id}
+```
+
+Add typed client wrappers and normalize collection item status/counts in `conference-collections.ts`.
+
+- [ ] **Step 5: Preserve localStorage collection boundary**
+
+Read `useMediaSelection.ts` and make one explicit choice:
+
+- migrate existing local collections to durable collections,
+- bridge by showing local collections separately,
+- or leave local collections as local-only and label them as such.
+
+Record the choice in the inventory artifact.
+
+- [ ] **Step 6: Run focused verification**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Collections/test_conference_media_collections.py \
+  -v
+
+bunx vitest run \
+  apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts \
+  apps/packages/ui/src/services/__tests__/server-capabilities.test.ts
+
+git diff --check
+```
+
+- [ ] **Step 7: Run Bandit**
+
+```bash
+source .venv/bin/activate && python -m bandit \
+  -r tldw_Server_API/app/core/DB_Management/Collections_DB.py \
+     tldw_Server_API/app/api/v1/endpoints/media/collections.py \
+  -f json -o /tmp/bandit_bulk_conference_collections.json
+```
+
+Expected: no new high/medium findings in touched code.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md \
+  tldw_Server_API/app/core/DB_Management/Collections_DB.py \
+  tldw_Server_API/app/api/v1/schemas/media_collections.py \
+  tldw_Server_API/app/api/v1/endpoints/media/collections.py \
+  tldw_Server_API/app/api/v1/endpoints/media/__init__.py \
+  tldw_Server_API/tests/Collections/test_conference_media_collections.py \
+  apps/packages/ui/src/services/tldw/server-capabilities.ts \
+  apps/packages/ui/src/services/tldw/domains/media.ts \
+  apps/packages/ui/src/services/tldw/conference-collections.ts \
+  apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
+git commit -m "feat: add durable conference media collections"
+```
+
+## Task 3: Batch Metadata In Quick Ingest
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/types.ts`
+- Create: `apps/packages/ui/src/components/Common/QuickIngest/BatchMetadataPanel.tsx`
+- Create: `apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx`
+- Modify: `apps/packages/ui/src/services/tldw/conference-collections.ts`
+- Modify: `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`
+- Modify: `apps/packages/ui/src/entries/background.ts`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx`
+- Test: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+
+- [ ] **Step 1: Write failing UI tests for inherited metadata**
+
+Add a Quick Ingest integration test:
+
+```tsx
+await user.type(screen.getByLabelText(/Conference name/i), "Strange Loop")
+await user.type(screen.getByLabelText(/Event year/i), "2012")
+await user.type(screen.getByLabelText(/Shared tags/i), "conference, clojure")
+
+await user.click(screen.getByRole("button", { name: /Review/i }))
+
+expect(screen.getByText(/Strange Loop/i)).toBeInTheDocument()
+expect(screen.getByText(/34 selected/i)).toBeInTheDocument()
+```
+
+Add an item override test for one speaker/title.
+
+- [ ] **Step 2: Run failing UI tests**
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+```
+
+Expected: FAIL because batch metadata controls and persisted session fields do not exist.
+
+- [ ] **Step 3: Add metadata types and helpers**
+
+Add types:
+
+```ts
+export type ConferenceBatchMetadata = {
+  collectionName: string
+  conferenceName?: string
+  eventDate?: string
+  eventYear?: string
+  sharedTags: string[]
+  sourcePlaylistUrl?: string
+}
+
+export type ConferenceItemMetadataOverride = {
+  title?: string
+  speaker?: string
+  talkDate?: string
+  track?: string
+  tags?: string[]
+  selected: boolean
+}
+```
+
+Add pure merge helpers in `conference-collections.ts`.
+
+- [ ] **Step 4: Implement batch metadata panel and item table**
+
+Use compact forms and progressive disclosure. Batch fields are visible; per-item overrides live in a table/drawer and are optional.
+
+- [ ] **Step 5: Submit metadata before or atomically with jobs**
+
+Update quick-ingest submission so selected preflight items create planned collection items before jobs are submitted. If the API supports atomic create+submit, use that. Otherwise:
+
+1. Create collection.
+2. Create planned selected items.
+3. Submit jobs with planned item IDs/idempotency keys.
+4. Mark item `submit_failed` if submission fails.
+
+- [ ] **Step 6: Mirror extension runtime payload**
+
+Apply the same fields in `apps/packages/ui/src/entries/background.ts` so extension-runtime Quick Ingest does not drop collection metadata.
+
+- [ ] **Step 7: Run verification**
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx \
+  apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts \
+  apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+
+git diff --check
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Common/QuickIngest/types.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/BatchMetadataPanel.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx \
+  apps/packages/ui/src/services/tldw/conference-collections.ts \
+  apps/packages/ui/src/services/tldw/quick-ingest-batch.ts \
+  apps/packages/ui/src/entries/background.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx \
+  apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+git commit -m "feat: add conference metadata to quick ingest"
+```
+
+## Task 4: Jobs-Backed Ingest Run Tracking
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py`
+- Modify: `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
+- Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py`
+- Modify: `apps/packages/ui/src/services/tldw/ingest-jobs-orchestrator.ts`
+- Modify: `apps/packages/ui/src/services/tldw/ingest-job-results.ts`
+- Modify: `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`
+- Modify: `apps/packages/ui/src/store/quick-ingest-session.ts`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/ProcessingStep.tsx`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_ingest_jobs_events_stream.py`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx`
+- Test: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+
+- [ ] **Step 1: Write failing backend tests for planned item binding**
+
+Test that job payload/status includes planned item ID:
+
+```python
+def test_submit_jobs_preserves_collection_item_binding(client):
+    response = client.post(
+        "/api/v1/media/ingest/jobs",
+        data={
+            "media_type": "video",
+            "urls": ["https://www.youtube.com/watch?v=a"],
+            "collection_id": "conf_1",
+            "planned_item_ids": json.dumps(["item_1"]),
+            "idempotency_keys": json.dumps(["conf_1:item_1:0"]),
+        },
+    )
+
+    job = response.json()["jobs"][0]
+    assert job["status"] == "queued"
+```
+
+Then fetch job and assert payload-derived `collection_id` and `planned_item_id` appear in status.
+
+- [ ] **Step 2: Run failing backend tests**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py \
+  -v
+```
+
+- [ ] **Step 3: Extend job payload contract**
+
+Accept optional collection/run form fields in `AddMediaForm` or endpoint-specific parsing, validate lengths match URL count, and write:
+
+```python
+payload.update({
+    "collection_id": collection_id,
+    "planned_item_id": planned_item_id,
+    "idempotency_key": idempotency_key,
+})
+```
+
+Do not put secrets or cookies in the job payload.
+
+- [ ] **Step 4: Resolve item statuses in worker**
+
+On terminal result:
+
+- `completed` with media ID -> collection item `completed`
+- completed duplicate/skipped existing -> `skipped_existing` if user opted in
+- exception/failure -> `failed`
+- cancellation -> `cancelled`
+
+For job creation failures in the submit endpoint, mark planned item `submit_failed` with source URL/error.
+
+- [ ] **Step 5: Update frontend tracking**
+
+Extend `PersistedQuickIngestTracking` with collection/run IDs and planned item mapping. Ensure refresh restore can show:
+
+- queued/running/completed/failed/cancelled counts
+- durable mode vs synchronous fallback
+- retry all retryable failures
+- export failed URLs
+
+- [ ] **Step 6: Run verification**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/integration/test_ingest_jobs_events_stream.py \
+  -v
+
+bunx vitest run \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx \
+  apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+
+git diff --check
+```
+
+- [ ] **Step 7: Bandit**
+
+```bash
+source .venv/bin/activate && python -m bandit \
+  -r tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py \
+     tldw_Server_API/app/services/media_ingest_jobs_worker.py \
+     tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py \
+  -f json -o /tmp/bandit_bulk_conference_jobs.json
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py \
+  tldw_Server_API/app/services/media_ingest_jobs_worker.py \
+  tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py \
+  apps/packages/ui/src/services/tldw/ingest-jobs-orchestrator.ts \
+  apps/packages/ui/src/services/tldw/ingest-job-results.ts \
+  apps/packages/ui/src/services/tldw/quick-ingest-batch.ts \
+  apps/packages/ui/src/store/quick-ingest-session.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/ProcessingStep.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx \
+  apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+git commit -m "feat: track conference ingest runs through media jobs"
+```
+
+## Task 5: Results And Collection Handoff
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/ResultsListItem.tsx`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/types.ts`
+- Modify: `apps/packages/ui/src/services/tldw/conference-collections.ts`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx`
+
+- [ ] **Step 1: Write failing grouped-results test**
+
+```tsx
+render(<WizardResultsStep results={[
+  completedResult,
+  skippedExistingResult,
+  submitFailedResult,
+  failedResult,
+  cancelledResult,
+]} collectionId="conf_1" />)
+
+expect(screen.getByText(/Succeeded/i)).toBeInTheDocument()
+expect(screen.getByText(/Skipped existing/i)).toBeInTheDocument()
+expect(screen.getByText(/Submit failed/i)).toBeInTheDocument()
+expect(screen.getByRole("button", { name: /Open collection/i })).toBeEnabled()
+```
+
+- [ ] **Step 2: Run failing UI tests**
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+```
+
+- [ ] **Step 3: Implement grouped result model and CTAs**
+
+Primary CTA: open conference collection.
+
+Secondary CTAs:
+
+- retry all retryable failures
+- export failed URLs
+- review failed items
+- ingest more
+- ask this collection only when `hasKnowledgeQaMediaScope` is true and collection readiness is nonzero
+
+- [ ] **Step 4: Separate submit failures from processing failures**
+
+Use distinct outcome/status copy:
+
+```ts
+const RESULT_GROUP_LABELS = {
+  submit_failed: "Not submitted",
+  failed: "Failed during processing",
+}
+```
+
+Export should include source URL, title, collection item ID, status, error summary, and retry attempt.
+
+- [ ] **Step 5: Run verification**
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx \
+  apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
+
+git diff --check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/ResultsListItem.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/types.ts \
+  apps/packages/ui/src/services/tldw/conference-collections.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+git commit -m "feat: hand off bulk ingest results to collections"
+```
+
+## Task 6: Conference Collection Review And Scoped QA
+
+**Files:**
+- Modify/create after route inventory: `apps/packages/ui/src/components/Review/ConferenceCollectionReview.tsx`
+- Modify/create after route inventory: `apps/packages/ui/src/components/Review/__tests__/conference-collection-review.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx`
+- Modify: `apps/packages/ui/src/services/tldw/domains/chat-rag.ts`
+- Modify backend RAG files identified by current scope support inventory.
+- Test: `tldw_Server_API/tests/RAG/test_conference_collection_scope.py`
+- Test: `apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/conference-scope.test.tsx`
+
+- [ ] **Step 1: Inventory current Knowledge QA/RAG scope contract**
+
+Search:
+
+```bash
+rg -n "media_ids|source_ids|filters|selection|rag/search|KnowledgeQA" \
+  tldw_Server_API/app/api/v1/endpoints \
+  tldw_Server_API/app/core/RAG \
+  apps/packages/ui/src/components/Option/KnowledgeQA \
+  apps/packages/ui/src/services/tldw
+```
+
+Record the actual contract in Task 0's inventory or a new short note before modifying RAG.
+
+- [ ] **Step 2: Write failing backend scoped retrieval test**
+
+```python
+def test_conference_collection_scope_limits_rag_to_ready_media(client, seeded_collection):
+    response = client.post(
+        "/api/v1/rag/search",
+        json={
+            "query": "What did the keynote say about macros?",
+            "collection_id": seeded_collection.id,
+        },
+    )
+
+    assert response.status_code == 200
+    assert {hit["media_id"] for hit in response.json()["results"]} <= seeded_collection.ready_media_ids
+```
+
+- [ ] **Step 3: Implement or reuse backend-enforced scope**
+
+If existing RAG selection filters support media IDs, map collection ID to ready media IDs server-side. If not, add a minimal request field and retrieval filter. Do not rely on client-only filtering.
+
+- [ ] **Step 4: Write failing review UI test**
+
+Assert talk list, transcript readiness counts, next/previous navigation, compare selected, and disabled QA when no items are ready.
+
+- [ ] **Step 5: Implement collection review UI**
+
+Minimum V1:
+
+- ordered talk list
+- status badges for planned/processing/completed/skipped/submit_failed/failed/cancelled
+- transcript/summary readiness
+- previous/next talk navigation
+- selected-talk comparison using metadata plus available summaries/excerpts
+- scoped QA CTA with readiness copy
+
+- [ ] **Step 6: Run verification**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/RAG/test_conference_collection_scope.py \
+  -v
+
+bunx vitest run \
+  apps/packages/ui/src/components/Review/__tests__/conference-collection-review.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/conference-scope.test.tsx
+
+git diff --check
+```
+
+- [ ] **Step 7: Bandit**
+
+```bash
+source .venv/bin/activate && python -m bandit \
+  -r tldw_Server_API/app/api/v1/endpoints \
+     tldw_Server_API/app/core/RAG \
+  -f json -o /tmp/bandit_bulk_conference_scoped_rag.json
+```
+
+Review only findings in touched RAG/API files.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  tldw_Server_API/tests/RAG/test_conference_collection_scope.py \
+  apps/packages/ui/src/components/Review/ConferenceCollectionReview.tsx \
+  apps/packages/ui/src/components/Review/__tests__/conference-collection-review.test.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx \
+  apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/conference-scope.test.tsx \
+  apps/packages/ui/src/services/tldw/domains/chat-rag.ts
+git commit -m "feat: review conference collections with scoped qa"
+```
+
+## Task 7: Extension Playlist Capture
+
+**Files:**
+- Modify: `apps/packages/ui/src/utils/quick-ingest-open.ts`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
+- Modify: `apps/packages/ui/src/entries/background.ts`
+- Test: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx`
+- Test: `apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts`
+- Test as available: `apps/tldw-frontend/extension/__tests__/*`
+
+- [ ] **Step 1: Write failing context-handoff tests**
+
+Add a test that `requestQuickIngestOpen` accepts:
+
+```ts
+requestQuickIngestOpen({
+  source: "extension_active_tab",
+  url: "https://www.youtube.com/watch?v=a&list=PLx",
+  sourceKind: "youtube_watch_playlist",
+  action: "playlist_preflight",
+})
+```
+
+And that Sidepanel passes this detail to the modal/open request.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx \
+  apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts
+```
+
+- [ ] **Step 3: Add typed Quick Ingest open detail**
+
+In `quick-ingest-open.ts`:
+
+```ts
+export type QuickIngestOpenDetail =
+  | { source: "manual"; action?: "normal" }
+  | {
+      source: "extension_active_tab"
+      url: string
+      sourceKind?: "youtube_playlist" | "youtube_watch_playlist" | "unknown"
+      action: "playlist_preflight"
+    }
+```
+
+- [ ] **Step 4: Detect active-tab playlist context**
+
+Use active-tab URL or existing sidepanel context, not content-script parsing. Show "Import playlist to tldw" only when the URL has a YouTube playlist/list context and extension readiness allows it.
+
+- [ ] **Step 5: Seed shared preflight**
+
+Quick Ingest should consume the open detail and start the same preflight path as paste-from-WebUI.
+
+- [ ] **Step 6: Run verification**
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+
+git diff --check
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  apps/packages/ui/src/utils/quick-ingest-open.ts \
+  apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx \
+  apps/packages/ui/src/components/Sidepanel/Chat/form.tsx \
+  apps/packages/ui/src/entries/background.ts \
+  apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx
+git commit -m "feat: add extension playlist quick ingest handoff"
+```
+
+## Task 8: Duplicate And Failure Recovery
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py`
+- Modify: `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
+- Modify: `apps/packages/ui/src/services/tldw/ingest-job-results.ts`
+- Modify: `apps/packages/ui/src/services/tldw/conference-collections.ts`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py`
+- Test: `apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts`
+- Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx`
+
+- [ ] **Step 1: Write failing duplicate policy tests**
+
+Policies:
+
+- skip
+- overwrite
+- update metadata only
+- include existing in collection
+
+Assert each policy produces expected planned item status and job submission behavior.
+
+- [ ] **Step 2: Write failing failure taxonomy tests**
+
+Classify conservative failure types:
+
+```ts
+expect(classifyConferenceIngestFailure("Private video")).toBe("auth_required")
+expect(classifyConferenceIngestFailure("HTTP Error 404")).toBe("unavailable")
+expect(classifyConferenceIngestFailure("timed out")).toBe("timeout")
+```
+
+- [ ] **Step 3: Implement duplicate policy UI and payloads**
+
+Expose policy choice in preflight/results only when duplicates exist. Default should avoid surprise overwrite.
+
+- [ ] **Step 4: Implement selected-subset retry**
+
+Retry selected applies only to retryable `submit_failed`, `failed`, or `cancelled` items. It must use collection item ID plus retry attempt/idempotency key and must skip completed items.
+
+- [ ] **Step 5: Run verification**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py \
+  -v
+
+bunx vitest run \
+  apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx
+
+git diff --check
+```
+
+- [ ] **Step 6: Bandit**
+
+```bash
+source .venv/bin/activate && python -m bandit \
+  -r tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py \
+     tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py \
+     tldw_Server_API/app/services/media_ingest_jobs_worker.py \
+  -f json -o /tmp/bandit_bulk_conference_recovery.json
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py \
+  tldw_Server_API/app/services/media_ingest_jobs_worker.py \
+  apps/packages/ui/src/services/tldw/ingest-job-results.ts \
+  apps/packages/ui/src/services/tldw/conference-collections.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py \
+  apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx
+git commit -m "feat: recover duplicate and failed playlist items"
+```
+
+## Task 9: Notifications, Full-Path QA, And Documentation
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx`
+- Modify/add: `apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts`
+- Modify/add: `tldw_Server_API/tests/frontend_e2e/test_quick_ingest_media_workflow.py`
+- Create: `Docs/User_Guides/Bulk_Conference_Playlist_Ingest.md`
+- Modify if needed: `Docs/API-related/Media_Ingest_Jobs_API.md`
+- Test fixtures as needed under existing frontend/backend test fixture directories.
+
+- [ ] **Step 1: Add mocked 34-item playlist fixture**
+
+Create a deterministic fixture with 34 metadata-only items, duplicates, and failure permutations. Do not depend on real YouTube or downloads in automated tests.
+
+- [ ] **Step 2: Write full-path WebUI test**
+
+Test:
+
+1. paste playlist URL
+2. preflight expands to 34 items
+3. deselect one item
+4. set conference metadata once
+5. submit mocked jobs
+6. receive mixed mocked events
+7. open collection
+8. see readiness counts
+
+- [ ] **Step 3: Write extension handoff test**
+
+Assert active-tab playlist context opens the same preflight state as WebUI paste.
+
+- [ ] **Step 4: Add completion notification**
+
+Use existing WebUI/extension notification/message patterns. Notification should include collection name and mixed success counts; it should not claim all searchable until readiness counts confirm it.
+
+- [ ] **Step 5: Write user documentation**
+
+Document:
+
+- playlist preflight
+- conference metadata
+- durable vs degraded mode
+- failure export/retry
+- collection review
+- scoped Knowledge QA readiness
+
+- [ ] **Step 6: Run full verification**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py \
+  tldw_Server_API/tests/Collections/test_conference_media_collections.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py \
+  tldw_Server_API/tests/RAG/test_conference_collection_scope.py \
+  -v
+
+bunx vitest run \
+  apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts \
+  apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx
+
+npx playwright test apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+
+git diff --check
+```
+
+- [ ] **Step 7: Final Bandit touched backend sweep**
+
+```bash
+source .venv/bin/activate && python -m bandit \
+  -r tldw_Server_API/app/api/v1/endpoints/media \
+     tldw_Server_API/app/core/Ingestion_Media_Processing/Video \
+     tldw_Server_API/app/services/media_ingest_jobs_worker.py \
+     tldw_Server_API/app/core/DB_Management/Collections_DB.py \
+  -f json -o /tmp/bandit_bulk_conference_final.json
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx \
+  apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts \
+  tldw_Server_API/tests/frontend_e2e/test_quick_ingest_media_workflow.py \
+  Docs/User_Guides/Bulk_Conference_Playlist_Ingest.md \
+  Docs/API-related/Media_Ingest_Jobs_API.md
+git commit -m "test: verify bulk conference ingest workflow"
+```
+
+## Cross-Stage Review Checklist
+
+- [ ] Preflight remains read-only: no jobs, no media rows, no collection mutation.
+- [ ] Server capabilities distinguish endpoint presence, worker availability, SSE, durable collection support, playlist preflight, and scoped QA.
+- [ ] Collection identity is stable and not tag-only.
+- [ ] Planned, processing, completed, skipped_existing, `submit_failed`, failed, and cancelled item states are represented.
+- [ ] Submit failures keep source URL, metadata, error, and export/retry path.
+- [ ] Retry is idempotent by collection item and retry attempt.
+- [ ] Synchronous fallback preserves metadata and clearly communicates weaker recovery.
+- [ ] Extension capture hands off to shared preflight and does not duplicate playlist parsing.
+- [ ] Scoped QA is backend-enforced and shows ready/not-ready counts.
+- [ ] One-off Quick Ingest remains unchanged.
+
+## Execution Notes
+
+- The writing-plans skill recommends an external plan-document-reviewer subagent. In this environment, subagents are only allowed when the user explicitly asks for delegation, so this plan should receive a local self-review or a user-requested delegated review before implementation.
+- Before implementation, update `TASK-399` or create follow-on Backlog tasks per stage so code edits are tracked according to the repo instructions.
+- If a stage exceeds the file scope above, split it before coding rather than broadening the PR.

--- a/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
@@ -757,7 +757,7 @@ git commit -m "feat: add conference metadata to quick ingest"
 - Test: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx`
 - Test: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
 
-- [ ] **Step 1: Write failing backend tests for planned item binding**
+- [x] **Step 1: Write failing backend tests for planned item binding**
 
 Test that job payload/status includes planned item ID:
 
@@ -780,7 +780,7 @@ def test_submit_jobs_preserves_collection_item_binding(client):
 
 Then fetch job and assert payload-derived `collection_id` and `planned_item_id` appear in status.
 
-- [ ] **Step 2: Run failing backend tests**
+- [x] **Step 2: Run failing backend tests**
 
 ```bash
 source .venv/bin/activate && python -m pytest \
@@ -789,7 +789,7 @@ source .venv/bin/activate && python -m pytest \
   -v
 ```
 
-- [ ] **Step 3: Extend job payload contract**
+- [x] **Step 3: Extend job payload contract**
 
 Accept optional collection/run form fields in `AddMediaForm` or endpoint-specific parsing, validate lengths match URL count, and write:
 
@@ -803,7 +803,7 @@ payload.update({
 
 Do not put secrets or cookies in the job payload.
 
-- [ ] **Step 4: Resolve item statuses in worker**
+- [x] **Step 4: Resolve item statuses in worker**
 
 On terminal result:
 
@@ -814,7 +814,7 @@ On terminal result:
 
 For job creation failures in the submit endpoint, mark planned item `submit_failed` with source URL/error.
 
-- [ ] **Step 5: Update frontend tracking**
+- [x] **Step 5: Update frontend tracking**
 
 Extend `PersistedQuickIngestTracking` with collection/run IDs and planned item mapping. Ensure refresh restore can show:
 
@@ -823,7 +823,7 @@ Extend `PersistedQuickIngestTracking` with collection/run IDs and planned item m
 - retry all retryable failures
 - export failed URLs
 
-- [ ] **Step 6: Run verification**
+- [x] **Step 6: Run verification**
 
 ```bash
 source .venv/bin/activate && python -m pytest \
@@ -839,7 +839,7 @@ bunx vitest run \
 git diff --check
 ```
 
-- [ ] **Step 7: Bandit**
+- [x] **Step 7: Bandit**
 
 ```bash
 source .venv/bin/activate && python -m bandit \
@@ -849,7 +849,7 @@ source .venv/bin/activate && python -m bandit \
   -f json -o /tmp/bandit_bulk_conference_jobs.json
 ```
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add \
@@ -868,6 +868,13 @@ git add \
   apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
 git commit -m "feat: track conference ingest runs through media jobs"
 ```
+
+Completion notes:
+
+- Implemented planned item binding through `/api/v1/media/ingest/jobs`, worker terminal status sync, synchronous fallback resolution, persisted Quick Ingest run tracking, and Processing Step durable tracking/export affordances.
+- Submit-time job creation failures now mark planned items `submit_failed`; terminal job results without a media id fail closed instead of leaving planned items stuck in `processing`.
+- `ingest-jobs-orchestrator.ts`, `ingest-job-results.ts`, and `FloatingProgressWidget.tsx` were left unchanged after review because the active direct-job path for this slice is handled by `quick-ingest-batch.ts`, the persisted session store, `ProcessingStep.tsx`, and the existing Results Panel retry/export controls.
+- Verification run: focused backend pytest `33 passed`, focused frontend Vitest `73 passed`, `git diff --check` passed, and Bandit reported zero findings for touched backend files.
 
 ## Task 5: Results And Collection Handoff
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -232,9 +232,14 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   onQuickProcess,
 }) => {
   const { t } = useTranslation(["option"])
-  const { state, setQueueItems, setConferenceBatchMetadata, goNext } =
-    useIngestWizard()
-  const { queueItems, conferenceBatchMetadata } = state
+  const {
+    state,
+    setQueueItems,
+    setPlaylistPreflightSeed,
+    setConferenceBatchMetadata,
+    goNext,
+  } = useIngestWizard()
+  const { queueItems, conferenceBatchMetadata, playlistPreflightSeed } = state
 
   const [urlInput, setUrlInput] = useState("")
   const [playlistPreflightUrl, setPlaylistPreflightUrl] = useState("")
@@ -242,6 +247,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   const [playlistPreflightLoading, setPlaylistPreflightLoading] = useState(false)
   const [playlistPreflightError, setPlaylistPreflightError] = useState<string | null>(null)
   const { capabilities } = useServerCapabilities()
+  const seededPlaylistUrlRef = React.useRef<string | null>(null)
 
   const qi = useCallback(
     (key: string, defaultValue: string, options?: Record<string, unknown>) =>
@@ -343,6 +349,35 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
       setPlaylistPreflightLoading(false)
     }
   }, [primaryPlaylistCandidateUrl])
+
+  React.useEffect(() => {
+    if (
+      !playlistPreflightSeed ||
+      playlistPreflightSeed.action !== "playlist_preflight" ||
+      typeof playlistPreflightSeed.url !== "string"
+    ) {
+      return
+    }
+
+    const seededUrl = playlistPreflightSeed.url.trim()
+    if (!seededUrl) return
+
+    seededPlaylistUrlRef.current = seededUrl
+    setUrlInput(seededUrl)
+    setPlaylistPreflight(null)
+    setPlaylistPreflightUrl("")
+    setPlaylistPreflightError(null)
+    setPlaylistPreflightSeed(null)
+  }, [playlistPreflightSeed, setPlaylistPreflightSeed])
+
+  React.useEffect(() => {
+    if (!seededPlaylistUrlRef.current) return
+    if (!shouldOfferPlaylistPreflight) return
+    if (primaryPlaylistCandidateUrl !== seededPlaylistUrlRef.current) return
+
+    seededPlaylistUrlRef.current = null
+    void handlePreviewPlaylist()
+  }, [handlePreviewPlaylist, primaryPlaylistCandidateUrl, shouldOfferPlaylistPreflight])
 
   const handleAddPreflightItems = useCallback(() => {
     if (!playlistPreflight) return

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -17,7 +17,10 @@ import type { DetectedMediaType, WizardQueueItem, QueueItemValidation } from "./
 import { useIngestWizard } from "./IngestWizardContext"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { Alert as DesignSystemAlert, Badge } from "@/components/ui/primitives"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import type { PlaylistPreflightResult } from "@/services/tldw/playlist-preflight"
 import { FileDropZone } from "./QueueTab/FileDropZone"
+import { PlaylistPreflightPanel } from "./PlaylistPreflightPanel"
 import {
   QUICK_INGEST_MAX_FILE_SIZE_LABEL,
   QUICK_INGEST_MAX_FILE_SIZE,
@@ -112,6 +115,20 @@ export const detectTypeFromUrl = (url: string): DetectedMediaType => {
     return "web"
   } catch {
     return "web"
+  }
+}
+
+export const detectPlaylistPreflightCandidate = (url: string): boolean => {
+  try {
+    const parsed = new URL(url)
+    const hostname = parsed.hostname.toLowerCase()
+    if (!hostnameMatches(hostname, "youtube.com") && !hostnameMatches(hostname, "youtu.be")) {
+      return false
+    }
+    const playlistId = parsed.searchParams.get("list")?.trim()
+    return Boolean(playlistId)
+  } catch {
+    return false
   }
 }
 
@@ -218,6 +235,11 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   const { queueItems } = state
 
   const [urlInput, setUrlInput] = useState("")
+  const [playlistPreflightUrl, setPlaylistPreflightUrl] = useState("")
+  const [playlistPreflight, setPlaylistPreflight] = useState<PlaylistPreflightResult | null>(null)
+  const [playlistPreflightLoading, setPlaylistPreflightLoading] = useState(false)
+  const [playlistPreflightError, setPlaylistPreflightError] = useState<string | null>(null)
+  const { capabilities } = useServerCapabilities()
 
   const qi = useCallback(
     (key: string, defaultValue: string, options?: Record<string, unknown>) =>
@@ -277,7 +299,105 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
 
     setQueueItems([...queueItems, ...newItems])
     setUrlInput("")
+    setPlaylistPreflight(null)
+    setPlaylistPreflightUrl("")
+    setPlaylistPreflightError(null)
   }, [urlInput, queueItems, setQueueItems])
+
+  const playlistCandidateUrls = useMemo(
+    () =>
+      urlInput
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .filter(detectPlaylistPreflightCandidate),
+    [urlInput]
+  )
+  const primaryPlaylistCandidateUrl = playlistCandidateUrls[0] || ""
+  const shouldOfferPlaylistPreflight =
+    Boolean(capabilities?.hasMediaPlaylistPreflight) && Boolean(primaryPlaylistCandidateUrl)
+
+  const handlePreviewPlaylist = useCallback(async () => {
+    if (!primaryPlaylistCandidateUrl) return
+    setPlaylistPreflightLoading(true)
+    setPlaylistPreflightError(null)
+    try {
+      const result = await tldwClient.preflightPlaylist({
+        url: primaryPlaylistCandidateUrl,
+        max_items: 100,
+        timeoutMs: 60_000
+      })
+      setPlaylistPreflight(result)
+      setPlaylistPreflightUrl(primaryPlaylistCandidateUrl)
+    } catch (error) {
+      setPlaylistPreflight(null)
+      setPlaylistPreflightUrl(primaryPlaylistCandidateUrl)
+      setPlaylistPreflightError(
+        error instanceof Error && error.message
+          ? error.message
+          : "Playlist preview failed."
+      )
+    } finally {
+      setPlaylistPreflightLoading(false)
+    }
+  }, [primaryPlaylistCandidateUrl])
+
+  const handleAddPreflightItems = useCallback(() => {
+    if (!playlistPreflight) return
+    const newItems: WizardQueueItem[] = []
+    const selectedItems = playlistPreflight.items.filter(
+      (item) => item.selected && item.sourceUrl
+    )
+    for (const preflightItem of selectedItems) {
+      const detectedType = detectTypeFromUrl(preflightItem.sourceUrl)
+      const item: WizardQueueItem = {
+        id: crypto.randomUUID(),
+        url: preflightItem.sourceUrl,
+        detectedType,
+        icon: ICON_NAME_MAP[detectedType],
+        fileSize: 0,
+        validation: { valid: true },
+        playlist: {
+          playlistId: playlistPreflight.playlistId,
+          playlistTitle: playlistPreflight.playlistTitle,
+          ordinal: preflightItem.ordinal,
+          normalizedSourceId: preflightItem.normalizedSourceId,
+          duplicateStatus: preflightItem.duplicateStatus
+        }
+      }
+      item.validation = validateQueueItem(item, [...queueItems, ...newItems])
+      newItems.push(item)
+    }
+    if (newItems.length === 0) return
+    setQueueItems([...queueItems, ...newItems])
+    setUrlInput((current) =>
+      current
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line && line !== playlistPreflightUrl)
+        .join("\n")
+    )
+    setPlaylistPreflight(null)
+    setPlaylistPreflightUrl("")
+    setPlaylistPreflightError(null)
+  }, [playlistPreflight, playlistPreflightUrl, queueItems, setQueueItems])
+
+  const handlePreflightItemSelectionChange = useCallback(
+    (ordinal: number, selected: boolean) => {
+      setPlaylistPreflight((current) => {
+        if (!current) return current
+        const items = current.items.map((item) =>
+          item.ordinal === ordinal ? { ...item, selected } : item
+        )
+        return {
+          ...current,
+          selectedCount: items.filter((item) => item.selected && item.sourceUrl).length,
+          items
+        }
+      })
+    },
+    []
+  )
 
   // Handle Enter key in URL input
   const handleUrlKeyDown = useCallback(
@@ -317,7 +437,6 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     [queueItems]
   )
 
-  const { capabilities } = useServerCapabilities()
   const ffmpegMissing = capabilities?.ffmpegAvailable === false
   const hasAvMediaItems = useMemo(
     () =>
@@ -392,6 +511,22 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
             </Button>
           </div>
         </div>
+
+        {shouldOfferPlaylistPreflight && (
+          <PlaylistPreflightPanel
+            candidateUrl={primaryPlaylistCandidateUrl}
+            loading={playlistPreflightLoading}
+            error={playlistPreflightError}
+            result={
+              playlistPreflightUrl === primaryPlaylistCandidateUrl
+                ? playlistPreflight
+                : null
+            }
+            onPreview={handlePreviewPlaylist}
+            onAddItems={handleAddPreflightItems}
+            onItemSelectionChange={handlePreflightItemSelectionChange}
+          />
+        )}
       </div>
 
       {/* FFmpeg missing warning for audio/video items */}

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -520,11 +520,15 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   }, [setQueueItems])
 
   const hasItems = queueItems.length > 0
-  const validItemCount = useMemo(
-    () => queueItems.filter((item) => item.validation.valid).length,
+  const selectedItems = useMemo(
+    () => queueItems.filter((item) => item.conferenceOverride?.selected !== false),
     [queueItems]
   )
-  const invalidItemCount = queueItems.length - validItemCount
+  const validItemCount = useMemo(
+    () => selectedItems.filter((item) => item.validation.valid).length,
+    [selectedItems]
+  )
+  const invalidItemCount = selectedItems.length - validItemCount
   const canProceed = validItemCount > 0
   const canStartProcessing = canProceed && isOnlineForIngest && !isCheckingConnection
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -21,6 +21,7 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 import type { PlaylistPreflightResult } from "@/services/tldw/playlist-preflight"
 import { FileDropZone } from "./QueueTab/FileDropZone"
 import { PlaylistPreflightPanel } from "./PlaylistPreflightPanel"
+import { BatchMetadataPanel } from "./BatchMetadataPanel"
 import {
   QUICK_INGEST_MAX_FILE_SIZE_LABEL,
   QUICK_INGEST_MAX_FILE_SIZE,
@@ -231,8 +232,9 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   onQuickProcess,
 }) => {
   const { t } = useTranslation(["option"])
-  const { state, setQueueItems, goNext } = useIngestWizard()
-  const { queueItems } = state
+  const { state, setQueueItems, setConferenceBatchMetadata, goNext } =
+    useIngestWizard()
+  const { queueItems, conferenceBatchMetadata } = state
 
   const [urlInput, setUrlInput] = useState("")
   const [playlistPreflightUrl, setPlaylistPreflightUrl] = useState("")
@@ -370,6 +372,18 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     }
     if (newItems.length === 0) return
     setQueueItems([...queueItems, ...newItems])
+    setConferenceBatchMetadata({
+      collectionName:
+        conferenceBatchMetadata?.collectionName ||
+        playlistPreflight.playlistTitle ||
+        "",
+      conferenceName: conferenceBatchMetadata?.conferenceName,
+      eventDate: conferenceBatchMetadata?.eventDate,
+      eventYear: conferenceBatchMetadata?.eventYear,
+      sharedTags: conferenceBatchMetadata?.sharedTags ?? [],
+      sourcePlaylistUrl:
+        conferenceBatchMetadata?.sourcePlaylistUrl || playlistPreflightUrl,
+    })
     setUrlInput((current) =>
       current
         .split("\n")
@@ -380,7 +394,14 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     setPlaylistPreflight(null)
     setPlaylistPreflightUrl("")
     setPlaylistPreflightError(null)
-  }, [playlistPreflight, playlistPreflightUrl, queueItems, setQueueItems])
+  }, [
+    conferenceBatchMetadata,
+    playlistPreflight,
+    playlistPreflightUrl,
+    queueItems,
+    setConferenceBatchMetadata,
+    setQueueItems,
+  ])
 
   const handlePreflightItemSelectionChange = useCallback(
     (ordinal: number, selected: boolean) => {
@@ -700,6 +721,8 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
           </div>
         </div>
       )}
+
+      {hasItems && <BatchMetadataPanel />}
 
       {/* Action buttons */}
       <div className="mt-4 flex items-center justify-end gap-2">

--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -13,7 +13,12 @@ import {
   X,
   Plus,
 } from "lucide-react"
-import type { DetectedMediaType, WizardQueueItem, QueueItemValidation } from "./types"
+import type {
+  ConferenceDuplicatePolicy,
+  DetectedMediaType,
+  WizardQueueItem,
+  QueueItemValidation,
+} from "./types"
 import { useIngestWizard } from "./IngestWizardContext"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { Alert as DesignSystemAlert, Badge } from "@/components/ui/primitives"
@@ -133,6 +138,9 @@ export const detectPlaylistPreflightCandidate = (url: string): boolean => {
   }
 }
 
+const isDuplicatePreflightStatus = (status: string | undefined): boolean =>
+  status === "duplicate_existing" || status === "duplicate_in_batch"
+
 const isValidUrl = (raw: string): boolean => {
   const trimmed = raw.trim()
   if (!trimmed) return false
@@ -244,6 +252,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   const [urlInput, setUrlInput] = useState("")
   const [playlistPreflightUrl, setPlaylistPreflightUrl] = useState("")
   const [playlistPreflight, setPlaylistPreflight] = useState<PlaylistPreflightResult | null>(null)
+  const [duplicatePolicy, setDuplicatePolicy] = useState<ConferenceDuplicatePolicy>("skip")
   const [playlistPreflightLoading, setPlaylistPreflightLoading] = useState(false)
   const [playlistPreflightError, setPlaylistPreflightError] = useState<string | null>(null)
   const { capabilities } = useServerCapabilities()
@@ -309,6 +318,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     setUrlInput("")
     setPlaylistPreflight(null)
     setPlaylistPreflightUrl("")
+    setDuplicatePolicy("skip")
     setPlaylistPreflightError(null)
   }, [urlInput, queueItems, setQueueItems])
 
@@ -337,6 +347,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
       })
       setPlaylistPreflight(result)
       setPlaylistPreflightUrl(primaryPlaylistCandidateUrl)
+      setDuplicatePolicy("skip")
     } catch (error) {
       setPlaylistPreflight(null)
       setPlaylistPreflightUrl(primaryPlaylistCandidateUrl)
@@ -366,6 +377,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     setUrlInput(seededUrl)
     setPlaylistPreflight(null)
     setPlaylistPreflightUrl("")
+    setDuplicatePolicy("skip")
     setPlaylistPreflightError(null)
     setPlaylistPreflightSeed(null)
   }, [playlistPreflightSeed, setPlaylistPreflightSeed])
@@ -400,6 +412,12 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
           ordinal: preflightItem.ordinal,
           normalizedSourceId: preflightItem.normalizedSourceId,
           duplicateStatus: preflightItem.duplicateStatus
+        },
+        conferenceOverride: {
+          selected: true,
+          ...(isDuplicatePreflightStatus(preflightItem.duplicateStatus)
+            ? { duplicatePolicy }
+            : {})
         }
       }
       item.validation = validateQueueItem(item, [...queueItems, ...newItems])
@@ -428,9 +446,11 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
     )
     setPlaylistPreflight(null)
     setPlaylistPreflightUrl("")
+    setDuplicatePolicy("skip")
     setPlaylistPreflightError(null)
   }, [
     conferenceBatchMetadata,
+    duplicatePolicy,
     playlistPreflight,
     playlistPreflightUrl,
     queueItems,
@@ -445,6 +465,26 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
         const items = current.items.map((item) =>
           item.ordinal === ordinal ? { ...item, selected } : item
         )
+        return {
+          ...current,
+          selectedCount: items.filter((item) => item.selected && item.sourceUrl).length,
+          items
+        }
+      })
+    },
+    []
+  )
+
+  const handleDuplicatePolicyChange = useCallback(
+    (policy: ConferenceDuplicatePolicy) => {
+      setDuplicatePolicy(policy)
+      setPlaylistPreflight((current) => {
+        if (!current) return current
+        const items = current.items.map((item) => {
+          if (!item.sourceUrl) return { ...item, selected: false }
+          if (!isDuplicatePreflightStatus(item.duplicateStatus)) return item
+          return { ...item, selected: policy !== "skip" }
+        })
         return {
           ...current,
           selectedCount: items.filter((item) => item.selected && item.sourceUrl).length,
@@ -581,6 +621,8 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
             onPreview={handlePreviewPlaylist}
             onAddItems={handleAddPreflightItems}
             onItemSelectionChange={handlePreflightItemSelectionChange}
+            duplicatePolicy={duplicatePolicy}
+            onDuplicatePolicyChange={handleDuplicatePolicyChange}
           />
         )}
       </div>

--- a/apps/packages/ui/src/components/Common/QuickIngest/BatchMetadataPanel.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/BatchMetadataPanel.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback, useMemo, useState } from "react"
+import { Input, Tag, Typography } from "antd"
+import type { ConferenceBatchMetadata } from "./types"
+import { useIngestWizard } from "./IngestWizardContext"
+import { ItemMetadataTable } from "./ItemMetadataTable"
+
+const parseTags = (value: string): string[] =>
+  value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+
+const inferCollectionName = (
+  current: ConferenceBatchMetadata | null,
+  playlistTitle?: string | null
+): string => current?.collectionName || playlistTitle || ""
+
+const isLikelyConferenceVideo = (itemUrl?: string): boolean => {
+  if (!itemUrl) return false
+  try {
+    const hostname = new URL(itemUrl).hostname.toLowerCase()
+    return hostname === "youtube.com" ||
+      hostname.endsWith(".youtube.com") ||
+      hostname === "youtu.be"
+  } catch {
+    return false
+  }
+}
+
+export const BatchMetadataPanel: React.FC = () => {
+  const { state, setConferenceBatchMetadata } = useIngestWizard()
+  const { queueItems, conferenceBatchMetadata } = state
+  const [sharedTagInput, setSharedTagInput] = useState(
+    () => conferenceBatchMetadata?.sharedTags.join(", ") ?? ""
+  )
+
+  const firstPlaylist = queueItems.find((item) => item.playlist?.playlistTitle)
+    ?.playlist
+  const selectedCount = useMemo(
+    () =>
+      queueItems.filter((item) => item.conferenceOverride?.selected !== false)
+        .length,
+    [queueItems]
+  )
+  const hasPlaylistItems = queueItems.some((item) => item.playlist)
+  const likelyConferenceVideoBatch =
+    queueItems.length > 1 &&
+    queueItems.every(
+      (item) =>
+        item.detectedType === "video" ||
+        Boolean(item.playlist) ||
+        isLikelyConferenceVideo(item.url)
+    )
+  const shouldShow = hasPlaylistItems || likelyConferenceVideoBatch
+
+  const metadata: ConferenceBatchMetadata = useMemo(
+    () => ({
+      collectionName: inferCollectionName(
+        conferenceBatchMetadata,
+        firstPlaylist?.playlistTitle
+      ),
+      conferenceName: conferenceBatchMetadata?.conferenceName ?? "",
+      eventDate: conferenceBatchMetadata?.eventDate ?? "",
+      eventYear: conferenceBatchMetadata?.eventYear ?? "",
+      sharedTags: conferenceBatchMetadata?.sharedTags ?? [],
+      sourcePlaylistUrl: conferenceBatchMetadata?.sourcePlaylistUrl ?? "",
+    }),
+    [conferenceBatchMetadata, firstPlaylist?.playlistTitle]
+  )
+
+  const updateMetadata = useCallback(
+    (patch: Partial<ConferenceBatchMetadata>) => {
+      setConferenceBatchMetadata({
+        ...metadata,
+        ...patch,
+        sharedTags: patch.sharedTags ?? metadata.sharedTags,
+      })
+    },
+    [metadata, setConferenceBatchMetadata]
+  )
+
+  if (!shouldShow) return null
+
+  return (
+    <section
+      className="mt-4 rounded-md border border-border bg-surface px-3 py-3"
+      aria-label="Conference batch metadata"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <Typography.Text className="block text-sm font-medium text-text">
+            Conference batch
+          </Typography.Text>
+          <Typography.Text className="block text-[11px] text-text-muted">
+            {selectedCount} selected
+          </Typography.Text>
+        </div>
+        {metadata.sharedTags.length > 0 && (
+          <div className="flex flex-wrap justify-end gap-1">
+            {metadata.sharedTags.map((tag) => (
+              <Tag key={tag} className="!mr-0">
+                {tag}
+              </Tag>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <label className="text-xs text-text-muted">
+          Collection name
+          <Input
+            className="mt-1"
+            aria-label="Collection name"
+            value={metadata.collectionName}
+            onChange={(event) =>
+              updateMetadata({ collectionName: event.target.value })
+            }
+          />
+        </label>
+        <label className="text-xs text-text-muted">
+          Conference name
+          <Input
+            className="mt-1"
+            aria-label="Conference name"
+            value={metadata.conferenceName}
+            onChange={(event) =>
+              updateMetadata({ conferenceName: event.target.value })
+            }
+          />
+        </label>
+        <label className="text-xs text-text-muted">
+          Event year
+          <Input
+            className="mt-1"
+            aria-label="Event year"
+            value={metadata.eventYear}
+            onChange={(event) => updateMetadata({ eventYear: event.target.value })}
+          />
+        </label>
+        <label className="text-xs text-text-muted">
+          Shared tags
+          <Input
+            className="mt-1"
+            aria-label="Shared tags"
+            value={sharedTagInput}
+            placeholder="conference, track"
+            onChange={(event) => {
+              setSharedTagInput(event.target.value)
+              updateMetadata({ sharedTags: parseTags(event.target.value) })
+            }}
+          />
+        </label>
+      </div>
+
+      <ItemMetadataTable />
+    </section>
+  )
+}
+
+export default BatchMetadataPanel

--- a/apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { AlertTriangle, Loader2, Check, ExternalLink, XCircle } from "lucide-react"
 import { useIngestWizard } from "./IngestWizardContext"
 import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
+import type { WizardResultItem } from "./types"
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -14,6 +15,71 @@ const AUTO_DISMISS_DELAY_MS = 10_000
 
 type WidgetTerminalState = "complete" | "failed" | "cancelled" | "interrupted"
 
+type CompletionSummaryInput = {
+  collectionName?: string | null
+  completedCount: number
+  totalCount: number
+  results: WizardResultItem[]
+}
+
+const plural = (count: number, singular: string, pluralLabel: string): string =>
+  `${count} ${count === 1 ? singular : pluralLabel}`
+
+export const buildFloatingProgressCompletionSummary = ({
+  collectionName,
+  completedCount,
+  totalCount,
+  results,
+}: CompletionSummaryInput): {
+  title: string
+  detail: string | null
+  readinessHint: string | null
+} => {
+  const title = collectionName?.trim() || ""
+  if (results.length === 0) {
+    return {
+      title,
+      detail:
+        totalCount > 0
+          ? `${completedCount}/${totalCount} finished`
+          : null,
+      readinessHint: null,
+    }
+  }
+
+  let succeeded = 0
+  let skipped = 0
+  let failed = 0
+  let cancelled = 0
+  for (const item of results) {
+    if (item.outcome === "cancelled") {
+      cancelled += 1
+    } else if (item.outcome === "skipped") {
+      skipped += 1
+    } else if (item.status === "error" || item.outcome === "failed" || item.outcome === "submit_failed") {
+      failed += 1
+    } else {
+      succeeded += 1
+    }
+  }
+
+  const parts = [
+    succeeded > 0 ? plural(succeeded, "succeeded", "succeeded") : null,
+    skipped > 0 ? plural(skipped, "skipped", "skipped") : null,
+    failed > 0 ? plural(failed, "failed", "failed") : null,
+    cancelled > 0 ? plural(cancelled, "cancelled", "cancelled") : null,
+  ].filter((part): part is string => Boolean(part))
+
+  return {
+    title,
+    detail: parts.length > 0 ? parts.join(", ") : null,
+    readinessHint:
+      collectionName && results.length > 1
+        ? "Open the wizard for collection readiness and retry options."
+        : null,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -21,7 +87,7 @@ type WidgetTerminalState = "complete" | "failed" | "cancelled" | "interrupted"
 export const FloatingProgressWidget: React.FC = () => {
   const { t } = useTranslation(["option"])
   const { state, restore } = useIngestWizard()
-  const { processingState, isMinimized } = state
+  const { processingState, isMinimized, results, conferenceBatchMetadata } = state
   const { sessionVisibility, sessionLifecycle, showSession } = useQuickIngestSessionStore((store) => ({
     sessionLifecycle: store.session?.lifecycle,
     sessionVisibility: store.session?.visibility,
@@ -106,6 +172,18 @@ export const FloatingProgressWidget: React.FC = () => {
     sessionLifecycle,
   ])
 
+  const allDone = terminalState !== null
+  const completionSummary = useMemo(
+    () =>
+      buildFloatingProgressCompletionSummary({
+        collectionName: conferenceBatchMetadata?.collectionName,
+        completedCount,
+        totalCount,
+        results,
+      }),
+    [completedCount, conferenceBatchMetadata?.collectionName, results, totalCount]
+  )
+
   // Auto-dismiss after completion
   useEffect(() => {
     if (!isMinimized) {
@@ -187,7 +265,7 @@ export const FloatingProgressWidget: React.FC = () => {
             {terminalPresentation ? (
               <>
                 {terminalPresentation.icon}
-                <span>{terminalPresentation.label}</span>
+                <span>{completionSummary.title || terminalPresentation.label}</span>
               </>
             ) : (
               <>
@@ -213,6 +291,14 @@ export const FloatingProgressWidget: React.FC = () => {
               "widget.processingHint",
               "Processing and indexing content..."
             )}
+          </p>
+        )}
+
+        {allDone && (completionSummary.detail || completionSummary.readinessHint) && (
+          <p className="text-[11px] leading-tight text-text-muted">
+            {completionSummary.detail}
+            {completionSummary.detail && completionSummary.readinessHint ? " " : ""}
+            {completionSummary.readinessHint}
           </p>
         )}
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
@@ -22,6 +22,7 @@ import {
   mergePresetConfig,
   configMatchesPreset,
 } from "./presets"
+import type { QuickIngestOpenDetail } from "@/utils/quick-ingest-open"
 
 // ---------------------------------------------------------------------------
 // State shape
@@ -36,6 +37,7 @@ export type IngestWizardState = {
   customBasePreset: Exclude<IngestPreset, "custom">
   presetConfig: PresetConfig
   customOptions: Partial<PresetConfig>
+  playlistPreflightSeed: QuickIngestOpenDetail | null
   conferenceBatchMetadata: ConferenceBatchMetadata | null
   processingState: WizardProcessingState
   results: WizardResultItem[]
@@ -53,6 +55,7 @@ type Action =
   | { type: "SET_QUEUE_ITEMS"; items: WizardQueueItem[] }
   | { type: "SET_PRESET"; preset: IngestPreset }
   | { type: "SET_CUSTOM_OPTIONS"; options: Partial<PresetConfig> }
+  | { type: "SET_PLAYLIST_PREFLIGHT_SEED"; seed: QuickIngestOpenDetail | null }
   | { type: "SET_CONFERENCE_BATCH_METADATA"; metadata: ConferenceBatchMetadata | null }
   | { type: "START_PROCESSING" }
   | { type: "CANCEL_PROCESSING" }
@@ -162,6 +165,7 @@ const createInitialState = (): IngestWizardState => ({
   customBasePreset: DEFAULT_PRESET,
   presetConfig: DEFAULT_PRESETS[DEFAULT_PRESET],
   customOptions: {},
+  playlistPreflightSeed: null,
   conferenceBatchMetadata: null,
   processingState: { ...INITIAL_PROCESSING_STATE },
   results: [],
@@ -182,6 +186,8 @@ const createInitialStateFromSeed = (
     customBasePreset: seed.customBasePreset ?? base.customBasePreset,
     presetConfig: seed.presetConfig ?? base.presetConfig,
     customOptions: seed.customOptions ?? base.customOptions,
+    playlistPreflightSeed:
+      seed.playlistPreflightSeed ?? base.playlistPreflightSeed,
     conferenceBatchMetadata:
       seed.conferenceBatchMetadata ?? base.conferenceBatchMetadata,
     processingState: seed.processingState
@@ -281,6 +287,9 @@ const reducer = (state: IngestWizardState, action: Action): IngestWizardState =>
 
     case "SET_CONFERENCE_BATCH_METADATA":
       return { ...state, conferenceBatchMetadata: action.metadata }
+
+    case "SET_PLAYLIST_PREFLIGHT_SEED":
+      return { ...state, playlistPreflightSeed: action.seed }
 
     case "START_PROCESSING": {
       const perItemProgress = buildInitialProgress(state.queueItems)
@@ -394,6 +403,7 @@ type IngestWizardContextValue = {
   // Presets & options
   setPreset: (preset: IngestPreset) => void
   setCustomOptions: (options: Partial<PresetConfig>) => void
+  setPlaylistPreflightSeed: (seed: QuickIngestOpenDetail | null) => void
   setConferenceBatchMetadata: (metadata: ConferenceBatchMetadata | null) => void
   // Processing
   startProcessing: () => void
@@ -460,6 +470,11 @@ export const IngestWizardProvider: React.FC<IngestWizardProviderProps> = ({
       dispatch({ type: "SET_CUSTOM_OPTIONS", options }),
     []
   )
+  const setPlaylistPreflightSeed = useCallback(
+    (seed: QuickIngestOpenDetail | null) =>
+      dispatch({ type: "SET_PLAYLIST_PREFLIGHT_SEED", seed }),
+    []
+  )
   const setConferenceBatchMetadata = useCallback(
     (metadata: ConferenceBatchMetadata | null) =>
       dispatch({ type: "SET_CONFERENCE_BATCH_METADATA", metadata }),
@@ -508,6 +523,7 @@ export const IngestWizardProvider: React.FC<IngestWizardProviderProps> = ({
       setQueueItems,
       setPreset,
       setCustomOptions,
+      setPlaylistPreflightSeed,
       setConferenceBatchMetadata,
       startProcessing,
       skipToProcessing,
@@ -528,6 +544,7 @@ export const IngestWizardProvider: React.FC<IngestWizardProviderProps> = ({
       setQueueItems,
       setPreset,
       setCustomOptions,
+      setPlaylistPreflightSeed,
       setConferenceBatchMetadata,
       startProcessing,
       skipToProcessing,

--- a/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
@@ -14,6 +14,7 @@ import type {
   WizardProcessingState,
   WizardResultItem,
   ItemProgress,
+  ConferenceBatchMetadata,
 } from "./types"
 import {
   DEFAULT_PRESETS,
@@ -35,6 +36,7 @@ export type IngestWizardState = {
   customBasePreset: Exclude<IngestPreset, "custom">
   presetConfig: PresetConfig
   customOptions: Partial<PresetConfig>
+  conferenceBatchMetadata: ConferenceBatchMetadata | null
   processingState: WizardProcessingState
   results: WizardResultItem[]
   isMinimized: boolean
@@ -51,6 +53,7 @@ type Action =
   | { type: "SET_QUEUE_ITEMS"; items: WizardQueueItem[] }
   | { type: "SET_PRESET"; preset: IngestPreset }
   | { type: "SET_CUSTOM_OPTIONS"; options: Partial<PresetConfig> }
+  | { type: "SET_CONFERENCE_BATCH_METADATA"; metadata: ConferenceBatchMetadata | null }
   | { type: "START_PROCESSING" }
   | { type: "CANCEL_PROCESSING" }
   | { type: "CANCEL_ITEM"; id: string }
@@ -121,7 +124,10 @@ const mergeCustomOptions = (
 
 const buildInitialProgress = (items: WizardQueueItem[]): ItemProgress[] =>
   items
-    .filter((item) => item.validation.valid)
+    .filter(
+      (item) =>
+        item.validation.valid && item.conferenceOverride?.selected !== false
+    )
     .map((item) => ({
       id: item.id,
       status: "queued" as const,
@@ -156,6 +162,7 @@ const createInitialState = (): IngestWizardState => ({
   customBasePreset: DEFAULT_PRESET,
   presetConfig: DEFAULT_PRESETS[DEFAULT_PRESET],
   customOptions: {},
+  conferenceBatchMetadata: null,
   processingState: { ...INITIAL_PROCESSING_STATE },
   results: [],
   isMinimized: false,
@@ -175,6 +182,8 @@ const createInitialStateFromSeed = (
     customBasePreset: seed.customBasePreset ?? base.customBasePreset,
     presetConfig: seed.presetConfig ?? base.presetConfig,
     customOptions: seed.customOptions ?? base.customOptions,
+    conferenceBatchMetadata:
+      seed.conferenceBatchMetadata ?? base.conferenceBatchMetadata,
     processingState: seed.processingState
       ? {
           ...INITIAL_PROCESSING_STATE,
@@ -269,6 +278,9 @@ const reducer = (state: IngestWizardState, action: Action): IngestWizardState =>
         presetConfig,
       }
     }
+
+    case "SET_CONFERENCE_BATCH_METADATA":
+      return { ...state, conferenceBatchMetadata: action.metadata }
 
     case "START_PROCESSING": {
       const perItemProgress = buildInitialProgress(state.queueItems)
@@ -382,6 +394,7 @@ type IngestWizardContextValue = {
   // Presets & options
   setPreset: (preset: IngestPreset) => void
   setCustomOptions: (options: Partial<PresetConfig>) => void
+  setConferenceBatchMetadata: (metadata: ConferenceBatchMetadata | null) => void
   // Processing
   startProcessing: () => void
   skipToProcessing: () => void
@@ -447,6 +460,11 @@ export const IngestWizardProvider: React.FC<IngestWizardProviderProps> = ({
       dispatch({ type: "SET_CUSTOM_OPTIONS", options }),
     []
   )
+  const setConferenceBatchMetadata = useCallback(
+    (metadata: ConferenceBatchMetadata | null) =>
+      dispatch({ type: "SET_CONFERENCE_BATCH_METADATA", metadata }),
+    []
+  )
   const startProcessing = useCallback(
     () => dispatch({ type: "START_PROCESSING" }),
     []
@@ -490,6 +508,7 @@ export const IngestWizardProvider: React.FC<IngestWizardProviderProps> = ({
       setQueueItems,
       setPreset,
       setCustomOptions,
+      setConferenceBatchMetadata,
       startProcessing,
       skipToProcessing,
       cancelProcessing,
@@ -509,6 +528,7 @@ export const IngestWizardProvider: React.FC<IngestWizardProviderProps> = ({
       setQueueItems,
       setPreset,
       setCustomOptions,
+      setConferenceBatchMetadata,
       startProcessing,
       skipToProcessing,
       cancelProcessing,

--- a/apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx
@@ -1,0 +1,131 @@
+import React, { useCallback } from "react"
+import { Input, Typography } from "antd"
+import type {
+  ConferenceItemMetadataOverride,
+  WizardQueueItem,
+} from "./types"
+import { useIngestWizard } from "./IngestWizardContext"
+
+const parseTags = (value: string): string[] =>
+  value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+
+const stringifyTags = (tags?: string[]): string => (tags || []).join(", ")
+
+const getItemDisplay = (item: WizardQueueItem, index: number): string =>
+  item.conferenceOverride?.title ||
+  item.fileName ||
+  item.url ||
+  `Item ${index + 1}`
+
+export const ItemMetadataTable: React.FC = () => {
+  const { state, setQueueItems } = useIngestWizard()
+  const { queueItems } = state
+
+  const updateOverride = useCallback(
+    (
+      itemId: string,
+      patch: Partial<ConferenceItemMetadataOverride>
+    ) => {
+      setQueueItems(
+        queueItems.map((item) =>
+          item.id === itemId
+            ? {
+                ...item,
+                conferenceOverride: {
+                  selected: item.conferenceOverride?.selected ?? true,
+                  ...(item.conferenceOverride || {}),
+                  ...patch,
+                },
+              }
+            : item
+        )
+      )
+    },
+    [queueItems, setQueueItems]
+  )
+
+  if (queueItems.length === 0) return null
+
+  return (
+    <div className="mt-3 rounded-md border border-border">
+      <div className="grid grid-cols-[48px_minmax(160px,1.4fr)_minmax(120px,1fr)_minmax(100px,0.8fr)_minmax(120px,1fr)] gap-2 border-b border-border bg-surface2 px-2 py-1.5 text-[11px] font-medium uppercase text-text-muted">
+        <span>Use</span>
+        <span>Title</span>
+        <span>Speaker</span>
+        <span>Track</span>
+        <span>Tags</span>
+      </div>
+      <div className="max-h-72 overflow-y-auto">
+        {queueItems.map((item, index) => {
+          const override = item.conferenceOverride
+          const selected = override?.selected ?? true
+          const itemNumber = index + 1
+
+          return (
+            <div
+              key={item.id}
+              className="grid grid-cols-[48px_minmax(160px,1.4fr)_minmax(120px,1fr)_minmax(100px,0.8fr)_minmax(120px,1fr)] gap-2 border-b border-border px-2 py-2 last:border-b-0"
+            >
+              <label className="flex items-center">
+                <input
+                  type="checkbox"
+                  checked={selected}
+                  aria-label={`Include item ${itemNumber}`}
+                  onChange={(event) =>
+                    updateOverride(item.id, { selected: event.target.checked })
+                  }
+                />
+              </label>
+              <div className="min-w-0">
+                <Input
+                  size="small"
+                  aria-label={`Title override for item ${itemNumber}`}
+                  value={override?.title ?? ""}
+                  placeholder={getItemDisplay(item, index)}
+                  onChange={(event) =>
+                    updateOverride(item.id, {
+                      title: event.target.value,
+                    })
+                  }
+                />
+                <Typography.Text className="mt-0.5 block truncate text-[10px] text-text-muted">
+                  {item.url || item.fileName || item.id}
+                </Typography.Text>
+              </div>
+              <Input
+                size="small"
+                aria-label={`Speaker for item ${itemNumber}`}
+                value={override?.speaker ?? ""}
+                onChange={(event) =>
+                  updateOverride(item.id, { speaker: event.target.value })
+                }
+              />
+              <Input
+                size="small"
+                aria-label={`Track for item ${itemNumber}`}
+                value={override?.track ?? ""}
+                onChange={(event) =>
+                  updateOverride(item.id, { track: event.target.value })
+                }
+              />
+              <Input
+                size="small"
+                aria-label={`Tags for item ${itemNumber}`}
+                value={stringifyTags(override?.tags)}
+                placeholder="tag, tag"
+                onChange={(event) =>
+                  updateOverride(item.id, { tags: parseTags(event.target.value) })
+                }
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default ItemMetadataTable

--- a/apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import { Input, Typography } from "antd"
 import type {
   ConferenceItemMetadataOverride,
@@ -23,6 +23,7 @@ const getItemDisplay = (item: WizardQueueItem, index: number): string =>
 export const ItemMetadataTable: React.FC = () => {
   const { state, setQueueItems } = useIngestWizard()
   const { queueItems } = state
+  const [tagDrafts, setTagDrafts] = useState<Record<string, string>>({})
 
   const updateOverride = useCallback(
     (
@@ -46,6 +47,29 @@ export const ItemMetadataTable: React.FC = () => {
     },
     [queueItems, setQueueItems]
   )
+
+  const commitTags = useCallback(
+    (itemId: string, rawValue: string) => {
+      updateOverride(itemId, { tags: parseTags(rawValue) })
+      setTagDrafts((prev) => {
+        if (!(itemId in prev)) return prev
+        const next = { ...prev }
+        delete next[itemId]
+        return next
+      })
+    },
+    [updateOverride]
+  )
+
+  useEffect(() => {
+    setTagDrafts((prev) => {
+      const itemIds = new Set(queueItems.map((item) => item.id))
+      const next = Object.fromEntries(
+        Object.entries(prev).filter(([itemId]) => itemIds.has(itemId))
+      )
+      return Object.keys(next).length === Object.keys(prev).length ? prev : next
+    })
+  }, [queueItems])
 
   if (queueItems.length === 0) return null
 
@@ -114,11 +138,20 @@ export const ItemMetadataTable: React.FC = () => {
               <Input
                 size="small"
                 aria-label={`Tags for item ${itemNumber}`}
-                value={stringifyTags(override?.tags)}
+                value={tagDrafts[item.id] ?? stringifyTags(override?.tags)}
                 placeholder="tag, tag"
                 onChange={(event) =>
-                  updateOverride(item.id, { tags: parseTags(event.target.value) })
+                  setTagDrafts((prev) => ({
+                    ...prev,
+                    [item.id]: event.target.value,
+                  }))
                 }
+                onBlur={(event) => commitTags(item.id, event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.currentTarget.blur()
+                  }
+                }}
               />
             </div>
           )

--- a/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
@@ -1,0 +1,121 @@
+import React from "react"
+import { Alert, Button, Checkbox, List, Tag, Typography } from "antd"
+import { ListVideo, Plus, RefreshCw } from "lucide-react"
+import type { PlaylistPreflightResult } from "@/services/tldw/playlist-preflight"
+
+type PlaylistPreflightPanelProps = {
+  candidateUrl: string
+  loading?: boolean
+  error?: string | null
+  result?: PlaylistPreflightResult | null
+  onPreview: () => void
+  onAddItems: () => void
+  onItemSelectionChange?: (ordinal: number, selected: boolean) => void
+}
+
+export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
+  candidateUrl,
+  loading = false,
+  error = null,
+  result = null,
+  onPreview,
+  onAddItems,
+  onItemSelectionChange
+}) => {
+  const selectedCount =
+    result?.items.filter((item) => item.selected && item.sourceUrl).length ?? 0
+  const duplicateCount =
+    result?.duplicateCount ??
+    result?.items.filter((item) => item.duplicateStatus !== "new").length ??
+    0
+
+  return (
+    <div className="rounded-md border border-border bg-surface px-3 py-2">
+      <div className="flex items-start gap-2">
+        <ListVideo className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <Typography.Text className="block text-sm font-medium">
+            {result?.playlistTitle || "Playlist detected"}
+          </Typography.Text>
+          <Typography.Text className="block truncate text-[11px] text-text-muted">
+            {candidateUrl}
+          </Typography.Text>
+        </div>
+        <Button
+          size="small"
+          type={result ? "default" : "primary"}
+          loading={loading}
+          onClick={onPreview}
+          icon={<RefreshCw className="h-3.5 w-3.5" />}
+        >
+          {result ? "Refresh" : "Preview"}
+        </Button>
+      </div>
+
+      {error && (
+        <Alert
+          className="mt-2"
+          type="warning"
+          showIcon
+          message={error}
+        />
+      )}
+
+      {result && (
+        <div className="mt-2">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Tag color="blue">{result.itemCount} items</Tag>
+            <Tag color="green">{selectedCount} selected</Tag>
+            {duplicateCount > 0 && <Tag color="warning">{duplicateCount} duplicates</Tag>}
+          </div>
+
+          <List
+            className="mt-2 max-h-36 overflow-y-auto rounded border border-border"
+            size="small"
+            dataSource={result.items}
+            renderItem={(item) => (
+              <List.Item className="!px-2 !py-1">
+                <Checkbox
+                  className="mr-2"
+                  checked={item.selected}
+                  disabled={!item.sourceUrl}
+                  aria-label={`Select ${item.title}`}
+                  onChange={(event) =>
+                    onItemSelectionChange?.(item.ordinal, event.target.checked)
+                  }
+                />
+                <div className="min-w-0 flex-1">
+                  <Typography.Text className="block truncate text-xs">
+                    {item.ordinal}. {item.title}
+                  </Typography.Text>
+                  <Typography.Text className="block truncate text-[11px] text-text-muted">
+                    {item.sourceUrl}
+                  </Typography.Text>
+                </div>
+                {item.duplicateStatus !== "new" && (
+                  <Tag color="warning" className="!mr-0">
+                    duplicate
+                  </Tag>
+                )}
+              </List.Item>
+            )}
+          />
+
+          <div className="mt-2 flex justify-end">
+            <Button
+              size="small"
+              type="primary"
+              onClick={onAddItems}
+              disabled={selectedCount === 0}
+              icon={<Plus className="h-3.5 w-3.5" />}
+            >
+              Add {selectedCount}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PlaylistPreflightPanel

--- a/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
@@ -1,16 +1,22 @@
 import React from "react"
-import { Alert, Button, Checkbox, List, Tag, Typography } from "antd"
+import { Alert, Button, Checkbox, List, Radio, Tag, Typography } from "antd"
 import { ListVideo, Plus, RefreshCw } from "lucide-react"
 import type { PlaylistPreflightResult } from "@/services/tldw/playlist-preflight"
+import type { ConferenceDuplicatePolicy } from "./types"
+
+const isDuplicatePreflightStatus = (status: string | undefined): boolean =>
+  status === "duplicate_existing" || status === "duplicate_in_batch"
 
 type PlaylistPreflightPanelProps = {
   candidateUrl: string
   loading?: boolean
   error?: string | null
   result?: PlaylistPreflightResult | null
+  duplicatePolicy?: ConferenceDuplicatePolicy
   onPreview: () => void
   onAddItems: () => void
   onItemSelectionChange?: (ordinal: number, selected: boolean) => void
+  onDuplicatePolicyChange?: (policy: ConferenceDuplicatePolicy) => void
 }
 
 export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
@@ -18,15 +24,17 @@ export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
   loading = false,
   error = null,
   result = null,
+  duplicatePolicy = "skip",
   onPreview,
   onAddItems,
-  onItemSelectionChange
+  onItemSelectionChange,
+  onDuplicatePolicyChange
 }) => {
   const selectedCount =
     result?.items.filter((item) => item.selected && item.sourceUrl).length ?? 0
   const duplicateCount =
     result?.duplicateCount ??
-    result?.items.filter((item) => item.duplicateStatus !== "new").length ??
+    result?.items.filter((item) => isDuplicatePreflightStatus(item.duplicateStatus)).length ??
     0
 
   return (
@@ -69,6 +77,28 @@ export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
             {duplicateCount > 0 && <Tag color="warning">{duplicateCount} duplicates</Tag>}
           </div>
 
+          {duplicateCount > 0 && (
+            <div className="mt-2 rounded border border-amber-500/20 bg-amber-500/5 px-2 py-1.5">
+              <Typography.Text className="block text-[11px] font-medium text-text-muted">
+                Duplicate policy
+              </Typography.Text>
+              <Radio.Group
+                className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs"
+                value={duplicatePolicy}
+                onChange={(event) =>
+                  onDuplicatePolicyChange?.(
+                    event.target.value as ConferenceDuplicatePolicy
+                  )
+                }
+              >
+                <Radio value="skip">Skip duplicates</Radio>
+                <Radio value="overwrite">Overwrite</Radio>
+                <Radio value="update_metadata_only">Update metadata only</Radio>
+                <Radio value="include_existing">Include existing</Radio>
+              </Radio.Group>
+            </div>
+          )}
+
           <List
             className="mt-2 max-h-36 overflow-y-auto rounded border border-border"
             size="small"
@@ -92,7 +122,7 @@ export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
                     {item.sourceUrl}
                   </Typography.Text>
                 </div>
-                {item.duplicateStatus !== "new" && (
+                {isDuplicatePreflightStatus(item.duplicateStatus) && (
                   <Tag color="warning" className="!mr-0">
                     duplicate
                   </Tag>

--- a/apps/packages/ui/src/components/Common/QuickIngest/ProcessingStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ProcessingStep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Check,
@@ -18,6 +18,7 @@ import {
 } from "lucide-react"
 import type { ItemProgress, ItemProgressStatus, WizardQueueItem } from "./types"
 import { useIngestWizard } from "./IngestWizardContext"
+import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -51,6 +52,14 @@ const TERMINAL_STATUSES = new Set<ItemProgressStatus>([
   "failed",
   "cancelled",
 ])
+
+type FailedProcessingItem = {
+  id: string
+  label: string
+  sourceUrl?: string
+  fileName?: string
+  error?: string
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -344,6 +353,8 @@ export const ProcessingStep: React.FC = () => {
   const { t } = useTranslation(["option"])
   const { state, cancelProcessing, cancelItem, minimize } = useIngestWizard()
   const { processingState, queueItems } = state
+  const tracking = useQuickIngestSessionStore((store) => store.session?.tracking)
+  const [failedExportNotice, setFailedExportNotice] = useState<string | null>(null)
 
   const qi = useCallback(
     (key: string, defaultValue: string, options?: Record<string, unknown>) =>
@@ -361,6 +372,83 @@ export const ProcessingStep: React.FC = () => {
     }
     return map
   }, [queueItems])
+
+  const trackingSummary = useMemo(() => {
+    if (!tracking) return null
+
+    const plannedCount = tracking.plannedItemIds?.length ?? 0
+    const jobCount = tracking.jobIds?.length ?? 0
+    const batchCount = tracking.batchIds?.length ?? (tracking.batchId ? 1 : 0)
+    const hasAnyTracking =
+      Boolean(tracking.collectionId) ||
+      plannedCount > 0 ||
+      jobCount > 0 ||
+      batchCount > 0 ||
+      Boolean(tracking.sessionId)
+
+    if (!hasAnyTracking) return null
+
+    const modeLabel =
+      tracking.durableMode === "durable_collection"
+        ? qi("processing.tracking.durable", "Durable collection tracking")
+        : tracking.durableMode === "degraded"
+          ? qi("processing.tracking.degraded", "Local run tracking")
+          : qi("processing.tracking.job", "Job tracking")
+
+    const details: string[] = []
+    if (tracking.collectionId) {
+      details.push(
+        qi("processing.tracking.collection", "Collection {{id}}", {
+          id: tracking.collectionId,
+        })
+      )
+    }
+    if (plannedCount > 0) {
+      details.push(
+        plannedCount === 1
+          ? qi("processing.tracking.plannedOne", "1 planned item")
+          : qi("processing.tracking.plannedMany", "{{count}} planned items", {
+              count: plannedCount,
+            })
+      )
+    }
+    if (jobCount > 0) {
+      details.push(
+        jobCount === 1
+          ? qi("processing.tracking.jobOne", "1 job")
+          : qi("processing.tracking.jobMany", "{{count}} jobs", {
+              count: jobCount,
+            })
+      )
+    } else if (batchCount > 0) {
+      details.push(
+        batchCount === 1
+          ? qi("processing.tracking.batchOne", "1 batch")
+          : qi("processing.tracking.batchMany", "{{count}} batches", {
+              count: batchCount,
+            })
+      )
+    }
+
+    return { modeLabel, details }
+  }, [qi, tracking])
+
+  const failedItems = useMemo<FailedProcessingItem[]>(() => {
+    return processingState.perItemProgress
+      .filter((progress) => progress.status === "failed")
+      .map((progress) => {
+        const queueItem = queueItemMap.get(progress.id)
+        const sourceUrl = queueItem?.url
+        const fileName = queueItem?.fileName
+        return {
+          id: progress.id,
+          label: sourceUrl || fileName || queueItem?.id || progress.id,
+          sourceUrl,
+          fileName,
+          error: progress.error,
+        }
+      })
+  }, [processingState.perItemProgress, queueItemMap])
 
   // Compute summary counts
   const counts = useMemo(() => {
@@ -409,6 +497,60 @@ export const ProcessingStep: React.FC = () => {
     [cancelItem]
   )
 
+  const handleExportFailedItems = useCallback(async () => {
+    if (failedItems.length === 0) {
+      setFailedExportNotice(
+        qi("processing.failedExportEmpty", "No failed items to export.")
+      )
+      return
+    }
+
+    const text = failedItems
+      .map((item, index) => {
+        const lines = [`#${index + 1}`]
+        if (item.sourceUrl) {
+          lines.push(`URL: ${item.sourceUrl}`)
+        } else if (item.fileName) {
+          lines.push(`File: ${item.fileName}`)
+        } else {
+          lines.push(`Item: ${item.label}`)
+        }
+        lines.push(`ID: ${item.id}`)
+        if (item.error) {
+          lines.push(`Error: ${item.error}`)
+        }
+        return lines.join("\n")
+      })
+      .join("\n\n")
+
+    try {
+      if (
+        typeof navigator === "undefined" ||
+        typeof navigator.clipboard?.writeText !== "function"
+      ) {
+        throw new Error("Clipboard unavailable")
+      }
+      await navigator.clipboard.writeText(text)
+      setFailedExportNotice(
+        qi("processing.failedExportCopied", "Failed list copied.")
+      )
+      return
+    } catch {
+      if (typeof document !== "undefined" && typeof URL !== "undefined") {
+        const blob = new Blob([text], { type: "text/plain" })
+        const url = URL.createObjectURL(blob)
+        const anchor = document.createElement("a")
+        anchor.href = url
+        anchor.download = "quick-ingest-failed-items.txt"
+        anchor.click()
+        URL.revokeObjectURL(url)
+        setFailedExportNotice(
+          qi("processing.failedExportDownloaded", "Failed list downloaded.")
+        )
+      }
+    }
+  }, [failedItems, qi])
+
   return (
     <div className="flex flex-col gap-4 p-4">
       {/* Header */}
@@ -437,6 +579,30 @@ export const ProcessingStep: React.FC = () => {
           style={{ width: `${overallPercent}%` }}
         />
       </div>
+
+      {/* Durable run tracking */}
+      {trackingSummary && (
+        <div
+          className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-surface2 px-3 py-2 text-xs text-text-muted"
+          data-testid="quick-ingest-run-tracking"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="font-medium text-text">{trackingSummary.modeLabel}</span>
+          {trackingSummary.details.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              {trackingSummary.details.map((detail) => (
+                <span
+                  key={detail}
+                  className="rounded border border-border bg-surface px-2 py-0.5"
+                >
+                  {detail}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Descriptive processing banner */}
       {processingState.status === "running" && counts.processing > 0 && (
@@ -544,6 +710,36 @@ export const ProcessingStep: React.FC = () => {
           )}
         </div>
       </div>
+
+      {failedItems.length > 0 && (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-danger/20 bg-danger/5 px-3 py-2 text-xs">
+          <div className="min-w-0 text-danger">
+            <span className="font-medium">
+              {failedItems.length === 1
+                ? qi("processing.failedItemsOne", "1 failed item")
+                : qi("processing.failedItemsMany", "{{count}} failed items", {
+                    count: failedItems.length,
+                  })}
+            </span>
+            {failedExportNotice && (
+              <span className="ml-2 text-text-muted">{failedExportNotice}</span>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              void handleExportFailedItems()
+            }}
+            className="rounded-md border border-danger/30 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus"
+            aria-label={qi(
+              "processing.exportFailedListAria",
+              "Export failed items list"
+            )}
+          >
+            {qi("processing.exportFailedList", "Export failed list")}
+          </button>
+        </div>
+      )}
 
       {/* Action buttons */}
       <div className="flex items-center justify-end gap-2">

--- a/apps/packages/ui/src/components/Common/QuickIngest/ResultsListItem.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ResultsListItem.tsx
@@ -31,21 +31,25 @@ export const ResultsListItem: React.FC<ResultsListItemProps> = React.memo(
         ? t("quickIngest.resultStatusSkipped", "Skipped")
         : outcome === "cancelled"
           ? t("quickIngest.resultStatusCancelled", "Cancelled")
-        : outcome === "processed"
-          ? t("quickIngest.resultStatusProcessed", "Processed")
-          : outcome === "ingested"
-            ? t("quickIngest.resultStatusIngested", "Ingested")
-            : t("quickIngest.statusFailed", "Failed")
+          : outcome === "submit_failed"
+            ? t("quickIngest.resultStatusSubmitFailed", "Not submitted")
+            : outcome === "processed"
+              ? t("quickIngest.resultStatusProcessed", "Processed")
+              : outcome === "ingested"
+                ? t("quickIngest.resultStatusIngested", "Ingested")
+                : t("quickIngest.statusFailed", "Failed")
     const outcomeColor =
       outcome === "skipped"
         ? "gold"
         : outcome === "cancelled"
           ? "orange"
-        : outcome === "processed"
-          ? "blue"
-          : outcome === "ingested"
-            ? "green"
-            : "red"
+          : outcome === "submit_failed"
+            ? "volcano"
+            : outcome === "processed"
+              ? "blue"
+              : outcome === "ingested"
+                ? "green"
+                : "red"
     const handleDownloadJson = React.useCallback(() => {
       onDownloadJson(item)
     }, [item, onDownloadJson])

--- a/apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ReviewStep.tsx
@@ -107,12 +107,16 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
     [t]
   )
 
-  const { queueItems, selectedPreset, presetConfig } = state
+  const { queueItems, selectedPreset, presetConfig, conferenceBatchMetadata } = state
+  const selectedQueueItems = useMemo(
+    () => queueItems.filter((item) => item.conferenceOverride?.selected !== false),
+    [queueItems]
+  )
 
   // Compute total estimated time
   const totalEstimatedSeconds = useMemo(
-    () => estimateTotalSeconds(queueItems, selectedPreset),
-    [queueItems, selectedPreset]
+    () => estimateTotalSeconds(selectedQueueItems, selectedPreset),
+    [selectedQueueItems, selectedPreset]
   )
 
   const estimatedTimeLabel = useMemo(
@@ -129,8 +133,8 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
   // Storage mode
   const storageMode = presetConfig.storeRemote ? "Server" : "Local"
   const validItemCount = useMemo(
-    () => queueItems.filter((item) => item.validation.valid).length,
-    [queueItems]
+    () => selectedQueueItems.filter((item) => item.validation.valid).length,
+    [selectedQueueItems]
   )
   const canStartProcessing =
     validItemCount > 0 && isOnlineForIngest && !isCheckingConnection
@@ -146,7 +150,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
     const result: string[] = []
 
     // Large files
-    queueItems.forEach((item) => {
+    selectedQueueItems.forEach((item) => {
       if (item.fileSize > LARGE_FILE_THRESHOLD) {
         const name = item.fileName ?? item.url ?? item.id
         const size = formatFileSize(item.fileSize)
@@ -169,21 +173,22 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
     }
 
     // Large batch
-    if (queueItems.length > LARGE_BATCH_THRESHOLD) {
+    if (selectedQueueItems.length > LARGE_BATCH_THRESHOLD) {
       result.push(
         qi(
           "review.warnLargeBatch",
           "{{count}} items queued -- consider processing in smaller batches for better feedback",
-          { count: queueItems.length }
+          { count: selectedQueueItems.length }
         )
       )
     }
 
     return result
-  }, [queueItems, totalEstimatedSeconds, estimatedTimeLabel, qi])
+  }, [selectedQueueItems, totalEstimatedSeconds, estimatedTimeLabel, qi])
 
   // Item display name
   const getItemLabel = useCallback((item: WizardQueueItem): string => {
+    if (item.conferenceOverride?.title) return item.conferenceOverride.title
     if (item.fileName) return item.fileName
     if (item.url) {
       // Truncate long URLs for display
@@ -201,8 +206,8 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
           {qi("review.title", "Ready to Process")}
         </h2>
         <p className="mt-1 text-sm text-text-muted">
-          {qi("review.summary", "{{count}} items | {{preset}} preset | {{time}} estimated", {
-            count: queueItems.length,
+          {qi("review.summary", "{{count}} items | {{preset}} preset | ~{{time}} estimated", {
+            count: selectedQueueItems.length,
             preset: presetLabel,
             time: estimatedTimeLabel,
           })}
@@ -211,12 +216,41 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
 
       {/* Scrollable item list */}
       <div className="flex-1 overflow-y-auto px-4 py-3 sm:px-6">
+        {conferenceBatchMetadata && (
+          <div
+            className="mb-3 rounded-md border border-border bg-surface px-3 py-2 text-sm"
+            aria-label="Conference batch review"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium text-text">
+                {conferenceBatchMetadata.collectionName || "Conference batch"}
+              </span>
+              <span className="text-text-muted">
+                {selectedQueueItems.length} selected
+              </span>
+            </div>
+            <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-text-muted">
+              {conferenceBatchMetadata.conferenceName && (
+                <span>{conferenceBatchMetadata.conferenceName}</span>
+              )}
+              {conferenceBatchMetadata.eventYear && (
+                <span>{conferenceBatchMetadata.eventYear}</span>
+              )}
+              {conferenceBatchMetadata.eventDate && (
+                <span>{conferenceBatchMetadata.eventDate}</span>
+              )}
+              {conferenceBatchMetadata.sharedTags.length > 0 && (
+                <span>{conferenceBatchMetadata.sharedTags.join(", ")}</span>
+              )}
+            </div>
+          </div>
+        )}
         <ul
           className="divide-y divide-border rounded-lg border border-border bg-surface2"
           role="list"
           aria-label={qi("review.itemList.ariaLabel", "Items to process")}
         >
-          {queueItems.map((item) => {
+          {selectedQueueItems.map((item) => {
             const IconComponent = TYPE_ICONS[item.detectedType] ?? File
             const ops = getOperationDescription(item.detectedType, selectedPreset, presetConfig)
             const label = getItemLabel(item)
@@ -232,6 +266,11 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
                 />
                 <span className="min-w-0 flex-1 truncate font-medium text-text" title={item.fileName ?? item.url}>
                   {label}
+                  {item.conferenceOverride?.speaker && (
+                    <span className="ml-2 font-normal text-text-muted">
+                      {item.conferenceOverride.speaker}
+                    </span>
+                  )}
                 </span>
                 <span className="flex-shrink-0 whitespace-nowrap text-xs text-text-muted">
                   {presetLabel} &middot; {ops}

--- a/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
@@ -7,13 +7,18 @@ import {
   RefreshCw,
   ExternalLink,
   MessageSquare,
+  Trash2,
   Search,
   BookOpen,
   Download,
 } from "lucide-react"
 import type { WizardResultItem } from "./types"
 import { shouldKeepOriginalFile } from "@/services/tldw/media-routing"
-import { buildConferenceFailedResultExportText } from "@/services/tldw/conference-collections"
+import {
+  buildConferenceFailedResultExportText,
+  buildConferenceRetryRequestItems,
+  type ConferenceRetryRequestItem,
+} from "@/services/tldw/conference-collections"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
 import { useIngestWizard } from "./IngestWizardContext"
@@ -33,7 +38,10 @@ import {
 
 type WizardResultsStepProps = {
   onClose: () => void
-  onRetryItems?: (itemIds: string[]) => void
+  onRetryItems?: (
+    itemIds: string[],
+    retryItems?: ConferenceRetryRequestItem[]
+  ) => void
   onOpenMedia?: (item: WizardResultItem) => void
   onDiscussInChat?: (item: WizardResultItem) => void
   onSearchKnowledge?: () => void
@@ -235,14 +243,16 @@ type ErrorRowProps = {
   item: WizardResultItem
   category: ErrorCategory
   qi: (key: string, defaultValue: string, options?: Record<string, unknown>) => string
-  onRetry?: (id: string) => void
+  onRetry?: (item: WizardResultItem) => void
+  onRemove?: (id: string) => void
 }
 
 const ErrorRow: React.FC<ErrorRowProps> = React.memo(
-  ({ item, category, qi, onRetry }) => {
+  ({ item, category, qi, onRetry, onRemove }) => {
     const label = item.title || item.fileName || item.url || item.id
 
-    const handleRetry = useCallback(() => onRetry?.(item.id), [item.id, onRetry])
+    const handleRetry = useCallback(() => onRetry?.(item), [item, onRetry])
+    const handleRemove = useCallback(() => onRemove?.(item.id), [item.id, onRemove])
 
     return (
       <div className="rounded-md border border-danger/20 bg-danger/5 px-3 py-2">
@@ -279,6 +289,17 @@ const ErrorRow: React.FC<ErrorRowProps> = React.memo(
               >
                 <RefreshCw className="h-3 w-3" aria-hidden="true" />
                 {qi("wizard.results.retry", "Retry")}
+              </button>
+            )}
+            {onRemove && (
+              <button
+                type="button"
+                onClick={handleRemove}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-text-muted hover:bg-danger/10 hover:text-danger transition-colors"
+                aria-label={qi("wizard.results.removeItemAria", "Remove {{name}}", { name: label })}
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+                {qi("wizard.results.remove", "Remove")}
               </button>
             )}
           </div>
@@ -366,21 +387,39 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
 
   // -- Retryable error IDs --------------------------------------------------
 
+  const conferenceRetryRequests = useMemo(
+    () => (hasDurableCollection ? buildConferenceRetryRequestItems(failures) : []),
+    [failures, hasDurableCollection]
+  )
+
+  const conferenceRetryRequestsByResultId = useMemo(
+    () =>
+      new Map(
+        conferenceRetryRequests.map((request) => [request.resultId, request])
+      ),
+    [conferenceRetryRequests]
+  )
+
   const retryableIds = useMemo(
     () =>
-      failures
-        .filter((e) => errorCategories.get(e.id)?.retryable)
-        .map((e) => e.id),
-    [failures, errorCategories]
+      hasDurableCollection
+        ? conferenceRetryRequests.map((request) => request.collectionItemId)
+        : failures
+            .filter((e) => errorCategories.get(e.id)?.retryable)
+            .map((e) => e.id),
+    [conferenceRetryRequests, errorCategories, failures, hasDurableCollection]
   )
 
   // -- Callbacks ------------------------------------------------------------
 
   const handleRetryAll = useCallback(() => {
     if (retryableIds.length > 0) {
-      onRetryItems?.(retryableIds)
+      onRetryItems?.(
+        retryableIds,
+        hasDurableCollection ? conferenceRetryRequests : undefined
+      )
     }
-  }, [retryableIds, onRetryItems])
+  }, [conferenceRetryRequests, hasDurableCollection, retryableIds, onRetryItems])
 
   const handleOpenCollection = useCallback(() => {
     if (collectionId) {
@@ -417,10 +456,41 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
   }, [failures, qi])
 
   const handleRetrySingle = useCallback(
-    (id: string) => {
-      onRetryItems?.([id])
+    (item: WizardResultItem) => {
+      if (hasDurableCollection) {
+        const retryRequest = conferenceRetryRequestsByResultId.get(item.id)
+        if (retryRequest) {
+          onRetryItems?.([retryRequest.collectionItemId], [retryRequest])
+        }
+        return
+      }
+      onRetryItems?.([item.id])
     },
-    [onRetryItems]
+    [conferenceRetryRequestsByResultId, hasDurableCollection, onRetryItems]
+  )
+
+  const getRetryHandlerForItem = useCallback(
+    (item: WizardResultItem) => {
+      if (!onRetryItems) return undefined
+      if (!hasDurableCollection) return handleRetrySingle
+      return conferenceRetryRequestsByResultId.has(item.id)
+        ? handleRetrySingle
+        : undefined
+    },
+    [
+      conferenceRetryRequestsByResultId,
+      handleRetrySingle,
+      hasDurableCollection,
+      onRetryItems,
+    ]
+  )
+
+  const handleRemoveSingle = useCallback(
+    (_id: string) => {
+      // Remove is a no-op placeholder; parent will handle via onRetryItems
+      // or a future onRemoveItems callback.
+    },
+    []
   )
 
   const handleIngestMore = useCallback(() => {
@@ -618,7 +688,7 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                   item={item}
                   category={errorCategories.get(item.id) ?? classifyError(item.error)}
                   qi={qi}
-                  onRetry={onRetryItems ? handleRetrySingle : undefined}
+                  onRetry={getRetryHandlerForItem(item)}
                   onRemove={handleRemoveSingle}
                 />
               ))}
@@ -645,7 +715,7 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                   item={item}
                   category={errorCategories.get(item.id) ?? classifyError(item.error)}
                   qi={qi}
-                  onRetry={onRetryItems ? handleRetrySingle : undefined}
+                  onRetry={getRetryHandlerForItem(item)}
                   onRemove={handleRemoveSingle}
                 />
               ))}
@@ -672,7 +742,8 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                   item={item}
                   category={errorCategories.get(item.id) ?? classifyError(item.error)}
                   qi={qi}
-                  onRetry={onRetryItems ? handleRetrySingle : undefined}
+                  onRetry={getRetryHandlerForItem(item)}
+                  onRemove={handleRemoveSingle}
                 />
               ))}
             </div>

--- a/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Check,
@@ -9,9 +9,13 @@ import {
   MessageSquare,
   Search,
   BookOpen,
+  Download,
 } from "lucide-react"
 import type { WizardResultItem } from "./types"
 import { shouldKeepOriginalFile } from "@/services/tldw/media-routing"
+import { buildConferenceFailedResultExportText } from "@/services/tldw/conference-collections"
+import { useServerCapabilities } from "@/hooks/useServerCapabilities"
+import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
 import { useIngestWizard } from "./IngestWizardContext"
 import { classifyError } from "./ErrorClassification"
 import type { ErrorCategory } from "./ErrorClassification"
@@ -34,6 +38,7 @@ type WizardResultsStepProps = {
   onDiscussInChat?: (item: WizardResultItem) => void
   onSearchKnowledge?: () => void
   onOpenWorkspace?: (item: WizardResultItem) => void
+  onOpenCollection?: (collectionId: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -58,6 +63,44 @@ function formatElapsed(seconds: number): string {
   const m = Math.floor(rounded / 60)
   const s = rounded % 60
   return `${m}:${String(s).padStart(2, "0")}`
+}
+
+type ResultGroups = {
+  successes: WizardResultItem[]
+  skippedExisting: WizardResultItem[]
+  submitFailed: WizardResultItem[]
+  failedProcessing: WizardResultItem[]
+  cancelled: WizardResultItem[]
+}
+
+function groupResultItems(results: WizardResultItem[]): ResultGroups {
+  const groups: ResultGroups = {
+    successes: [],
+    skippedExisting: [],
+    submitFailed: [],
+    failedProcessing: [],
+    cancelled: [],
+  }
+
+  for (const item of results) {
+    if (item.outcome === "skipped") {
+      groups.skippedExisting.push(item)
+    } else if (item.outcome === "submit_failed") {
+      groups.submitFailed.push(item)
+    } else if (item.outcome === "cancelled") {
+      groups.cancelled.push(item)
+    } else if (item.status === "error" || item.outcome === "failed") {
+      groups.failedProcessing.push(item)
+    } else {
+      groups.successes.push(item)
+    }
+  }
+
+  return groups
+}
+
+function hasReadyMedia(item: WizardResultItem): boolean {
+  return item.mediaId != null
 }
 
 // ---------------------------------------------------------------------------
@@ -257,10 +300,14 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
   onDiscussInChat,
   onSearchKnowledge,
   onOpenWorkspace,
+  onOpenCollection,
 }) => {
   const { t } = useTranslation(["option"])
   const { state, reset } = useIngestWizard()
   const { results, processingState } = state
+  const tracking = useQuickIngestSessionStore((store) => store.session?.tracking)
+  const { capabilities } = useServerCapabilities()
+  const [exportNotice, setExportNotice] = useState<string | null>(null)
 
   const qi = useCallback(
     (key: string, defaultValue: string, options?: Record<string, unknown>) =>
@@ -270,39 +317,61 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
     [t]
   )
 
-  // -- Partition results into successes, skipped, and errors ----------------
+  // -- Partition results into conference-friendly outcome groups ------------
 
-  const { successes, skipped, errors } = useMemo(() => {
-    const s: WizardResultItem[] = []
-    const sk: WizardResultItem[] = []
-    const e: WizardResultItem[] = []
-    for (const item of results) {
-      if (item.status === "error" || item.outcome === "failed") {
-        e.push(item)
-      } else if (item.outcome === "skipped") {
-        sk.push(item)
-      } else {
-        s.push(item)
-      }
-    }
-    return { successes: s, skipped: sk, errors: e }
-  }, [results])
+  const {
+    successes,
+    skippedExisting,
+    submitFailed,
+    failedProcessing,
+    cancelled,
+  } = useMemo(() => groupResultItems(results), [results])
+
+  const failures = useMemo(
+    () => [...submitFailed, ...failedProcessing, ...cancelled],
+    [submitFailed, failedProcessing, cancelled]
+  )
+
+  const collectionId = tracking?.collectionId
+  const hasDurableCollection =
+    Boolean(collectionId) && tracking?.durableMode === "durable_collection"
+  const readyCollectionItemCount = useMemo(
+    () => [...successes, ...skippedExisting].filter(hasReadyMedia).length,
+    [successes, skippedExisting]
+  )
+  const canAskCollection =
+    hasDurableCollection &&
+    readyCollectionItemCount > 0 &&
+    Boolean(onSearchKnowledge) &&
+    Boolean(capabilities?.hasKnowledgeQaMediaScope)
+  const showGenericSearch =
+    successes.length > 0 && Boolean(onSearchKnowledge) && !hasDurableCollection
+  const hasWorkspaceOpenTarget =
+    Boolean(onOpenWorkspace) &&
+    successes.some((item) => item.persisted && shouldKeepOriginalFile(item.type))
+  const showCollectionOpen =
+    hasDurableCollection && Boolean(onOpenCollection) && Boolean(collectionId)
+  const showNextSteps =
+    showGenericSearch || hasWorkspaceOpenTarget || showCollectionOpen || canAskCollection
 
   // -- Classify each error --------------------------------------------------
 
   const errorCategories = useMemo(() => {
     const map = new Map<string, ErrorCategory>()
-    for (const item of errors) {
+    for (const item of failures) {
       map.set(item.id, classifyError(item.error))
     }
     return map
-  }, [errors])
+  }, [failures])
 
   // -- Retryable error IDs --------------------------------------------------
 
   const retryableIds = useMemo(
-    () => errors.filter((e) => errorCategories.get(e.id)?.retryable).map((e) => e.id),
-    [errors, errorCategories]
+    () =>
+      failures
+        .filter((e) => errorCategories.get(e.id)?.retryable)
+        .map((e) => e.id),
+    [failures, errorCategories]
   )
 
   // -- Callbacks ------------------------------------------------------------
@@ -312,6 +381,40 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
       onRetryItems?.(retryableIds)
     }
   }, [retryableIds, onRetryItems])
+
+  const handleOpenCollection = useCallback(() => {
+    if (collectionId) {
+      onOpenCollection?.(collectionId)
+    }
+  }, [collectionId, onOpenCollection])
+
+  const handleExportFailedItems = useCallback(async () => {
+    const text = buildConferenceFailedResultExportText(failures)
+    if (!text) return
+    try {
+      if (
+        typeof navigator === "undefined" ||
+        typeof navigator.clipboard?.writeText !== "function"
+      ) {
+        throw new Error("Clipboard unavailable")
+      }
+      await navigator.clipboard.writeText(text)
+      setExportNotice(qi("wizard.results.failedExportCopied", "Failed item list copied."))
+    } catch {
+      if (typeof document !== "undefined" && typeof URL !== "undefined") {
+        const blob = new Blob([text], { type: "text/plain" })
+        const url = URL.createObjectURL(blob)
+        const anchor = document.createElement("a")
+        anchor.href = url
+        anchor.download = "quick-ingest-failed-conference-items.txt"
+        anchor.click()
+        URL.revokeObjectURL(url)
+        setExportNotice(qi("wizard.results.failedExportDownloaded", "Failed item list downloaded."))
+      } else {
+        setExportNotice(qi("wizard.results.failedExportUnavailable", "Failed item list could not be exported."))
+      }
+    }
+  }, [failures, qi])
 
   const handleRetrySingle = useCallback(
     (id: string) => {
@@ -342,7 +445,7 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
           <section aria-label={qi("wizard.results.completedSection", "Completed items")}>
             <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-text-muted">
               <Check className="h-3.5 w-3.5 text-green-500" aria-hidden="true" />
-              {qi("wizard.results.completedHeading", "Completed ({{count}})", {
+              {qi("wizard.results.succeededHeading", "Succeeded ({{count}})", {
                 count: successes.length,
               })}
             </h3>
@@ -361,13 +464,39 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
         )}
 
         {/* Next steps CTAs */}
-        {successes.length > 0 && (onSearchKnowledge || onOpenWorkspace) && (
+        {showNextSteps && (
           <div className="mt-4 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3">
             <p className="mb-2 text-xs font-medium text-text-muted">
               {qi("wizard.results.nextSteps", "What's next?")}
             </p>
             <div className="flex flex-wrap gap-2">
-              {onSearchKnowledge && (
+              {showCollectionOpen && collectionId && (
+                <button
+                  type="button"
+                  onClick={handleOpenCollection}
+                  className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-surface2 transition-colors"
+                  aria-label={qi(
+                    "wizard.results.openCollectionAria",
+                    "Open collection {{collectionId}}",
+                    { collectionId }
+                  )}
+                >
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                  {qi("wizard.results.openCollection", "Open collection")}
+                </button>
+              )}
+              {canAskCollection && (
+                <button
+                  type="button"
+                  onClick={onSearchKnowledge}
+                  className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-surface2 transition-colors"
+                  aria-label={qi("wizard.results.askCollectionAria", "Ask this collection")}
+                >
+                  <MessageSquare className="h-3.5 w-3.5" aria-hidden="true" />
+                  {qi("wizard.results.askCollection", "Ask this collection")}
+                </button>
+              )}
+              {showGenericSearch && onSearchKnowledge && (
                 <button
                   type="button"
                   onClick={onSearchKnowledge}
@@ -378,7 +507,7 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                   {qi("wizard.results.searchKnowledge", "Search in Knowledge")}
                 </button>
               )}
-              {onOpenWorkspace && successes.some(s => s.persisted && shouldKeepOriginalFile(s.type)) && (
+              {hasWorkspaceOpenTarget && onOpenWorkspace && (
                 <button
                   type="button"
                   onClick={() => {
@@ -397,19 +526,19 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
         )}
 
         {/* Skipped (duplicates) */}
-        {skipped.length > 0 && (
+        {skippedExisting.length > 0 && (
           <section
             aria-label={qi("wizard.results.skippedSection", "Skipped items")}
             className={successes.length > 0 ? "mt-4" : ""}
           >
             <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-amber-600">
               <AlertTriangle className="h-3.5 w-3.5 text-amber-500" aria-hidden="true" />
-              {qi("wizard.results.skippedHeading", "Skipped ({{count}})", {
-                count: skipped.length,
+              {qi("wizard.results.skippedExistingHeading", "Skipped existing ({{count}})", {
+                count: skippedExisting.length,
               })}
             </h3>
             <div className="space-y-1">
-              {skipped.map((item) => (
+              {skippedExisting.map((item) => (
                 <SkippedRow
                   key={item.id}
                   item={item}
@@ -422,19 +551,33 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
           </section>
         )}
 
-        {/* Errors */}
-        {errors.length > 0 && (
-          <section
-            aria-label={qi("wizard.results.errorsSection", "Error items")}
-            className={successes.length > 0 || skipped.length > 0 ? "mt-4" : ""}
+        {/* Failure export/retry actions */}
+        {failures.length > 0 && (
+          <div
+            className={
+              successes.length > 0 || skippedExisting.length > 0
+                ? "mt-4 flex flex-wrap items-center justify-between gap-2 rounded-md border border-danger/15 bg-danger/5 px-3 py-2"
+                : "flex flex-wrap items-center justify-between gap-2 rounded-md border border-danger/15 bg-danger/5 px-3 py-2"
+            }
           >
-            <div className="mb-2 flex items-center justify-between">
-              <h3 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-danger">
-                <X className="h-3.5 w-3.5" aria-hidden="true" />
-                {qi("wizard.results.errorsHeading", "Errors ({{count}})", {
-                  count: errors.length,
-                })}
-              </h3>
+            <span className="text-xs font-medium text-danger">
+              {qi("wizard.results.reviewFailedItems", "Review failed items")}
+            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              {exportNotice && (
+                <span className="text-xs text-text-muted">{exportNotice}</span>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  void handleExportFailedItems()
+                }}
+                className="flex items-center gap-1 rounded-md border border-border bg-surface px-2.5 py-1 text-xs font-medium text-text hover:bg-surface2 transition-colors"
+                aria-label={qi("wizard.results.exportFailedListAria", "Export failed items list")}
+              >
+                <Download className="h-3 w-3" aria-hidden="true" />
+                {qi("wizard.results.exportFailedList", "Export failed list")}
+              </button>
               {retryableIds.length > 1 && onRetryItems && (
                 <button
                   type="button"
@@ -453,8 +596,77 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                 </button>
               )}
             </div>
+          </div>
+        )}
+
+        {/* Submission failures */}
+        {submitFailed.length > 0 && (
+          <section
+            aria-label={qi("wizard.results.submitFailedSection", "Not submitted items")}
+            className="mt-4"
+          >
+            <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-danger">
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+              {qi("wizard.results.submitFailedHeading", "Not submitted ({{count}})", {
+                count: submitFailed.length,
+              })}
+            </h3>
             <div className="space-y-2">
-              {errors.map((item) => (
+              {submitFailed.map((item) => (
+                <ErrorRow
+                  key={item.id}
+                  item={item}
+                  category={errorCategories.get(item.id) ?? classifyError(item.error)}
+                  qi={qi}
+                  onRetry={onRetryItems ? handleRetrySingle : undefined}
+                  onRemove={handleRemoveSingle}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Processing failures */}
+        {failedProcessing.length > 0 && (
+          <section
+            aria-label={qi("wizard.results.errorsSection", "Error items")}
+            className="mt-4"
+          >
+            <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-danger">
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+              {qi("wizard.results.failedProcessingHeading", "Failed during processing ({{count}})", {
+                count: failedProcessing.length,
+              })}
+            </h3>
+            <div className="space-y-2">
+              {failedProcessing.map((item) => (
+                <ErrorRow
+                  key={item.id}
+                  item={item}
+                  category={errorCategories.get(item.id) ?? classifyError(item.error)}
+                  qi={qi}
+                  onRetry={onRetryItems ? handleRetrySingle : undefined}
+                  onRemove={handleRemoveSingle}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Cancelled */}
+        {cancelled.length > 0 && (
+          <section
+            aria-label={qi("wizard.results.cancelledSection", "Cancelled items")}
+            className="mt-4"
+          >
+            <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-text-muted">
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+              {qi("wizard.results.cancelledHeading", "Cancelled ({{count}})", {
+                count: cancelled.length,
+              })}
+            </h3>
+            <div className="space-y-2">
+              {cancelled.map((item) => (
                 <ErrorRow
                   key={item.id}
                   item={item}
@@ -483,20 +695,24 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
         <div className="border-t border-border px-4 py-3">
           {/* Summary line */}
           <p className="mb-3 text-center text-xs text-text-muted">
-            {skipped.length > 0
+            {skippedExisting.length > 0 ||
+            submitFailed.length > 0 ||
+            cancelled.length > 0
               ? qi(
-                  "wizard.results.summaryWithSkipped",
-                  "Total: {{success}} succeeded, {{skipped}} skipped, {{failed}} failed",
+                  "wizard.results.summaryWithOutcomeGroups",
+                  "Total: {{success}} succeeded, {{skipped}} skipped, {{notSubmitted}} not submitted, {{failed}} failed, {{cancelled}} cancelled",
                   {
                     success: successes.length,
-                    skipped: skipped.length,
-                    failed: errors.length,
+                    skipped: skippedExisting.length,
+                    notSubmitted: submitFailed.length,
+                    failed: failedProcessing.length,
+                    cancelled: cancelled.length,
                   }
                 )
               : qi(
                   "wizard.results.summary",
                   "Total: {{success}} succeeded, {{failed}} failed",
-                  { success: successes.length, failed: errors.length }
+                  { success: successes.length, failed: failedProcessing.length }
                 )}
             {elapsedLabel && (
               <>

--- a/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
@@ -485,14 +485,6 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
     ]
   )
 
-  const handleRemoveSingle = useCallback(
-    (_id: string) => {
-      // Remove is a no-op placeholder; parent will handle via onRetryItems
-      // or a future onRemoveItems callback.
-    },
-    []
-  )
-
   const handleIngestMore = useCallback(() => {
     reset()
   }, [reset])
@@ -689,7 +681,6 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                   category={errorCategories.get(item.id) ?? classifyError(item.error)}
                   qi={qi}
                   onRetry={getRetryHandlerForItem(item)}
-                  onRemove={handleRemoveSingle}
                 />
               ))}
             </div>
@@ -716,7 +707,6 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                   category={errorCategories.get(item.id) ?? classifyError(item.error)}
                   qi={qi}
                   onRetry={getRetryHandlerForItem(item)}
-                  onRemove={handleRemoveSingle}
                 />
               ))}
             </div>
@@ -743,7 +733,6 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
                   category={errorCategories.get(item.id) ?? classifyError(item.error)}
                   qi={qi}
                   onRetry={getRetryHandlerForItem(item)}
-                  onRemove={handleRemoveSingle}
                 />
               ))}
             </div>

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/AddContentStep.url-detection.test.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/AddContentStep.url-detection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { detectTypeFromUrl } from "../AddContentStep"
+import { detectPlaylistPreflightCandidate, detectTypeFromUrl } from "../AddContentStep"
 import { normalizeUrlForDedupe } from "@/entries/shared/ingest-payloads"
 
 describe("detectTypeFromUrl", () => {
@@ -15,6 +15,24 @@ describe("detectTypeFromUrl", () => {
     expect(detectTypeFromUrl("https://youtube.com.evil.test/watch?v=123")).toBe("web")
     expect(detectTypeFromUrl("https://evil-youtube.com/watch?v=123")).toBe("web")
     expect(detectTypeFromUrl("https://soundcloud.com.evil.test/track")).toBe("web")
+  })
+
+  it("identifies YouTube playlist URLs as preflight candidates", () => {
+    expect(
+      detectPlaylistPreflightCandidate(
+        "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B"
+      )
+    ).toBe(true)
+    expect(
+      detectPlaylistPreflightCandidate("https://www.youtube.com/playlist?list=PLtest")
+    ).toBe(true)
+  })
+
+  it("does not identify single videos or lookalike hosts as playlist preflight candidates", () => {
+    expect(detectPlaylistPreflightCandidate("https://www.youtube.com/watch?v=abc123")).toBe(false)
+    expect(
+      detectPlaylistPreflightCandidate("https://youtube.com.evil.test/watch?v=abc&list=PLtest")
+    ).toBe(false)
   })
 })
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx
@@ -2,10 +2,9 @@
 import React from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { cleanup, render, screen } from "@testing-library/react"
-import {
-  IngestWizardProvider,
-} from "../IngestWizardContext"
+
 import { FloatingProgressWidget } from "../FloatingProgressWidget"
+import { IngestWizardProvider } from "../IngestWizardContext"
 import type { ItemProgressStatus, ProcessingStatus } from "../types"
 import {
   createEmptyQuickIngestSession,
@@ -14,15 +13,22 @@ import {
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, defaultOrOpts?: any) => {
-      if (typeof defaultOrOpts === "string") return defaultOrOpts
-      if (defaultOrOpts?.defaultValue) {
-        return defaultOrOpts.defaultValue.replace(
-          /\{\{(\w+)\}\}/g,
-          (_: string, token: string) => String(defaultOrOpts[token] ?? "")
-        )
-      }
-      return key
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+            [k: string]: unknown
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      const value = defaultValueOrOptions?.defaultValue || key
+      return value.replace(/\{\{(\w+)\}\}/g, (_match: string, token: string) =>
+        defaultValueOrOptions?.[token] == null
+          ? `{{${token}}}`
+          : String(defaultValueOrOptions[token])
+      )
     },
   }),
 }))
@@ -42,8 +48,10 @@ vi.mock("lucide-react", () => {
 
 afterEach(() => {
   cleanup()
+  vi.useRealTimers()
   useQuickIngestSessionStore.setState({
     session: null,
+    triggerSummary: { count: 0, label: null, hadFailure: false },
   })
 })
 
@@ -56,12 +64,13 @@ const renderWidget = ({
   itemStatus: ItemProgressStatus
   lifecycle?: "completed" | "partial_failure" | "cancelled" | "interrupted"
 }) => {
-  const session = {
-    ...createEmptyQuickIngestSession(),
-    visibility: "hidden" as const,
-    lifecycle,
-  }
-  useQuickIngestSessionStore.setState({ session })
+  useQuickIngestSessionStore.setState({
+    session: {
+      ...createEmptyQuickIngestSession(),
+      visibility: "hidden",
+      lifecycle,
+    },
+  })
 
   render(
     <IngestWizardProvider
@@ -88,7 +97,7 @@ const renderWidget = ({
   )
 }
 
-describe("FloatingProgressWidget terminal states", () => {
+describe("FloatingProgressWidget", () => {
   it("shows Done for complete minimized sessions", () => {
     renderWidget({ processingStatus: "complete", itemStatus: "complete" })
 
@@ -123,5 +132,101 @@ describe("FloatingProgressWidget terminal states", () => {
     })
 
     expect(screen.getByRole("status")).toHaveTextContent("Interrupted")
+  })
+
+  it("summarizes completed conference runs without overstating search readiness", () => {
+    useQuickIngestSessionStore.setState({
+      session: {
+        ...createEmptyQuickIngestSession(),
+        visibility: "hidden",
+        lifecycle: "partial_failure",
+      },
+      triggerSummary: { count: 4, label: "1 failed", hadFailure: true },
+    })
+
+    render(
+      <IngestWizardProvider
+        initialState={{
+          isMinimized: true,
+          conferenceBatchMetadata: {
+            collectionName: "Conference 2010",
+            conferenceName: "Conference",
+            eventYear: "2010",
+            sharedTags: ["conference"],
+            sourcePlaylistUrl: "https://www.youtube.com/playlist?list=PLtest",
+          },
+          processingState: {
+            status: "error",
+            elapsed: 120,
+            estimatedRemaining: 0,
+            perItemProgress: [
+              {
+                id: "ok-1",
+                status: "complete",
+                progressPercent: 100,
+                currentStage: "Complete",
+                estimatedRemaining: 0,
+              },
+              {
+                id: "ok-2",
+                status: "complete",
+                progressPercent: 100,
+                currentStage: "Complete",
+                estimatedRemaining: 0,
+              },
+              {
+                id: "skip-1",
+                status: "complete",
+                progressPercent: 100,
+                currentStage: "Complete",
+                estimatedRemaining: 0,
+              },
+              {
+                id: "failed-1",
+                status: "failed",
+                progressPercent: 100,
+                currentStage: "Failed",
+                estimatedRemaining: 0,
+              },
+            ],
+          },
+          results: [
+            {
+              id: "ok-1",
+              status: "ok",
+              outcome: "processed",
+              type: "video",
+            },
+            {
+              id: "ok-2",
+              status: "ok",
+              outcome: "processed",
+              type: "video",
+            },
+            {
+              id: "skip-1",
+              status: "ok",
+              outcome: "skipped",
+              type: "video",
+            },
+            {
+              id: "failed-1",
+              status: "error",
+              outcome: "failed",
+              type: "video",
+              error: "Download failed",
+            },
+          ],
+        }}
+      >
+        <FloatingProgressWidget />
+      </IngestWizardProvider>
+    )
+
+    const widget = screen.getByRole("status", { name: "Ingest progress" })
+    expect(widget).toHaveTextContent("Conference 2010")
+    expect(widget).toHaveTextContent("2 succeeded, 1 skipped, 1 failed")
+    expect(widget).toHaveTextContent("Open the wizard for collection readiness")
+    expect(widget).not.toHaveTextContent(/searchable/i)
   })
 })

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
@@ -50,4 +50,30 @@ describe("PlaylistPreflightPanel", () => {
 
     expect(onItemSelectionChange).toHaveBeenCalledWith(2, false)
   })
+
+  it("shows duplicate policy controls only when duplicates are present", () => {
+    const onDuplicatePolicyChange = vi.fn()
+    const result = buildResult()
+    result.duplicateCount = 1
+    result.items[1] = {
+      ...result.items[1],
+      duplicateStatus: "duplicate_existing",
+      selected: false
+    }
+
+    render(
+      <PlaylistPreflightPanel
+        candidateUrl="https://www.youtube.com/playlist?list=PLtest"
+        result={result}
+        duplicatePolicy="skip"
+        onDuplicatePolicyChange={onDuplicatePolicyChange}
+        onPreview={vi.fn()}
+        onAddItems={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("radio", { name: "Include existing" }))
+
+    expect(onDuplicatePolicyChange).toHaveBeenCalledWith("include_existing")
+  })
 })

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { PlaylistPreflightPanel } from "../PlaylistPreflightPanel"
+import type { PlaylistPreflightResult } from "@/services/tldw/playlist-preflight"
+
+const buildResult = (): PlaylistPreflightResult => ({
+  sourceUrl: "https://www.youtube.com/playlist?list=PLtest",
+  sourceKind: "youtube_playlist",
+  playlistId: "PLtest",
+  playlistTitle: "Conference 2010",
+  videoId: null,
+  itemCount: 6,
+  selectedCount: 6,
+  duplicateCount: 0,
+  warnings: [],
+  items: Array.from({ length: 6 }, (_, index) => ({
+    id: `youtube:video:item-${index + 1}`,
+    ordinal: index + 1,
+    sourceUrl: `https://www.youtube.com/watch?v=item-${index + 1}`,
+    normalizedSourceId: `youtube:video:item-${index + 1}`,
+    sourceKind: "youtube_video",
+    title: `Talk ${index + 1}`,
+    speaker: null,
+    durationSeconds: null,
+    publishedAt: null,
+    thumbnailUrl: null,
+    duplicateStatus: "new",
+    duplicateOfOrdinal: null,
+    selected: true
+  }))
+})
+
+describe("PlaylistPreflightPanel", () => {
+  it("shows the full preflight item list and emits item selection changes", () => {
+    const onItemSelectionChange = vi.fn()
+    render(
+      <PlaylistPreflightPanel
+        candidateUrl="https://www.youtube.com/playlist?list=PLtest"
+        result={buildResult()}
+        onPreview={vi.fn()}
+        onAddItems={vi.fn()}
+        onItemSelectionChange={onItemSelectionChange}
+      />
+    )
+
+    expect(screen.getByText("6. Talk 6")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Talk 2" }))
+
+    expect(onItemSelectionChange).toHaveBeenCalledWith(2, false)
+  })
+})

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -1,4 +1,6 @@
 import React from "react"
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -537,6 +539,27 @@ const expandAdvancedOptions = async (user: ReturnType<typeof userEvent.setup>) =
 // ---------------------------------------------------------------------------
 
 describe("QuickIngestWizardModal — full wizard flow integration", () => {
+  it("hydrates playlist preflight seed from typed open detail", () => {
+    const candidates = [
+      path.resolve(__dirname, "../IngestWizardContext.tsx"),
+      path.resolve(process.cwd(), "src/components/Common/QuickIngest/IngestWizardContext.tsx"),
+      path.resolve(
+        process.cwd(),
+        "../packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx"
+      ),
+      path.resolve(
+        process.cwd(),
+        "apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx"
+      )
+    ]
+    const contextPath = candidates.find((candidate) => existsSync(candidate))
+    expect(contextPath).toBeTruthy()
+    const source = readFileSync(contextPath!, "utf8")
+
+    expect(source).toContain("playlistPreflightSeed")
+    expect(source).toContain("SET_PLAYLIST_PREFLIGHT_SEED")
+  })
+
   let onClose: () => void
 
   beforeEach(() => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 // ---------------------------------------------------------------------------
@@ -1110,12 +1110,79 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
 
     // Both items should appear
     await waitFor(() => {
-      expect(screen.getByText("https://example.com/page1")).toBeTruthy()
-      expect(screen.getByText("https://example.com/page2")).toBeTruthy()
+      expect(screen.getAllByText("https://example.com/page1").length).toBeGreaterThan(0)
+      expect(screen.getAllByText("https://example.com/page2").length).toBeGreaterThan(0)
     })
 
     // The configure button should reference 2 items
     expect(screen.getByText(/Configure 2 items/i)).toBeTruthy()
+  })
+
+  it("captures shared conference metadata for a 34-talk batch and shows it in review", async () => {
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={onClose} />)
+
+    const textarea = screen.getByPlaceholderText(/https:\/\/example\.com/i)
+    const urls = Array.from(
+      { length: 34 },
+      (_, index) => `https://youtube.com/watch?v=conference-talk-${index + 1}`
+    ).join("\n")
+
+    fireEvent.change(textarea, { target: { value: urls } })
+    await user.click(screen.getByRole("button", { name: /Add URLs to queue/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Configure 34 items/i)).toBeTruthy()
+    })
+
+    await user.type(screen.getByLabelText("Collection name"), "Strange Loop 2012")
+    await user.type(screen.getByLabelText("Conference name"), "Strange Loop")
+    await user.type(screen.getByLabelText("Event year"), "2012")
+    await user.type(screen.getByLabelText("Shared tags"), "conference, clojure")
+
+    await user.click(screen.getByText(/Configure 34 items/i))
+    await user.click(await screen.findByText("Next"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Ready to Process")).toBeTruthy()
+    })
+    expect(screen.getByText(/34 selected/i)).toBeTruthy()
+    expect(screen.getByText(/Strange Loop 2012/i)).toBeTruthy()
+    expect(screen.getByText("Strange Loop")).toBeTruthy()
+    expect(screen.getAllByText("2012").length).toBeGreaterThan(0)
+    expect(screen.getByText(/conference, clojure/i)).toBeTruthy()
+  })
+
+  it("allows overriding one talk title and speaker inside a conference batch", async () => {
+    const user = userEvent.setup()
+    render(<WizardTestHarness onClose={onClose} />)
+
+    const textarea = screen.getByPlaceholderText(/https:\/\/example\.com/i)
+    fireEvent.change(textarea, {
+      target: {
+        value:
+          "https://youtube.com/watch?v=talk-1\nhttps://youtube.com/watch?v=talk-2",
+      },
+    })
+    await user.click(screen.getByRole("button", { name: /Add URLs to queue/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Configure 2 items/i)).toBeTruthy()
+    })
+
+    await user.type(screen.getByLabelText("Collection name"), "Strange Loop 2012")
+    await user.type(screen.getByLabelText("Conference name"), "Strange Loop")
+    await user.type(screen.getByLabelText("Title override for item 1"), "Simplicity Matters")
+    await user.type(screen.getByLabelText("Speaker for item 1"), "Rich Hickey")
+
+    await user.click(screen.getByText(/Configure 2 items/i))
+    await user.click(await screen.findByText("Next"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Ready to Process")).toBeTruthy()
+    })
+    expect(screen.getByText("Simplicity Matters")).toBeTruthy()
+    expect(screen.getByText(/Rich Hickey/i)).toBeTruthy()
   })
 
   // -------------------------------------------------------------------------

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -929,98 +929,106 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
 
   it("Step 4 — shows durable collection tracking and exports failed URLs", async () => {
     const user = userEvent.setup()
+    const originalClipboard = navigator.clipboard
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
     })
 
-    useQuickIngestSessionStore.getState().createDraftSession({
-      lifecycle: "processing",
-      tracking: {
-        mode: "webui-direct",
-        sessionId: "qi-test",
-        batchId: "batch-1",
-        collectionId: "7",
-        plannedItemIds: ["11", "12"],
-        jobIds: [501, 502],
-        jobIdToCollectionItemId: {
-          "501": "11",
-          "502": "12",
+    try {
+      useQuickIngestSessionStore.getState().createDraftSession({
+        lifecycle: "processing",
+        tracking: {
+          mode: "webui-direct",
+          sessionId: "qi-test",
+          batchId: "batch-1",
+          collectionId: "7",
+          plannedItemIds: ["11", "12"],
+          jobIds: [501, 502],
+          jobIdToCollectionItemId: {
+            "501": "11",
+            "502": "12",
+          },
+          durableMode: "durable_collection",
+          startedAt: 1234,
         },
-        durableMode: "durable_collection",
-        startedAt: 1234,
-      },
-    })
+      })
 
-    render(
-      <WizardTestHarness
-        onClose={onClose}
-        initialState={{
-          currentStep: 4,
-          highestStep: 4,
-          queueItems: [
-            {
-              id: "talk-1",
-              kind: "url",
-              url: "https://example.com/fail",
-              detectedType: "video",
-              icon: "Video",
-              fileSize: 0,
-              validation: { valid: true },
-            },
-            {
-              id: "talk-2",
-              kind: "url",
-              url: "https://example.com/processing",
-              detectedType: "video",
-              icon: "Video",
-              fileSize: 0,
-              validation: { valid: true },
-            },
-          ],
-          processingState: {
-            status: "running",
-            elapsed: 42,
-            estimatedRemaining: 120,
-            perItemProgress: [
+      render(
+        <WizardTestHarness
+          onClose={onClose}
+          initialState={{
+            currentStep: 4,
+            highestStep: 4,
+            queueItems: [
               {
                 id: "talk-1",
-                status: "failed",
-                progressPercent: 100,
-                currentStage: "processing",
-                estimatedRemaining: 0,
-                error: "Timed out while downloading",
+                kind: "url",
+                url: "https://example.com/fail",
+                detectedType: "video",
+                icon: "Video",
+                fileSize: 0,
+                validation: { valid: true },
               },
               {
                 id: "talk-2",
-                status: "processing",
-                progressPercent: 50,
-                currentStage: "processing",
-                estimatedRemaining: 120,
+                kind: "url",
+                url: "https://example.com/processing",
+                detectedType: "video",
+                icon: "Video",
+                fileSize: 0,
+                validation: { valid: true },
               },
             ],
-          },
-        }}
-      />
-    )
-
-    const trackingPanel = screen.getByTestId("quick-ingest-run-tracking")
-    expect(trackingPanel).toHaveTextContent("Durable collection tracking")
-    expect(trackingPanel).toHaveTextContent("Collection 7")
-    expect(trackingPanel).toHaveTextContent("2 planned items")
-    expect(trackingPanel).toHaveTextContent("2 jobs")
-
-    await user.click(
-      screen.getByRole("button", { name: "Export failed items list" })
-    )
-
-    await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        expect.stringContaining("https://example.com/fail")
+            processingState: {
+              status: "running",
+              elapsed: 42,
+              estimatedRemaining: 120,
+              perItemProgress: [
+                {
+                  id: "talk-1",
+                  status: "failed",
+                  progressPercent: 100,
+                  currentStage: "processing",
+                  estimatedRemaining: 0,
+                  error: "Timed out while downloading",
+                },
+                {
+                  id: "talk-2",
+                  status: "processing",
+                  progressPercent: 50,
+                  currentStage: "processing",
+                  estimatedRemaining: 120,
+                },
+              ],
+            },
+          }}
+        />
       )
-    })
-    expect(writeText.mock.calls[0]?.[0]).toContain("Timed out while downloading")
+
+      const trackingPanel = screen.getByTestId("quick-ingest-run-tracking")
+      expect(trackingPanel).toHaveTextContent("Durable collection tracking")
+      expect(trackingPanel).toHaveTextContent("Collection 7")
+      expect(trackingPanel).toHaveTextContent("2 planned items")
+      expect(trackingPanel).toHaveTextContent("2 jobs")
+
+      await user.click(
+        screen.getByRole("button", { name: "Export failed items list" })
+      )
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          expect.stringContaining("https://example.com/fail")
+        )
+      })
+      expect(writeText.mock.calls[0]?.[0]).toContain("Timed out while downloading")
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      })
+    }
   })
 
   // -------------------------------------------------------------------------

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -372,6 +372,7 @@ vi.stubGlobal(
 import {
   IngestWizardProvider,
   useIngestWizard,
+  type IngestWizardState,
 } from "@/components/Common/QuickIngest/IngestWizardContext"
 import { AddContentStep } from "@/components/Common/QuickIngest/AddContentStep"
 import { WizardConfigureStep } from "@/components/Common/QuickIngest/WizardConfigureStep"
@@ -469,6 +470,7 @@ const WizardTestHarness: React.FC<{
   isCheckingConnection?: boolean
   onRetryConnection?: () => void
   onQuickProcess?: () => void
+  initialState?: Partial<IngestWizardState>
 }> = ({
   onClose,
   isOnlineForIngest,
@@ -476,9 +478,10 @@ const WizardTestHarness: React.FC<{
   isCheckingConnection,
   onRetryConnection,
   onQuickProcess,
+  initialState,
 }) => {
   return (
-    <IngestWizardProvider>
+    <IngestWizardProvider initialState={initialState}>
       <ContextSpy />
       <InnerWizardContent
         onClose={onClose}
@@ -537,6 +540,10 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
   beforeEach(() => {
     onClose = vi.fn()
     ctxRef = null
+    useQuickIngestSessionStore.setState({
+      session: null,
+      triggerSummary: { count: 0, label: null, hadFailure: false },
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -893,6 +900,102 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
 
     // Cancel All button should be present
     expect(screen.getByText("Cancel All")).toBeTruthy()
+  })
+
+  it("Step 4 — shows durable collection tracking and exports failed URLs", async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    })
+
+    useQuickIngestSessionStore.getState().createDraftSession({
+      lifecycle: "processing",
+      tracking: {
+        mode: "webui-direct",
+        sessionId: "qi-test",
+        batchId: "batch-1",
+        collectionId: "7",
+        plannedItemIds: ["11", "12"],
+        jobIds: [501, 502],
+        jobIdToCollectionItemId: {
+          "501": "11",
+          "502": "12",
+        },
+        durableMode: "durable_collection",
+        startedAt: 1234,
+      },
+    })
+
+    render(
+      <WizardTestHarness
+        onClose={onClose}
+        initialState={{
+          currentStep: 4,
+          highestStep: 4,
+          queueItems: [
+            {
+              id: "talk-1",
+              kind: "url",
+              url: "https://example.com/fail",
+              detectedType: "video",
+              icon: "Video",
+              fileSize: 0,
+              validation: { valid: true },
+            },
+            {
+              id: "talk-2",
+              kind: "url",
+              url: "https://example.com/processing",
+              detectedType: "video",
+              icon: "Video",
+              fileSize: 0,
+              validation: { valid: true },
+            },
+          ],
+          processingState: {
+            status: "running",
+            elapsed: 42,
+            estimatedRemaining: 120,
+            perItemProgress: [
+              {
+                id: "talk-1",
+                status: "failed",
+                progressPercent: 100,
+                currentStage: "processing",
+                estimatedRemaining: 0,
+                error: "Timed out while downloading",
+              },
+              {
+                id: "talk-2",
+                status: "processing",
+                progressPercent: 50,
+                currentStage: "processing",
+                estimatedRemaining: 120,
+              },
+            ],
+          },
+        }}
+      />
+    )
+
+    const trackingPanel = screen.getByTestId("quick-ingest-run-tracking")
+    expect(trackingPanel).toHaveTextContent("Durable collection tracking")
+    expect(trackingPanel).toHaveTextContent("Collection 7")
+    expect(trackingPanel).toHaveTextContent("2 planned items")
+    expect(trackingPanel).toHaveTextContent("2 jobs")
+
+    await user.click(
+      screen.getByRole("button", { name: "Export failed items list" })
+    )
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining("https://example.com/fail")
+      )
+    })
+    expect(writeText.mock.calls[0]?.[0]).toContain("Timed out while downloading")
   })
 
   // -------------------------------------------------------------------------

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
@@ -246,6 +246,8 @@ vi.mock("lucide-react", () => {
     "MessageSquare",
     "RefreshCw",
     "Trash2",
+    "Search",
+    "Download",
   ]
   const mocks: Record<string, any> = {}
   for (const name of iconNames) {
@@ -1188,7 +1190,7 @@ describe("QuickIngestWizardModal — full wizard flow integration", () => {
       expect(screen.getByTestId("wizard-results-step")).toBeTruthy()
     })
 
-    expect(screen.getByText("Skipped (1)")).toBeTruthy()
+    expect(screen.getByText("Skipped existing (1)")).toBeTruthy()
     expect(screen.getByText("Existing Article")).toBeTruthy()
     expect(
       screen.getByText(/1 succeeded.*1 skipped.*1 failed/i)

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   cancelQuickIngestSession: vi.fn(),
   reattachQuickIngestSession: vi.fn(),
   checkConnection: vi.fn(),
+  navigate: vi.fn(),
   runtimeListeners: [] as Array<(message: any) => void>,
 }))
 
@@ -92,11 +93,13 @@ vi.mock("antd", () => ({
 
 vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router-dom")>()
-  return { ...actual, useNavigate: () => vi.fn() }
+  return { ...actual, useNavigate: () => mocks.navigate }
 })
 
 vi.mock("@/routes/route-paths", () => ({
   DOCUMENT_WORKSPACE_PATH: "/document-workspace",
+  buildMediaCollectionReviewPath: (collectionId: string | number) =>
+    `/media-collections/${collectionId}`,
 }))
 
 vi.mock("@/store/connection", () => ({
@@ -270,7 +273,11 @@ vi.mock("@/components/Common/QuickIngest/WizardResultsStep", async () => {
     typeof import("@/components/Common/QuickIngest/IngestWizardContext")
   >("@/components/Common/QuickIngest/IngestWizardContext")
   return {
-    WizardResultsStep: () => {
+    WizardResultsStep: ({
+      onOpenCollection,
+    }: {
+      onOpenCollection?: (collectionId: string) => void
+    }) => {
       const { state } = actual.useIngestWizard()
       return (
         <div data-testid="wizard-results">
@@ -280,6 +287,14 @@ vi.mock("@/components/Common/QuickIngest/WizardResultsStep", async () => {
               {item.id}:{item.outcome}:{item.message || ""}
             </div>
           ))}
+          {onOpenCollection ? (
+            <button
+              type="button"
+              onClick={() => onOpenCollection("7")}
+            >
+              Open collection
+            </button>
+          ) : null}
         </div>
       )
     },
@@ -310,6 +325,7 @@ describe("QuickIngestWizardModal session runtime", () => {
     mocks.cancelQuickIngestSession.mockReset()
     mocks.reattachQuickIngestSession.mockReset()
     mocks.checkConnection.mockReset()
+    mocks.navigate.mockReset()
     mocks.cancelQuickIngestSession.mockResolvedValue({ ok: true })
     useQuickIngestSessionStore.setState({
       session: null,
@@ -1294,6 +1310,48 @@ describe("QuickIngestWizardModal session runtime", () => {
           }),
         ])
       )
+    })
+  })
+
+  it("opens durable conference collections from terminal results", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    useQuickIngestSessionStore.getState().upsertSession({
+      ...createEmptyQuickIngestSession(),
+      lifecycle: "completed",
+      currentStep: 5,
+      highestStep: 5,
+      processingState: {
+        status: "complete",
+        perItemProgress: [],
+        elapsed: 7,
+        estimatedRemaining: 0,
+      },
+      results: [
+        {
+          id: "conference-talk-1",
+          status: "ok",
+          url: "https://youtube.com/watch?v=talk-1",
+          type: "video",
+          mediaId: "101",
+        } as any,
+      ],
+      tracking: {
+        mode: "webui-direct",
+        sessionId: "qi-direct-conference",
+        collectionId: "7",
+        durableMode: "durable_collection",
+        startedAt: 1234,
+      } as any,
+    })
+
+    render(<QuickIngestWizardModal open onClose={onClose} />)
+
+    await user.click(screen.getByRole("button", { name: "Open collection" }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(mocks.navigate).toHaveBeenCalledWith("/media-collections/7")
     })
   })
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -172,7 +172,8 @@ vi.mock("@/components/Common/QuickIngest/AddContentStep", async () => {
   >("@/components/Common/QuickIngest/IngestWizardContext")
   return {
     AddContentStep: ({ onQuickProcess }: { onQuickProcess?: () => void }) => {
-      const { state, setQueueItems } = actual.useIngestWizard()
+      const context = actual.useIngestWizard() as any
+      const { state, setQueueItems } = context
       return (
         <div>
           <button
@@ -191,6 +192,43 @@ vi.mock("@/components/Common/QuickIngest/AddContentStep", async () => {
             }}
           >
             Queue And Process
+          </button>
+          <button
+            onClick={() => {
+              context.setConferenceBatchMetadata({
+                collectionName: "Strange Loop 2012",
+                conferenceName: "Strange Loop",
+                eventYear: "2012",
+                sharedTags: ["conference", "clojure"],
+                sourcePlaylistUrl: "https://youtube.com/playlist?list=PL-conf",
+              })
+              setQueueItems([
+                {
+                  id: "conference-talk-1",
+                  url: "https://youtube.com/watch?v=talk-1",
+                  detectedType: "video",
+                  icon: "Film",
+                  fileSize: 0,
+                  validation: { valid: true },
+                  playlist: {
+                    playlistId: "PL-conf",
+                    playlistTitle: "Strange Loop 2012",
+                    ordinal: 1,
+                    normalizedSourceId: "youtube:video:talk-1",
+                    duplicateStatus: "new",
+                  },
+                  conferenceOverride: {
+                    selected: true,
+                    title: "Simplicity Matters",
+                    speaker: "Rich Hickey",
+                    tags: ["keynote"],
+                  },
+                },
+              ])
+              onQuickProcess?.()
+            }}
+          >
+            Queue Conference And Process
           </button>
           {state.queueItems.map((item) => (
             <div key={item.id} data-testid={`queued-item-${item.id}`}>
@@ -340,6 +378,66 @@ describe("QuickIngestWizardModal session runtime", () => {
     await waitFor(() => {
       expect(screen.getByTestId("wizard-results")).toHaveTextContent("complete:1")
     })
+  })
+
+  it("submits conference batch metadata and item overrides through the session payload", async () => {
+    const user = userEvent.setup()
+    useQuickIngestSessionStore.getState().createDraftSession()
+    mocks.startQuickIngestSession.mockResolvedValue({
+      ok: true,
+      sessionId: "qi-direct-conference",
+    })
+    mocks.submitQuickIngestBatch.mockResolvedValue({
+      ok: true,
+      results: [
+        {
+          id: "conference-talk-1",
+          status: "ok",
+          url: "https://youtube.com/watch?v=talk-1",
+          type: "video",
+        },
+      ],
+    })
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Queue Conference And Process" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.submitQuickIngestBatch).toHaveBeenCalledTimes(1)
+    })
+    expect(mocks.submitQuickIngestBatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __quickIngestSessionId: "qi-direct-conference",
+        conferenceBatchMetadata: {
+          collectionName: "Strange Loop 2012",
+          conferenceName: "Strange Loop",
+          eventYear: "2012",
+          sharedTags: ["conference", "clojure"],
+          sourcePlaylistUrl: "https://youtube.com/playlist?list=PL-conf",
+        },
+        entries: [
+          expect.objectContaining({
+            id: "conference-talk-1",
+            url: "https://youtube.com/watch?v=talk-1",
+            type: "video",
+            playlist: expect.objectContaining({
+              playlistId: "PL-conf",
+              ordinal: 1,
+              normalizedSourceId: "youtube:video:talk-1",
+            }),
+            conferenceOverride: expect.objectContaining({
+              selected: true,
+              title: "Simplicity Matters",
+              speaker: "Rich Hickey",
+              tags: ["keynote"],
+            }),
+          }),
+        ],
+      })
+    )
   })
 
   it("does not pre-seed direct tracking item identities before backend submissions are acknowledged", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -530,9 +530,13 @@ describe("QuickIngestWizardModal session runtime", () => {
         batchId: "batch-77",
         batchIds: ["batch-77"],
         jobIds: [77],
+        collectionId: "7",
+        plannedItemIds: ["11"],
         itemIds: ["queued-url-1"],
         submittedItemIds: ["queued-url-1"],
         jobIdToItemId: { "77": "queued-url-1" },
+        jobIdToCollectionItemId: { "77": "11" },
+        durableMode: "durable_collection",
         startedAt: Date.now(),
       })
       return new Promise(() => {})
@@ -567,6 +571,10 @@ describe("QuickIngestWizardModal session runtime", () => {
           sessionId: "qi-direct-late-tracking",
           batchIds: ["batch-77"],
           jobIds: [77],
+          collectionId: "7",
+          plannedItemIds: ["11"],
+          jobIdToCollectionItemId: { "77": "11" },
+          durableMode: "durable_collection",
         })
       )
     })

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ResultsListItem } from "../ResultsListItem"
+import type { ResultItemWithMediaId } from "../types"
+
+vi.mock("antd", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  List: {
+    Item: ({ actions, children }: any) => (
+      <div>
+        <div>{children}</div>
+        <div>{actions}</div>
+      </div>
+    ),
+  },
+  Tag: ({ children, color }: any) => (
+    <span data-color={color}>{children}</span>
+  ),
+}))
+
+const t = (_key: string, defaultValue?: any) =>
+  typeof defaultValue === "string"
+    ? defaultValue
+    : defaultValue?.defaultValue ?? _key
+
+describe("ResultsListItem status labels", () => {
+  it("labels submit failures distinctly from processing failures", () => {
+    const item: ResultItemWithMediaId = {
+      id: "submit-1",
+      status: "error",
+      outcome: "submit_failed",
+      type: "video",
+      url: "https://example.com/talk",
+      mediaId: null,
+      error: "Queue unavailable",
+    }
+
+    render(
+      <ResultsListItem
+        item={item}
+        processOnly={false}
+        onDownloadJson={vi.fn()}
+        onOpenMedia={vi.fn()}
+        onDiscussInChat={vi.fn()}
+        t={t as any}
+      />
+    )
+
+    expect(screen.getByText("Not submitted")).toBeTruthy()
+    expect(screen.queryByText("Failed")).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx
@@ -454,4 +454,98 @@ describe("WizardResultsStep navigation buttons", () => {
 
     expect(screen.queryByText("Ask this collection")).toBeNull()
   })
+
+  it("retries durable failed collection items with retry request metadata", () => {
+    const onRetryItems = vi.fn()
+    wizardHarness.results = [
+      {
+        id: "ok-1",
+        status: "ok" as const,
+        type: "video",
+        title: "Opening Keynote",
+        mediaId: 101,
+        collectionItemId: "11",
+      } as any,
+      {
+        id: "submit-1",
+        status: "error" as const,
+        outcome: "submit_failed",
+        type: "video",
+        title: "Submit Blocked",
+        error: "timed out",
+        collectionItemId: "13",
+      } as any,
+      {
+        id: "failed-1",
+        status: "error" as const,
+        outcome: "failed",
+        type: "video",
+        title: "Bad Video",
+        error: "timed out",
+        collectionItemId: "14",
+        retryAttempt: 2,
+      } as any,
+      {
+        id: "cancel-1",
+        status: "error" as const,
+        outcome: "cancelled",
+        type: "video",
+        title: "Cancelled Talk",
+        error: "cancelled",
+        collectionItemId: "15",
+      } as any,
+      {
+        id: "legacy-failed",
+        status: "error" as const,
+        outcome: "failed",
+        type: "video",
+        title: "Legacy Failed",
+        error: "timed out",
+      } as any,
+    ]
+    sessionHarness.tracking = {
+      mode: "webui-direct",
+      collectionId: "7",
+      plannedItemIds: ["11", "13", "14", "15"],
+      durableMode: "durable_collection",
+      startedAt: "2026-05-16T12:00:00Z",
+    }
+
+    render(
+      <WizardResultsStep
+        onClose={vi.fn()}
+        onRetryItems={onRetryItems}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Retry all 3 retryable errors",
+      })
+    )
+
+    expect(onRetryItems).toHaveBeenCalledWith(
+      ["13", "14", "15"],
+      [
+        {
+          resultId: "submit-1",
+          collectionItemId: "13",
+          retryAttempt: 1,
+          idempotencyKey: "conference-retry-13-1",
+        },
+        {
+          resultId: "failed-1",
+          collectionItemId: "14",
+          retryAttempt: 3,
+          idempotencyKey: "conference-retry-14-3",
+        },
+        {
+          resultId: "cancel-1",
+          collectionItemId: "15",
+          retryAttempt: 1,
+          idempotencyKey: "conference-retry-15-1",
+        },
+      ]
+    )
+  })
 })

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/WizardResultsStep.navigation.test.tsx
@@ -9,11 +9,24 @@ const wizardHarness = vi.hoisted(() => ({
   reset: vi.fn(),
 }))
 
+const sessionHarness = vi.hoisted(() => ({
+  tracking: undefined as any,
+}))
+
+const capabilitiesHarness = vi.hoisted(() => ({
+  capabilities: { hasKnowledgeQaMediaScope: false } as any,
+  loading: false,
+  refresh: vi.fn(),
+}))
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, opts?: any) => {
       if (typeof opts === "string") return opts
-      return opts?.defaultValue ?? key
+      const value = opts?.defaultValue ?? key
+      return value.replace(/\{\{(\w+)\}\}/g, (_match: string, token: string) =>
+        opts?.[token] == null ? `{{${token}}}` : String(opts[token])
+      )
     },
   }),
 }))
@@ -25,6 +38,23 @@ vi.mock("../IngestWizardContext", () => ({
       processingState: { elapsed: 10 },
     },
     reset: wizardHarness.reset,
+  }),
+}))
+
+vi.mock("@/store/quick-ingest-session", () => ({
+  useQuickIngestSessionStore: (selector: any) =>
+    selector({
+      session: sessionHarness.tracking
+        ? { tracking: sessionHarness.tracking }
+        : null,
+    }),
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: capabilitiesHarness.capabilities,
+    loading: capabilitiesHarness.loading,
+    refresh: capabilitiesHarness.refresh,
   }),
 }))
 
@@ -47,6 +77,10 @@ describe("WizardResultsStep navigation buttons", () => {
 
   beforeEach(() => {
     wizardHarness.reset.mockReset()
+    sessionHarness.tracking = undefined
+    capabilitiesHarness.capabilities = { hasKnowledgeQaMediaScope: false }
+    capabilitiesHarness.loading = false
+    capabilitiesHarness.refresh.mockReset()
     setSinglePdfResult()
   })
 
@@ -212,5 +246,212 @@ describe("WizardResultsStep navigation buttons", () => {
     render(<WizardResultsStep onClose={vi.fn()} />)
     expect(screen.queryByText("Search in Knowledge")).toBeNull()
     expect(screen.queryByText("Open in Workspace")).toBeNull()
+  })
+
+  it("groups conference outcomes and opens the durable collection", () => {
+    const onOpenCollection = vi.fn()
+    wizardHarness.results = [
+      {
+        id: "ok-1",
+        status: "ok" as const,
+        type: "video",
+        title: "Opening Keynote",
+        mediaId: 101,
+        collectionItemId: "11",
+      } as any,
+      {
+        id: "skip-1",
+        status: "ok" as const,
+        outcome: "skipped",
+        type: "video",
+        title: "Existing Talk",
+        mediaId: 102,
+        collectionItemId: "12",
+      } as any,
+      {
+        id: "submit-1",
+        status: "error" as const,
+        outcome: "submit_failed",
+        type: "video",
+        url: "https://example.com/submit",
+        title: "Submit Blocked",
+        error: "Queue unavailable",
+        collectionItemId: "13",
+      } as any,
+      {
+        id: "failed-1",
+        status: "error" as const,
+        outcome: "failed",
+        type: "video",
+        url: "https://example.com/fail",
+        title: "Bad Video",
+        error: "Download failed",
+        collectionItemId: "14",
+        retryAttempt: 2,
+      } as any,
+      {
+        id: "cancel-1",
+        status: "error" as const,
+        outcome: "cancelled",
+        type: "video",
+        url: "https://example.com/cancel",
+        title: "Cancelled Talk",
+        error: "Cancelled by user",
+        collectionItemId: "15",
+      } as any,
+    ]
+    sessionHarness.tracking = {
+      mode: "webui-direct",
+      collectionId: "7",
+      plannedItemIds: ["11", "12", "13", "14", "15"],
+      durableMode: "durable_collection",
+      startedAt: "2026-05-16T12:00:00Z",
+    }
+
+    render(
+      <WizardResultsStep
+        onClose={vi.fn()}
+        onOpenCollection={onOpenCollection}
+      />
+    )
+
+    expect(screen.getByText("Succeeded (1)")).toBeTruthy()
+    expect(screen.getByText("Skipped existing (1)")).toBeTruthy()
+    expect(screen.getByText("Not submitted (1)")).toBeTruthy()
+    expect(screen.getByText("Failed during processing (1)")).toBeTruthy()
+    expect(screen.getByText("Cancelled (1)")).toBeTruthy()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open collection 7" })
+    )
+    expect(onOpenCollection).toHaveBeenCalledWith("7")
+  })
+
+  it("only exposes Ask this collection when media-scope QA is supported and collection content is ready", () => {
+    const onSearchKnowledge = vi.fn()
+    capabilitiesHarness.capabilities = { hasKnowledgeQaMediaScope: true }
+    sessionHarness.tracking = {
+      mode: "webui-direct",
+      collectionId: "7",
+      plannedItemIds: ["11"],
+      durableMode: "durable_collection",
+      startedAt: "2026-05-16T12:00:00Z",
+    }
+    setSinglePdfResult({
+      type: "video",
+      mediaId: 101,
+      persisted: true,
+      collectionItemId: "11",
+    } as any)
+
+    render(
+      <WizardResultsStep
+        onClose={vi.fn()}
+        onSearchKnowledge={onSearchKnowledge}
+      />
+    )
+
+    const askButton = screen.getByRole("button", {
+      name: "Ask this collection",
+    })
+    fireEvent.click(askButton)
+    expect(onSearchKnowledge).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText("Search in Knowledge")).toBeNull()
+  })
+
+  it("keeps the collection handoff available when every item failed", () => {
+    const onOpenCollection = vi.fn()
+    wizardHarness.results = [
+      {
+        id: "failed-1",
+        status: "error" as const,
+        outcome: "failed",
+        type: "video",
+        title: "Bad Video",
+        error: "Download failed",
+        collectionItemId: "14",
+      } as any,
+    ]
+    sessionHarness.tracking = {
+      mode: "webui-direct",
+      collectionId: "7",
+      plannedItemIds: ["14"],
+      durableMode: "durable_collection",
+      startedAt: "2026-05-16T12:00:00Z",
+    }
+
+    render(
+      <WizardResultsStep
+        onClose={vi.fn()}
+        onOpenCollection={onOpenCollection}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open collection 7" })
+    )
+    expect(onOpenCollection).toHaveBeenCalledWith("7")
+  })
+
+  it("allows collection-scoped QA when only skipped existing content is ready", () => {
+    const onSearchKnowledge = vi.fn()
+    capabilitiesHarness.capabilities = { hasKnowledgeQaMediaScope: true }
+    wizardHarness.results = [
+      {
+        id: "skip-1",
+        status: "ok" as const,
+        outcome: "skipped",
+        type: "video",
+        title: "Existing Talk",
+        mediaId: 102,
+        collectionItemId: "12",
+      } as any,
+    ]
+    sessionHarness.tracking = {
+      mode: "webui-direct",
+      collectionId: "7",
+      plannedItemIds: ["12"],
+      durableMode: "durable_collection",
+      startedAt: "2026-05-16T12:00:00Z",
+    }
+
+    render(
+      <WizardResultsStep
+        onClose={vi.fn()}
+        onSearchKnowledge={onSearchKnowledge}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Ask this collection" })
+    )
+    expect(onSearchKnowledge).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not expose collection-scoped QA when the server lacks media-scope support", () => {
+    const onSearchKnowledge = vi.fn()
+    capabilitiesHarness.capabilities = { hasKnowledgeQaMediaScope: false }
+    sessionHarness.tracking = {
+      mode: "webui-direct",
+      collectionId: "7",
+      plannedItemIds: ["11"],
+      durableMode: "durable_collection",
+      startedAt: "2026-05-16T12:00:00Z",
+    }
+    setSinglePdfResult({
+      type: "video",
+      mediaId: 101,
+      persisted: true,
+      collectionItemId: "11",
+    } as any)
+
+    render(
+      <WizardResultsStep
+        onClose={vi.fn()}
+        onSearchKnowledge={onSearchKnowledge}
+      />
+    )
+
+    expect(screen.queryByText("Ask this collection")).toBeNull()
   })
 })

--- a/apps/packages/ui/src/components/Common/QuickIngest/types.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/types.ts
@@ -204,6 +204,24 @@ export type PlaylistQueueMetadata = {
   duplicateStatus?: "new" | "duplicate_in_batch" | "duplicate_existing" | "unknown"
 }
 
+export type ConferenceBatchMetadata = {
+  collectionName: string
+  conferenceName?: string
+  eventDate?: string
+  eventYear?: string
+  sharedTags: string[]
+  sourcePlaylistUrl?: string
+}
+
+export type ConferenceItemMetadataOverride = {
+  title?: string
+  speaker?: string
+  talkDate?: string
+  track?: string
+  tags?: string[]
+  selected: boolean
+}
+
 /**
  * An item in the wizard's ingest queue (files + URLs with detected types).
  */
@@ -236,6 +254,8 @@ export type WizardQueueItem = {
   validation: QueueItemValidation
   /** Metadata carried from a playlist preflight response. */
   playlist?: PlaylistQueueMetadata
+  /** Conference-specific metadata overrides for bulk review workflows. */
+  conferenceOverride?: ConferenceItemMetadataOverride
 }
 
 /**

--- a/apps/packages/ui/src/components/Common/QuickIngest/types.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/types.ts
@@ -34,6 +34,7 @@ export type ResultOutcome =
   | "ingested"
   | "processed"
   | "skipped"
+  | "submit_failed"
   | "failed"
   | "cancelled"
 
@@ -324,6 +325,10 @@ export type WizardResultItem = ResultItem & {
   durationMs?: number
   /** Media ID returned from the server. */
   mediaId?: string | number | null
+  /** Durable collection item ID for bulk conference ingestion handoff. */
+  collectionItemId?: string | number | null
+  /** Retry attempt count associated with the latest ingest attempt. */
+  retryAttempt?: number | null
   /** Title extracted or assigned during processing. */
   title?: string | null
   /** Non-error informational message (e.g., "Already exists in library"). */

--- a/apps/packages/ui/src/components/Common/QuickIngest/types.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/types.ts
@@ -142,11 +142,15 @@ export type PersistedQuickIngestTracking = {
   sessionId?: string
   batchId?: string
   batchIds?: string[]
+  collectionId?: string
+  plannedItemIds?: string[]
   jobIds?: number[]
   submittedItemIds?: string[]
   /** @deprecated use submittedItemIds */
   itemIds?: string[]
   jobIdToItemId?: Record<string, string>
+  jobIdToCollectionItemId?: Record<string, string>
+  durableMode?: "durable_collection" | "degraded" | "unknown"
   startedAt?: number
 }
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/types.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/types.ts
@@ -196,6 +196,14 @@ export type QueueItemValidation = {
   warnings?: string[]
 }
 
+export type PlaylistQueueMetadata = {
+  playlistId?: string | null
+  playlistTitle?: string | null
+  ordinal?: number
+  normalizedSourceId?: string | null
+  duplicateStatus?: "new" | "duplicate_in_batch" | "duplicate_existing" | "unknown"
+}
+
 /**
  * An item in the wizard's ingest queue (files + URLs with detected types).
  */
@@ -226,6 +234,8 @@ export type WizardQueueItem = {
   mimeType?: string
   /** Validation state for this item. */
   validation: QueueItemValidation
+  /** Metadata carried from a playlist preflight response. */
+  playlist?: PlaylistQueueMetadata
 }
 
 /**

--- a/apps/packages/ui/src/components/Common/QuickIngest/types.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/types.ts
@@ -209,6 +209,12 @@ export type PlaylistQueueMetadata = {
   duplicateStatus?: "new" | "duplicate_in_batch" | "duplicate_existing" | "unknown"
 }
 
+export type ConferenceDuplicatePolicy =
+  | "skip"
+  | "overwrite"
+  | "update_metadata_only"
+  | "include_existing"
+
 export type ConferenceBatchMetadata = {
   collectionName: string
   conferenceName?: string
@@ -224,6 +230,7 @@ export type ConferenceItemMetadataOverride = {
   talkDate?: string
   track?: string
   tags?: string[]
+  duplicatePolicy?: ConferenceDuplicatePolicy
   selected: boolean
 }
 
@@ -329,6 +336,8 @@ export type WizardResultItem = ResultItem & {
   collectionItemId?: string | number | null
   /** Retry attempt count associated with the latest ingest attempt. */
   retryAttempt?: number | null
+  /** Idempotency key for durable retry operations. */
+  idempotencyKey?: string | null
   /** Title extracted or assigned during processing. */
   title?: string | null
   /** Non-error informational message (e.g., "Already exists in library"). */

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -57,6 +57,7 @@ import {
   DUPLICATE_SKIP_MESSAGE,
   isDbMessageDuplicate,
 } from "./QuickIngest/constants"
+import { isQuickIngestPlaylistPreflightDetail } from "@/utils/quick-ingest-open"
 
 // ---------------------------------------------------------------------------
 // Props
@@ -560,6 +561,9 @@ const buildInitialWizardState = (
   customBasePreset: session.customBasePreset,
   presetConfig: session.presetConfig,
   customOptions: session.customOptions,
+  playlistPreflightSeed: isQuickIngestPlaylistPreflightDetail(session.openDetail)
+    ? session.openDetail
+    : null,
   processingState: session.processingState,
   results: session.results,
   conferenceBatchMetadata: session.conferenceBatchMetadata ?? null,
@@ -583,6 +587,7 @@ const buildSessionPatchFromWizardState = (
     conferenceBatchMetadata: state.conferenceBatchMetadata,
     processingState: state.processingState,
     results: state.results,
+    openDetail: state.playlistPreflightSeed,
     badge: {
       queueCount:
         lifecycle === "draft"

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -1254,8 +1254,11 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
 
   const finalizeFailure = useCallback(
     (message: string, outcome: "failed" | "cancelled") => {
+      const trackedEligibleItems = trackedQueueItems.filter(
+        (item) => item.validation.valid && item.conferenceOverride?.selected !== false
+      )
       const fallbackItems =
-        trackedQueueItems.length > 0 ? trackedQueueItems : validQueueItems
+        trackedEligibleItems.length > 0 ? trackedEligibleItems : validQueueItems
       const existingResultIds = new Set(
         resultsRef.current
           .map((result) => String(result.id || "").trim())

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -221,6 +221,9 @@ const normalizeWizardResult = (
       item.mediaId ??
       extractCompletedIngestJobMediaId(item.data),
     persisted: item.persisted,
+    collectionItemId: item.collectionItemId ?? null,
+    retryAttempt: item.retryAttempt ?? null,
+    idempotencyKey: item.idempotencyKey ?? null,
     message: isDuplicate
       ? DUPLICATE_SKIP_MESSAGE
       : typeof item.message === "string" ? item.message : undefined,
@@ -403,6 +406,9 @@ const buildPersistedReattachSignature = (
   const jobIdToItemId = Object.entries(tracking.jobIdToItemId ?? {})
     .map(([jobId, itemId]) => `${jobId}:${String(itemId || "").trim()}`)
     .sort()
+  const jobIdToCollectionItemId = Object.entries(tracking.jobIdToCollectionItemId ?? {})
+    .map(([jobId, itemId]) => `${jobId}:${String(itemId || "").trim()}`)
+    .sort()
 
   return [
     mode,
@@ -411,6 +417,7 @@ const buildPersistedReattachSignature = (
     jobIds.join(","),
     itemIds.join(","),
     jobIdToItemId.join(","),
+    jobIdToCollectionItemId.join(","),
   ].join("|")
 }
 
@@ -691,6 +698,9 @@ const buildResultsFromReattachedJobs = (
             extractCompletedIngestJobError(job.result) ||
             `Quick ingest ${jobStatus || "failed"}.`,
       mediaId: extractCompletedIngestJobMediaId(job.result),
+      collectionItemId: tracking?.jobIdToCollectionItemId?.[String(job.jobId)] ?? null,
+      retryAttempt: null,
+      idempotencyKey: null,
       title: job.result?.title ?? null,
       data: job.result,
       message: isDuplicate ? DUPLICATE_SKIP_MESSAGE : undefined,

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -29,7 +29,10 @@ import {
   extractCompletedIngestJobError,
   extractCompletedIngestJobMediaId,
 } from "@/services/tldw/ingest-job-results"
-import { DOCUMENT_WORKSPACE_PATH } from "@/routes/route-paths"
+import {
+  DOCUMENT_WORKSPACE_PATH,
+  buildMediaCollectionReviewPath,
+} from "@/routes/route-paths"
 import {
   type PersistedWizardQueueItem,
   type QuickIngestSessionLifecycle,
@@ -1589,6 +1592,15 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     [navigate, onClose]
   )
 
+  const handleOpenCollection = useCallback(
+    (collectionId: string) => {
+      const collectionPath = buildMediaCollectionReviewPath(collectionId)
+      onClose()
+      navigate(collectionPath)
+    },
+    [navigate, onClose]
+  )
+
   // Render the current step
   const stepContent = useMemo(() => {
     switch (currentStep) {
@@ -1626,6 +1638,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
             onOpenMedia={handleOpenMedia}
             onSearchKnowledge={handleSearchKnowledge}
             onOpenWorkspace={handleOpenWorkspace}
+            onOpenCollection={handleOpenCollection}
           />
         )
       default:
@@ -1635,6 +1648,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     connectionRecoveryMessage,
     currentStep,
     handleOpenMedia,
+    handleOpenCollection,
     handleOpenWorkspace,
     handleQuickProcess,
     handleRetryConnection,

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -41,9 +41,12 @@ import { useConnectionStore } from "@/store/connection"
 import { ConnectionPhase } from "@/types/connection"
 import type {
   CommonOptions,
+  ConferenceBatchMetadata,
+  ConferenceItemMetadataOverride,
   DetectedMediaType,
   ItemProgress,
   ItemProgressStatus,
+  PlaylistQueueMetadata,
   PersistedQuickIngestTracking,
   ReattachedQuickIngestJob,
   TypeDefaults,
@@ -74,6 +77,8 @@ type QuickIngestRequestPayload = {
     url: string
     type: QuickIngestEntryType
     defaults?: TypeDefaults
+    playlist?: PlaylistQueueMetadata
+    conferenceOverride?: ConferenceItemMetadataOverride
   }>
   files: Array<{
     id: string
@@ -81,12 +86,14 @@ type QuickIngestRequestPayload = {
     type?: string
     data: number[]
     defaults?: TypeDefaults
+    conferenceOverride?: ConferenceItemMetadataOverride
   }>
   storeRemote: boolean
   processOnly: boolean
   common: CommonOptions
   advancedValues: Record<string, unknown>
   fileDefaults: TypeDefaults
+  conferenceBatchMetadata?: ConferenceBatchMetadata | null
   __quickIngestSessionId?: string
 }
 
@@ -297,6 +304,8 @@ const buildPersistedQueueItems = (
     fileSize: item.file?.size ?? item.fileSize,
     mimeType: item.file?.type || item.mimeType,
     validation: item.validation,
+    playlist: item.playlist,
+    conferenceOverride: item.conferenceOverride,
     fileStub:
       item.file || item.fileStub
         ? {
@@ -419,6 +428,8 @@ const hydrateQueueItems = (
         fileSize: item.fileSize,
         mimeType: item.mimeType,
         validation: item.validation,
+        playlist: item.playlist,
+        conferenceOverride: item.conferenceOverride,
       }
     }
 
@@ -439,6 +450,8 @@ const hydrateQueueItems = (
         valid: false,
         warnings,
       },
+      playlist: item.playlist,
+      conferenceOverride: item.conferenceOverride,
       fileStub: item.fileStub || {
         key: item.key,
         lastModified: item.lastModified,
@@ -549,6 +562,7 @@ const buildInitialWizardState = (
   customOptions: session.customOptions,
   processingState: session.processingState,
   results: session.results,
+  conferenceBatchMetadata: session.conferenceBatchMetadata ?? null,
   isMinimized:
     session.visibility === "hidden" && session.lifecycle === "processing",
 })
@@ -566,6 +580,7 @@ const buildSessionPatchFromWizardState = (
     customBasePreset: state.customBasePreset,
     presetConfig: state.presetConfig,
     customOptions: state.customOptions,
+    conferenceBatchMetadata: state.conferenceBatchMetadata,
     processingState: state.processingState,
     results: state.results,
     badge: {
@@ -718,6 +733,7 @@ const buildProgressFromReattachedJobs = (
 
 const buildQuickIngestPayload = async (
   items: WizardQueueItem[],
+  conferenceBatchMetadata: ConferenceBatchMetadata | null,
   options: QuickIngestRequestPayload["common"] & {
     storeRemote: boolean
     reviewBeforeStorage: boolean
@@ -725,7 +741,9 @@ const buildQuickIngestPayload = async (
     typeDefaults: TypeDefaults
   }
 ): Promise<QuickIngestRequestPayload> => {
-  const validItems = items.filter((item) => item.validation.valid)
+  const validItems = items.filter(
+    (item) => item.validation.valid && item.conferenceOverride?.selected !== false
+  )
   const entries = validItems
     .filter((item): item is WizardQueueItem & { url: string } => Boolean(item.url))
     .map((item) => ({
@@ -733,6 +751,8 @@ const buildQuickIngestPayload = async (
       url: item.url,
       type: mapDetectedTypeToEntryType(item.detectedType),
       defaults: buildDefaultsForQueueItem(item, options.typeDefaults),
+      playlist: item.playlist,
+      conferenceOverride: item.conferenceOverride,
     }))
 
   const files = await Promise.all(
@@ -744,6 +764,7 @@ const buildQuickIngestPayload = async (
         type: item.file.type || undefined,
         data: Array.from(new Uint8Array(await item.file.arrayBuffer())),
         defaults: buildDefaultsForQueueItem(item, options.typeDefaults),
+        conferenceOverride: item.conferenceOverride,
       }))
   )
 
@@ -762,6 +783,7 @@ const buildQuickIngestPayload = async (
     },
     advancedValues: options.advancedValues ?? {},
     fileDefaults: options.typeDefaults,
+    conferenceBatchMetadata,
   }
 }
 
@@ -809,7 +831,10 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
   const runStartedAtRef = useRef<number | null>(null)
   const cancelledSessionIdsRef = useRef<Set<string>>(new Set())
   const validQueueItems = useMemo(
-    () => queueItems.filter((item) => item.validation.valid),
+    () =>
+      queueItems.filter(
+        (item) => item.validation.valid && item.conferenceOverride?.selected !== false
+      ),
     [queueItems]
   )
   const trackedQueueItems = useMemo(
@@ -1332,13 +1357,17 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
         // Best effort; background proxy handles auth for direct runtimes.
       }
 
-      const requestPayload = await buildQuickIngestPayload(validQueueItems, {
-        ...presetConfig.common,
-        storeRemote: presetConfig.storeRemote,
-        reviewBeforeStorage: presetConfig.reviewBeforeStorage,
-        advancedValues: presetConfig.advancedValues,
-        typeDefaults: presetConfig.typeDefaults,
-      })
+      const requestPayload = await buildQuickIngestPayload(
+        validQueueItems,
+        state.conferenceBatchMetadata,
+        {
+          ...presetConfig.common,
+          storeRemote: presetConfig.storeRemote,
+          reviewBeforeStorage: presetConfig.reviewBeforeStorage,
+          advancedValues: presetConfig.advancedValues,
+          typeDefaults: presetConfig.typeDefaults,
+        }
+      )
 
       const startAck = await startQuickIngestSession(requestPayload)
       if (!startAck?.ok || !startAck?.sessionId) {
@@ -1417,6 +1446,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     presetConfig.reviewBeforeStorage,
     presetConfig.storeRemote,
     presetConfig.typeDefaults,
+    state.conferenceBatchMetadata,
     markProcessingTracking,
     validQueueItems,
   ])

--- a/apps/packages/ui/src/components/Layouts/QuickIngestButton.tsx
+++ b/apps/packages/ui/src/components/Layouts/QuickIngestButton.tsx
@@ -6,7 +6,9 @@ import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
 import { createEventHost } from "@/utils/create-event-host"
 import {
   consumePendingQuickIngestOpen,
+  createQuickIngestSessionSeedFromOpenDetail,
   rememberQuickIngestOpenRequest,
+  type QuickIngestOpenDetail,
   type QuickIngestPendingOpenOptions,
 } from "@/utils/quick-ingest-open"
 
@@ -39,10 +41,11 @@ export const useQuickIngestEvents = (options?: QuickIngestEventsOptions) => {
   )
   const quickIngestReadyRef = useRef(false)
   const pendingQuickIngestIntroRef = useRef(false)
-  const { session, createDraftSession, showSession, hideSession } =
+  const { session, createDraftSession, upsertSession, showSession, hideSession } =
     useQuickIngestSessionStore((s) => ({
       session: s.session,
       createDraftSession: s.createDraftSession,
+      upsertSession: s.upsertSession,
       showSession: s.showSession,
       hideSession: s.hideSession,
     }))
@@ -63,14 +66,18 @@ export const useQuickIngestEvents = (options?: QuickIngestEventsOptions) => {
   }, [])
 
   const performOpenQuickIngest = useCallback(
-    (options?: QuickIngestOpenOptions) => {
+    (options?: QuickIngestOpenOptions, detail?: QuickIngestOpenDetail) => {
       const { autoProcessQueued = false, focusTrigger = true } = options || {}
+      const seed = createQuickIngestSessionSeedFromOpenDetail(detail)
       setQuickIngestAutoProcessQueued(autoProcessQueued)
       const currentSession = useQuickIngestSessionStore.getState().session
       if (currentSession) {
+        if (seed) {
+          upsertSession(seed)
+        }
         showSession()
       } else {
-        createDraftSession()
+        createDraftSession(seed ?? undefined)
       }
       if (focusTrigger && focusTriggerRef?.current) {
         requestAnimationFrame(() => {
@@ -78,12 +85,12 @@ export const useQuickIngestEvents = (options?: QuickIngestEventsOptions) => {
         })
       }
     },
-    [createDraftSession, focusTriggerRef, showSession]
+    [createDraftSession, focusTriggerRef, showSession, upsertSession]
   )
 
   const performOpenQuickIngestIntro = useCallback(
-    (options?: QuickIngestOpenOptions) => {
-      performOpenQuickIngest({ ...options, focusTrigger: false })
+    (options?: QuickIngestOpenOptions, detail?: QuickIngestOpenDetail) => {
+      performOpenQuickIngest({ ...options, focusTrigger: false }, detail)
       if (quickIngestReadyRef.current) {
         window.dispatchEvent(new CustomEvent("tldw:quick-ingest-force-intro"))
       } else {
@@ -99,21 +106,21 @@ export const useQuickIngestEvents = (options?: QuickIngestEventsOptions) => {
       return false
     }
     if (pending.mode === "intro") {
-      performOpenQuickIngestIntro(pending.options)
+      performOpenQuickIngestIntro(pending.options, pending.detail)
       return true
     }
-    performOpenQuickIngest(pending.options)
+    performOpenQuickIngest(pending.options, pending.detail)
     return true
   }, [performOpenQuickIngest, performOpenQuickIngestIntro])
 
   const openQuickIngest = useCallback(
-    (nextOptions?: QuickIngestOpenOptions) => {
+    (nextOptions?: QuickIngestOpenOptions, detail?: QuickIngestOpenDetail) => {
       if (!quickIngestSessionHydrated) {
-        rememberQuickIngestOpenRequest("normal", undefined, nextOptions)
+        rememberQuickIngestOpenRequest("normal", detail, nextOptions)
         void rehydrateQuickIngestSession()
         return
       }
-      performOpenQuickIngest(nextOptions)
+      performOpenQuickIngest(nextOptions, detail)
     },
     [performOpenQuickIngest, quickIngestSessionHydrated, rehydrateQuickIngestSession]
   )
@@ -133,8 +140,11 @@ export const useQuickIngestEvents = (options?: QuickIngestEventsOptions) => {
 
   // Global event listeners for opening quick ingest
   useEffect(() => {
-    const handler = () => {
-      openQuickIngest()
+    const handler = (event: Event) => {
+      openQuickIngest(
+        undefined,
+        (event as CustomEvent<QuickIngestOpenDetail>).detail
+      )
     }
     window.addEventListener("tldw:open-quick-ingest", handler)
     return () => {

--- a/apps/packages/ui/src/components/Layouts/QuickIngestButton.tsx
+++ b/apps/packages/ui/src/components/Layouts/QuickIngestButton.tsx
@@ -41,14 +41,11 @@ export const useQuickIngestEvents = (options?: QuickIngestEventsOptions) => {
   )
   const quickIngestReadyRef = useRef(false)
   const pendingQuickIngestIntroRef = useRef(false)
-  const { session, createDraftSession, upsertSession, showSession, hideSession } =
-    useQuickIngestSessionStore((s) => ({
-      session: s.session,
-      createDraftSession: s.createDraftSession,
-      upsertSession: s.upsertSession,
-      showSession: s.showSession,
-      hideSession: s.hideSession,
-    }))
+  const session = useQuickIngestSessionStore((s) => s.session)
+  const createDraftSession = useQuickIngestSessionStore((s) => s.createDraftSession)
+  const upsertSession = useQuickIngestSessionStore((s) => s.upsertSession)
+  const showSession = useQuickIngestSessionStore((s) => s.showSession)
+  const hideSession = useQuickIngestSessionStore((s) => s.hideSession)
   const quickIngestOpen = session?.visibility === "visible"
   const hasQuickIngestSession = Boolean(session)
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
@@ -1183,6 +1183,12 @@ function buildScopeSnapshot(
     preset,
     sources: [...settings.sources],
     webFallback: Boolean(settings.enable_web_fallback),
+    collectionId:
+      typeof settings.collection_id === "number" &&
+      Number.isInteger(settings.collection_id) &&
+      settings.collection_id > 0
+        ? settings.collection_id
+        : null,
     includeMediaIds: Array.isArray(settings.include_media_ids)
       ? settings.include_media_ids
           .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
@@ -1199,6 +1205,12 @@ function buildScopeSnapshot(
 function createRestorableSettingsSnapshot(settings: RagSettings): Partial<RagSettings> {
   return {
     sources: Array.isArray(settings.sources) ? [...settings.sources] : [],
+    collection_id:
+      typeof settings.collection_id === "number" &&
+      Number.isInteger(settings.collection_id) &&
+      settings.collection_id > 0
+        ? settings.collection_id
+        : undefined,
     include_media_ids: Array.isArray(settings.include_media_ids)
       ? settings.include_media_ids
           .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
@@ -1258,6 +1270,14 @@ function normalizeRestorableSettingsSnapshot(
     normalized.include_media_ids = candidate.include_media_ids
       .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
       .map((value) => Math.round(value))
+  }
+
+  if (
+    typeof candidate.collection_id === "number" &&
+    Number.isInteger(candidate.collection_id) &&
+    candidate.collection_id > 0
+  ) {
+    normalized.collection_id = candidate.collection_id
   }
 
   if (Array.isArray(candidate.include_note_ids)) {

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/ExpertSettings.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/SettingsPanel/ExpertSettings.tsx
@@ -128,6 +128,7 @@ const NULLABLE_STRING_KEYS = new Set<RagKey>([
 ])
 
 const NULLABLE_NUMBER_KEYS = new Set<RagKey>([
+  "collection_id",
   "accumulation_time_budget_sec",
   "subquery_time_budget_sec",
   "subquery_doc_budget",

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/conference-scope.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/conference-scope.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_RAG_SETTINGS,
+  buildRagSearchRequest,
+} from "@/services/rag/unified-rag"
+import { buildConferenceCollectionKnowledgeQaOptions } from "../conference-scope"
+
+describe("conference collection Knowledge QA scope", () => {
+  it("builds backend-owned collection scoped RAG options", () => {
+    const scope = buildConferenceCollectionKnowledgeQaOptions(44)
+    const request = buildRagSearchRequest({
+      ...DEFAULT_RAG_SETTINGS,
+      ...scope,
+      query: "What themes repeat across the conference?",
+    })
+
+    expect(scope).toEqual({
+      collection_id: 44,
+      sources: ["media_db"],
+    })
+    expect(request.options.collection_id).toBe(44)
+    expect(request.options.sources).toEqual(["media_db"])
+    expect(request.options.include_media_ids).toBeUndefined()
+  })
+
+  it("rejects missing or invalid collection identifiers", () => {
+    expect(() => buildConferenceCollectionKnowledgeQaOptions(0)).toThrow(
+      "collection_id_required"
+    )
+    expect(() => buildConferenceCollectionKnowledgeQaOptions("not-a-number")).toThrow(
+      "collection_id_required"
+    )
+    expect(() => buildConferenceCollectionKnowledgeQaOptions("44abc")).toThrow(
+      "collection_id_required"
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/conference-scope.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/conference-scope.ts
@@ -1,0 +1,24 @@
+import type { RagSettings } from "@/services/rag/unified-rag"
+
+export type ConferenceCollectionKnowledgeQaOptions = Pick<
+  Partial<RagSettings>,
+  "collection_id" | "sources"
+>
+
+const normalizeCollectionId = (collectionId: number | string): number => {
+  const numeric =
+    typeof collectionId === "number"
+      ? collectionId
+      : Number(collectionId.trim())
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    throw new Error("collection_id_required")
+  }
+  return numeric
+}
+
+export const buildConferenceCollectionKnowledgeQaOptions = (
+  collectionId: number | string
+): ConferenceCollectionKnowledgeQaOptions => ({
+  collection_id: normalizeCollectionId(collectionId),
+  sources: ["media_db"],
+})

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/index.tsx
@@ -30,6 +30,8 @@ const LazyExportDialog = React.lazy(() =>
   import("./ExportDialog").then((module) => ({ default: module.ExportDialog })),
 )
 
+export { buildConferenceCollectionKnowledgeQaOptions } from "./conference-scope"
+
 const ROUTE_HYDRATION_RETRY_DELAY_MS = 1500
 const ROUTE_HYDRATION_MAX_RETRIES = 2
 

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/types.ts
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/types.ts
@@ -17,6 +17,7 @@ export type ScopeSnapshot = {
   preset: RagPresetName
   sources: RagSettings["sources"]
   webFallback: boolean
+  collectionId: number | null
   includeMediaIds: number[]
   includeNoteIds: string[]
 }

--- a/apps/packages/ui/src/components/Review/ConferenceCollectionReview.tsx
+++ b/apps/packages/ui/src/components/Review/ConferenceCollectionReview.tsx
@@ -1,0 +1,379 @@
+import React from "react"
+import { ChevronLeft, ChevronRight, ExternalLink, MessageSquareText } from "lucide-react"
+import type {
+  MediaCollection,
+  MediaCollectionItem,
+  MediaCollectionItemStatus,
+} from "@/services/tldw/conference-collections"
+
+type ConferenceCollectionReviewProps = {
+  collection: MediaCollection
+  onAskCollection?: (scope: { collectionId: number; mediaIds: number[] }) => void
+  onOpenMedia?: (mediaId: number) => void
+  className?: string
+}
+
+const READY_STATUSES = new Set<MediaCollectionItemStatus>([
+  "completed",
+  "skipped_existing",
+])
+
+const IN_PROGRESS_STATUSES = new Set<MediaCollectionItemStatus>([
+  "planned",
+  "processing",
+])
+
+const ISSUE_STATUSES = new Set<MediaCollectionItemStatus>([
+  "submit_failed",
+  "failed",
+  "cancelled",
+])
+
+const STATUS_LABELS: Record<MediaCollectionItemStatus, string> = {
+  planned: "Planned",
+  processing: "Processing",
+  completed: "Completed",
+  skipped_existing: "Skipped existing",
+  submit_failed: "Not submitted",
+  failed: "Failed",
+  cancelled: "Cancelled",
+}
+
+const statusTone = (status: MediaCollectionItemStatus): string => {
+  if (READY_STATUSES.has(status)) {
+    return "border-success/30 bg-success/10 text-success"
+  }
+  if (status === "processing" || status === "planned") {
+    return "border-primary/30 bg-primary/10 text-primary"
+  }
+  return "border-danger/30 bg-danger/10 text-danger"
+}
+
+const isReadyItem = (item: MediaCollectionItem): boolean =>
+  READY_STATUSES.has(item.status) &&
+  typeof item.mediaId === "number" &&
+  Number.isFinite(item.mediaId) &&
+  item.mediaId > 0
+
+const getItemTitle = (item: MediaCollectionItem): string =>
+  item.title?.trim() || `Talk ${item.ordinal}`
+
+const getMetadataString = (
+  item: MediaCollectionItem,
+  key: "summary" | "excerpt" | "description"
+): string | null => {
+  const value = item.metadata?.[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+const formatTalkMeta = (item: MediaCollectionItem): string => {
+  const parts = [item.speaker, item.track, item.publishedAt]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map((value) => value.trim())
+  return parts.join(" / ")
+}
+
+const sortCollectionItems = (
+  items: MediaCollectionItem[]
+): MediaCollectionItem[] =>
+  [...items].sort((left, right) => {
+    if (left.ordinal !== right.ordinal) return left.ordinal - right.ordinal
+    return left.id - right.id
+  })
+
+export function ConferenceCollectionReview({
+  collection,
+  onAskCollection,
+  onOpenMedia,
+  className = "",
+}: ConferenceCollectionReviewProps) {
+  const orderedItems = React.useMemo(
+    () => sortCollectionItems(collection.items),
+    [collection.items]
+  )
+  const readyItems = React.useMemo(
+    () => orderedItems.filter(isReadyItem),
+    [orderedItems]
+  )
+  const readyMediaIds = React.useMemo(
+    () => Array.from(new Set(readyItems.map((item) => item.mediaId as number))),
+    [readyItems]
+  )
+  const inProgressCount = orderedItems.filter((item) =>
+    IN_PROGRESS_STATUSES.has(item.status)
+  ).length
+  const issueCount = orderedItems.filter((item) =>
+    ISSUE_STATUSES.has(item.status)
+  ).length
+  const [activeItemId, setActiveItemId] = React.useState<number | null>(
+    () => orderedItems[0]?.id ?? null
+  )
+  const [selectedCompareIds, setSelectedCompareIds] = React.useState<number[]>([])
+
+  React.useEffect(() => {
+    if (orderedItems.length === 0) {
+      setActiveItemId(null)
+      return
+    }
+    setActiveItemId((current) =>
+      current != null && orderedItems.some((item) => item.id === current)
+        ? current
+        : orderedItems[0].id
+    )
+  }, [orderedItems])
+
+  const activeIndex = Math.max(
+    0,
+    orderedItems.findIndex((item) => item.id === activeItemId)
+  )
+  const activeItem = orderedItems[activeIndex] ?? null
+  const selectedCompareItems = orderedItems.filter((item) =>
+    selectedCompareIds.includes(item.id)
+  )
+  const qaDisabled = readyMediaIds.length === 0
+
+  const handlePrevious = () => {
+    if (activeIndex <= 0) return
+    setActiveItemId(orderedItems[activeIndex - 1].id)
+  }
+
+  const handleNext = () => {
+    if (activeIndex >= orderedItems.length - 1) return
+    setActiveItemId(orderedItems[activeIndex + 1].id)
+  }
+
+  const toggleCompare = (itemId: number) => {
+    setSelectedCompareIds((current) =>
+      current.includes(itemId)
+        ? current.filter((value) => value !== itemId)
+        : [...current, itemId]
+    )
+  }
+
+  const askCollection = () => {
+    if (qaDisabled) return
+    onAskCollection?.({
+      collectionId: collection.id,
+      mediaIds: readyMediaIds,
+    })
+  }
+
+  return (
+    <section className={`space-y-4 text-text ${className}`}>
+      <header className="flex flex-col gap-3 border-b border-border pb-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <h2 className="truncate text-lg font-semibold">{collection.name}</h2>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+            <span>{orderedItems.length} talks</span>
+            <span>{readyItems.length} ready</span>
+            {inProgressCount > 0 && <span>{inProgressCount} in progress</span>}
+            {issueCount > 0 && <span>{issueCount} need attention</span>}
+          </div>
+        </div>
+        <div className="flex flex-col items-start gap-1 md:items-end">
+          <button
+            type="button"
+            onClick={askCollection}
+            disabled={qaDisabled}
+            className="inline-flex h-9 items-center gap-2 rounded-md border border-primary/40 px-3 text-sm font-medium text-primary hover:bg-primary/10 disabled:cursor-not-allowed disabled:border-border disabled:text-text-muted disabled:hover:bg-transparent"
+          >
+            <MessageSquareText className="h-4 w-4" aria-hidden="true" />
+            Ask this collection
+          </button>
+          <div className="text-xs text-text-muted" aria-live="polite">
+            {qaDisabled ? (
+              <>
+                <div>No ready talks yet</div>
+                <div>Waiting for completed or skipped-existing items.</div>
+              </>
+            ) : (
+              <div>{readyItems.length} ready talks will be searched.</div>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <div className="grid min-h-[420px] gap-4 lg:grid-cols-[minmax(240px,320px)_1fr]">
+        <aside className="min-h-0 rounded-md border border-border bg-surface">
+          <div className="border-b border-border px-3 py-2 text-xs font-medium text-text-muted">
+            Conference order
+          </div>
+          <ul
+            className="max-h-[520px] divide-y divide-border overflow-auto"
+            data-testid="conference-talk-list"
+          >
+            {orderedItems.map((item) => {
+              const title = getItemTitle(item)
+              const itemMeta = formatTalkMeta(item)
+              const selected = selectedCompareIds.includes(item.id)
+              const active = activeItem?.id === item.id
+              return (
+                <li
+                  key={item.id}
+                  className={`flex gap-2 px-3 py-2 ${active ? "bg-primary/5" : ""}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected}
+                    aria-label={`Compare ${title}`}
+                    onChange={() => toggleCompare(item.id)}
+                    className="mt-1 h-4 w-4 rounded border-border"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setActiveItemId(item.id)}
+                    aria-current={active ? "true" : undefined}
+                    className="min-w-0 flex-1 text-left"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate text-sm font-medium">
+                        {item.ordinal}. {title}
+                      </span>
+                      <span
+                        className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${statusTone(item.status)}`}
+                      >
+                        {STATUS_LABELS[item.status]}
+                      </span>
+                    </div>
+                    {itemMeta && (
+                      <div className="mt-1 truncate text-xs text-text-muted">
+                        {itemMeta}
+                      </div>
+                    )}
+                    {item.errorSummary && (
+                      <div className="mt-1 truncate text-xs text-danger">
+                        {item.errorSummary}
+                      </div>
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </aside>
+
+        <main className="min-w-0 rounded-md border border-border bg-surface p-4">
+          {activeItem ? (
+            <div className="space-y-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-lg font-semibold">
+                    {getItemTitle(activeItem)}
+                  </h3>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[10px] font-medium ${statusTone(activeItem.status)}`}
+                    >
+                      {STATUS_LABELS[activeItem.status]}
+                    </span>
+                    {formatTalkMeta(activeItem) && (
+                      <span>{formatTalkMeta(activeItem)}</span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handlePrevious}
+                    disabled={activeIndex <= 0}
+                    className="inline-flex h-8 items-center gap-1 rounded-md border border-border px-2 text-xs hover:bg-surface2 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+                    Previous talk
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleNext}
+                    disabled={activeIndex >= orderedItems.length - 1}
+                    className="inline-flex h-8 items-center gap-1 rounded-md border border-border px-2 text-xs hover:bg-surface2 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Next talk
+                    <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="rounded-md border border-border bg-surface2 p-3">
+                  <div className="text-xs font-medium text-text-muted">Summary</div>
+                  <p className="mt-2 text-sm leading-6">
+                    {getMetadataString(activeItem, "summary") ||
+                      getMetadataString(activeItem, "description") ||
+                      "No summary yet."}
+                  </p>
+                </div>
+                <div className="rounded-md border border-border bg-surface2 p-3">
+                  <div className="text-xs font-medium text-text-muted">Transcript excerpt</div>
+                  <p className="mt-2 text-sm leading-6">
+                    {getMetadataString(activeItem, "excerpt") ||
+                      "No transcript excerpt yet."}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (activeItem.mediaId) onOpenMedia?.(activeItem.mediaId)
+                  }}
+                  disabled={!activeItem.mediaId}
+                  className="inline-flex h-8 items-center gap-1 rounded-md border border-border px-3 text-xs hover:bg-surface2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                  Open media
+                </button>
+                {activeItem.sourceUrl && (
+                  <a
+                    href={activeItem.sourceUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-primary hover:underline"
+                  >
+                    Source URL
+                  </a>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="py-10 text-center text-sm text-text-muted">
+              No talks in this collection.
+            </div>
+          )}
+        </main>
+      </div>
+
+      {selectedCompareItems.length >= 2 && (
+        <section className="rounded-md border border-border bg-surface p-4">
+          <h3 className="text-sm font-semibold">
+            Comparing {selectedCompareItems.length} talks
+          </h3>
+          <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {selectedCompareItems.map((item) => (
+              <article
+                key={item.id}
+                className="rounded-md border border-border bg-surface2 p-3"
+              >
+                <div className="text-sm font-medium">{getItemTitle(item)}</div>
+                {formatTalkMeta(item) && (
+                  <div className="mt-1 text-xs text-text-muted">
+                    {formatTalkMeta(item)}
+                  </div>
+                )}
+                <p className="mt-2 text-sm leading-6">
+                  {getMetadataString(item, "summary") ||
+                    getMetadataString(item, "excerpt") ||
+                    "No summary or excerpt yet."}
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+    </section>
+  )
+}
+
+export { isReadyItem as isConferenceCollectionReadyItem }

--- a/apps/packages/ui/src/components/Review/__tests__/conference-collection-review.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/conference-collection-review.test.tsx
@@ -1,0 +1,174 @@
+import React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { ConferenceCollectionReview } from "../ConferenceCollectionReview"
+import type {
+  MediaCollection,
+  MediaCollectionItem,
+} from "@/services/tldw/conference-collections"
+
+const makeItem = (
+  overrides: Partial<MediaCollectionItem>
+): MediaCollectionItem => ({
+  id: overrides.id ?? 1,
+  collectionId: overrides.collectionId ?? 44,
+  ordinal: overrides.ordinal ?? 1,
+  sourceUrl: overrides.sourceUrl ?? "https://www.youtube.com/watch?v=talk",
+  normalizedSourceId: overrides.normalizedSourceId ?? null,
+  sourceKind: overrides.sourceKind ?? "youtube",
+  title: overrides.title ?? "Untitled talk",
+  speaker: overrides.speaker ?? null,
+  publishedAt: overrides.publishedAt ?? null,
+  track: overrides.track ?? null,
+  duplicateStatus: overrides.duplicateStatus ?? "new",
+  status: overrides.status ?? "completed",
+  mediaId: overrides.mediaId ?? null,
+  contentItemId: overrides.contentItemId ?? null,
+  latestJobId: overrides.latestJobId ?? null,
+  latestRunId: overrides.latestRunId ?? null,
+  idempotencyKey: overrides.idempotencyKey ?? null,
+  retryCount: overrides.retryCount ?? 0,
+  errorSummary: overrides.errorSummary ?? null,
+  warnings: overrides.warnings ?? [],
+  metadata: overrides.metadata ?? {},
+  tags: overrides.tags ?? [],
+  createdAt: overrides.createdAt ?? "2026-05-16T10:00:00.000Z",
+  updatedAt: overrides.updatedAt ?? "2026-05-16T10:00:00.000Z",
+})
+
+const makeCollection = (
+  items: MediaCollectionItem[]
+): MediaCollection => ({
+  id: 44,
+  name: "Strange Loop 2010",
+  kind: "conference",
+  description: "Conference talks",
+  sourceUrl: "https://www.youtube.com/playlist?list=PL0065D9B288E6804B",
+  metadata: {
+    conferenceName: "Strange Loop",
+    year: "2010",
+  },
+  defaultTags: ["strange-loop", "conference"],
+  createdAt: "2026-05-16T10:00:00.000Z",
+  updatedAt: "2026-05-16T10:00:00.000Z",
+  items,
+})
+
+describe("ConferenceCollectionReview", () => {
+  it("shows ordered talks, readiness, navigation, comparison, and scoped QA", () => {
+    const onAskCollection = vi.fn()
+    const onOpenMedia = vi.fn()
+    const collection = makeCollection([
+      makeItem({
+        id: 1,
+        ordinal: 2,
+        title: "Compiler internals",
+        speaker: "Grace",
+        track: "Languages",
+        status: "skipped_existing",
+        mediaId: 102,
+        metadata: {
+          summary: "Compiler summary",
+          excerpt: "Compiler excerpt",
+        },
+      }),
+      makeItem({
+        id: 2,
+        ordinal: 1,
+        title: "Macro keynote",
+        speaker: "Ada",
+        track: "Keynote",
+        status: "completed",
+        mediaId: 101,
+        metadata: {
+          summary: "Macro summary",
+          excerpt: "Macro excerpt",
+        },
+      }),
+      makeItem({
+        id: 3,
+        ordinal: 3,
+        title: "Panel discussion",
+        speaker: "Alan",
+        status: "processing",
+        mediaId: 103,
+      }),
+    ])
+
+    render(
+      <ConferenceCollectionReview
+        collection={collection}
+        onAskCollection={onAskCollection}
+        onOpenMedia={onOpenMedia}
+      />
+    )
+
+    expect(screen.getByRole("heading", { name: "Strange Loop 2010" })).toBeInTheDocument()
+    expect(screen.getByText("2 ready")).toBeInTheDocument()
+    expect(screen.getByText("1 in progress")).toBeInTheDocument()
+
+    const rows = within(screen.getByTestId("conference-talk-list")).getAllByRole("listitem")
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Macro keynote"),
+      expect.stringContaining("Compiler internals"),
+      expect.stringContaining("Panel discussion"),
+    ])
+    expect(rows[0]).toHaveTextContent("Completed")
+    expect(rows[1]).toHaveTextContent("Skipped existing")
+    expect(rows[2]).toHaveTextContent("Processing")
+
+    expect(screen.getByRole("heading", { name: "Macro keynote" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Next talk" }))
+    expect(screen.getByRole("heading", { name: "Compiler internals" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Open media" }))
+    expect(onOpenMedia).toHaveBeenCalledWith(102)
+
+    fireEvent.click(screen.getByLabelText("Compare Macro keynote"))
+    fireEvent.click(screen.getByLabelText("Compare Compiler internals"))
+    expect(screen.getByText("Comparing 2 talks")).toBeInTheDocument()
+    expect(screen.getByText("Macro summary")).toBeInTheDocument()
+    expect(screen.getByText("Compiler excerpt")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask this collection" }))
+    expect(onAskCollection).toHaveBeenCalledWith({
+      collectionId: 44,
+      mediaIds: [101, 102],
+    })
+  })
+
+  it("disables scoped QA with readiness copy when no talks are ready", () => {
+    const onAskCollection = vi.fn()
+    const collection = makeCollection([
+      makeItem({
+        id: 1,
+        ordinal: 1,
+        title: "Queued talk",
+        status: "planned",
+        mediaId: null,
+      }),
+      makeItem({
+        id: 2,
+        ordinal: 2,
+        title: "Failed talk",
+        status: "failed",
+        mediaId: null,
+        errorSummary: "Download failed",
+      }),
+    ])
+
+    render(
+      <ConferenceCollectionReview
+        collection={collection}
+        onAskCollection={onAskCollection}
+      />
+    )
+
+    const askButton = screen.getByRole("button", { name: "Ask this collection" })
+    expect(askButton).toBeDisabled()
+    expect(screen.getByText("No ready talks yet")).toBeInTheDocument()
+    expect(screen.getByText("Waiting for completed or skipped-existing items.")).toBeInTheDocument()
+
+    fireEvent.click(askButton)
+    expect(onAskCollection).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -300,7 +300,7 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   const openQuickIngest = async () => {
     const detail =
       playlistImportEnabled
-        ? activePlaylistDetail ?? (await resolveActivePlaylistDetail())
+        ? (await resolveActivePlaylistDetail()) ?? activePlaylistDetail
         : null
     requestQuickIngestOpen(detail ?? undefined)
     setMoreOpen(false)

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -23,7 +23,11 @@ import { useMcpTools } from "@/hooks/useMcpTools"
 import { browser } from "wxt/browser"
 import { useStorage } from "@plasmohq/storage/hook"
 import { fetchChatModels } from "@/services/tldw-server"
-import { requestQuickIngestOpen } from "@/utils/quick-ingest-open"
+import {
+  buildQuickIngestOpenDetailFromUrl,
+  requestQuickIngestOpen,
+  type QuickIngestOpenDetail
+} from "@/utils/quick-ingest-open"
 import type { ToolChoice } from "@/store/option"
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings"
 import type { ConversationContextComposition } from "@/types/conversation-context"
@@ -95,6 +99,8 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
   >(undefined)
   const moreBtnRef = React.useRef<HTMLButtonElement>(null)
   const { capabilities } = useServerCapabilities()
+  const [activePlaylistDetail, setActivePlaylistDetail] =
+    React.useState<QuickIngestOpenDetail | null>(null)
   const {
     hasMcp,
     healthState: mcpHealthState,
@@ -247,8 +253,56 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     setSystemPromptOverride(undefined)
   }, [selectedSystemPrompt])
 
-  const openQuickIngest = () => {
-    requestQuickIngestOpen()
+  const playlistImportEnabled =
+    Boolean(isConnected) && Boolean(capabilities?.hasMediaPlaylistPreflight)
+
+  const resolveActivePlaylistDetail =
+    React.useCallback(async (): Promise<QuickIngestOpenDetail | null> => {
+      if (!playlistImportEnabled) return null
+      try {
+        const tabs = await browser.tabs?.query({
+          active: true,
+          currentWindow: true
+        })
+        const activeTab = tabs?.find(
+          (tab) => typeof tab.url === "string" && tab.url.trim().length > 0
+        )
+        return activeTab?.url ? buildQuickIngestOpenDetailFromUrl(activeTab.url) : null
+      } catch {
+        return null
+      }
+    }, [playlistImportEnabled])
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    if (!moreOpen || !playlistImportEnabled) {
+      setActivePlaylistDetail(null)
+      return
+    }
+
+    void resolveActivePlaylistDetail().then((detail) => {
+      if (!cancelled) {
+        setActivePlaylistDetail(detail)
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [moreOpen, playlistImportEnabled, resolveActivePlaylistDetail])
+
+  const quickIngestLabel =
+    playlistImportEnabled && activePlaylistDetail
+      ? t("sidepanel:controlRow.importPlaylist", "Import playlist to tldw")
+      : t("sidepanel:controlRow.quickIngest", "Quick Ingest")
+
+  const openQuickIngest = async () => {
+    const detail =
+      playlistImportEnabled
+        ? activePlaylistDetail ?? (await resolveActivePlaylistDetail())
+        : null
+    requestQuickIngestOpen(detail ?? undefined)
     setMoreOpen(false)
     requestAnimationFrame(() => moreBtnRef.current?.focus())
   }
@@ -638,13 +692,15 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
       </div>
       <button
         type="button"
-        onClick={openQuickIngest}
+        onClick={() => {
+          void openQuickIngest()
+        }}
         data-testid="chat-quick-ingest"
         className="w-full text-left text-sm px-3 py-2 rounded flex items-center gap-2 hover:bg-surface2"
-        title={t("sidepanel:controlRow.quickIngest", "Quick Ingest")}
+        title={quickIngestLabel}
       >
         <UploadCloud className="size-4 text-text-subtle" />
-        {t("sidepanel:controlRow.quickIngest", "Quick Ingest")}
+        {quickIngestLabel}
       </button>
       <button
         type="button"

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.queue.contract.test.tsx
@@ -26,6 +26,30 @@ const resolveSidepanelFormPath = () => {
 
 const sidepanelFormSource = readFileSync(resolveSidepanelFormPath(), "utf8")
 
+const resolveControlRowPath = () => {
+  const candidates = [
+    path.resolve(__dirname, "../ControlRow.tsx"),
+    path.resolve(process.cwd(), "src/components/Sidepanel/Chat/ControlRow.tsx"),
+    path.resolve(
+      process.cwd(),
+      "../packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx"
+    ),
+    path.resolve(
+      process.cwd(),
+      "apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx"
+    )
+  ]
+
+  const resolved = candidates.find((candidate) => existsSync(candidate))
+  if (!resolved) {
+    throw new Error("Unable to locate Sidepanel chat ControlRow source")
+  }
+
+  return resolved
+}
+
+const controlRowSource = readFileSync(resolveControlRowPath(), "utf8")
+
 describe("sidepanel queued request contract", () => {
   it("uses the shared queued request panel and orchestration hook", () => {
     expect(sidepanelFormSource).toContain('from "@/components/Common/ChatQueuePanel"')
@@ -68,5 +92,14 @@ describe("sidepanel queued request contract", () => {
     expect(sidepanelFormSource).toContain("const { form, draftSaved, clearDraft } = useComposerText")
     expect(sidepanelFormSource).toContain("clearDraft()")
     expect(sidepanelFormSource).toContain("onChange={attachmentHandler.onFileInputChange}")
+  })
+
+  it("passes extension playlist handoff detail into the Quick Ingest session", () => {
+    expect(sidepanelFormSource).toContain(
+      "createQuickIngestSessionSeedFromOpenDetail(detail)"
+    )
+    expect(sidepanelFormSource).toContain("upsertQuickIngestSession(seed)")
+    expect(controlRowSource).toContain("buildQuickIngestOpenDetailFromUrl")
+    expect(controlRowSource).toContain("Import playlist to tldw")
   })
 })

--- a/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
@@ -103,6 +103,10 @@ import { useSetting } from "@/hooks/useSetting"
 import { useFocusComposerOnConnect } from "@/hooks/useComposerFocus"
 import { useQuickIngestStore } from "@/store/quick-ingest"
 import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
+import {
+  createQuickIngestSessionSeedFromOpenDetail,
+  type QuickIngestOpenDetail
+} from "@/utils/quick-ingest-open"
 import { useUiModeStore } from "@/store/ui-mode"
 import { useStoreMessageOption } from "@/store/option"
 import { shallow } from "zustand/shallow"
@@ -487,12 +491,14 @@ export const SidepanelForm = ({
   const {
     quickIngestSession,
     createDraftQuickIngestSession,
+    upsertQuickIngestSession,
     showQuickIngestSession,
     hideQuickIngestSession
   } = useQuickIngestSessionStore(
     (state) => ({
       quickIngestSession: state.session,
       createDraftQuickIngestSession: state.createDraftSession,
+      upsertQuickIngestSession: state.upsertSession,
       showQuickIngestSession: state.showSession,
       hideQuickIngestSession: state.hideSession
     }),
@@ -888,12 +894,16 @@ export const SidepanelForm = ({
     browserSupportsSpeechRecognition || hasServerStt || hasServerVoiceChat
 
   // Composer window events hook
-  const handleOpenQuickIngest = React.useCallback(() => {
+  const handleOpenQuickIngest = React.useCallback((detail?: QuickIngestOpenDetail) => {
+    const seed = createQuickIngestSessionSeedFromOpenDetail(detail)
     setAutoProcessQueuedIngest(false)
     if (quickIngestSession) {
+      if (seed) {
+        upsertQuickIngestSession(seed)
+      }
       showQuickIngestSession()
     } else {
-      createDraftQuickIngestSession()
+      createDraftQuickIngestSession(seed ?? undefined)
     }
     setIngestOpen(true)
     requestAnimationFrame(() => {
@@ -902,7 +912,8 @@ export const SidepanelForm = ({
   }, [
     createDraftQuickIngestSession,
     quickIngestSession,
-    showQuickIngestSession
+    showQuickIngestSession,
+    upsertQuickIngestSession
   ])
 
   const {
@@ -1992,18 +2003,23 @@ export const SidepanelForm = ({
     window.dispatchEvent(new CustomEvent("tldw:toggle-rag"))
   }, [])
 
-  const handleQuickIngestOpen = React.useCallback(() => {
+  const handleQuickIngestOpen = React.useCallback((detail?: QuickIngestOpenDetail) => {
+    const seed = createQuickIngestSessionSeedFromOpenDetail(detail)
     setAutoProcessQueuedIngest(false)
     if (quickIngestSession) {
+      if (seed) {
+        upsertQuickIngestSession(seed)
+      }
       showQuickIngestSession()
     } else {
-      createDraftQuickIngestSession()
+      createDraftQuickIngestSession(seed ?? undefined)
     }
     setIngestOpen(true)
   }, [
     createDraftQuickIngestSession,
     quickIngestSession,
-    showQuickIngestSession
+    showQuickIngestSession,
+    upsertQuickIngestSession
   ])
 
   const handleProcessQueuedIngest = React.useCallback(() => {

--- a/apps/packages/ui/src/entries/background.ts
+++ b/apps/packages/ui/src/entries/background.ts
@@ -61,6 +61,10 @@ import {
   extractCompletedIngestJobError,
   extractCompletedIngestJobMediaId,
 } from "@/services/tldw/ingest-job-results";
+import {
+  buildConferenceCollectionCreatePayload,
+  buildConferenceCollectionItemPayload,
+} from "@/services/tldw/conference-collections";
 
 type BackgroundDiagnostics = {
   startedAt: number;
@@ -1775,8 +1779,16 @@ export default defineBackground({
       payload: any,
       runtimeContext?: QuickIngestSessionRunContext,
     ): Promise<{ ok: boolean; results: any[] }> => {
-      const entries = Array.isArray(payload?.entries) ? payload.entries : [];
-      const files = Array.isArray(payload?.files) ? payload.files : [];
+      const entries = Array.isArray(payload?.entries)
+        ? payload.entries.filter(
+            (entry: any) => entry?.conferenceOverride?.selected !== false,
+          )
+        : [];
+      const files = Array.isArray(payload?.files)
+        ? payload.files.filter(
+            (file: any) => file?.conferenceOverride?.selected !== false,
+          )
+        : [];
       const storeRemote = Boolean(payload?.storeRemote);
       const processOnly = Boolean(payload?.processOnly);
       const common = payload?.common || {};
@@ -1817,6 +1829,20 @@ export default defineBackground({
       };
       const queuedRemoteJobs =
         createIngestJobsTracker<QuickIngestRemoteResultMeta>();
+      const conferenceBatchMetadata =
+        payload?.conferenceBatchMetadata &&
+        typeof payload.conferenceBatchMetadata === "object"
+          ? payload.conferenceBatchMetadata
+          : null;
+      type PlannedConferenceCollectionItem = {
+        collectionId: number;
+        itemId: number;
+        idempotencyKey?: string | null;
+      };
+      const plannedConferenceItems = new Map<
+        string,
+        PlannedConferenceCollectionItem
+      >();
 
       const isCancelled = () =>
         Boolean(
@@ -1909,6 +1935,120 @@ export default defineBackground({
           autoApplyTemplate,
         });
         return fields;
+      };
+
+      const hasConferenceMetadata = (): boolean =>
+        Boolean(
+          conferenceBatchMetadata &&
+            (
+              String(conferenceBatchMetadata.collectionName || "").trim() ||
+              String(conferenceBatchMetadata.conferenceName || "").trim() ||
+              String(conferenceBatchMetadata.sourcePlaylistUrl || "").trim() ||
+              (Array.isArray(conferenceBatchMetadata.sharedTags) &&
+                conferenceBatchMetadata.sharedTags.length > 0)
+            ),
+        );
+
+      const getConferenceFallbackName = (): string | null => {
+        for (const entry of entries) {
+          const title = String(entry?.playlist?.playlistTitle || "").trim();
+          if (title) return title;
+        }
+        return null;
+      };
+
+      const createPlannedConferenceItems = async () => {
+        if (!shouldStoreRemote || !hasConferenceMetadata()) return;
+        const selectedEntries = entries.filter((entry: any) =>
+          String(entry?.url || "").trim(),
+        );
+        if (selectedEntries.length === 0) return;
+
+        const collectionResp = (await handleTldwRequest({
+          path: "/api/v1/media/collections",
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: buildConferenceCollectionCreatePayload(
+            conferenceBatchMetadata,
+            getConferenceFallbackName(),
+          ),
+          timeoutMs: ingestTimeoutMs,
+        })) as
+          | { ok: boolean; error?: string; status?: number; data?: any }
+          | undefined;
+        if (!collectionResp?.ok) {
+          throw new Error(
+            collectionResp?.error ||
+              `Collection creation failed: ${collectionResp?.status}`,
+          );
+        }
+        const collectionId = Number(collectionResp.data?.id);
+        if (!Number.isFinite(collectionId) || collectionId <= 0) {
+          throw new Error("Collection creation returned no collection id.");
+        }
+
+        for (const entry of selectedEntries) {
+          const itemResp = (await handleTldwRequest({
+            path: `/api/v1/media/collections/${encodeURIComponent(
+              String(collectionId),
+            )}/items`,
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: buildConferenceCollectionItemPayload(conferenceBatchMetadata, {
+              id: String(entry.id || ""),
+              url: String(entry.url || ""),
+              playlist: entry.playlist,
+              conferenceOverride: entry.conferenceOverride,
+            }),
+            timeoutMs: ingestTimeoutMs,
+          })) as
+            | { ok: boolean; error?: string; status?: number; data?: any }
+            | undefined;
+          if (!itemResp?.ok) {
+            throw new Error(
+              itemResp?.error || `Collection item failed: ${itemResp?.status}`,
+            );
+          }
+          const itemId = Number(itemResp.data?.id);
+          if (Number.isFinite(itemId) && itemId > 0) {
+            plannedConferenceItems.set(String(entry.id || ""), {
+              collectionId,
+              itemId,
+              idempotencyKey:
+                typeof itemResp.data?.idempotency_key === "string"
+                  ? itemResp.data.idempotency_key
+                  : null,
+            });
+          }
+        }
+      };
+
+      const patchPlannedConferenceItem = async (
+        planned: PlannedConferenceCollectionItem | undefined,
+        body: Record<string, unknown>,
+      ) => {
+        if (!planned) return;
+        await handleTldwRequest({
+          path: `/api/v1/media/collections/${encodeURIComponent(
+            String(planned.collectionId),
+          )}/items/${encodeURIComponent(String(planned.itemId))}`,
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body,
+          timeoutMs: ingestTimeoutMs,
+        }).catch((error) => {
+          logBackgroundError("quick ingest collection item patch", error);
+        });
+      };
+
+      const applyPlannedConferenceFields = (
+        fields: Record<string, any>,
+        planned: PlannedConferenceCollectionItem | undefined,
+      ) => {
+        if (!planned) return;
+        fields.media_collection_id = planned.collectionId;
+        fields.media_collection_item_id = planned.itemId;
+        if (planned.idempotencyKey) fields.idempotency_key = planned.idempotencyKey;
       };
 
       const processWebScrape = async (url: string, entry?: any) => {
@@ -2150,6 +2290,8 @@ export default defineBackground({
         });
       };
 
+      await createPlannedConferenceItems();
+
       for (const r of entries) {
         if (isCancelled()) break;
         const url = String(r?.url || "").trim();
@@ -2158,6 +2300,11 @@ export default defineBackground({
           r?.type && typeof r.type === "string" ? r.type : "auto";
         const t =
           explicitType === "auto" ? inferMediaTypeFromUrl(url) : explicitType;
+        const plannedConferenceItem = plannedConferenceItems.get(
+          String(r.id || ""),
+        );
+        let jobSubmitted = false;
+        let latestJobId: number | undefined;
         try {
           let data: any;
           if (shouldStoreRemote) {
@@ -2170,6 +2317,7 @@ export default defineBackground({
               r,
               resolvedDefaults,
             );
+            applyPlannedConferenceFields(fields, plannedConferenceItem);
             fields.urls = [url];
             const resp = await handleUpload({
               path: "/api/v1/media/ingest/jobs",
@@ -2185,10 +2333,20 @@ export default defineBackground({
               }
               data = await submitPersistentAddFallback({ fields });
             } else {
-              trackRemoteJobs(resp.data, {
+              const trackedCount = trackRemoteJobs(resp.data, {
                 id: String(r.id || crypto.randomUUID()),
                 url,
                 type: t,
+              });
+              const jobIds = queuedRemoteJobs.getJobIds();
+              latestJobId = jobIds[jobIds.length - trackedCount];
+              jobSubmitted = trackedCount > 0;
+              await patchPlannedConferenceItem(plannedConferenceItem, {
+                status: "processing",
+                latest_job_id:
+                  typeof latestJobId === "number"
+                    ? String(latestJobId)
+                    : undefined,
               });
               continue;
             }
@@ -2219,6 +2377,12 @@ export default defineBackground({
           emitProgress(result);
         } catch (e: any) {
           if (isCancelled()) break;
+          await patchPlannedConferenceItem(plannedConferenceItem, {
+            status: jobSubmitted ? "failed" : "submit_failed",
+            latest_job_id:
+              typeof latestJobId === "number" ? String(latestJobId) : undefined,
+            error_summary: e?.message || "Request failed",
+          });
           const result = {
             id: r.id,
             status: "error",
@@ -2331,6 +2495,20 @@ export default defineBackground({
       if (shouldStoreRemote && queuedRemoteJobs.hasItems()) {
         const remoteResults = await pollQueuedRemoteJobs();
         for (const result of remoteResults) {
+          await patchPlannedConferenceItem(
+            plannedConferenceItems.get(String(result?.id || "")),
+            {
+              status: result?.status === "ok" ? "completed" : "failed",
+              media_id:
+                result?.status === "ok"
+                  ? extractCompletedIngestJobMediaId(result?.data)
+                  : undefined,
+              error_summary:
+                result?.status === "ok"
+                  ? undefined
+                  : String(result?.error || "Ingest failed"),
+            },
+          );
           out.push(result);
           emitProgress(result);
         }

--- a/apps/packages/ui/src/entries/background.ts
+++ b/apps/packages/ui/src/entries/background.ts
@@ -1964,61 +1964,77 @@ export default defineBackground({
         );
         if (selectedEntries.length === 0) return;
 
-        const collectionResp = (await handleTldwRequest({
-          path: "/api/v1/media/collections",
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: buildConferenceCollectionCreatePayload(
-            conferenceBatchMetadata,
-            getConferenceFallbackName(),
-          ),
-          timeoutMs: ingestTimeoutMs,
-        })) as
-          | { ok: boolean; error?: string; status?: number; data?: any }
-          | undefined;
-        if (!collectionResp?.ok) {
-          throw new Error(
-            collectionResp?.error ||
-              `Collection creation failed: ${collectionResp?.status}`,
-          );
-        }
-        const collectionId = Number(collectionResp.data?.id);
-        if (!Number.isFinite(collectionId) || collectionId <= 0) {
-          throw new Error("Collection creation returned no collection id.");
-        }
-
-        for (const entry of selectedEntries) {
-          const itemResp = (await handleTldwRequest({
-            path: `/api/v1/media/collections/${encodeURIComponent(
-              String(collectionId),
-            )}/items`,
+        let collectionId: number | null = null;
+        try {
+          const collectionResp = (await handleTldwRequest({
+            path: "/api/v1/media/collections",
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: buildConferenceCollectionItemPayload(conferenceBatchMetadata, {
-              id: String(entry.id || ""),
-              url: String(entry.url || ""),
-              playlist: entry.playlist,
-              conferenceOverride: entry.conferenceOverride,
-            }),
+            body: buildConferenceCollectionCreatePayload(
+              conferenceBatchMetadata,
+              getConferenceFallbackName(),
+            ),
             timeoutMs: ingestTimeoutMs,
           })) as
             | { ok: boolean; error?: string; status?: number; data?: any }
             | undefined;
-          if (!itemResp?.ok) {
+          if (!collectionResp?.ok) {
             throw new Error(
-              itemResp?.error || `Collection item failed: ${itemResp?.status}`,
+              collectionResp?.error ||
+                `Collection creation failed: ${collectionResp?.status}`,
             );
           }
-          const itemId = Number(itemResp.data?.id);
-          if (Number.isFinite(itemId) && itemId > 0) {
-            plannedConferenceItems.set(String(entry.id || ""), {
-              collectionId,
-              itemId,
-              idempotencyKey:
-                typeof itemResp.data?.idempotency_key === "string"
-                  ? itemResp.data.idempotency_key
-                  : null,
-            });
+          const parsedCollectionId = Number(collectionResp.data?.id);
+          if (!Number.isFinite(parsedCollectionId) || parsedCollectionId <= 0) {
+            throw new Error("Collection creation returned no collection id.");
+          }
+          collectionId = parsedCollectionId;
+        } catch (error) {
+          console.debug("[tldw] conference collection planning failed", error);
+          return;
+        }
+        if (collectionId === null) return;
+
+        for (const entry of selectedEntries) {
+          try {
+            const itemResp = (await handleTldwRequest({
+              path: `/api/v1/media/collections/${encodeURIComponent(
+                String(collectionId),
+              )}/items`,
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: buildConferenceCollectionItemPayload(conferenceBatchMetadata, {
+                id: String(entry.id || ""),
+                url: String(entry.url || ""),
+                playlist: entry.playlist,
+                conferenceOverride: entry.conferenceOverride,
+              }),
+              timeoutMs: ingestTimeoutMs,
+            })) as
+              | { ok: boolean; error?: string; status?: number; data?: any }
+              | undefined;
+            if (!itemResp?.ok) {
+              throw new Error(
+                itemResp?.error || `Collection item failed: ${itemResp?.status}`,
+              );
+            }
+            const itemId = Number(itemResp.data?.id);
+            if (Number.isFinite(itemId) && itemId > 0) {
+              plannedConferenceItems.set(String(entry.id || ""), {
+                collectionId,
+                itemId,
+                idempotencyKey:
+                  typeof itemResp.data?.idempotency_key === "string"
+                    ? itemResp.data.idempotency_key
+                    : null,
+              });
+            }
+          } catch (error) {
+            console.debug(
+              "[tldw] conference collection item planning failed",
+              { collectionId, entryId: entry?.id },
+              error,
+            );
           }
         }
       };

--- a/apps/packages/ui/src/entries/background.ts
+++ b/apps/packages/ui/src/entries/background.ts
@@ -2048,7 +2048,11 @@ export default defineBackground({
         if (!planned) return;
         fields.media_collection_id = planned.collectionId;
         fields.media_collection_item_id = planned.itemId;
-        if (planned.idempotencyKey) fields.idempotency_key = planned.idempotencyKey;
+        fields.planned_item_ids = [String(planned.itemId)];
+        if (planned.idempotencyKey) {
+          fields.idempotency_key = planned.idempotencyKey;
+          fields.idempotency_keys = [planned.idempotencyKey];
+        }
       };
 
       const processWebScrape = async (url: string, entry?: any) => {
@@ -2330,6 +2334,9 @@ export default defineBackground({
               if (!shouldFallbackToPersistentAdd(toFallbackCandidate(resp))) {
                 const msg = resp?.error || `Upload failed: ${resp?.status}`;
                 throw new Error(msg);
+              }
+              if (typeof latestJobId === "number") {
+                fields.media_ingest_job_id = String(latestJobId);
               }
               data = await submitPersistentAddFallback({ fields });
             } else {

--- a/apps/packages/ui/src/hooks/useComposerEvents.tsx
+++ b/apps/packages/ui/src/hooks/useComposerEvents.tsx
@@ -1,10 +1,11 @@
 import React from "react"
+import type { QuickIngestOpenDetail } from "@/utils/quick-ingest-open"
 
 export interface ComposerEventHandlers {
   /** Called when tldw:focus-composer event is fired */
   onFocusComposer?: () => void
   /** Called when tldw:open-quick-ingest event is fired */
-  onOpenQuickIngest?: () => void
+  onOpenQuickIngest?: (detail?: QuickIngestOpenDetail) => void
 }
 
 export interface DocumentGeneratorSeed {
@@ -97,8 +98,8 @@ export const useComposerEvents = (
   // tldw:open-quick-ingest
   React.useEffect(() => {
     if (!onOpenQuickIngest) return
-    const handler = () => {
-      onOpenQuickIngest()
+    const handler = (event: Event) => {
+      onOpenQuickIngest((event as CustomEvent<QuickIngestOpenDetail>).detail)
     }
     window.addEventListener("tldw:open-quick-ingest", handler)
     return () => {

--- a/apps/packages/ui/src/routes/option-media-collection.tsx
+++ b/apps/packages/ui/src/routes/option-media-collection.tsx
@@ -1,0 +1,102 @@
+import React from "react"
+import OptionLayout from "~/components/Layouts/Layout"
+import { useNavigate, useParams } from "react-router-dom"
+import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
+import { ConferenceCollectionReview } from "@/components/Review/ConferenceCollectionReview"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import type { MediaCollection } from "@/services/tldw/conference-collections"
+
+const OptionMediaCollectionInner = () => {
+  const { collectionId } = useParams<{ collectionId?: string }>()
+  const navigate = useNavigate()
+  const [collection, setCollection] = React.useState<MediaCollection | null>(null)
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    const normalizedId = String(collectionId || "").trim()
+    if (!normalizedId) {
+      setLoading(false)
+      setError("Collection id is required.")
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    tldwClient
+      .getMediaCollection(normalizedId, { timeoutMs: 30_000 })
+      .then((loaded) => {
+        if (cancelled) return
+        setCollection(loaded)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(
+          err instanceof Error && err.message
+            ? err.message
+            : "Collection could not be loaded."
+        )
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [collectionId])
+
+  if (loading) {
+    return (
+      <div className="rounded-md border border-border bg-surface px-4 py-6 text-sm text-text-muted">
+        Loading collection...
+      </div>
+    )
+  }
+
+  if (error || !collection) {
+    return (
+      <div className="rounded-md border border-danger/30 bg-danger/5 px-4 py-6">
+        <h1 className="text-lg font-semibold text-text">Collection unavailable</h1>
+        <p className="mt-2 text-sm text-text-muted">
+          {error || "Collection could not be loaded."}
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/media-multi")}
+          className="mt-4 rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-surface2"
+        >
+          Back to Media Review
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <ConferenceCollectionReview
+      collection={collection}
+      onOpenMedia={(mediaId) => navigate(`/media/${mediaId}/view`)}
+      onAskCollection={({ collectionId: scopedCollectionId }) =>
+        navigate(`/knowledge?collection_id=${encodeURIComponent(String(scopedCollectionId))}`)
+      }
+    />
+  )
+}
+
+const OptionMediaCollection = () => {
+  return (
+    <OptionLayout>
+      <RouteErrorBoundary
+        routeId="media-collection"
+        routeLabel="Conference Collection"
+      >
+        <OptionMediaCollectionInner />
+      </RouteErrorBoundary>
+    </OptionLayout>
+  )
+}
+
+export default OptionMediaCollection

--- a/apps/packages/ui/src/routes/option-media-review-route-registry.tsx
+++ b/apps/packages/ui/src/routes/option-media-review-route-registry.tsx
@@ -2,6 +2,7 @@ import { lazy } from "react"
 import { Navigate } from "react-router-dom"
 
 import type { RouteDefinition } from "./route-registry"
+import { MEDIA_COLLECTION_REVIEW_PATH } from "./route-paths"
 
 import OptionMediaMulti from "./option-media-multi"
 
@@ -21,7 +22,7 @@ export const optionMediaReviewRoutes: RouteDefinition[] = [
   },
   {
     kind: "options",
-    path: "/media-collections/:collectionId",
+    path: MEDIA_COLLECTION_REVIEW_PATH,
     element: <OptionMediaCollection />,
   },
   {

--- a/apps/packages/ui/src/routes/option-media-review-route-registry.tsx
+++ b/apps/packages/ui/src/routes/option-media-review-route-registry.tsx
@@ -6,6 +6,7 @@ import type { RouteDefinition } from "./route-registry"
 import OptionMediaMulti from "./option-media-multi"
 
 const OptionContentReview = lazy(() => import("./option-content-review"))
+const OptionMediaCollection = lazy(() => import("./option-media-collection"))
 
 export const optionMediaReviewRoutes: RouteDefinition[] = [
   {
@@ -17,6 +18,11 @@ export const optionMediaReviewRoutes: RouteDefinition[] = [
     kind: "options",
     path: "/media-multi",
     element: <OptionMediaMulti />,
+  },
+  {
+    kind: "options",
+    path: "/media-collections/:collectionId",
+    element: <OptionMediaCollection />,
   },
   {
     kind: "options",

--- a/apps/packages/ui/src/routes/route-paths.ts
+++ b/apps/packages/ui/src/routes/route-paths.ts
@@ -23,6 +23,8 @@ export const SOURCES_PATH = "/sources"
 export const SOURCES_NEW_PATH = "/sources/new"
 export const SOURCES_DETAIL_PATH = "/sources/:sourceId"
 export const ADMIN_SOURCES_PATH = "/admin/sources"
+export const MEDIA_COLLECTIONS_PATH = "/media-collections"
+export const MEDIA_COLLECTION_REVIEW_PATH = `${MEDIA_COLLECTIONS_PATH}/:collectionId`
 
 export const VIEWPORT_CONSTRAINED_PATHS = [
   CHAT_WORKSPACE_PATH,
@@ -114,3 +116,7 @@ export const buildChatThreadPath = (
   const encoded = params.toString()
   return encoded ? `${CHAT_PATH}?${encoded}` : CHAT_PATH
 }
+
+export const buildMediaCollectionReviewPath = (
+  collectionId: string | number
+): string => `${MEDIA_COLLECTIONS_PATH}/${encodeURIComponent(String(collectionId))}`

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -1325,6 +1325,115 @@ describe("submitQuickIngestBatch", () => {
     )
   })
 
+  it("skips direct ingest submission for existing conference items when policy includes existing", async () => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string; body?: any }) => {
+      const path = String(request?.path || "")
+      if (path === "/api/v1/media/collections") {
+        return {
+          id: 9,
+          name: "Conference Batch",
+          kind: "conference",
+          metadata: {},
+          default_tags: [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+          items: []
+        }
+      }
+      if (path === "/api/v1/media/collections/9/items") {
+        return {
+          id: 91,
+          collection_id: 9,
+          ordinal: 3,
+          source_url: request.body?.source_url,
+          duplicate_status: request.body?.duplicate_status,
+          status: request.body?.status,
+          retry_count: 0,
+          idempotency_key: "conference-9-3",
+          warnings: [],
+          metadata: request.body?.metadata || {},
+          tags: [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z"
+        }
+      }
+      if (path === "/api/v1/media/collections/9/items/91") {
+        return {
+          id: 91,
+          collection_id: 9,
+          ordinal: 3,
+          source_url: "https://youtube.com/watch?v=existing",
+          duplicate_status: "duplicate_existing",
+          status: request.body?.status,
+          retry_count: request.body?.retry_count || 0,
+          warnings: [],
+          metadata: {},
+          tags: [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z"
+        }
+      }
+      throw new Error(`Unexpected bgRequest path: ${path}`)
+    })
+
+    const result = await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "existing-talk",
+          url: "https://youtube.com/watch?v=existing",
+          type: "video",
+          playlist: {
+            playlistId: "PL-conf",
+            playlistTitle: "Conference Batch",
+            ordinal: 3,
+            normalizedSourceId: "youtube:video:existing",
+            duplicateStatus: "duplicate_existing"
+          },
+          conferenceOverride: {
+            selected: true,
+            duplicatePolicy: "include_existing",
+            title: "Existing Talk"
+          }
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      conferenceBatchMetadata: {
+        collectionName: "Conference Batch",
+        sharedTags: []
+      },
+      common: {
+        perform_analysis: true,
+        perform_chunking: false,
+        overwrite_existing: false
+      },
+      advancedValues: {},
+      __quickIngestSessionId: "qi-direct-duplicate-policy"
+    } as any)
+
+    expect(mocks.bgUpload).not.toHaveBeenCalled()
+    expect(result.results?.[0]).toMatchObject({
+      id: "existing-talk",
+      status: "ok",
+      outcome: "skipped",
+      collectionItemId: 91,
+      idempotencyKey: "conference-9-3"
+    })
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/collections/9/items",
+        method: "POST",
+        body: expect.objectContaining({
+          status: "skipped_existing",
+          metadata: expect.objectContaining({
+            duplicate_policy: "include_existing"
+          })
+        })
+      })
+    )
+  })
+
   it("marks planned conference items as submit_failed when direct job submission fails", async () => {
     mocks.bgUpload.mockRejectedValueOnce(new Error("job submit failed"))
     mocks.bgRequest.mockImplementation(async (request: { path?: string; body?: any }) => {

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -1134,6 +1134,275 @@ describe("submitQuickIngestBatch", () => {
     })
   })
 
+  it("creates planned conference collection items before direct job submission", async () => {
+    mocks.bgUpload
+      .mockResolvedValueOnce({
+        batch_id: "batch-talk-1",
+        jobs: [{ id: 501 }]
+      })
+      .mockResolvedValueOnce({
+        batch_id: "batch-talk-2",
+        jobs: [{ id: 502 }]
+      })
+    mocks.bgRequest.mockImplementation(async (request: { path?: string; body?: any }) => {
+      const path = String(request?.path || "")
+      if (path === "/api/v1/media/collections") {
+        return {
+          id: 7,
+          name: "Strange Loop 2012",
+          kind: "conference",
+          source_url: "https://youtube.com/playlist?list=PL-conf",
+          metadata: request.body?.metadata || {},
+          default_tags: request.body?.default_tags || [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+          items: []
+        }
+      }
+      if (path === "/api/v1/media/collections/7/items") {
+        const ordinal = Number(request.body?.ordinal || 0)
+        return {
+          id: ordinal === 1 ? 11 : 12,
+          collection_id: 7,
+          ordinal,
+          source_url: request.body?.source_url,
+          normalized_source_id: request.body?.normalized_source_id,
+          source_kind: request.body?.source_kind,
+          title: request.body?.title,
+          speaker: request.body?.speaker,
+          duplicate_status: request.body?.duplicate_status || "new",
+          status: "planned",
+          retry_count: 0,
+          idempotency_key: `conference-7-${ordinal}`,
+          warnings: [],
+          metadata: request.body?.metadata || {},
+          tags: request.body?.tags || [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z"
+        }
+      }
+      if (path === "/api/v1/media/ingest/jobs/501" || path === "/api/v1/media/ingest/jobs/502") {
+        return {
+          ok: true,
+          data: {
+            status: "completed",
+            result: { media_id: path.endsWith("501") ? 901 : 902 }
+          }
+        }
+      }
+      if (path === "/api/v1/media/collections/7/items/11" || path === "/api/v1/media/collections/7/items/12") {
+        return {
+          id: path.endsWith("/11") ? 11 : 12,
+          collection_id: 7,
+          ordinal: path.endsWith("/11") ? 1 : 2,
+          source_url: request.body?.source_url || "https://youtube.com/watch?v=talk",
+          duplicate_status: "new",
+          status: request.body?.status || "processing",
+          retry_count: 0,
+          warnings: [],
+          metadata: {},
+          tags: [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z"
+        }
+      }
+      throw new Error(`Unexpected bgRequest path: ${path}`)
+    })
+
+    await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "talk-1",
+          url: "https://youtube.com/watch?v=talk-1",
+          type: "video",
+          playlist: {
+            playlistId: "PL-conf",
+            playlistTitle: "Strange Loop 2012",
+            ordinal: 1,
+            normalizedSourceId: "youtube:video:talk-1",
+            duplicateStatus: "new"
+          },
+          conferenceOverride: {
+            selected: true,
+            title: "Simplicity Matters",
+            speaker: "Rich Hickey",
+            tags: ["keynote"]
+          }
+        },
+        {
+          id: "talk-2",
+          url: "https://youtube.com/watch?v=talk-2",
+          type: "video",
+          playlist: {
+            playlistId: "PL-conf",
+            playlistTitle: "Strange Loop 2012",
+            ordinal: 2,
+            normalizedSourceId: "youtube:video:talk-2",
+            duplicateStatus: "new"
+          },
+          conferenceOverride: {
+            selected: true,
+            speaker: "Alex Miller"
+          }
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      conferenceBatchMetadata: {
+        collectionName: "Strange Loop 2012",
+        conferenceName: "Strange Loop",
+        eventYear: "2012",
+        sharedTags: ["conference", "clojure"],
+        sourcePlaylistUrl: "https://youtube.com/playlist?list=PL-conf"
+      },
+      common: {
+        perform_analysis: true,
+        perform_chunking: false,
+        overwrite_existing: false
+      },
+      advancedValues: {}
+    } as any)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/collections",
+        method: "POST",
+        body: expect.objectContaining({
+          name: "Strange Loop 2012",
+          kind: "conference",
+          source_url: "https://youtube.com/playlist?list=PL-conf",
+          metadata: expect.objectContaining({
+            conference_name: "Strange Loop",
+            event_year: "2012",
+            source_playlist_url: "https://youtube.com/playlist?list=PL-conf"
+          }),
+          default_tags: ["conference", "clojure"]
+        })
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/collections/7/items",
+        method: "POST",
+        body: expect.objectContaining({
+          ordinal: 1,
+          source_url: "https://youtube.com/watch?v=talk-1",
+          normalized_source_id: "youtube:video:talk-1",
+          title: "Simplicity Matters",
+          speaker: "Rich Hickey",
+          tags: ["conference", "clojure", "keynote"]
+        })
+      })
+    )
+    expect(mocks.bgUpload).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          media_collection_id: 7,
+          media_collection_item_id: 11,
+          idempotency_key: "conference-7-1"
+        })
+      })
+    )
+  })
+
+  it("marks planned conference items as submit_failed when direct job submission fails", async () => {
+    mocks.bgUpload.mockRejectedValueOnce(new Error("job submit failed"))
+    mocks.bgRequest.mockImplementation(async (request: { path?: string; body?: any }) => {
+      const path = String(request?.path || "")
+      if (path === "/api/v1/media/collections") {
+        return {
+          id: 8,
+          name: "Conference Batch",
+          kind: "conference",
+          metadata: {},
+          default_tags: [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+          items: []
+        }
+      }
+      if (path === "/api/v1/media/collections/8/items") {
+        return {
+          id: 81,
+          collection_id: 8,
+          ordinal: 1,
+          source_url: request.body?.source_url,
+          duplicate_status: "new",
+          status: "planned",
+          retry_count: 0,
+          warnings: [],
+          metadata: {},
+          tags: [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z"
+        }
+      }
+      if (path === "/api/v1/media/collections/8/items/81") {
+        return {
+          id: 81,
+          collection_id: 8,
+          ordinal: 1,
+          source_url: "https://youtube.com/watch?v=failed",
+          duplicate_status: "new",
+          status: request.body?.status,
+          error_summary: request.body?.error_summary,
+          retry_count: 0,
+          warnings: [],
+          metadata: {},
+          tags: [],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z"
+        }
+      }
+      throw new Error(`Unexpected bgRequest path: ${path}`)
+    })
+
+    const result = await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "failed-talk",
+          url: "https://youtube.com/watch?v=failed",
+          type: "video",
+          conferenceOverride: {
+            selected: true,
+            title: "Failed Talk"
+          }
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      conferenceBatchMetadata: {
+        collectionName: "Conference Batch",
+        sharedTags: []
+      },
+      common: {
+        perform_analysis: true,
+        perform_chunking: false,
+        overwrite_existing: false
+      },
+      advancedValues: {}
+    } as any)
+
+    expect(result.results?.[0]).toMatchObject({
+      id: "failed-talk",
+      status: "error",
+      error: "job submit failed"
+    })
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/collections/8/items/81",
+        method: "PATCH",
+        body: expect.objectContaining({
+          status: "submit_failed",
+          error_summary: "job submit failed"
+        })
+      })
+    )
+  })
+
   it("returns a direct session ack for mv3 extension pages", async () => {
     mocks.runtimeId = "ext-1"
 

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -1135,6 +1135,8 @@ describe("submitQuickIngestBatch", () => {
   })
 
   it("creates planned conference collection items before direct job submission", async () => {
+    const onTrackingMetadata = vi.fn()
+
     mocks.bgUpload
       .mockResolvedValueOnce({
         batch_id: "batch-talk-1",
@@ -1261,7 +1263,9 @@ describe("submitQuickIngestBatch", () => {
         perform_chunking: false,
         overwrite_existing: false
       },
-      advancedValues: {}
+      advancedValues: {},
+      __quickIngestSessionId: "qi-direct-conference-run",
+      onTrackingMetadata
     } as any)
 
     expect(mocks.bgRequest).toHaveBeenCalledWith(
@@ -1303,6 +1307,20 @@ describe("submitQuickIngestBatch", () => {
           media_collection_item_id: 11,
           idempotency_key: "conference-7-1"
         })
+      })
+    )
+    expect(onTrackingMetadata).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        mode: "webui-direct",
+        sessionId: "qi-direct-conference-run",
+        batchId: "batch-talk-1",
+        collectionId: "7",
+        plannedItemIds: ["11"],
+        jobIdToCollectionItemId: {
+          "501": "11"
+        },
+        durableMode: "durable_collection"
       })
     )
   })

--- a/apps/packages/ui/src/services/__tests__/server-capabilities.test.ts
+++ b/apps/packages/ui/src/services/__tests__/server-capabilities.test.ts
@@ -167,6 +167,7 @@ describe("server capabilities docs-info merge", () => {
       info: { version: "bulk-ingest-capabilities" },
       paths: {
         "/api/v1/media/playlists/preflight": {},
+        "/api/v1/media/collections": {},
         "/api/v1/media/ingest/jobs": {},
         "/api/v1/media/ingest/jobs/events/stream": {}
       }
@@ -177,7 +178,7 @@ describe("server capabilities docs-info merge", () => {
         hasMediaIngestJobs: true,
         hasMediaIngestJobEvents: true,
         hasMediaIngestWorker: false,
-        hasDurableMediaCollections: false,
+        hasDurableMediaCollections: true,
         hasKnowledgeQaMediaScope: false
       }
     })
@@ -190,7 +191,7 @@ describe("server capabilities docs-info merge", () => {
     expect(capabilities.hasMediaIngestJobs).toBe(true)
     expect(capabilities.hasMediaIngestJobEvents).toBe(true)
     expect(capabilities.hasMediaIngestWorker).toBe(false)
-    expect(capabilities.hasDurableMediaCollections).toBe(false)
+    expect(capabilities.hasDurableMediaCollections).toBe(true)
     expect(capabilities.hasKnowledgeQaMediaScope).toBe(false)
   })
 

--- a/apps/packages/ui/src/services/__tests__/server-capabilities.test.ts
+++ b/apps/packages/ui/src/services/__tests__/server-capabilities.test.ts
@@ -162,6 +162,38 @@ describe("server capabilities docs-info merge", () => {
     expect(capabilities.hasMedia).toBe(true)
   })
 
+  it("detects playlist preflight and keeps worker availability separate from job endpoints", async () => {
+    mocks.getOpenAPISpec.mockResolvedValue({
+      info: { version: "bulk-ingest-capabilities" },
+      paths: {
+        "/api/v1/media/playlists/preflight": {},
+        "/api/v1/media/ingest/jobs": {},
+        "/api/v1/media/ingest/jobs/events/stream": {}
+      }
+    })
+    mocks.bgRequest.mockResolvedValue({
+      capabilities: {
+        hasMediaPlaylistPreflight: true,
+        hasMediaIngestJobs: true,
+        hasMediaIngestJobEvents: true,
+        hasMediaIngestWorker: false,
+        hasDurableMediaCollections: false,
+        hasKnowledgeQaMediaScope: false
+      }
+    })
+
+    const { getServerCapabilities } = await importCapabilitiesModule()
+    const capabilities = await getServerCapabilities()
+
+    expect(capabilities.hasMedia).toBe(true)
+    expect(capabilities.hasMediaPlaylistPreflight).toBe(true)
+    expect(capabilities.hasMediaIngestJobs).toBe(true)
+    expect(capabilities.hasMediaIngestJobEvents).toBe(true)
+    expect(capabilities.hasMediaIngestWorker).toBe(false)
+    expect(capabilities.hasDurableMediaCollections).toBe(false)
+    expect(capabilities.hasKnowledgeQaMediaScope).toBe(false)
+  })
+
   it("detects ingestion source capability from advertised source routes", async () => {
     mocks.getOpenAPISpec.mockResolvedValue({
       info: { version: "ingestion-sources-version" },

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.media-ingest.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.media-ingest.test.ts
@@ -156,6 +156,28 @@ describe("TldwApiClient media ingest contract", () => {
     )
   })
 
+  it("preflights playlist URLs through the metadata-only media endpoint", async () => {
+    mocks.bgRequest.mockResolvedValue({ playlist_id: "PLtest", items: [] })
+
+    const client = new TldwApiClient()
+    await client.preflightPlaylist({
+      url: "https://www.youtube.com/playlist?list=PLtest",
+      max_items: 34
+    })
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/playlists/preflight",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: {
+          url: "https://www.youtube.com/playlist?list=PLtest",
+          max_items: 34
+        }
+      })
+    )
+  })
+
   it("uploads character imports using binary payloads", async () => {
     mocks.bgUpload.mockResolvedValue({
       id: 123,

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.media-ingest.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.media-ingest.test.ts
@@ -178,6 +178,30 @@ describe("TldwApiClient media ingest contract", () => {
     )
   })
 
+  it("sends server-side playlist preflight timeout derived from timeoutMs", async () => {
+    mocks.bgRequest.mockResolvedValue({ playlist_id: "PLtest", items: [] })
+
+    const client = new TldwApiClient()
+    await client.preflightPlaylist({
+      url: "https://www.youtube.com/playlist?list=PLtest",
+      maxItems: 34,
+      timeoutMs: 120000
+    })
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/playlists/preflight",
+        method: "POST",
+        body: {
+          url: "https://www.youtube.com/playlist?list=PLtest",
+          max_items: 34,
+          timeout_seconds: 60
+        },
+        timeoutMs: 120000
+      })
+    )
+  })
+
   it("uploads character imports using binary payloads", async () => {
     mocks.bgUpload.mockResolvedValue({
       id: 123,

--- a/apps/packages/ui/src/services/rag/unified-rag.ts
+++ b/apps/packages/ui/src/services/rag/unified-rag.ts
@@ -83,6 +83,7 @@ export type RagSettings = {
   cache_threshold: number
   adaptive_cache: boolean
   keyword_filter: string
+  collection_id: number | null
   include_media_ids: number[]
   include_note_ids: string[]
   enable_security_filter: boolean
@@ -289,6 +290,7 @@ export const DEFAULT_RAG_SETTINGS: RagSettings = {
   cache_threshold: 0.8,
   adaptive_cache: true,
   keyword_filter: "",
+  collection_id: null,
   include_media_ids: [],
   include_note_ids: [],
   enable_security_filter: true,

--- a/apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
@@ -10,8 +10,12 @@ vi.mock("@/services/background-proxy", () => ({
 }))
 
 import {
+  buildConferenceRetryRequestItems,
   buildConferenceFailedResultExportText,
+  classifyConferenceIngestFailure,
   getMediaCollectionStatusCounts,
+  resolveConferenceDuplicatePolicy,
+  buildConferenceCollectionItemPayload,
   normalizeMediaCollectionResponse
 } from "@/services/tldw/conference-collections"
 import { mediaMethods } from "@/services/tldw/domains/media"
@@ -184,5 +188,140 @@ describe("conference media collection normalizers", () => {
     expect(text).toContain("Status: failed")
     expect(text).toContain("Retry attempt: 2")
     expect(text).toContain("Error: Download failed")
+  })
+
+  it("resolves duplicate policies into planned status and submit behavior", () => {
+    expect(
+      resolveConferenceDuplicatePolicy("duplicate_existing", "skip")
+    ).toMatchObject({
+      plannedStatus: "skipped_existing",
+      shouldSubmitJob: false
+    })
+    expect(
+      resolveConferenceDuplicatePolicy("duplicate_existing", "overwrite")
+    ).toMatchObject({
+      plannedStatus: "planned",
+      shouldSubmitJob: true,
+      forceOverwrite: true
+    })
+    expect(
+      resolveConferenceDuplicatePolicy("duplicate_existing", "update_metadata_only")
+    ).toMatchObject({
+      plannedStatus: "skipped_existing",
+      shouldSubmitJob: false
+    })
+    expect(
+      resolveConferenceDuplicatePolicy("duplicate_existing", "include_existing")
+    ).toMatchObject({
+      plannedStatus: "skipped_existing",
+      shouldSubmitJob: false
+    })
+    expect(resolveConferenceDuplicatePolicy("new", "skip")).toMatchObject({
+      plannedStatus: "planned",
+      shouldSubmitJob: true
+    })
+    expect(resolveConferenceDuplicatePolicy("unknown", "skip")).toMatchObject({
+      plannedStatus: "planned",
+      shouldSubmitJob: true
+    })
+  })
+
+  it("adds duplicate policy metadata to planned collection item payloads", () => {
+    const payload = buildConferenceCollectionItemPayload(
+      {
+        collectionName: "Conference 2026",
+        sharedTags: ["conference"],
+        sourcePlaylistUrl: "https://www.youtube.com/playlist?list=PLtest"
+      },
+      {
+        id: "entry-1",
+        url: "https://www.youtube.com/watch?v=a",
+        playlist: {
+          playlistId: "PLtest",
+          ordinal: 1,
+          normalizedSourceId: "youtube:video:a",
+          duplicateStatus: "duplicate_existing"
+        },
+        conferenceOverride: {
+          selected: true,
+          duplicatePolicy: "include_existing",
+          title: "Existing Talk"
+        }
+      }
+    )
+
+    expect(payload.status).toBe("skipped_existing")
+    expect(payload.duplicate_status).toBe("duplicate_existing")
+    expect(payload.metadata).toMatchObject({
+      duplicate_policy: "include_existing",
+      quick_ingest_item_id: "entry-1"
+    })
+  })
+
+  it("classifies conservative conference ingest failure categories", () => {
+    expect(classifyConferenceIngestFailure("Private video")).toBe("auth_required")
+    expect(classifyConferenceIngestFailure("HTTP Error 404")).toBe("unavailable")
+    expect(classifyConferenceIngestFailure("timed out")).toBe("timeout")
+  })
+
+  it("builds selected retry requests from durable failed collection items only", () => {
+    const retryItems = buildConferenceRetryRequestItems([
+      {
+        id: "ok-1",
+        status: "ok",
+        outcome: "processed",
+        type: "video",
+        collectionItemId: "11"
+      } as any,
+      {
+        id: "submit-1",
+        status: "error",
+        outcome: "submit_failed",
+        type: "video",
+        collectionItemId: "13"
+      } as any,
+      {
+        id: "failed-1",
+        status: "error",
+        outcome: "failed",
+        type: "video",
+        collectionItemId: "14",
+        retryAttempt: 2
+      } as any,
+      {
+        id: "cancel-1",
+        status: "error",
+        outcome: "cancelled",
+        type: "video",
+        collectionItemId: "15"
+      } as any,
+      {
+        id: "legacy-failed",
+        status: "error",
+        outcome: "failed",
+        type: "video"
+      } as any
+    ])
+
+    expect(retryItems).toEqual([
+      {
+        resultId: "submit-1",
+        collectionItemId: "13",
+        retryAttempt: 1,
+        idempotencyKey: "conference-retry-13-1"
+      },
+      {
+        resultId: "failed-1",
+        collectionItemId: "14",
+        retryAttempt: 3,
+        idempotencyKey: "conference-retry-14-3"
+      },
+      {
+        resultId: "cancel-1",
+        collectionItemId: "15",
+        retryAttempt: 1,
+        idempotencyKey: "conference-retry-15-1"
+      }
+    ])
   })
 })

--- a/apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/services/background-proxy", () => ({
 }))
 
 import {
+  buildConferenceFailedResultExportText,
   getMediaCollectionStatusCounts,
   normalizeMediaCollectionResponse
 } from "@/services/tldw/conference-collections"
@@ -146,5 +147,42 @@ describe("conference media collection normalizers", () => {
         }
       })
     )
+  })
+
+  it("exports failed conference result rows with collection and retry context", () => {
+    const text = buildConferenceFailedResultExportText([
+      {
+        id: "submit-1",
+        status: "error",
+        outcome: "submit_failed",
+        type: "video",
+        title: "Submit Blocked",
+        url: "https://example.com/submit",
+        collectionItemId: "13",
+        error: "Queue unavailable"
+      } as any,
+      {
+        id: "failed-1",
+        status: "error",
+        outcome: "failed",
+        type: "video",
+        title: "Bad Video",
+        url: "https://example.com/fail",
+        collectionItemId: "14",
+        retryAttempt: 2,
+        error: "Download failed"
+      } as any
+    ])
+
+    expect(text).toContain("Title: Submit Blocked")
+    expect(text).toContain("URL: https://example.com/submit")
+    expect(text).toContain("Collection item: 13")
+    expect(text).toContain("Status: submit_failed")
+    expect(text).toContain("Error: Queue unavailable")
+    expect(text).toContain("Title: Bad Video")
+    expect(text).toContain("Collection item: 14")
+    expect(text).toContain("Status: failed")
+    expect(text).toContain("Retry attempt: 2")
+    expect(text).toContain("Error: Download failed")
   })
 })

--- a/apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: (...args: unknown[]) =>
+    (mocks.bgRequest as (...args: unknown[]) => unknown)(...args)
+}))
+
+import {
+  getMediaCollectionStatusCounts,
+  normalizeMediaCollectionResponse
+} from "@/services/tldw/conference-collections"
+import { mediaMethods } from "@/services/tldw/domains/media"
+
+describe("conference media collection normalizers", () => {
+  beforeEach(() => {
+    mocks.bgRequest.mockReset()
+  })
+
+  it("normalizes collection metadata, items, and status counts", () => {
+    const normalized = normalizeMediaCollectionResponse({
+      id: 7,
+      name: "Conference 2026",
+      kind: "conference",
+      source_url: "https://www.youtube.com/playlist?list=PLtest",
+      metadata: { conference_name: "Conference" },
+      default_tags: ["conference"],
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-02T00:00:00Z",
+      items: [
+        {
+          id: 11,
+          collection_id: 7,
+          ordinal: 1,
+          source_url: "https://www.youtube.com/watch?v=a",
+          normalized_source_id: "youtube:video:a",
+          source_kind: "youtube_video",
+          title: "Opening Keynote",
+          speaker: "Ada Lovelace",
+          duplicate_status: "new",
+          status: "completed",
+          media_id: 101,
+          content_item_id: 201,
+          retry_count: 0,
+          warnings: [],
+          metadata: { track: "Main" },
+          tags: ["keynote"],
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-02T00:00:00Z"
+        },
+        {
+          id: 12,
+          collection_id: 7,
+          ordinal: 2,
+          source_url: "https://www.youtube.com/watch?v=b",
+          duplicate_status: "duplicate_in_batch",
+          status: "failed",
+          retry_count: 1,
+          error_summary: "Download failed",
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-02T00:00:00Z"
+        }
+      ]
+    })
+
+    expect(normalized.sourceUrl).toBe("https://www.youtube.com/playlist?list=PLtest")
+    expect(normalized.metadata.conference_name).toBe("Conference")
+    expect(normalized.defaultTags).toEqual(["conference"])
+    expect(normalized.items[0]).toMatchObject({
+      id: 11,
+      sourceUrl: "https://www.youtube.com/watch?v=a",
+      normalizedSourceId: "youtube:video:a",
+      contentItemId: 201,
+      mediaId: 101,
+      status: "completed"
+    })
+    expect(getMediaCollectionStatusCounts(normalized)).toEqual({
+      total: 2,
+      planned: 0,
+      processing: 0,
+      completed: 1,
+      skippedExisting: 0,
+      submitFailed: 0,
+      failed: 1,
+      cancelled: 0
+    })
+  })
+
+  it("uses media collection endpoints through the shared media domain", async () => {
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        id: 7,
+        name: "Conference 2026",
+        kind: "conference",
+        metadata: {},
+        default_tags: [],
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-01T00:00:00Z",
+        items: []
+      })
+      .mockResolvedValueOnce({
+        id: 11,
+        collection_id: 7,
+        ordinal: 1,
+        source_url: "https://www.youtube.com/watch?v=a",
+        duplicate_status: "new",
+        status: "planned",
+        retry_count: 0,
+        warnings: [],
+        metadata: {},
+        tags: [],
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-01T00:00:00Z"
+      })
+
+    const collection = await mediaMethods.createMediaCollection({
+      name: "Conference 2026",
+      kind: "conference"
+    })
+    const item = await mediaMethods.addMediaCollectionItem(7, {
+      source_url: "https://www.youtube.com/watch?v=a",
+      status: "planned"
+    })
+
+    expect(collection.id).toBe(7)
+    expect(item.collectionId).toBe(7)
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/api/v1/media/collections",
+        method: "POST",
+        body: { name: "Conference 2026", kind: "conference" }
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: "/api/v1/media/collections/7/items",
+        method: "POST",
+        body: {
+          source_url: "https://www.youtube.com/watch?v=a",
+          status: "planned"
+        }
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isPlaylistPreflightDuplicate,
+  normalizePlaylistPreflightResponse
+} from "@/services/tldw/playlist-preflight"
+
+describe("playlist preflight normalizers", () => {
+  it("normalizes item IDs, selected defaults, and duplicate counts", () => {
+    const normalized = normalizePlaylistPreflightResponse({
+      source_url: "https://www.youtube.com/playlist?list=PLtest",
+      source_kind: "youtube_playlist",
+      playlist_id: "PLtest",
+      playlist_title: "Conference 2010",
+      item_count: 2,
+      selected_count: 1,
+      duplicate_count: 1,
+      warnings: ["One duplicate"],
+      items: [
+        {
+          ordinal: 1,
+          source_url: "https://www.youtube.com/watch?v=abc123",
+          normalized_source_id: "youtube:video:abc123",
+          source_kind: "youtube_video",
+          title: "Opening Keynote",
+          duplicate_status: "new"
+        },
+        {
+          ordinal: 2,
+          source_url: "https://www.youtube.com/watch?v=abc123",
+          normalized_source_id: "youtube:video:abc123",
+          source_kind: "youtube_video",
+          title: "Opening Keynote again",
+          duplicate_status: "duplicate_in_batch",
+          duplicate_of_ordinal: 1,
+          selected: false
+        }
+      ]
+    })
+
+    expect(normalized.playlistId).toBe("PLtest")
+    expect(normalized.items[0]).toMatchObject({
+      id: "youtube:video:abc123",
+      ordinal: 1,
+      selected: true
+    })
+    expect(normalized.items[1].selected).toBe(false)
+    expect(normalized.duplicateCount).toBe(1)
+    expect(isPlaylistPreflightDuplicate(normalized.items[1])).toBe(true)
+  })
+})

--- a/apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts
@@ -34,6 +34,14 @@ describe("playlist preflight normalizers", () => {
           duplicate_status: "duplicate_in_batch",
           duplicate_of_ordinal: 1,
           selected: false
+        },
+        {
+          ordinal: 3,
+          source_url: "https://www.youtube.com/watch?v=def456",
+          normalized_source_id: "youtube:video:def456",
+          source_kind: "youtube_video",
+          title: "Unknown status talk",
+          duplicate_status: "server_future_status"
         }
       ]
     })
@@ -45,6 +53,10 @@ describe("playlist preflight normalizers", () => {
       selected: true
     })
     expect(normalized.items[1].selected).toBe(false)
+    expect(normalized.items[2]).toMatchObject({
+      duplicateStatus: "new",
+      selected: true
+    })
     expect(normalized.duplicateCount).toBe(1)
     expect(isPlaylistPreflightDuplicate(normalized.items[1])).toBe(true)
   })

--- a/apps/packages/ui/src/services/tldw/conference-collections.ts
+++ b/apps/packages/ui/src/services/tldw/conference-collections.ts
@@ -1,3 +1,9 @@
+import type {
+  ConferenceBatchMetadata,
+  ConferenceItemMetadataOverride,
+  PlaylistQueueMetadata,
+} from "@/components/Common/QuickIngest/types"
+
 export type MediaCollectionItemStatus =
   | "planned"
   | "processing"
@@ -110,6 +116,136 @@ export type MediaCollectionStatusCounts = {
   submitFailed: number
   failed: number
   cancelled: number
+}
+
+export type ConferenceCollectionCreatePayload = {
+  name: string
+  kind: "conference"
+  description?: string | null
+  source_url?: string | null
+  metadata: Record<string, unknown>
+  default_tags: string[]
+}
+
+export type ConferenceCollectionItemPayload = {
+  ordinal?: number
+  source_url: string
+  normalized_source_id?: string | null
+  source_kind?: string | null
+  title?: string | null
+  speaker?: string | null
+  published_at?: string | null
+  track?: string | null
+  duplicate_status?: string | null
+  status?: MediaCollectionItemStatus
+  idempotency_key?: string | null
+  metadata: Record<string, unknown>
+  tags: string[]
+}
+
+export type ConferenceCollectionItemMergeInput = {
+  id: string
+  url: string
+  playlist?: PlaylistQueueMetadata
+  conferenceOverride?: ConferenceItemMetadataOverride
+}
+
+const compactString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+export const normalizeConferenceTagList = (value: unknown): string[] => {
+  const raw = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(",")
+      : []
+  return Array.from(
+    new Set(
+      raw
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+        .filter(Boolean)
+    )
+  )
+}
+
+export const mergeConferenceTags = (
+  sharedTags: unknown,
+  itemTags: unknown
+): string[] =>
+  normalizeConferenceTagList([
+    ...normalizeConferenceTagList(sharedTags),
+    ...normalizeConferenceTagList(itemTags),
+  ])
+
+export const buildConferenceCollectionCreatePayload = (
+  metadata: ConferenceBatchMetadata,
+  fallbackName?: string | null
+): ConferenceCollectionCreatePayload => {
+  const sourcePlaylistUrl = compactString(metadata.sourcePlaylistUrl)
+  const collectionMetadata: Record<string, unknown> = {}
+  const conferenceName = compactString(metadata.conferenceName)
+  const eventDate = compactString(metadata.eventDate)
+  const eventYear = compactString(metadata.eventYear)
+
+  if (conferenceName) collectionMetadata.conference_name = conferenceName
+  if (eventDate) collectionMetadata.event_date = eventDate
+  if (eventYear) collectionMetadata.event_year = eventYear
+  if (sourcePlaylistUrl) {
+    collectionMetadata.source_playlist_url = sourcePlaylistUrl
+  }
+
+  return {
+    name:
+      compactString(metadata.collectionName) ||
+      conferenceName ||
+      compactString(fallbackName) ||
+      "Conference batch",
+    kind: "conference",
+    source_url: sourcePlaylistUrl ?? null,
+    metadata: collectionMetadata,
+    default_tags: normalizeConferenceTagList(metadata.sharedTags),
+  }
+}
+
+export const buildConferenceCollectionItemPayload = (
+  batchMetadata: ConferenceBatchMetadata,
+  item: ConferenceCollectionItemMergeInput
+): ConferenceCollectionItemPayload => {
+  const override = item.conferenceOverride
+  const playlist = item.playlist
+  const ordinal = playlist?.ordinal
+  const metadata: Record<string, unknown> = {
+    quick_ingest_item_id: item.id,
+  }
+  const playlistId = compactString(playlist?.playlistId ?? undefined)
+  const playlistTitle = compactString(playlist?.playlistTitle ?? undefined)
+  if (playlistId) metadata.playlist_id = playlistId
+  if (playlistTitle) metadata.playlist_title = playlistTitle
+  if (ordinal != null) metadata.playlist_ordinal = ordinal
+  if (compactString(batchMetadata.eventYear)) {
+    metadata.event_year = compactString(batchMetadata.eventYear)
+  }
+
+  return {
+    ordinal,
+    source_url: item.url,
+    normalized_source_id: compactString(playlist?.normalizedSourceId ?? undefined) ?? null,
+    source_kind: playlistId ? "youtube_video" : null,
+    title: compactString(override?.title) ?? null,
+    speaker: compactString(override?.speaker) ?? null,
+    published_at:
+      compactString(override?.talkDate) ??
+      compactString(batchMetadata.eventDate) ??
+      null,
+    track: compactString(override?.track) ?? null,
+    duplicate_status: compactString(playlist?.duplicateStatus ?? undefined) ?? "unknown",
+    status: "planned",
+    metadata,
+    tags: mergeConferenceTags(batchMetadata.sharedTags, override?.tags),
+  }
 }
 
 const nullableString = (value: unknown): string | null => {

--- a/apps/packages/ui/src/services/tldw/conference-collections.ts
+++ b/apps/packages/ui/src/services/tldw/conference-collections.ts
@@ -1,0 +1,248 @@
+export type MediaCollectionItemStatus =
+  | "planned"
+  | "processing"
+  | "completed"
+  | "skipped_existing"
+  | "submit_failed"
+  | "failed"
+  | "cancelled"
+
+export type ApiMediaCollectionItem = {
+  id?: number
+  collection_id?: number
+  ordinal?: number
+  source_url?: string
+  normalized_source_id?: string | null
+  source_kind?: string | null
+  title?: string | null
+  speaker?: string | null
+  published_at?: string | null
+  track?: string | null
+  duplicate_status?: string | null
+  status?: string | null
+  media_id?: number | null
+  content_item_id?: number | null
+  latest_job_id?: string | null
+  latest_run_id?: number | null
+  idempotency_key?: string | null
+  retry_count?: number
+  error_summary?: string | null
+  warnings?: string[]
+  metadata?: Record<string, unknown>
+  tags?: string[]
+  created_at?: string
+  updated_at?: string
+}
+
+export type ApiMediaCollection = {
+  id?: number
+  name?: string
+  kind?: string
+  description?: string | null
+  source_url?: string | null
+  metadata?: Record<string, unknown>
+  default_tags?: string[]
+  created_at?: string
+  updated_at?: string
+  items?: ApiMediaCollectionItem[]
+}
+
+export type ApiMediaCollectionListResponse = {
+  items?: ApiMediaCollection[]
+  total?: number
+  page?: number
+  size?: number
+}
+
+export type MediaCollectionItem = {
+  id: number
+  collectionId: number
+  ordinal: number
+  sourceUrl: string
+  normalizedSourceId: string | null
+  sourceKind: string | null
+  title: string | null
+  speaker: string | null
+  publishedAt: string | null
+  track: string | null
+  duplicateStatus: string
+  status: MediaCollectionItemStatus
+  mediaId: number | null
+  contentItemId: number | null
+  latestJobId: string | null
+  latestRunId: number | null
+  idempotencyKey: string | null
+  retryCount: number
+  errorSummary: string | null
+  warnings: string[]
+  metadata: Record<string, unknown>
+  tags: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+export type MediaCollection = {
+  id: number
+  name: string
+  kind: string
+  description: string | null
+  sourceUrl: string | null
+  metadata: Record<string, unknown>
+  defaultTags: string[]
+  createdAt: string
+  updatedAt: string
+  items: MediaCollectionItem[]
+}
+
+export type MediaCollectionList = {
+  items: MediaCollection[]
+  total: number
+  page: number
+  size: number
+}
+
+export type MediaCollectionStatusCounts = {
+  total: number
+  planned: number
+  processing: number
+  completed: number
+  skippedExisting: number
+  submitFailed: number
+  failed: number
+  cancelled: number
+}
+
+const nullableString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const finiteNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value)
+  }
+  return fallback
+}
+
+const finiteNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value)
+  }
+  return null
+}
+
+const normalizeRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>) }
+    : {}
+
+const normalizeStringList = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value
+        .filter((entry): entry is string => typeof entry === "string")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    : []
+
+export const normalizeMediaCollectionItemStatus = (
+  value: unknown
+): MediaCollectionItemStatus => {
+  if (
+    value === "planned" ||
+    value === "processing" ||
+    value === "completed" ||
+    value === "skipped_existing" ||
+    value === "submit_failed" ||
+    value === "failed" ||
+    value === "cancelled"
+  ) {
+    return value
+  }
+  return "planned"
+}
+
+export const normalizeMediaCollectionItem = (
+  payload: ApiMediaCollectionItem
+): MediaCollectionItem => ({
+  id: finiteNumber(payload?.id),
+  collectionId: finiteNumber(payload?.collection_id),
+  ordinal: finiteNumber(payload?.ordinal, 1),
+  sourceUrl: nullableString(payload?.source_url) || "",
+  normalizedSourceId: nullableString(payload?.normalized_source_id),
+  sourceKind: nullableString(payload?.source_kind),
+  title: nullableString(payload?.title),
+  speaker: nullableString(payload?.speaker),
+  publishedAt: nullableString(payload?.published_at),
+  track: nullableString(payload?.track),
+  duplicateStatus: nullableString(payload?.duplicate_status) || "unknown",
+  status: normalizeMediaCollectionItemStatus(payload?.status),
+  mediaId: finiteNumberOrNull(payload?.media_id),
+  contentItemId: finiteNumberOrNull(payload?.content_item_id),
+  latestJobId: nullableString(payload?.latest_job_id),
+  latestRunId: finiteNumberOrNull(payload?.latest_run_id),
+  idempotencyKey: nullableString(payload?.idempotency_key),
+  retryCount: finiteNumber(payload?.retry_count),
+  errorSummary: nullableString(payload?.error_summary),
+  warnings: normalizeStringList(payload?.warnings),
+  metadata: normalizeRecord(payload?.metadata),
+  tags: normalizeStringList(payload?.tags),
+  createdAt: nullableString(payload?.created_at) || "",
+  updatedAt: nullableString(payload?.updated_at) || ""
+})
+
+export const normalizeMediaCollectionResponse = (
+  payload: ApiMediaCollection
+): MediaCollection => ({
+  id: finiteNumber(payload?.id),
+  name: nullableString(payload?.name) || "Untitled collection",
+  kind: nullableString(payload?.kind) || "conference",
+  description: nullableString(payload?.description),
+  sourceUrl: nullableString(payload?.source_url),
+  metadata: normalizeRecord(payload?.metadata),
+  defaultTags: normalizeStringList(payload?.default_tags),
+  createdAt: nullableString(payload?.created_at) || "",
+  updatedAt: nullableString(payload?.updated_at) || "",
+  items: Array.isArray(payload?.items)
+    ? payload.items.map((item) => normalizeMediaCollectionItem(item))
+    : []
+})
+
+export const normalizeMediaCollectionListResponse = (
+  payload: ApiMediaCollectionListResponse
+): MediaCollectionList => {
+  const items = Array.isArray(payload?.items)
+    ? payload.items.map((item) => normalizeMediaCollectionResponse(item))
+    : []
+  return {
+    items,
+    total: finiteNumber(payload?.total, items.length),
+    page: finiteNumber(payload?.page, 1),
+    size: finiteNumber(payload?.size, items.length || 20)
+  }
+}
+
+export const getMediaCollectionStatusCounts = (
+  collection: Pick<MediaCollection, "items">
+): MediaCollectionStatusCounts => {
+  const counts: MediaCollectionStatusCounts = {
+    total: collection.items.length,
+    planned: 0,
+    processing: 0,
+    completed: 0,
+    skippedExisting: 0,
+    submitFailed: 0,
+    failed: 0,
+    cancelled: 0
+  }
+  for (const item of collection.items) {
+    if (item.status === "skipped_existing") {
+      counts.skippedExisting += 1
+    } else if (item.status === "submit_failed") {
+      counts.submitFailed += 1
+    } else {
+      counts[item.status] += 1
+    }
+  }
+  return counts
+}

--- a/apps/packages/ui/src/services/tldw/conference-collections.ts
+++ b/apps/packages/ui/src/services/tldw/conference-collections.ts
@@ -2,6 +2,7 @@ import type {
   ConferenceBatchMetadata,
   ConferenceItemMetadataOverride,
   PlaylistQueueMetadata,
+  WizardResultItem,
 } from "@/components/Common/QuickIngest/types"
 
 export type MediaCollectionItemStatus =
@@ -382,3 +383,45 @@ export const getMediaCollectionStatusCounts = (
   }
   return counts
 }
+
+export const getConferenceResultExportStatus = (
+  item: Pick<WizardResultItem, "outcome" | "status">
+): string => {
+  if (item.outcome === "submit_failed") return "submit_failed"
+  if (item.outcome === "cancelled") return "cancelled"
+  if (item.outcome === "failed" || item.status === "error") return "failed"
+  if (item.outcome === "skipped") return "skipped_existing"
+  return item.outcome || "completed"
+}
+
+export const buildConferenceFailedResultExportText = (
+  items: WizardResultItem[]
+): string =>
+  items
+    .map((item, index) => {
+      const title =
+        compactString(item.title) ||
+        compactString(item.fileName) ||
+        compactString(item.url) ||
+        item.id
+      const lines = [`#${index + 1}`, `Title: ${title}`]
+      const url = compactString(item.url)
+      const collectionItemId =
+        item.collectionItemId == null
+          ? undefined
+          : compactString(String(item.collectionItemId))
+      const retryAttempt =
+        typeof item.retryAttempt === "number" && Number.isFinite(item.retryAttempt)
+          ? Math.trunc(item.retryAttempt)
+          : null
+      const errorSummary = compactString(item.error) || compactString(item.message)
+
+      if (url) lines.push(`URL: ${url}`)
+      if (collectionItemId) lines.push(`Collection item: ${collectionItemId}`)
+      lines.push(`Status: ${getConferenceResultExportStatus(item)}`)
+      if (retryAttempt != null) lines.push(`Retry attempt: ${retryAttempt}`)
+      if (errorSummary) lines.push(`Error: ${errorSummary}`)
+
+      return lines.join("\n")
+    })
+    .join("\n\n")

--- a/apps/packages/ui/src/services/tldw/conference-collections.ts
+++ b/apps/packages/ui/src/services/tldw/conference-collections.ts
@@ -1,5 +1,6 @@
 import type {
   ConferenceBatchMetadata,
+  ConferenceDuplicatePolicy,
   ConferenceItemMetadataOverride,
   PlaylistQueueMetadata,
   WizardResultItem,
@@ -119,6 +120,29 @@ export type MediaCollectionStatusCounts = {
   cancelled: number
 }
 
+export type ConferenceDuplicatePolicyResolution = {
+  policy: ConferenceDuplicatePolicy
+  plannedStatus: MediaCollectionItemStatus
+  shouldSubmitJob: boolean
+  forceOverwrite: boolean
+}
+
+export type ConferenceIngestFailureKind =
+  | "auth_required"
+  | "unavailable"
+  | "timeout"
+  | "cancelled"
+  | "validation"
+  | "server"
+  | "unknown"
+
+export type ConferenceRetryRequestItem = {
+  resultId: string
+  collectionItemId: string
+  retryAttempt: number
+  idempotencyKey: string
+}
+
 export type ConferenceCollectionCreatePayload = {
   name: string
   kind: "conference"
@@ -156,6 +180,130 @@ const compactString = (value: unknown): string | undefined => {
   const trimmed = value.trim()
   return trimmed || undefined
 }
+
+export const CONFERENCE_DUPLICATE_POLICIES: ConferenceDuplicatePolicy[] = [
+  "skip",
+  "overwrite",
+  "update_metadata_only",
+  "include_existing",
+]
+
+export const normalizeConferenceDuplicatePolicy = (
+  value: unknown
+): ConferenceDuplicatePolicy =>
+  CONFERENCE_DUPLICATE_POLICIES.includes(value as ConferenceDuplicatePolicy)
+    ? (value as ConferenceDuplicatePolicy)
+    : "skip"
+
+const isDuplicateStatus = (value: unknown): boolean => {
+  const normalized = compactString(value)?.toLowerCase()
+  return normalized === "duplicate_existing" || normalized === "duplicate_in_batch"
+}
+
+export const resolveConferenceDuplicatePolicy = (
+  duplicateStatus: unknown,
+  policy: unknown
+): ConferenceDuplicatePolicyResolution => {
+  const resolvedPolicy = normalizeConferenceDuplicatePolicy(policy)
+  if (!isDuplicateStatus(duplicateStatus)) {
+    return {
+      policy: resolvedPolicy,
+      plannedStatus: "planned",
+      shouldSubmitJob: true,
+      forceOverwrite: false,
+    }
+  }
+
+  if (resolvedPolicy === "overwrite") {
+    return {
+      policy: resolvedPolicy,
+      plannedStatus: "planned",
+      shouldSubmitJob: true,
+      forceOverwrite: true,
+    }
+  }
+
+  return {
+    policy: resolvedPolicy,
+    plannedStatus: "skipped_existing",
+    shouldSubmitJob: false,
+    forceOverwrite: false,
+  }
+}
+
+export const classifyConferenceIngestFailure = (
+  value: unknown
+): ConferenceIngestFailureKind => {
+  const message = String(value || "").trim().toLowerCase()
+  if (!message) return "unknown"
+  if (
+    message.includes("private") ||
+    message.includes("sign in") ||
+    message.includes("login") ||
+    message.includes("unauthorized") ||
+    message.includes("forbidden") ||
+    message.includes("403")
+  ) {
+    return "auth_required"
+  }
+  if (
+    message.includes("404") ||
+    message.includes("not found") ||
+    message.includes("unavailable") ||
+    message.includes("removed")
+  ) {
+    return "unavailable"
+  }
+  if (
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("deadline")
+  ) {
+    return "timeout"
+  }
+  if (message.includes("cancelled") || message.includes("canceled")) {
+    return "cancelled"
+  }
+  if (message.includes("invalid") || message.includes("unsupported")) {
+    return "validation"
+  }
+  if (message.includes("500") || message.includes("server")) {
+    return "server"
+  }
+  return "unknown"
+}
+
+const isRetryableConferenceOutcome = (
+  item: Pick<WizardResultItem, "status" | "outcome">
+): boolean =>
+  item.outcome === "submit_failed" ||
+  item.outcome === "failed" ||
+  item.outcome === "cancelled" ||
+  item.status === "error"
+
+export const buildConferenceRetryRequestItems = (
+  items: WizardResultItem[]
+): ConferenceRetryRequestItem[] =>
+  items
+    .filter(isRetryableConferenceOutcome)
+    .map((item) => {
+      const collectionItemId =
+        item.collectionItemId == null
+          ? undefined
+          : compactString(String(item.collectionItemId))
+      if (!collectionItemId) return null
+      const retryAttempt =
+        typeof item.retryAttempt === "number" && Number.isFinite(item.retryAttempt)
+          ? Math.trunc(item.retryAttempt) + 1
+          : 1
+      return {
+        resultId: item.id,
+        collectionItemId,
+        retryAttempt,
+        idempotencyKey: `conference-retry-${collectionItemId}-${retryAttempt}`,
+      }
+    })
+    .filter((item): item is ConferenceRetryRequestItem => Boolean(item))
 
 export const normalizeConferenceTagList = (value: unknown): string[] => {
   const raw = Array.isArray(value)
@@ -217,6 +365,13 @@ export const buildConferenceCollectionItemPayload = (
 ): ConferenceCollectionItemPayload => {
   const override = item.conferenceOverride
   const playlist = item.playlist
+  const duplicatePolicy = normalizeConferenceDuplicatePolicy(
+    override?.duplicatePolicy
+  )
+  const duplicateResolution = resolveConferenceDuplicatePolicy(
+    playlist?.duplicateStatus,
+    duplicatePolicy
+  )
   const ordinal = playlist?.ordinal
   const metadata: Record<string, unknown> = {
     quick_ingest_item_id: item.id,
@@ -228,6 +383,9 @@ export const buildConferenceCollectionItemPayload = (
   if (ordinal != null) metadata.playlist_ordinal = ordinal
   if (compactString(batchMetadata.eventYear)) {
     metadata.event_year = compactString(batchMetadata.eventYear)
+  }
+  if (isDuplicateStatus(playlist?.duplicateStatus)) {
+    metadata.duplicate_policy = duplicatePolicy
   }
 
   return {
@@ -243,7 +401,7 @@ export const buildConferenceCollectionItemPayload = (
       null,
     track: compactString(override?.track) ?? null,
     duplicate_status: compactString(playlist?.duplicateStatus ?? undefined) ?? "unknown",
-    status: "planned",
+    status: duplicateResolution.plannedStatus,
     metadata,
     tags: mergeConferenceTags(batchMetadata.sharedTags, override?.tags),
   }

--- a/apps/packages/ui/src/services/tldw/domains/media.ts
+++ b/apps/packages/ui/src/services/tldw/domains/media.ts
@@ -141,15 +141,25 @@ export const mediaMethods = {
     url: string
     max_items?: number
     maxItems?: number
+    timeout_seconds?: number
     timeoutMs?: number
   }): Promise<PlaylistPreflightResult> {
-    const { timeoutMs, maxItems, max_items, ...rest } = payload || {}
-    const body = {
+    const { timeoutMs, maxItems, max_items, timeout_seconds, ...rest } = payload || {}
+    const requestedTimeoutSeconds =
+      typeof timeout_seconds === "number"
+        ? timeout_seconds
+        : typeof timeoutMs === "number"
+          ? Math.ceil(timeoutMs / 1000)
+          : undefined
+    const body: Record<string, unknown> = {
       ...rest,
       max_items: max_items ?? maxItems
     }
     if (typeof body.max_items === "undefined") {
-      delete (body as Record<string, unknown>).max_items
+      delete body.max_items
+    }
+    if (typeof requestedTimeoutSeconds === "number" && Number.isFinite(requestedTimeoutSeconds)) {
+      body.timeout_seconds = Math.min(60, Math.max(1, Math.ceil(requestedTimeoutSeconds)))
     }
     const response = await bgRequest<ApiPlaylistPreflightResponse>({
       path: "/api/v1/media/playlists/preflight",

--- a/apps/packages/ui/src/services/tldw/domains/media.ts
+++ b/apps/packages/ui/src/services/tldw/domains/media.ts
@@ -16,6 +16,11 @@ import type {
   ReferenceImageCandidate,
   ReferenceImageListResponse
 } from "../TldwApiClient"
+import {
+  normalizePlaylistPreflightResponse,
+  type ApiPlaylistPreflightResponse,
+  type PlaylistPreflightResult
+} from "@/services/tldw/playlist-preflight"
 
 /**
  * Builds a query string from a record of parameters.
@@ -119,6 +124,30 @@ export const mediaMethods = {
       fields: normalized,
       timeoutMs
     })
+  },
+
+  async preflightPlaylist(payload: {
+    url: string
+    max_items?: number
+    maxItems?: number
+    timeoutMs?: number
+  }): Promise<PlaylistPreflightResult> {
+    const { timeoutMs, maxItems, max_items, ...rest } = payload || {}
+    const body = {
+      ...rest,
+      max_items: max_items ?? maxItems
+    }
+    if (typeof body.max_items === "undefined") {
+      delete (body as Record<string, unknown>).max_items
+    }
+    const response = await bgRequest<ApiPlaylistPreflightResponse>({
+      path: "/api/v1/media/playlists/preflight",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      timeoutMs
+    })
+    return normalizePlaylistPreflightResponse(response)
   },
 
   async getMediaIngestJob(

--- a/apps/packages/ui/src/services/tldw/domains/media.ts
+++ b/apps/packages/ui/src/services/tldw/domains/media.ts
@@ -21,6 +21,17 @@ import {
   type ApiPlaylistPreflightResponse,
   type PlaylistPreflightResult
 } from "@/services/tldw/playlist-preflight"
+import {
+  normalizeMediaCollectionItem,
+  normalizeMediaCollectionListResponse,
+  normalizeMediaCollectionResponse,
+  type ApiMediaCollection,
+  type ApiMediaCollectionItem,
+  type ApiMediaCollectionListResponse,
+  type MediaCollection,
+  type MediaCollectionItem,
+  type MediaCollectionList
+} from "@/services/tldw/conference-collections"
 
 /**
  * Builds a query string from a record of parameters.
@@ -148,6 +159,102 @@ export const mediaMethods = {
       timeoutMs
     })
     return normalizePlaylistPreflightResponse(response)
+  },
+
+  async createMediaCollection(
+    payload: Record<string, any>,
+    options?: { timeoutMs?: number }
+  ): Promise<MediaCollection> {
+    const response = await bgRequest<ApiMediaCollection>({
+      path: "/api/v1/media/collections",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      timeoutMs: options?.timeoutMs
+    })
+    return normalizeMediaCollectionResponse(response)
+  },
+
+  async listMediaCollections(
+    params?: {
+      kind?: string
+      page?: number
+      size?: number
+    },
+    options?: { timeoutMs?: number; signal?: AbortSignal }
+  ): Promise<MediaCollectionList> {
+    const query = buildQuery(params as Record<string, any>)
+    const response = await bgRequest<ApiMediaCollectionListResponse>({
+      path: `/api/v1/media/collections${query}`,
+      method: "GET",
+      timeoutMs: options?.timeoutMs,
+      abortSignal: options?.signal
+    })
+    return normalizeMediaCollectionListResponse(response)
+  },
+
+  async getMediaCollection(
+    collectionId: number | string,
+    options?: { timeoutMs?: number; signal?: AbortSignal }
+  ): Promise<MediaCollection> {
+    const id = encodeURIComponent(String(collectionId))
+    const response = await bgRequest<ApiMediaCollection>({
+      path: `/api/v1/media/collections/${id}`,
+      method: "GET",
+      timeoutMs: options?.timeoutMs,
+      abortSignal: options?.signal
+    })
+    return normalizeMediaCollectionResponse(response)
+  },
+
+  async updateMediaCollection(
+    collectionId: number | string,
+    payload: Record<string, any>,
+    options?: { timeoutMs?: number }
+  ): Promise<MediaCollection> {
+    const id = encodeURIComponent(String(collectionId))
+    const response = await bgRequest<ApiMediaCollection>({
+      path: `/api/v1/media/collections/${id}`,
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      timeoutMs: options?.timeoutMs
+    })
+    return normalizeMediaCollectionResponse(response)
+  },
+
+  async addMediaCollectionItem(
+    collectionId: number | string,
+    payload: Record<string, any>,
+    options?: { timeoutMs?: number }
+  ): Promise<MediaCollectionItem> {
+    const id = encodeURIComponent(String(collectionId))
+    const response = await bgRequest<ApiMediaCollectionItem>({
+      path: `/api/v1/media/collections/${id}/items`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      timeoutMs: options?.timeoutMs
+    })
+    return normalizeMediaCollectionItem(response)
+  },
+
+  async updateMediaCollectionItem(
+    collectionId: number | string,
+    itemId: number | string,
+    payload: Record<string, any>,
+    options?: { timeoutMs?: number }
+  ): Promise<MediaCollectionItem> {
+    const id = encodeURIComponent(String(collectionId))
+    const item = encodeURIComponent(String(itemId))
+    const response = await bgRequest<ApiMediaCollectionItem>({
+      path: `/api/v1/media/collections/${id}/items/${item}`,
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      timeoutMs: options?.timeoutMs
+    })
+    return normalizeMediaCollectionItem(response)
   },
 
   async getMediaIngestJob(
@@ -1373,3 +1480,5 @@ export const mediaMethods = {
     })
   }
 }
+
+export type MediaMethods = typeof mediaMethods

--- a/apps/packages/ui/src/services/tldw/playlist-preflight.ts
+++ b/apps/packages/ui/src/services/tldw/playlist-preflight.ts
@@ -1,0 +1,147 @@
+export type PlaylistDuplicateStatus =
+  | "new"
+  | "duplicate_in_batch"
+  | "duplicate_existing"
+  | "unknown"
+
+export type ApiPlaylistPreflightItem = {
+  ordinal?: number
+  source_url?: string
+  normalized_source_id?: string | null
+  source_kind?: string
+  title?: string | null
+  speaker?: string | null
+  duration_seconds?: number | null
+  published_at?: string | null
+  thumbnail_url?: string | null
+  duplicate_status?: PlaylistDuplicateStatus | string | null
+  duplicate_of_ordinal?: number | null
+  selected?: boolean | null
+}
+
+export type ApiPlaylistPreflightResponse = {
+  source_url?: string
+  source_kind?: string
+  playlist_id?: string | null
+  playlist_title?: string | null
+  video_id?: string | null
+  item_count?: number
+  selected_count?: number
+  duplicate_count?: number
+  warnings?: string[]
+  items?: ApiPlaylistPreflightItem[]
+}
+
+export type PlaylistPreflightItem = {
+  id: string
+  ordinal: number
+  sourceUrl: string
+  normalizedSourceId: string | null
+  sourceKind: string
+  title: string
+  speaker: string | null
+  durationSeconds: number | null
+  publishedAt: string | null
+  thumbnailUrl: string | null
+  duplicateStatus: PlaylistDuplicateStatus
+  duplicateOfOrdinal: number | null
+  selected: boolean
+}
+
+export type PlaylistPreflightResult = {
+  sourceUrl: string
+  sourceKind: string
+  playlistId: string | null
+  playlistTitle: string | null
+  videoId: string | null
+  itemCount: number
+  selectedCount: number
+  duplicateCount: number
+  warnings: string[]
+  items: PlaylistPreflightItem[]
+}
+
+const normalizeDuplicateStatus = (value: unknown): PlaylistDuplicateStatus => {
+  if (
+    value === "new" ||
+    value === "duplicate_in_batch" ||
+    value === "duplicate_existing" ||
+    value === "unknown"
+  ) {
+    return value
+  }
+  return "unknown"
+}
+
+const nullableString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const finiteNumberOrNull = (value: unknown): number | null => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null
+  return value
+}
+
+export const isPlaylistPreflightDuplicate = (
+  item: Pick<PlaylistPreflightItem, "duplicateStatus">
+): boolean => item.duplicateStatus !== "new"
+
+export const normalizePlaylistPreflightResponse = (
+  payload: ApiPlaylistPreflightResponse
+): PlaylistPreflightResult => {
+  const items = Array.isArray(payload?.items) ? payload.items : []
+  const normalizedItems = items.map((item, index) => {
+    const ordinal =
+      typeof item?.ordinal === "number" && Number.isFinite(item.ordinal) && item.ordinal > 0
+        ? Math.floor(item.ordinal)
+        : index + 1
+    const sourceUrl = nullableString(item?.source_url) || ""
+    const normalizedSourceId = nullableString(item?.normalized_source_id)
+    const duplicateStatus = normalizeDuplicateStatus(item?.duplicate_status)
+    const id = normalizedSourceId || sourceUrl || `playlist-item-${ordinal}`
+    return {
+      id,
+      ordinal,
+      sourceUrl,
+      normalizedSourceId,
+      sourceKind: nullableString(item?.source_kind) || "generic_url",
+      title: nullableString(item?.title) || sourceUrl || `Item ${ordinal}`,
+      speaker: nullableString(item?.speaker),
+      durationSeconds: finiteNumberOrNull(item?.duration_seconds),
+      publishedAt: nullableString(item?.published_at),
+      thumbnailUrl: nullableString(item?.thumbnail_url),
+      duplicateStatus,
+      duplicateOfOrdinal: finiteNumberOrNull(item?.duplicate_of_ordinal),
+      selected:
+        typeof item?.selected === "boolean"
+          ? item.selected
+          : duplicateStatus === "new"
+    }
+  })
+
+  return {
+    sourceUrl: nullableString(payload?.source_url) || "",
+    sourceKind: nullableString(payload?.source_kind) || "generic_url",
+    playlistId: nullableString(payload?.playlist_id),
+    playlistTitle: nullableString(payload?.playlist_title),
+    videoId: nullableString(payload?.video_id),
+    itemCount:
+      typeof payload?.item_count === "number" && Number.isFinite(payload.item_count)
+        ? payload.item_count
+        : normalizedItems.length,
+    selectedCount:
+      typeof payload?.selected_count === "number" && Number.isFinite(payload.selected_count)
+        ? payload.selected_count
+        : normalizedItems.filter((item) => item.selected).length,
+    duplicateCount:
+      typeof payload?.duplicate_count === "number" && Number.isFinite(payload.duplicate_count)
+        ? payload.duplicate_count
+        : normalizedItems.filter(isPlaylistPreflightDuplicate).length,
+    warnings: Array.isArray(payload?.warnings)
+      ? payload.warnings.filter((item): item is string => typeof item === "string")
+      : [],
+    items: normalizedItems
+  }
+}

--- a/apps/packages/ui/src/services/tldw/playlist-preflight.ts
+++ b/apps/packages/ui/src/services/tldw/playlist-preflight.ts
@@ -70,7 +70,7 @@ const normalizeDuplicateStatus = (value: unknown): PlaylistDuplicateStatus => {
   ) {
     return value
   }
-  return "unknown"
+  return "new"
 }
 
 const nullableString = (value: unknown): string | null => {

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -18,15 +18,29 @@ import {
   extractIngestJobIds,
   pollSingleIngestJob,
 } from "@/services/tldw/ingest-jobs-orchestrator";
+import { extractCompletedIngestJobMediaId } from "@/services/tldw/ingest-job-results";
 import {
   normalizePersistentAddResponse,
   shouldFallbackToPersistentAdd,
 } from "@/services/tldw/quick-ingest-fallback";
-import type { PersistedQuickIngestTracking } from "@/components/Common/QuickIngest/types";
+import type {
+  ConferenceBatchMetadata,
+  ConferenceItemMetadataOverride,
+  PersistedQuickIngestTracking,
+  PlaylistQueueMetadata,
+} from "@/components/Common/QuickIngest/types";
 import {
   DUPLICATE_SKIP_MESSAGE,
   isDbMessageDuplicate,
 } from "@/components/Common/QuickIngest/constants";
+import {
+  buildConferenceCollectionCreatePayload,
+  buildConferenceCollectionItemPayload,
+  normalizeMediaCollectionItem,
+  normalizeMediaCollectionResponse,
+  type ApiMediaCollection,
+  type ApiMediaCollectionItem,
+} from "@/services/tldw/conference-collections";
 
 type TypeDefaults = {
   audio?: { language?: string; diarize?: boolean };
@@ -40,6 +54,8 @@ type QuickIngestEntry = {
   type: "auto" | "html" | "pdf" | "document" | "audio" | "video";
   defaults?: TypeDefaults;
   keywords?: string;
+  playlist?: PlaylistQueueMetadata;
+  conferenceOverride?: ConferenceItemMetadataOverride;
   audio?: { language?: string; diarize?: boolean };
   document?: { ocr?: boolean };
   video?: { captions?: boolean };
@@ -51,6 +67,7 @@ type QuickIngestFilePayload = {
   type?: string;
   data?: number[] | Uint8Array | ArrayBuffer;
   defaults?: TypeDefaults;
+  conferenceOverride?: ConferenceItemMetadataOverride;
 };
 
 type QuickIngestBatchInput = {
@@ -68,6 +85,7 @@ type QuickIngestBatchInput = {
   };
   advancedValues?: Record<string, any>;
   fileDefaults?: TypeDefaults;
+  conferenceBatchMetadata?: ConferenceBatchMetadata | null;
   chunkingTemplateName?: string;
   autoApplyTemplate?: boolean;
   __quickIngestSessionId?: string;
@@ -524,11 +542,135 @@ const processWebScrape = async ({
   });
 };
 
+type PlannedConferenceCollectionItem = {
+  collectionId: number;
+  itemId: number;
+  idempotencyKey?: string | null;
+};
+
+type PlannedConferenceCollection = {
+  collectionId: number;
+  itemsByEntryId: Map<string, PlannedConferenceCollectionItem>;
+};
+
+const hasUsableConferenceMetadata = (
+  metadata: QuickIngestBatchInput["conferenceBatchMetadata"],
+): metadata is ConferenceBatchMetadata =>
+  Boolean(
+    metadata &&
+      typeof metadata === "object" &&
+      (
+        String(metadata.collectionName || "").trim() ||
+        String(metadata.conferenceName || "").trim() ||
+        String(metadata.sourcePlaylistUrl || "").trim() ||
+        (Array.isArray(metadata.sharedTags) && metadata.sharedTags.length > 0)
+      ),
+  );
+
+const getConferenceFallbackName = (entries: QuickIngestEntry[]): string | null => {
+  for (const entry of entries) {
+    const title = String(entry?.playlist?.playlistTitle || "").trim();
+    if (title) return title;
+  }
+  return null;
+};
+
+const createPlannedConferenceCollection = async (
+  input: QuickIngestBatchInput,
+  entries: QuickIngestEntry[],
+): Promise<PlannedConferenceCollection | null> => {
+  if (!hasUsableConferenceMetadata(input.conferenceBatchMetadata)) return null;
+  const selectedEntries = entries.filter(
+    (entry) =>
+      String(entry?.url || "").trim() &&
+      entry?.conferenceOverride?.selected !== false,
+  );
+  if (selectedEntries.length === 0) return null;
+
+  const collection = normalizeMediaCollectionResponse(
+    await bgRequest<ApiMediaCollection>({
+      path: "/api/v1/media/collections",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: buildConferenceCollectionCreatePayload(
+        input.conferenceBatchMetadata,
+        getConferenceFallbackName(selectedEntries),
+      ),
+      timeoutMs: DIRECT_INGEST_TIMEOUT_MS,
+      ...DIRECT_QUICK_INGEST_TRANSPORT,
+    }),
+  );
+
+  const itemsByEntryId = new Map<string, PlannedConferenceCollectionItem>();
+  for (const entry of selectedEntries) {
+    const item = normalizeMediaCollectionItem(
+      await bgRequest<ApiMediaCollectionItem>({
+        path: `/api/v1/media/collections/${encodeURIComponent(String(collection.id))}/items`,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: buildConferenceCollectionItemPayload(input.conferenceBatchMetadata, {
+          id: entry.id,
+          url: entry.url,
+          playlist: entry.playlist,
+          conferenceOverride: entry.conferenceOverride,
+        }),
+        timeoutMs: DIRECT_INGEST_TIMEOUT_MS,
+        ...DIRECT_QUICK_INGEST_TRANSPORT,
+      }),
+    );
+    itemsByEntryId.set(entry.id, {
+      collectionId: collection.id,
+      itemId: item.id,
+      idempotencyKey: item.idempotencyKey,
+    });
+  }
+
+  return {
+    collectionId: collection.id,
+    itemsByEntryId,
+  };
+};
+
+const patchConferenceCollectionItem = async (
+  planned: PlannedConferenceCollectionItem | undefined,
+  payload: Record<string, unknown>,
+): Promise<void> => {
+  if (!planned) return;
+  await bgRequest<ApiMediaCollectionItem>({
+    path: `/api/v1/media/collections/${encodeURIComponent(
+      String(planned.collectionId),
+    )}/items/${encodeURIComponent(String(planned.itemId))}`,
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    timeoutMs: DIRECT_INGEST_TIMEOUT_MS,
+    ...DIRECT_QUICK_INGEST_TRANSPORT,
+  }).catch(() => {
+    // Collection status updates should not hide the ingest result itself.
+  });
+};
+
+const applyPlannedConferenceFields = (
+  fields: Record<string, any>,
+  planned: PlannedConferenceCollectionItem | undefined,
+) => {
+  if (!planned) return;
+  fields.media_collection_id = planned.collectionId;
+  fields.media_collection_item_id = planned.itemId;
+  if (planned.idempotencyKey) {
+    fields.idempotency_key = planned.idempotencyKey;
+  }
+};
+
 const runDirectQuickIngestBatch = async (
   input: QuickIngestBatchInput,
 ): Promise<QuickIngestBatchResponse> => {
-  const entries = Array.isArray(input.entries) ? input.entries : [];
-  const files = Array.isArray(input.files) ? input.files : [];
+  const entries = Array.isArray(input.entries)
+    ? input.entries.filter((entry) => entry?.conferenceOverride?.selected !== false)
+    : [];
+  const files = Array.isArray(input.files)
+    ? input.files.filter((file) => file?.conferenceOverride?.selected !== false)
+    : [];
   const fileDefaults =
     input.fileDefaults && typeof input.fileDefaults === "object"
       ? input.fileDefaults
@@ -539,6 +681,9 @@ const runDirectQuickIngestBatch = async (
     String(input.__quickIngestSessionId || "").trim() || undefined;
 
   const out: QuickIngestBatchResult[] = [];
+  const conferencePlan = shouldStoreRemote
+    ? await createPlannedConferenceCollection(input, entries)
+    : null;
 
   const pollIngestJobStatus = async (
     jobId: number,
@@ -595,6 +740,10 @@ const runDirectQuickIngestBatch = async (
       const resolvedType =
         explicitType === "auto" ? inferIngestTypeFromUrl(url) : explicitType;
 
+      const plannedConferenceItem =
+        conferencePlan?.itemsByEntryId.get(entry.id);
+      let jobSubmitted = false;
+      let latestJobId: number | undefined;
       try {
         let data: unknown;
         if (shouldStoreRemote) {
@@ -610,6 +759,7 @@ const runDirectQuickIngestBatch = async (
             chunkingTemplateName: input.chunkingTemplateName,
             autoApplyTemplate: input.autoApplyTemplate,
           });
+          applyPlannedConferenceFields(fields, plannedConferenceItem);
           fields.urls = [url];
           try {
             const submitData = await bgUpload<any>({
@@ -624,6 +774,13 @@ const runDirectQuickIngestBatch = async (
             if (!batchId || jobIds.length === 0) {
               throw new Error("Ingest job submission returned no job IDs.");
             }
+            const firstJobId = jobIds[0];
+            jobSubmitted = true;
+            latestJobId = firstJobId;
+            await patchConferenceCollectionItem(plannedConferenceItem, {
+              status: "processing",
+              latest_job_id: String(firstJobId),
+            });
             const directTracker = ensureDirectSessionTracker(directSessionId);
             directTracker?.trackJobs(batchId, jobIds, { sourceId: entry.id });
             input.onTrackingMetadata?.({
@@ -637,7 +794,6 @@ const runDirectQuickIngestBatch = async (
               jobIdToItemId: buildJobIdToItemId(jobIds, entry.id),
               startedAt: Date.now(),
             });
-            const firstJobId = jobIds[0];
             const pollResult = await pollIngestJobStatus(
               firstJobId,
               DIRECT_INGEST_TIMEOUT_MS,
@@ -646,10 +802,22 @@ const runDirectQuickIngestBatch = async (
               throw new Error(String(pollResult.error || "Ingest failed"));
             }
             data = pollResult.data;
+            await patchConferenceCollectionItem(plannedConferenceItem, {
+              status: "completed",
+              latest_job_id: String(latestJobId),
+              media_id: extractCompletedIngestJobMediaId(pollResult.data),
+            });
           } catch (error) {
             if (!shouldFallbackToPersistentAdd(error)) {
               throw error;
             }
+            await patchConferenceCollectionItem(plannedConferenceItem, {
+              status: jobSubmitted ? "failed" : "submit_failed",
+              latest_job_id:
+                typeof latestJobId === "number" ? String(latestJobId) : undefined,
+              error_summary:
+                error instanceof Error ? error.message : String(error || "Submit failed"),
+            });
             data = await submitPersistentAdd({ fields });
           }
         } else if (resolvedType === "html") {
@@ -694,6 +862,15 @@ const runDirectQuickIngestBatch = async (
           persisted: false,
         });
       } catch (error) {
+        await patchConferenceCollectionItem(plannedConferenceItem, {
+          status: jobSubmitted ? "failed" : "submit_failed",
+          latest_job_id:
+            typeof latestJobId === "number" ? String(latestJobId) : undefined,
+          error_summary:
+            error instanceof Error
+              ? error.message
+              : String(error || "Request failed"),
+        });
         out.push({
           id: entry.id,
           status: "error",

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -190,6 +190,16 @@ const buildJobIdToItemId = (
 ): Record<string, string> =>
   Object.fromEntries(jobIds.map((jobId) => [String(jobId), sourceItemId]));
 
+const buildJobIdToCollectionItemId = (
+  jobIds: number[],
+  planned: PlannedConferenceCollectionItem | undefined,
+): Record<string, string> | undefined => {
+  if (!planned) return undefined;
+  return Object.fromEntries(
+    jobIds.map((jobId) => [String(jobId), String(planned.itemId)]),
+  );
+};
+
 const ensureDirectSessionTracker = (
   sessionId: string | undefined,
 ): DirectQuickIngestTracker | undefined => {
@@ -657,8 +667,10 @@ const applyPlannedConferenceFields = (
   if (!planned) return;
   fields.media_collection_id = planned.collectionId;
   fields.media_collection_item_id = planned.itemId;
+  fields.planned_item_ids = [String(planned.itemId)];
   if (planned.idempotencyKey) {
     fields.idempotency_key = planned.idempotencyKey;
+    fields.idempotency_keys = [planned.idempotencyKey];
   }
 };
 
@@ -788,10 +800,21 @@ const runDirectQuickIngestBatch = async (
               sessionId: directSessionId,
               batchId,
               batchIds: [batchId],
+              collectionId: plannedConferenceItem
+                ? String(plannedConferenceItem.collectionId)
+                : undefined,
+              plannedItemIds: plannedConferenceItem
+                ? [String(plannedConferenceItem.itemId)]
+                : undefined,
               jobIds,
               submittedItemIds: [entry.id],
               itemIds: [entry.id],
               jobIdToItemId: buildJobIdToItemId(jobIds, entry.id),
+              jobIdToCollectionItemId: buildJobIdToCollectionItemId(
+                jobIds,
+                plannedConferenceItem,
+              ),
+              durableMode: plannedConferenceItem ? "durable_collection" : undefined,
               startedAt: Date.now(),
             });
             const pollResult = await pollIngestJobStatus(
@@ -818,6 +841,9 @@ const runDirectQuickIngestBatch = async (
               error_summary:
                 error instanceof Error ? error.message : String(error || "Submit failed"),
             });
+            if (typeof latestJobId === "number") {
+              fields.media_ingest_job_id = String(latestJobId);
+            }
             data = await submitPersistentAdd({ fields });
           }
         } else if (resolvedType === "html") {

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -18,7 +18,10 @@ import {
   extractIngestJobIds,
   pollSingleIngestJob,
 } from "@/services/tldw/ingest-jobs-orchestrator";
-import { extractCompletedIngestJobMediaId } from "@/services/tldw/ingest-job-results";
+import {
+  completedIngestJobIndicatesSkipped,
+  extractCompletedIngestJobMediaId,
+} from "@/services/tldw/ingest-job-results";
 import {
   normalizePersistentAddResponse,
   shouldFallbackToPersistentAdd,
@@ -38,6 +41,7 @@ import {
   buildConferenceCollectionItemPayload,
   normalizeMediaCollectionItem,
   normalizeMediaCollectionResponse,
+  resolveConferenceDuplicatePolicy,
   type ApiMediaCollection,
   type ApiMediaCollectionItem,
 } from "@/services/tldw/conference-collections";
@@ -95,7 +99,7 @@ type QuickIngestBatchInput = {
 type QuickIngestBatchResult = {
   id: string;
   status: "ok" | "error";
-  outcome?: "skipped";
+  outcome?: "skipped" | "submit_failed" | "failed" | "cancelled";
   url?: string;
   fileName?: string;
   type: string;
@@ -103,6 +107,9 @@ type QuickIngestBatchResult = {
   error?: string;
   message?: string;
   persisted?: boolean;
+  collectionItemId?: string | number | null;
+  retryAttempt?: number | null;
+  idempotencyKey?: string | null;
 };
 
 type QuickIngestBatchResponse = {
@@ -754,10 +761,40 @@ const runDirectQuickIngestBatch = async (
 
       const plannedConferenceItem =
         conferencePlan?.itemsByEntryId.get(entry.id);
+      const duplicatePolicyResolution = resolveConferenceDuplicatePolicy(
+        entry.playlist?.duplicateStatus,
+        entry.conferenceOverride?.duplicatePolicy,
+      );
       let jobSubmitted = false;
       let latestJobId: number | undefined;
       try {
+        if (
+          shouldStoreRemote &&
+          plannedConferenceItem &&
+          !duplicatePolicyResolution.shouldSubmitJob
+        ) {
+          await patchConferenceCollectionItem(plannedConferenceItem, {
+            status: duplicatePolicyResolution.plannedStatus,
+            retry_count: 0,
+          });
+          out.push({
+            id: entry.id,
+            status: "ok",
+            outcome: "skipped",
+            url,
+            type: resolvedType,
+            collectionItemId: plannedConferenceItem.itemId,
+            retryAttempt: 0,
+            idempotencyKey: plannedConferenceItem.idempotencyKey ?? null,
+            message: DUPLICATE_SKIP_MESSAGE,
+            persisted: false,
+          });
+          continue;
+        }
+
         let data: unknown;
+        let resultOutcome: QuickIngestBatchResult["outcome"];
+        let resultMessage: string | undefined;
         if (shouldStoreRemote) {
           const fields = buildFields({
             rawType: resolvedType,
@@ -771,6 +808,9 @@ const runDirectQuickIngestBatch = async (
             chunkingTemplateName: input.chunkingTemplateName,
             autoApplyTemplate: input.autoApplyTemplate,
           });
+          if (duplicatePolicyResolution.forceOverwrite) {
+            fields.overwrite_existing = true;
+          }
           applyPlannedConferenceFields(fields, plannedConferenceItem);
           fields.urls = [url];
           try {
@@ -825,8 +865,15 @@ const runDirectQuickIngestBatch = async (
               throw new Error(String(pollResult.error || "Ingest failed"));
             }
             data = pollResult.data;
+            const completedDuplicate = completedIngestJobIndicatesSkipped(
+              pollResult.data,
+            );
+            if (completedDuplicate) {
+              resultOutcome = "skipped";
+              resultMessage = DUPLICATE_SKIP_MESSAGE;
+            }
             await patchConferenceCollectionItem(plannedConferenceItem, {
-              status: "completed",
+              status: completedDuplicate ? "skipped_existing" : "completed",
               latest_job_id: String(latestJobId),
               media_id: extractCompletedIngestJobMediaId(pollResult.data),
             });
@@ -845,6 +892,17 @@ const runDirectQuickIngestBatch = async (
               fields.media_ingest_job_id = String(latestJobId);
             }
             data = await submitPersistentAdd({ fields });
+            const fallbackDuplicate = completedIngestJobIndicatesSkipped(data);
+            if (fallbackDuplicate) {
+              resultOutcome = "skipped";
+              resultMessage = DUPLICATE_SKIP_MESSAGE;
+            }
+            await patchConferenceCollectionItem(plannedConferenceItem, {
+              status: fallbackDuplicate ? "skipped_existing" : "completed",
+              latest_job_id:
+                typeof latestJobId === "number" ? String(latestJobId) : undefined,
+              media_id: extractCompletedIngestJobMediaId(data),
+            });
           }
         } else if (resolvedType === "html") {
           data = await processWebScrape({
@@ -882,14 +940,20 @@ const runDirectQuickIngestBatch = async (
         out.push({
           id: entry.id,
           status: "ok",
+          outcome: resultOutcome,
           url,
           type: resolvedType,
           data,
+          message: resultMessage,
           persisted: false,
+          collectionItemId: plannedConferenceItem?.itemId ?? null,
+          retryAttempt: plannedConferenceItem ? 0 : null,
+          idempotencyKey: plannedConferenceItem?.idempotencyKey ?? null,
         });
       } catch (error) {
+        const outcome = jobSubmitted ? "failed" : "submit_failed";
         await patchConferenceCollectionItem(plannedConferenceItem, {
-          status: jobSubmitted ? "failed" : "submit_failed",
+          status: outcome,
           latest_job_id:
             typeof latestJobId === "number" ? String(latestJobId) : undefined,
           error_summary:
@@ -900,12 +964,16 @@ const runDirectQuickIngestBatch = async (
         out.push({
           id: entry.id,
           status: "error",
+          outcome,
           url,
           type: resolvedType,
           error:
             error instanceof Error
               ? error.message
               : String(error || "Request failed"),
+          collectionItemId: plannedConferenceItem?.itemId ?? null,
+          retryAttempt: plannedConferenceItem ? 0 : null,
+          idempotencyKey: plannedConferenceItem?.idempotencyKey ?? null,
         });
       }
     }

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -700,9 +700,14 @@ const runDirectQuickIngestBatch = async (
     String(input.__quickIngestSessionId || "").trim() || undefined;
 
   const out: QuickIngestBatchResult[] = [];
-  const conferencePlan = shouldStoreRemote
-    ? await createPlannedConferenceCollection(input, entries)
-    : null;
+  let conferencePlan: PlannedConferenceCollection | null = null;
+  if (shouldStoreRemote) {
+    try {
+      conferencePlan = await createPlannedConferenceCollection(input, entries);
+    } catch (error) {
+      console.warn("[tldw] Conference collection planning failed", error);
+    }
+  }
 
   const pollIngestJobStatus = async (
     jobId: number,
@@ -766,6 +771,7 @@ const runDirectQuickIngestBatch = async (
         entry.conferenceOverride?.duplicatePolicy,
       );
       let jobSubmitted = false;
+      let localProcessingAttempted = false;
       let latestJobId: number | undefined;
       try {
         if (
@@ -891,6 +897,7 @@ const runDirectQuickIngestBatch = async (
             if (typeof latestJobId === "number") {
               fields.media_ingest_job_id = String(latestJobId);
             }
+            localProcessingAttempted = true;
             data = await submitPersistentAdd({ fields });
             const fallbackDuplicate = completedIngestJobIndicatesSkipped(data);
             if (fallbackDuplicate) {
@@ -905,6 +912,7 @@ const runDirectQuickIngestBatch = async (
             });
           }
         } else if (resolvedType === "html") {
+          localProcessingAttempted = true;
           data = await processWebScrape({
             url,
             entry,
@@ -928,6 +936,7 @@ const runDirectQuickIngestBatch = async (
             persist: false,
           });
           fields.urls = [url];
+          localProcessingAttempted = true;
           data = await bgUpload<any>({
             path: getProcessPathForType(resolvedType),
             method: "POST",
@@ -951,7 +960,8 @@ const runDirectQuickIngestBatch = async (
           idempotencyKey: plannedConferenceItem?.idempotencyKey ?? null,
         });
       } catch (error) {
-        const outcome = jobSubmitted ? "failed" : "submit_failed";
+        const outcome =
+          jobSubmitted || localProcessingAttempted ? "failed" : "submit_failed";
         await patchConferenceCollectionItem(plannedConferenceItem, {
           status: outcome,
           latest_job_id:

--- a/apps/packages/ui/src/services/tldw/server-capabilities.ts
+++ b/apps/packages/ui/src/services/tldw/server-capabilities.ts
@@ -6,6 +6,12 @@ export type ServerCapabilities = {
   hasChat: boolean
   hasRag: boolean
   hasMedia: boolean
+  hasMediaPlaylistPreflight?: boolean
+  hasMediaIngestJobs?: boolean
+  hasMediaIngestJobEvents?: boolean
+  hasMediaIngestWorker?: boolean
+  hasDurableMediaCollections?: boolean
+  hasKnowledgeQaMediaScope?: boolean
   hasNotes: boolean
   hasSlides: boolean
   hasPresentationStudio: boolean
@@ -50,6 +56,12 @@ const defaultCapabilities: ServerCapabilities = {
   hasChat: false,
   hasRag: false,
   hasMedia: false,
+  hasMediaPlaylistPreflight: false,
+  hasMediaIngestJobs: false,
+  hasMediaIngestJobEvents: false,
+  hasMediaIngestWorker: false,
+  hasDurableMediaCollections: false,
+  hasKnowledgeQaMediaScope: false,
   hasNotes: false,
   hasSlides: false,
   hasPresentationStudio: false,
@@ -100,7 +112,9 @@ const fallbackSpec = {
       "/api/v1/rag/health",
       "/api/v1/rag/",
       "/api/v1/rag/feedback/implicit",
+      "/api/v1/media/playlists/preflight",
       "/api/v1/media/ingest/jobs",
+      "/api/v1/media/ingest/jobs/events/stream",
       "/api/v1/media/add",
       "/api/v1/media/",
       "/api/v1/media/process-videos",
@@ -356,13 +370,36 @@ const applyDocsInfoFeatureGates = (
     docsInfo,
     "hasPresentationRender"
   )
+  const mediaPlaylistPreflightEnabled = extractFeatureFlag(
+    docsInfo,
+    "hasMediaPlaylistPreflight"
+  )
+  const mediaIngestJobsEnabled = extractFeatureFlag(docsInfo, "hasMediaIngestJobs")
+  const mediaIngestJobEventsEnabled = extractFeatureFlag(
+    docsInfo,
+    "hasMediaIngestJobEvents"
+  )
+  const mediaIngestWorkerEnabled = extractFeatureFlag(
+    docsInfo,
+    "hasMediaIngestWorker"
+  )
+  const durableMediaCollectionsEnabled = extractFeatureFlag(
+    docsInfo,
+    "hasDurableMediaCollections"
+  )
+  const knowledgeQaMediaScopeEnabled = extractFeatureFlag(
+    docsInfo,
+    "hasKnowledgeQaMediaScope"
+  )
   const personaFeatureEnabled = extractFeatureFlag(docsInfo, "persona")
   const personalizationFeatureEnabled = extractFeatureFlag(
     docsInfo,
     "personalization"
   )
-  const mergeFeatureFlag = (computed: boolean, explicit: boolean | null): boolean =>
-    explicit === null ? computed : explicit
+  const mergeFeatureFlag = (
+    computed: boolean | undefined,
+    explicit: boolean | null
+  ): boolean => (explicit === null ? Boolean(computed) : explicit)
   const hasStt = mergeFeatureFlag(capabilities.hasStt, sttFeatureEnabled)
   const hasTts = mergeFeatureFlag(capabilities.hasTts, ttsFeatureEnabled)
   const hasVoiceChat = mergeFeatureFlag(
@@ -400,6 +437,30 @@ const applyDocsInfoFeatureGates = (
     hasSlides,
     hasPresentationStudio,
     hasPresentationRender,
+    hasMediaPlaylistPreflight: mergeFeatureFlag(
+      capabilities.hasMediaPlaylistPreflight,
+      mediaPlaylistPreflightEnabled
+    ),
+    hasMediaIngestJobs: mergeFeatureFlag(
+      capabilities.hasMediaIngestJobs,
+      mediaIngestJobsEnabled
+    ),
+    hasMediaIngestJobEvents: mergeFeatureFlag(
+      capabilities.hasMediaIngestJobEvents,
+      mediaIngestJobEventsEnabled
+    ),
+    hasMediaIngestWorker: mergeFeatureFlag(
+      capabilities.hasMediaIngestWorker,
+      mediaIngestWorkerEnabled
+    ),
+    hasDurableMediaCollections: mergeFeatureFlag(
+      capabilities.hasDurableMediaCollections,
+      durableMediaCollectionsEnabled
+    ),
+    hasKnowledgeQaMediaScope: mergeFeatureFlag(
+      capabilities.hasKnowledgeQaMediaScope,
+      knowledgeQaMediaScopeEnabled
+    ),
     hasPersona:
       personaFeatureEnabled === null
         ? capabilities.hasPersona
@@ -450,16 +511,27 @@ const computeCapabilities = (
     has("/api/v1/audio/chat/stream") || (hasStt && hasTts)
   const hasVoiceConversationTransport =
     specSource === "fallback" ? false : has("/api/v1/audio/chat/stream")
+  const hasMediaPlaylistPreflight = has("/api/v1/media/playlists/preflight")
+  const hasMediaIngestJobs = has("/api/v1/media/ingest/jobs")
+  const hasMediaIngestJobEvents = has("/api/v1/media/ingest/jobs/events/stream")
+  const hasDurableMediaCollections = has("/api/v1/media/collections")
 
   return {
     hasChat: has("/api/v1/chat/completions"),
     hasRag: has("/api/v1/rag/search") || has("/api/v1/rag/health") || has("/api/v1/rag/"),
     hasMedia:
-      has("/api/v1/media/ingest/jobs") ||
+      hasMediaPlaylistPreflight ||
+      hasMediaIngestJobs ||
       has("/api/v1/media/add") ||
       has("/api/v1/media/") ||
       has("/api/v1/media/process-videos") ||
       has("/api/v1/media/process-documents"),
+    hasMediaPlaylistPreflight,
+    hasMediaIngestJobs,
+    hasMediaIngestJobEvents,
+    hasMediaIngestWorker: false,
+    hasDurableMediaCollections,
+    hasKnowledgeQaMediaScope: false,
     hasNotes: has("/api/v1/notes/"),
     hasSlides,
     hasPresentationStudio,

--- a/apps/packages/ui/src/services/tldw/server-capabilities.ts
+++ b/apps/packages/ui/src/services/tldw/server-capabilities.ts
@@ -115,6 +115,7 @@ const fallbackSpec = {
       "/api/v1/media/playlists/preflight",
       "/api/v1/media/ingest/jobs",
       "/api/v1/media/ingest/jobs/events/stream",
+      "/api/v1/media/collections",
       "/api/v1/media/add",
       "/api/v1/media/",
       "/api/v1/media/process-videos",
@@ -522,6 +523,7 @@ const computeCapabilities = (
     hasMedia:
       hasMediaPlaylistPreflight ||
       hasMediaIngestJobs ||
+      hasDurableMediaCollections ||
       has("/api/v1/media/add") ||
       has("/api/v1/media/") ||
       has("/api/v1/media/process-videos") ||

--- a/apps/packages/ui/src/store/quick-ingest-session.ts
+++ b/apps/packages/ui/src/store/quick-ingest-session.ts
@@ -9,6 +9,9 @@ import type {
   WizardResultItem,
   WizardStep,
   DetectedMediaType,
+  ConferenceBatchMetadata,
+  ConferenceItemMetadataOverride,
+  PlaylistQueueMetadata,
 } from "@/components/Common/QuickIngest/types"
 import { DEFAULT_PRESET, DEFAULT_PRESETS } from "@/components/Common/QuickIngest/presets"
 
@@ -50,6 +53,8 @@ export type PersistedWizardQueueItem = {
   fileSize: number
   mimeType?: string
   validation: QueueItemValidation
+  playlist?: PlaylistQueueMetadata
+  conferenceOverride?: ConferenceItemMetadataOverride
   fileStub?: {
     key?: string
     instanceId?: string
@@ -93,6 +98,7 @@ export type QuickIngestSessionRecord = {
   customOptions: Partial<PresetConfig>
   processingState: WizardProcessingState
   results: WizardResultItem[]
+  conferenceBatchMetadata?: ConferenceBatchMetadata | null
   badge: QuickIngestSessionBadge
   resultSummary: QuickIngestSessionResultSummary
   tracking?: PersistedQuickIngestTracking
@@ -330,6 +336,8 @@ const sanitizeQueueItems = (
             ? item.type
             : undefined,
       validation: item?.validation || { valid: true },
+      playlist: item?.playlist,
+      conferenceOverride: item?.conferenceOverride,
     }
 
     if (item?.fileStub) {
@@ -454,6 +462,7 @@ const sanitizeSession = (
     customOptions: session.customOptions || {},
     processingState: session.processingState || { ...INITIAL_PROCESSING_STATE },
     results: Array.isArray(session.results) ? session.results : [],
+    conferenceBatchMetadata: session.conferenceBatchMetadata ?? null,
     badge: {
       queueCount: Math.max(
         0,
@@ -503,6 +512,7 @@ export const createEmptyQuickIngestSession = (): QuickIngestSessionRecord => {
     customOptions: {},
     processingState: { ...INITIAL_PROCESSING_STATE },
     results: [],
+    conferenceBatchMetadata: null,
     badge: {
       queueCount: 0,
       hasRecentFailure: false,

--- a/apps/packages/ui/src/store/quick-ingest-session.ts
+++ b/apps/packages/ui/src/store/quick-ingest-session.ts
@@ -30,11 +30,15 @@ export type PersistedQuickIngestTracking = {
   sessionId?: string
   batchId?: string
   batchIds?: string[]
+  collectionId?: string
+  plannedItemIds?: string[]
   jobIds?: number[]
   submittedItemIds?: string[]
   /** @deprecated use submittedItemIds */
   itemIds?: string[]
   jobIdToItemId?: Record<string, string>
+  jobIdToCollectionItemId?: Record<string, string>
+  durableMode?: "durable_collection" | "degraded" | "unknown"
   startedAt?: number
 }
 
@@ -233,7 +237,15 @@ const sanitizeTracking = (
       : []),
     ...(Array.isArray(tracking.itemIds) ? tracking.itemIds : []),
   ])
+  const plannedItemIds = normalizeStringIds(
+    Array.isArray(tracking.plannedItemIds) ? tracking.plannedItemIds : []
+  )
   const jobIdToItemIdEntries = Object.entries(tracking.jobIdToItemId || {})
+    .map(([jobId, itemId]) => [String(jobId || "").trim(), String(itemId || "").trim()] as const)
+    .filter(([jobId, itemId]) => jobId && itemId)
+  const jobIdToCollectionItemIdEntries = Object.entries(
+    tracking.jobIdToCollectionItemId || {}
+  )
     .map(([jobId, itemId]) => [String(jobId || "").trim(), String(itemId || "").trim()] as const)
     .filter(([jobId, itemId]) => jobId && itemId)
   const normalizedMode =
@@ -250,6 +262,8 @@ const sanitizeTracking = (
       tracking.batchId?.trim() ||
       (batchIds.length > 0 ? batchIds[batchIds.length - 1] : undefined),
     batchIds: batchIds.length > 0 ? batchIds : undefined,
+    collectionId: tracking.collectionId?.trim() || undefined,
+    plannedItemIds: plannedItemIds.length > 0 ? plannedItemIds : undefined,
     jobIds: jobIds && jobIds.length > 0 ? Array.from(new Set(jobIds)) : undefined,
     submittedItemIds:
       submittedItemIds.length > 0 ? submittedItemIds : undefined,
@@ -257,6 +271,16 @@ const sanitizeTracking = (
     jobIdToItemId:
       jobIdToItemIdEntries.length > 0
         ? Object.fromEntries(jobIdToItemIdEntries)
+        : undefined,
+    jobIdToCollectionItemId:
+      jobIdToCollectionItemIdEntries.length > 0
+        ? Object.fromEntries(jobIdToCollectionItemIdEntries)
+        : undefined,
+    durableMode:
+      tracking.durableMode === "durable_collection" ||
+      tracking.durableMode === "degraded" ||
+      tracking.durableMode === "unknown"
+        ? tracking.durableMode
         : undefined,
     startedAt:
       typeof tracking.startedAt === "number" && Number.isFinite(tracking.startedAt)
@@ -284,6 +308,11 @@ const mergeTracking = (
     sessionId: next.sessionId || base.sessionId,
     batchId: next.batchId || base.batchId,
     batchIds: [...(base.batchIds || []), ...(next.batchIds || [])],
+    collectionId: next.collectionId || base.collectionId,
+    plannedItemIds: [
+      ...(base.plannedItemIds || []),
+      ...(next.plannedItemIds || []),
+    ],
     jobIds: [...(base.jobIds || []), ...(next.jobIds || [])],
     submittedItemIds: [
       ...(base.submittedItemIds || base.itemIds || []),
@@ -293,6 +322,11 @@ const mergeTracking = (
       ...(base.jobIdToItemId || {}),
       ...(next.jobIdToItemId || {}),
     },
+    jobIdToCollectionItemId: {
+      ...(base.jobIdToCollectionItemId || {}),
+      ...(next.jobIdToCollectionItemId || {}),
+    },
+    durableMode: next.durableMode || base.durableMode,
     startedAt: base.startedAt || next.startedAt,
   })
 }

--- a/apps/packages/ui/src/store/quick-ingest-session.ts
+++ b/apps/packages/ui/src/store/quick-ingest-session.ts
@@ -14,6 +14,7 @@ import type {
   PlaylistQueueMetadata,
 } from "@/components/Common/QuickIngest/types"
 import { DEFAULT_PRESET, DEFAULT_PRESETS } from "@/components/Common/QuickIngest/presets"
+import type { QuickIngestOpenDetail } from "@/utils/quick-ingest-open"
 
 const STORAGE_KEY = "tldw-quick-ingest-session"
 
@@ -102,6 +103,7 @@ export type QuickIngestSessionRecord = {
   customOptions: Partial<PresetConfig>
   processingState: WizardProcessingState
   results: WizardResultItem[]
+  openDetail?: QuickIngestOpenDetail | null
   conferenceBatchMetadata?: ConferenceBatchMetadata | null
   badge: QuickIngestSessionBadge
   resultSummary: QuickIngestSessionResultSummary
@@ -496,6 +498,10 @@ const sanitizeSession = (
     customOptions: session.customOptions || {},
     processingState: session.processingState || { ...INITIAL_PROCESSING_STATE },
     results: Array.isArray(session.results) ? session.results : [],
+    openDetail:
+      session.openDetail && typeof session.openDetail === "object"
+        ? session.openDetail
+        : null,
     conferenceBatchMetadata: session.conferenceBatchMetadata ?? null,
     badge: {
       queueCount: Math.max(
@@ -546,6 +552,7 @@ export const createEmptyQuickIngestSession = (): QuickIngestSessionRecord => {
     customOptions: {},
     processingState: { ...INITIAL_PROCESSING_STATE },
     results: [],
+    openDetail: null,
     conferenceBatchMetadata: null,
     badge: {
       queueCount: 0,

--- a/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildQuickIngestOpenDetailFromUrl,
+  createQuickIngestSessionSeedFromOpenDetail,
+  requestQuickIngestOpen,
+} from "../quick-ingest-open"
+
+describe("quick ingest open handoff", () => {
+  it("builds a typed extension playlist preflight detail from an active tab URL", () => {
+    expect(
+      buildQuickIngestOpenDetailFromUrl(
+        "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B"
+      )
+    ).toEqual({
+      source: "extension_active_tab",
+      url: "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B",
+      sourceKind: "youtube_watch_playlist",
+      action: "playlist_preflight",
+    })
+
+    expect(
+      buildQuickIngestOpenDetailFromUrl(
+        "https://www.youtube.com/playlist?list=PL0065D9B288E6804B"
+      )?.sourceKind
+    ).toBe("youtube_playlist")
+    expect(
+      buildQuickIngestOpenDetailFromUrl("https://www.youtube.com/watch?v=abc123")
+    ).toBeNull()
+  })
+
+  it("stores typed detail on the pending request and dispatches it in the event", () => {
+    const events: unknown[] = []
+    window.addEventListener("tldw:open-quick-ingest", (event) => {
+      events.push((event as CustomEvent).detail)
+    })
+
+    const detail = {
+      source: "extension_active_tab" as const,
+      url: "https://www.youtube.com/watch?v=a&list=PLx",
+      sourceKind: "youtube_watch_playlist" as const,
+      action: "playlist_preflight" as const,
+    }
+
+    const request = requestQuickIngestOpen(detail)
+
+    expect(request?.detail).toEqual(detail)
+    expect(events).toEqual([detail])
+  })
+
+  it("creates a wizard session seed that starts playlist preflight", () => {
+    const detail = {
+      source: "extension_active_tab" as const,
+      url: "https://www.youtube.com/watch?v=a&list=PLx",
+      sourceKind: "youtube_watch_playlist" as const,
+      action: "playlist_preflight" as const,
+    }
+
+    expect(createQuickIngestSessionSeedFromOpenDetail(detail)).toEqual({
+      openDetail: detail,
+    })
+  })
+})

--- a/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
@@ -30,9 +30,10 @@ describe("quick ingest open handoff", () => {
 
   it("stores typed detail on the pending request and dispatches it in the event", () => {
     const events: unknown[] = []
-    window.addEventListener("tldw:open-quick-ingest", (event) => {
+    const listener = (event: Event) => {
       events.push((event as CustomEvent).detail)
-    })
+    }
+    window.addEventListener("tldw:open-quick-ingest", listener)
 
     const detail = {
       source: "extension_active_tab" as const,
@@ -41,10 +42,14 @@ describe("quick ingest open handoff", () => {
       action: "playlist_preflight" as const,
     }
 
-    const request = requestQuickIngestOpen(detail)
+    try {
+      const request = requestQuickIngestOpen(detail)
 
-    expect(request?.detail).toEqual(detail)
-    expect(events).toEqual([detail])
+      expect(request?.detail).toEqual(detail)
+      expect(events).toEqual([detail])
+    } finally {
+      window.removeEventListener("tldw:open-quick-ingest", listener)
+    }
   })
 
   it("creates a wizard session seed that starts playlist preflight", () => {

--- a/apps/packages/ui/src/utils/quick-ingest-open.ts
+++ b/apps/packages/ui/src/utils/quick-ingest-open.ts
@@ -1,5 +1,28 @@
 export type QuickIngestPendingOpenMode = "normal" | "intro"
 
+export type QuickIngestPlaylistSourceKind =
+  | "youtube_playlist"
+  | "youtube_watch_playlist"
+  | "unknown"
+
+export type QuickIngestOpenDetail =
+  | {
+      source: "manual"
+      action?: "normal"
+    }
+  | {
+      source: "extension_active_tab"
+      url: string
+      sourceKind?: QuickIngestPlaylistSourceKind
+      action: "playlist_preflight"
+    }
+  | {
+      source?: string
+      action?: string
+      url?: string
+      [key: string]: unknown
+    }
+
 export type QuickIngestPendingOpenOptions = {
   autoProcessQueued?: boolean
   focusTrigger?: boolean
@@ -8,7 +31,7 @@ export type QuickIngestPendingOpenOptions = {
 export type QuickIngestPendingOpenRequest = {
   mode: QuickIngestPendingOpenMode
   at: number
-  detail?: unknown
+  detail?: QuickIngestOpenDetail
   options?: QuickIngestPendingOpenOptions
 }
 
@@ -25,7 +48,7 @@ const getQuickIngestWindow = (): QuickIngestWindow | null => {
 
 const buildPendingOpenRequest = (
   mode: QuickIngestPendingOpenMode,
-  detail?: unknown,
+  detail?: QuickIngestOpenDetail,
   options?: QuickIngestPendingOpenOptions
 ): QuickIngestPendingOpenRequest => ({
   mode,
@@ -34,9 +57,16 @@ const buildPendingOpenRequest = (
   options,
 })
 
+const normalizeQuickIngestOpenDetail = (
+  detail: unknown
+): QuickIngestOpenDetail | undefined =>
+  detail && typeof detail === "object"
+    ? (detail as QuickIngestOpenDetail)
+    : undefined
+
 const dispatchQuickIngestOpenEvent = (
   mode: QuickIngestPendingOpenMode,
-  detail?: unknown
+  detail?: QuickIngestOpenDetail
 ): void => {
   const scope = getQuickIngestWindow()
   if (!scope) return
@@ -54,7 +84,11 @@ export const rememberQuickIngestOpenRequest = (
 ): QuickIngestPendingOpenRequest | null => {
   const scope = getQuickIngestWindow()
   if (!scope) return null
-  const request = buildPendingOpenRequest(mode, detail, options)
+  const request = buildPendingOpenRequest(
+    mode,
+    normalizeQuickIngestOpenDetail(detail),
+    options
+  )
   scope.__tldwPendingQuickIngestOpen = request
   return request
 }
@@ -63,8 +97,9 @@ export const requestQuickIngestOpen = (
   detail?: unknown,
   options?: QuickIngestPendingOpenOptions
 ): QuickIngestPendingOpenRequest | null => {
-  const request = rememberQuickIngestOpenRequest("normal", detail, options)
-  dispatchQuickIngestOpenEvent("normal", detail)
+  const normalizedDetail = normalizeQuickIngestOpenDetail(detail)
+  const request = rememberQuickIngestOpenRequest("normal", normalizedDetail, options)
+  dispatchQuickIngestOpenEvent("normal", normalizedDetail)
   return request
 }
 
@@ -72,8 +107,9 @@ export const requestQuickIngestIntro = (
   detail?: unknown,
   options?: QuickIngestPendingOpenOptions
 ): QuickIngestPendingOpenRequest | null => {
-  const request = rememberQuickIngestOpenRequest("intro", detail, options)
-  dispatchQuickIngestOpenEvent("intro", detail)
+  const normalizedDetail = normalizeQuickIngestOpenDetail(detail)
+  const request = rememberQuickIngestOpenRequest("intro", normalizedDetail, options)
+  dispatchQuickIngestOpenEvent("intro", normalizedDetail)
   return request
 }
 
@@ -85,3 +121,63 @@ export const consumePendingQuickIngestOpen = (): QuickIngestPendingOpenRequest |
   }
   return request
 }
+
+const hostnameMatches = (hostname: string, allowedHost: string): boolean =>
+  hostname === allowedHost || hostname.endsWith(`.${allowedHost}`)
+
+export const getQuickIngestPlaylistSourceKind = (
+  rawUrl: string
+): QuickIngestPlaylistSourceKind | null => {
+  try {
+    const parsed = new URL(rawUrl.trim())
+    const hostname = parsed.hostname.toLowerCase()
+    if (!hostnameMatches(hostname, "youtube.com") && !hostnameMatches(hostname, "youtu.be")) {
+      return null
+    }
+    const playlistId = parsed.searchParams.get("list")?.trim()
+    if (!playlistId) return null
+    const pathname = parsed.pathname.toLowerCase()
+    if (pathname === "/playlist") return "youtube_playlist"
+    if (pathname === "/watch" || hostnameMatches(hostname, "youtu.be")) {
+      return "youtube_watch_playlist"
+    }
+    return "unknown"
+  } catch {
+    return null
+  }
+}
+
+export const buildQuickIngestOpenDetailFromUrl = (
+  rawUrl: string
+): QuickIngestOpenDetail | null => {
+  const url = rawUrl.trim()
+  const sourceKind = getQuickIngestPlaylistSourceKind(url)
+  if (!sourceKind) return null
+  return {
+    source: "extension_active_tab",
+    url,
+    sourceKind,
+    action: "playlist_preflight",
+  }
+}
+
+export const isQuickIngestPlaylistPreflightDetail = (
+  detail: QuickIngestOpenDetail | null | undefined
+): detail is Extract<
+  QuickIngestOpenDetail,
+  { source: "extension_active_tab"; action: "playlist_preflight" }
+> =>
+  Boolean(
+    detail &&
+      detail.source === "extension_active_tab" &&
+      detail.action === "playlist_preflight" &&
+      typeof detail.url === "string" &&
+      detail.url.trim().length > 0
+  )
+
+export const createQuickIngestSessionSeedFromOpenDetail = (
+  detail: QuickIngestOpenDetail | null | undefined
+): { openDetail: QuickIngestOpenDetail } | null =>
+  isQuickIngestPlaylistPreflightDetail(detail)
+    ? { openDetail: detail }
+    : null

--- a/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
@@ -548,6 +548,8 @@ test.describe("Media Ingestion Workflow", () => {
           capabilities: {
             hasMediaPlaylistPreflight: true,
             hasMediaIngestJobs: true,
+            hasMediaIngestJobEvents: true,
+            hasMediaIngestWorker: true,
             hasDurableMediaCollections: true,
             hasKnowledgeQaMediaScope: true,
           },
@@ -1262,6 +1264,8 @@ test.describe("Media Ingestion Workflow", () => {
       await authedPage.addInitScript(() => {
         localStorage.removeItem("tldw-quick-ingest-session")
         localStorage.removeItem("__tldwServerCapabilitiesCacheV3")
+        sessionStorage.removeItem("tldw-quick-ingest-session")
+        sessionStorage.removeItem("__tldwServerCapabilitiesCacheV3")
       })
       const bulkApis = await mockBulkConferenceApis(authedPage)
 
@@ -1329,6 +1333,8 @@ test.describe("Media Ingestion Workflow", () => {
       await authedPage.addInitScript(() => {
         localStorage.removeItem("tldw-quick-ingest-session")
         localStorage.removeItem("__tldwServerCapabilitiesCacheV3")
+        sessionStorage.removeItem("tldw-quick-ingest-session")
+        sessionStorage.removeItem("__tldwServerCapabilitiesCacheV3")
       })
       await mockBulkConferenceApis(authedPage)
 

--- a/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
@@ -9,6 +9,7 @@
  * - Content review flow
  */
 import { test, expect, skipIfServerUnavailable, assertNoCriticalErrors } from "../utils/fixtures"
+import type { Page, Route } from "@playwright/test"
 import { MediaPage } from "../utils/page-objects"
 import {
   seedAuth,
@@ -423,6 +424,296 @@ test.describe("Media Ingestion Workflow", () => {
       "e2e/fixtures/media/quick-ingest-sample.mkv"
     )
     const quickIngestFixtureUrl = "https://example.com/e2e/quick-ingest-source.html"
+    const bulkConferencePlaylistUrl =
+      "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B"
+    const bulkConferenceCollectionId = 700
+
+    const fulfillJson = async (
+      route: Route,
+      status: number,
+      body: Record<string, unknown>
+    ) => {
+      await route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      })
+    }
+
+    const buildBulkConferencePreflightFixture = () => {
+      const items = Array.from({ length: 34 }, (_, index) => {
+        const ordinal = index + 1
+        const videoId =
+          ordinal === 18 ? "conference-talk-08" : `conference-talk-${String(ordinal).padStart(2, "0")}`
+        const duplicateStatus =
+          ordinal === 8
+            ? "duplicate_existing"
+            : ordinal === 18
+              ? "duplicate_in_batch"
+              : "new"
+        return {
+          ordinal,
+          source_url: `https://www.youtube.com/watch?v=${videoId}`,
+          normalized_source_id: `youtube:video:${videoId}`,
+          source_kind: "youtube_video",
+          title: `Talk ${ordinal}`,
+          speaker: `Speaker ${ordinal}`,
+          duration_seconds: 1800 + ordinal,
+          published_at: `2010-09-${String(Math.min(ordinal, 28)).padStart(2, "0")}`,
+          thumbnail_url: null,
+          duplicate_status: duplicateStatus,
+          duplicate_of_ordinal: ordinal === 18 ? 8 : null,
+          selected: duplicateStatus === "new",
+        }
+      })
+
+      return {
+        source_url: bulkConferencePlaylistUrl,
+        source_kind: "youtube_watch_playlist",
+        playlist_id: "PL0065D9B288E6804B",
+        playlist_title: "Conference 2010",
+        video_id: "PrNmmN6qBiw",
+        item_count: items.length,
+        selected_count: items.filter((item) => item.selected).length,
+        duplicate_count: items.filter((item) => item.duplicate_status !== "new").length,
+        warnings: [],
+        items,
+      }
+    }
+
+    const mockBulkConferenceApis = async (page: Page) => {
+      const preflight = buildBulkConferencePreflightFixture()
+      const collectionItems = new Map<number, Record<string, any>>()
+      const jobToCollectionItem = new Map<number, number>()
+      let nextCollectionItemId = 900
+      let nextJobId = 1200
+      let submittedJobCount = 0
+
+      await page.route("**/openapi.json", async (route) => {
+        await fulfillJson(route, 200, {
+          openapi: "3.1.0",
+          info: { title: "tldw e2e", version: "e2e" },
+          paths: {
+            "/api/v1/media": { get: {} },
+            "/api/v1/media/playlists/preflight": { post: {} },
+            "/api/v1/media/ingest/jobs": { post: {} },
+            "/api/v1/media/collections": { get: {}, post: {} },
+            "/api/v1/media/collections/{collection_id}": { get: {} },
+            "/api/v1/rag/search": { post: {} },
+          },
+        })
+      })
+      await page.route("**/api/v1/config/docs-info", async (route) => {
+        await fulfillJson(route, 200, {
+          capabilities: {
+            hasMediaPlaylistPreflight: true,
+            hasMediaIngestJobs: true,
+            hasDurableMediaCollections: true,
+            hasKnowledgeQaMediaScope: true,
+          },
+        })
+      })
+      await page.route("**/api/v1/health", async (route) => {
+        await fulfillJson(route, 200, { status: "ok", version: "e2e" })
+      })
+      await page.route(/\/api\/v1\/media\/?(?:\?|$)/, async (route, request) => {
+        if (request.method().toUpperCase() !== "GET") {
+          await route.continue()
+          return
+        }
+        await fulfillJson(route, 200, {
+          items: [],
+          pagination: {
+            page: 1,
+            results_per_page: 20,
+            total_items: 0,
+            total_pages: 1,
+          },
+        })
+      })
+      await page.route("**/api/v1/media/playlists/preflight", async (route, request) => {
+        if (request.method().toUpperCase() !== "POST") {
+          await route.continue()
+          return
+        }
+        await fulfillJson(route, 200, preflight)
+      })
+      await page.route("**/api/v1/media/collections", async (route, request) => {
+        const url = new URL(request.url())
+        if (
+          request.method().toUpperCase() !== "POST" ||
+          url.pathname.replace(/\/+$/, "") !== "/api/v1/media/collections"
+        ) {
+          await route.continue()
+          return
+        }
+        await fulfillJson(route, 200, {
+          id: bulkConferenceCollectionId,
+          name: "Conference 2010 Review",
+          kind: "conference",
+          source_url: bulkConferencePlaylistUrl,
+          metadata: {
+            conference_name: "Conference",
+            event_year: "2010",
+            source_playlist_url: bulkConferencePlaylistUrl,
+          },
+          default_tags: ["conference", "talks"],
+          created_at: "2026-05-16T00:00:00Z",
+          updated_at: "2026-05-16T00:00:00Z",
+          items: [],
+        })
+      })
+      await page.route(
+        `**/api/v1/media/collections/${bulkConferenceCollectionId}/items`,
+        async (route, request) => {
+          if (request.method().toUpperCase() !== "POST") {
+            await route.continue()
+            return
+          }
+          const payload = request.postDataJSON() as Record<string, any>
+          const itemId = nextCollectionItemId++
+          const item = {
+            id: itemId,
+            collection_id: bulkConferenceCollectionId,
+            ordinal: payload.ordinal,
+            source_url: payload.source_url,
+            normalized_source_id: payload.normalized_source_id,
+            source_kind: payload.source_kind,
+            title: payload.title || `Talk ${payload.ordinal}`,
+            speaker: payload.speaker || null,
+            published_at: payload.published_at || null,
+            track: payload.track || null,
+            duplicate_status: payload.duplicate_status || "new",
+            status: payload.status || "planned",
+            media_id:
+              payload.duplicate_status && payload.duplicate_status !== "new"
+                ? 5000 + Number(payload.ordinal || 0)
+                : null,
+            content_item_id: null,
+            latest_job_id: null,
+            latest_run_id: null,
+            idempotency_key: `collection-${itemId}-attempt-0`,
+            retry_count: 0,
+            error_summary: null,
+            warnings: [],
+            metadata: payload.metadata || {},
+            tags: payload.tags || [],
+            created_at: "2026-05-16T00:00:00Z",
+            updated_at: "2026-05-16T00:00:00Z",
+          }
+          collectionItems.set(itemId, item)
+          await fulfillJson(route, 200, item)
+        }
+      )
+      await page.route(
+        `**/api/v1/media/collections/${bulkConferenceCollectionId}/items/*`,
+        async (route, request) => {
+          if (request.method().toUpperCase() !== "PATCH") {
+            await route.continue()
+            return
+          }
+          const url = new URL(request.url())
+          const itemId = Number(url.pathname.split("/").pop())
+          const patch = request.postDataJSON() as Record<string, any>
+          const current = collectionItems.get(itemId) || {
+            id: itemId,
+            collection_id: bulkConferenceCollectionId,
+          }
+          const next = {
+            ...current,
+            ...patch,
+            media_id:
+              patch.media_id != null
+                ? Number(patch.media_id)
+                : current.media_id ?? null,
+            updated_at: "2026-05-16T00:01:00Z",
+          }
+          collectionItems.set(itemId, next)
+          await fulfillJson(route, 200, next)
+        }
+      )
+      await page.route("**/api/v1/media/ingest/jobs", async (route, request) => {
+        const url = new URL(request.url())
+        if (
+          request.method().toUpperCase() !== "POST" ||
+          url.pathname.replace(/\/+$/, "") !== "/api/v1/media/ingest/jobs"
+        ) {
+          await route.continue()
+          return
+        }
+        submittedJobCount += 1
+        const jobId = nextJobId++
+        const form = request.postDataBuffer()
+        const body = form?.toString("utf8") ?? ""
+        const plannedMatch = body.match(/name="media_collection_item_id"\r\n\r\n([^\r\n]+)/)
+        const plannedItemId = plannedMatch ? Number(plannedMatch[1]) : 0
+        if (plannedItemId) {
+          jobToCollectionItem.set(jobId, plannedItemId)
+        }
+        await fulfillJson(route, 200, {
+          batch_id: `bulk-batch-${jobId}`,
+          job_ids: [jobId],
+          jobs: [{ id: jobId, status: "queued" }],
+        })
+      })
+      await page.route("**/api/v1/media/ingest/jobs/*", async (route, request) => {
+        if (request.method().toUpperCase() !== "GET") {
+          await route.continue()
+          return
+        }
+        const url = new URL(request.url())
+        const jobId = Number(url.pathname.split("/").pop())
+        const collectionItemId = jobToCollectionItem.get(jobId)
+        const isFailed = jobId === 1209
+        await fulfillJson(route, 200, {
+          job_id: jobId,
+          status: "completed",
+          progress_percent: 100,
+          result: isFailed
+            ? {
+                status: "Error",
+                error: "Download failed for mocked talk",
+                source_url: `https://www.youtube.com/watch?v=conference-talk-failed`,
+              }
+            : {
+                status: "Success",
+                media_id: collectionItemId ? 7000 + collectionItemId : jobId,
+                source_url: `https://www.youtube.com/watch?v=conference-talk-${jobId}`,
+                title: `Processed talk ${jobId}`,
+              },
+        })
+      })
+      await page.route(
+        `**/api/v1/media/collections/${bulkConferenceCollectionId}`,
+        async (route, request) => {
+          if (request.method().toUpperCase() !== "GET") {
+            await route.continue()
+            return
+          }
+          await fulfillJson(route, 200, {
+            id: bulkConferenceCollectionId,
+            name: "Conference 2010 Review",
+            kind: "conference",
+            description: "Conference talks",
+            source_url: bulkConferencePlaylistUrl,
+            metadata: {
+              conference_name: "Conference",
+              event_year: "2010",
+            },
+            default_tags: ["conference", "talks"],
+            created_at: "2026-05-16T00:00:00Z",
+            updated_at: "2026-05-16T00:01:00Z",
+            items: Array.from(collectionItems.values()).sort(
+              (left, right) => Number(left.ordinal || 0) - Number(right.ordinal || 0)
+            ),
+          })
+        }
+      )
+
+      return {
+        getSubmittedJobCount: () => submittedJobCount,
+      }
+    }
     const createUniqueQuickIngestFixtureCopy = (): string => {
       const fixture = path.parse(quickIngestFixtureFile)
       const uniqueFixtureFile = path.join(
@@ -917,6 +1208,108 @@ test.describe("Media Ingestion Workflow", () => {
       })
       await expect(dialog).toContainText(/processing/i)
       await expect(processQueuedCta).toHaveCount(0)
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+
+    test("quick ingest handles a mocked 34-talk conference playlist through collection review", async ({
+      authedPage,
+      diagnostics
+    }) => {
+      test.setTimeout(180_000)
+      await authedPage.addInitScript(() => {
+        localStorage.removeItem("tldw-quick-ingest-session")
+        localStorage.removeItem("__tldwServerCapabilitiesCacheV3")
+      })
+      const bulkApis = await mockBulkConferenceApis(authedPage)
+
+      await authedPage.goto("/media", { waitUntil: "domcontentloaded" })
+      await waitForConnection(authedPage)
+      const dialog = await openQuickIngestDialog(authedPage)
+      const urlInput = dialog.locator("textarea").first()
+
+      await urlInput.fill(bulkConferencePlaylistUrl)
+      await dialog.getByRole("button", { name: "Preview" }).click()
+
+      await expect(dialog).toContainText("Conference 2010", { timeout: 20_000 })
+      await expect(dialog).toContainText("34 items")
+      await expect(dialog).toContainText("32 selected")
+      await expect(dialog).toContainText("2 duplicates")
+
+      await dialog.getByLabel("Include existing").check()
+      await expect(dialog).toContainText("34 selected")
+      await dialog.getByRole("checkbox", { name: "Select Talk 3", exact: true }).uncheck()
+      await expect(dialog).toContainText("33 selected")
+      await dialog.getByRole("button", { name: "Add 33" }).click()
+
+      const metadataPanel = dialog.getByLabel("Conference batch metadata")
+      await expect(metadataPanel).toContainText("33 selected")
+      await metadataPanel.getByLabel("Collection name").fill("Conference 2010 Review")
+      await metadataPanel.getByLabel("Conference name").fill("Conference")
+      await metadataPanel.getByLabel("Event year").fill("2010")
+      await metadataPanel.getByLabel("Shared tags").fill("conference, talks")
+
+      await dialog.getByRole("button", { name: /configure 33 items/i }).click()
+      await dialog.getByRole("button", { name: "Next" }).click()
+      await expect(dialog).toContainText("Ready to Process")
+      await dialog.getByRole("button", { name: /start processing/i }).click()
+
+      await expect(dialog.getByTestId("wizard-results-step")).toBeVisible({
+        timeout: 120_000,
+      })
+      await expect(dialog).toContainText("Succeeded (30)")
+      await expect(dialog).toContainText("Skipped existing (2)")
+      await expect(dialog).toContainText("Failed during processing (1)")
+      await expect(dialog).toContainText(
+        "Total: 30 succeeded, 2 skipped, 0 not submitted, 1 failed, 0 cancelled"
+      )
+      expect(bulkApis.getSubmittedJobCount()).toBe(31)
+
+      await dialog.getByRole("button", { name: "Open collection" }).click()
+      await expect(authedPage).toHaveURL(/\/media-collections\/700/, {
+        timeout: 20_000,
+      })
+      await expect(
+        authedPage.getByRole("heading", { name: "Conference 2010 Review" })
+      ).toBeVisible({ timeout: 20_000 })
+      await expect(authedPage.getByText("33 talks", { exact: true })).toBeVisible()
+      await expect(authedPage.getByText("32 ready", { exact: true })).toBeVisible()
+      await expect(authedPage.getByText("1 need attention", { exact: true })).toBeVisible()
+      await expect(authedPage.getByText("Talk 1").first()).toBeVisible()
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+
+    test("quick ingest extension playlist handoff opens the shared preflight state", async ({
+      authedPage,
+      diagnostics
+    }) => {
+      await authedPage.addInitScript(() => {
+        localStorage.removeItem("tldw-quick-ingest-session")
+        localStorage.removeItem("__tldwServerCapabilitiesCacheV3")
+      })
+      await mockBulkConferenceApis(authedPage)
+
+      await authedPage.goto("/media", { waitUntil: "domcontentloaded" })
+      await waitForConnection(authedPage)
+      await authedPage.evaluate((url) => {
+        window.dispatchEvent(
+          new CustomEvent("tldw:open-quick-ingest", {
+            detail: {
+              source: "extension_active_tab",
+              action: "playlist_preflight",
+              sourceKind: "youtube_watch_playlist",
+              url,
+            },
+          })
+        )
+      }, bulkConferencePlaylistUrl)
+
+      const dialog = authedPage.getByRole("dialog", { name: /quick ingest/i }).first()
+      await expect(dialog).toBeVisible({ timeout: 20_000 })
+      await expect(dialog).toContainText("Conference 2010", { timeout: 20_000 })
+      await expect(dialog).toContainText("34 items")
+      await expect(dialog).toContainText("32 selected")
 
       await assertNoCriticalErrors(diagnostics)
     })

--- a/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
@@ -32,9 +32,49 @@ import {
 import * as path from "path"
 import * as fs from "fs"
 
+const emptyMediaListResponse = {
+  items: [],
+  pagination: {
+    page: 1,
+    results_per_page: 20,
+    total_items: 0,
+    total_pages: 1,
+  },
+}
+
+const stubOfflineMediaReadApis = async (page: Page) => {
+  await page.route(/\/api\/v1\/media\/?(?:\?.*)?$/, async (route, request) => {
+    if (request.method().toUpperCase() !== "GET") {
+      await route.continue()
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(emptyMediaListResponse),
+    })
+  })
+
+  await page.route(/\/api\/v1\/media\/search(?:\?.*)?$/, async (route, request) => {
+    const method = request.method().toUpperCase()
+    if (method !== "GET" && method !== "POST") {
+      await route.continue()
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(emptyMediaListResponse),
+    })
+  })
+}
+
 test.describe("Media Ingestion Workflow", () => {
   test.beforeEach(async ({ page }) => {
     await seedAuth(page)
+    await stubOfflineMediaReadApis(page)
   })
 
   test.describe("Media Page Navigation", () => {
@@ -863,7 +903,9 @@ test.describe("Media Ingestion Workflow", () => {
       }
 
       let emptyStateTrigger = authedPage
-        .getByRole("button", { name: /open quick ingest/i })
+        .getByTestId("first-ingest-tutorial")
+        .getByRole("button", { name: /^ingest$/i })
+        .or(authedPage.getByRole("button", { name: /open quick ingest/i }))
         .first()
       if (!(await emptyStateTrigger.isVisible().catch(() => false))) {
         const skipTutorial = authedPage.getByRole("button", { name: /skip for now/i }).first()
@@ -1342,10 +1384,12 @@ test.describe("Media Ingestion Workflow", () => {
     }) => {
       const mediaPage = new MediaPage(authedPage)
       await mediaPage.gotoReview()
-      await authedPage.getByRole("link", { name: /open updated page/i }).click()
-      await expect(authedPage).toHaveURL(/\/media-multi(?:[/?#].*)?$/, {
-        timeout: 20_000
-      })
+      const updatedPageLink = authedPage.getByTestId("route-redirect-open-updated-page")
+      await expect(updatedPageLink).toBeVisible({ timeout: 20_000 })
+      await Promise.all([
+        authedPage.waitForURL(/\/media-multi(?:[/?#].*)?$/, { timeout: 20_000 }),
+        updatedPageLink.evaluate((link) => (link as HTMLAnchorElement).click()),
+      ])
 
       await assertNoCriticalErrors(diagnostics)
     })

--- a/apps/tldw-frontend/extension/routes/option-media-collection.tsx
+++ b/apps/tldw-frontend/extension/routes/option-media-collection.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/routes/option-media-collection"

--- a/apps/tldw-frontend/extension/routes/route-registry.tsx
+++ b/apps/tldw-frontend/extension/routes/route-registry.tsx
@@ -134,6 +134,7 @@ const OptionTldwSettings = createSettingsRoute(
   "TldwSettings"
 )
 const OptionMedia = lazy(() => import("./option-media"))
+const OptionMediaCollection = lazy(() => import("./option-media-collection"))
 const OptionMediaMulti = lazy(() => import("./option-media-multi"))
 const OptionNotes = lazy(() => import("./option-notes"))
 const OptionWorldBooks = createSettingsRoute(
@@ -727,6 +728,11 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       icon: Microscope,
       order: 1
     }
+  },
+  {
+    kind: "options",
+    path: "/media-collections/:collectionId",
+    element: <OptionMediaCollection />
   },
   {
     kind: "options",

--- a/apps/tldw-frontend/pages/media-collections/[collectionId].tsx
+++ b/apps/tldw-frontend/pages/media-collections/[collectionId].tsx
@@ -1,0 +1,5 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-media-collection"), {
+  ssr: false,
+})

--- a/backlog/tasks/task-400 - Inventory-bulk-conference-collection-contract-for-implementation.md
+++ b/backlog/tasks/task-400 - Inventory-bulk-conference-collection-contract-for-implementation.md
@@ -45,10 +45,10 @@ Task 0 contract inventory drafted, verified, and committed. Verification: rg con
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-400 - Inventory-bulk-conference-collection-contract-for-implementation.md
+++ b/backlog/tasks/task-400 - Inventory-bulk-conference-collection-contract-for-implementation.md
@@ -1,0 +1,54 @@
+---
+id: TASK-400
+title: Inventory bulk conference collection contract for implementation
+status: Done
+labels:
+- quick-ingest
+- media-ingest
+- collections
+- ux
+priority: Medium
+documentation:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+- backlog/tasks/task-400 - Inventory-bulk-conference-collection-contract-for-implementation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Task 0 from the bulk conference ingest workflow implementation plan. Inspect the current Collections DB, item endpoint, media ingest jobs, sync persistence, review localStorage collections, and WebUI service contracts. Produce a contract inventory that selects the durable source of truth and records rejected alternatives before backend/UI implementation starts.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 0 contract inventory drafted, verified, and committed. Verification: rg confirmed Selected Contract, Rejected Alternatives, and API Placement headings; git diff --check passed. Bandit skipped because this slice changes only documentation and Backlog task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-401 - Implement-playlist-preflight-and-basic-dedupe-for-bulk-conference-ingest.md
+++ b/backlog/tasks/task-401 - Implement-playlist-preflight-and-basic-dedupe-for-bulk-conference-ingest.md
@@ -1,0 +1,80 @@
+---
+id: TASK-401
+title: Implement playlist preflight and basic dedupe for bulk conference ingest
+status: Done
+labels:
+- quick-ingest
+- media-ingest
+- playlist
+- frontend
+- backend
+priority: High
+documentation:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+- Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+modified_files:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+- tldw_Server_API/app/api/v1/schemas/media_playlist_preflight.py
+- tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
+- tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
+- tldw_Server_API/app/api/v1/endpoints/media/__init__.py
+- tldw_Server_API/app/api/v1/endpoints/config_info.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py
+- tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+- apps/packages/ui/src/services/tldw/server-capabilities.ts
+- apps/packages/ui/src/services/tldw/domains/media.ts
+- apps/packages/ui/src/services/tldw/playlist-preflight.ts
+- apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts
+- apps/packages/ui/src/services/__tests__/server-capabilities.test.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.media-ingest.test.ts
+- apps/packages/ui/src/components/Common/QuickIngest/types.ts
+- apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/AddContentStep.url-detection.test.ts
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Task 1 from the bulk conference ingest workflow implementation plan. Use TDD: add backend classification/dedupe/endpoint/capability tests and frontend normalizer/capability/UI detection tests before implementation. Implement metadata-only playlist preflight, basic duplicate-in-batch detection, granular capability flags, and the first shared Quick Ingest affordance for playlist-capable URLs.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added metadata-only playlist preflight endpoint at `POST /api/v1/media/playlists/preflight` with timeout handling, single-video fail-closed validation, truncation warnings, and duplicate-in-batch detection.
+- Added granular server capability flags for playlist preflight, ingest jobs, ingest job events, worker availability, durable media collections, and scoped Knowledge QA.
+- Added shared frontend client normalizers and a Quick Ingest playlist preflight panel gated by `hasMediaPlaylistPreflight`.
+- Added full-list playlist preview selection controls so users can deselect talks before queueing them.
+- Kept durable collections and scoped Knowledge QA disabled until later planned tasks implement those backend contracts.
+- Verification: focused backend pytest `9 passed`; focused frontend Vitest `5 passed, 44 tests passed`; `git diff --check` clean; Bandit touched backend scan wrote `/tmp/bandit_bulk_playlist_preflight.json` with zero results.
+- Known skip: shared UI `tsc --noEmit --project ../packages/ui/tsconfig.json` still fails on existing repo-wide type errors outside this slice.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Task 1 of the bulk conference workflow plan: first-time users pasting a YouTube playlist URL into Quick Ingest now get a server-backed preflight affordance instead of adding one opaque URL. The slice covers playlist URL classification, yt-dlp metadata-only extraction, duplicate-in-batch marking, timeout/error handling, capability discovery, a typed frontend API wrapper, and focused tests for backend and shared UI behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-402 - Implement-durable-conference-media-collections.md
+++ b/backlog/tasks/task-402 - Implement-durable-conference-media-collections.md
@@ -1,0 +1,82 @@
+---
+id: TASK-402
+title: Implement durable conference media collections
+status: Done
+labels:
+- media-ingest
+- collections
+- backend
+- frontend
+priority: High
+documentation:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+- Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+modified_files:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+- Docs/superpowers/plans/2026-05-16-bulk-conference-contract-inventory.md
+- tldw_Server_API/app/core/DB_Management/Collections_DB.py
+- tldw_Server_API/app/api/v1/schemas/media_collections.py
+- tldw_Server_API/app/api/v1/endpoints/media/collections.py
+- tldw_Server_API/app/api/v1/endpoints/media/__init__.py
+- tldw_Server_API/app/api/v1/endpoints/config_info.py
+- tldw_Server_API/tests/Collections/test_conference_media_collections.py
+- tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+- apps/packages/ui/src/services/tldw/domains/media.ts
+- apps/packages/ui/src/services/tldw/conference-collections.ts
+- apps/packages/ui/src/services/tldw/__tests__/conference-collections.test.ts
+- apps/packages/ui/src/services/__tests__/server-capabilities.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Task 2 from the bulk conference ingest workflow implementation plan. Add durable owner-scoped conference/media collection storage, planned item membership, basic collection CRUD/status APIs, frontend service normalizers/wrappers, and keep localStorage review collections explicitly local-only until a migration feature exists.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Task 2 from the bulk conference ingest workflow plan.
+
+- Added durable `media_collections`, `media_collection_items`, and `media_collection_runs` schema inside `CollectionsDatabase`.
+- Added collection create/list/get/update/delete helpers, ordered planned-item membership, item status updates, and media/content resolution helpers.
+- Added `/api/v1/media/collections` CRUD and item endpoints under the existing media subrouter.
+- Advertised durable media collection capability through docs-info once the route exists.
+- Added shared frontend normalizers and `mediaMethods` wrappers for collection CRUD and item updates.
+- Recorded the explicit boundary that `media:collections:v1` remains a local-only manual review collection store until a migration UX slice exists.
+
+Verification:
+
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Collections/test_conference_media_collections.py tldw_Server_API/tests/Config/test_docs_info_capabilities.py::test_docs_info_exposes_bulk_conference_ingest_capabilities -q`
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/node_modules/.bin/vitest run -c vitest.config.ts ../packages/ui/src/services/tldw/__tests__/conference-collections.test.ts ../packages/ui/src/services/__tests__/server-capabilities.test.ts`
+- `git diff --check`
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/Collections_DB.py tldw_Server_API/app/api/v1/endpoints/media/collections.py tldw_Server_API/app/api/v1/schemas/media_collections.py tldw_Server_API/app/api/v1/endpoints/config_info.py -f json -o /tmp/bandit_bulk_conference_collections.json`
+
+Known skip: full shared UI TypeScript still fails on repo-wide pre-existing errors outside this slice. After adding the missing local `MediaMethods` export, the rerun did not report touched files from this task.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added durable conference/media collection storage and APIs plus shared frontend service support, preserving planned playlist items separately from resolved content_items and leaving existing localStorage review collections local-only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-403 - Implement-Quick-Ingest-batch-conference-metadata.md
+++ b/backlog/tasks/task-403 - Implement-Quick-Ingest-batch-conference-metadata.md
@@ -1,0 +1,53 @@
+---
+id: TASK-403
+title: Implement Quick Ingest batch conference metadata
+status: Done
+labels:
+- bulk-conference
+- quick-ingest
+- webui
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Task 3 for the bulk conference ingestion workflow plan. Add shared conference metadata, per-item overrides, and submission payload support to Quick Ingest for playlist/conference batches.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Quick Ingest exposes shared conference metadata fields for likely playlist or multi-video batches.
+- [x] Quick Ingest supports per-item title, speaker, track, tag, and selected-item overrides.
+- [x] Wizard session persistence carries conference metadata, playlist metadata, and item overrides into processing payloads.
+- [x] Direct WebUI and extension-runtime submission paths create durable planned media collection items before job submission.
+- [x] Submit failures mark planned collection items as `submit_failed`.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `ConferenceBatchMetadata` and `ConferenceItemMetadataOverride` to the Quick Ingest queue model.
+- Added compact batch and item metadata controls that appear for playlist items and likely multi-video conference batches.
+- Persisted conference metadata and playlist/item override metadata through the Quick Ingest session store.
+- Added collection payload merge helpers in `conference-collections.ts`.
+- Updated direct and background Quick Ingest submission paths to create collections/items, attach planned item IDs to job fields, and patch item status on submit/progress/failure.
+- Verification: focused Vitest suite passed, 74 tests across wizard integration/session, conference collection service, and batch submission. `git diff --check` passed. Shared UI `tsc` still fails on the existing repo-wide baseline; a touched-file filter for Quick Ingest/conference/background paths produced no matches.
+- Bandit was not run because this slice only touched TypeScript/TSX, plan docs, and Backlog task files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 3 complete: Quick Ingest can capture shared conference metadata, per-item overrides, carry them through session persistence, and create durable planned collection items before batch job submission for direct and extension-runtime paths.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-404 - Implement-Jobs-backed-conference-ingest-tracking.md
+++ b/backlog/tasks/task-404 - Implement-Jobs-backed-conference-ingest-tracking.md
@@ -1,0 +1,73 @@
+---
+id: TASK-404
+title: Implement Jobs-backed conference ingest tracking
+status: Done
+labels:
+- bulk-conference-ingest
+- quick-ingest
+- media-jobs
+priority: High
+modified_files:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+- tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+- tldw_Server_API/app/services/media_ingest_jobs_worker.py
+- tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+- tldw_Server_API/app/api/v1/schemas/media_request_models.py
+- tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_collections_dual_write.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_add_deps_error_mapping.py
+- apps/packages/ui/src/components/Common/QuickIngest/types.ts
+- apps/packages/ui/src/components/Common/QuickIngest/ProcessingStep.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+- apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+- apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+- apps/packages/ui/src/store/quick-ingest-session.ts
+- apps/packages/ui/src/entries/background.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Media ingest job submission accepts collection/run metadata, validates per-URL arrays, and preserves planned collection item IDs in job status without storing secrets.
+- [x] #2 Media ingest worker maps terminal job outcomes to planned collection item statuses: processing, completed, skipped_existing, failed, cancelled, submit_failed, and missing-media-id failed.
+- [x] #3 Frontend persisted Quick Ingest tracking restores collection/run IDs, planned item mapping, durable/degraded mode, counts, and failed URL export affordances; retry remains in the existing Results Panel controls and later selected-subset retry task.
+- [x] #4 Focused backend and frontend tests cover planned item binding, worker status updates, synchronous fallback binding, and restored run tracking.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md#task-4-jobs-backed-ingest-run-tracking
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Task 4 against the existing media jobs and collections contracts. Job submission now carries `collection_id`, `planned_item_id`, and `idempotency_key`, validates per-URL planned/idempotency arrays, and marks planned items `submit_failed` if job creation fails.
+
+The worker marks planned items `processing`, `completed`, `skipped_existing`, `failed`, and `cancelled`, and fails closed when a terminal result lacks a media id. Synchronous fallback carries `media_collection_item_id` and `media_ingest_job_id` and resolves planned items.
+
+Quick Ingest persisted tracking now stores `collectionId`, `plannedItemIds`, `jobIdToCollectionItemId`, and `durableMode`; `ProcessingStep` shows durable tracking and can export failed item lists.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 4 complete. Verification: pytest media job/fallback slice 33 passed; Vitest Quick Ingest slice 73 passed; git diff --check passed; Bandit on touched backend files reported zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Focused pytest and Vitest suites pass for touched media job and Quick Ingest paths.
+- [x] #2 git diff --check passes.
+- [x] #3 Bandit is run on touched backend files and reports zero findings.
+- [x] #4 Plan Task 4 checkboxes and Backlog task are updated before commit.
+<!-- DOD:END -->

--- a/backlog/tasks/task-405 - Implement-bulk-ingest-results-collection-handoff.md
+++ b/backlog/tasks/task-405 - Implement-bulk-ingest-results-collection-handoff.md
@@ -1,0 +1,50 @@
+---
+id: TASK-405
+title: Implement bulk ingest results collection handoff
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 01:04'
+labels:
+  - bulk-conference-ingest
+  - quick-ingest
+  - collections
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Results step groups completed, skipped existing, submit failed, failed, and cancelled outcomes with distinct copy.
+- [x] #2 Results step exposes a primary collection handoff CTA when durable collection tracking is present.
+- [x] #3 Failed export includes source URL, title, collection item id, status, error summary, and retry attempt where available.
+- [x] #4 Collection-scoped QA CTA only appears when knowledge QA media scope capability is present and collection readiness is nonzero.
+- [x] #5 Focused Vitest coverage verifies grouping, handoff CTAs, and existing integration flow remains intact.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Task 5 results handoff: WizardResultsStep now groups succeeded, skipped existing, not submitted, failed during processing, and cancelled outcomes; exposes durable collection handoff even when all items fail; gates Ask this collection on hasKnowledgeQaMediaScope plus ready completed/skipped media; and exports failed rows with URL, title, collection item id, status, error summary, and retry attempt. ResultsListItem now labels submit_failed as Not submitted.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Focused Vitest suite passed: WizardResultsStep.navigation, QuickIngestWizardModal.integration, ResultsListItem.status, and conference-collections helpers (40 tests). git diff --check passed. Frontend tsc --noEmit remains blocked by unrelated pre-existing errors in EmbeddingsModelSelectionConfig.tsx, persona-visuals.ts, and lib/api/vnPlay.ts.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Focused Vitest suites pass for WizardResultsStep, QuickIngestWizardModal integration, and conference collection helpers.
+- [x] #2 git diff --check passes.
+- [x] #3 Plan Task 5 checkboxes and Backlog task are updated before commit.
+<!-- DOD:END -->

--- a/backlog/tasks/task-406 - Review-conference-collections-with-scoped-QA.md
+++ b/backlog/tasks/task-406 - Review-conference-collections-with-scoped-QA.md
@@ -1,0 +1,52 @@
+---
+id: TASK-406
+title: Review conference collections with scoped QA
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 01:21'
+labels:
+  - bulk-conference-ingest
+  - conference-review
+  - rag
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 RAG search accepts a backend-owned conference collection scope and resolves it to ready media IDs server-side.
+- [x] #2 Collection scoped RAG returns no results outside completed or skipped-existing collection media IDs.
+- [x] #3 Conference collection review UI shows ordered talks with status/readiness, previous/next navigation, selected comparison, and scoped QA affordance.
+- [x] #4 Scoped QA affordance is disabled with clear readiness copy when no collection items are ready.
+- [x] #5 Focused backend and frontend tests cover scoped RAG and review UI behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented backend-owned collection_id resolution for scoped RAG; added conference review UI, Knowledge QA scope helper, focused tests, and verification.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 6 completed. Scoped Knowledge QA is backend-enforced by collection_id to ready media IDs; conference review UI now supports ordered navigation, status/readiness, comparison, and QA handoff. Focused backend/frontend tests, Bandit, and diff checks passed; frontend typecheck still has unrelated baseline failures.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Focused backend scoped RAG pytest passes.
+- [x] #2 Focused ConferenceCollectionReview and KnowledgeQA Vitest tests pass.
+- [x] #3 Bandit runs on touched backend RAG/API files with no new findings.
+- [x] #4 git diff --check passes.
+- [x] #5 Plan Task 6 and Backlog task are updated before commit.
+<!-- DOD:END -->

--- a/backlog/tasks/task-407 - Add-extension-playlist-quick-ingest-handoff.md
+++ b/backlog/tasks/task-407 - Add-extension-playlist-quick-ingest-handoff.md
@@ -1,0 +1,50 @@
+---
+id: TASK-407
+title: Add extension playlist quick ingest handoff
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 01:38'
+labels:
+  - bulk-conference-ingest
+  - extension
+  - quick-ingest
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 7 from the bulk conference ingest plan: typed Quick Ingest open detail, sidepanel active-tab playlist quick action, and shared preflight seed for extension playlist capture.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 requestQuickIngestOpen accepts a typed extension_active_tab playlist_preflight detail.
+- [x] #2 Sidepanel passes active-tab YouTube playlist context into the shared Quick Ingest open request.
+- [x] #3 Quick Ingest consumes the open detail and seeds the playlist preflight path.
+- [x] #4 Focused Sidepanel/Quick Ingest tests cover the handoff contract.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented typed Quick Ingest open detail and active-tab YouTube playlist detection in the sidepanel quick action. The shared Quick Ingest event/session path now persists the detail, hydrates it into wizard state, and seeds the existing playlist preflight path. background.ts was reviewed but left unchanged because active-tab resolution happens in ControlRow at click time and existing background runtime metadata handling already covers queued batch processing. Verification: focused quick-ingest-open, sidepanel form contract, QuickIngestWizardModal integration, and sidepanel route registry Vitest suites pass; git diff --check passes; TypeScript still fails only on unrelated baseline files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 7 complete. Extension sidepanel users on a YouTube playlist/watch-with-list tab now see a playlist-aware Quick Ingest action when playlist preflight is supported, and the shared modal starts the existing playlist preflight flow from that tab context. Focused Vitest suites and route registry tests pass; TypeScript still fails only on unrelated baseline files; git diff check passes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-408 - Add-duplicate-and-failure-recovery-for-conference-ingest.md
+++ b/backlog/tasks/task-408 - Add-duplicate-and-failure-recovery-for-conference-ingest.md
@@ -1,0 +1,52 @@
+---
+id: TASK-408
+title: Add duplicate and failure recovery for conference ingest
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 01:56'
+labels:
+  - bulk-conference-ingest
+  - quick-ingest
+  - recovery
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 8 from the bulk conference ingest plan: duplicate policy controls and conservative failure/retry recovery for conference playlist batches.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Duplicate policy choices cover skip, overwrite, update metadata only, and include existing in collection without surprising overwrite defaults.
+- [x] #2 Failure taxonomy classifies common ingest failures into conservative retry/user-action categories.
+- [x] #3 Retry selected only targets retryable submit_failed, failed, or cancelled collection items and skips completed items.
+- [x] #4 Focused backend/frontend tests cover duplicate policy, failure taxonomy, and selected-subset retry behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Task 8 duplicate/failure recovery slice. Added duplicate policy resolution that only treats duplicate_existing and duplicate_in_batch as confirmed duplicates; unknown/new stay planned. Added Quick Ingest preflight duplicate policy controls and queue metadata propagation. Direct quick-ingest batch now skips non-overwrite duplicate policy items without submitting ingest jobs, forces overwrite only for the overwrite policy, preserves collection item/idempotency metadata in results, and marks submit_failed/failed outcomes with durable collection item IDs. Wizard results now builds retry-all payloads from durable collection item IDs plus retry attempt/idempotency metadata and excludes legacy non-durable failures from durable retry-all.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 8 complete: duplicate policies, conservative failure taxonomy helpers, durable retry request construction, direct duplicate skip/overwrite handling, and focused backend/frontend coverage are in place. Verification: pytest playlist preflight + media ingest worker 26 passed; focused Vitest suites 48 passed; git diff --check passed; Bandit on touched backend playlist preflight module produced zero findings. Full frontend tsc still has pre-existing baseline errors outside this slice in EmbeddingsModelSelectionConfig.tsx, persona-visuals.ts, and lib/api/vnPlay.ts.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-409 - Add-notifications-and-QA-docs-for-conference-ingest.md
+++ b/backlog/tasks/task-409 - Add-notifications-and-QA-docs-for-conference-ingest.md
@@ -1,0 +1,77 @@
+---
+id: TASK-409
+title: Add notifications and QA docs for conference ingest
+status: Done
+labels:
+- bulk-conference-ingest
+- quick-ingest
+- qa
+- docs
+priority: High
+modified_files:
+- Docs/superpowers/plans/2026-05-16-bulk-conference-ingest-workflow-implementation-plan.md
+- Docs/User_Guides/Bulk_Conference_Playlist_Ingest.md
+- Docs/User_Guides/index.md
+- apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/FloatingProgressWidget.test.tsx
+- apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+- apps/packages/ui/src/routes/route-paths.ts
+- apps/packages/ui/src/routes/option-media-collection.tsx
+- apps/packages/ui/src/routes/option-media-review-route-registry.tsx
+- apps/tldw-frontend/pages/media-collections/[collectionId].tsx
+- apps/tldw-frontend/extension/routes/option-media-collection.tsx
+- apps/tldw-frontend/extension/routes/route-registry.tsx
+- apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 9 from the bulk conference ingest plan: mocked full-path QA coverage, completion notification affordance, and user documentation for the bulk conference playlist workflow.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Deterministic 34-item playlist fixture/test coverage exercises bulk preflight and mixed outcomes without real YouTube/downloads.
+- [x] #2 Quick Ingest completion notification summarizes collection name and mixed success/failure/skipped counts without overstating search readiness.
+- [x] #3 User documentation covers playlist preflight, conference metadata, durable/degraded modes, failure export/retry, collection review, and scoped Knowledge QA readiness.
+- [x] #4 Focused verification, diff check, and Bandit status are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added a mocked 34-talk playlist fixture in the media ingest Playwright workflow, including duplicate-existing, duplicate-in-batch, deselection, one mocked processing failure, collection creation, and collection review navigation.
+- Added WebUI/extension shared handoff coverage for the active-tab playlist event path without real YouTube requests or downloads.
+- Added a minimized Quick Ingest completion summary for conference collections, including collection name and succeeded/skipped/failed/cancelled counts without claiming search readiness.
+- Wired the durable collection result CTA to a shared `/media-collections/:collectionId` route for WebUI and extension shells.
+- Added the bulk conference playlist user guide and linked it from the user guide index.
+- `Docs/API-related/Media_Ingest_Jobs_API.md` and `tldw_Server_API/tests/frontend_e2e/test_quick_ingest_media_workflow.py` did not need edits for this QA/docs slice.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 9 completed. The conference workflow now has deterministic browser QA for a 34-item playlist through preflight, shared metadata, mixed mocked ingest outcomes, extension handoff, and collection review. The floating completion widget summarizes mixed collection outcomes without overstating readiness, and user documentation covers preflight, duplicate policies, durable/degraded behavior, recovery, review, and scoped QA readiness.
+
+Verification recorded:
+- Backend focused pytest: `46 passed, 9 warnings`.
+- Frontend focused Vitest: `7 files passed`, `68 tests passed`.
+- Additional FloatingProgressWidget focused Vitest after final helper polish: `1 passed`.
+- Focused Playwright conference tests: `2 passed`.
+- Full `media-ingest.spec.ts` Playwright file: `15 passed`, `12 skipped`, `3 failed` due to existing broader-file drift outside the new conference workflow: missing legacy media search textbox, missing legacy empty-state "open quick ingest" trigger, and unstable legacy review-route link click.
+- `tsc --noEmit`: still blocked only by known baseline errors in `EmbeddingsModelSelectionConfig.tsx`, `persona-visuals.ts`, and `lib/api/vnPlay.ts`.
+- `git diff --check`: passed.
+- Bandit touched backend sweep: zero findings in `/tmp/bandit_bulk_conference_final.json`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-410 - Stabilize-media-ingest-Playwright-workflow-baselines.md
+++ b/backlog/tasks/task-410 - Stabilize-media-ingest-Playwright-workflow-baselines.md
@@ -1,0 +1,52 @@
+---
+id: TASK-410
+title: Stabilize media ingest Playwright workflow baselines
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 03:29'
+labels:
+  - bulk-conference-ingest
+  - e2e
+  - qa
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the remaining broader media-ingest Playwright workflow failures observed after Task 9 so the full workflow file can be used as a reliable closeout gate. Scope is limited to current UI/test alignment for media page readiness, Quick Ingest trigger discovery, and legacy review-route navigation stability.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Media ingest workflow tests stub offline media list/search reads so /media does not throw a Next runtime overlay without a live backend.
+- [x] #2 Quick Ingest visible-trigger test accepts the current first-ingest Ingest CTA while preserving the legacy Open Quick Ingest fallback.
+- [x] #3 Legacy review-route navigation test avoids the hydration-unstable pointer click while still verifying navigation to /media-multi.
+- [x] #4 Focused and full-file Playwright verification is recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Patched apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts only. Added empty media list/search route stubs in beforeEach for offline /media rendering, widened the visible Quick Ingest trigger expectation to include the current first-ingest CTA, and switched the legacy /review -> /media-multi navigation assertion to invoke the verified moved-route anchor from page context.
+
+Verification recorded: focused baseline set passed (3 passed), conference playlist/extension handoff set passed (2 passed), legacy redirect focused test passed (1 passed), and full media-ingest file completed with 18 passed / 12 skipped. The skipped tests are existing backend-dependent cases when the backend health fixture is unavailable. Bandit was not run because this is a frontend Playwright test-only change with no Python/runtime code touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stabilized the media ingest Playwright workflow baselines for the browser/offline path and the bulk conference workflow. Full-file verification now completes with the current backend-dependent skips rather than failing on /media runtime overlays or the legacy route click race.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418 - Address-PR-1814-review-comments.md
+++ b/backlog/tasks/task-418 - Address-PR-1814-review-comments.md
@@ -1,0 +1,63 @@
+---
+id: TASK-418
+title: Address PR 1814 review comments
+status: In Progress
+labels:
+- pr-review
+- bulk-conference-ingest
+- qodo
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/1814
+- https://github.com/rmusser01/tldw_server/pull/1814#pullrequestreview-4304768094
+modified_files:
+- tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py
+- tldw_Server_API/app/api/v1/endpoints/media/collections.py
+- tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
+- apps/packages/ui/src/services/tldw/domains/media.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.media-ingest.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address actionable Qodo review comments on PR #1814 for the bulk conference ingest workflow. Scope: playlist preflight error/timeout handling and deterministic tests, collection read endpoint rate limiting, ingest job helper docstrings and collection DB dependency injection, and client preflight timeout propagation. Treat bot quota/progress comments and pending checks as non-actionable unless they produce concrete failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Bound playlist preflight extraction with a dedicated executor and capacity gate; map invalid extractor responses to explicit 502 responses.
+2. Add collection read endpoint rate limiting and read permission checks.
+3. Move collection submit-failure status updates to an injected collections DB dependency and document new ingest job helpers.
+4. Propagate UI playlist preflight timeoutMs into server-side timeout_seconds with server limit clamping.
+5. Replace timeout sleep coverage with deterministic async timeout simulation and add invalid extractor response coverage.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+In progress: review fixes implemented locally and focused verification passing. Backend focused pytest passed: playlist preflight endpoint, media ingest jobs endpoint, conference collections. Frontend focused Vitest passed from apps/tldw-frontend. Bandit on touched backend endpoints reported zero findings. Pending: commit, push, and re-check PR review threads/checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418 - Address-PR-1814-review-comments.md
+++ b/backlog/tasks/task-418 - Address-PR-1814-review-comments.md
@@ -1,33 +1,63 @@
 ---
 id: TASK-418
 title: Address PR 1814 review comments
-status: In Progress
+status: Done
 labels:
 - pr-review
 - bulk-conference-ingest
 - qodo
+- coderabbit
 priority: Medium
 references:
 - https://github.com/rmusser01/tldw_server/pull/1814
 - https://github.com/rmusser01/tldw_server/pull/1814#pullrequestreview-4304768094
 modified_files:
+- apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/ItemMetadataTable.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+- apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+- apps/packages/ui/src/components/Layouts/QuickIngestButton.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+- apps/packages/ui/src/entries/background.ts
+- apps/packages/ui/src/routes/option-media-review-route-registry.tsx
+- apps/packages/ui/src/services/tldw/__tests__/playlist-preflight.test.ts
+- apps/packages/ui/src/services/tldw/playlist-preflight.ts
+- apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+- apps/packages/ui/src/services/tldw/server-capabilities.ts
+- apps/packages/ui/src/utils/__tests__/quick-ingest-open.test.ts
+- apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+- backlog/tasks/task-400 - Inventory-bulk-conference-collection-contract-for-implementation.md
 - tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
 - tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py
 - tldw_Server_API/app/api/v1/endpoints/media/collections.py
 - tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
 - tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
-- apps/packages/ui/src/services/tldw/domains/media.ts
-- apps/packages/ui/src/services/__tests__/tldw-api-client.media-ingest.test.ts
+- tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+- tldw_Server_API/app/api/v1/schemas/media_request_models.py
+- tldw_Server_API/app/core/DB_Management/Collections_DB.py
+- tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
+- tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+- tldw_Server_API/app/services/media_ingest_jobs_worker.py
+- tldw_Server_API/tests/Collections/test_conference_media_collections.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_collections_dual_write.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Address actionable Qodo review comments on PR #1814 for the bulk conference ingest workflow. Scope: playlist preflight error/timeout handling and deterministic tests, collection read endpoint rate limiting, ingest job helper docstrings and collection DB dependency injection, and client preflight timeout propagation. Treat bot quota/progress comments and pending checks as non-actionable unless they produce concrete failures.
+Address actionable Qodo and CodeRabbit review comments on PR #1814 for the bulk conference ingest workflow. Scope covers playlist preflight error/timeout handling, collection read controls, ingest job collection binding and partial-failure behavior, durable collection status safety, WebUI/extension quick-ingest batch affordances, server capability detection, RAG collection scoping, and focused regression coverage. Treat bot quota/progress comments and pending checks as non-actionable unless they produce concrete failures.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] Actionable Qodo review comments are addressed or verified non-actionable.
+- [x] Actionable CodeRabbit inline and review-body comments are addressed or verified non-actionable.
+- [x] Focused backend and frontend regression tests pass.
+- [x] Bandit and diff whitespace checks pass.
+- [x] Changes are committed and pushed to PR #1814 branch.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,21 +73,37 @@ Address actionable Qodo review comments on PR #1814 for the bulk conference inge
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implemented second-pass CodeRabbit fixes after the first Qodo-focused commit:
+- Deselected conference items are filtered in failure fallbacks and valid counts.
+- Tag edits commit on blur/Enter rather than every keypress.
+- No-op remove actions were removed from results.
+- Quick ingest state selectors and active-tab URL resolution were tightened.
+- Conference planning failures no longer abort batches.
+- Local processing errors are no longer misclassified as submit failures.
+- Fallback capabilities include durable media collections.
+- Duplicate status normalization defaults future/unknown server values to new.
+- Collection list pagination is sanitized before DB access.
+- Partial URL job creation failures preserve successfully queued jobs and mark only failed planned items submit_failed.
+- Playlist preflight exposes stable 422 details and missing-source entries are not selectable.
+- Collection item ordinals are guarded, and successful resolution clears stale failure metadata.
+- Batch persistence no longer reuses one form-level planned item id across multiple results.
+- Worker collection error summaries redact sensitive details.
+- Streaming RAG applies collection scope.
+- Task-400 DoD was aligned with the completed inventory work.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-In progress: review fixes implemented locally and focused verification passing. Backend focused pytest passed: playlist preflight endpoint, media ingest jobs endpoint, conference collections. Frontend focused Vitest passed from apps/tldw-frontend. Bandit on touched backend endpoints reported zero findings. Pending: commit, push, and re-check PR review threads/checks.
+Done: Qodo and CodeRabbit review comments addressed, with focused regression coverage added. Verification passed: backend focused pytest (60 passed), frontend focused Vitest (9 files / 142 tests passed), git diff --check, and Bandit over touched backend files with JSON output at /tmp/bandit_pr1814_coderabbit.json. Pending after commit/push: refresh live PR checks and resolve addressed review threads that remain current.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/media_add_deps.py
@@ -298,6 +298,18 @@ async def get_add_media_form(
         None,
         description="Embedding provider (huggingface, openai, etc)",
     ),
+    media_collection_id: str | None = Form(
+        None,
+        description="Optional durable media collection id associated with this ingest item",
+    ),
+    media_collection_item_id: str | None = Form(
+        None,
+        description="Optional planned durable media collection item id to resolve after ingest",
+    ),
+    media_ingest_job_id: str | None = Form(
+        None,
+        description="Optional media ingest job id that produced this fallback ingest",
+    ),
 ) -> AddMediaForm:
     """
     Dependency function to parse form data for the /media/add endpoint and
@@ -423,6 +435,9 @@ async def get_add_media_form(
             embedding_dispatch_mode=embedding_dispatch_mode,
             embedding_model=embedding_model,
             embedding_provider=embedding_provider,
+            media_collection_id=media_collection_id,
+            media_collection_item_id=media_collection_item_id,
+            media_ingest_job_id=media_ingest_job_id,
         )
         return form_instance
     except ValidationError as exc:

--- a/tldw_Server_API/app/api/v1/endpoints/config_info.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_info.py
@@ -26,6 +26,7 @@ from tldw_Server_API.app.core.custom_openai_providers import (
     iter_custom_openai_provider_names,
 )
 from tldw_Server_API.app.core.testing import is_truthy
+from tldw_Server_API.app.services.worker_startup_policy import worker_path_enabled
 
 router = APIRouter()
 _DOCS_API_KEY_PLACEHOLDER = "YOUR_API_KEY"
@@ -120,6 +121,7 @@ def load_safe_config() -> dict:
 
     # Feature flags / capabilities (safe to expose)
     try:
+        has_media_routes = bool(config_mod.route_enabled("media", default_stable=True))
         has_audio_http = bool(config_mod.route_enabled("audio", default_stable=True))
         has_audio_websocket = bool(config_mod.route_enabled("audio-websocket", default_stable=True))
         caps = {
@@ -140,6 +142,19 @@ def load_safe_config() -> dict:
         caps["hasVoiceChat"] = bool(has_audio_http or has_audio_websocket)
         caps["hasVoiceConversationTransport"] = bool(has_audio_websocket)
         caps["hasAudio"] = bool(caps["hasStt"] or caps["hasTts"] or caps["hasVoiceChat"])
+        caps["hasMediaPlaylistPreflight"] = has_media_routes
+        caps["hasMediaIngestJobs"] = has_media_routes
+        caps["hasMediaIngestJobEvents"] = has_media_routes
+        caps["hasMediaIngestWorker"] = bool(
+            worker_path_enabled(
+                "MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED",
+                "media-ingest-heavy-jobs",
+                default_stable=False,
+                test_mode=False,
+            )
+        )
+        caps["hasDurableMediaCollections"] = False
+        caps["hasKnowledgeQaMediaScope"] = False
         # expose both for backward-compat and forward-looking UI
         safe_config["supported_features"] = caps
         safe_config["capabilities"] = caps

--- a/tldw_Server_API/app/api/v1/endpoints/config_info.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_info.py
@@ -153,7 +153,7 @@ def load_safe_config() -> dict:
                 test_mode=False,
             )
         )
-        caps["hasDurableMediaCollections"] = False
+        caps["hasDurableMediaCollections"] = has_media_routes
         caps["hasKnowledgeQaMediaScope"] = False
         # expose both for backward-compat and forward-looking UI
         safe_config["supported_features"] = caps

--- a/tldw_Server_API/app/api/v1/endpoints/config_info.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_info.py
@@ -154,7 +154,7 @@ def load_safe_config() -> dict:
             )
         )
         caps["hasDurableMediaCollections"] = has_media_routes
-        caps["hasKnowledgeQaMediaScope"] = False
+        caps["hasKnowledgeQaMediaScope"] = has_media_routes
         # expose both for backward-compat and forward-looking UI
         safe_config["supported_features"] = caps
         safe_config["capabilities"] = caps

--- a/tldw_Server_API/app/api/v1/endpoints/media/__init__.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/__init__.py
@@ -103,6 +103,7 @@ _MEDIA_ENDPOINT_MODULES: tuple[str, ...] = (
     "ingest_web_content",
     "ingest_jobs",
     "playlist_preflight",
+    "collections",
     "process_code",
     "process_documents",
     "process_pdfs",

--- a/tldw_Server_API/app/api/v1/endpoints/media/__init__.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/__init__.py
@@ -102,6 +102,7 @@ _MEDIA_ENDPOINT_MODULES: tuple[str, ...] = (
     "debug",
     "ingest_web_content",
     "ingest_jobs",
+    "playlist_preflight",
     "process_code",
     "process_documents",
     "process_pdfs",

--- a/tldw_Server_API/app/api/v1/endpoints/media/collections.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/collections.py
@@ -130,12 +130,14 @@ async def list_media_collections(
     size: int = 20,
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
 ) -> MediaCollectionListResponse:
-    rows, total = db.list_media_collections(kind=kind, page=page, size=size)
+    page_clean = max(1, int(page or 1))
+    size_clean = min(100, max(1, int(size or 20)))
+    rows, total = db.list_media_collections(kind=kind, page=page_clean, size=size_clean)
     return MediaCollectionListResponse(
         items=[_collection_response(row) for row in rows],
         total=total,
-        page=max(1, int(page or 1)),
-        size=min(100, max(1, int(size or 20))),
+        page=page_clean,
+        size=size_clean,
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/collections.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/collections.py
@@ -18,7 +18,7 @@ from tldw_Server_API.app.api.v1.schemas.media_collections import (
     MediaCollectionResponse,
     MediaCollectionUpdateRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
+from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE, MEDIA_READ
 from tldw_Server_API.app.core.DB_Management.Collections_DB import (
     CollectionsDatabase,
     MediaCollectionItemRow,
@@ -119,6 +119,10 @@ async def create_media_collection(
     response_model=MediaCollectionListResponse,
     summary="List durable media collections",
     tags=["Media Collections"],
+    dependencies=[
+        Depends(RequirePermission(MEDIA_READ)),
+        Depends(rbac_rate_limit("media.read")),
+    ],
 )
 async def list_media_collections(
     kind: str | None = None,
@@ -140,6 +144,10 @@ async def list_media_collections(
     response_model=MediaCollectionResponse,
     summary="Get a durable media collection",
     tags=["Media Collections"],
+    dependencies=[
+        Depends(RequirePermission(MEDIA_READ)),
+        Depends(rbac_rate_limit("media.read")),
+    ],
 )
 async def get_media_collection(
     collection_id: int,

--- a/tldw_Server_API/app/api/v1/endpoints/media/collections.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/collections.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import (
+    get_collections_db_for_user,
+)
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    rbac_rate_limit,
+)
+from tldw_Server_API.app.api.v1.schemas.media_collections import (
+    MediaCollectionCreateRequest,
+    MediaCollectionItemCreateRequest,
+    MediaCollectionItemResponse,
+    MediaCollectionItemUpdateRequest,
+    MediaCollectionListResponse,
+    MediaCollectionResponse,
+    MediaCollectionUpdateRequest,
+)
+from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
+from tldw_Server_API.app.core.DB_Management.Collections_DB import (
+    CollectionsDatabase,
+    MediaCollectionItemRow,
+    MediaCollectionRow,
+)
+
+
+router = APIRouter()
+
+
+def _item_response(row: MediaCollectionItemRow) -> MediaCollectionItemResponse:
+    return MediaCollectionItemResponse(
+        id=row.id,
+        collection_id=row.collection_id,
+        ordinal=row.ordinal,
+        source_url=row.source_url,
+        normalized_source_id=row.normalized_source_id,
+        source_kind=row.source_kind,
+        title=row.title,
+        speaker=row.speaker,
+        published_at=row.published_at,
+        track=row.track,
+        duplicate_status=row.duplicate_status,
+        status=row.status,
+        media_id=row.media_id,
+        content_item_id=row.content_item_id,
+        latest_job_id=row.latest_job_id,
+        latest_run_id=row.latest_run_id,
+        idempotency_key=row.idempotency_key,
+        retry_count=row.retry_count,
+        error_summary=row.error_summary,
+        warnings=row.warnings,
+        metadata=row.metadata,
+        tags=row.tags,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _collection_response(row: MediaCollectionRow) -> MediaCollectionResponse:
+    return MediaCollectionResponse(
+        id=row.id,
+        name=row.name,
+        kind=row.kind,
+        description=row.description,
+        source_url=row.source_url,
+        metadata=row.metadata,
+        default_tags=row.default_tags,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        items=[_item_response(item) for item in row.items],
+    )
+
+
+def _raise_collection_error(exc: Exception) -> None:
+    if isinstance(exc, KeyError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    if isinstance(exc, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    raise exc
+
+
+@router.post(
+    "/collections",
+    response_model=MediaCollectionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a durable media collection",
+    tags=["Media Collections"],
+    dependencies=[
+        Depends(RequirePermission(MEDIA_CREATE)),
+        Depends(rbac_rate_limit("media.create")),
+    ],
+)
+async def create_media_collection(
+    payload: MediaCollectionCreateRequest,
+    db: CollectionsDatabase = Depends(get_collections_db_for_user),
+) -> MediaCollectionResponse:
+    try:
+        row = db.create_media_collection(
+            name=payload.name,
+            kind=payload.kind,
+            description=payload.description,
+            source_url=payload.source_url,
+            metadata=payload.metadata,
+            default_tags=payload.default_tags,
+        )
+        return _collection_response(row)
+    except Exception as exc:
+        _raise_collection_error(exc)
+        raise
+
+
+@router.get(
+    "/collections",
+    response_model=MediaCollectionListResponse,
+    summary="List durable media collections",
+    tags=["Media Collections"],
+)
+async def list_media_collections(
+    kind: str | None = None,
+    page: int = 1,
+    size: int = 20,
+    db: CollectionsDatabase = Depends(get_collections_db_for_user),
+) -> MediaCollectionListResponse:
+    rows, total = db.list_media_collections(kind=kind, page=page, size=size)
+    return MediaCollectionListResponse(
+        items=[_collection_response(row) for row in rows],
+        total=total,
+        page=max(1, int(page or 1)),
+        size=min(100, max(1, int(size or 20))),
+    )
+
+
+@router.get(
+    "/collections/{collection_id}",
+    response_model=MediaCollectionResponse,
+    summary="Get a durable media collection",
+    tags=["Media Collections"],
+)
+async def get_media_collection(
+    collection_id: int,
+    db: CollectionsDatabase = Depends(get_collections_db_for_user),
+) -> MediaCollectionResponse:
+    try:
+        return _collection_response(db.get_media_collection(collection_id))
+    except Exception as exc:
+        _raise_collection_error(exc)
+        raise
+
+
+@router.patch(
+    "/collections/{collection_id}",
+    response_model=MediaCollectionResponse,
+    summary="Update a durable media collection",
+    tags=["Media Collections"],
+    dependencies=[
+        Depends(RequirePermission(MEDIA_CREATE)),
+        Depends(rbac_rate_limit("media.create")),
+    ],
+)
+async def update_media_collection(
+    collection_id: int,
+    payload: MediaCollectionUpdateRequest,
+    db: CollectionsDatabase = Depends(get_collections_db_for_user),
+) -> MediaCollectionResponse:
+    try:
+        row = db.update_media_collection(
+            collection_id,
+            **payload.model_dump(exclude_unset=True),
+        )
+        return _collection_response(row)
+    except Exception as exc:
+        _raise_collection_error(exc)
+        raise
+
+
+@router.post(
+    "/collections/{collection_id}/items",
+    response_model=MediaCollectionItemResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add an item to a durable media collection",
+    tags=["Media Collections"],
+    dependencies=[
+        Depends(RequirePermission(MEDIA_CREATE)),
+        Depends(rbac_rate_limit("media.create")),
+    ],
+)
+async def add_media_collection_item(
+    collection_id: int,
+    payload: MediaCollectionItemCreateRequest,
+    db: CollectionsDatabase = Depends(get_collections_db_for_user),
+) -> MediaCollectionItemResponse:
+    try:
+        row = db.add_media_collection_item(
+            collection_id=collection_id,
+            source_url=payload.source_url,
+            normalized_source_id=payload.normalized_source_id,
+            source_kind=payload.source_kind,
+            status=payload.status,
+            ordinal=payload.ordinal,
+            title=payload.title,
+            speaker=payload.speaker,
+            published_at=payload.published_at,
+            track=payload.track,
+            duplicate_status=payload.duplicate_status,
+            media_id=payload.media_id,
+            content_item_id=payload.content_item_id,
+            latest_job_id=payload.latest_job_id,
+            latest_run_id=payload.latest_run_id,
+            idempotency_key=payload.idempotency_key,
+            retry_count=payload.retry_count,
+            error_summary=payload.error_summary,
+            warnings=payload.warnings,
+            metadata=payload.metadata,
+            tags=payload.tags,
+        )
+        return _item_response(row)
+    except Exception as exc:
+        _raise_collection_error(exc)
+        raise
+
+
+@router.patch(
+    "/collections/{collection_id}/items/{item_id}",
+    response_model=MediaCollectionItemResponse,
+    summary="Update a durable media collection item",
+    tags=["Media Collections"],
+    dependencies=[
+        Depends(RequirePermission(MEDIA_CREATE)),
+        Depends(rbac_rate_limit("media.create")),
+    ],
+)
+async def update_media_collection_item(
+    collection_id: int,
+    item_id: int,
+    payload: MediaCollectionItemUpdateRequest,
+    db: CollectionsDatabase = Depends(get_collections_db_for_user),
+) -> MediaCollectionItemResponse:
+    try:
+        current = db.get_media_collection_item(item_id)
+        if current.collection_id != collection_id:
+            raise KeyError("media_collection_item_not_found")
+        row = db.update_media_collection_item(
+            item_id,
+            **payload.model_dump(exclude_unset=True),
+        )
+        return _item_response(row)
+    except Exception as exc:
+        _raise_collection_error(exc)
+        raise

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -17,7 +17,15 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, User
+from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import try_get_collections_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    check_rate_limit,
+    get_auth_principal,
+    get_request_user,
+    rbac_rate_limit,
+    RequirePermission,
+    User,
+)
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -164,6 +172,7 @@ def _validate_submit_inputs(
 
 
 def _coerce_form_string_list(value: Any) -> list[str]:
+    """Return trimmed form values from repeated fields, JSON strings, or scalar input."""
     if value is None:
         return []
     raw_values = value if isinstance(value, list) else [value]
@@ -193,11 +202,13 @@ def _coerce_form_string_list(value: Any) -> list[str]:
 
 
 def _coerce_form_string(value: Any) -> str | None:
+    """Return the first normalized form string value, if one is present."""
     values = _coerce_form_string_list(value)
     return values[0] if values else None
 
 
 def _coerce_positive_int(value: Any) -> int | None:
+    """Parse a positive integer identifier from form data, ignoring invalid values."""
     try:
         parsed = int(value)
     except (TypeError, ValueError):
@@ -211,6 +222,7 @@ def _validate_per_url_binding_list(
     values: list[str],
     url_count: int,
 ) -> None:
+    """Ensure optional per-URL binding arrays line up with the submitted URL count."""
     if not values:
         return
     if len(values) == url_count:
@@ -231,6 +243,7 @@ def _resolve_submit_bindings(
     idempotency_key: Any,
     idempotency_keys: Any,
 ) -> tuple[str | None, list[str], list[str]]:
+    """Normalize collection, planned-item, and idempotency bindings for URL jobs."""
     collection_id_value = _coerce_form_string(media_collection_id) or _coerce_form_string(collection_id)
     planned_values = _coerce_form_string_list(planned_item_ids)
     single_planned = _coerce_form_string(media_collection_item_id)
@@ -262,6 +275,7 @@ def _apply_collection_binding_to_payload(
     planned_item_id: str | None,
     idempotency_key: str | None,
 ) -> None:
+    """Attach durable collection binding fields to a job payload when supplied."""
     if collection_id:
         payload["collection_id"] = collection_id
     if planned_item_id:
@@ -271,6 +285,7 @@ def _apply_collection_binding_to_payload(
 
 
 def _submit_failure_message(exc: Exception) -> str:
+    """Return a bounded, user-safe message for collection submit-failure tracking."""
     if isinstance(exc, HTTPException):
         detail = exc.detail
         if isinstance(detail, str):
@@ -281,17 +296,16 @@ def _submit_failure_message(exc: Exception) -> str:
 
 def _mark_collection_item_submit_failed(
     *,
-    user_id: str,
+    collections_db: CollectionsDatabase | None,
     planned_item_id: Any,
     error_summary: str,
 ) -> None:
+    """Mark a planned collection item as submit_failed using the injected DB handle."""
     item_id = _coerce_positive_int(planned_item_id)
-    if item_id is None:
+    if item_id is None or collections_db is None:
         return
 
-    collections_db = None
     try:
-        collections_db = CollectionsDatabase.for_user(user_id=user_id)
         collections_db.update_media_collection_item_status(
             item_id,
             status="submit_failed",
@@ -300,14 +314,10 @@ def _mark_collection_item_submit_failed(
         )
     except Exception as exc:
         logger.warning(
-            "Media collection item submit-failure sync failed for user {}: {}",
-            user_id,
+            "Media collection item submit-failure sync failed for item {}: {}",
+            item_id,
             exc,
         )
-    finally:
-        if collections_db is not None:
-            with contextlib.suppress(Exception):
-                collections_db.close()
 
 
 def _normalize_payload(payload: Any) -> dict[str, Any]:
@@ -412,25 +422,17 @@ def _create_media_ingest_job(
         message = str(exc).strip() or "Invalid media ingest job request"
         normalized = message.lower()
         status_code = (
-            status.HTTP_429_TOO_MANY_REQUESTS
-            if "concurrent job limit" in normalized
-            else status.HTTP_400_BAD_REQUEST
+            status.HTTP_429_TOO_MANY_REQUESTS if "concurrent job limit" in normalized else status.HTTP_400_BAD_REQUEST
         )
         raise HTTPException(status_code=status_code, detail=message) from exc
 
 
 def _principal_has_admin_claims(principal: AuthPrincipal) -> bool:
-    roles = {
-        str(role).strip().lower()
-        for role in (principal.roles or [])
-        if str(role).strip()
-    }
+    roles = {str(role).strip().lower() for role in (principal.roles or []) if str(role).strip()}
     if "admin" in roles:
         return True
     permissions = {
-        str(permission).strip().lower()
-        for permission in (principal.permissions or [])
-        if str(permission).strip()
+        str(permission).strip().lower() for permission in (principal.permissions or []) if str(permission).strip()
     }
     return bool(permissions & _ADMIN_CLAIM_PERMISSIONS)
 
@@ -608,6 +610,7 @@ async def submit_media_ingest_jobs(
     ),
     current_user: User = Depends(get_request_user),
     jm: JobManager = Depends(get_job_manager),
+    collections_db: CollectionsDatabase | None = Depends(try_get_collections_db_for_user),
 ) -> SubmitMediaIngestJobsResponse:
     rid = ensure_request_id(request) if request is not None else None
     tp = ensure_traceparent(request) if request is not None else ""
@@ -673,7 +676,7 @@ async def submit_media_ingest_jobs(
                 raise ValueError(f"Job creation returned no id: {row!r}")
         except Exception as exc:
             _mark_collection_item_submit_failed(
-                user_id=str(current_user.id),
+                collections_db=collections_db,
                 planned_item_id=planned_item_id,
                 error_summary=_submit_failure_message(exc),
             )
@@ -999,10 +1002,13 @@ async def stream_media_ingest_job_events(
 
             if tracked_job_ids:
                 refreshed = [jm.get_job(job_id) for job_id in tracked_job_ids]
-                if all(
-                    (job or {}).get("status") in {"completed", "failed", "cancelled", "quarantined"}
-                    for job in refreshed
-                ) and not rows:
+                if (
+                    all(
+                        (job or {}).get("status") in {"completed", "failed", "cancelled", "quarantined"}
+                        for job in refreshed
+                    )
+                    and not rows
+                ):
                     break
 
             await asyncio.sleep(poll_interval)

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -12,7 +12,7 @@ from typing import Any
 from uuid import uuid4
 
 from cachetools import LRUCache
-from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -28,6 +28,7 @@ from tldw_Server_API.app.api.v1.schemas.media_request_models import AddMediaForm
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
     save_uploaded_files,
@@ -75,6 +76,9 @@ class MediaIngestJobItem(BaseModel):
     source: str
     source_kind: str
     status: str
+    collection_id: str | None = None
+    planned_item_id: str | None = None
+    idempotency_key: str | None = None
 
 
 class SubmitMediaIngestJobsResponse(BaseModel):
@@ -102,6 +106,9 @@ class MediaIngestJobStatus(BaseModel):
     source: str | None = None
     source_kind: str | None = None
     batch_id: str | None = None
+    collection_id: str | None = None
+    planned_item_id: str | None = None
+    idempotency_key: str | None = None
 
 
 class CancelMediaIngestJobResponse(BaseModel):
@@ -154,6 +161,153 @@ def _validate_submit_inputs(
             "'urls' list or one 'file' in the 'files' list must be provided."
         ),
     )
+
+
+def _coerce_form_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    raw_values = value if isinstance(value, list) else [value]
+    out: list[str] = []
+    for raw in raw_values:
+        if raw is None:
+            continue
+        if isinstance(raw, (list, tuple)):
+            out.extend(_coerce_form_string_list(list(raw)))
+            continue
+        text = str(raw).strip()
+        if not text:
+            continue
+        if text.startswith("[") or text.startswith('"'):
+            try:
+                parsed = json.loads(text)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                parsed = None
+            if isinstance(parsed, list):
+                out.extend(str(item).strip() for item in parsed if str(item).strip())
+                continue
+            if isinstance(parsed, str) and parsed.strip():
+                out.append(parsed.strip())
+                continue
+        out.append(text)
+    return out
+
+
+def _coerce_form_string(value: Any) -> str | None:
+    values = _coerce_form_string_list(value)
+    return values[0] if values else None
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _validate_per_url_binding_list(
+    *,
+    name: str,
+    values: list[str],
+    url_count: int,
+) -> None:
+    if not values:
+        return
+    if len(values) == url_count:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=f"{name} must match the number of URL items.",
+    )
+
+
+def _resolve_submit_bindings(
+    *,
+    url_count: int,
+    media_collection_id: Any,
+    collection_id: Any,
+    media_collection_item_id: Any,
+    planned_item_ids: Any,
+    idempotency_key: Any,
+    idempotency_keys: Any,
+) -> tuple[str | None, list[str], list[str]]:
+    collection_id_value = _coerce_form_string(media_collection_id) or _coerce_form_string(collection_id)
+    planned_values = _coerce_form_string_list(planned_item_ids)
+    single_planned = _coerce_form_string(media_collection_item_id)
+    if single_planned and not planned_values:
+        planned_values = [single_planned]
+
+    key_values = _coerce_form_string_list(idempotency_keys)
+    single_key = _coerce_form_string(idempotency_key)
+    if single_key and not key_values:
+        key_values = [single_key]
+
+    _validate_per_url_binding_list(
+        name="planned_item_ids",
+        values=planned_values,
+        url_count=url_count,
+    )
+    _validate_per_url_binding_list(
+        name="idempotency_keys",
+        values=key_values,
+        url_count=url_count,
+    )
+    return collection_id_value, planned_values, key_values
+
+
+def _apply_collection_binding_to_payload(
+    payload: dict[str, Any],
+    *,
+    collection_id: str | None,
+    planned_item_id: str | None,
+    idempotency_key: str | None,
+) -> None:
+    if collection_id:
+        payload["collection_id"] = collection_id
+    if planned_item_id:
+        payload["planned_item_id"] = planned_item_id
+    if idempotency_key:
+        payload["idempotency_key"] = idempotency_key
+
+
+def _submit_failure_message(exc: Exception) -> str:
+    if isinstance(exc, HTTPException):
+        detail = exc.detail
+        if isinstance(detail, str):
+            return detail.strip() or "Media ingest job submission failed"
+        return str(detail).strip() or "Media ingest job submission failed"
+    return str(exc).strip() or "Media ingest job submission failed"
+
+
+def _mark_collection_item_submit_failed(
+    *,
+    user_id: str,
+    planned_item_id: Any,
+    error_summary: str,
+) -> None:
+    item_id = _coerce_positive_int(planned_item_id)
+    if item_id is None:
+        return
+
+    collections_db = None
+    try:
+        collections_db = CollectionsDatabase.for_user(user_id=user_id)
+        collections_db.update_media_collection_item_status(
+            item_id,
+            status="submit_failed",
+            latest_job_id=None,
+            error_summary=error_summary[:1000],
+        )
+    except Exception as exc:
+        logger.warning(
+            "Media collection item submit-failure sync failed for user {}: {}",
+            user_id,
+            exc,
+        )
+    finally:
+        if collections_db is not None:
+            with contextlib.suppress(Exception):
+                collections_db.close()
 
 
 def _normalize_payload(payload: Any) -> dict[str, Any]:
@@ -250,6 +404,7 @@ def _create_media_ingest_job(
             owner_user_id=str(current_user.id),
             priority=5,
             max_retries=3,
+            idempotency_key=payload.get("idempotency_key"),
             request_id=request_id,
             trace_id=trace_id,
         )
@@ -308,6 +463,9 @@ def _job_to_status(job: dict[str, Any]) -> MediaIngestJobStatus:
         source=payload.get("source"),
         source_kind=payload.get("source_kind"),
         batch_id=payload.get("batch_id"),
+        collection_id=payload.get("collection_id"),
+        planned_item_id=payload.get("planned_item_id"),
+        idempotency_key=payload.get("idempotency_key"),
     )
 
 
@@ -424,6 +582,30 @@ async def submit_media_ingest_jobs(
     request: Request,
     form_data: AddMediaForm = Depends(get_add_media_form),
     files: list[UploadFile] | None = File(None, description="Optional media uploads"),
+    media_collection_id: str | None = Form(
+        None,
+        description="Optional durable media collection id for this job batch",
+    ),
+    collection_id: str | None = Form(
+        None,
+        description="Alias for media_collection_id",
+    ),
+    media_collection_item_id: str | None = Form(
+        None,
+        description="Optional planned collection item id for single-item submits",
+    ),
+    planned_item_ids: list[str] | None = Form(
+        None,
+        description="Optional JSON/list of planned collection item ids, one per URL",
+    ),
+    idempotency_key: str | None = Form(
+        None,
+        description="Optional idempotency key for single-item submits",
+    ),
+    idempotency_keys: list[str] | None = Form(
+        None,
+        description="Optional JSON/list of idempotency keys, one per URL",
+    ),
     current_user: User = Depends(get_request_user),
     jm: JobManager = Depends(get_job_manager),
 ) -> SubmitMediaIngestJobsResponse:
@@ -446,9 +628,22 @@ async def submit_media_ingest_jobs(
     errors: list[str] = []
 
     url_list = form_data.urls or []
+    collection_id_value, planned_item_values, idempotency_key_values = _resolve_submit_bindings(
+        url_count=len([url for url in url_list if url and str(url).strip()]),
+        media_collection_id=media_collection_id,
+        collection_id=collection_id,
+        media_collection_item_id=media_collection_item_id,
+        planned_item_ids=planned_item_ids,
+        idempotency_key=idempotency_key,
+        idempotency_keys=idempotency_keys,
+    )
+
+    url_index = 0
     for url in url_list:
         if not url or not str(url).strip():
             continue
+        planned_item_id = planned_item_values[url_index] if planned_item_values else None
+        item_idempotency_key = idempotency_key_values[url_index] if idempotency_key_values else None
         payload = {
             "batch_id": batch_id,
             "media_type": str(form_data.media_type),
@@ -457,18 +652,32 @@ async def submit_media_ingest_jobs(
             "input_ref": str(url).strip(),
             "options": options,
         }
-        row = _create_media_ingest_job(
-            jm=jm,
-            selected_queue=selected_queue,
-            payload=payload,
-            current_user=current_user,
-            batch_id=batch_id,
-            request_id=rid,
-            trace_id=tp or None,
+        _apply_collection_binding_to_payload(
+            payload,
+            collection_id=collection_id_value,
+            planned_item_id=planned_item_id,
+            idempotency_key=item_idempotency_key,
         )
-        row_id = row.get("id")
-        if row_id is None:
-            raise ValueError(f"Job creation returned no id: {row!r}")
+        try:
+            row = _create_media_ingest_job(
+                jm=jm,
+                selected_queue=selected_queue,
+                payload=payload,
+                current_user=current_user,
+                batch_id=batch_id,
+                request_id=rid,
+                trace_id=tp or None,
+            )
+            row_id = row.get("id")
+            if row_id is None:
+                raise ValueError(f"Job creation returned no id: {row!r}")
+        except Exception as exc:
+            _mark_collection_item_submit_failed(
+                user_id=str(current_user.id),
+                planned_item_id=planned_item_id,
+                error_summary=_submit_failure_message(exc),
+            )
+            raise
         jobs.append(
             MediaIngestJobItem(
                 id=int(row_id),
@@ -476,8 +685,12 @@ async def submit_media_ingest_jobs(
                 source=payload["source"],
                 source_kind="url",
                 status=row.get("status"),
+                collection_id=payload.get("collection_id"),
+                planned_item_id=payload.get("planned_item_id"),
+                idempotency_key=payload.get("idempotency_key"),
             )
         )
+        url_index += 1
 
     if files:
         for upload in files:

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -629,10 +629,13 @@ async def submit_media_ingest_jobs(
     batch_id = str(uuid4())
     jobs: list[MediaIngestJobItem] = []
     errors: list[str] = []
+    first_url_submit_exception: Exception | None = None
+    url_failure_count = 0
 
     url_list = form_data.urls or []
+    valid_url_count = len([url for url in url_list if url and str(url).strip()])
     collection_id_value, planned_item_values, idempotency_key_values = _resolve_submit_bindings(
-        url_count=len([url for url in url_list if url and str(url).strip()]),
+        url_count=valid_url_count,
         media_collection_id=media_collection_id,
         collection_id=collection_id,
         media_collection_item_id=media_collection_item_id,
@@ -675,12 +678,18 @@ async def submit_media_ingest_jobs(
             if row_id is None:
                 raise ValueError(f"Job creation returned no id: {row!r}")
         except Exception as exc:
+            url_failure_count += 1
+            if first_url_submit_exception is None:
+                first_url_submit_exception = exc
+            error_message = _submit_failure_message(exc)
             _mark_collection_item_submit_failed(
                 collections_db=collections_db,
                 planned_item_id=planned_item_id,
-                error_summary=_submit_failure_message(exc),
+                error_summary=error_message,
             )
-            raise
+            errors.append(f"{payload['source']}: {error_message}")
+            url_index += 1
+            continue
         jobs.append(
             MediaIngestJobItem(
                 id=int(row_id),
@@ -766,6 +775,8 @@ async def submit_media_ingest_jobs(
                     _cleanup_dir(temp_dir_path)
 
     if not jobs:
+        if first_url_submit_exception is not None and valid_url_count == 1 and url_failure_count == 1 and not files:
+            raise first_url_submit_exception
         if errors:
             return JSONResponse(
                 status_code=status.HTTP_207_MULTI_STATUS,

--- a/tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+
+from fastapi import APIRouter, Depends, HTTPException
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    User,
+    get_request_user,
+    rbac_rate_limit,
+)
+from tldw_Server_API.app.api.v1.schemas.media_playlist_preflight import (
+    PlaylistPreflightRequest,
+    PlaylistPreflightResponse,
+)
+from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
+from tldw_Server_API.app.core.Ingestion_Media_Processing.Video.playlist_preflight import (
+    PlaylistPreflightData,
+    preflight_playlist_url,
+)
+
+
+router = APIRouter()
+
+
+def _coerce_preflight_response(result) -> PlaylistPreflightResponse:
+    if isinstance(result, PlaylistPreflightResponse):
+        return result
+    if isinstance(result, PlaylistPreflightData):
+        return PlaylistPreflightResponse.model_validate(result.to_dict())
+    if isinstance(result, dict):
+        return PlaylistPreflightResponse.model_validate(result)
+    raise ValueError("playlist_preflight_invalid_result")
+
+
+@router.post(
+    "/playlists/preflight",
+    response_model=PlaylistPreflightResponse,
+    summary="Preflight a playlist URL without downloading media",
+    tags=["Media Playlist Preflight"],
+    dependencies=[
+        Depends(RequirePermission(MEDIA_CREATE)),
+        Depends(rbac_rate_limit("media.create")),
+    ],
+)
+async def preflight_playlist(
+    payload: PlaylistPreflightRequest,
+    _current_user: User = Depends(get_request_user),
+) -> PlaylistPreflightResponse:
+    loop = asyncio.get_running_loop()
+    try:
+        extraction = loop.run_in_executor(
+            None,
+            partial(
+                preflight_playlist_url,
+                payload.url,
+                max_items=payload.max_items,
+            ),
+        )
+        result = await asyncio.wait_for(extraction, timeout=payload.timeout_seconds)
+        return _coerce_preflight_response(result)
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="playlist_preflight_timeout") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("Playlist preflight failed for {}: {}", payload.url, exc)
+        raise HTTPException(status_code=502, detail="playlist_preflight_failed") from exc

--- a/tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
@@ -109,7 +109,8 @@ async def preflight_playlist(
     except PlaylistPreflightResultError as exc:
         raise HTTPException(status_code=502, detail="playlist_preflight_invalid_result") from exc
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        logger.warning("Playlist preflight validation failed for {}: {}", payload.url, exc)
+        raise HTTPException(status_code=422, detail="playlist_preflight_invalid_request") from exc
     except HTTPException:
         raise
     except Exception as exc:

--- a/tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/playlist_preflight.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
+from threading import BoundedSemaphore
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
+from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     RequirePermission,
@@ -25,15 +30,61 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.Video.playlist_prefligh
 
 router = APIRouter()
 
+_PLAYLIST_PREFLIGHT_MAX_WORKERS = 2
+_PLAYLIST_PREFLIGHT_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_PLAYLIST_PREFLIGHT_MAX_WORKERS,
+    thread_name_prefix="playlist-preflight",
+)
+_PLAYLIST_PREFLIGHT_CAPACITY = BoundedSemaphore(value=_PLAYLIST_PREFLIGHT_MAX_WORKERS)
+PlaylistPreflightRawResult = PlaylistPreflightResponse | PlaylistPreflightData | Mapping[str, Any]
 
-def _coerce_preflight_response(result) -> PlaylistPreflightResponse:
+
+class PlaylistPreflightResultError(ValueError):
+    """Raised when the preflight extractor returns an invalid response contract."""
+
+
+def _coerce_preflight_response(result: PlaylistPreflightRawResult) -> PlaylistPreflightResponse:
+    """Normalize supported extractor outputs into the public response model."""
     if isinstance(result, PlaylistPreflightResponse):
         return result
-    if isinstance(result, PlaylistPreflightData):
-        return PlaylistPreflightResponse.model_validate(result.to_dict())
-    if isinstance(result, dict):
-        return PlaylistPreflightResponse.model_validate(result)
-    raise ValueError("playlist_preflight_invalid_result")
+    try:
+        if isinstance(result, PlaylistPreflightData):
+            return PlaylistPreflightResponse.model_validate(result.to_dict())
+        if isinstance(result, Mapping):
+            return PlaylistPreflightResponse.model_validate(dict(result))
+    except ValidationError as exc:
+        raise PlaylistPreflightResultError("playlist_preflight_invalid_result") from exc
+    raise PlaylistPreflightResultError("playlist_preflight_invalid_result")
+
+
+def _preflight_playlist_url_with_capacity(url: str, *, max_items: int) -> PlaylistPreflightRawResult:
+    """Run the blocking extractor and release API capacity after actual thread completion."""
+    try:
+        return preflight_playlist_url(url, max_items=max_items)
+    finally:
+        _PLAYLIST_PREFLIGHT_CAPACITY.release()
+
+
+async def _run_preflight_with_timeout(payload: PlaylistPreflightRequest) -> PlaylistPreflightRawResult:
+    """Run playlist extraction in a bounded executor with request-level timeout handling."""
+    if not _PLAYLIST_PREFLIGHT_CAPACITY.acquire(blocking=False):
+        raise HTTPException(status_code=429, detail="playlist_preflight_busy")
+
+    loop = asyncio.get_running_loop()
+    try:
+        extraction = loop.run_in_executor(
+            _PLAYLIST_PREFLIGHT_EXECUTOR,
+            partial(
+                _preflight_playlist_url_with_capacity,
+                payload.url,
+                max_items=payload.max_items,
+            ),
+        )
+    except Exception:
+        _PLAYLIST_PREFLIGHT_CAPACITY.release()
+        raise
+
+    return await asyncio.wait_for(extraction, timeout=payload.timeout_seconds)
 
 
 @router.post(
@@ -50,20 +101,13 @@ async def preflight_playlist(
     payload: PlaylistPreflightRequest,
     _current_user: User = Depends(get_request_user),
 ) -> PlaylistPreflightResponse:
-    loop = asyncio.get_running_loop()
     try:
-        extraction = loop.run_in_executor(
-            None,
-            partial(
-                preflight_playlist_url,
-                payload.url,
-                max_items=payload.max_items,
-            ),
-        )
-        result = await asyncio.wait_for(extraction, timeout=payload.timeout_seconds)
+        result = await _run_preflight_with_timeout(payload)
         return _coerce_preflight_response(result)
     except asyncio.TimeoutError as exc:
         raise HTTPException(status_code=504, detail="playlist_preflight_timeout") from exc
+    except PlaylistPreflightResultError as exc:
+        raise HTTPException(status_code=502, detail="playlist_preflight_invalid_result") from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except HTTPException:

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -22,6 +22,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_
 
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
 
 # Dependencies
@@ -39,6 +40,7 @@ from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_READ
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.DB_Management.Prompts_DB import PromptsDatabase
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.RAG.rag_service.agentic_chunker import (
@@ -88,6 +90,69 @@ _BATCH_ROUND2_DEFAULT_FIELDS = {
     "enable_image_search",
     "enable_video_search",
 }
+
+_READY_MEDIA_COLLECTION_STATUSES = frozenset({"completed", "skipped_existing"})
+_EMPTY_MEDIA_SCOPE_SENTINEL = -1
+
+
+def _copy_rag_request_with_updates(
+    request: UnifiedRAGRequest,
+    updates: dict[str, Any],
+) -> UnifiedRAGRequest:
+    """Return a copy of a RAG request using the active Pydantic compatibility API."""
+    model_copy = getattr(request, "model_copy", None)
+    if callable(model_copy):
+        return model_copy(update=updates)
+    return request.copy(update=updates)
+
+
+def _ready_media_ids_from_collection(collection: Any) -> list[int]:
+    """Extract ordered, unique ready media IDs from a durable media collection row."""
+    ready_ids: list[int] = []
+    seen: set[int] = set()
+    for item in getattr(collection, "items", []) or []:
+        if getattr(item, "status", None) not in _READY_MEDIA_COLLECTION_STATUSES:
+            continue
+        media_id = getattr(item, "media_id", None)
+        if not isinstance(media_id, int) or media_id <= 0 or media_id in seen:
+            continue
+        ready_ids.append(media_id)
+        seen.add(media_id)
+    return ready_ids
+
+
+def _apply_media_collection_scope(
+    request: UnifiedRAGRequest,
+    collections_db: CollectionsDatabase,
+) -> UnifiedRAGRequest:
+    """Resolve request.collection_id to backend-owned ready media IDs for RAG retrieval."""
+    collection_id = getattr(request, "collection_id", None)
+    if collection_id is None:
+        return request
+
+    try:
+        collection = collections_db.get_media_collection(int(collection_id))
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="media_collection_not_found",
+        ) from exc
+    ready_media_ids = _ready_media_ids_from_collection(collection)
+    explicit_media_ids = request.include_media_ids
+    if explicit_media_ids is not None:
+        ready_set = set(ready_media_ids)
+        scoped_media_ids = [
+            int(media_id)
+            for media_id in explicit_media_ids
+            if isinstance(media_id, int) and media_id in ready_set
+        ]
+    else:
+        scoped_media_ids = ready_media_ids
+
+    if not scoped_media_ids:
+        scoped_media_ids = [_EMPTY_MEDIA_SCOPE_SENTINEL]
+
+    return _copy_rag_request_with_updates(request, {"include_media_ids": scoped_media_ids})
 
 
 def _search_agent_setting(env_key: str, config_key: str) -> Optional[str]:
@@ -1159,6 +1224,7 @@ async def unified_search_endpoint(
     media_db: Any = Depends(get_media_db_for_user),
     chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
+    collections_db: CollectionsDatabase = Depends(get_collections_db_for_user),
 ):
     """
     Unified RAG search with all features as parameters.
@@ -1168,6 +1234,7 @@ async def unified_search_endpoint(
     is accessible by setting the appropriate parameter.
     """
     try:
+        request = _apply_media_collection_scope(request, collections_db)
         logger.info(f"Unified RAG search: query='{request.query}', user={current_user.username if current_user else 'anonymous'}")
         # Topic monitoring (non-blocking) for query text
         try:
@@ -1314,6 +1381,8 @@ async def unified_search_endpoint(
         if result.errors and request.debug_mode:
             logger.warning(f"Errors during processing: {result.errors}")
 
+    except HTTPException:
+        raise
     except Exception as e:  # noqa: BLE001 - surface as HTTP 500 with context
         logger.exception("Unified search error: {}", e)
         detail = "Search failed due to an internal error."

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -1962,9 +1962,11 @@ async def unified_search_stream_endpoint(
     media_db: Any = Depends(get_media_db_for_user),
     chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     prompts_db: PromptsDatabase = Depends(get_prompts_db_for_user),
+    collections_db: CollectionsDatabase = Depends(get_collections_db_for_user),
 ):
     if not request.enable_generation:
         raise HTTPException(status_code=400, detail="enable_generation must be true for streaming.")
+    request = _apply_media_collection_scope(request, collections_db)
 
     # Streaming search counts as a single RAG query.
     await _log_rag_queries_for_org(request_raw, current_user, units=1)

--- a/tldw_Server_API/app/api/v1/schemas/media_collections.py
+++ b/tldw_Server_API/app/api/v1/schemas/media_collections.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+MediaCollectionItemStatus = Literal[
+    "planned",
+    "processing",
+    "completed",
+    "skipped_existing",
+    "submit_failed",
+    "failed",
+    "cancelled",
+]
+
+
+class MediaCollectionCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1)
+    kind: str = Field("conference", min_length=1)
+    description: str | None = None
+    source_url: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    default_tags: list[str] = Field(default_factory=list)
+
+    @field_validator("name", "kind")
+    @classmethod
+    def _trim_required_string(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("value must not be empty")
+        return trimmed
+
+
+class MediaCollectionUpdateRequest(BaseModel):
+    name: str | None = None
+    kind: str | None = None
+    description: str | None = None
+    source_url: str | None = None
+    metadata: dict[str, Any] | None = None
+    default_tags: list[str] | None = None
+
+    @field_validator("name", "kind")
+    @classmethod
+    def _trim_optional_required_string(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("value must not be empty")
+        return trimmed
+
+
+class MediaCollectionItemCreateRequest(BaseModel):
+    source_url: str = Field(..., min_length=1)
+    normalized_source_id: str | None = None
+    source_kind: str | None = None
+    status: MediaCollectionItemStatus = "planned"
+    ordinal: int | None = Field(default=None, ge=1)
+    title: str | None = None
+    speaker: str | None = None
+    published_at: str | None = None
+    track: str | None = None
+    duplicate_status: str = "unknown"
+    media_id: int | None = None
+    content_item_id: int | None = None
+    latest_job_id: str | None = None
+    latest_run_id: int | None = None
+    idempotency_key: str | None = None
+    retry_count: int = Field(0, ge=0)
+    error_summary: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+
+    @field_validator("source_url")
+    @classmethod
+    def _trim_source_url(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("source_url must not be empty")
+        return trimmed
+
+
+class MediaCollectionItemUpdateRequest(BaseModel):
+    ordinal: int | None = Field(default=None, ge=1)
+    title: str | None = None
+    speaker: str | None = None
+    published_at: str | None = None
+    track: str | None = None
+    duplicate_status: str | None = None
+    status: MediaCollectionItemStatus | None = None
+    media_id: int | None = None
+    content_item_id: int | None = None
+    latest_job_id: str | None = None
+    latest_run_id: int | None = None
+    idempotency_key: str | None = None
+    retry_count: int | None = Field(default=None, ge=0)
+    error_summary: str | None = None
+    warnings: list[str] | None = None
+    metadata: dict[str, Any] | None = None
+    tags: list[str] | None = None
+
+
+class MediaCollectionItemResponse(BaseModel):
+    id: int
+    collection_id: int
+    ordinal: int
+    source_url: str
+    normalized_source_id: str | None = None
+    source_kind: str | None = None
+    title: str | None = None
+    speaker: str | None = None
+    published_at: str | None = None
+    track: str | None = None
+    duplicate_status: str
+    status: str
+    media_id: int | None = None
+    content_item_id: int | None = None
+    latest_job_id: str | None = None
+    latest_run_id: int | None = None
+    idempotency_key: str | None = None
+    retry_count: int
+    error_summary: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    created_at: str
+    updated_at: str
+
+
+class MediaCollectionResponse(BaseModel):
+    id: int
+    name: str
+    kind: str
+    description: str | None = None
+    source_url: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    default_tags: list[str] = Field(default_factory=list)
+    created_at: str
+    updated_at: str
+    items: list[MediaCollectionItemResponse] = Field(default_factory=list)
+
+
+class MediaCollectionListResponse(BaseModel):
+    items: list[MediaCollectionResponse]
+    total: int
+    page: int
+    size: int

--- a/tldw_Server_API/app/api/v1/schemas/media_playlist_preflight.py
+++ b/tldw_Server_API/app/api/v1/schemas/media_playlist_preflight.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field, field_validator
+
+
+PlaylistDuplicateStatus = Literal[
+    "new",
+    "duplicate_in_batch",
+    "duplicate_existing",
+    "unknown",
+]
+
+
+class PlaylistPreflightRequest(BaseModel):
+    url: str = Field(..., min_length=1, description="Playlist or playlist-context URL to inspect")
+    max_items: int = Field(100, ge=1, le=500, description="Maximum playlist entries to return")
+    timeout_seconds: int = Field(20, ge=1, le=60, description="Maximum preflight wait time")
+
+    @field_validator("url")
+    @classmethod
+    def _validate_http_url(cls, value: str) -> str:
+        trimmed = value.strip()
+        parsed = urlparse(trimmed)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("url must be an http(s) URL")
+        return trimmed
+
+
+class PlaylistPreflightItem(BaseModel):
+    ordinal: int = Field(..., ge=1)
+    source_url: str
+    normalized_source_id: str | None = None
+    source_kind: str
+    title: str | None = None
+    speaker: str | None = None
+    duration_seconds: int | None = None
+    published_at: str | None = None
+    thumbnail_url: str | None = None
+    duplicate_status: PlaylistDuplicateStatus = "unknown"
+    duplicate_of_ordinal: int | None = None
+    selected: bool = True
+
+
+class PlaylistPreflightResponse(BaseModel):
+    source_url: str
+    source_kind: str
+    playlist_id: str | None = None
+    playlist_title: str | None = None
+    video_id: str | None = None
+    item_count: int
+    selected_count: int
+    duplicate_count: int
+    warnings: list[str] = Field(default_factory=list)
+    items: list[PlaylistPreflightItem] = Field(default_factory=list)

--- a/tldw_Server_API/app/api/v1/schemas/media_request_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/media_request_models.py
@@ -502,6 +502,20 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
     )
     embedding_provider: Optional[str] = Field(None, description="Embedding provider (huggingface, openai, etc)")
 
+    # --- Durable media collection binding (used by async-job fallback paths) ---
+    media_collection_id: Optional[str] = Field(
+        None,
+        description="Optional durable media collection id associated with this ingest item",
+    )
+    media_collection_item_id: Optional[str] = Field(
+        None,
+        description="Optional planned durable media collection item id to resolve after ingest",
+    )
+    media_ingest_job_id: Optional[str] = Field(
+        None,
+        description="Optional media ingest job id that produced this fallback ingest",
+    )
+
     # --- Deprecated/Less Common ---
     perform_rolling_summarization: bool = Field(False, description="Perform rolling summarization (legacy?)")
     summarize_recursively: bool = Field(

--- a/tldw_Server_API/app/api/v1/schemas/media_request_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/media_request_models.py
@@ -503,13 +503,15 @@ class AddMediaForm(ChunkingOptions, AudioVideoOptions, PdfOptions):
     embedding_provider: Optional[str] = Field(None, description="Embedding provider (huggingface, openai, etc)")
 
     # --- Durable media collection binding (used by async-job fallback paths) ---
-    media_collection_id: Optional[str] = Field(
+    media_collection_id: Optional[int] = Field(
         None,
-        description="Optional durable media collection id associated with this ingest item",
+        ge=1,
+        description="Optional numeric durable media collection id associated with this ingest item",
     )
-    media_collection_item_id: Optional[str] = Field(
+    media_collection_item_id: Optional[int] = Field(
         None,
-        description="Optional planned durable media collection item id to resolve after ingest",
+        ge=1,
+        description="Optional numeric planned durable media collection item id to resolve after ingest",
     )
     media_ingest_job_id: Optional[str] = Field(
         None,

--- a/tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py
+++ b/tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py
@@ -301,6 +301,12 @@ class UnifiedRAGRequest(BaseModel):
         description="Restrict search to these Media DB item IDs",
         example=[1, 2, 3]
     )
+    collection_id: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Restrict search to ready media items in this durable media collection",
+        example=7,
+    )
     include_note_ids: Optional[list[str]] = Field(
         default=None,
         description="Restrict search to these Note IDs (ChaChaNotes UUIDs)",

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -137,6 +137,9 @@ _SQLITE_PRAGMA_TABLES = {
     "content_item_tags",
     "content_items",
     "file_artifacts",
+    "media_collection_items",
+    "media_collection_runs",
+    "media_collections",
     "notification_preferences",
     "notification_bridge_state",
     "output_templates",
@@ -147,6 +150,17 @@ _SQLITE_PRAGMA_TABLES = {
     "reading_digest_schedules",
     "reading_highlights",
     "user_notifications",
+}
+
+
+CONFERENCE_ITEM_STATUSES = {
+    "planned",
+    "processing",
+    "completed",
+    "skipped_existing",
+    "submit_failed",
+    "failed",
+    "cancelled",
 }
 
 
@@ -224,6 +238,51 @@ class ContentItemRow:
     tags: list[str]
     is_new: bool = False
     content_changed: bool = False
+
+
+@dataclass
+class MediaCollectionItemRow:
+    id: int
+    user_id: str
+    collection_id: int
+    ordinal: int
+    source_url: str
+    normalized_source_id: str | None
+    source_kind: str | None
+    title: str | None
+    speaker: str | None
+    published_at: str | None
+    track: str | None
+    duplicate_status: str
+    status: str
+    media_id: int | None
+    content_item_id: int | None
+    latest_job_id: str | None
+    latest_run_id: int | None
+    idempotency_key: str | None
+    retry_count: int
+    error_summary: str | None
+    warnings: list[str]
+    metadata: dict[str, Any]
+    tags: list[str]
+    created_at: str
+    updated_at: str
+
+
+@dataclass
+class MediaCollectionRow:
+    id: int
+    user_id: str
+    name: str
+    kind: str
+    description: str | None
+    source_url: str | None
+    metadata: dict[str, Any]
+    default_tags: list[str]
+    deleted: bool
+    created_at: str
+    updated_at: str
+    items: list[MediaCollectionItemRow]
 
 
 @dataclass
@@ -1595,6 +1654,85 @@ class CollectionsDatabase:
             CREATE INDEX IF NOT EXISTS idx_content_items_job ON content_items(job_id);
             CREATE INDEX IF NOT EXISTS idx_content_items_run ON content_items(run_id);
 
+            CREATE TABLE IF NOT EXISTS media_collections (
+                id BIGSERIAL PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                description TEXT,
+                source_url TEXT,
+                metadata_json TEXT,
+                default_tags_json TEXT,
+                deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_media_collections_user_updated
+                ON media_collections(user_id, deleted, updated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_media_collections_user_kind
+                ON media_collections(user_id, kind, deleted, updated_at DESC);
+
+            CREATE TABLE IF NOT EXISTS media_collection_items (
+                id BIGSERIAL PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                collection_id BIGINT NOT NULL,
+                ordinal INTEGER NOT NULL,
+                source_url TEXT NOT NULL,
+                normalized_source_id TEXT,
+                source_kind TEXT,
+                title TEXT,
+                speaker TEXT,
+                published_at TEXT,
+                track TEXT,
+                duplicate_status TEXT NOT NULL DEFAULT 'unknown',
+                status TEXT NOT NULL DEFAULT 'planned',
+                media_id BIGINT,
+                content_item_id BIGINT,
+                latest_job_id TEXT,
+                latest_run_id BIGINT,
+                idempotency_key TEXT,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                error_summary TEXT,
+                warnings_json TEXT,
+                metadata_json TEXT,
+                tags_json TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_collection
+                ON media_collection_items(user_id, collection_id, ordinal);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_source
+                ON media_collection_items(user_id, normalized_source_id);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_media
+                ON media_collection_items(user_id, media_id);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_job
+                ON media_collection_items(user_id, latest_job_id);
+
+            CREATE TABLE IF NOT EXISTS media_collection_runs (
+                id BIGSERIAL PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                collection_id BIGINT NOT NULL,
+                batch_id TEXT,
+                status TEXT NOT NULL,
+                requested_count INTEGER NOT NULL DEFAULT 0,
+                queued_count INTEGER NOT NULL DEFAULT 0,
+                processing_count INTEGER NOT NULL DEFAULT 0,
+                completed_count INTEGER NOT NULL DEFAULT 0,
+                failed_count INTEGER NOT NULL DEFAULT 0,
+                skipped_count INTEGER NOT NULL DEFAULT 0,
+                cancelled_count INTEGER NOT NULL DEFAULT 0,
+                options_json TEXT,
+                summary_json TEXT,
+                started_at TEXT,
+                completed_at TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_media_collection_runs_collection
+                ON media_collection_runs(user_id, collection_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_runs_batch
+                ON media_collection_runs(user_id, batch_id);
+
             CREATE TABLE IF NOT EXISTS content_item_tags (
                 item_id BIGINT NOT NULL,
                 tag_id BIGINT NOT NULL,
@@ -1665,6 +1803,85 @@ class CollectionsDatabase:
             CREATE INDEX IF NOT EXISTS idx_content_items_user_domain ON content_items(user_id, domain);
             CREATE INDEX IF NOT EXISTS idx_content_items_job ON content_items(job_id);
             CREATE INDEX IF NOT EXISTS idx_content_items_run ON content_items(run_id);
+
+            CREATE TABLE IF NOT EXISTS media_collections (
+                id INTEGER PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                description TEXT,
+                source_url TEXT,
+                metadata_json TEXT,
+                default_tags_json TEXT,
+                deleted INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_media_collections_user_updated
+                ON media_collections(user_id, deleted, updated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_media_collections_user_kind
+                ON media_collections(user_id, kind, deleted, updated_at DESC);
+
+            CREATE TABLE IF NOT EXISTS media_collection_items (
+                id INTEGER PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                collection_id INTEGER NOT NULL,
+                ordinal INTEGER NOT NULL,
+                source_url TEXT NOT NULL,
+                normalized_source_id TEXT,
+                source_kind TEXT,
+                title TEXT,
+                speaker TEXT,
+                published_at TEXT,
+                track TEXT,
+                duplicate_status TEXT NOT NULL DEFAULT 'unknown',
+                status TEXT NOT NULL DEFAULT 'planned',
+                media_id INTEGER,
+                content_item_id INTEGER,
+                latest_job_id TEXT,
+                latest_run_id INTEGER,
+                idempotency_key TEXT,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                error_summary TEXT,
+                warnings_json TEXT,
+                metadata_json TEXT,
+                tags_json TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_collection
+                ON media_collection_items(user_id, collection_id, ordinal);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_source
+                ON media_collection_items(user_id, normalized_source_id);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_media
+                ON media_collection_items(user_id, media_id);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_items_job
+                ON media_collection_items(user_id, latest_job_id);
+
+            CREATE TABLE IF NOT EXISTS media_collection_runs (
+                id INTEGER PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                collection_id INTEGER NOT NULL,
+                batch_id TEXT,
+                status TEXT NOT NULL,
+                requested_count INTEGER NOT NULL DEFAULT 0,
+                queued_count INTEGER NOT NULL DEFAULT 0,
+                processing_count INTEGER NOT NULL DEFAULT 0,
+                completed_count INTEGER NOT NULL DEFAULT 0,
+                failed_count INTEGER NOT NULL DEFAULT 0,
+                skipped_count INTEGER NOT NULL DEFAULT 0,
+                cancelled_count INTEGER NOT NULL DEFAULT 0,
+                options_json TEXT,
+                summary_json TEXT,
+                started_at TEXT,
+                completed_at TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_media_collection_runs_collection
+                ON media_collection_runs(user_id, collection_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_media_collection_runs_batch
+                ON media_collection_runs(user_id, batch_id);
 
             CREATE TABLE IF NOT EXISTS content_item_tags (
                 item_id INTEGER NOT NULL,
@@ -2285,6 +2502,542 @@ class CollectionsDatabase:
             return None
         tags_map = self._fetch_tags_for_item_ids([int(row.get("id"))])
         return self._row_to_content_item(row, tags_map.get(int(row.get("id")), []))
+
+    @staticmethod
+    def _json_dumps_or_none(value: Any) -> str | None:
+        if value is None:
+            return None
+        return json.dumps(value, ensure_ascii=False)
+
+    @staticmethod
+    def _json_loads_dict(raw: str | None) -> dict[str, Any]:
+        if not raw:
+            return {}
+        try:
+            payload = json.loads(raw)
+        except _COLLECTIONS_NONCRITICAL_EXCEPTIONS:
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _json_loads_string_list(raw: str | None) -> list[str]:
+        if not raw:
+            return []
+        try:
+            payload = json.loads(raw)
+        except _COLLECTIONS_NONCRITICAL_EXCEPTIONS:
+            return []
+        if not isinstance(payload, list):
+            return []
+        return [
+            item.strip()
+            for item in payload
+            if isinstance(item, str) and item.strip()
+        ]
+
+    @staticmethod
+    def _normalize_string_list(values: Iterable[str] | None) -> list[str]:
+        if values is None:
+            return []
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            item = str(value).strip()
+            if not item or item in seen:
+                continue
+            seen.add(item)
+            normalized.append(item)
+        return normalized
+
+    @staticmethod
+    def _normalize_collection_status(status: str) -> str:
+        normalized = str(status or "").strip()
+        if normalized not in CONFERENCE_ITEM_STATUSES:
+            raise ValueError("invalid_media_collection_item_status")
+        return normalized
+
+    def _row_to_media_collection_item(self, row: dict[str, Any]) -> MediaCollectionItemRow:
+        return MediaCollectionItemRow(
+            id=int(row.get("id")),
+            user_id=str(row.get("user_id")),
+            collection_id=int(row.get("collection_id")),
+            ordinal=int(row.get("ordinal") or 0),
+            source_url=str(row.get("source_url") or ""),
+            normalized_source_id=row.get("normalized_source_id"),
+            source_kind=row.get("source_kind"),
+            title=row.get("title"),
+            speaker=row.get("speaker"),
+            published_at=row.get("published_at"),
+            track=row.get("track"),
+            duplicate_status=str(row.get("duplicate_status") or "unknown"),
+            status=str(row.get("status") or "planned"),
+            media_id=(int(row.get("media_id")) if row.get("media_id") is not None else None),
+            content_item_id=(
+                int(row.get("content_item_id"))
+                if row.get("content_item_id") is not None
+                else None
+            ),
+            latest_job_id=row.get("latest_job_id"),
+            latest_run_id=(
+                int(row.get("latest_run_id"))
+                if row.get("latest_run_id") is not None
+                else None
+            ),
+            idempotency_key=row.get("idempotency_key"),
+            retry_count=int(row.get("retry_count") or 0),
+            error_summary=row.get("error_summary"),
+            warnings=self._json_loads_string_list(row.get("warnings_json")),
+            metadata=self._json_loads_dict(row.get("metadata_json")),
+            tags=self._json_loads_string_list(row.get("tags_json")),
+            created_at=str(row.get("created_at")),
+            updated_at=str(row.get("updated_at")),
+        )
+
+    def _fetch_media_collection_items(self, collection_id: int) -> list[MediaCollectionItemRow]:
+        rows = self.backend.execute(
+            """
+            SELECT id, user_id, collection_id, ordinal, source_url, normalized_source_id,
+                   source_kind, title, speaker, published_at, track, duplicate_status,
+                   status, media_id, content_item_id, latest_job_id, latest_run_id,
+                   idempotency_key, retry_count, error_summary, warnings_json,
+                   metadata_json, tags_json, created_at, updated_at
+            FROM media_collection_items
+            WHERE collection_id = ? AND user_id = ?
+            ORDER BY ordinal ASC, id ASC
+            """,
+            (collection_id, self.user_id),
+        ).rows
+        return [self._row_to_media_collection_item(row) for row in rows]
+
+    def _row_to_media_collection(
+        self,
+        row: dict[str, Any],
+        *,
+        include_items: bool = True,
+    ) -> MediaCollectionRow:
+        collection_id = int(row.get("id"))
+        return MediaCollectionRow(
+            id=collection_id,
+            user_id=str(row.get("user_id")),
+            name=str(row.get("name")),
+            kind=str(row.get("kind")),
+            description=row.get("description"),
+            source_url=row.get("source_url"),
+            metadata=self._json_loads_dict(row.get("metadata_json")),
+            default_tags=self._json_loads_string_list(row.get("default_tags_json")),
+            deleted=bool(row.get("deleted", 0)),
+            created_at=str(row.get("created_at")),
+            updated_at=str(row.get("updated_at")),
+            items=self._fetch_media_collection_items(collection_id) if include_items else [],
+        )
+
+    def create_media_collection(
+        self,
+        *,
+        name: str,
+        kind: str,
+        description: str | None = None,
+        source_url: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        default_tags: Iterable[str] | None = None,
+    ) -> MediaCollectionRow:
+        """Create a stable, user-owned media collection."""
+        name_value = str(name or "").strip()
+        kind_value = str(kind or "").strip()
+        if not name_value:
+            raise ValueError("media_collection_name_required")
+        if not kind_value:
+            raise ValueError("media_collection_kind_required")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise ValueError("media_collection_metadata_must_be_object")
+
+        now = _utcnow_iso()
+        result = self._execute_insert(
+            """
+            INSERT INTO media_collections (
+                user_id, name, kind, description, source_url, metadata_json,
+                default_tags_json, deleted, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                self.user_id,
+                name_value,
+                kind_value,
+                description.strip() if isinstance(description, str) and description.strip() else None,
+                source_url.strip() if isinstance(source_url, str) and source_url.strip() else None,
+                self._json_dumps_or_none(metadata or {}),
+                self._json_dumps_or_none(self._normalize_string_list(default_tags)),
+                self._coerce_bool_flag(False, postgres=self.backend.backend_type == BackendType.POSTGRESQL),
+                now,
+                now,
+            ),
+        )
+        collection_id = self._extract_lastrowid(result)
+        if not collection_id:
+            raise DatabaseError("Failed to insert media collection")
+        return self.get_media_collection(collection_id)
+
+    def get_media_collection(self, collection_id: int) -> MediaCollectionRow:
+        """Return collection metadata plus ordered membership."""
+        row = self.backend.execute(
+            """
+            SELECT id, user_id, name, kind, description, source_url, metadata_json,
+                   default_tags_json, deleted, created_at, updated_at
+            FROM media_collections
+            WHERE id = ? AND user_id = ? AND deleted = ?
+            """,
+            (
+                int(collection_id),
+                self.user_id,
+                self._coerce_bool_flag(False, postgres=self.backend.backend_type == BackendType.POSTGRESQL),
+            ),
+        ).first
+        if not row:
+            raise KeyError("media_collection_not_found")
+        return self._row_to_media_collection(row)
+
+    def list_media_collections(
+        self,
+        *,
+        kind: str | None = None,
+        page: int = 1,
+        size: int = 20,
+    ) -> tuple[list[MediaCollectionRow], int]:
+        """List durable media collections for the current user."""
+        page_value = max(1, int(page or 1))
+        size_value = min(100, max(1, int(size or 20)))
+        offset = (page_value - 1) * size_value
+        where = ["user_id = ?", "deleted = ?"]
+        params: list[Any] = [
+            self.user_id,
+            self._coerce_bool_flag(False, postgres=self.backend.backend_type == BackendType.POSTGRESQL),
+        ]
+        if kind is not None and str(kind).strip():
+            where.append("kind = ?")
+            params.append(str(kind).strip())
+        where_sql = " AND ".join(where)
+        total = _count_row_total(
+            self.backend.execute(
+                f"SELECT COUNT(*) AS total FROM media_collections WHERE {where_sql}",  # nosec B608
+                tuple(params),
+            ).first
+        )
+        rows = self.backend.execute(
+            f"""
+            SELECT id, user_id, name, kind, description, source_url, metadata_json,
+                   default_tags_json, deleted, created_at, updated_at
+            FROM media_collections
+            WHERE {where_sql}
+            ORDER BY updated_at DESC, id DESC
+            LIMIT ? OFFSET ?
+            """,  # nosec B608
+            tuple([*params, size_value, offset]),
+        ).rows
+        return [self._row_to_media_collection(row) for row in rows], total
+
+    def update_media_collection(
+        self,
+        collection_id: int,
+        *,
+        name: str | None = None,
+        kind: str | None = None,
+        description: str | None = None,
+        source_url: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        default_tags: Iterable[str] | None = None,
+    ) -> MediaCollectionRow:
+        """Update collection-level metadata without changing membership."""
+        self.get_media_collection(collection_id)
+        fields: list[str] = []
+        params: list[Any] = []
+
+        def add_field(field: str, value: Any) -> None:
+            fields.append(f"{field} = ?")
+            params.append(value)
+
+        if name is not None:
+            name_value = str(name).strip()
+            if not name_value:
+                raise ValueError("media_collection_name_required")
+            add_field("name", name_value)
+        if kind is not None:
+            kind_value = str(kind).strip()
+            if not kind_value:
+                raise ValueError("media_collection_kind_required")
+            add_field("kind", kind_value)
+        if description is not None:
+            add_field("description", description.strip() if description.strip() else None)
+        if source_url is not None:
+            add_field("source_url", source_url.strip() if source_url.strip() else None)
+        if metadata is not None:
+            if not isinstance(metadata, dict):
+                raise ValueError("media_collection_metadata_must_be_object")
+            add_field("metadata_json", self._json_dumps_or_none(metadata))
+        if default_tags is not None:
+            add_field(
+                "default_tags_json",
+                self._json_dumps_or_none(self._normalize_string_list(default_tags)),
+            )
+        if not fields:
+            return self.get_media_collection(collection_id)
+        add_field("updated_at", _utcnow_iso())
+        self.backend.execute(
+            f"UPDATE media_collections SET {', '.join(fields)} WHERE id = ? AND user_id = ?",  # nosec B608
+            tuple([*params, int(collection_id), self.user_id]),
+        )
+        return self.get_media_collection(collection_id)
+
+    def delete_media_collection(self, collection_id: int) -> bool:
+        """Soft-delete a media collection and hide it from collection lists."""
+        self.get_media_collection(collection_id)
+        self.backend.execute(
+            "UPDATE media_collections SET deleted = ?, updated_at = ? WHERE id = ? AND user_id = ?",
+            (
+                self._coerce_bool_flag(True, postgres=self.backend.backend_type == BackendType.POSTGRESQL),
+                _utcnow_iso(),
+                int(collection_id),
+                self.user_id,
+            ),
+        )
+        return True
+
+    def _next_media_collection_ordinal(self, collection_id: int) -> int:
+        row = self.backend.execute(
+            """
+            SELECT COALESCE(MAX(ordinal), 0) + 1 AS next_ordinal
+            FROM media_collection_items
+            WHERE collection_id = ? AND user_id = ?
+            """,
+            (int(collection_id), self.user_id),
+        ).first
+        if not row:
+            return 1
+        return int(row.get("next_ordinal") or 1)
+
+    def add_media_collection_item(
+        self,
+        *,
+        collection_id: int,
+        source_url: str,
+        normalized_source_id: str | None = None,
+        source_kind: str | None = None,
+        status: str = "planned",
+        ordinal: int | None = None,
+        title: str | None = None,
+        speaker: str | None = None,
+        published_at: str | None = None,
+        track: str | None = None,
+        duplicate_status: str = "unknown",
+        media_id: int | None = None,
+        content_item_id: int | None = None,
+        latest_job_id: str | None = None,
+        latest_run_id: int | None = None,
+        idempotency_key: str | None = None,
+        retry_count: int = 0,
+        error_summary: str | None = None,
+        warnings: Iterable[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        tags: Iterable[str] | None = None,
+    ) -> MediaCollectionItemRow:
+        """Add an unresolved planned/source item to a media collection."""
+        self.get_media_collection(collection_id)
+        source_url_value = str(source_url or "").strip()
+        if not source_url_value:
+            raise ValueError("media_collection_item_source_url_required")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise ValueError("media_collection_item_metadata_must_be_object")
+        status_value = self._normalize_collection_status(status)
+        ordinal_value = int(ordinal) if ordinal is not None else self._next_media_collection_ordinal(collection_id)
+        if ordinal_value < 1:
+            raise ValueError("media_collection_item_ordinal_invalid")
+
+        now = _utcnow_iso()
+        result = self._execute_insert(
+            """
+            INSERT INTO media_collection_items (
+                user_id, collection_id, ordinal, source_url, normalized_source_id,
+                source_kind, title, speaker, published_at, track, duplicate_status,
+                status, media_id, content_item_id, latest_job_id, latest_run_id,
+                idempotency_key, retry_count, error_summary, warnings_json,
+                metadata_json, tags_json, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                self.user_id,
+                int(collection_id),
+                ordinal_value,
+                source_url_value,
+                normalized_source_id.strip() if isinstance(normalized_source_id, str) and normalized_source_id.strip() else None,
+                source_kind.strip() if isinstance(source_kind, str) and source_kind.strip() else None,
+                title.strip() if isinstance(title, str) and title.strip() else None,
+                speaker.strip() if isinstance(speaker, str) and speaker.strip() else None,
+                published_at.strip() if isinstance(published_at, str) and published_at.strip() else None,
+                track.strip() if isinstance(track, str) and track.strip() else None,
+                str(duplicate_status or "unknown").strip() or "unknown",
+                status_value,
+                int(media_id) if media_id is not None else None,
+                int(content_item_id) if content_item_id is not None else None,
+                latest_job_id.strip() if isinstance(latest_job_id, str) and latest_job_id.strip() else None,
+                int(latest_run_id) if latest_run_id is not None else None,
+                idempotency_key.strip() if isinstance(idempotency_key, str) and idempotency_key.strip() else None,
+                max(0, int(retry_count or 0)),
+                error_summary.strip() if isinstance(error_summary, str) and error_summary.strip() else None,
+                self._json_dumps_or_none(self._normalize_string_list(warnings)),
+                self._json_dumps_or_none(metadata or {}),
+                self._json_dumps_or_none(self._normalize_string_list(tags)),
+                now,
+                now,
+            ),
+        )
+        item_id = self._extract_lastrowid(result)
+        if not item_id:
+            raise DatabaseError("Failed to insert media collection item")
+        self.backend.execute(
+            "UPDATE media_collections SET updated_at = ? WHERE id = ? AND user_id = ?",
+            (now, int(collection_id), self.user_id),
+        )
+        return self.get_media_collection_item(item_id)
+
+    def get_media_collection_item(self, item_id: int) -> MediaCollectionItemRow:
+        row = self.backend.execute(
+            """
+            SELECT id, user_id, collection_id, ordinal, source_url, normalized_source_id,
+                   source_kind, title, speaker, published_at, track, duplicate_status,
+                   status, media_id, content_item_id, latest_job_id, latest_run_id,
+                   idempotency_key, retry_count, error_summary, warnings_json,
+                   metadata_json, tags_json, created_at, updated_at
+            FROM media_collection_items
+            WHERE id = ? AND user_id = ?
+            """,
+            (int(item_id), self.user_id),
+        ).first
+        if not row:
+            raise KeyError("media_collection_item_not_found")
+        return self._row_to_media_collection_item(row)
+
+    def update_media_collection_item(
+        self,
+        item_id: int,
+        *,
+        ordinal: int | None = None,
+        title: str | None = None,
+        speaker: str | None = None,
+        published_at: str | None = None,
+        track: str | None = None,
+        duplicate_status: str | None = None,
+        status: str | None = None,
+        media_id: int | None = None,
+        content_item_id: int | None = None,
+        latest_job_id: str | None = None,
+        latest_run_id: int | None = None,
+        idempotency_key: str | None = None,
+        retry_count: int | None = None,
+        error_summary: str | None = None,
+        warnings: Iterable[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        tags: Iterable[str] | None = None,
+    ) -> MediaCollectionItemRow:
+        """Update a planned/resolved collection item without touching content_items."""
+        existing = self.get_media_collection_item(item_id)
+        fields: list[str] = []
+        params: list[Any] = []
+
+        def add_field(field: str, value: Any) -> None:
+            fields.append(f"{field} = ?")
+            params.append(value)
+
+        if ordinal is not None:
+            ordinal_value = int(ordinal)
+            if ordinal_value < 1:
+                raise ValueError("media_collection_item_ordinal_invalid")
+            add_field("ordinal", ordinal_value)
+        if title is not None:
+            add_field("title", title.strip() if title.strip() else None)
+        if speaker is not None:
+            add_field("speaker", speaker.strip() if speaker.strip() else None)
+        if published_at is not None:
+            add_field("published_at", published_at.strip() if published_at.strip() else None)
+        if track is not None:
+            add_field("track", track.strip() if track.strip() else None)
+        if duplicate_status is not None:
+            add_field("duplicate_status", str(duplicate_status or "unknown").strip() or "unknown")
+        if status is not None:
+            add_field("status", self._normalize_collection_status(status))
+        if media_id is not None:
+            add_field("media_id", int(media_id))
+        if content_item_id is not None:
+            add_field("content_item_id", int(content_item_id))
+        if latest_job_id is not None:
+            add_field("latest_job_id", latest_job_id.strip() if latest_job_id.strip() else None)
+        if latest_run_id is not None:
+            add_field("latest_run_id", int(latest_run_id))
+        if idempotency_key is not None:
+            add_field("idempotency_key", idempotency_key.strip() if idempotency_key.strip() else None)
+        if retry_count is not None:
+            add_field("retry_count", max(0, int(retry_count)))
+        if error_summary is not None:
+            add_field("error_summary", error_summary.strip() if error_summary.strip() else None)
+        if warnings is not None:
+            add_field("warnings_json", self._json_dumps_or_none(self._normalize_string_list(warnings)))
+        if metadata is not None:
+            if not isinstance(metadata, dict):
+                raise ValueError("media_collection_item_metadata_must_be_object")
+            add_field("metadata_json", self._json_dumps_or_none(metadata))
+        if tags is not None:
+            add_field("tags_json", self._json_dumps_or_none(self._normalize_string_list(tags)))
+        if not fields:
+            return existing
+        now = _utcnow_iso()
+        add_field("updated_at", now)
+        self.backend.execute(
+            f"UPDATE media_collection_items SET {', '.join(fields)} WHERE id = ? AND user_id = ?",  # nosec B608
+            tuple([*params, int(item_id), self.user_id]),
+        )
+        self.backend.execute(
+            "UPDATE media_collections SET updated_at = ? WHERE id = ? AND user_id = ?",
+            (now, existing.collection_id, self.user_id),
+        )
+        return self.get_media_collection_item(item_id)
+
+    def update_media_collection_item_status(
+        self,
+        item_id: int,
+        *,
+        status: str,
+        error_summary: str | None = None,
+        warnings: Iterable[str] | None = None,
+        latest_job_id: str | None = None,
+        latest_run_id: int | None = None,
+    ) -> MediaCollectionItemRow:
+        """Update processing status without losing source metadata."""
+        return self.update_media_collection_item(
+            item_id,
+            status=status,
+            error_summary=error_summary,
+            warnings=warnings,
+            latest_job_id=latest_job_id,
+            latest_run_id=latest_run_id,
+        )
+
+    def resolve_media_collection_item(
+        self,
+        item_id: int,
+        *,
+        media_id: int,
+        content_item_id: int | None = None,
+        status: str = "completed",
+        latest_job_id: str | None = None,
+        latest_run_id: int | None = None,
+    ) -> MediaCollectionItemRow:
+        """Resolve a planned item to an existing or newly created media row."""
+        return self.update_media_collection_item(
+            item_id,
+            status=status,
+            media_id=media_id,
+            content_item_id=content_item_id,
+            latest_job_id=latest_job_id,
+            latest_run_id=latest_run_id,
+        )
 
     def upsert_content_item(
         self,

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -1701,6 +1701,8 @@ class CollectionsDatabase:
             );
             CREATE INDEX IF NOT EXISTS idx_media_collection_items_collection
                 ON media_collection_items(user_id, collection_id, ordinal);
+            CREATE UNIQUE INDEX IF NOT EXISTS ux_media_collection_items_collection_ordinal
+                ON media_collection_items(user_id, collection_id, ordinal);
             CREATE INDEX IF NOT EXISTS idx_media_collection_items_source
                 ON media_collection_items(user_id, normalized_source_id);
             CREATE INDEX IF NOT EXISTS idx_media_collection_items_media
@@ -1850,6 +1852,8 @@ class CollectionsDatabase:
                 updated_at TEXT NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_media_collection_items_collection
+                ON media_collection_items(user_id, collection_id, ordinal);
+            CREATE UNIQUE INDEX IF NOT EXISTS ux_media_collection_items_collection_ordinal
                 ON media_collection_items(user_id, collection_id, ordinal);
             CREATE INDEX IF NOT EXISTS idx_media_collection_items_source
                 ON media_collection_items(user_id, normalized_source_id);
@@ -2814,6 +2818,36 @@ class CollectionsDatabase:
             return 1
         return int(row.get("next_ordinal") or 1)
 
+    def _ensure_media_collection_ordinal_available(
+        self,
+        *,
+        collection_id: int,
+        ordinal: int,
+        exclude_item_id: int | None = None,
+    ) -> None:
+        if exclude_item_id is None:
+            row = self.backend.execute(
+                """
+                SELECT id
+                FROM media_collection_items
+                WHERE collection_id = ? AND user_id = ? AND ordinal = ?
+                LIMIT 1
+                """,
+                (int(collection_id), self.user_id, int(ordinal)),
+            ).first
+        else:
+            row = self.backend.execute(
+                """
+                SELECT id
+                FROM media_collection_items
+                WHERE collection_id = ? AND user_id = ? AND ordinal = ? AND id != ?
+                LIMIT 1
+                """,
+                (int(collection_id), self.user_id, int(ordinal), int(exclude_item_id)),
+            ).first
+        if row:
+            raise ValueError("media_collection_item_ordinal_duplicate")
+
     def add_media_collection_item(
         self,
         *,
@@ -2850,6 +2884,10 @@ class CollectionsDatabase:
         ordinal_value = int(ordinal) if ordinal is not None else self._next_media_collection_ordinal(collection_id)
         if ordinal_value < 1:
             raise ValueError("media_collection_item_ordinal_invalid")
+        self._ensure_media_collection_ordinal_available(
+            collection_id=collection_id,
+            ordinal=ordinal_value,
+        )
 
         now = _utcnow_iso()
         result = self._execute_insert(
@@ -2950,6 +2988,11 @@ class CollectionsDatabase:
             ordinal_value = int(ordinal)
             if ordinal_value < 1:
                 raise ValueError("media_collection_item_ordinal_invalid")
+            self._ensure_media_collection_ordinal_available(
+                collection_id=existing.collection_id,
+                ordinal=ordinal_value,
+                exclude_item_id=existing.id,
+            )
             add_field("ordinal", ordinal_value)
         if title is not None:
             add_field("title", title.strip() if title.strip() else None)
@@ -3037,6 +3080,8 @@ class CollectionsDatabase:
             content_item_id=content_item_id,
             latest_job_id=latest_job_id,
             latest_run_id=latest_run_id,
+            error_summary="",
+            warnings=[],
         )
 
     def upsert_content_item(

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
@@ -68,9 +68,7 @@ def _hostname_matches(hostname: str, allowed_host: str) -> bool:
 
 
 def _is_youtube_host(hostname: str) -> bool:
-    return _hostname_matches(hostname, "youtube.com") or _hostname_matches(
-        hostname, "youtu.be"
-    )
+    return _hostname_matches(hostname, "youtube.com") or _hostname_matches(hostname, "youtu.be")
 
 
 def _first_query_value(query: dict[str, list[str]], key: str) -> str | None:
@@ -210,9 +208,7 @@ def _source_url_from_entry(
 
     extractor = _string_or_none(entry.get("extractor_key") or entry.get("ie_key"))
     entry_id = _string_or_none(entry.get("id") or candidate)
-    if entry_id and (
-        assume_youtube or (extractor and extractor.lower().startswith("youtube"))
-    ):
+    if entry_id and (assume_youtube or (extractor and extractor.lower().startswith("youtube"))):
         return canonical_youtube_video_url(entry_id)
     return candidate
 
@@ -238,9 +234,10 @@ def normalize_preflight_items(raw_items: list[dict[str, Any]]) -> list[PlaylistP
             except ValueError:
                 normalized_source_id = normalized_source_id or f"url:{source_url}"
 
+        has_source = bool(source_url)
         dedupe_key = normalized_source_id or source_url
         duplicate_of = seen.get(dedupe_key)
-        duplicate_status = "duplicate_in_batch" if duplicate_of is not None else "new"
+        duplicate_status = "unknown" if not has_source else "duplicate_in_batch" if duplicate_of is not None else "new"
         if duplicate_of is None and dedupe_key:
             seen[dedupe_key] = ordinal
 
@@ -251,15 +248,13 @@ def normalize_preflight_items(raw_items: list[dict[str, Any]]) -> list[PlaylistP
                 normalized_source_id=normalized_source_id,
                 source_kind=source_kind,
                 title=_string_or_none(raw.get("title")),
-                speaker=_string_or_none(
-                    raw.get("speaker") or raw.get("channel") or raw.get("uploader")
-                ),
+                speaker=_string_or_none(raw.get("speaker") or raw.get("channel") or raw.get("uploader")),
                 duration_seconds=_coerce_duration(raw.get("duration") or raw.get("duration_seconds")),
                 published_at=_string_or_none(raw.get("published_at") or raw.get("upload_date")),
                 thumbnail_url=_string_or_none(raw.get("thumbnail") or raw.get("thumbnail_url")),
                 duplicate_status=duplicate_status,
                 duplicate_of_ordinal=duplicate_of,
-                selected=duplicate_status == "new",
+                selected=duplicate_status == "new" and has_source,
             )
         )
 
@@ -348,10 +343,13 @@ def extract_playlist_preflight(
     for index, entry in enumerate(limited_entries, start=1):
         raw_item = dict(entry)
         raw_item["ordinal"] = index
-        raw_item["source_url"] = _source_url_from_entry(
+        source_url = _source_url_from_entry(
             entry,
             assume_youtube=assume_youtube_entries,
         )
+        if not source_url:
+            warnings.append(f"Playlist entry {index} has no source URL.")
+        raw_item["source_url"] = source_url
         raw_items.append(raw_item)
 
     items = normalize_preflight_items(raw_items)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+
+@dataclass(frozen=True)
+class PlaylistUrlClassification:
+    source_url: str
+    source_kind: str
+    is_playlist: bool
+    playlist_id: str | None = None
+    video_id: str | None = None
+    normalized_source_id: str | None = None
+
+
+@dataclass(frozen=True)
+class PlaylistPreflightItemData:
+    ordinal: int
+    source_url: str
+    normalized_source_id: str | None
+    source_kind: str
+    title: str | None
+    speaker: str | None
+    duration_seconds: int | None
+    published_at: str | None
+    thumbnail_url: str | None
+    duplicate_status: str
+    duplicate_of_ordinal: int | None
+    selected: bool
+
+
+@dataclass(frozen=True)
+class PlaylistPreflightData:
+    source_url: str
+    source_kind: str
+    playlist_id: str | None
+    playlist_title: str | None
+    video_id: str | None
+    item_count: int
+    selected_count: int
+    duplicate_count: int
+    warnings: list[str]
+    items: list[PlaylistPreflightItemData]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["items"] = [asdict(item) for item in self.items]
+        return payload
+
+
+def _hostname_matches(hostname: str, allowed_host: str) -> bool:
+    return hostname == allowed_host or hostname.endswith(f".{allowed_host}")
+
+
+def _is_youtube_host(hostname: str) -> bool:
+    return _hostname_matches(hostname, "youtube.com") or _hostname_matches(
+        hostname, "youtu.be"
+    )
+
+
+def _first_query_value(query: dict[str, list[str]], key: str) -> str | None:
+    values = query.get(key) or []
+    for value in values:
+        trimmed = str(value or "").strip()
+        if trimmed:
+            return trimmed
+    return None
+
+
+def _youtube_video_id(parsed) -> str | None:
+    hostname = parsed.hostname.lower() if parsed.hostname else ""
+    path_parts = [part for part in parsed.path.split("/") if part]
+    query = parse_qs(parsed.query)
+    if _hostname_matches(hostname, "youtu.be") and path_parts:
+        return path_parts[0]
+    if path_parts and path_parts[0] in {"shorts", "embed", "live"} and len(path_parts) > 1:
+        return path_parts[1]
+    if parsed.path == "/watch":
+        return _first_query_value(query, "v")
+    return None
+
+
+def _canonical_url_without_fragment(url: str) -> str:
+    parsed = urlparse(url.strip())
+    hostname = parsed.hostname.lower() if parsed.hostname else parsed.netloc.lower()
+    netloc = hostname
+    if parsed.port:
+        netloc = f"{hostname}:{parsed.port}"
+    query = urlencode(sorted(parse_qs(parsed.query, keep_blank_values=True).items()), doseq=True)
+    return urlunparse(
+        (
+            parsed.scheme.lower(),
+            netloc,
+            parsed.path or "/",
+            "",
+            query,
+            "",
+        )
+    )
+
+
+def canonical_youtube_video_url(video_id: str) -> str:
+    return f"https://www.youtube.com/watch?v={video_id}"
+
+
+def classify_playlist_url(url: str) -> PlaylistUrlClassification:
+    trimmed = str(url or "").strip()
+    parsed = urlparse(trimmed)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("unsupported_url")
+
+    hostname = parsed.hostname.lower() if parsed.hostname else ""
+    query = parse_qs(parsed.query)
+    playlist_id = _first_query_value(query, "list")
+    video_id = _youtube_video_id(parsed) if _is_youtube_host(hostname) else None
+
+    if _is_youtube_host(hostname):
+        if parsed.path == "/playlist" and playlist_id:
+            return PlaylistUrlClassification(
+                source_url=trimmed,
+                source_kind="youtube_playlist",
+                is_playlist=True,
+                playlist_id=playlist_id,
+                video_id=None,
+                normalized_source_id=f"youtube:playlist:{playlist_id}",
+            )
+        if playlist_id and video_id:
+            return PlaylistUrlClassification(
+                source_url=trimmed,
+                source_kind="youtube_watch_playlist",
+                is_playlist=True,
+                playlist_id=playlist_id,
+                video_id=video_id,
+                normalized_source_id=f"youtube:playlist:{playlist_id}",
+            )
+        if playlist_id:
+            return PlaylistUrlClassification(
+                source_url=trimmed,
+                source_kind="youtube_playlist",
+                is_playlist=True,
+                playlist_id=playlist_id,
+                video_id=None,
+                normalized_source_id=f"youtube:playlist:{playlist_id}",
+            )
+        if video_id:
+            return PlaylistUrlClassification(
+                source_url=trimmed,
+                source_kind="youtube_video",
+                is_playlist=False,
+                playlist_id=None,
+                video_id=video_id,
+                normalized_source_id=f"youtube:video:{video_id}",
+            )
+
+    return PlaylistUrlClassification(
+        source_url=trimmed,
+        source_kind="generic_url",
+        is_playlist=False,
+        playlist_id=playlist_id,
+        video_id=video_id,
+        normalized_source_id=f"url:{_canonical_url_without_fragment(trimmed)}",
+    )
+
+
+def _coerce_duration(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _source_url_from_entry(
+    entry: dict[str, Any],
+    *,
+    assume_youtube: bool = False,
+) -> str | None:
+    for key in ("source_url", "webpage_url", "original_url"):
+        value = _string_or_none(entry.get(key))
+        if value and value.startswith(("http://", "https://")):
+            return value
+
+    candidate = _string_or_none(entry.get("url"))
+    if candidate and candidate.startswith(("http://", "https://")):
+        return candidate
+
+    extractor = _string_or_none(entry.get("extractor_key") or entry.get("ie_key"))
+    entry_id = _string_or_none(entry.get("id") or candidate)
+    if entry_id and (
+        assume_youtube or (extractor and extractor.lower().startswith("youtube"))
+    ):
+        return canonical_youtube_video_url(entry_id)
+    return candidate
+
+
+def normalize_preflight_items(raw_items: list[dict[str, Any]]) -> list[PlaylistPreflightItemData]:
+    seen: dict[str, int] = {}
+    normalized: list[PlaylistPreflightItemData] = []
+
+    for index, raw in enumerate(raw_items):
+        ordinal = int(raw.get("ordinal") or index + 1)
+        source_url = _source_url_from_entry(raw) or ""
+        source_kind = str(raw.get("source_kind") or "generic_url")
+        normalized_source_id = _string_or_none(raw.get("normalized_source_id"))
+
+        if source_url:
+            try:
+                classified = classify_playlist_url(source_url)
+                source_kind = str(raw.get("source_kind") or classified.source_kind)
+                normalized_source_id = normalized_source_id or classified.normalized_source_id
+                source_hostname = urlparse(source_url).hostname or ""
+                if classified.video_id and _is_youtube_host(source_hostname.lower()):
+                    source_url = canonical_youtube_video_url(classified.video_id)
+            except ValueError:
+                normalized_source_id = normalized_source_id or f"url:{source_url}"
+
+        dedupe_key = normalized_source_id or source_url
+        duplicate_of = seen.get(dedupe_key)
+        duplicate_status = "duplicate_in_batch" if duplicate_of is not None else "new"
+        if duplicate_of is None and dedupe_key:
+            seen[dedupe_key] = ordinal
+
+        normalized.append(
+            PlaylistPreflightItemData(
+                ordinal=ordinal,
+                source_url=source_url,
+                normalized_source_id=normalized_source_id,
+                source_kind=source_kind,
+                title=_string_or_none(raw.get("title")),
+                speaker=_string_or_none(
+                    raw.get("speaker") or raw.get("channel") or raw.get("uploader")
+                ),
+                duration_seconds=_coerce_duration(raw.get("duration") or raw.get("duration_seconds")),
+                published_at=_string_or_none(raw.get("published_at") or raw.get("upload_date")),
+                thumbnail_url=_string_or_none(raw.get("thumbnail") or raw.get("thumbnail_url")),
+                duplicate_status=duplicate_status,
+                duplicate_of_ordinal=duplicate_of,
+                selected=duplicate_status == "new",
+            )
+        )
+
+    return normalized
+
+
+def _youtube_dl_class():
+    import yt_dlp  # type: ignore
+
+    return yt_dlp.YoutubeDL
+
+
+def extract_playlist_preflight(
+    url: str,
+    *,
+    max_items: int = 100,
+    youtube_dl_cls: type | None = None,
+) -> PlaylistPreflightData:
+    classified = classify_playlist_url(url)
+    if not classified.is_playlist:
+        raise ValueError("not_playlist_url")
+
+    ydl_cls = youtube_dl_cls or _youtube_dl_class()
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "skip_download": True,
+        "extract_flat": True,
+        "noplaylist": False,
+    }
+
+    with ydl_cls(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=False)
+
+    if not isinstance(info, dict):
+        raise ValueError("playlist_metadata_unavailable")
+
+    entries = [entry for entry in (info.get("entries") or []) if isinstance(entry, dict)]
+    warnings: list[str] = []
+    if len(entries) > max_items:
+        warnings.append(f"Playlist truncated to {max_items} items.")
+    limited_entries = entries[:max_items]
+
+    raw_items: list[dict[str, Any]] = []
+    assume_youtube_entries = classified.source_kind.startswith("youtube")
+    for index, entry in enumerate(limited_entries, start=1):
+        raw_item = dict(entry)
+        raw_item["ordinal"] = index
+        raw_item["source_url"] = _source_url_from_entry(
+            entry,
+            assume_youtube=assume_youtube_entries,
+        )
+        raw_items.append(raw_item)
+
+    items = normalize_preflight_items(raw_items)
+    duplicate_count = sum(1 for item in items if item.duplicate_status != "new")
+    selected_count = sum(1 for item in items if item.selected)
+
+    return PlaylistPreflightData(
+        source_url=url,
+        source_kind=classified.source_kind,
+        playlist_id=_string_or_none(info.get("id")) or classified.playlist_id,
+        playlist_title=_string_or_none(info.get("title")),
+        video_id=classified.video_id,
+        item_count=len(items),
+        selected_count=selected_count,
+        duplicate_count=duplicate_count,
+        warnings=warnings,
+        items=items,
+    )
+
+
+preflight_playlist_url = extract_playlist_preflight

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/playlist_preflight.py
@@ -50,6 +50,19 @@ class PlaylistPreflightData:
         return payload
 
 
+@dataclass(frozen=True)
+class DuplicatePolicyAction:
+    policy: str
+    planned_status: str
+    should_submit_job: bool
+    force_overwrite: bool
+
+
+def _is_duplicate_status(value: str | None) -> bool:
+    normalized = str(value or "").strip().lower()
+    return normalized in {"duplicate_existing", "duplicate_in_batch"}
+
+
 def _hostname_matches(hostname: str, allowed_host: str) -> bool:
     return hostname == allowed_host or hostname.endswith(f".{allowed_host}")
 
@@ -251,6 +264,46 @@ def normalize_preflight_items(raw_items: list[dict[str, Any]]) -> list[PlaylistP
         )
 
     return normalized
+
+
+def resolve_duplicate_policy_action(
+    *,
+    duplicate_status: str | None,
+    policy: str | None,
+) -> DuplicatePolicyAction:
+    """Resolve duplicate policy into collection status and job submission behavior."""
+    normalized_duplicate_status = str(duplicate_status or "unknown").strip() or "unknown"
+    normalized_policy = str(policy or "skip").strip() or "skip"
+    if normalized_policy not in {
+        "skip",
+        "overwrite",
+        "update_metadata_only",
+        "include_existing",
+    }:
+        normalized_policy = "skip"
+
+    if not _is_duplicate_status(normalized_duplicate_status):
+        return DuplicatePolicyAction(
+            policy=normalized_policy,
+            planned_status="planned",
+            should_submit_job=True,
+            force_overwrite=False,
+        )
+
+    if normalized_policy == "overwrite":
+        return DuplicatePolicyAction(
+            policy=normalized_policy,
+            planned_status="planned",
+            should_submit_job=True,
+            force_overwrite=True,
+        )
+
+    return DuplicatePolicyAction(
+        policy=normalized_policy,
+        planned_status="skipped_existing",
+        should_submit_job=False,
+        force_overwrite=False,
+    )
 
 
 def _youtube_dl_class():

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -2083,6 +2083,29 @@ def sync_media_add_results_to_collections(
             result["collections_item_id"] = item_row.id
             result["collections_origin"] = collections_origin
 
+            planned_item_id_raw = (
+                getattr(form_data, "media_collection_item_id", None)
+                or getattr(form_data, "planned_item_id", None)
+            )
+            try:
+                planned_item_id = int(planned_item_id_raw) if planned_item_id_raw is not None else None
+            except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
+                planned_item_id = None
+            if planned_item_id is not None and planned_item_id > 0:
+                latest_job_id = getattr(form_data, "media_ingest_job_id", None)
+                resolved_status = "completed"
+                status_text = str(result.get("status") or "").strip().lower()
+                message_text = str(result.get("db_message") or result.get("message") or "").lower()
+                if status_text in {"skipped", "duplicate", "skipped_existing"} or "already exists" in message_text:
+                    resolved_status = "skipped_existing"
+                collections_db.resolve_media_collection_item(
+                    planned_item_id,
+                    media_id=media_id,
+                    status=resolved_status,
+                    latest_job_id=str(latest_job_id).strip() if latest_job_id is not None else None,
+                )
+                result["media_collection_item_id"] = planned_item_id
+
     except _PERSISTENCE_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning("Collections dual-write failed: {}", exc)
         for result in results:

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -2083,8 +2083,10 @@ def sync_media_add_results_to_collections(
             result["collections_item_id"] = item_row.id
             result["collections_origin"] = collections_origin
 
+            result_planned_item_id_raw = result.get("media_collection_item_id") or result.get("planned_item_id")
             planned_item_id_raw = (
-                getattr(form_data, "media_collection_item_id", None)
+                result_planned_item_id_raw
+                or getattr(form_data, "media_collection_item_id", None)
                 or getattr(form_data, "planned_item_id", None)
             )
             try:
@@ -2092,6 +2094,11 @@ def sync_media_add_results_to_collections(
             except _PERSISTENCE_NONCRITICAL_EXCEPTIONS:
                 planned_item_id = None
             if planned_item_id is not None and planned_item_id > 0:
+                if len(results) > 1 and result_planned_item_id_raw is None:
+                    _ensure_warnings_list(result).append(
+                        "Skipped collection item resolution: missing per-result planned item id for batch ingest."
+                    )
+                    continue
                 latest_job_id = getattr(form_data, "media_ingest_job_id", None)
                 resolved_status = "completed"
                 status_text = str(result.get("status") or "").strip().lower()

--- a/tldw_Server_API/app/core/RAG/rag_service/agentic_chunker.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/agentic_chunker.py
@@ -267,6 +267,7 @@ async def agentic_rag_pipeline(
     effective_top_k = max(1, int(effective_retrieval_plan.top_k or top_k or 10))
     effective_min_score = float(effective_retrieval_plan.min_score if effective_retrieval_plan.min_score is not None else min_score or 0.0)
     effective_index_namespace = effective_retrieval_plan.index_namespace
+    allowed_media_ids = (resolved_request.payload or {}).get("include_media_ids")
     effective_hybrid_alpha = _coerce_float(
         (resolved_request.payload or {}).get("hybrid_alpha", hybrid_alpha),
         default=_coerce_float(hybrid_alpha, 0.7),
@@ -314,6 +315,7 @@ async def agentic_rag_pipeline(
             retrieval_plan=effective_retrieval_plan,
             retriever=retriever,
             retrieval_config=config,
+            allowed_media_ids=allowed_media_ids,
         )
         docs = list(retrieved_evidence.documents)
     except (AttributeError, ConnectionError, OSError, RuntimeError, TypeError, ValueError, TimeoutError):
@@ -345,6 +347,7 @@ async def agentic_rag_pipeline(
             fallback_docs = await fb_retriever.retrieve(
                 query=effective_query,
                 media_type=None,
+                allowed_media_ids=allowed_media_ids,
             )
             if fallback_docs:
                 docs = fallback_docs

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -33,6 +34,13 @@ from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 
 _MEDIA_DOMAIN = "media_ingest"
 _MEDIA_JOB_TYPE = "media_ingest_item"
+_SECRET_QUERY_RE = re.compile(r"(?i)([?&](?:token|apikey|api_key|access_key|signature|sig|password|key)=)[^&\s,;]+")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b((?:bearer|token|api[_-]?key|access[_-]?key|password|secret)\s*[:=]\s*)[^\s,;]+"
+)
+_LONG_HEX_RE = re.compile(r"\b[0-9a-fA-F]{32,}\b")
+_POSIX_PATH_RE = re.compile(r"(?<!\w)/(?:Users|private|tmp|var|Volumes|home|opt|etc|mnt)/[^\s,;]+")
+_WINDOWS_PATH_RE = re.compile(r"\b[A-Za-z]:\\[^\s,;]+")
 _MARK_PROCESSED_CONFLICT_RETRIES = 3
 _MARK_PROCESSED_CONFLICT_BACKOFF_SECONDS = 0.05
 
@@ -135,15 +143,19 @@ def _coerce_positive_int(value: Any) -> int | None:
 
 
 def _planned_collection_item_id(payload: dict[str, Any]) -> int | None:
-    return _coerce_positive_int(
-        payload.get("planned_item_id") or payload.get("media_collection_item_id")
-    )
+    return _coerce_positive_int(payload.get("planned_item_id") or payload.get("media_collection_item_id"))
 
 
 def _truncate_collection_error(value: Any) -> str | None:
     text = str(value or "").strip()
     if not text:
         return None
+    text = _SECRET_QUERY_RE.sub(r"\1[redacted]", text)
+    text = _SECRET_ASSIGNMENT_RE.sub(r"\1[redacted]", text)
+    text = _LONG_HEX_RE.sub("[redacted-hex]", text)
+    text = _POSIX_PATH_RE.sub("[redacted-path]", text)
+    text = _WINDOWS_PATH_RE.sub("[redacted-path]", text)
+    text = " ".join(text.split())
     return text[:1000]
 
 

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -14,6 +14,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.schemas.media_request_models import AddMediaForm
 from tldw_Server_API.app.core.Chunking.templates import TemplateClassifier
 from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.DB_Management.DB_Manager import mark_media_as_processed
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.media_db.api import create_media_database
@@ -125,6 +126,128 @@ def _normalize_payload(value: Any) -> dict[str, Any]:
     return {}
 
 
+def _coerce_positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _planned_collection_item_id(payload: dict[str, Any]) -> int | None:
+    return _coerce_positive_int(
+        payload.get("planned_item_id") or payload.get("media_collection_item_id")
+    )
+
+
+def _truncate_collection_error(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    return text[:1000]
+
+
+def _with_collections_db(user_id: str, callback) -> None:
+    collections_db = None
+    try:
+        collections_db = CollectionsDatabase.for_user(user_id=user_id)
+        callback(collections_db)
+    except Exception as exc:
+        logger.warning("Media collection item sync failed for user {}: {}", user_id, exc)
+    finally:
+        if collections_db is not None:
+            with contextlib.suppress(Exception):
+                collections_db.close()
+
+
+def _mark_collection_item_status(
+    *,
+    user_id: str,
+    item_id: int | None,
+    status: str,
+    latest_job_id: str,
+    error_summary: str | None = None,
+) -> None:
+    if item_id is None:
+        return
+
+    def _update(collections_db):
+        kwargs: dict[str, Any] = {
+            "status": status,
+            "latest_job_id": latest_job_id,
+        }
+        if error_summary is not None:
+            kwargs["error_summary"] = _truncate_collection_error(error_summary)
+        collections_db.update_media_collection_item_status(item_id, **kwargs)
+
+    _with_collections_db(user_id, _update)
+
+
+def _is_skipped_existing_result(result_item: dict[str, Any]) -> bool:
+    status = str(result_item.get("status") or "").strip().lower()
+    if status in {"skipped", "duplicate", "skipped_existing"}:
+        return True
+    message = str(result_item.get("db_message") or result_item.get("message") or "").lower()
+    return "already exists" in message or "duplicate" in message
+
+
+def _is_failed_result(result_item: dict[str, Any]) -> bool:
+    status = str(result_item.get("status") or "").strip().lower()
+    if status in {"error", "failed", "failure", "quarantined", "timeout"}:
+        return True
+    return bool(str(result_item.get("error") or "").strip())
+
+
+def _sync_collection_item_terminal_result(
+    *,
+    user_id: str,
+    item_id: int | None,
+    latest_job_id: str,
+    result_item: dict[str, Any],
+) -> None:
+    if item_id is None:
+        return
+
+    media_id = _coerce_positive_int(result_item.get("db_id") or result_item.get("media_id"))
+    if media_id is not None and not _is_failed_result(result_item):
+        resolved_status = "skipped_existing" if _is_skipped_existing_result(result_item) else "completed"
+
+        def _resolve(collections_db):
+            collections_db.resolve_media_collection_item(
+                item_id,
+                media_id=media_id,
+                status=resolved_status,
+                latest_job_id=latest_job_id,
+            )
+
+        _with_collections_db(user_id, _resolve)
+        return
+
+    if _is_failed_result(result_item):
+        error_summary = (
+            result_item.get("error")
+            or result_item.get("db_message")
+            or result_item.get("message")
+            or "Media ingest failed"
+        )
+        _mark_collection_item_status(
+            user_id=user_id,
+            item_id=item_id,
+            status="failed",
+            latest_job_id=latest_job_id,
+            error_summary=str(error_summary),
+        )
+        return
+
+    _mark_collection_item_status(
+        user_id=user_id,
+        item_id=item_id,
+        status="failed",
+        latest_job_id=latest_job_id,
+        error_summary="No media id returned",
+    )
+
+
 def _resolve_user_id(job: dict[str, Any], payload: dict[str, Any]) -> str:
     owner = job.get("owner_user_id") or payload.get("user_id")
     if owner is None or str(owner).strip() == "":
@@ -216,11 +339,13 @@ async def _schedule_embeddings(
 
 async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressState) -> dict[str, Any]:
     job_id = int(job.get("id"))
+    latest_job_id = str(job_id)
     payload = _normalize_payload(job.get("payload"))
     if str(job.get("job_type") or "").lower() != _MEDIA_JOB_TYPE:
         raise MediaIngestJobError("unsupported job_type", retryable=False)
 
     user_id = _resolve_user_id(job, payload)
+    planned_item_id = _planned_collection_item_id(payload)
     source = payload.get("source")
     if not source:
         raise MediaIngestJobError("missing source", retryable=False)
@@ -239,8 +364,22 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
     db = None
     try:
         if _should_cancel(jm, job_id):
+            _mark_collection_item_status(
+                user_id=user_id,
+                item_id=planned_item_id,
+                status="cancelled",
+                latest_job_id=latest_job_id,
+                error_summary="cancel requested before start",
+            )
             jm.finalize_cancelled(job_id, reason="cancel requested before start")
             return {}
+
+        _mark_collection_item_status(
+            user_id=user_id,
+            item_id=planned_item_id,
+            status="processing",
+            latest_job_id=latest_job_id,
+        )
 
         progress.percent = 5.0
         progress.message = "prepare"
@@ -319,6 +458,13 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
             results = [result]
 
         if _should_cancel(jm, job_id):
+            _mark_collection_item_status(
+                user_id=user_id,
+                item_id=planned_item_id,
+                status="cancelled",
+                latest_job_id=latest_job_id,
+                error_summary="cancel requested during processing",
+            )
             jm.finalize_cancelled(job_id, reason="cancel requested during processing")
             return {}
 
@@ -361,9 +507,31 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
             }
             if final_chunking_plan is not None:
                 job_result["chunking_plan"] = final_chunking_plan
+            _sync_collection_item_terminal_result(
+                user_id=user_id,
+                item_id=planned_item_id,
+                latest_job_id=latest_job_id,
+                result_item=result_item,
+            )
             return job_result
+        _mark_collection_item_status(
+            user_id=user_id,
+            item_id=planned_item_id,
+            status="failed",
+            latest_job_id=latest_job_id,
+            error_summary="No result produced",
+        )
         return {"status": "Error", "error": "No result produced"}
 
+    except Exception as exc:
+        _mark_collection_item_status(
+            user_id=user_id,
+            item_id=planned_item_id,
+            status="failed",
+            latest_job_id=latest_job_id,
+            error_summary=str(exc) or "Media ingest failed",
+        )
+        raise
     finally:
         if db is not None:
             with contextlib.suppress(Exception):

--- a/tldw_Server_API/tests/Collections/test_conference_media_collections.py
+++ b/tldw_Server_API/tests/Collections/test_conference_media_collections.py
@@ -1,0 +1,255 @@
+import shutil
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def collections_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CollectionsDatabase:
+    base_dir = tmp_path / "user_dbs"
+    shutil.rmtree(base_dir, ignore_errors=True)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+
+    db = CollectionsDatabase.for_user(user_id=8042)
+    try:
+        yield db
+    finally:
+        db.close()
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+
+def test_conference_collection_persists_planned_and_resolved_items(
+    collections_db: CollectionsDatabase,
+) -> None:
+    collection = collections_db.create_media_collection(
+        name="PyCon 2026",
+        kind="conference",
+        description="Talks to ingest after the conference.",
+        source_url="https://www.youtube.com/playlist?list=PLpycon2026",
+        metadata={"conference_name": "PyCon", "event_year": "2026"},
+        default_tags=["pycon", "python"],
+    )
+    planned = collections_db.add_media_collection_item(
+        collection_id=collection.id,
+        source_url="https://www.youtube.com/watch?v=opening",
+        normalized_source_id="youtube:video:opening",
+        source_kind="youtube_video",
+        ordinal=1,
+        title="Opening Keynote",
+        speaker="Ada Lovelace",
+        published_at="2026-05-01",
+        status="planned",
+        tags=["keynote"],
+        metadata={"track": "Main"},
+    )
+
+    collections_db.resolve_media_collection_item(
+        planned.id,
+        media_id=123,
+        content_item_id=456,
+        status="completed",
+        latest_job_id="job-123",
+    )
+
+    loaded = collections_db.get_media_collection(collection.id)
+
+    assert loaded.id == collection.id
+    assert loaded.name == "PyCon 2026"
+    assert loaded.source_url == "https://www.youtube.com/playlist?list=PLpycon2026"
+    assert loaded.metadata["conference_name"] == "PyCon"
+    assert loaded.default_tags == ["pycon", "python"]
+    assert len(loaded.items) == 1
+    assert loaded.items[0].ordinal == 1
+    assert loaded.items[0].source_url == "https://www.youtube.com/watch?v=opening"
+    assert loaded.items[0].title == "Opening Keynote"
+    assert loaded.items[0].speaker == "Ada Lovelace"
+    assert loaded.items[0].metadata["track"] == "Main"
+    assert loaded.items[0].tags == ["keynote"]
+    assert loaded.items[0].status == "completed"
+    assert loaded.items[0].media_id == 123
+    assert loaded.items[0].content_item_id == 456
+    assert loaded.items[0].latest_job_id == "job-123"
+
+
+def test_planned_collection_items_do_not_create_or_overwrite_content_items(
+    collections_db: CollectionsDatabase,
+) -> None:
+    source_url = "https://www.youtube.com/watch?v=repeated"
+    collection = collections_db.create_media_collection(
+        name="Conference playlist",
+        kind="conference",
+    )
+
+    first_planned = collections_db.add_media_collection_item(
+        collection_id=collection.id,
+        source_url=source_url,
+        normalized_source_id="youtube:video:repeated",
+        source_kind="youtube_video",
+        title="Talk in the playlist",
+        status="planned",
+    )
+
+    assert first_planned.id > 0
+    assert collections_db.get_content_item_by_url(source_url) is None
+
+    resolved_content = collections_db.upsert_content_item(
+        origin="media",
+        origin_type="video",
+        origin_id=987,
+        url=source_url,
+        canonical_url=source_url,
+        domain="youtube.com",
+        title="Resolved media title",
+        summary=None,
+        content_hash=None,
+        word_count=None,
+        published_at=None,
+        status="completed",
+        media_id=987,
+        tags=["resolved"],
+    )
+
+    second_planned = collections_db.add_media_collection_item(
+        collection_id=collection.id,
+        source_url=source_url,
+        normalized_source_id="youtube:video:repeated",
+        source_kind="youtube_video",
+        title="Same talk appears twice in the plan",
+        status="planned",
+    )
+
+    content_after_plans = collections_db.get_content_item_by_url(source_url)
+    loaded = collections_db.get_media_collection(collection.id)
+
+    assert content_after_plans is not None
+    assert content_after_plans.id == resolved_content.id
+    assert content_after_plans.title == "Resolved media title"
+    assert [item.id for item in loaded.items] == [first_planned.id, second_planned.id]
+    assert [item.content_item_id for item in loaded.items] == [None, None]
+
+
+def test_media_collections_can_be_listed_updated_and_soft_deleted(
+    collections_db: CollectionsDatabase,
+) -> None:
+    collections_db.create_media_collection(name="Other", kind="manual")
+    conference = collections_db.create_media_collection(
+        name="Original title",
+        kind="conference",
+        metadata={"conference_name": "Original"},
+    )
+
+    updated = collections_db.update_media_collection(
+        conference.id,
+        name="Updated title",
+        metadata={"conference_name": "Updated"},
+        default_tags=["conference"],
+    )
+    listed, total = collections_db.list_media_collections(kind="conference", page=1, size=20)
+
+    assert updated.name == "Updated title"
+    assert updated.metadata["conference_name"] == "Updated"
+    assert updated.default_tags == ["conference"]
+    assert total == 1
+    assert [item.id for item in listed] == [conference.id]
+
+    assert collections_db.delete_media_collection(conference.id) is True
+
+    listed_after_delete, total_after_delete = collections_db.list_media_collections(
+        kind="conference",
+        page=1,
+        size=20,
+    )
+    assert total_after_delete == 0
+    assert listed_after_delete == []
+
+
+def test_media_collections_router_exposes_collection_crud(
+    collections_db: CollectionsDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "test-api-key-12345")
+
+    from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import (
+        get_collections_db_for_user,
+    )
+    from tldw_Server_API.app.api.v1.endpoints.media import collections as media_collections
+
+    app = FastAPI()
+    app.include_router(media_collections.router, prefix="/api/v1/media", tags=["media"])
+    app.dependency_overrides[get_collections_db_for_user] = lambda: collections_db
+
+    with TestClient(app) as client:
+        create_response = client.post(
+            "/api/v1/media/collections",
+            json={
+                "name": "Conference 2026",
+                "kind": "conference",
+                "source_url": "https://www.youtube.com/playlist?list=PLtest",
+                "metadata": {"conference_name": "Conference", "event_year": "2026"},
+                "default_tags": ["conference"],
+            },
+            headers={"X-API-KEY": "test-api-key-12345"},
+        )
+        assert create_response.status_code == 201, create_response.text
+        collection = create_response.json()
+        collection_id = collection["id"]
+
+        item_response = client.post(
+            f"/api/v1/media/collections/{collection_id}/items",
+            json={
+                "source_url": "https://www.youtube.com/watch?v=abc123",
+                "normalized_source_id": "youtube:video:abc123",
+                "source_kind": "youtube_video",
+                "ordinal": 1,
+                "title": "Opening Keynote",
+                "speaker": "Ada Lovelace",
+                "status": "planned",
+                "metadata": {"track": "Main"},
+                "tags": ["keynote"],
+            },
+            headers={"X-API-KEY": "test-api-key-12345"},
+        )
+        assert item_response.status_code == 201, item_response.text
+        item_id = item_response.json()["id"]
+
+        patch_response = client.patch(
+            f"/api/v1/media/collections/{collection_id}/items/{item_id}",
+            json={
+                "status": "completed",
+                "media_id": 321,
+                "content_item_id": 654,
+                "latest_job_id": "job-321",
+            },
+            headers={"X-API-KEY": "test-api-key-12345"},
+        )
+        assert patch_response.status_code == 200, patch_response.text
+        assert patch_response.json()["status"] == "completed"
+
+        get_response = client.get(
+            f"/api/v1/media/collections/{collection_id}",
+            headers={"X-API-KEY": "test-api-key-12345"},
+        )
+        assert get_response.status_code == 200, get_response.text
+        loaded = get_response.json()
+        assert loaded["metadata"]["conference_name"] == "Conference"
+        assert loaded["items"][0]["media_id"] == 321
+        assert loaded["items"][0]["content_item_id"] == 654

--- a/tldw_Server_API/tests/Collections/test_conference_media_collections.py
+++ b/tldw_Server_API/tests/Collections/test_conference_media_collections.py
@@ -17,8 +17,7 @@ def collections_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Collectio
     base_dir = tmp_path / "user_dbs"
     shutil.rmtree(base_dir, ignore_errors=True)
     base_dir.mkdir(parents=True, exist_ok=True)
-    prev_base_dir = settings.get("USER_DB_BASE_DIR")
-    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setattr(settings, "USER_DB_BASE_DIR", str(base_dir), raising=False)
     monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
 
     db = CollectionsDatabase.for_user(user_id=8042)
@@ -26,13 +25,6 @@ def collections_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Collectio
         yield db
     finally:
         db.close()
-        if prev_base_dir is not None:
-            settings.USER_DB_BASE_DIR = prev_base_dir
-        else:
-            try:
-                del settings.USER_DB_BASE_DIR
-            except AttributeError:
-                pass
 
 
 def test_conference_collection_persists_planned_and_resolved_items(
@@ -143,6 +135,73 @@ def test_planned_collection_items_do_not_create_or_overwrite_content_items(
     assert content_after_plans.title == "Resolved media title"
     assert [item.id for item in loaded.items] == [first_planned.id, second_planned.id]
     assert [item.content_item_id for item in loaded.items] == [None, None]
+
+
+def test_collection_item_ordinals_are_unique_within_collection(
+    collections_db: CollectionsDatabase,
+) -> None:
+    collection = collections_db.create_media_collection(
+        name="Conference playlist",
+        kind="conference",
+    )
+    first = collections_db.add_media_collection_item(
+        collection_id=collection.id,
+        source_url="https://example.com/talk-1",
+        ordinal=1,
+        status="planned",
+    )
+    second = collections_db.add_media_collection_item(
+        collection_id=collection.id,
+        source_url="https://example.com/talk-2",
+        ordinal=2,
+        status="planned",
+    )
+
+    with pytest.raises(ValueError, match="media_collection_item_ordinal_duplicate"):
+        collections_db.add_media_collection_item(
+            collection_id=collection.id,
+            source_url="https://example.com/talk-duplicate",
+            ordinal=1,
+            status="planned",
+        )
+
+    with pytest.raises(ValueError, match="media_collection_item_ordinal_duplicate"):
+        collections_db.update_media_collection_item(second.id, ordinal=first.ordinal)
+
+
+def test_resolving_collection_item_clears_stale_failure_metadata(
+    collections_db: CollectionsDatabase,
+) -> None:
+    collection = collections_db.create_media_collection(
+        name="Conference playlist",
+        kind="conference",
+    )
+    planned = collections_db.add_media_collection_item(
+        collection_id=collection.id,
+        source_url="https://example.com/talk-failed-once",
+        ordinal=1,
+        status="planned",
+    )
+    collections_db.update_media_collection_item_status(
+        planned.id,
+        status="failed",
+        error_summary="private video",
+        warnings=["download failed"],
+        latest_job_id="job-failed",
+    )
+
+    resolved = collections_db.resolve_media_collection_item(
+        planned.id,
+        media_id=123,
+        content_item_id=456,
+        status="completed",
+        latest_job_id="job-retry",
+    )
+
+    assert resolved.status == "completed"
+    assert resolved.error_summary is None
+    assert resolved.warnings == []
+    assert resolved.latest_job_id == "job-retry"
 
 
 def test_media_collections_can_be_listed_updated_and_soft_deleted(

--- a/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+++ b/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
@@ -159,6 +159,30 @@ def test_docs_info_exposes_audio_capabilities_from_audio_and_websocket_routes(
     assert safe_config["supported_features"] == safe_config["capabilities"]
 
 
+def test_docs_info_exposes_bulk_conference_ingest_capabilities(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.txt"
+    _write_minimal_config(config_path)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("ROUTES_DISABLE", raising=False)
+    monkeypatch.delenv("ROUTES_ENABLE", raising=False)
+    monkeypatch.delenv("MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED", raising=False)
+    config_mod._route_toggle_policy.cache_clear()
+
+    safe_config = config_info.load_safe_config()
+    caps = safe_config["capabilities"]
+
+    assert caps["hasMediaPlaylistPreflight"] is True
+    assert caps["hasMediaIngestJobs"] is True
+    assert caps["hasMediaIngestJobEvents"] is True
+    assert caps["hasMediaIngestWorker"] is False
+    assert caps["hasDurableMediaCollections"] is False
+    assert caps["hasKnowledgeQaMediaScope"] is False
+    assert safe_config["supported_features"] == caps
+
+
 def test_docs_info_disables_voice_transport_when_audio_websocket_route_disabled(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+++ b/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
@@ -178,7 +178,7 @@ def test_docs_info_exposes_bulk_conference_ingest_capabilities(
     assert caps["hasMediaIngestJobs"] is True
     assert caps["hasMediaIngestJobEvents"] is True
     assert caps["hasMediaIngestWorker"] is False
-    assert caps["hasDurableMediaCollections"] is False
+    assert caps["hasDurableMediaCollections"] is True
     assert caps["hasKnowledgeQaMediaScope"] is False
     assert safe_config["supported_features"] == caps
 

--- a/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+++ b/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
@@ -179,7 +179,7 @@ def test_docs_info_exposes_bulk_conference_ingest_capabilities(
     assert caps["hasMediaIngestJobEvents"] is True
     assert caps["hasMediaIngestWorker"] is False
     assert caps["hasDurableMediaCollections"] is True
-    assert caps["hasKnowledgeQaMediaScope"] is False
+    assert caps["hasKnowledgeQaMediaScope"] is True
     assert safe_config["supported_features"] == caps
 
 

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_add_deps_error_mapping.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_add_deps_error_mapping.py
@@ -152,6 +152,22 @@ async def test_get_add_media_form_sanitizes_urls_json_fallback_debug_log():
 
 
 @pytest.mark.asyncio
+async def test_get_add_media_form_carries_collection_fallback_binding_fields():
+    form = await media_add_deps.get_add_media_form(
+        **_form_kwargs(
+            urls=["https://example.test/watch"],
+            media_collection_id="42",
+            media_collection_item_id="88",
+            media_ingest_job_id="1234",
+        )
+    )
+
+    assert form.media_collection_id == "42"
+    assert form.media_collection_item_id == "88"
+    assert form.media_ingest_job_id == "1234"
+
+
+@pytest.mark.asyncio
 async def test_get_add_media_form_sanitizes_context_window_fallback_debug_log():
     raw_context_window_size = "/private/tmp/raw-secret-value?token=secret-token"
 

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from pathlib import Path
 
@@ -118,6 +119,116 @@ def test_submit_media_ingest_jobs_creates_one_job_per_item(
     assert Path(file_payload["source"]).exists()
 
     shutil.rmtree(file_payload["temp_dir"], ignore_errors=True)
+
+
+def test_submit_media_ingest_jobs_preserves_collection_item_binding(
+    media_ingest_jobs_client,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+
+    captured: list[dict] = []
+
+    from tldw_Server_API.app.core.Jobs import manager as jobs_manager
+
+    def fake_create_job(
+        self,
+        *,
+        payload,
+        batch_group=None,
+        **_kwargs,
+    ):
+        captured.append({"payload": payload, "batch_group": batch_group})
+        return {"id": len(captured), "uuid": f"u{len(captured)}", "status": "queued"}
+
+    def fake_get_job(self, job_id):
+        payload = captured[int(job_id) - 1]["payload"]
+        return {
+            "id": int(job_id),
+            "domain": "media_ingest",
+            "job_type": "media_ingest_item",
+            "owner_user_id": "1",
+            "status": "queued",
+            "created_at": "2026-01-01T00:00:00Z",
+            "started_at": None,
+            "completed_at": None,
+            "cancelled_at": None,
+            "cancellation_reason": None,
+            "progress_percent": 0.0,
+            "progress_message": "queued",
+            "payload": payload,
+            "result": None,
+            "error_message": None,
+        }
+
+    monkeypatch.setattr(jobs_manager.JobManager, "create_job", fake_create_job, raising=True)
+    monkeypatch.setattr(jobs_manager.JobManager, "get_job", fake_get_job, raising=True)
+
+    resp = media_ingest_jobs_client.post(
+        "/api/v1/media/ingest/jobs",
+        data={
+            "media_type": "video",
+            "urls": "https://www.youtube.com/watch?v=talk-1",
+            "media_collection_id": "42",
+            "planned_item_ids": json.dumps(["101"]),
+            "idempotency_keys": json.dumps(["conference-42-101-0"]),
+        },
+        headers={"X-API-KEY": "test-api-key-12345"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    job = body["jobs"][0]
+    assert job["collection_id"] == "42"
+    assert job["planned_item_id"] == "101"
+    assert job["idempotency_key"] == "conference-42-101-0"
+    assert captured[0]["payload"]["collection_id"] == "42"
+    assert captured[0]["payload"]["planned_item_id"] == "101"
+    assert captured[0]["payload"]["idempotency_key"] == "conference-42-101-0"
+
+    status_resp = media_ingest_jobs_client.get(
+        "/api/v1/media/ingest/jobs/1",
+        headers={"X-API-KEY": "test-api-key-12345"},
+    )
+
+    assert status_resp.status_code == 200, status_resp.text
+    status_body = status_resp.json()
+    assert status_body["collection_id"] == "42"
+    assert status_body["planned_item_id"] == "101"
+    assert status_body["idempotency_key"] == "conference-42-101-0"
+
+
+def test_submit_media_ingest_jobs_rejects_mismatched_collection_item_bindings(
+    media_ingest_jobs_client,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+
+    from tldw_Server_API.app.core.Jobs import manager as jobs_manager
+
+    def fake_create_job(self, **_kwargs):
+        raise AssertionError("job creation should not run when binding arrays do not match urls")
+
+    monkeypatch.setattr(jobs_manager.JobManager, "create_job", fake_create_job, raising=True)
+
+    resp = media_ingest_jobs_client.post(
+        "/api/v1/media/ingest/jobs",
+        data={
+            "media_type": "video",
+            "urls": [
+                "https://www.youtube.com/watch?v=talk-1",
+                "https://www.youtube.com/watch?v=talk-2",
+            ],
+            "media_collection_id": "42",
+            "planned_item_ids": json.dumps(["101"]),
+        },
+        headers={"X-API-KEY": "test-api-key-12345"},
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "planned_item_ids must match the number of URL items" in resp.text
 
 
 def test_submit_media_ingest_jobs_sanitizes_upload_staging_failure(
@@ -297,6 +408,58 @@ def test_submit_media_ingest_jobs_returns_429_for_concurrent_job_limit(
 
     assert resp.status_code == 429, resp.text
     assert resp.json()["detail"] == "User 1 has reached the maximum concurrent job limit (5)"
+
+
+def test_submit_media_ingest_jobs_marks_planned_item_submit_failed_on_job_error(
+    media_ingest_jobs_client,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+
+    from tldw_Server_API.app.api.v1.endpoints.media import ingest_jobs
+    from tldw_Server_API.app.core.Jobs import manager as jobs_manager
+
+    status_updates: list[dict] = []
+
+    class _FakeCollectionsDatabase:
+        @classmethod
+        def for_user(cls, user_id):  # noqa: ARG003
+            return cls()
+
+        def update_media_collection_item_status(self, item_id, **kwargs):
+            status_updates.append({"item_id": item_id, **kwargs})
+
+        def close(self):
+            return None
+
+    def fake_create_job(self, **_kwargs):
+        raise BadRequestError("queue unavailable")
+
+    monkeypatch.setattr(ingest_jobs, "CollectionsDatabase", _FakeCollectionsDatabase, raising=False)
+    monkeypatch.setattr(jobs_manager.JobManager, "create_job", fake_create_job, raising=True)
+
+    resp = media_ingest_jobs_client.post(
+        "/api/v1/media/ingest/jobs",
+        data={
+            "media_type": "video",
+            "urls": "https://example.com/talk-submit-fails",
+            "media_collection_id": "42",
+            "planned_item_ids": json.dumps(["101"]),
+        },
+        headers={"X-API-KEY": "test-api-key-12345"},
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "queue unavailable"
+    assert status_updates == [
+        {
+            "item_id": 101,
+            "status": "submit_failed",
+            "latest_job_id": None,
+            "error_summary": "queue unavailable",
+        }
+    ]
 
 
 def test_submit_media_ingest_jobs_routes_heavy_request_to_default_queue_when_heavy_worker_unavailable(

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
@@ -417,49 +417,53 @@ def test_submit_media_ingest_jobs_marks_planned_item_submit_failed_on_job_error(
 ):
     monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
 
-    from tldw_Server_API.app.api.v1.endpoints.media import ingest_jobs
+    from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import (
+        try_get_collections_db_for_user,
+    )
     from tldw_Server_API.app.core.Jobs import manager as jobs_manager
 
     status_updates: list[dict] = []
 
     class _FakeCollectionsDatabase:
-        @classmethod
-        def for_user(cls, user_id):  # noqa: ARG003
-            return cls()
-
         def update_media_collection_item_status(self, item_id, **kwargs):
             status_updates.append({"item_id": item_id, **kwargs})
 
-        def close(self):
-            return None
+    async def _collections_db_override():
+        return _FakeCollectionsDatabase()
 
     def fake_create_job(self, **_kwargs):
         raise BadRequestError("queue unavailable")
 
-    monkeypatch.setattr(ingest_jobs, "CollectionsDatabase", _FakeCollectionsDatabase, raising=False)
     monkeypatch.setattr(jobs_manager.JobManager, "create_job", fake_create_job, raising=True)
+    media_ingest_jobs_client.app.dependency_overrides[try_get_collections_db_for_user] = _collections_db_override
 
-    resp = media_ingest_jobs_client.post(
-        "/api/v1/media/ingest/jobs",
-        data={
-            "media_type": "video",
-            "urls": "https://example.com/talk-submit-fails",
-            "media_collection_id": "42",
-            "planned_item_ids": json.dumps(["101"]),
-        },
-        headers={"X-API-KEY": "test-api-key-12345"},
-    )
+    try:
+        resp = media_ingest_jobs_client.post(
+            "/api/v1/media/ingest/jobs",
+            data={
+                "media_type": "video",
+                "urls": "https://example.com/talk-submit-fails",
+                "media_collection_id": "42",
+                "planned_item_ids": json.dumps(["101"]),
+            },
+            headers={"X-API-KEY": "test-api-key-12345"},
+        )
 
-    assert resp.status_code == 400, resp.text
-    assert resp.json()["detail"] == "queue unavailable"
-    assert status_updates == [
-        {
-            "item_id": 101,
-            "status": "submit_failed",
-            "latest_job_id": None,
-            "error_summary": "queue unavailable",
-        }
-    ]
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"] == "queue unavailable"
+        assert status_updates == [
+            {
+                "item_id": 101,
+                "status": "submit_failed",
+                "latest_job_id": None,
+                "error_summary": "queue unavailable",
+            }
+        ]
+    finally:
+        media_ingest_jobs_client.app.dependency_overrides.pop(
+            try_get_collections_db_for_user,
+            None,
+        )
 
 
 def test_submit_media_ingest_jobs_routes_heavy_request_to_default_queue_when_heavy_worker_unavailable(

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py
@@ -466,6 +466,82 @@ def test_submit_media_ingest_jobs_marks_planned_item_submit_failed_on_job_error(
         )
 
 
+def test_submit_media_ingest_jobs_keeps_created_url_jobs_when_later_url_fails(
+    media_ingest_jobs_client,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+
+    from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import (
+        try_get_collections_db_for_user,
+    )
+    from tldw_Server_API.app.core.Jobs import manager as jobs_manager
+
+    captured_payloads: list[dict] = []
+    status_updates: list[dict] = []
+
+    class _FakeCollectionsDatabase:
+        def update_media_collection_item_status(self, item_id, **kwargs):
+            status_updates.append({"item_id": item_id, **kwargs})
+
+    async def _collections_db_override():
+        return _FakeCollectionsDatabase()
+
+    def fake_create_job(self, *, payload, **_kwargs):
+        captured_payloads.append(payload)
+        if payload["source"].endswith("talk-2"):
+            raise BadRequestError("queue unavailable")
+        return {"id": len(captured_payloads), "uuid": f"u{len(captured_payloads)}", "status": "queued"}
+
+    monkeypatch.setattr(jobs_manager.JobManager, "create_job", fake_create_job, raising=True)
+    media_ingest_jobs_client.app.dependency_overrides[try_get_collections_db_for_user] = _collections_db_override
+
+    try:
+        resp = media_ingest_jobs_client.post(
+            "/api/v1/media/ingest/jobs",
+            data={
+                "media_type": "video",
+                "urls": [
+                    "https://example.com/talk-1",
+                    "https://example.com/talk-2",
+                ],
+                "media_collection_id": "42",
+                "planned_item_ids": json.dumps(["101", "102"]),
+            },
+            headers={"X-API-KEY": "test-api-key-12345"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["jobs"] == [
+            {
+                "id": 1,
+                "uuid": "u1",
+                "source": "https://example.com/talk-1",
+                "source_kind": "url",
+                "status": "queued",
+                "collection_id": "42",
+                "planned_item_id": "101",
+                "idempotency_key": None,
+            }
+        ]
+        assert body["errors"] == ["https://example.com/talk-2: queue unavailable"]
+        assert status_updates == [
+            {
+                "item_id": 102,
+                "status": "submit_failed",
+                "latest_job_id": None,
+                "error_summary": "queue unavailable",
+            }
+        ]
+    finally:
+        media_ingest_jobs_client.app.dependency_overrides.pop(
+            try_get_collections_db_for_user,
+            None,
+        )
+
+
 def test_submit_media_ingest_jobs_routes_heavy_request_to_default_queue_when_heavy_worker_unavailable(
     media_ingest_jobs_client,
     monkeypatch,

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -4,6 +4,32 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+class _CollectionUpdateRecorder:
+    def __init__(self) -> None:
+        self.status_updates: list[dict] = []
+        self.resolutions: list[dict] = []
+
+    def update_media_collection_item_status(self, item_id: int, **kwargs):
+        self.status_updates.append({"item_id": item_id, **kwargs})
+        return {"id": item_id, **kwargs}
+
+    def resolve_media_collection_item(self, item_id: int, **kwargs):
+        self.resolutions.append({"item_id": item_id, **kwargs})
+        return {"id": item_id, **kwargs}
+
+    def close(self):
+        return None
+
+
+def _install_fake_collections_db(monkeypatch, worker, recorder: _CollectionUpdateRecorder):
+    class _FakeCollectionsDatabase:
+        @classmethod
+        def for_user(cls, user_id):  # noqa: ARG003
+            return recorder
+
+    monkeypatch.setattr(worker, "CollectionsDatabase", _FakeCollectionsDatabase, raising=False)
+
+
 @pytest.mark.asyncio
 async def test_media_ingest_worker_honors_cancel_before_processing(monkeypatch, tmp_path):
     monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
@@ -47,6 +73,292 @@ async def test_media_ingest_worker_honors_cancel_before_processing(monkeypatch, 
     updated = jm.get_job(job_id)
     assert updated is not None
     assert updated.get("status") == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_media_ingest_worker_marks_planned_collection_item_completed(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    recorder = _CollectionUpdateRecorder()
+    _install_fake_collections_db(monkeypatch, worker, recorder)
+
+    class _DummyDB:
+        db_path_str = str(tmp_path / "media.db")
+        client_id = "media_ingest_test"
+
+        def close_connection(self):
+            return None
+
+    async def _fake_process_batch_media(**_kwargs):
+        return [
+            {
+                "status": "Success",
+                "db_id": 456,
+                "media_uuid": "media-uuid-456",
+                "warnings": None,
+                "db_message": "Media added to database.",
+            }
+        ]
+
+    async def _fake_chunking_resolver(*_args, **_kwargs):
+        return None, None
+
+    monkeypatch.setattr(worker, "_create_db", lambda _user_id: _DummyDB(), raising=True)
+    monkeypatch.setattr(worker, "process_batch_media", _fake_process_batch_media, raising=True)
+    monkeypatch.setattr(
+        worker,
+        "async_resolve_chunking_options_and_plan",
+        _fake_chunking_resolver,
+        raising=True,
+    )
+
+    jm = JobManager()
+    row = jm.create_job(
+        domain="media_ingest",
+        queue="default",
+        job_type="media_ingest_item",
+        payload={
+            "batch_id": "batch-conf-complete",
+            "media_type": "video",
+            "source": "https://example.com/talk-1",
+            "source_kind": "url",
+            "input_ref": "https://example.com/talk-1",
+            "collection_id": "42",
+            "planned_item_id": "101",
+            "idempotency_key": "conference-42-101-0",
+            "options": {"media_type": "video"},
+        },
+        owner_user_id="1",
+    )
+
+    result = await worker._handle_job(
+        jm.get_job(int(row.get("id"))),
+        jm,
+        worker._ProgressState(),
+    )
+
+    assert result["media_id"] == 456
+    assert recorder.status_updates == [
+        {
+            "item_id": 101,
+            "status": "processing",
+            "latest_job_id": str(row.get("id")),
+        }
+    ]
+    assert recorder.resolutions == [
+        {
+            "item_id": 101,
+            "media_id": 456,
+            "status": "completed",
+            "latest_job_id": str(row.get("id")),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_media_ingest_worker_marks_duplicate_result_skipped_existing(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    recorder = _CollectionUpdateRecorder()
+    _install_fake_collections_db(monkeypatch, worker, recorder)
+
+    class _DummyDB:
+        db_path_str = str(tmp_path / "media.db")
+        client_id = "media_ingest_test"
+
+        def close_connection(self):
+            return None
+
+    async def _fake_process_batch_media(**_kwargs):
+        return [
+            {
+                "status": "Skipped",
+                "db_id": 789,
+                "media_uuid": "existing-media-uuid",
+                "warnings": None,
+                "db_message": "Media already exists.",
+            }
+        ]
+
+    async def _fake_chunking_resolver(*_args, **_kwargs):
+        return None, None
+
+    monkeypatch.setattr(worker, "_create_db", lambda _user_id: _DummyDB(), raising=True)
+    monkeypatch.setattr(worker, "process_batch_media", _fake_process_batch_media, raising=True)
+    monkeypatch.setattr(
+        worker,
+        "async_resolve_chunking_options_and_plan",
+        _fake_chunking_resolver,
+        raising=True,
+    )
+
+    jm = JobManager()
+    row = jm.create_job(
+        domain="media_ingest",
+        queue="default",
+        job_type="media_ingest_item",
+        payload={
+            "batch_id": "batch-conf-skip",
+            "media_type": "video",
+            "source": "https://example.com/talk-2",
+            "source_kind": "url",
+            "input_ref": "https://example.com/talk-2",
+            "collection_id": "42",
+            "planned_item_id": "102",
+            "options": {"media_type": "video"},
+        },
+        owner_user_id="1",
+    )
+
+    await worker._handle_job(jm.get_job(int(row.get("id"))), jm, worker._ProgressState())
+
+    assert recorder.resolutions == [
+        {
+            "item_id": 102,
+            "media_id": 789,
+            "status": "skipped_existing",
+            "latest_job_id": str(row.get("id")),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_media_ingest_worker_marks_missing_media_id_failed(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    recorder = _CollectionUpdateRecorder()
+    _install_fake_collections_db(monkeypatch, worker, recorder)
+
+    class _DummyDB:
+        db_path_str = str(tmp_path / "media.db")
+        client_id = "media_ingest_test"
+
+        def close_connection(self):
+            return None
+
+    async def _fake_process_batch_media(**_kwargs):
+        return [
+            {
+                "status": "Success",
+                "media_uuid": None,
+                "warnings": None,
+                "db_message": "Media was accepted without a row id.",
+            }
+        ]
+
+    async def _fake_chunking_resolver(*_args, **_kwargs):
+        return None, None
+
+    monkeypatch.setattr(worker, "_create_db", lambda _user_id: _DummyDB(), raising=True)
+    monkeypatch.setattr(worker, "process_batch_media", _fake_process_batch_media, raising=True)
+    monkeypatch.setattr(
+        worker,
+        "async_resolve_chunking_options_and_plan",
+        _fake_chunking_resolver,
+        raising=True,
+    )
+
+    jm = JobManager()
+    row = jm.create_job(
+        domain="media_ingest",
+        queue="default",
+        job_type="media_ingest_item",
+        payload={
+            "batch_id": "batch-conf-no-media-id",
+            "media_type": "video",
+            "source": "https://example.com/talk-no-media-id",
+            "source_kind": "url",
+            "input_ref": "https://example.com/talk-no-media-id",
+            "collection_id": "42",
+            "planned_item_id": "104",
+            "options": {"media_type": "video"},
+        },
+        owner_user_id="1",
+    )
+
+    await worker._handle_job(jm.get_job(int(row.get("id"))), jm, worker._ProgressState())
+
+    assert recorder.resolutions == []
+    assert recorder.status_updates[-1] == {
+        "item_id": 104,
+        "status": "failed",
+        "latest_job_id": str(row.get("id")),
+        "error_summary": "No media id returned",
+    }
+
+
+@pytest.mark.asyncio
+async def test_media_ingest_worker_marks_planned_collection_item_failed_on_exception(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    recorder = _CollectionUpdateRecorder()
+    _install_fake_collections_db(monkeypatch, worker, recorder)
+
+    class _DummyDB:
+        db_path_str = str(tmp_path / "media.db")
+        client_id = "media_ingest_test"
+
+        def close_connection(self):
+            return None
+
+    async def _fake_process_batch_media(**_kwargs):
+        raise RuntimeError("private video")
+
+    async def _fake_chunking_resolver(*_args, **_kwargs):
+        return None, None
+
+    monkeypatch.setattr(worker, "_create_db", lambda _user_id: _DummyDB(), raising=True)
+    monkeypatch.setattr(worker, "process_batch_media", _fake_process_batch_media, raising=True)
+    monkeypatch.setattr(
+        worker,
+        "async_resolve_chunking_options_and_plan",
+        _fake_chunking_resolver,
+        raising=True,
+    )
+
+    jm = JobManager()
+    row = jm.create_job(
+        domain="media_ingest",
+        queue="default",
+        job_type="media_ingest_item",
+        payload={
+            "batch_id": "batch-conf-fail",
+            "media_type": "video",
+            "source": "https://example.com/private-talk",
+            "source_kind": "url",
+            "input_ref": "https://example.com/private-talk",
+            "collection_id": "42",
+            "planned_item_id": "103",
+            "options": {"media_type": "video"},
+        },
+        owner_user_id="1",
+    )
+
+    with pytest.raises(RuntimeError, match="private video"):
+        await worker._handle_job(jm.get_job(int(row.get("id"))), jm, worker._ProgressState())
+
+    assert recorder.status_updates[-1] == {
+        "item_id": 103,
+        "status": "failed",
+        "latest_job_id": str(row.get("id")),
+        "error_summary": "private video",
+    }
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -30,6 +30,27 @@ def _install_fake_collections_db(monkeypatch, worker, recorder: _CollectionUpdat
     monkeypatch.setattr(worker, "CollectionsDatabase", _FakeCollectionsDatabase, raising=False)
 
 
+def test_truncate_collection_error_redacts_sensitive_details():
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    raw = (
+        "failed token=super-secret at /private/tmp/video.mp4 "
+        "url=https://example.com/watch?api_key=secret-value "
+        "hash=0123456789abcdef0123456789abcdef"
+    )
+
+    sanitized = worker._truncate_collection_error(raw)
+
+    assert sanitized is not None
+    assert "super-secret" not in sanitized
+    assert "secret-value" not in sanitized
+    assert "/private/tmp/video.mp4" not in sanitized
+    assert "0123456789abcdef0123456789abcdef" not in sanitized
+    assert "[redacted]" in sanitized
+    assert "[redacted-path]" in sanitized
+    assert "[redacted-hex]" in sanitized
+
+
 @pytest.mark.asyncio
 async def test_media_ingest_worker_honors_cancel_before_processing(monkeypatch, tmp_path):
     monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_collections_dual_write.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_collections_dual_write.py
@@ -166,6 +166,109 @@ def test_sync_media_add_results_resolves_planned_collection_item(monkeypatch):
     ]
 
 
+def test_sync_media_add_results_uses_per_result_planned_item_ids_for_batch(monkeypatch):
+    _FakeCollectionsDatabase.reset()
+    monkeypatch.setattr(
+        collections_db_module,
+        "CollectionsDatabase",
+        _FakeCollectionsDatabase,
+    )
+
+    results = [
+        {
+            "status": "Success",
+            "db_id": "456",
+            "input_ref": "https://example.com/conf-talk-1",
+            "processing_source": "https://example.com/conf-talk-1",
+            "media_type": "video",
+            "planned_item_id": "88",
+        },
+        {
+            "status": "Success",
+            "db_id": "789",
+            "input_ref": "https://example.com/conf-talk-2",
+            "processing_source": "https://example.com/conf-talk-2",
+            "media_type": "video",
+            "media_collection_item_id": "89",
+        },
+    ]
+
+    persistence.sync_media_add_results_to_collections(
+        results=results,
+        form_data=SimpleNamespace(
+            media_type="video",
+            keywords=[],
+            media_ingest_job_id="1234",
+        ),
+        current_user=SimpleNamespace(id=42),
+        db=SimpleNamespace(backend=object()),
+    )
+
+    instance = _FakeCollectionsDatabase.last_instance
+    assert instance is not None
+    assert instance.resolve_calls == [
+        {
+            "item_id": 88,
+            "media_id": 456,
+            "status": "completed",
+            "latest_job_id": "1234",
+        },
+        {
+            "item_id": 89,
+            "media_id": 789,
+            "status": "completed",
+            "latest_job_id": "1234",
+        },
+    ]
+
+
+def test_sync_media_add_results_does_not_reuse_form_planned_item_id_for_batch(monkeypatch):
+    _FakeCollectionsDatabase.reset()
+    monkeypatch.setattr(
+        collections_db_module,
+        "CollectionsDatabase",
+        _FakeCollectionsDatabase,
+    )
+
+    results = [
+        {
+            "status": "Success",
+            "db_id": "456",
+            "input_ref": "https://example.com/conf-talk-1",
+            "processing_source": "https://example.com/conf-talk-1",
+            "media_type": "video",
+        },
+        {
+            "status": "Success",
+            "db_id": "789",
+            "input_ref": "https://example.com/conf-talk-2",
+            "processing_source": "https://example.com/conf-talk-2",
+            "media_type": "video",
+        },
+    ]
+
+    persistence.sync_media_add_results_to_collections(
+        results=results,
+        form_data=SimpleNamespace(
+            media_type="video",
+            keywords=[],
+            media_collection_item_id="88",
+            media_ingest_job_id="1234",
+        ),
+        current_user=SimpleNamespace(id=42),
+        db=SimpleNamespace(backend=object()),
+    )
+
+    instance = _FakeCollectionsDatabase.last_instance
+    assert instance is not None
+    assert instance.resolve_calls == []
+    assert all(
+        "Skipped collection item resolution: missing per-result planned item id for batch ingest."
+        in result.get("warnings", [])
+        for result in results
+    )
+
+
 def test_sync_media_add_results_to_collections_adds_warning_on_failure(monkeypatch):
     _FakeCollectionsDatabase.reset()
     _FakeCollectionsDatabase.should_raise = True

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_collections_dual_write.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_persistence_collections_dual_write.py
@@ -20,6 +20,7 @@ class _FakeCollectionsDatabase:
 
     def __init__(self) -> None:
         self.upsert_calls: list[dict[str, Any]] = []
+        self.resolve_calls: list[dict[str, Any]] = []
         self.closed = False
         _FakeCollectionsDatabase.last_instance = self
 
@@ -45,6 +46,10 @@ class _FakeCollectionsDatabase:
         if self.should_raise:
             raise RuntimeError("collections failure")
         return SimpleNamespace(id=901)
+
+    def resolve_media_collection_item(self, item_id: int, **kwargs: Any) -> Any:
+        self.resolve_calls.append({"item_id": item_id, **kwargs})
+        return SimpleNamespace(id=item_id)
 
     def close(self) -> None:
         self.closed = True
@@ -117,6 +122,48 @@ def test_sync_media_add_results_to_collections_writes_expected_payload(monkeypat
 
     assert results[0]["collections_item_id"] == 901
     assert results[0]["collections_origin"] == "media_add"
+
+
+def test_sync_media_add_results_resolves_planned_collection_item(monkeypatch):
+    _FakeCollectionsDatabase.reset()
+    monkeypatch.setattr(
+        collections_db_module,
+        "CollectionsDatabase",
+        _FakeCollectionsDatabase,
+    )
+
+    results = [
+        {
+            "status": "Success",
+            "db_id": "456",
+            "input_ref": "https://example.com/conf-talk",
+            "processing_source": "https://example.com/conf-talk",
+            "media_type": "video",
+        }
+    ]
+
+    persistence.sync_media_add_results_to_collections(
+        results=results,
+        form_data=SimpleNamespace(
+            media_type="video",
+            keywords=[],
+            media_collection_item_id="88",
+            media_ingest_job_id="1234",
+        ),
+        current_user=SimpleNamespace(id=42),
+        db=SimpleNamespace(backend=object()),
+    )
+
+    instance = _FakeCollectionsDatabase.last_instance
+    assert instance is not None
+    assert instance.resolve_calls == [
+        {
+            "item_id": 88,
+            "media_id": 456,
+            "status": "completed",
+            "latest_job_id": "1234",
+        }
+    ]
 
 
 def test_sync_media_add_results_to_collections_adds_warning_on_failure(monkeypatch):

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
@@ -1,0 +1,162 @@
+import pytest
+
+from tldw_Server_API.app.core.Ingestion_Media_Processing.Video.playlist_preflight import (
+    classify_playlist_url,
+    extract_playlist_preflight,
+    normalize_preflight_items,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_youtube_watch_list_url_detects_playlist_context():
+    parsed = classify_playlist_url(
+        "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B"
+    )
+
+    assert parsed.source_kind == "youtube_watch_playlist"
+    assert parsed.playlist_id == "PL0065D9B288E6804B"
+    assert parsed.video_id == "PrNmmN6qBiw"
+    assert parsed.is_playlist is True
+
+
+def test_preflight_duplicate_in_batch_uses_normalized_source_id():
+    items = normalize_preflight_items(
+        [
+            {"source_url": "https://youtu.be/abc123", "title": "A"},
+            {"source_url": "https://www.youtube.com/watch?v=abc123", "title": "A duplicate"},
+        ]
+    )
+
+    assert [item.duplicate_status for item in items] == [
+        "new",
+        "duplicate_in_batch",
+    ]
+    assert items[1].duplicate_of_ordinal == 1
+
+
+def test_generic_entry_id_is_not_assumed_to_be_youtube_video():
+    items = normalize_preflight_items(
+        [
+            {
+                "id": "generic-entry-123",
+                "url": "generic-entry-123",
+                "title": "Conference archive page",
+            }
+        ]
+    )
+
+    assert items[0].source_url == "generic-entry-123"
+    assert items[0].normalized_source_id == "url:generic-entry-123"
+
+
+def test_extract_playlist_preflight_rejects_single_video_url():
+    class FakeYoutubeDL:
+        def __init__(self, _opts):
+            pass
+
+        def __enter__(self):
+            raise AssertionError("single-video URLs should fail before yt-dlp extraction")
+
+        def __exit__(self, *_args):
+            return False
+
+    with pytest.raises(ValueError, match="not_playlist_url"):
+        extract_playlist_preflight(
+            "https://www.youtube.com/watch?v=abc123",
+            youtube_dl_cls=FakeYoutubeDL,
+        )
+
+
+def test_extract_playlist_preflight_uses_metadata_only_ytdlp_options():
+    calls = []
+
+    class FakeYoutubeDL:
+        def __init__(self, opts):
+            self.opts = opts
+
+        def __enter__(self):
+            calls.append(("enter", self.opts))
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def extract_info(self, url, *, download):
+            calls.append(("extract", url, download))
+            return {
+                "id": "PLtest",
+                "title": "Conference 2010",
+                "webpage_url": "https://www.youtube.com/playlist?list=PLtest",
+                "entries": [
+                    {
+                        "id": "abc123",
+                        "url": "abc123",
+                        "title": "Opening Keynote",
+                        "duration": 120,
+                        "channel": "Conference Org",
+                    },
+                    {
+                        "id": "def456",
+                        "webpage_url": "https://www.youtube.com/watch?v=def456",
+                        "title": "Systems Talk",
+                        "duration": 240,
+                    },
+                ],
+            }
+
+    result = extract_playlist_preflight(
+        "https://www.youtube.com/playlist?list=PLtest",
+        max_items=10,
+        youtube_dl_cls=FakeYoutubeDL,
+    )
+
+    assert result.playlist_id == "PLtest"
+    assert result.playlist_title == "Conference 2010"
+    assert result.item_count == 2
+    assert [item.source_url for item in result.items] == [
+        "https://www.youtube.com/watch?v=abc123",
+        "https://www.youtube.com/watch?v=def456",
+    ]
+    assert calls[0][1]["skip_download"] is True
+    assert calls[0][1]["extract_flat"] is True
+    assert calls[1] == (
+        "extract",
+        "https://www.youtube.com/playlist?list=PLtest",
+        False,
+    )
+
+
+def test_extract_playlist_preflight_truncates_large_playlist():
+    class FakeYoutubeDL:
+        def __init__(self, _opts):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def extract_info(self, _url, *, download):
+            assert download is False
+            return {
+                "id": "PLtest",
+                "title": "Conference 2010",
+                "entries": [
+                    {"id": "abc123", "url": "abc123", "title": "Opening"},
+                    {"id": "def456", "url": "def456", "title": "Systems"},
+                    {"id": "ghi789", "url": "ghi789", "title": "Closing"},
+                ],
+            }
+
+    result = extract_playlist_preflight(
+        "https://www.youtube.com/playlist?list=PLtest",
+        max_items=2,
+        youtube_dl_cls=FakeYoutubeDL,
+    )
+
+    assert result.item_count == 2
+    assert result.selected_count == 2
+    assert result.warnings == ["Playlist truncated to 2 items."]

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
@@ -12,9 +12,7 @@ pytestmark = pytest.mark.unit
 
 
 def test_youtube_watch_list_url_detects_playlist_context():
-    parsed = classify_playlist_url(
-        "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B"
-    )
+    parsed = classify_playlist_url("https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B")
 
     assert parsed.source_kind == "youtube_watch_playlist"
     assert parsed.playlist_id == "PL0065D9B288E6804B"
@@ -50,6 +48,21 @@ def test_generic_entry_id_is_not_assumed_to_be_youtube_video():
 
     assert items[0].source_url == "generic-entry-123"
     assert items[0].normalized_source_id == "url:generic-entry-123"
+
+
+def test_preflight_item_without_source_is_not_selected():
+    items = normalize_preflight_items(
+        [
+            {
+                "ordinal": 1,
+                "title": "Private unavailable talk",
+            }
+        ]
+    )
+
+    assert items[0].source_url == ""
+    assert items[0].duplicate_status == "unknown"
+    assert items[0].selected is False
 
 
 def test_extract_playlist_preflight_rejects_single_video_url():
@@ -161,6 +174,41 @@ def test_extract_playlist_preflight_truncates_large_playlist():
     assert result.item_count == 2
     assert result.selected_count == 2
     assert result.warnings == ["Playlist truncated to 2 items."]
+
+
+def test_extract_playlist_preflight_warns_and_deselects_entry_without_source():
+    class FakeYoutubeDL:
+        def __init__(self, _opts):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def extract_info(self, _url, *, download):
+            assert download is False
+            return {
+                "id": "PLtest",
+                "title": "Conference 2010",
+                "entries": [
+                    {"title": "Private unavailable talk"},
+                ],
+            }
+
+    result = extract_playlist_preflight(
+        "https://www.youtube.com/playlist?list=PLtest",
+        max_items=10,
+        youtube_dl_cls=FakeYoutubeDL,
+    )
+
+    assert result.item_count == 1
+    assert result.selected_count == 0
+    assert result.duplicate_count == 1
+    assert result.warnings == ["Playlist entry 1 has no source URL."]
+    assert result.items[0].duplicate_status == "unknown"
+    assert result.items[0].selected is False
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight.py
@@ -4,6 +4,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.Video.playlist_prefligh
     classify_playlist_url,
     extract_playlist_preflight,
     normalize_preflight_items,
+    resolve_duplicate_policy_action,
 )
 
 
@@ -160,3 +161,42 @@ def test_extract_playlist_preflight_truncates_large_playlist():
     assert result.item_count == 2
     assert result.selected_count == 2
     assert result.warnings == ["Playlist truncated to 2 items."]
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_status", "expected_submit"),
+    [
+        ("skip", "skipped_existing", False),
+        ("overwrite", "planned", True),
+        ("update_metadata_only", "skipped_existing", False),
+        ("include_existing", "skipped_existing", False),
+    ],
+)
+def test_duplicate_policy_action_for_existing_duplicate(policy, expected_status, expected_submit):
+    action = resolve_duplicate_policy_action(
+        duplicate_status="duplicate_existing",
+        policy=policy,
+    )
+
+    assert action.planned_status == expected_status
+    assert action.should_submit_job is expected_submit
+
+
+def test_duplicate_policy_action_does_not_skip_new_items():
+    action = resolve_duplicate_policy_action(
+        duplicate_status="new",
+        policy="skip",
+    )
+
+    assert action.planned_status == "planned"
+    assert action.should_submit_job is True
+
+
+def test_duplicate_policy_action_does_not_skip_unknown_items():
+    action = resolve_duplicate_policy_action(
+        duplicate_status="unknown",
+        policy="skip",
+    )
+
+    assert action.planned_status == "planned"
+    assert action.should_submit_job is True

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py
@@ -1,0 +1,127 @@
+import pytest
+import time
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def playlist_preflight_client(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "test-api-key-12345")
+
+    from tldw_Server_API.app.api.v1.endpoints.media import playlist_preflight
+
+    app = FastAPI()
+    app.include_router(playlist_preflight.router, prefix="/api/v1/media", tags=["media"])
+    with TestClient(app) as client:
+        yield client, playlist_preflight
+
+
+def test_playlist_preflight_endpoint_returns_metadata_only_items(
+    playlist_preflight_client,
+    monkeypatch,
+):
+    client, playlist_preflight = playlist_preflight_client
+
+    from tldw_Server_API.app.api.v1.schemas.media_playlist_preflight import (
+        PlaylistPreflightItem,
+        PlaylistPreflightResponse,
+    )
+
+    def fake_preflight_playlist_url(url: str, *, max_items: int):
+        assert url == "https://www.youtube.com/playlist?list=PLtest"
+        assert max_items == 34
+        return PlaylistPreflightResponse(
+            source_url=url,
+            source_kind="youtube_playlist",
+            playlist_id="PLtest",
+            playlist_title="Conference 2010",
+            video_id=None,
+            item_count=1,
+            selected_count=1,
+            duplicate_count=0,
+            warnings=[],
+            items=[
+                PlaylistPreflightItem(
+                    ordinal=1,
+                    source_url="https://www.youtube.com/watch?v=abc123",
+                    normalized_source_id="youtube:video:abc123",
+                    source_kind="youtube_video",
+                    title="Opening Keynote",
+                    speaker="Conference Org",
+                    duration_seconds=120,
+                    published_at=None,
+                    thumbnail_url=None,
+                    duplicate_status="new",
+                    duplicate_of_ordinal=None,
+                    selected=True,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        playlist_preflight,
+        "preflight_playlist_url",
+        fake_preflight_playlist_url,
+        raising=True,
+    )
+
+    resp = client.post(
+        "/api/v1/media/playlists/preflight",
+        json={
+            "url": "https://www.youtube.com/playlist?list=PLtest",
+            "max_items": 34,
+        },
+        headers={"X-API-KEY": "test-api-key-12345"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["playlist_title"] == "Conference 2010"
+    assert body["items"][0]["source_url"] == "https://www.youtube.com/watch?v=abc123"
+    assert body["items"][0]["duplicate_status"] == "new"
+    assert "cookies" not in resp.text.lower()
+    assert "authorization" not in resp.text.lower()
+
+
+def test_playlist_preflight_endpoint_returns_timeout_status(
+    playlist_preflight_client,
+    monkeypatch,
+):
+    client, playlist_preflight = playlist_preflight_client
+
+    def slow_preflight_playlist_url(url: str, *, max_items: int):
+        assert url == "https://www.youtube.com/playlist?list=PLtest"
+        assert max_items == 34
+        time.sleep(1.2)
+        return {
+            "source_url": url,
+            "source_kind": "youtube_playlist",
+            "item_count": 0,
+            "selected_count": 0,
+            "duplicate_count": 0,
+        }
+
+    monkeypatch.setattr(
+        playlist_preflight,
+        "preflight_playlist_url",
+        slow_preflight_playlist_url,
+        raising=True,
+    )
+
+    resp = client.post(
+        "/api/v1/media/playlists/preflight",
+        json={
+            "url": "https://www.youtube.com/playlist?list=PLtest",
+            "max_items": 34,
+            "timeout_seconds": 1,
+        },
+        headers={"X-API-KEY": "test-api-key-12345"},
+    )
+
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "playlist_preflight_timeout"

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_playlist_preflight_endpoint.py
@@ -1,5 +1,6 @@
+import asyncio
+
 import pytest
-import time
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -94,22 +95,16 @@ def test_playlist_preflight_endpoint_returns_timeout_status(
 ):
     client, playlist_preflight = playlist_preflight_client
 
-    def slow_preflight_playlist_url(url: str, *, max_items: int):
-        assert url == "https://www.youtube.com/playlist?list=PLtest"
-        assert max_items == 34
-        time.sleep(1.2)
-        return {
-            "source_url": url,
-            "source_kind": "youtube_playlist",
-            "item_count": 0,
-            "selected_count": 0,
-            "duplicate_count": 0,
-        }
+    async def timeout_preflight(payload):
+        assert payload.url == "https://www.youtube.com/playlist?list=PLtest"
+        assert payload.max_items == 34
+        assert payload.timeout_seconds == 1
+        raise asyncio.TimeoutError
 
     monkeypatch.setattr(
         playlist_preflight,
-        "preflight_playlist_url",
-        slow_preflight_playlist_url,
+        "_run_preflight_with_timeout",
+        timeout_preflight,
         raising=True,
     )
 
@@ -125,3 +120,35 @@ def test_playlist_preflight_endpoint_returns_timeout_status(
 
     assert resp.status_code == 504
     assert resp.json()["detail"] == "playlist_preflight_timeout"
+
+
+def test_playlist_preflight_endpoint_maps_invalid_extractor_result_to_bad_gateway(
+    playlist_preflight_client,
+    monkeypatch,
+):
+    client, playlist_preflight = playlist_preflight_client
+
+    async def invalid_preflight_result(payload):
+        return {
+            "source_url": payload.url,
+            "source_kind": "youtube_playlist",
+        }
+
+    monkeypatch.setattr(
+        playlist_preflight,
+        "_run_preflight_with_timeout",
+        invalid_preflight_result,
+        raising=True,
+    )
+
+    resp = client.post(
+        "/api/v1/media/playlists/preflight",
+        json={
+            "url": "https://www.youtube.com/playlist?list=PLtest",
+            "max_items": 34,
+        },
+        headers={"X-API-KEY": "test-api-key-12345"},
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "playlist_preflight_invalid_result"

--- a/tldw_Server_API/tests/RAG/test_conference_collection_scope.py
+++ b/tldw_Server_API/tests/RAG/test_conference_collection_scope.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import HTTPException
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints.rag_unified import (
+    _apply_media_collection_scope,
+)
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import UnifiedRAGRequest
+
+
+class _FakeCollectionsDb:
+    def __init__(self, items: list[SimpleNamespace]) -> None:
+        self.items = items
+        self.requested_collection_id: int | None = None
+
+    def get_media_collection(self, collection_id: int) -> SimpleNamespace:
+        self.requested_collection_id = collection_id
+        return SimpleNamespace(id=collection_id, items=self.items)
+
+
+def _item(status: str, media_id: int | None) -> SimpleNamespace:
+    return SimpleNamespace(status=status, media_id=media_id)
+
+
+class _MissingCollectionDb:
+    def get_media_collection(self, collection_id: int) -> SimpleNamespace:
+        raise KeyError("media_collection_not_found")
+
+
+def test_conference_collection_scope_limits_rag_to_ready_media() -> None:
+    request = UnifiedRAGRequest(query="keynote", collection_id=7)
+    db = _FakeCollectionsDb(
+        [
+            _item("completed", 101),
+            _item("skipped_existing", 102),
+            _item("processing", 103),
+            _item("failed", 104),
+            _item("completed", None),
+        ]
+    )
+
+    scoped = _apply_media_collection_scope(request, db)
+
+    assert db.requested_collection_id == 7
+    assert scoped.include_media_ids == [101, 102]
+
+
+def test_conference_collection_scope_intersects_explicit_media_ids() -> None:
+    request = UnifiedRAGRequest(
+        query="keynote",
+        collection_id=7,
+        include_media_ids=[101, 999],
+    )
+    db = _FakeCollectionsDb(
+        [
+            _item("completed", 101),
+            _item("completed", 102),
+        ]
+    )
+
+    scoped = _apply_media_collection_scope(request, db)
+
+    assert scoped.include_media_ids == [101]
+
+
+def test_conference_collection_scope_fails_closed_when_nothing_is_ready() -> None:
+    request = UnifiedRAGRequest(query="keynote", collection_id=7)
+    db = _FakeCollectionsDb(
+        [
+            _item("planned", None),
+            _item("failed", 104),
+            _item("cancelled", 105),
+        ]
+    )
+
+    scoped = _apply_media_collection_scope(request, db)
+
+    assert scoped.include_media_ids == [-1]
+
+
+def test_conference_collection_scope_reports_missing_collection() -> None:
+    request = UnifiedRAGRequest(query="keynote", collection_id=7)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _apply_media_collection_scope(request, _MissingCollectionDb())
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "media_collection_not_found"


### PR DESCRIPTION
## Change summary

TODO: Human maintainer must write this before merge. This PR is materially AI-authored; per repo policy, the final merge gate requires a human-owned summary explaining what changed and why these implementation choices were made.

## Summary

- Adds the staged bulk conference playlist ingest workflow across Quick Ingest, backend playlist preflight, conference collections, Jobs-backed ingest tracking, results handoff, and review surfaces.
- Adds extension playlist handoff support, duplicate/failure recovery affordances, completion notification behavior, user docs, and mocked end-to-end workflow coverage.
- Stabilizes the media ingest Playwright baseline so the browser/offline path no longer fails on /media runtime overlays or the legacy review-route click race.

## Test plan

- [x] `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' ./node_modules/.bin/playwright test e2e/workflows/media-ingest.spec.ts -g "display interface|visible media page triggers|legacy review route to media-multi" --project=chromium --reporter=line` - 3 passed
- [x] `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' ./node_modules/.bin/playwright test e2e/workflows/media-ingest.spec.ts -g "conference playlist|extension playlist handoff" --project=chromium --reporter=line` - 2 passed
- [x] `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' ./node_modules/.bin/playwright test e2e/workflows/media-ingest.spec.ts -g "legacy review route to media-multi" --project=chromium --reporter=line` - 1 passed
- [x] `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' ./node_modules/.bin/playwright test e2e/workflows/media-ingest.spec.ts --project=chromium --reporter=line` - 18 passed, 12 skipped; skips are existing backend-dependent cases when the backend health fixture is unavailable
- [x] `git diff --check`

## Notes

- Stage-level Backlog task records TASK-399 through TASK-410 document the implementation slices and local verification notes.
- Kept as draft until the human-authored Change summary is supplied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bulk conference playlist ingest workflow with playlist preflight, durable media collections, jobs-backed tracking, a collection review page, and scoped Knowledge QA. Also adds an extension handoff, clearer failure/retry handling, and stabilizes ingest tests.

- New Features
  - Playlist preflight: detect YouTube playlist/watch URLs; metadata-only preview with duplicate detection, per-item selection, duplicate policy, batch tags/title, per-item overrides, and server-side timeout mapping.
  - Durable collections: create collection + planned items, submit only selected, map jobs to collection items; statuses include planned/processing/completed/skipped_existing/submit_failed/failed/cancelled; review route `/media-collections/:id` with ordered items, counts, nav, and Ask/Open CTAs.
  - Results and recovery: distinct submit_failed vs failed, export failed items, build retry payloads (only retry-eligible), open collection review on completion, improved floating progress summary; fallback ingest resolves planned items via AddMedia form bindings.
  - Knowledge QA: backend-owned `collection_id` scope with a small helper; Ask Collection CTA only when capability exists and items are ready.
  - Browser extension: detects active-tab playlist context and opens Quick Ingest with a typed `playlist_preflight` seed; collection review route available in the extension shell.
  - Capabilities: server exposes `hasMediaPlaylistPreflight`, `hasDurableMediaCollections`, `hasMediaIngestJobs`, `hasMediaIngestJobEvents`, `hasMediaIngestWorker`, and `hasKnowledgeQaMediaScope`; UI adapts accordingly.
  - Docs/tests: added Bulk Conference Playlist Ingest guide; broad unit/e2e coverage; stabilized Playwright media-ingest baselines.

- Migration
  - Requires backend support for `/api/v1/media/playlists/preflight`, `/api/v1/media/collections`, jobs binding to planned collection items, AddMedia fallback fields (`media_collection_id`, `media_collection_item_id`, `media_ingest_job_id`), and RAG `collection_id`; capabilities advertised via config-info.
  - No breaking changes; the flow degrades gracefully when capabilities are unavailable.

<sup>Written for commit e124d26f60af17338abfc7e73ea889d3051cd91e. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1814?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

