### PR TITLE
Reconcile llama.cpp runtime profiles

### DIFF
--- a/backlog/tasks/task-419 - Implement-llama.cpp-runtime-reconciliation.md
+++ b/backlog/tasks/task-419 - Implement-llama.cpp-runtime-reconciliation.md
@@ -1,0 +1,64 @@
+---
+id: TASK-419
+title: Implement llama.cpp runtime reconciliation
+status: Done
+labels:
+- llamacpp
+- local-llm
+- backend
+priority: medium
+documentation:
+- Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+modified_files:
+- tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_models.py
+- tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_reconciler.py
+- tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+- tldw_Server_API/app/services/startup_heavy_init.py
+- tldw_Server_API/app/services/shutdown_resource_cleanup.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_reconciler.py
+- tldw_Server_API/tests/Services/test_startup_heavy_init.py
+- tldw_Server_API/tests/Services/test_shutdown_resource_cleanup.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 1 from the llama.cpp managed runtime closeout plan: startup/shutdown reconciliation for autostart profiles, bounded restart behavior, and durable last-failure metadata.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Add tests covering autostart reconciliation, disabled/non-autostart skips, failed start metadata, max restart suppression, pause suppression, and shutdown behavior.
+- [x] #2 Add llama.cpp runtime reconciler service that delegates process ownership to the existing supervisor.
+- [x] #3 Persist bounded last runtime failure metadata without storing logs or raw environment.
+- [x] #4 Hook reconciliation into startup/shutdown lifecycle following existing service patterns.
+- [x] #5 Run focused backend tests, diff checks, and Bandit on touched Python paths before PR.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Used the existing supervisor/store boundary rather than adding a parallel process registry. The reconciler decides eligibility and delegates locking, launch, stop, and persistence through `LlamaCppSupervisor`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Task 1 from the llama.cpp managed runtime closeout plan. Added a thin LlamaCppRuntimeReconciler for autostart reconciliation, max restart suppression, pause-aware skips, and shutdown delegation. Added bounded durable last_runtime_failure metadata to profiles with supervisor helpers to record, clear, and expose failed runtime status after process restart. Wired reconciliation into local LLM startup and shutdown helpers. Verification: llama.cpp local focused suite 51 passed; service lifecycle suite 13 passed; runtime API suite 11 passed; git diff --check passed; ASCII scan found no non-ASCII in touched code; Bandit on touched app paths reported errors=0 and results=0.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-419 - Implement-llama.cpp-runtime-reconciliation.md
+++ b/backlog/tasks/task-419 - Implement-llama.cpp-runtime-reconciliation.md
@@ -16,6 +16,7 @@ modified_files:
 - tldw_Server_API/app/services/startup_heavy_init.py
 - tldw_Server_API/app/services/shutdown_resource_cleanup.py
 - tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_reconciler.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
 - tldw_Server_API/tests/Services/test_startup_heavy_init.py
 - tldw_Server_API/tests/Services/test_shutdown_resource_cleanup.py
 ---
@@ -50,7 +51,7 @@ Used the existing supervisor/store boundary rather than adding a parallel proces
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented Task 1 from the llama.cpp managed runtime closeout plan. Added a thin LlamaCppRuntimeReconciler for autostart reconciliation, max restart suppression, pause-aware skips, and shutdown delegation. Added bounded durable last_runtime_failure metadata to profiles with supervisor helpers to record, clear, and expose failed runtime status after process restart. Wired reconciliation into local LLM startup and shutdown helpers. Verification: llama.cpp local focused suite 51 passed; service lifecycle suite 13 passed; runtime API suite 11 passed; git diff --check passed; ASCII scan found no non-ASCII in touched code; Bandit on touched app paths reported errors=0 and results=0.
+Addressed PR #1816 review feedback. Reconciler shutdown is isolated from local LLM manager cleanup, supervisor shutdown now attempts every owned runner before reporting stop failures, reconstructed FAILED runtime state prefers the persisted resolved failure model_path, new helper functions have explicit docstrings, and startup/shutdown test helpers now have type hints. Verification: supervisor/reconciler focused suite 27 passed; service lifecycle focused suite 14 passed; broader llama.cpp local/API suite 64 passed; shutdown resource cleanup suite 9 passed after final signature cleanup; git diff --check passed; ASCII scan found no non-ASCII in touched code; Bandit on touched app paths reported errors=0 and results=0.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_models.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_models.py
@@ -47,6 +47,7 @@ class LlamaCppProfile(BaseModel):
     server_args: dict[str, object] = Field(default_factory=dict)
     autostart: bool = False
     restart_policy: dict[str, object] = Field(default_factory=dict)
+    last_runtime_failure: dict[str, object] = Field(default_factory=dict)
     provider_alias: str | None = None
     tags: list[str] = Field(default_factory=list)
 

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_reconciler.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_reconciler.py
@@ -88,6 +88,7 @@ class LlamaCppRuntimeReconciler:
 
 
 def _restart_count(profile: LlamaCppProfile) -> int:
+    """Return persisted restart attempts, treating missing or invalid metadata as zero."""
     try:
         return max(0, int(profile.last_runtime_failure.get("restart_count") or 0))
     except (TypeError, ValueError):
@@ -95,6 +96,7 @@ def _restart_count(profile: LlamaCppProfile) -> int:
 
 
 def _max_restarts(profile: LlamaCppProfile) -> int:
