### PR TITLE
Add no-Docker quick-launch scripts

### DIFF
--- a/Docs/Design/2026-05-17-quick-launch-scripts.md
+++ b/Docs/Design/2026-05-17-quick-launch-scripts.md
@@ -1,0 +1,30 @@
+# Quick-Launch Shortcut Scripts Design
+
+Task: `TASK-419`
+
+## Goal
+
+Add OS-native no-Docker shortcut scripts for self-hosters who want the local single-user API path without needing `make`.
+
+## Design
+
+The scripts are thin wrappers around the existing local single-user setup contract. They do not create a parallel installer or duplicate the setup wizard logic. Each launcher creates `.venv` if needed, installs the editable package into that venv, runs `tldw_Server_API.cli.wizard.cli init --profile local-single`, and starts `uvicorn` on `127.0.0.1:8000`.
+
+## Files
+
+- `quick-launch.sh`: Linux and shell-first macOS launcher.
+- `quick-launch.command`: macOS Finder-friendly wrapper that delegates to `quick-launch.sh`.
+- `quick-launch.ps1`: Windows PowerShell launcher.
+- `tldw_Server_API/tests/Utils/test_quick_launch_scripts.py`: contract tests for launchers.
+- `README.md` and `Docs/Getting_Started/Profile_Local_Single_User.md`: onboarding references.
+
+## Constraints
+
+- Do not call Docker or require Make.
+- Do not reference deprecated Gradio-era entrypoints such as `summarize.py -gui`.
+- Do not print `SINGLE_USER_API_KEY` by default; point users to the env file or existing explicit secret paths.
+- Keep custom host/port support limited to environment variables so the default remains boring and local.
+
+## Verification
+
+Focused verification should include the new contract tests, existing onboarding contract tests, and Bandit over the touched scripts/tests/docs scope.

--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -19,7 +19,21 @@ make install-local
 make setup-local-single
 ```
 
-PowerShell / no-`make` equivalent:
+No-`make` shortcut scripts from the repository root:
+
+```bash
+# macOS/Linux terminal
+./quick-launch.sh
+```
+
+```powershell
+# Windows PowerShell
+.\quick-launch.ps1
+```
+
+On macOS, you can also double-click `quick-launch.command` from Finder. These shortcuts create or update `.venv`, run the `local-single` setup wizard, and start the API at `http://127.0.0.1:8000`.
+
+PowerShell / manual no-`make` equivalent:
 
 ```powershell
 py -3.12 -m venv .venv
@@ -38,7 +52,7 @@ py -3.12 -m venv .venv
 make start-local-single
 ```
 
-PowerShell / no-`make` equivalent:
+PowerShell / manual no-`make` equivalent:
 
 ```powershell
 .\.venv\Scripts\python -m uvicorn tldw_Server_API.app.main:app --host 127.0.0.1 --port 8000

--- a/Docs/Getting_Started/README.md
+++ b/Docs/Getting_Started/README.md
@@ -35,6 +35,7 @@ Canonical base profiles:
    - Prepare: `make setup-local-single`
    - Start: `make start-local-single`
    - Verify: `make verify-local-single`
+   - No-`make` shortcuts: `./quick-launch.sh`, `quick-launch.command`, or `.\quick-launch.ps1`
 
 Generated multi-user admin bootstrap:
 

--- a/Docs/Published/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Published/Getting_Started/Profile_Local_Single_User.md
@@ -19,7 +19,21 @@ make install-local
 make setup-local-single
 ```
 
-PowerShell / no-`make` equivalent:
+No-`make` shortcut scripts from the repository root:
+
+```bash
+# macOS/Linux terminal
+./quick-launch.sh
+```
+
+```powershell
+# Windows PowerShell
+.\quick-launch.ps1
+```
+
+On macOS, you can also double-click `quick-launch.command` from Finder. These shortcuts create or update `.venv`, run the `local-single` setup wizard, and start the API at `http://127.0.0.1:8000`.
+
+PowerShell / manual no-`make` equivalent:
 
 ```powershell
 py -3.12 -m venv .venv
@@ -38,7 +52,7 @@ py -3.12 -m venv .venv
 make start-local-single
 ```
 
