### PR TITLE
Docs: reconcile Buddy Codex default catalog

### DIFF
--- a/Docs/Code_Documentation/Persona_Visual_Packs.md
+++ b/Docs/Code_Documentation/Persona_Visual_Packs.md
@@ -151,7 +151,7 @@ screen-position movement, not generic tool activity. They are declared in the
 pack `state_catalog`, so runtimes that do not know those states can still fall
 back through normal state resolution.
 
-### Simple Buddy Creator Reference
+### Buddy Creator Reference
 
 tldw's user-facing Buddy creation flow should use the hatch-pet workflow as a
 reference model, retuned around the Persona Visual functionality available in
@@ -163,19 +163,22 @@ inactive draft creation, optional library reuse, MCP-triggerable custom states,
 and explicit activation.
 
 The goal is not to require users to understand Codex pet internals before they
-can make a Buddy. The simple path should guide users through the smallest useful
-asset workflow and then store the result as a normal Persona Visual draft pack.
-The full Codex-compatible path should remain available when users want import,
-export, or reuse with Codex pets.
+can make a Buddy. The simple path is a UX path over the same Persona Visual
+draft/review model: it guides users through the smallest useful asset workflow
+and stores the result as a normal Persona Visual draft pack. It is not a
+separate lower compatibility contract for bundled defaults. When users want
+import, export, or reuse with Codex pets, the full Codex-compatible path remains
+first-class.
 
 The tldw-retuned creation modes are:
 
-1. **Simple Buddy mode**: user provides a name, description, optional reference
+1. **Guided Buddy mode**: user provides a name, description, optional reference
    image, and style notes. tldw helps create one neutral anchor and the minimum
    runtime states needed for a usable Buddy: `idle`, `listening`, `thinking`,
    `speaking`, and `error`. If the Buddy can move around the screen, it can also
    add `moving_right` and `moving_left`. The output is a Persona Visual draft
-   pack with review evidence.
+   pack with review evidence, and can later be upgraded or exported through the
+   Codex-compatible atlas path.
 2. **Codex-compatible mode**: user creates the full nine-row Codex atlas:
    `idle`, `running-right`, `running-left`, `waving`, `jumping`, `failed`,
    `waiting`, `running`, and `review`. tldw imports the result as a Persona
@@ -240,11 +243,12 @@ they are clearer:
 8. `review` maps to focused thinking or approval review.
 
 Basic defaults and simple user-created Buddies can stay visually simple, but
-their final production packets should still pass the same identity,
-transparency, state semantics, and review process. The earlier 3x4 source sheets
-are acceptable as concept review evidence; they should be converted into either
-the simple tldw draft-pack contract or the full Codex-compatible atlas contract
-before the pack is treated as a final bundled default.
+their production packets should still pass the same identity, transparency,
+state semantics, and review process. The earlier 3x4 source sheets are
+acceptable as concept review evidence. For bundled defaults, the current 96x96
+Persona Visual packets are accepted runtime assets, and Codex Buddy reuse should
+upgrade or package them through the Codex-compatible atlas contract instead of
+creating a separate simple-only default format.
 
 ## Sprite Atlas Packs
 
@@ -377,8 +381,10 @@ recovery flows. They are not global Persona Visual pack rows or shared library
 entries. Listing the catalog returns safe fixture metadata only, and copying a
 starter always creates a normal user-owned draft pack before activation.
 
-The current bundled catalog exposes twelve starter IDs in stable order while the
-basic tier is being rebuilt into the six approved defaults:
+The current bundled catalog exposes twelve starter IDs in stable order. The
+basic tier is the six bundled Codex Buddy defaults; the intermediate and
+intricate tiers remain bundled scaffold entries until their reviewed production
+assets are authored:
 
 1. `search-lens-basic`
 2. `index-card-basic`
@@ -393,21 +399,22 @@ basic tier is being rebuilt into the six approved defaults:
 11. `action-guide-intricate`
 12. `elaborate-persona-intricate`
 
-These map to the approved basic, intermediate, and intricate tiers from the
-Persona Buddy default catalog design. The bundled basic tier is Search Lens,
-Index Card, Archive Cube, Paperclip, Terminal Tile, and Migu. The approved 3x4
-basic sheets are retained as review evidence and Simple Buddy production
-packets. Full Codex-pet-compatible atlas packets can be produced from the same
-neutral-anchor process when a bundled default or user-created Buddy needs the
-Codex import/export pathway.
+The bundled basic tier is Search Lens, Index Card, Archive Cube, Paperclip,
+Terminal Tile, and Migu. Earlier tracker text that described only three basic
+defaults is stale; this six-pack is the current basic tier. The existing
+package-backed 96x96 frame packets are accepted art-ready Persona Visual
+runtime assets for those six defaults, with neutral/preview assets and required
+state coverage. They are not the final interchange ceiling. When a default pack
+needs cross-app portability or Codex Buddy parity, the production target is the
+Codex/Petdex-compatible path: `pet.json` plus a 1536x1872, 8x9
+`spritesheet.webp`/PNG atlas imported through the Codex pet adapter.
 