+    """Return the non-negative restart limit configured on a profile."""
     try:
         return max(0, int(profile.restart_policy.get("max_restarts") or 0))
     except (TypeError, ValueError):

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_reconciler.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_reconciler.py
@@ -1,0 +1,104 @@
+"""Startup and shutdown reconciliation for managed llama.cpp profiles."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
+    LlamaCppProfile,
+    LlamaCppRuntime,
+    LlamaCppRuntimeState,
+)
+from tldw_Server_API.app.core.Local_LLM.llamacpp_supervisor_service import LlamaCppSupervisor
+
+SleepCallable = Callable[[float], Awaitable[Any]]
+
+
+class LlamaCppRuntimeReconciler:
+    """Reconcile durable llama.cpp profile definitions with owned runners."""
+
+    def __init__(
+        self,
+        supervisor: LlamaCppSupervisor,
+        *,
+        sleep: SleepCallable = asyncio.sleep,
+    ) -> None:
+        self.supervisor = supervisor
+        self.sleep = sleep
+
+    async def reconcile_startup(self) -> list[LlamaCppRuntime]:
+        """Run one startup reconciliation pass for autostart profiles."""
+        return await self.reconcile_once()
+
+    async def reconcile_once(self) -> list[LlamaCppRuntime]:
+        """Start eligible autostart profiles and persist bounded failures."""
+        runtimes: list[LlamaCppRuntime] = []
+        for profile in self.supervisor.list_profiles():
+            if not self._should_reconcile(profile):
+                continue
+            runtime = self.supervisor.get_runtime(profile.profile_id)
+            if runtime.state in {LlamaCppRuntimeState.STARTING, LlamaCppRuntimeState.RUNNING}:
+                continue
+            if self._restart_limit_reached(profile):
+                runtimes.append(self.supervisor.runtime_from_last_failure(profile))
+                continue
+            runtimes.append(await self._start_or_record_failure(profile))
+        return runtimes
+
+    async def shutdown(self) -> None:
+        """Stop supervisor-owned runners without adopting external PIDs."""
+        await self.supervisor.shutdown()
+
+    def _should_reconcile(self, profile: LlamaCppProfile) -> bool:
+        if not profile.enabled or not profile.autostart:
+            return False
+        return not self.supervisor.is_profile_paused(profile.profile_id)
+
+    def _restart_limit_reached(self, profile: LlamaCppProfile) -> bool:
+        restart_count = _restart_count(profile)
+        if restart_count <= 0:
+            return False
+        max_restarts = _max_restarts(profile)
+        return restart_count >= max_restarts
+
+    async def _start_or_record_failure(self, profile: LlamaCppProfile) -> LlamaCppRuntime:
+        try:
+            runtime = await self.supervisor.start_profile(profile.profile_id)
+        except Exception as exc:  # noqa: BLE001 - reconciler must isolate per-profile startup failures.
+            logger.warning("Failed to reconcile llama.cpp profile {}: {}", profile.profile_id, exc)
+            runtime = self._current_runtime_or_none(profile.profile_id)
+            return await self.supervisor.record_runtime_failure(
+                profile.profile_id,
+                runtime=runtime,
+                error=exc,
+                restart_count=_restart_count(profile) + 1,
+            )
+        await self.supervisor.clear_runtime_failure(profile.profile_id)
+        return runtime
+
+    def _current_runtime_or_none(self, profile_id: str) -> LlamaCppRuntime | None:
+        try:
+            return self.supervisor.get_runtime(profile_id)
+        except Exception:  # noqa: BLE001 - failure recording should still preserve the original error.
+            return None
+
+
+def _restart_count(profile: LlamaCppProfile) -> int:
+    try:
+        return max(0, int(profile.last_runtime_failure.get("restart_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _max_restarts(profile: LlamaCppProfile) -> int:
+    try:
+        return max(0, int(profile.restart_policy.get("max_restarts") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+__all__ = ["LlamaCppRuntimeReconciler"]

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import weakref
+from datetime import UTC, datetime
 from ipaddress import ip_address
 from pathlib import Path
 from typing import Any, Callable, Protocol
@@ -31,6 +32,8 @@ from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
 )
 
 RunnerFactory = Callable[[LlamaCppConfig, str], Any]
+
+_MAX_FAILURE_TEXT_LENGTH = 500
 
 
 class LlamaCppProfileCreateInput(Protocol):
@@ -189,7 +192,10 @@ class LlamaCppSupervisor:
                 path_resolver=self._resolve_launch_asset_path,
             )
             launch_profile = profile.model_copy(update={"server_args": resolved.server_args})
-            return await runner.start(resolved.model_path, launch_profile)
+            runtime = await runner.start(resolved.model_path, launch_profile)
+            if profile.last_runtime_failure:
+                await self._store_upsert(profile.model_copy(update={"last_runtime_failure": {}}))
+            return runtime
 
     async def stop_profile(self, profile_id: str, disable: bool = False) -> LlamaCppRuntime:
         async with self._lock_for(profile_id):
@@ -230,9 +236,63 @@ class LlamaCppSupervisor:
         runner = self._runners.get(profile_id)
         if runner is not None:
             return runner.status()
-        if self.store.get(profile_id) is not None:
+        profile = self.store.get(profile_id)
+        if profile is not None:
+            if profile.last_runtime_failure:
+                return self.runtime_from_last_failure(profile)
             return LlamaCppRuntime(profile_id=profile_id, state=LlamaCppRuntimeState.DEFINED)
         raise LlamaCppProfileNotFoundError(f"Llama.cpp profile '{profile_id}' was not found.")
+
+    def is_profile_paused(self, profile_id: str) -> bool:
+        """Return True when a profile is paused in the current process."""
+        return profile_id in self._paused
+
+    async def record_runtime_failure(
+        self,
+        profile_id: str,
+        *,
+        runtime: LlamaCppRuntime | None = None,
+        error: BaseException | None = None,
+        restart_count: int | None = None,
+    ) -> LlamaCppRuntime:
+        """Persist bounded failure metadata for one managed runtime profile."""
+        async with self._lock_for(profile_id):
+            profile = self._require_profile(profile_id)
+            metadata = self._failure_metadata(
+                profile=profile,
+                runtime=runtime,
+                error=error,
+                restart_count=restart_count,
+            )
+            updated = await self._store_upsert(profile.model_copy(update={"last_runtime_failure": metadata}))
+            return self.runtime_from_last_failure(updated)
+
+    async def clear_runtime_failure(self, profile_id: str) -> LlamaCppProfile:
+        """Clear durable failure metadata for one managed runtime profile."""
+        async with self._lock_for(profile_id):
+            profile = self._require_profile(profile_id)
+            if not profile.last_runtime_failure:
+                return profile
+            return await self._store_upsert(profile.model_copy(update={"last_runtime_failure": {}}))
+
+    def runtime_from_last_failure(self, profile: LlamaCppProfile) -> LlamaCppRuntime:
+        """Build runtime status from a profile's durable failure metadata."""
+        failure = profile.last_runtime_failure
+        return LlamaCppRuntime(
+            profile_id=profile.profile_id,
+            state=LlamaCppRuntimeState.FAILED,
+            host=profile.host,
+            port=profile.port,
+            endpoint=f"http://{profile.host}:{profile.port}" if profile.host and profile.port else None,
+            model_id=profile.model_id,
+            model_path=profile.model_path,
+            stopped_at=_str_or_none(failure.get("stopped_at")),
+            restart_count=_non_negative_int(failure.get("restart_count")),
+            exit_code=_optional_int(failure.get("exit_code")),
+            last_error=_str_or_none(failure.get("last_error")),
+            health={"ready": False},
+            message=_str_or_none(failure.get("last_error")) or "Last llama.cpp start failed.",
+        )
 
     def tail_logs(self, profile_id: str, lines: int) -> dict[str, object]:
         self._require_profile(profile_id)