-PowerShell / no-`make` equivalent:
+PowerShell / manual no-`make` equivalent:
 
 ```powershell
 .\.venv\Scripts\python -m uvicorn tldw_Server_API.app.main:app --host 127.0.0.1 --port 8000

--- a/Docs/Published/Getting_Started/README.md
+++ b/Docs/Published/Getting_Started/README.md
@@ -35,6 +35,7 @@ Canonical base profiles:
    - Prepare: `make setup-local-single`
    - Start: `make start-local-single`
    - Verify: `make verify-local-single`
+   - No-`make` shortcuts: `./quick-launch.sh`, `quick-launch.command`, or `.\quick-launch.ps1`
 
 Generated multi-user admin bootstrap:
 

--- a/Docs/superpowers/plans/2026-05-17-quick-launch-scripts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-quick-launch-scripts-implementation-plan.md
@@ -1,0 +1,80 @@
+# Quick-Launch Scripts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add no-Docker quick-launch scripts for local single-user self-hosters on Linux, macOS, and Windows.
+
+**Architecture:** Use OS-native wrappers that delegate to the existing local-single setup/start contract. The scripts own shell ergonomics only; setup behavior remains in the existing wizard and package install path.
+
+**Tech Stack:** Bash, macOS `.command`, PowerShell, pytest contract tests, Markdown docs.
+
+---
+
+Task: `TASK-419`
+
+### Task 1: Script Contract Tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/Utils/test_quick_launch_scripts.py`
+
+- [x] **Step 1: Write failing contract tests**
+
+Add tests that require `quick-launch.sh`, `quick-launch.command`, and `quick-launch.ps1`; assert they use `local-single`, `uvicorn`, `.venv`, and `tldw_Server_API.cli.wizard.cli`; assert they do not use Docker, Make, `summarize.py`, or print API keys by default.
+
+- [x] **Step 2: Run tests to verify they fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_quick_launch_scripts.py -q`
+
+Expected: FAIL because the scripts do not exist yet.
+
+### Task 2: Quick-Launch Scripts
+
+**Files:**
+- Create: `quick-launch.sh`
+- Create: `quick-launch.command`
+- Create: `quick-launch.ps1`
+
+- [x] **Step 1: Implement minimal launchers**
+
+Create scripts that locate the repo root, create/install `.venv`, run the local-single setup wizard, then start `uvicorn` on `127.0.0.1:8000`.
+
+- [x] **Step 2: Run contract tests**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_quick_launch_scripts.py -q`
+
+Expected: PASS.
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
+
+- [x] **Step 1: Add docs tests if needed**
+
+Extend existing onboarding doc tests only if the new docs wording needs a guard.
+
+- [x] **Step 2: Update docs**
+
+Mention the quick-launch scripts in the no-Docker local path without replacing the canonical Makefile workflow.
+
+- [x] **Step 3: Run docs/onboarding tests**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_quick_launch_scripts.py tldw_Server_API/tests/Utils/test_makefile_onboarding_profiles.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py -q`
+
+Expected: PASS.
+
+### Task 4: Final Verification
+
+**Files:**
+- Modify: `backlog/tasks/task-419 - Add-no-Docker-quick-launch-shortcut-scripts.md`
+
+- [x] **Step 1: Run Bandit**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r quick-launch.sh quick-launch.command quick-launch.ps1 tldw_Server_API/tests/Utils/test_quick_launch_scripts.py -f json -o /tmp/bandit_quick_launch_scripts.json`
+
+Expected: exit 0 or documented no-new-findings result.
+
+- [x] **Step 2: Update Backlog task**
+
+Record touched files, verification results, known skips, and final summary in `TASK-419`.

--- a/README.md
+++ b/README.md
@@ -318,7 +318,12 @@ make verify-local-single
 Use these paths when `make` is not available.
 
 Local single-user:
-- Follow [Manual Setup](#manual-setup) below, then start with `python -m uvicorn tldw_Server_API.app.main:app --reload`.
+- Shortcut scripts from the repository root:
+  - macOS/Linux terminal: `./quick-launch.sh`
+  - macOS Finder: double-click `quick-launch.command`
+  - Windows PowerShell: `.\quick-launch.ps1`
+- These scripts create or update `.venv`, run the `local-single` setup wizard, and start the API at `http://127.0.0.1:8000`.
+- For manual control, follow [Manual Setup](#manual-setup) below, then start with `python -m uvicorn tldw_Server_API.app.main:app --reload`.
 
 Docker single-user + WebUI:
 ```powershell

--- a/backlog/tasks/task-419 - Add-no-Docker-quick-launch-shortcut-scripts.md
+++ b/backlog/tasks/task-419 - Add-no-Docker-quick-launch-shortcut-scripts.md
@@ -1,0 +1,68 @@
+---
+id: TASK-419
+title: Add no-Docker quick-launch shortcut scripts
+status: Done
+priority: Medium
+documentation:
+- Docs/Design/2026-05-17-quick-launch-scripts.md
+- Docs/Getting_Started/Profile_Local_Single_User.md
+- README.md
+modified_files:
+- quick-launch.sh
+- quick-launch.command
+- quick-launch.ps1
+- README.md
+- Docs/Getting_Started/README.md
+- Docs/Getting_Started/Profile_Local_Single_User.md
+- Docs/Published/Getting_Started/README.md
+- Docs/Published/Getting_Started/Profile_Local_Single_User.md
+- Docs/Design/2026-05-17-quick-launch-scripts.md
+- Docs/superpowers/plans/2026-05-17-quick-launch-scripts-implementation-plan.md
+- tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
+- tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add OS-native quick-launch scripts for local single-user self-hosters who are not using Docker or Make. Keep scripts as thin wrappers around the existing local-single setup/start contract, document them, and add contract tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Repo-root quick-launch scripts exist for Linux/macOS shell, macOS Finder, and Windows PowerShell.
+- [x] #2 Scripts reuse the existing local-single wizard/profile and start uvicorn without Docker or Make.
+- [x] #3 Scripts avoid deprecated `summarize.py`/`-gui` entrypoints and do not print API keys by default.
+- [x] #4 README and Getting Started local profile docs mention the no-Make/no-Docker shortcuts.
+- [x] #5 Focused tests, shell syntax check, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-17-quick-launch-scripts-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `quick-launch.sh`, `quick-launch.command`, and `quick-launch.ps1` as thin wrappers around the existing `local-single` setup wizard and uvicorn start command.
+- Added contract tests for script presence, local-single wiring, no Docker/Make/legacy Gradio usage, no default API-key printing, and documentation discoverability.
+- Ran focused pytest, Bash syntax checks, `git diff --check`, and Bandit for touched Python tests. PowerShell syntax execution was skipped because neither `pwsh` nor `powershell` is available on this host.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Linux/macOS, macOS Finder, and Windows PowerShell quick-launch scripts for the local single-user no-Docker path. The scripts create/update .venv, run the existing local-single setup wizard, start uvicorn at 127.0.0.1:8000, avoid printing API keys by default, and are documented in README plus Getting Started local profile docs. Verification: focused onboarding/script pytest suite passed; bash syntax check passed; Bandit found no issues in touched Python tests. PowerShell syntax execution was not run because pwsh/powershell is unavailable on this host.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-419 - Add-no-Docker-quick-launch-shortcut-scripts.md
+++ b/backlog/tasks/task-419 - Add-no-Docker-quick-launch-shortcut-scripts.md
@@ -20,6 +20,8 @@ modified_files:
 - Docs/superpowers/plans/2026-05-17-quick-launch-scripts-implementation-plan.md
 - tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
 - tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/1817
 ---
 
 ## Description
@@ -54,7 +56,7 @@ Docs/superpowers/plans/2026-05-17-quick-launch-scripts-implementation-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added Linux/macOS, macOS Finder, and Windows PowerShell quick-launch scripts for the local single-user no-Docker path. The scripts create/update .venv, run the existing local-single setup wizard, start uvicorn at 127.0.0.1:8000, avoid printing API keys by default, and are documented in README plus Getting Started local profile docs. Verification: focused onboarding/script pytest suite passed; bash syntax check passed; Bandit found no issues in touched Python tests. PowerShell syntax execution was not run because pwsh/powershell is unavailable on this host.
+Added Linux/macOS, macOS Finder, and Windows PowerShell quick-launch scripts for the local single-user no-Docker path. The scripts create/update .venv, run the existing local-single setup wizard, start uvicorn at 127.0.0.1:8000, avoid printing API keys by default, and are documented in README plus Getting Started local profile docs. Verification: focused onboarding/script pytest suite passed; bash syntax check passed; Bandit found no issues in touched Python tests. PowerShell syntax execution was not run because pwsh/powershell is unavailable on this host. Draft PR: https://github.com/rmusser01/tldw_server/pull/1817
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-419 - Add-no-Docker-quick-launch-shortcut-scripts.md
+++ b/backlog/tasks/task-419 - Add-no-Docker-quick-launch-shortcut-scripts.md
@@ -56,7 +56,7 @@ Docs/superpowers/plans/2026-05-17-quick-launch-scripts-implementation-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added Linux/macOS, macOS Finder, and Windows PowerShell quick-launch scripts for the local single-user no-Docker path. The scripts create/update .venv, run the existing local-single setup wizard, start uvicorn at 127.0.0.1:8000, avoid printing API keys by default, and are documented in README plus Getting Started local profile docs. Verification: focused onboarding/script pytest suite passed; bash syntax check passed; Bandit found no issues in touched Python tests. PowerShell syntax execution was not run because pwsh/powershell is unavailable on this host. Draft PR: https://github.com/rmusser01/tldw_server/pull/1817
+Addressed the actionable PR #1817 review comments for quick-launch scripts. Verification: focused review regression suite passed (17 tests), related onboarding/launcher contract suites passed (33 tests), `bash -n quick-launch.sh quick-launch.command` passed, Bandit reported 0 findings for touched Python tests, and `git diff --check` passed. PowerShell parser execution was not available on this host.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/quick-launch.command
+++ b/quick-launch.command
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# macOS Finder-friendly wrapper for quick-launch.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+exec "$SCRIPT_DIR/quick-launch.sh" "$@"

--- a/quick-launch.ps1
+++ b/quick-launch.ps1
@@ -4,7 +4,8 @@
 param(
     [string]$HostAddress,
     [int]$Port,
-    [switch]$SkipInstall
+    [switch]$SkipInstall,
+    [switch]$ForceInstall
 )
 
 $ErrorActionPreference = "Stop"
@@ -21,18 +22,39 @@ function Invoke-CheckedNative {
     }
 }
 
+function Resolve-QuickLaunchPort {
+    param(
+        [bool]$HasPortParameter,
+        [int]$PortParameter
+    )
+
+    if ($HasPortParameter) {
+        return $PortParameter
+    }
+
+    if ($env:TLDW_PORT) {
+        if ($env:TLDW_PORT -match '^\d+$') {
+            return [int]$env:TLDW_PORT
+        }
+
+        Write-Warning "[quick-launch] Ignoring invalid TLDW_PORT='$($env:TLDW_PORT)'; using 8000."
+    }
+
+    return 8000
+}
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 
 if (-not $HostAddress) {
     $HostAddress = if ($env:TLDW_HOST) { $env:TLDW_HOST } else { "127.0.0.1" }
 }
-if (-not $PSBoundParameters.ContainsKey("Port")) {
-    $Port = if ($env:TLDW_PORT) { [int]$env:TLDW_PORT } else { 8000 }
-}
+$HasPortParameter = $PSBoundParameters.ContainsKey("Port")
+$Port = Resolve-QuickLaunchPort -HasPortParameter $HasPortParameter -PortParameter $Port
 
 $VenvDir = if ($env:TLDW_VENV_DIR) { $env:TLDW_VENV_DIR } else { ".venv" }
 $VenvPython = Join-Path $VenvDir "Scripts/python.exe"
+$InstallMarker = Join-Path $VenvDir ".initialized"
 $EnvFile = if ($env:TLDW_ENV_FILE) { $env:TLDW_ENV_FILE } else { "tldw_Server_API/Config_Files/.env" }
 
 if ($env:TLDW_PYTHON) {
@@ -51,17 +73,26 @@ Write-Host ""
 
 Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"))
 
+$VenvCreated = $false
 if (-not (Test-Path $VenvPython)) {
     Write-Host "[quick-launch] Creating virtualenv at $VenvDir"
     Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-m", "venv", $VenvDir))
+    $VenvCreated = $true
 }
 
-if (-not $SkipInstall -and $env:TLDW_SKIP_INSTALL -ne "1") {
+if (
+    -not $SkipInstall `
+    -and $env:TLDW_SKIP_INSTALL -ne "1" `
+    -and ($ForceInstall -or $env:TLDW_FORCE_INSTALL -eq "1" -or $VenvCreated -or -not (Test-Path $InstallMarker))
+) {
     Write-Host "[quick-launch] Installing/updating local Python dependencies..."
     Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
     Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "-e", ".")
-} else {
+    New-Item -Path $InstallMarker -ItemType File -Force | Out-Null
+} elseif ($SkipInstall -or $env:TLDW_SKIP_INSTALL -eq "1") {
     Write-Host "[quick-launch] Skipping dependency install"
+} else {
+    Write-Host "[quick-launch] Dependency setup already completed; set TLDW_FORCE_INSTALL=1 or pass -ForceInstall to reinstall/update."
 }
 
 Write-Host "[quick-launch] Configuring local single-user profile..."

--- a/quick-launch.ps1
+++ b/quick-launch.ps1
@@ -1,0 +1,95 @@
+# Quick-launch local single-user tldw_server without Docker or Make.
+
+[CmdletBinding()]
+param(
+    [string]$HostAddress,
+    [int]$Port,
+    [switch]$SkipInstall
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-CheckedNative {
+    param(
+        [string]$FilePath,
+        [string[]]$Arguments
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "[quick-launch] Command failed with exit code $LASTEXITCODE`: $FilePath $($Arguments -join ' ')"
+    }
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $ScriptDir
+
+if (-not $HostAddress) {
+    $HostAddress = if ($env:TLDW_HOST) { $env:TLDW_HOST } else { "127.0.0.1" }
+}
+if (-not $PSBoundParameters.ContainsKey("Port")) {
+    $Port = if ($env:TLDW_PORT) { [int]$env:TLDW_PORT } else { 8000 }
+}
+
+$VenvDir = if ($env:TLDW_VENV_DIR) { $env:TLDW_VENV_DIR } else { ".venv" }
+$VenvPython = Join-Path $VenvDir "Scripts/python.exe"
+$EnvFile = if ($env:TLDW_ENV_FILE) { $env:TLDW_ENV_FILE } else { "tldw_Server_API/Config_Files/.env" }
+
+if ($env:TLDW_PYTHON) {
+    $PythonExe = $env:TLDW_PYTHON
+    $PythonArgs = @()
+} elseif (Get-Command py -ErrorAction SilentlyContinue) {
+    $PythonExe = "py"
+    $PythonArgs = @("-3")
+} else {
+    $PythonExe = "python"
+    $PythonArgs = @()
+}
+
+Write-Host "=== tldw_server quick launch ==="
+Write-Host ""
+
+Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"))
+
+if (-not (Test-Path $VenvPython)) {
+    Write-Host "[quick-launch] Creating virtualenv at $VenvDir"
+    Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-m", "venv", $VenvDir))
+}
+
+if (-not $SkipInstall -and $env:TLDW_SKIP_INSTALL -ne "1") {
+    Write-Host "[quick-launch] Installing/updating local Python dependencies..."
+    Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
+    Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "-e", ".")
+} else {
+    Write-Host "[quick-launch] Skipping dependency install"
+}
+
+Write-Host "[quick-launch] Configuring local single-user profile..."
+Invoke-CheckedNative -FilePath $VenvPython -Arguments @(
+    "-m",
+    "tldw_Server_API.cli.wizard.cli",
+    "init",
+    "--profile",
+    "local-single",
+    "--env-file",
+    $EnvFile,
+    "--default",
+    "--yes"
+)
+
+Write-Host ""
+Write-Host "[quick-launch] Starting API at http://$HostAddress`:$Port"
+Write-Host "[quick-launch] Docs:   http://$HostAddress`:$Port/docs"
+Write-Host "[quick-launch] Health: http://$HostAddress`:$Port/health"
+Write-Host ""
+
+$env:TLDW_ENV_FILE = $EnvFile
+Invoke-CheckedNative -FilePath $VenvPython -Arguments @(
+    "-m",
+    "uvicorn",
+    "tldw_Server_API.app.main:app",
+    "--host",
+    $HostAddress,
+    "--port",
+    "$Port"
+)