-Each final basic starter should include a neutral anchor, preview asset, and
-required state coverage for `idle`, `listening`, `thinking`, `speaking`, and
-`error`. When the starter targets the full Codex-compatible path, it should also
-include atlas-backed movement coverage for `moving_right` and `moving_left`. The
-existing 96x96 frame packets remain useful review artifacts and bundled Simple
-Buddy assets. New full-compatibility packets should use the Codex atlas
-interchange path.
+The approved 3x4 basic sheets and processed 96x96 frame packets remain review
+evidence and current bundled runtime assets. They should be treated as source
+or interim production evidence for any later Codex-compatible atlas upgrade,
+not as a separate lower-tier contract that overrides the Codex/Petdex
+compatibility direction. Codex `running-right` and `running-left` rows continue
+to map to tldw `moving_right` and `moving_left` movement states.
 
 The Search Lens source-sheet checkpoint is stored with its processed frame
 review packet:
@@ -445,9 +452,12 @@ The basic tier intentionally models the simplest user-facing creation process:
 start with one neutral anchor, preserve that silhouette, and author only the
 smallest state deltas needed for expressive runtime feedback. The bundled basic
 packs do not require a separate static talking sheet, reaction sheet, or
-tool-specific variants. For production import parity with Codex pets, a full
-compatibility packet can be a single 8x9 atlas derived from that same neutral
-anchor and reviewed with the hatch-style contact-sheet and motion-preview bar.
+tool-specific variants. For bundled defaults and users who want Codex Buddy
+reuse, the compatible production packet is a single 8x9 atlas derived from that
+same neutral anchor and reviewed with the hatch-style contact-sheet and
+motion-preview bar. The current two-frame 96x96 loops are the accepted tldw
+runtime packet for the merged basic slice; they do not replace the Codex atlas
+interchange path.
 
 #### `search-lens-basic`
 

--- a/Docs/superpowers/plans/2026-05-16-basic-buddy-default-assets-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-basic-buddy-default-assets-plan.md
@@ -8,7 +8,7 @@
 
 ## Stage 2: Replace Basic Scaffold Art
 **Goal**: Replace the basic tier's placeholder fixtures one approved Buddy at a time with Codex-pet-compatible atlas packets derived from one neutral-anchor identity per pack.
-**Success Criteria**: `search-lens-basic`, `index-card-basic`, `archive-cube-basic`, `paperclip-basic`, `terminal-tile-basic`, and `migu-marker-basic` each provide reviewed required-state loops plus neutral/preview assets before the six-pack basic tier is complete. Final production packets should fit the user-facing Simple Buddy Creator contract first, and can additionally target the Codex pet 8x9 atlas contract when full compatibility is needed. The creation process follows the hatch-style bar retuned for tldw: canonical neutral anchor, state rows/frames, deterministic assembly, contact-sheet review, motion-preview review when animated, inactive draft import, and explicit activation. The already approved 3x4 packets remain review/concept evidence until converted.
+**Success Criteria**: `search-lens-basic`, `index-card-basic`, `archive-cube-basic`, `paperclip-basic`, `terminal-tile-basic`, and `migu-marker-basic` each provide reviewed required-state loops plus neutral/preview assets before the six-pack basic tier is complete. The six basic defaults are the current basic tier. The merged 96x96 frame packets are accepted tldw runtime assets for the basic slice, while the final cross-app/interchange target is the Codex/Petdex-compatible 8x9 atlas contract when a default or user-created Buddy needs Codex Buddy parity. The creation process follows the hatch-style bar retuned for tldw: canonical neutral anchor, state rows/frames, deterministic assembly, contact-sheet review, motion-preview review when animated, inactive draft import, and explicit activation. The already approved 3x4 packets remain review/concept evidence for any later atlas upgrade instead of defining a separate lower-tier contract.
 **Tests**:
 - `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_starter_catalog.py -q`
 - `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py -q -k 'codex_pet'`
@@ -16,7 +16,7 @@
 
 ## Stage 3: Documentation And Review Evidence
 **Goal**: Document approved basic defaults, Codex-pet import compatibility, and review evidence for each accepted source sheet and processed frame packet.
-**Success Criteria**: Persona Visual docs distinguish bundled basic art-ready defaults from unfinished starters, preserve draft-first activation semantics, define the `moving_right` / `moving_left` movement-state translation for Codex pet running rows, and record hatch-pet as the reference workflow for a tldw-native Simple Buddy Creator flow with a simple draft-pack mode and a full Codex-compatible mode.
+**Success Criteria**: Persona Visual docs distinguish bundled basic art-ready defaults from unfinished starters, preserve draft-first activation semantics, define the `moving_right` / `moving_left` movement-state translation for Codex pet running rows, and record hatch-pet as the reference workflow for a tldw-native Buddy creation flow whose simple UX path still converges on the same Persona Visual draft/review contract and can produce or import full Codex-compatible packets.
 **Tests**: `git diff --check`
 **Status**: Complete
 