@@ -473,5 +533,59 @@ class LlamaCppSupervisor:
                     f"Running llama.cpp profile '{other_id}' already uses {runtime.host}:{runtime.port}."
                 )
 
+    def _failure_metadata(
+        self,
+        *,
+        profile: LlamaCppProfile,
+        runtime: LlamaCppRuntime | None,
+        error: BaseException | None,
+        restart_count: int | None,
+    ) -> dict[str, object]:
+        existing = profile.last_runtime_failure
+        last_error = (
+            (runtime.last_error if runtime is not None else None)
+            or (str(error) if error is not None else None)
+            or "Llama.cpp runtime failed."
+        )
+        metadata: dict[str, object] = {
+            "state": LlamaCppRuntimeState.FAILED.value,
+            "last_error": last_error[:_MAX_FAILURE_TEXT_LENGTH],
+            "restart_count": _non_negative_int(
+                restart_count if restart_count is not None else _non_negative_int(existing.get("restart_count")) + 1
+            ),
+            "recorded_at": datetime.now(UTC).isoformat(),
+        }
+        if runtime is not None:
+            if runtime.exit_code is not None:
+                metadata["exit_code"] = runtime.exit_code
+            if runtime.stopped_at:
+                metadata["stopped_at"] = runtime.stopped_at
+            if runtime.model_path:
+                metadata["model_path"] = runtime.model_path
+        return metadata
+
 
 __all__ = ["LlamaCppSupervisor"]
+
+
+def _non_negative_int(value: object) -> int:
+    try:
+        parsed = int(value) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0
+    return max(0, parsed)
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _str_or_none(value: object) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
@@ -285,7 +285,7 @@ class LlamaCppSupervisor:
             port=profile.port,
             endpoint=f"http://{profile.host}:{profile.port}" if profile.host and profile.port else None,
             model_id=profile.model_id,
-            model_path=profile.model_path,
+            model_path=_str_or_none(failure.get("model_path")) or profile.model_path,
             stopped_at=_str_or_none(failure.get("stopped_at")),
             restart_count=_non_negative_int(failure.get("restart_count")),
             exit_code=_optional_int(failure.get("exit_code")),
@@ -302,11 +302,18 @@ class LlamaCppSupervisor:
         return runner.tail_logs(lines)
 
     async def shutdown(self) -> None:
+        failures: list[tuple[str, BaseException]] = []
         for profile_id in list(self._runners):
-            async with self._lock_for(profile_id):
-                runner = self._runners.get(profile_id)
-                if runner is not None:
-                    await runner.stop()
+            try:
+                async with self._lock_for(profile_id):
+                    runner = self._runners.get(profile_id)
+                    if runner is not None:
+                        await runner.stop()
+            except Exception as exc:  # noqa: BLE001 - shutdown should attempt every owned runner.
+                failures.append((profile_id, exc))
+        if failures:
+            failed_ids = ", ".join(profile_id for profile_id, _exc in failures)
+            raise RuntimeError(f"Failed to stop llama.cpp runner(s): {failed_ids}") from failures[0][1]
 
     def cleanup_sync(self) -> None:
         for runner in list(self._runners.values()):
@@ -569,6 +576,7 @@ __all__ = ["LlamaCppSupervisor"]
 
 
 def _non_negative_int(value: object) -> int:
+    """Coerce a value to a non-negative integer, defaulting invalid values to zero."""
     try:
         parsed = int(value) if value is not None else 0
     except (TypeError, ValueError):
@@ -577,6 +585,7 @@ def _non_negative_int(value: object) -> int:
 
 
 def _optional_int(value: object) -> int | None:
+    """Coerce a value to int when possible, preserving missing or invalid values as None."""
     if value is None:
         return None
     try:
@@ -586,6 +595,7 @@ def _optional_int(value: object) -> int | None:
 
 
 def _str_or_none(value: object) -> str | None:
+    """Coerce a non-empty value to string while keeping missing values as None."""
     if value in (None, ""):
         return None
     return str(value)

--- a/tldw_Server_API/app/services/shutdown_resource_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_resource_cleanup.py
@@ -240,6 +240,11 @@ async def _shutdown_local_llm_manager(
     run_in_thread: Callable[[Callable[..., Any]], Awaitable[Any]],
 ) -> None:
     try:
+        reconciler = getattr(getattr(app, "state", None), "llamacpp_runtime_reconciler", None)
+        if reconciler is not None and hasattr(reconciler, "shutdown"):
+            await reconciler.shutdown()
+            app.state.llamacpp_runtime_reconciler = None
+            logger.info("App Shutdown: llama.cpp runtime reconciler shutdown complete")
         llm_manager = getattr(getattr(app, "state", None), "llm_manager", None)
         if llm_manager is not None and hasattr(llm_manager, "cleanup_on_exit"):
             await run_in_thread(llm_manager.cleanup_on_exit)

--- a/tldw_Server_API/app/services/shutdown_resource_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_resource_cleanup.py
@@ -239,12 +239,16 @@ async def _shutdown_local_llm_manager(
     guard_exceptions: tuple[type[BaseException], ...],
     run_in_thread: Callable[[Callable[..., Any]], Awaitable[Any]],
 ) -> None:
-    try:
-        reconciler = getattr(getattr(app, "state", None), "llamacpp_runtime_reconciler", None)
-        if reconciler is not None and hasattr(reconciler, "shutdown"):
+    reconciler = getattr(getattr(app, "state", None), "llamacpp_runtime_reconciler", None)
+    if reconciler is not None and hasattr(reconciler, "shutdown"):
+        try:
             await reconciler.shutdown()
             app.state.llamacpp_runtime_reconciler = None
             logger.info("App Shutdown: llama.cpp runtime reconciler shutdown complete")
+        except guard_exceptions as exc:
+            logger.exception(f"App Shutdown: Error stopping llama.cpp runtime reconciler: {exc}")
+
+    try:
         llm_manager = getattr(getattr(app, "state", None), "llm_manager", None)
         if llm_manager is not None and hasattr(llm_manager, "cleanup_on_exit"):
             await run_in_thread(llm_manager.cleanup_on_exit)