--- a/quick-launch.sh
+++ b/quick-launch.sh
@@ -8,10 +8,29 @@ cd "$SCRIPT_DIR"
 
 PYTHON_CMD="${TLDW_PYTHON:-python3}"
 VENV_DIR="${TLDW_VENV_DIR:-.venv}"
-VENV_PYTHON="$VENV_DIR/bin/python"
+INSTALL_MARKER="$VENV_DIR/.initialized"
 ENV_FILE="${TLDW_ENV_FILE:-tldw_Server_API/Config_Files/.env}"
 HOST="${TLDW_HOST:-127.0.0.1}"
 PORT="${TLDW_PORT:-8000}"
+
+resolve_venv_python() {
+    if [ -x "$VENV_DIR/bin/python" ]; then
+        printf '%s\n' "$VENV_DIR/bin/python"
+        return 0
+    fi
+
+    if [ -x "$VENV_DIR/Scripts/python" ]; then
+        printf '%s\n' "$VENV_DIR/Scripts/python"
+        return 0
+    fi
+
+    if [ -x "$VENV_DIR/Scripts/python.exe" ]; then
+        printf '%s\n' "$VENV_DIR/Scripts/python.exe"
+        return 0
+    fi
+
+    return 1
+}
 
 echo "=== tldw_server quick launch ==="
 echo ""