--- a/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-buddy-animation-pipeline-catalog-metadata-plan.md
@@ -275,7 +275,7 @@ Use this parametrization:
 @pytest.mark.parametrize(
     ("starter_pack_id", "complexity_tier", "required_group", "expected_output"),
     (
-        ("research-buddy-basic", "basic", "required_state_loops", "required_state_loops"),
+        ("search-lens-basic", "basic", "required_state_loops", "required_state_loops"),
         (
             "study-desk-intermediate",
             "intermediate",

--- a/Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md
+++ b/Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md
@@ -5,12 +5,20 @@ Status: Approved direction; design slice for TASK-347
 Owner: Codex brainstorming pass
 Backlog: TASK-347
 
+Supersession note: later asset-production work expanded the basic tier from the
+initial three-pack concept to the six Codex Buddy defaults: `search-lens-basic`,
+`index-card-basic`, `archive-cube-basic`, `paperclip-basic`,
+`terminal-tile-basic`, and `migu-marker-basic`. This document remains useful
+for the neutral-anchor pipeline and state-catalog design, but the current
+catalog list is the twelve starter IDs documented in
+`Docs/Code_Documentation/Persona_Visual_Packs.md`.
+
 ## Summary
 
-Define the next Persona/Buddy visual-pack design slice: a nine-pack default
-catalog, a user-facing asset creation flow based on a neutral identity anchor,
-and a V1-compatible state catalog extension that supports a large bounded set
-of custom state IDs and per-tool animation variants.
+Define the next Persona/Buddy visual-pack design slice: a bundled default
+starter catalog, a user-facing asset creation flow based on a neutral identity
+anchor, and a V1-compatible state catalog extension that supports a large
+bounded set of custom state IDs and per-tool animation variants.
 
 This is not a new renderer. It extends the existing Persona Visual Pack contract
 that uses `renderer_type: "sprite_frames"`, state-to-animation mappings,
@@ -62,7 +70,7 @@ review outputs, and only then compile accepted frames into runtime assets.
 
 ## Goals
 
-1. Define nine bundled default buddies across basic, intermediate, and intricate
+1. Define bundled default buddies across basic, intermediate, and intricate
    complexity tiers.
 2. Preserve a neutral-pose-first creation workflow for defaults and user-created
    buddies.
@@ -101,8 +109,8 @@ review outputs, and only then compile accepted frames into runtime assets.
   from that anchor.
 - Static expression sheets are for talking and reactive pose selection. They are
   not the animation system.
-- There should be nine bundled defaults: three basic, three intermediate, and
-  three intricate.
+- The current bundled starter catalog has twelve IDs: six basic Codex Buddy
+  defaults plus three intermediate and three intricate scaffold entries.
 - The sprite manifest should support custom state IDs and per-tool animation
   variants at a large but bounded scale without redefining repo-wide Manifest
   V2 terminology.
@@ -166,13 +174,16 @@ with optional steps for simpler designs.
 | Intermediate | Demonstrate richer authoring without high art cost | Neutral model sheet, expression sheet, several state strips | Required built-ins, optional built-ins, several custom tool/reaction states |
 | Intricate | Show the ceiling for expressive buddies | Full model sheet, static sheet, keyframes, validated strips, compiled atlas | Required built-ins, optional built-ins, many custom states and per-tool variants |
 
-## Nine Default Starter Buddies
+## Bundled Default Starter Buddies
 
 | ID | Tier | Concept | What It Demonstrates |
 | --- | --- | --- | --- |
-| `research-buddy-basic` | Basic | Clean assistant mascot/robot, close to the earlier mockup direction | Low-risk default with readable silhouette, simple idle/listening/thinking/speaking/error loops |
+| `search-lens-basic` | Basic | Friendly search-lens object Buddy | Low-risk Codex Buddy default with readable silhouette, simple idle/listening/thinking/speaking/error loops |
+| `index-card-basic` | Basic | Friendly tabbed-card object Buddy | Low-risk Codex Buddy default with readable silhouette and simple required-state loops |
+| `archive-cube-basic` | Basic | Friendly archive/storage cube Buddy | Object-based basic default with readable state changes |
+| `paperclip-basic` | Basic | Friendly paperclip object Buddy | Simple object Buddy proving low-complexity art can be expressive |
+| `terminal-tile-basic` | Basic | Friendly terminal-window tile Buddy | CLI-flavored object Buddy with simple required-state coverage |
 | `migu-marker-basic` | Basic | Rough marker-line "Migu" inspired buddy with teal twin-tail silhouette and playful wobble | User-art-friendly style; shows simple drawings can become usable buddies |
-| `minimal-helper-basic` | Basic | Simple geometric helper or object buddy | Lowest-complexity path for users who want a quick custom pack |
 | `study-desk-intermediate` | Intermediate | Original desk/study companion with calm posture and props | Neutral seated anchor, static talking sheet, short writing/listening/thinking loops |
 | `tool-helper-intermediate` | Intermediate | Utility-themed assistant with visual tool affordances | Per-tool variants for search, import, summarize, and approval-needed without high art complexity |
 | `object-creature-intermediate` | Intermediate | Non-human expressive creature or object | Confirms the format is not limited to humanoid characters |
@@ -180,8 +191,8 @@ with optional steps for simpler designs.
 | `action-guide-intricate` | Intricate | Energetic guide with anticipation, reaction, success, and error beats | More dynamic animation timing and expressive state transitions |
 | `elaborate-persona-intricate` | Intricate | High-detail fantasy or sci-fi persona buddy | Full high-ceiling pack with many custom states, atlas layout, and strict review/validation |
 
-All nine defaults should be bundled as starter packs and copied into user-owned
-inactive drafts when selected. They should not auto-activate on copy.
+All bundled defaults should be copied into user-owned inactive drafts when
+selected. They should not auto-activate on copy.
 
 Starter art production notes:
 
@@ -546,7 +557,7 @@ MCP:
 
 Catalog:
 
-- List all nine defaults with stable IDs and complexity metadata.
+- List all bundled defaults with stable IDs and complexity metadata.
 - Copy each starter into an inactive user-owned draft.
 - Ensure bundled defaults do not reuse protected character likenesses directly.
 

--- a/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-05-16-buddy-animation-pipeline-design.md
@@ -22,7 +22,7 @@ workflow:
 5. import or copy the result into an inactive Persona Visual draft pack,
 6. activate only after explicit user review.
 
-The current starter catalog already contains nine scaffold IDs and the runtime
+The current starter catalog contains twelve starter IDs and the runtime
 already supports bounded custom visual states through `state_catalog` and
 `authored_triggers`. This spec turns those scaffolds into a production-ready
 asset pipeline without claiming that finished default animation packs already
@@ -35,11 +35,13 @@ reuse:
 
 - `Docs/Code_Documentation/Persona_Visual_Packs.md` documents user-owned,
   persona-attached, manifest-backed packs, explicit activation, import/export,
-  generated-candidate review, personal library reuse, and the nine starter
-  scaffold IDs.
+  generated-candidate review, personal library reuse, the default-pack
+  production tracker, and the current twelve starter IDs.
 - `tldw_Server_API/app/core/Persona/visual_starter_fixtures.py` defines the
-  nine immutable starter scaffolds, production recipe metadata, complexity
-  tiers, expected asset groups, and current scaffold status.
+  immutable starter fixtures, production recipe metadata, complexity tiers,
+  expected asset groups, and current production status. The basic tier now
+  contains six art-ready defaults; intermediate and intricate starters remain
+  scaffolds until their reviewed production assets land.
 - `tldw_Server_API/app/core/Persona/visuals.py` validates sprite-frame manifests,
   frame timing, atlas regions, required states, custom state catalog entries,
   authored triggers, fallbacks, and bounds such as 256 custom states and 512
@@ -58,7 +60,7 @@ existing stack, not a new avatar runtime.
 
 ## Goals
 
-1. Define the final-art production workflow for nine bundled default Buddies.
+1. Define the final-art production workflow for bundled default Buddies.
 2. Preserve the existing Persona Visual pack contract and explicit activation
    model.
 3. Adapt the Puzzle Attack art pipeline pattern to Buddy assets: manifest-driven
@@ -82,17 +84,22 @@ existing stack, not a new avatar runtime.
 6. Do not use raw prompts, secrets, host-local paths, or provider payloads as
    durable user-facing provenance.
 
-## Nine Default Buddies
+## Bundled Default Starter Catalog
 
-The bundled defaults are organized as three complexity tiers. The existing
-starter IDs stay stable; final art replaces scaffold assets behind those
-contracts.
+The bundled defaults are organized as three complexity tiers. Earlier tracker
+and issue text described three basic defaults, but the current basic tier is the
+six Codex Buddy defaults: Search Lens, Index Card, Archive Cube, Paperclip,
+Terminal Tile, and Migu. The existing starter IDs stay stable; final art
+replaces scaffold assets behind those contracts.
 
 | Tier | Starter ID | Design intent | Production target |
 | --- | --- | --- | --- |
-| Basic | `research-buddy-basic` | Clean assistant mascot based on the original Buddy mockup direction. | One strong neutral anchor plus required-state loops. |
-| Basic | `migu-marker-basic` | Rough marker-line user-art feel inspired by the supplied Migu image. | Preserve hand-drawn charm; simple mouth and reaction changes. |
-| Basic | `minimal-helper-basic` | Geometric low-complexity helper. | Fast user-customizable baseline with few moving parts. |
+| Basic | `search-lens-basic` | Friendly search-lens object Buddy. | Reviewed neutral/preview assets and required-state loops; Codex atlas upgrade path. |
+| Basic | `index-card-basic` | Friendly tabbed card object Buddy. | Reviewed neutral/preview assets and required-state loops; Codex atlas upgrade path. |
+| Basic | `archive-cube-basic` | Friendly archive/storage cube Buddy. | Reviewed neutral/preview assets and required-state loops; Codex atlas upgrade path. |
+| Basic | `paperclip-basic` | Friendly paperclip object Buddy. | Reviewed neutral/preview assets and required-state loops; Codex atlas upgrade path. |
+| Basic | `terminal-tile-basic` | Friendly terminal-window tile Buddy. | Reviewed neutral/preview assets and required-state loops; Codex atlas upgrade path. |
+| Basic | `migu-marker-basic` | Rough marker-line user-art feel inspired by the supplied Migu image. | Preserve hand-drawn charm; reviewed required-state loops and Codex atlas upgrade path. |
 | Intermediate | `study-desk-intermediate` | Calm study companion in the Puzzle Attack clean anime/game-sprite style. | Neutral anchor, static talking sheet, separate required-state loops. |
 | Intermediate | `tool-helper-intermediate` | Utility-themed helper with exact tool variant support. | Required states plus at least one exact `tool_name` animation variant. |
 | Intermediate | `object-creature-intermediate` | Non-human expressive object companion. | Proves the format is not humanoid-only. |
@@ -105,6 +112,10 @@ companion in the same clean, readable game-art language as Puzzle Attack. It
 must not copy a protected character identity. The Migu default should preserve
 the user-art spirit of the reference image: playful proportions, visible marker
 quality, cyan twin-tail silhouette, and deliberately simple expression language.
+The six basic defaults currently ship as art-ready 96x96 Persona Visual frame
+packets; cross-app interchange or Codex Buddy reuse should use the documented
+Codex/Petdex `pet.json` plus 8x9 atlas path rather than treating those 96x96
+packets as the interchange ceiling.
 
 ## Complexity Tiers
 
@@ -112,7 +123,10 @@ quality, cyan twin-tail silhouette, and deliberately simple expression language.
 
 Basic Buddies optimize for quick creation and low art burden. A user should be
 able to create a usable Buddy from one neutral pose plus a small number of
-derived loops.
+derived loops. For bundled defaults, this tier is the six Codex Buddy defaults
+listed above. The simple tldw runtime packet may use separate frame assets, but
+the portability target for Codex Buddy parity is the Codex/Petdex 8x9 atlas
+contract.
 
 Required production assets:
 
@@ -393,12 +407,12 @@ Verification:
 
 ### Stage 2: Catalog Metadata Alignment
 
-Goal: make starter catalog metadata match the final nine-default production
-intent without adding fake animation assets.
+Goal: make starter catalog metadata match the current bundled default
+production intent without adding fake animation assets.
 
 Likely changes:
 
-- tighten production recipes for the nine IDs,
+- tighten production recipes for the starter IDs,
 - ensure final-art status stays `scaffold` until assets exist,
 - add doc/API tests proving the catalog is explicit about scaffold status.
 
@@ -464,7 +478,7 @@ Verification:
 
 ### Stage 6: Final Default Art Production
 
-Goal: produce the actual nine default Buddy animation packs.
+Goal: produce the actual bundled default Buddy animation packs.
 
 This is an asset-production effort, not a code-only patch. Each default should
 go through:

--- a/Docs/superpowers/specs/2026-05-16-persona-visual-recipe-generation-design.md
+++ b/Docs/superpowers/specs/2026-05-16-persona-visual-recipe-generation-design.md
@@ -6,7 +6,7 @@ Draft design for GitHub issue #1765 and Backlog TASK-406.
 
 ## Purpose
 
-Persona Visual starter packs now expose `production_recipe` metadata for the nine bundled starter scaffolds. That metadata describes the authored-asset workflow: identity brief, neutral anchor, static sheet guidance, animation output targets, and review checks. The next backend step is to let generation requests reference those recipe outputs while reusing the existing Persona Visual generation Jobs and generated-candidate review flow.
+Persona Visual starter packs now expose `production_recipe` metadata for the bundled starter catalog. That metadata describes the authored-asset workflow: identity brief, neutral anchor, static sheet guidance, animation output targets, and review checks. The next backend step is to let generation requests reference those recipe outputs while reusing the existing Persona Visual generation Jobs and generated-candidate review flow.
 
 This design is backend-only. It does not add WebUI behavior, final art generation, automatic activation, runtime renderer support, MCP provider execution, marketplace behavior, shared library behavior, or VN/CYOA behavior.
 
@@ -54,8 +54,8 @@ Recommended request shape:
   "prompt": "User direction layered onto the recipe",
   "target_state": "speaking",
   "backend": "configured-image-backend",
-  "starter_pack_id": "research-buddy-basic",
-  "recipe_output": "static_talking_reaction_sheet"
+  "starter_pack_id": "search-lens-basic",
+  "recipe_output": "required_state_loops"
 }
 ```
 
@@ -95,8 +95,8 @@ Add a `recipe_intent` object to the existing generation payload:
   "target_state": "speaking",
   "backend": "configured-image-backend",
   "recipe_intent": {
-    "starter_pack_id": "research-buddy-basic",
-    "recipe_output": "static_talking_reaction_sheet",
+    "starter_pack_id": "search-lens-basic",
+    "recipe_output": "required_state_loops",
     "correlation_id": "client-or-server-correlation-id",
     "user_prompt": "User direction layered onto the recipe",
     "identity_brief": "bounded recipe identity text",

--- a/backlog/tasks/task-347 - Design-Persona-Buddy-default-catalog-and-state-catalog-extension.md
+++ b/backlog/tasks/task-347 - Design-Persona-Buddy-default-catalog-and-state-catalog-extension.md
@@ -36,6 +36,8 @@ Create a repo-backed design spec for the Persona Buddy default visual catalog an
 <!-- SECTION:NOTES:BEGIN -->
 Created Docs/superpowers/specs/2026-05-14-persona-buddy-default-catalog-state-catalog-extension-design.md. The design keeps `sprite_frames` as the renderer, keeps sprite manifests on `manifest_version: 1`, treats `sprite_sheet` as an asset role, defines a neutral-anchor-first creation pipeline adapted from Puzzle Attack, documents the 9 default starter buddy catalog, and stages state catalog work across backend validation, frontend resolver/editor, MCP/generation jobs, asset pipeline, starter fixtures, docs, and verification.
 
+Supersession note from TASK-419: later asset-production work expanded the basic tier from the initial three-pack concept to the six Codex Buddy defaults (`search-lens-basic`, `index-card-basic`, `archive-cube-basic`, `paperclip-basic`, `terminal-tile-basic`, and `migu-marker-basic`). The current starter catalog source of truth is the twelve-ID catalog documented in `Docs/Code_Documentation/Persona_Visual_Packs.md`; this task remains the historical design record for the neutral-anchor pipeline and V1-compatible state catalog extension.
+
 Verification recorded: `git diff --check` passed for the new docs/task files; ASCII scan passed with no non-ASCII matches. Bandit is not applicable because this slice only changes Markdown documentation.
 
 PR review follow-up: addressed Qodo and Gemini feedback by reframing the work as a `sprite_frames` Manifest V1 state catalog extension instead of overloading repo-wide Manifest V2, changing the example manifest to `manifest_version: 1`, making Puzzle Attack references portable, removing the redundant lowercase rule, making `state_catalog.kind` mandatory, adding fallback-depth cap 8 to Stage 2 success criteria, and requiring state catalog capability advertisement only after validation and Buddy runtime support exist.
@@ -44,7 +46,7 @@ PR review follow-up: addressed Qodo and Gemini feedback by reframing the work as
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Designed the Persona/Buddy default visual catalog and V1-compatible state catalog extension. The spec defines 3 basic, 3 intermediate, and 3 intricate starter buddies, a neutral-pose-first asset pipeline, static talking sheet versus animation-strip boundaries, bounded custom state IDs, exact per-tool trigger matching, MCP/runtime behavior, editor UX, implementation stages, and verification expectations.
+Designed the Persona/Buddy default visual catalog and V1-compatible state catalog extension. The original spec defined 3 basic, 3 intermediate, and 3 intricate starter buddies, later superseded by the six-basic Codex Buddy catalog noted above. The still-current design pieces are the neutral-pose-first asset pipeline, static talking sheet versus animation-strip boundaries, bounded custom state IDs, exact per-tool trigger matching, MCP/runtime behavior, editor UX, implementation stages, and verification expectations.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-scaffolds.md
+++ b/backlog/tasks/task-394 - Expand-bundled-Persona-Visual-starter-catalog-scaffolds.md
@@ -44,9 +44,15 @@ Implement issue #1732 by adding nine server-owned Persona Visual starter catalog
 <!-- SECTION:NOTES:BEGIN -->
 Created after PR #1725 merged and issue #1695 closed. Issue #1732 tracks this next Persona/Buddy visual catalog slice under epic #1510.
 
+Supersession note from TASK-419: this task recorded the earlier nine-scaffold
+catalog expansion. Later basic-tier asset production replaced that basic set
+with the six Codex Buddy defaults and the current twelve-ID starter catalog.
+Keep this task as historical evidence for the scaffold expansion, not as the
+current basic-tier source of truth.
+
 Implementation started in worktree .worktrees/persona-visual-nine-starters-1732. Baseline focused starter catalog pytest passed before edits: 9 tests.
 
-Implemented nine bundled Persona Visual starter fixture packs with stable IDs, required sprite_frames states, custom-state examples, an atlas-backed starter, legacy research-buddy-starter alias support, API/test expectation updates, and docs for the nine-default catalog.
+Implemented the initial bundled Persona Visual starter fixture set with stable IDs, required sprite_frames states, custom-state examples, an atlas-backed starter, legacy research-buddy-starter alias support, API/test expectation updates, and docs for the then-current default catalog.
 
 Verification: focused starter catalog pytest passed with 20 tests; broader persona visual slice passed with 84 tests across starter catalog, visual API, and visual service; git diff --check passed; Bandit JSON report for touched Persona backend starter modules reported zero findings.
 
@@ -64,7 +70,7 @@ PR #1734 review fixes: wrapped the long fixture/test lines identified by Qodo an
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added nine bundled Persona Visual starter catalog scaffold fixtures across basic, intermediate, and intricate tiers. Added deterministic fixture PNG generation, custom-state and atlas metadata examples, legacy research-buddy-starter alias handling, updated API/service coverage, and documented that these are backend scaffolds rather than finished buddy art or completed animation packs. PR review fixes also wrap newly touched long Python lines and ensure multi-custom-state scaffolds use distinct variant fixture assets. Verification: focused starter catalog/API pytest passed with 25 tests after review fixes; prior broader persona visual slice passed with 84 tests; git diff --check passed; Bandit on touched Persona starter backend modules reported zero findings. Known skips/blockers: real default buddy art and neutral-pose-to-animation asset creation remain future work.
+Added the initial bundled Persona Visual starter catalog scaffold fixtures across basic, intermediate, and intricate tiers. Added deterministic fixture PNG generation, custom-state and atlas metadata examples, legacy research-buddy-starter alias handling, updated API/service coverage, and documented that these are backend scaffolds rather than finished buddy art or completed animation packs. PR review fixes also wrap newly touched long Python lines and ensure multi-custom-state scaffolds use distinct variant fixture assets. Verification: focused starter catalog/API pytest passed with 25 tests after review fixes; prior broader persona visual slice passed with 84 tests; git diff --check passed; Bandit on touched Persona starter backend modules reported zero findings. Known skips/blockers: real default buddy art and neutral-pose-to-animation asset creation remain future work.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
+++ b/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
@@ -59,7 +59,7 @@ Verification: focused Persona Visual starter/API pytest passed 94 tests; py_comp
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Persona Visual starter catalog responses now include structured production recipes for all nine bundled starter scaffolds. The recipes make the neutral-anchor-first authored-asset handoff explicit without bundling final art, executing generation, changing renderer support, or auto-activating copied drafts.
+Persona Visual starter catalog responses now include structured production recipes for the bundled starter catalog. The recipes make the neutral-anchor-first authored-asset handoff explicit without bundling final art, executing generation, changing renderer support, or auto-activating copied drafts.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
+++ b/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
@@ -44,7 +44,7 @@ Create a repo-backed design spec for the Persona Buddy default visual catalog an
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created the Buddy animation pipeline design spec and GitHub tracker issue #1787 under epic #1510. The spec covers the nine default Buddy catalog tiers, neutral-anchor-first workflow, static sheet versus timed animation separation, state_catalog/authored_triggers custom-state semantics, staged implementation slices, and verification expectations. Validation so far is documentation-focused: git diff --check passed. Bandit is not applicable because this slice only changes Markdown/Backlog tracking.
+Created the Buddy animation pipeline design spec and GitHub tracker issue #1787 under epic #1510. The spec originally tracked the nine-default Buddy catalog tiers; TASK-419 reconciles that with the later six-basic Codex Buddy expansion and current twelve-ID starter catalog. The still-current design covers the neutral-anchor-first workflow, static sheet versus timed animation separation, state_catalog/authored_triggers custom-state semantics, staged implementation slices, and verification expectations. Validation so far is documentation-focused: git diff --check passed. Bandit is not applicable because this slice only changes Markdown/Backlog tracking.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-415 - Produce-basic-tier-Buddy-default-animation-packs.md
+++ b/backlog/tasks/task-415 - Produce-basic-tier-Buddy-default-animation-packs.md
@@ -173,7 +173,7 @@ Produce and validate the six bundled basic tier Buddy defaults as production-rea
 - [x] #10 Basic-tier documentation and visual review evidence reflect the final six bundled basic defaults.
 - [x] #11 Codex/Petdex pet import preview and commit accept `pet.json` plus spritesheet `.zip` packages as draft Persona Visual packs.
 - [x] #12 Basic-tier production planning is pivoted to Codex-pet-compatible 8x9 atlas packets, with `moving_right` and `moving_left` as movement states.
-- [x] #13 Buddy creation docs use hatch-pet as the reference workflow for a tldw-native Simple Buddy Creator with simple draft-pack and full Codex-compatible modes.
+- [x] #13 Buddy creation docs use hatch-pet as the reference workflow for a tldw-native Buddy creator with Persona Visual draft-pack review and full Codex-compatible modes.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -202,7 +202,7 @@ Verification:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed the six-pack basic Buddy default slice. The catalog now exposes Search Lens, Index Card, Archive Cube, Paperclip, Terminal Tile, and Migu Marker as art-ready starter packs with package-backed 96x96 frame resources, required-state loops, neutral/preview assets, inactive draft copy semantics, and reaction.success coverage. Docs now include the final six review packets plus Simple Buddy/Codex-compatible creation guidance.
+Completed the six-pack basic Buddy default slice. The catalog now exposes Search Lens, Index Card, Archive Cube, Paperclip, Terminal Tile, and Migu Marker as art-ready starter packs with package-backed 96x96 frame resources, required-state loops, neutral/preview assets, inactive draft copy semantics, and reaction.success coverage. Docs now include the final six review packets plus Persona Visual draft-pack and Codex-compatible creation guidance.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -305,15 +305,15 @@ Verification:
 - /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Persona/visual_starter_fixtures.py tldw_Server_API/app/core/Persona/visual_portability/codex_pet.py tldw_Server_API/app/core/Persona/visual_portability/preview.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_basic_buddy_defaults.json -> 0 findings.
 - git diff --check -> passed.
 Hatch-pet reference checkpoint:
-- Persona Visual docs now treat hatch-pet as the reference workflow for a user-facing tldw Simple Buddy Creator, not as a tldw runtime dependency.
-- The documented creator flow has two modes: simple tldw draft-pack mode for name/description/reference/style plus core states, and full Codex-compatible mode for the nine-row `pet.json` plus `spritesheet.webp` atlas.
+- Persona Visual docs now treat hatch-pet as the reference workflow for user-facing tldw Buddy creation, not as a tldw runtime dependency.
+- The documented creator flow has a simple UX path for name/description/reference/style plus core states, and a full Codex-compatible mode for the nine-row `pet.json` plus `spritesheet.webp` atlas.
 - The documented Buddy process now uses tldw surfaces for Persona Garden review, Persona Visual draft storage, import-preview diagnostics, optional library reuse, MCP-triggerable custom states, and explicit activation.
 - The docs carry over hatch visual QA blockers such as identity drift, clipping, slot overlap, copied guides, nontransparent backgrounds, size popping, wrong facing direction, inert idle loops, and detached effects.
 Terminal Tile checkpoint:
 - User approved the Terminal Tile neutral anchor and 3x4 simple-state source sheet.
 - Source was copied into Docs/Code_Documentation/assets/buddy-defaults/terminal-tile-basic/source/ and chroma-keyed to alpha.
 - Processed v1 frame packet uses one stable global scale across all 12 frames, with tiny detached extraction specks removed before review.
-- Runtime starter catalog now includes terminal-tile-basic in stable order after paperclip-basic, replacing the old minimal-helper-basic basic slot.
+- Runtime starter catalog now includes terminal-tile-basic in stable order after paperclip-basic, replacing the previous geometric-helper placeholder basic slot.
 - terminal-tile-basic uses the approved v1 package-backed PNG frame packet, required state loops, and reaction.success.
 - Documentation now records the Terminal Tile review packet and recreation walkthrough.
 

--- a/backlog/tasks/task-419 - Reconcile-Buddy-default-Codex-compatible-catalog-docs.md
+++ b/backlog/tasks/task-419 - Reconcile-Buddy-default-Codex-compatible-catalog-docs.md
@@ -1,0 +1,77 @@
+---
+id: TASK-419
+title: Reconcile Buddy default Codex-compatible catalog docs
+status: In Progress
+labels:
+- persona
+- buddy
+- visual-packs
+- docs
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1510
+- https://github.com/rmusser01/tldw_server/issues/1787
+- https://github.com/rmusser01/tldw_server/issues/1803
+- https://github.com/rmusser01/tldw_server/issues/1807
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reconcile Persona/Buddy visual pack documentation and Backlog tracking so the current source of truth clearly states that the basic tier uses the six bundled defaults, Codex/Petdex import is first-class, additional packs are optional, and legacy simple-creator/3x4/96x96 artifacts are treated as source or interim review evidence rather than contradicting the final Codex-compatible direction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Docs remove stale three-basic default wording where this task touches the Buddy default contract.
+- [x] #2 Docs clarify that the six basic defaults are the basic tier and that final Codex-compatible default packs target the Codex/Petdex atlas/import contract, while currently bundled 96x96 frame packets remain accepted art-ready runtime assets until upgraded.
+- [x] #3 Backlog tracker notes the stale GitHub issue bodies and records the resolved local source-of-truth clarification.
+- [x] #4 No code behavior changes are made.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started in clean worktree `.worktrees/buddy-codex-contract-docs` on branch
+`codex/buddy-codex-contract-docs` from `origin/dev`; the dirty main checkout was
+not edited.
+
+Patched Persona Visual docs and Buddy pipeline specs so the current source of
+truth says the basic tier is the six Codex Buddy defaults:
+`search-lens-basic`, `index-card-basic`, `archive-cube-basic`,
+`paperclip-basic`, `terminal-tile-basic`, and `migu-marker-basic`. The docs now
+state that the current 96x96 frame packets are accepted art-ready tldw runtime
+assets, while Codex/Petdex `pet.json` plus 8x9 atlas packaging remains the
+cross-app compatibility target.
+
+Updated historical Backlog task notes for TASK-347, TASK-394, TASK-405,
+TASK-410, and TASK-415 to avoid treating older three-basic/nine-pack wording as
+the current catalog contract. Updated GitHub issue bodies for #1787, #1803, and
+#1807 so the external tracker matches the six-basic/twelve-starter catalog.
+
+Verification:
+- `git diff --check` passed.
+- `git diff --name-only` plus `git ls-files --others --exclude-standard` confirmed touched files are docs and Backlog task files only.
+- `rg -n "research-buddy-basic|minimal-helper-basic|three basic|3 basic|nine bundled|nine scaffold|nine default|nine immutable|Simple Buddy|simple tldw draft-pack" Docs backlog -S` now reports only explicit supersession notes and current compatibility wording.
+- Bandit skipped because this is docs/Backlog/GitHub tracker-only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Reconciled the Persona/Buddy default catalog docs and trackers around the
+current six-basic Codex Buddy tier. The repo docs now distinguish current
+art-ready 96x96 Persona Visual runtime packets from the Codex/Petdex 8x9 atlas
+compatibility target, and the external GitHub tracker issues no longer present
+the older three-basic/nine-default catalog as current.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Reconciles Persona/Buddy docs and Backlog tracker notes around the six basic Codex Buddy defaults.
- Clarifies that current 96x96 frame packets are accepted tldw runtime assets while Codex/Petdex pet.json + 8x9 atlas remains the cross-app compatibility target.
- Updates historical task notes so older three-basic/nine-default wording is marked as superseded, with no code behavior changes.

## Test Plan
- [x] git diff --check HEAD~1..HEAD
- [x] git status --short is clean after commit
- [x] GitHub issue bodies for #1787, #1803, and #1807 verified after tracker updates

## Change summary
_Human-authored change summary required before merge._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned Buddy catalog docs with the current six basic Codex Buddy defaults and the Codex/Petdex import path. Clarifies that 96x96 Persona Visual frame packets are accepted runtime assets while `pet.json` + 8x9 atlas is the cross-app target, and updates specs/backlog to mark earlier three-basic/nine-default wording as superseded; no code changes.

<sup>Written for commit 2bbc7e9f09de678a154b8da61b9dfe36e803af1e. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1818?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