--- a/tldw_Server_API/app/services/startup_heavy_init.py
+++ b/tldw_Server_API/app/services/startup_heavy_init.py
@@ -114,6 +114,7 @@ async def _init_local_llm_manager(
 
         manager = await asyncio.to_thread(LLMInferenceManager, LLMManagerConfig(**cfg_kwargs))
         app.state.llm_manager = manager
+        await _init_llamacpp_runtime_reconciler(app, manager, deferred=deferred)
         try:
             from tldw_Server_API.app.api.v1.endpoints import llamacpp as _llamacpp_module
 
@@ -132,6 +133,27 @@ async def _init_local_llm_manager(
                 "Local LLM inference manager not initialized; llama.cpp endpoints will return 503: "
                 f"{_llm_init_err}"
             )
+
+
+async def _init_llamacpp_runtime_reconciler(app: Any, manager: Any, *, deferred: bool) -> None:
+    supervisor = getattr(manager, "llamacpp_supervisor", None)
+    if supervisor is None:
+        return
+    try:
+        from tldw_Server_API.app.core.Local_LLM import llamacpp_runtime_reconciler as reconciler_module
+
+        reconciler = reconciler_module.LlamaCppRuntimeReconciler(supervisor)
+        app.state.llamacpp_runtime_reconciler = reconciler
+        await reconciler.reconcile_startup()
+        logger.info(
+            ("Deferred startup: " if deferred else "App Startup: ")
+            + "llama.cpp runtime reconciliation complete"
+        )
+    except Exception as exc:  # noqa: BLE001 - autostart reconciliation must not block API startup.
+        logger.warning(
+            ("Deferred startup: " if deferred else "App Startup: ")
+            + f"llama.cpp runtime reconciliation skipped/failed: {exc}"
+        )
 
 
 async def _init_mcp_server(app: Any, *, deferred: bool) -> Any | None:

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_reconciler.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_reconciler.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import asyncio
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Schemas import LlamaCppConfig
+from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_store import JsonLlamaCppProfileStore
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
+    LlamaCppPortPolicy,
+    LlamaCppProfile,
+    LlamaCppRuntime,
+    LlamaCppRuntimeState,
+)
+from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_reconciler import LlamaCppRuntimeReconciler
+from tldw_Server_API.app.core.Local_LLM.llamacpp_supervisor_service import LlamaCppSupervisor
+
+
+def make_config(tmp_path: Path) -> LlamaCppConfig:
+    executable = tmp_path / "bin" / "llama-server"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    return LlamaCppConfig(
+        executable_path=executable,
+        models_dir=models_dir,
+        default_host="127.0.0.1",
+        default_port=8080,
+        default_n_gpu_layers=0,
+        default_ctx_size=2048,
+        default_threads=None,
+        port_autoselect=True,
+        port_probe_max=3,
+        allowed_paths=[models_dir],
+        readiness_timeout=0.1,
+        stderr_read_timeout=0.1,
+        log_output_file=None,
+    )
+
+
+def make_model(config: LlamaCppConfig, name: str = "model.gguf") -> Path:
+    model_path = config.models_dir / name
+    model_path.write_text("not really gguf", encoding="utf-8")
+    return model_path
+
+
+def _llamacpp_parser(default_models_dir: Path) -> ConfigParser:
+    parser = ConfigParser()
+    parser.add_section("LlamaCpp")
+    parser["LlamaCpp"] = {
+        "enabled": "true",
+        "models_dir": str(default_models_dir),
+        "allowed_paths": "",
+        "registered_model_paths": "",
+        "imported_asset_folders": "",
+    }
+    return parser
+
+
+@pytest.fixture(autouse=True)
+def configure_inventory(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(tmp_path / "models"),
+    )
+
+
+def profile(
+    profile_id: str,
+    *,
+    model_path: Path,
+    port: int = 8181,
+    enabled: bool = True,
+    autostart: bool = False,
+    restart_policy: dict[str, object] | None = None,
+) -> LlamaCppProfile:
+    return LlamaCppProfile(
+        profile_id=profile_id,
+        name=f"Profile {profile_id}",
+        enabled=enabled,
+        model_path=str(model_path),
+        host="127.0.0.1",
+        port=port,
+        port_policy=LlamaCppPortPolicy.EXPLICIT,
+        server_args={"ctx_size": 4096},
+        autostart=autostart,
+        restart_policy=dict(restart_policy or {}),
+    )
+
+
+class FakeRunner:
+    def __init__(self, profile_id: str, calls: dict[str, int]):
+        self.profile_id = profile_id
+        self.calls = calls
+        self.runtime = LlamaCppRuntime(profile_id=profile_id, state=LlamaCppRuntimeState.DEFINED)
+        self.stop_calls = 0
+
+    async def start(self, model_path: Path, profile: LlamaCppProfile) -> LlamaCppRuntime:
+        self.calls[self.profile_id] = self.calls.get(self.profile_id, 0) + 1
+        await asyncio.sleep(0)
+        self.runtime = LlamaCppRuntime(
+            profile_id=self.profile_id,
+            state=LlamaCppRuntimeState.RUNNING,
+            pid=1000 + len(self.calls),
+            host=profile.host,
+            port=profile.port,
+            endpoint=f"http://{profile.host}:{profile.port}",
+            model_path=str(model_path),
+        )
+        return self.runtime
+
+    async def stop(self) -> LlamaCppRuntime:
+        self.stop_calls += 1
+        self.runtime = self.runtime.model_copy(
+            update={"state": LlamaCppRuntimeState.STOPPED, "pid": None, "message": "Stopped"}
+        )
+        return self.runtime
+
+    def status(self) -> LlamaCppRuntime:
+        return self.runtime
+
+    def cleanup_sync(self) -> None:
+        self.runtime = self.runtime.model_copy(update={"state": LlamaCppRuntimeState.STOPPED, "pid": None})
+
+
+class FailingRunner(FakeRunner):
+    async def start(self, model_path: Path, profile: LlamaCppProfile) -> LlamaCppRuntime:
+        self.calls[self.profile_id] = self.calls.get(self.profile_id, 0) + 1
+        await asyncio.sleep(0)
+        self.runtime = LlamaCppRuntime(
+            profile_id=self.profile_id,
+            state=LlamaCppRuntimeState.FAILED,
+            host=profile.host,
+            port=profile.port,
+            model_path=str(model_path),
+            exit_code=42,
+            last_error="boom",
+            message="boom",
+        )
+        raise ServerError("boom")
+
+
+class FakeRunnerFactory:
+    def __init__(self, runner_cls: type[FakeRunner] = FakeRunner):
+        self.runner_cls = runner_cls
+        self.calls: dict[str, int] = {}
+        self.runners: dict[str, FakeRunner] = {}
+
+    def __call__(self, _config: LlamaCppConfig, profile_id: str) -> FakeRunner:
+        runner = self.runner_cls(profile_id, self.calls)
+        self.runners[profile_id] = runner
+        return runner
+
+
+def make_supervisor(
+    tmp_path: Path,
+    *,
+    runner_cls: type[FakeRunner] = FakeRunner,
+) -> tuple[LlamaCppSupervisor, LlamaCppConfig, FakeRunnerFactory]:
+    config = make_config(tmp_path)
+    store = JsonLlamaCppProfileStore(tmp_path / "profiles.json")
+    factory = FakeRunnerFactory(runner_cls=runner_cls)
+    supervisor = LlamaCppSupervisor(config=config, store=store, runner_factory=factory)
+    return supervisor, config, factory
+
+
+@pytest.mark.asyncio
+async def test_reconciler_autostarts_only_enabled_autostart_profiles(tmp_path: Path) -> None:
+    supervisor, config, factory = make_supervisor(tmp_path)
+    first_model = make_model(config, "auto.gguf")
+    second_model = make_model(config, "manual.gguf")
+    disabled_model = make_model(config, "disabled.gguf")
+    supervisor.store.upsert(profile("auto", model_path=first_model, autostart=True, port=8181))
+    supervisor.store.upsert(profile("manual", model_path=second_model, autostart=False, port=8182))
+    supervisor.store.upsert(profile("disabled", model_path=disabled_model, enabled=False, autostart=True, port=8183))
+
+    runtimes = await LlamaCppRuntimeReconciler(supervisor).reconcile_startup()
+
+    assert [runtime.profile_id for runtime in runtimes] == ["auto"]
+    assert runtimes[0].state == LlamaCppRuntimeState.RUNNING
+    assert factory.calls == {"auto": 1}
+
+
+@pytest.mark.asyncio
+async def test_reconciler_records_failed_start_metadata_and_respects_max_restarts(tmp_path: Path) -> None:
+    supervisor, config, factory = make_supervisor(tmp_path, runner_cls=FailingRunner)
+    model_path = make_model(config, "failing.gguf")
+    supervisor.store.upsert(
+        profile(
+            "failing",
+            model_path=model_path,
+            autostart=True,
+            restart_policy={"max_restarts": 1},
+        )
+    )
+    reconciler = LlamaCppRuntimeReconciler(supervisor)
+
+    first = await reconciler.reconcile_once()
+    second = await reconciler.reconcile_once()
+
+    stored = supervisor.store.get("failing")
+    assert first[0].state == LlamaCppRuntimeState.FAILED
+    assert first[0].last_error == "boom"
+    assert second[0].state == LlamaCppRuntimeState.FAILED
+    assert factory.calls == {"failing": 1}
+    assert stored is not None
+    assert stored.last_runtime_failure["state"] == "failed"
+    assert stored.last_runtime_failure["last_error"] == "boom"
+    assert stored.last_runtime_failure["exit_code"] == 42
+    assert stored.last_runtime_failure["restart_count"] == 1
+    reloaded = LlamaCppSupervisor(
+        config=config,
+        store=JsonLlamaCppProfileStore(tmp_path / "profiles.json"),
+        runner_factory=FakeRunnerFactory(),
+    )
+    reloaded_runtime = reloaded.get_runtime("failing")
+    assert reloaded_runtime.state == LlamaCppRuntimeState.FAILED
+    assert reloaded_runtime.last_error == "boom"
+    assert reloaded_runtime.restart_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reconciler_skips_paused_profile_until_resume(tmp_path: Path) -> None:
+    supervisor, config, factory = make_supervisor(tmp_path)
+    model_path = make_model(config, "paused.gguf")
+    supervisor.store.upsert(profile("paused", model_path=model_path, autostart=True, port=8181))
+    await supervisor.pause_profile("paused")
+    reconciler = LlamaCppRuntimeReconciler(supervisor)
+
+    runtimes = await reconciler.reconcile_once()
+    resumed = await supervisor.resume_profile("paused")
+
+    assert runtimes == []
+    assert resumed.state == LlamaCppRuntimeState.RUNNING
+    assert factory.calls == {"paused": 1}
+
+
+@pytest.mark.asyncio
+async def test_reconciler_shutdown_stops_owned_runners_without_creating_new_ones(tmp_path: Path) -> None:
+    supervisor, config, factory = make_supervisor(tmp_path)
+    running_model = make_model(config, "running.gguf")
+    stored_model = make_model(config, "stored.gguf")
+    supervisor.store.upsert(profile("running", model_path=running_model, autostart=True, port=8181))
+    supervisor.store.upsert(profile("stored", model_path=stored_model, autostart=True, port=8182))
+    await supervisor.start_profile("running")
+
+    await LlamaCppRuntimeReconciler(supervisor).shutdown()
+
+    assert factory.runners["running"].stop_calls == 1
+    assert "stored" not in factory.runners

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
@@ -149,6 +149,12 @@ class FakeRunner:
         self.runtime = self.runtime.model_copy(update={"state": LlamaCppRuntimeState.STOPPED, "pid": None})
 
 