@@ -26,15 +45,26 @@ fi
     exit 1
 }
 
-if [ ! -x "$VENV_PYTHON" ]; then
+VENV_CREATED=0
+if ! VENV_PYTHON="$(resolve_venv_python)"; then
     echo "[quick-launch] Creating virtualenv at $VENV_DIR"
     "$PYTHON_CMD" -m venv "$VENV_DIR"
+    VENV_CREATED=1
+    if ! VENV_PYTHON="$(resolve_venv_python)"; then
+        echo "[quick-launch] Could not find Python in $VENV_DIR after creating the virtualenv." >&2
+        exit 1
+    fi
 fi
 
 if [ "${TLDW_SKIP_INSTALL:-0}" != "1" ]; then
-    echo "[quick-launch] Installing/updating local Python dependencies..."
-    "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel
-    "$VENV_PYTHON" -m pip install -e .
+    if [ "${TLDW_FORCE_INSTALL:-0}" = "1" ] || [ "$VENV_CREATED" = "1" ] || [ ! -f "$INSTALL_MARKER" ]; then
+        echo "[quick-launch] Installing/updating local Python dependencies..."
+        "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel
+        "$VENV_PYTHON" -m pip install -e .
+        touch "$INSTALL_MARKER"
+    else
+        echo "[quick-launch] Dependency setup already completed; set TLDW_FORCE_INSTALL=1 to reinstall/update."
+    fi
 else
     echo "[quick-launch] Skipping dependency install because TLDW_SKIP_INSTALL=1"
 fi

--- a/quick-launch.sh
+++ b/quick-launch.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Quick-launch local single-user tldw_server without Docker or Make.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+PYTHON_CMD="${TLDW_PYTHON:-python3}"
+VENV_DIR="${TLDW_VENV_DIR:-.venv}"
+VENV_PYTHON="$VENV_DIR/bin/python"
+ENV_FILE="${TLDW_ENV_FILE:-tldw_Server_API/Config_Files/.env}"
+HOST="${TLDW_HOST:-127.0.0.1}"
+PORT="${TLDW_PORT:-8000}"
+
+echo "=== tldw_server quick launch ==="
+echo ""
+
+if ! command -v "$PYTHON_CMD" >/dev/null 2>&1; then
+    echo "[quick-launch] $PYTHON_CMD not found. Install Python 3.10+ or set TLDW_PYTHON." >&2
+    exit 1
+fi
+
+"$PYTHON_CMD" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' || {
+    echo "[quick-launch] Python 3.10+ is required." >&2
+    exit 1
+}
+
+if [ ! -x "$VENV_PYTHON" ]; then
+    echo "[quick-launch] Creating virtualenv at $VENV_DIR"
+    "$PYTHON_CMD" -m venv "$VENV_DIR"
+fi
+
+if [ "${TLDW_SKIP_INSTALL:-0}" != "1" ]; then
+    echo "[quick-launch] Installing/updating local Python dependencies..."
+    "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel
+    "$VENV_PYTHON" -m pip install -e .
+else
+    echo "[quick-launch] Skipping dependency install because TLDW_SKIP_INSTALL=1"
+fi
+
+echo "[quick-launch] Configuring local single-user profile..."
+"$VENV_PYTHON" -m tldw_Server_API.cli.wizard.cli init \
+    --profile local-single \
+    --env-file "$ENV_FILE" \
+    --default \
+    --yes
+
+echo ""
+echo "[quick-launch] Starting API at http://$HOST:$PORT"
+echo "[quick-launch] Docs:   http://$HOST:$PORT/docs"
+echo "[quick-launch] Health: http://$HOST:$PORT/health"
+echo ""
+
+TLDW_ENV_FILE="$ENV_FILE" exec "$VENV_PYTHON" -m uvicorn \
+    tldw_Server_API.app.main:app \
+    --host "$HOST" \
+    --port "$PORT"

--- a/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
@@ -103,3 +103,24 @@ def test_getting_started_index_calls_out_default_webui_path() -> None:
         "Docker multi-user + Postgres" in text,
         "Getting Started index should keep the team/public deployment callout",
     )
+
+
+def test_no_make_local_quick_launch_shortcuts_are_documented() -> None:
+    """No-Make local self-hosters should be able to find the quick-launch scripts."""
+    docs = {
+        "README.md": Path("README.md").read_text(),
+        "Docs/Getting_Started/README.md": Path("Docs/Getting_Started/README.md").read_text(),
+        "Docs/Getting_Started/Profile_Local_Single_User.md": Path(
+            "Docs/Getting_Started/Profile_Local_Single_User.md"
+        ).read_text(),
+        "Docs/Published/Getting_Started/README.md": Path(
+            "Docs/Published/Getting_Started/README.md"
+        ).read_text(),
+        "Docs/Published/Getting_Started/Profile_Local_Single_User.md": Path(
+            "Docs/Published/Getting_Started/Profile_Local_Single_User.md"
+        ).read_text(),
+    }
+
+    for path, text in docs.items():
+        for script in ("quick-launch.sh", "quick-launch.command", "quick-launch.ps1"):
+            _require(script in text, f"{path} should document {script}")

--- a/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
@@ -11,9 +11,13 @@ def _require(condition: bool, message: str) -> None:
         pytest.fail(message)
 
 