+class StopFailingRunner(FakeRunner):
+    async def stop(self) -> LlamaCppRuntime:
+        self.stop_calls += 1
+        raise RuntimeError(f"stop failed for {self.profile_id}")
+
+
 class FakeRunnerFactory:
     def __init__(self):
         self.calls: dict[str, int] = {}
@@ -156,6 +162,16 @@ class FakeRunnerFactory:
 
     def __call__(self, config: LlamaCppConfig, profile_id: str) -> FakeRunner:
         runner = FakeRunner(profile_id, self.calls)
+        self.runners[profile_id] = runner
+        return runner
+
+
+class StopFailingRunnerFactory(FakeRunnerFactory):
+    def __call__(self, config: LlamaCppConfig, profile_id: str) -> FakeRunner:
+        if profile_id == "one":
+            runner = StopFailingRunner(profile_id, self.calls)
+        else:
+            runner = FakeRunner(profile_id, self.calls)
         self.runners[profile_id] = runner
         return runner
 
@@ -200,6 +216,28 @@ def make_supervisor(tmp_path: Path) -> tuple[LlamaCppSupervisor, LlamaCppConfig,
     factory = FakeRunnerFactory()
     supervisor = LlamaCppSupervisor(config=config, store=store, runner_factory=factory)
     return supervisor, config, factory
+
+
+def test_runtime_from_last_failure_prefers_persisted_model_path(tmp_path: Path) -> None:
+    supervisor, config, _factory = make_supervisor(tmp_path)
+    resolved_model = make_model(config, "resolved.gguf")
+    failed_profile = LlamaCppProfile(
+        profile_id="model-id-only",
+        name="Model ID Only",
+        model_id="gguf:model-id-only",
+        model_path=None,
+        last_runtime_failure={
+            "state": "failed",
+            "last_error": "boom",
+            "model_path": str(resolved_model),
+            "restart_count": 1,
+        },
+    )
+
+    runtime = supervisor.runtime_from_last_failure(failed_profile)
+
+    assert runtime.state == LlamaCppRuntimeState.FAILED
+    assert runtime.model_path == str(resolved_model)
 
 
 def configure_supervisor_assets(
@@ -550,6 +588,30 @@ async def test_supervisor_stop_pause_resume_and_cleanup(tmp_path: Path):
     assert resumed.state == LlamaCppRuntimeState.RUNNING
     assert factory.calls == {"one": 2}
     assert factory.runners["one"].cleaned is True
+
+
+@pytest.mark.asyncio
+async def test_supervisor_shutdown_attempts_all_runners_before_reporting_failure(tmp_path: Path) -> None:
+    config = make_config(tmp_path)
+    store = JsonLlamaCppProfileStore(tmp_path / "profiles.json")
+    factory = StopFailingRunnerFactory()
+    supervisor = LlamaCppSupervisor(config=config, store=store, runner_factory=factory)
+    first_model = make_model(config, "one.gguf")
+    second_model = make_model(config, "two.gguf")
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(profile_id="one", name="One", model_path=str(first_model), port=8181)
+    )
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(profile_id="two", name="Two", model_path=str(second_model), port=8182)
+    )
+    await supervisor.start_profile("one")
+    await supervisor.start_profile("two")
+
+    with pytest.raises(RuntimeError, match="one"):
+        await supervisor.shutdown()
+
+    assert factory.runners["one"].stop_calls == 1
+    assert factory.runners["two"].stop_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_shutdown_resource_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_resource_cleanup.py
@@ -238,3 +238,39 @@ async def test_shutdown_local_llm_manager_uses_thread_helper(
     )
 
     assert calls == ["to-thread", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_local_llm_manager_stops_llamacpp_reconciler_before_sync_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_resources = _import_shutdown_resource_cleanup()
+    calls: list[str] = []
+
+    class _Reconciler:
+        async def shutdown(self) -> None:
+            calls.append("reconciler")
+
+    class _LocalLLMManager:
+        def cleanup_on_exit(self) -> None:
+            calls.append("cleanup")
+
+    async def _fake_run_in_thread(fn):
+        calls.append("to-thread")
+        fn()
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            llamacpp_runtime_reconciler=_Reconciler(),
+            llm_manager=_LocalLLMManager(),
+        )
+    )
+
+    await shutdown_resources._shutdown_local_llm_manager(
+        app=app,
+        guard_exceptions=(RuntimeError,),
+        run_in_thread=_fake_run_in_thread,
+    )
+
+    assert calls == ["reconciler", "to-thread", "cleanup"]
+    assert app.state.llamacpp_runtime_reconciler is None