+def _read_text(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
 def test_readme_start_here_links_to_profile_index() -> None:
     """README should keep linking to the canonical onboarding profiles."""
-    text = Path("README.md").read_text()
+    text = _read_text("README.md")
     _require(
         "Docs/Getting_Started/README.md" in text,
         "README should link to the Getting Started index",
@@ -47,7 +51,7 @@ def test_readme_start_here_links_to_profile_index() -> None:
 
 def test_readme_quickstart_defaults_to_webui_before_local_dev() -> None:
     """README quickstart should lead with the Docker WebUI path."""
-    text = Path("README.md").read_text()
+    text = _read_text("README.md")
     _, separator, quickstart_section = text.partition("## Quickstart")
     _require(separator == "## Quickstart", "README should include a Quickstart section")
     _require(
@@ -70,7 +74,7 @@ def test_readme_quickstart_defaults_to_webui_before_local_dev() -> None:
 
 def test_getting_started_index_lists_profiles_and_audio_guides() -> None:
     """The Getting Started index should enumerate base profiles and audio guides."""
-    text = Path("Docs/Getting_Started/README.md").read_text()
+    text = _read_text("Docs/Getting_Started/README.md")
     _require(
         "Choose exactly one base setup profile" in text,
         "Getting Started index should explain the base-profile model",
@@ -93,7 +97,7 @@ def test_getting_started_index_lists_profiles_and_audio_guides() -> None:
 
 def test_getting_started_index_calls_out_default_webui_path() -> None:
     """The Getting Started index should call out the WebUI Docker default."""
-    text = Path("Docs/Getting_Started/README.md").read_text()
+    text = _read_text("Docs/Getting_Started/README.md")
     _require("make quickstart" in text, "Getting Started index should mention make quickstart")
     _require(
         "quickstart-docker-webui" in text,
@@ -108,17 +112,17 @@ def test_getting_started_index_calls_out_default_webui_path() -> None:
 def test_no_make_local_quick_launch_shortcuts_are_documented() -> None:
     """No-Make local self-hosters should be able to find the quick-launch scripts."""
     docs = {
-        "README.md": Path("README.md").read_text(),
-        "Docs/Getting_Started/README.md": Path("Docs/Getting_Started/README.md").read_text(),
-        "Docs/Getting_Started/Profile_Local_Single_User.md": Path(
+        "README.md": _read_text("README.md"),
+        "Docs/Getting_Started/README.md": _read_text("Docs/Getting_Started/README.md"),
+        "Docs/Getting_Started/Profile_Local_Single_User.md": _read_text(
             "Docs/Getting_Started/Profile_Local_Single_User.md"
-        ).read_text(),
-        "Docs/Published/Getting_Started/README.md": Path(
+        ),
+        "Docs/Published/Getting_Started/README.md": _read_text(
             "Docs/Published/Getting_Started/README.md"
-        ).read_text(),
-        "Docs/Published/Getting_Started/Profile_Local_Single_User.md": Path(
+        ),
+        "Docs/Published/Getting_Started/Profile_Local_Single_User.md": _read_text(
             "Docs/Published/Getting_Started/Profile_Local_Single_User.md"
-        ).read_text(),
+        ),
     }
 
     for path, text in docs.items():

--- a/tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
+++ b/tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
@@ -1,0 +1,113 @@
+"""Contract tests for no-Docker quick-launch scripts."""
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _require(condition: bool, message: str) -> None:
+    """Fail with a descriptive assertion message when a contract is broken."""
+    if not condition:
+        pytest.fail(message)
+
+
+def _read(path: str) -> str:
+    script_path = REPO_ROOT / path
+    if not script_path.exists():
+        pytest.fail(f"{path} should exist")
+    return script_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "quick-launch.sh",
+        "quick-launch.command",
+        "quick-launch.ps1",
+    ],
+)
+def test_quick_launch_scripts_exist(path: str) -> None:
+    """Each supported platform should have a repo-root quick-launch shortcut."""
+    _require((REPO_ROOT / path).is_file(), f"{path} should exist at the repository root")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "quick-launch.sh",
+        "quick-launch.ps1",
+    ],
+)
+def test_quick_launch_scripts_wrap_existing_local_single_contract(path: str) -> None:
+    """Launchers should reuse the existing local-single setup/start contract."""
+    text = _read(path)
+
+    for expected in (
+        ".venv",
+        "pip",
+        "install",
+        "tldw_Server_API.cli.wizard.cli",
+        "--profile",
+        "local-single",
+        "uvicorn",
+        "tldw_Server_API.app.main:app",
+        "127.0.0.1",
+        "8000",
+    ):
+        _require(expected in text, f"{path} should include {expected}")
+
+
+def test_macos_command_delegates_to_shell_launcher() -> None:
+    """The Finder-friendly macOS shortcut should reuse the shell launcher."""
+    text = _read("quick-launch.command")
+
+    _require("quick-launch.sh" in text, "quick-launch.command should delegate to quick-launch.sh")
+    _require("exec" in text, "quick-launch.command should replace itself with the shell launcher")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "quick-launch.sh",
+        "quick-launch.command",
+        "quick-launch.ps1",
+    ],
+)
+def test_quick_launch_scripts_do_not_use_docker_make_or_legacy_gradio(path: str) -> None:
+    """No-Docker launchers should not route through Docker, Make, or old UI entrypoints."""
+    text = _read(path)
+
+    forbidden_fragments = (
+        "docker compose",
+        "make quickstart",
+        "make install-local",
+        "summarize.py",
+        "-gui",
+    )
+    for fragment in forbidden_fragments:
+        _require(fragment not in text, f"{path} should not include {fragment}")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "quick-launch.sh",
+        "quick-launch.command",
+        "quick-launch.ps1",
+    ],
+)
+def test_quick_launch_scripts_do_not_print_api_keys_by_default(path: str) -> None:
+    """Default launch output should avoid echoing full API keys."""
+    text = _read(path)
+
+    forbidden_fragments = (
+        "grep '^SINGLE_USER_API_KEY='",
+        "Your API key",
+        "Your API Key",
+        "cut -d= -f2-",
+    )
+    for fragment in forbidden_fragments:
+        _require(fragment not in text, f"{path} should not include {fragment}")