--- a/tldw_Server_API/tests/Services/test_shutdown_resource_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_resource_cleanup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
@@ -225,7 +226,7 @@ async def test_shutdown_local_llm_manager_uses_thread_helper(
         def cleanup_on_exit(self) -> None:
             calls.append("cleanup")
 
-    async def _fake_run_in_thread(fn):
+    async def _fake_run_in_thread(fn: Callable[[], object]) -> None:
         calls.append("to-thread")
         fn()
 
@@ -241,9 +242,7 @@ async def test_shutdown_local_llm_manager_uses_thread_helper(
 
 
 @pytest.mark.asyncio
-async def test_shutdown_local_llm_manager_stops_llamacpp_reconciler_before_sync_cleanup(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_shutdown_local_llm_manager_stops_llamacpp_reconciler_before_sync_cleanup() -> None:
     shutdown_resources = _import_shutdown_resource_cleanup()
     calls: list[str] = []
 
@@ -255,7 +254,7 @@ async def test_shutdown_local_llm_manager_stops_llamacpp_reconciler_before_sync_
         def cleanup_on_exit(self) -> None:
             calls.append("cleanup")
 
-    async def _fake_run_in_thread(fn):
+    async def _fake_run_in_thread(fn: Callable[[], object]) -> None:
         calls.append("to-thread")
         fn()
 
@@ -274,3 +273,37 @@ async def test_shutdown_local_llm_manager_stops_llamacpp_reconciler_before_sync_
 
     assert calls == ["reconciler", "to-thread", "cleanup"]
     assert app.state.llamacpp_runtime_reconciler is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_local_llm_manager_cleans_up_after_reconciler_failure() -> None:
+    shutdown_resources = _import_shutdown_resource_cleanup()
+    calls: list[str] = []
+
+    class _Reconciler:
+        async def shutdown(self) -> None:
+            calls.append("reconciler")
+            raise RuntimeError("stop failed")
+
+    class _LocalLLMManager:
+        def cleanup_on_exit(self) -> None:
+            calls.append("cleanup")
+
+    async def _fake_run_in_thread(fn: Callable[[], object]) -> None:
+        calls.append("to-thread")
+        fn()
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            llamacpp_runtime_reconciler=_Reconciler(),
+            llm_manager=_LocalLLMManager(),
+        )
+    )
+
+    await shutdown_resources._shutdown_local_llm_manager(
+        app=app,
+        guard_exceptions=(RuntimeError,),
+        run_in_thread=_fake_run_in_thread,
+    )
+
+    assert calls == ["reconciler", "to-thread", "cleanup"]

--- a/tldw_Server_API/tests/Services/test_startup_heavy_init.py
+++ b/tldw_Server_API/tests/Services/test_startup_heavy_init.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -170,19 +171,19 @@ async def test_init_local_llm_manager_runs_llamacpp_runtime_reconciler(
     supervisor = object()
 
     class _Manager:
-        def __init__(self, _config):
+        def __init__(self, _config: object) -> None:
             self.llamacpp_supervisor = supervisor
 
     class _Reconciler:
-        def __init__(self, observed_supervisor):
+        def __init__(self, observed_supervisor: object) -> None:
             assert observed_supervisor is supervisor
             calls.append("created")
 
-        async def reconcile_startup(self):
+        async def reconcile_startup(self) -> list[object]:
             calls.append("reconcile")
             return []
 
-    async def _fake_to_thread(fn, *args, **kwargs):
+    async def _fake_to_thread(fn: Callable[..., object], *args: object, **kwargs: object) -> object:
         return fn(*args, **kwargs)
 
     from tldw_Server_API.app.core import Local_LLM as local_llm_package

--- a/tldw_Server_API/tests/Services/test_startup_heavy_init.py
+++ b/tldw_Server_API/tests/Services/test_startup_heavy_init.py
@@ -161,6 +161,59 @@ async def test_start_heavy_initializations_schedules_background_task_when_deferr
 
 
 @pytest.mark.asyncio
+async def test_init_local_llm_manager_runs_llamacpp_runtime_reconciler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_heavy = _import_startup_heavy_init()
+    calls: list[str] = []
+    app = SimpleNamespace(state=SimpleNamespace())
+    supervisor = object()
+
+    class _Manager:
+        def __init__(self, _config):
+            self.llamacpp_supervisor = supervisor
+
+    class _Reconciler:
+        def __init__(self, observed_supervisor):
+            assert observed_supervisor is supervisor
+            calls.append("created")
+
+        async def reconcile_startup(self):
+            calls.append("reconcile")
+            return []
+
+    async def _fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    from tldw_Server_API.app.core import Local_LLM as local_llm_package
+    from tldw_Server_API.app.core import config as config_module
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_runtime_reconciler
+
+    llamacpp_endpoint_module = ModuleType("tldw_Server_API.app.api.v1.endpoints.llamacpp")
+    monkeypatch.setattr(config_module, "get_llamacpp_handler_config", lambda: object())
+    monkeypatch.setattr(local_llm_package, "LLMInferenceManager", _Manager, raising=False)
+    monkeypatch.setattr(local_llm_package, "LLMManagerConfig", lambda **kwargs: kwargs, raising=False)
+    monkeypatch.setattr(llamacpp_runtime_reconciler, "LlamaCppRuntimeReconciler", _Reconciler)
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.api.v1.endpoints.llamacpp",
+        llamacpp_endpoint_module,
+    )
+    monkeypatch.setattr(startup_heavy.asyncio, "to_thread", _fake_to_thread)
+
+    await startup_heavy._init_local_llm_manager(
+        app,
+        route_enabled=lambda key: key in {"llm", "llamacpp"},
+        deferred=False,
+    )
+
+    assert calls == ["created", "reconcile"]
+    assert app.state.llm_manager.llamacpp_supervisor is supervisor
+    assert app.state.llamacpp_runtime_reconciler.__class__ is _Reconciler
+    assert llamacpp_endpoint_module.llm_manager is app.state.llm_manager
+
+
+@pytest.mark.asyncio
 async def test_init_embeddings_dim_check_strict_mode_reraises_mismatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Add `LlamaCppRuntimeReconciler` to reconcile enabled autostart profiles on startup while delegating process ownership to `LlamaCppSupervisor`.
- Persist bounded `last_runtime_failure` metadata on managed profiles and expose failed runtime status after process restart.
- Wire reconciler startup/shutdown into existing local LLM lifecycle helpers and add focused tests.
- Track the work in `TASK-419`.

## Verification

- `python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_store.py tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_reconciler.py tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py -q --tb=short`
- `python -m pytest tldw_Server_API/tests/Services/test_startup_heavy_init.py tldw_Server_API/tests/Services/test_shutdown_resource_cleanup.py -q --tb=short`
- `python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py -q --tb=short`
- `git diff --check`
- `python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_models.py tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_reconciler.py tldw_Server_API/app/services/startup_heavy_init.py tldw_Server_API/app/services/shutdown_resource_cleanup.py -f json -o /tmp/bandit_llamacpp_runtime_reconciler.json`

## Change Summary

Human-authored summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime reconciler for `llama.cpp` that autostarts eligible profiles on boot and persists bounded failure metadata. Integrates with app startup/shutdown and enhances `LlamaCppSupervisor` to reconstruct FAILED state, clear it on success, and stop all runners safely (TASK-419).

- **New Features**
  - Introduced `LlamaCppRuntimeReconciler` to start enabled `autostart` profiles, skip paused/disabled ones, and honor `restart_policy.max_restarts`.
  - Added `last_runtime_failure` on profiles and supervisor APIs to record/clear failures and return `FAILED` via `get_runtime`; successful starts now clear failure metadata.
  - Hooked reconciliation into `startup_heavy_init` (runs on boot) and `shutdown_resource_cleanup` (stops reconciler before manager cleanup).

- **Bug Fixes**
  - `runtime_from_last_failure` prefers the persisted resolved `model_path`; added typed coercion helpers.
  - `shutdown()` now attempts to stop every owned runner and then reports failures.

<sup>Written for commit be5d695d63faf836e84951889734b36764d37447. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1816?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