--- a/tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
+++ b/tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
@@ -68,6 +68,39 @@ def test_macos_command_delegates_to_shell_launcher() -> None:
     _require("exec" in text, "quick-launch.command should replace itself with the shell launcher")
 
 
+def test_shell_launcher_supports_git_bash_venv_layout() -> None:
+    """Shell launcher should work when a venv exposes Windows Scripts/python."""
+    text = _read("quick-launch.sh")
+
+    _require("resolve_venv_python" in text, "quick-launch.sh should resolve venv Python dynamically")
+    _require("$VENV_DIR/Scripts/python" in text, "quick-launch.sh should support Windows venv layout")
+    _require("$VENV_DIR/bin/python" in text, "quick-launch.sh should support POSIX venv layout")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "quick-launch.sh",
+        "quick-launch.ps1",
+    ],
+)
+def test_quick_launch_scripts_skip_reinstall_after_initial_setup(path: str) -> None:
+    """Quick launch should not force networked pip install on every run."""
+    text = _read(path)
+
+    _require(".initialized" in text, f"{path} should record completed local dependency setup")
+    _require("TLDW_FORCE_INSTALL" in text, f"{path} should allow explicit reinstall/update")
+
+
+def test_powershell_launcher_validates_env_port() -> None:
+    """PowerShell launcher should validate TLDW_PORT before casting to int."""
+    text = _read("quick-launch.ps1")
+
+    _require("Resolve-QuickLaunchPort" in text, "quick-launch.ps1 should use a port parsing helper")
+    _require("-match" in text and "\\d+" in text, "quick-launch.ps1 should validate numeric ports")
+    _require("TLDW_PORT" in text, "quick-launch.ps1 should keep env override support")
+
+
 @pytest.mark.parametrize(
     "path",
     [


### PR DESCRIPTION
## Summary

- What changed: added repo-root `quick-launch.sh`, `quick-launch.command`, and `quick-launch.ps1` for local single-user no-Docker startup; documented them in README and Getting Started docs; added contract tests for launcher behavior and docs discoverability.
- Why: self-hosters without Docker or Make need a first-run path that reuses the existing `local-single` setup wizard instead of stale/deprecated installer scripts.

## Change summary

Pending human-owned change summary before this PR is merge-ready. Per repo policy, the human requester should replace this placeholder with their own explanation of what changed and why these implementation choices were made.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_quick_launch_scripts.py tldw_Server_API/tests/Utils/test_makefile_onboarding_profiles.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py -q` (29 passed)
- [x] Docs updated (if behavior, routes, or config changed)
- [x] `bash -n quick-launch.sh quick-launch.command`
- [x] Bandit on touched Python tests: no findings in `/tmp/bandit_quick_launch_scripts.json`
- [ ] PowerShell parse check not run: `pwsh`/`powershell` unavailable on this macOS host

## UX Audit Checklist (v2 Stage 5)

- [ ] Not applicable: no WebUI/extension UI behavior changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] Not applicable: no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] Not applicable: no Watchlists polling/notifications/scale behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: revert `f8a24e0ab` to remove the launchers, docs, and contract tests.

Refs TASK-419

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OS-native quick-launch scripts to start the local single-user API without Docker or Make. They create `.venv`, run `tldw_Server_API.cli.wizard.cli` with the `local-single` profile, and start `uvicorn` at 127.0.0.1:8000; addresses TASK-419.

- New Features
  - Added `quick-launch.sh`, `quick-launch.command` (macOS Finder wrapper), and `quick-launch.ps1` that reuse the existing setup/start contract and avoid Docker/Make and legacy entrypoints.
  - Defaults to `127.0.0.1:8000`, with overrides via `TLDW_HOST`/`TLDW_PORT`.
  - Updated README and Getting Started docs (including published variants) to document the shortcuts.

- Bug Fixes
  - Hardened launchers: Python 3.10+ check, cross-platform venv resolution (POSIX/Windows), `.initialized` marker with `TLDW_FORCE_INSTALL`/`TLDW_SKIP_INSTALL`.
  - Safer defaults and ergonomics: no API keys printed; PowerShell validates `TLDW_PORT`; sets `TLDW_ENV_FILE` before starting `uvicorn`.
  - macOS `.command` delegates via `exec`; tests enforce no Docker/Make or legacy entrypoints and verify docs discoverability.

<sup>Written for commit 25ce0769e04cc056bbe2526543024461a1098c29. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1817?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

