### PR TITLE
Fix Workspace Playground UX controls

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-workspace-playground-media-filtering-pr1819.md
+++ b/Docs/superpowers/plans/2026-05-17-workspace-playground-media-filtering-pr1819.md
@@ -1,0 +1,64 @@
+# Workspace Playground Media Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add filtering and sorting to Workspace Playground Add Sources -> My Media and address the current PR #1819 review threads.
+
+**Architecture:** Keep the feature inside the existing AddSourceModal My Media tab. Reuse the existing `/api/v1/media/search` request shape for query, media type, keyword, and sort filters, and keep the default empty-filter path on `/api/v1/media`. Apply review fixes in the shared model selector and ChatPane without changing public behavior.
+
+**Tech Stack:** React, Ant Design, Vitest, Testing Library, Backlog.md.
+
+---
+
+### Task 1: My Media Filter Tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx`
+
+- [x] Add a failing test proving My Media sends `searchMedia` with `query`, `fields`, `media_types`, `must_have`, `sort_by`, and pagination when filters are active.
+- [x] Add a failing test proving Clear filters resets the filter UI and returns to default `listMedia`.
+- [x] Add or update the load-error test to assert the caught error is logged.
+- [x] Run `bun run test src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx --reporter=dot` and confirm the new tests fail for missing controls/behavior.
+
+### Task 2: Review Thread Tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx`
+
+- [x] Reused existing ChatPane model-selector coverage for dropdown open, search, favorites, settings fallback, and model selection.
+- [x] Keep existing settings navigation coverage passing after switching ChatPane to `useNavigate`.
+- [x] Run `bun run test src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx --reporter=dot`.
+
+### Task 3: My Media Filter Implementation
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/AddSourceModal.tsx`
+
+- [x] Introduce typed media-library item helpers to replace local `any` usage in the My Media tab.
+- [x] Add content type, keyword, and sort controls.
+- [x] Route active filters through `tldwClient.searchMedia`; route empty filters through `tldwClient.listMedia`.
+- [x] Reset selected media and pagination when filters change.
+- [x] Render item keywords when present and provide Clear filters.
+- [x] Log media load failures before showing the user-facing error.
+
+### Task 4: PR Review Fix Implementation
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx`
+- Modify: `apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx`
+
+- [x] Type `modelDropdownMenuItems` as `MenuProps["items"]`.
+- [x] Remove redundant model selector button `onClick` and the now-unused `openDropdown` callback.
+- [x] Add a typed chat model record for `composerModels`.
+- [x] Replace manual history mutation with `useNavigate`.
+
+### Task 5: Verification and PR Update
+
+**Files:**
+- Modify: `backlog/tasks/task-419 - Enhance-Workspace-Playground-Add-Sources-media-filtering.md`
+
+- [x] Run focused Workspace Playground tests.
+- [x] Run `git diff --check`.
+- [x] Update TASK-419 with touched files, verification, and final summary.
+- [ ] Commit and push the follow-up.
+- [ ] Reply to all addressed inline PR review threads and add a top-level PR update comment.

--- a/apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx
@@ -1,0 +1,147 @@
+import { ProviderIcons } from "@/components/Common/ProviderIcon"
+import { Dropdown, Tooltip } from "antd"
+import { ArrowRight, HelpCircle } from "lucide-react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+
+type ChatModelSelectorDropdownProps = {
+  activeModelKey?: string | null
+  apiModelLabel: string
+  catalogControls: React.ReactNode
+  connectionStatusLabel: string
+  connectionStatusWarning?: boolean
+  modelDropdownMenuItems: any[]
+  modelDropdownOpen: boolean
+  modelSelectorWarning?: boolean
+  onBeforeOpen?: () => void
+  placement?: "topLeft" | "bottomLeft"
+  resolvedProviderKey: string
+  setModelDropdownOpen: (open: boolean) => void
+  setModelSearchQuery: (query: string) => void
+}
+
+export const ChatModelSelectorDropdown = React.memo(
+  function ChatModelSelectorDropdown({
+    activeModelKey,
+    apiModelLabel,
+    catalogControls,
+    connectionStatusLabel,
+    connectionStatusWarning = false,
+    modelDropdownMenuItems,
+    modelDropdownOpen,
+    modelSelectorWarning = false,
+    onBeforeOpen,
+    placement = "topLeft",
+    resolvedProviderKey,
+    setModelDropdownOpen,
+    setModelSearchQuery
+  }: ChatModelSelectorDropdownProps) {
+    const { t } = useTranslation(["playground", "common"])
+
+    const openDropdown = React.useCallback(() => {
+      onBeforeOpen?.()
+      setModelDropdownOpen(true)
+    }, [onBeforeOpen, setModelDropdownOpen])
+
+    return (
+      <Dropdown
+        open={modelDropdownOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            onBeforeOpen?.()
+          }
+          setModelDropdownOpen(open)
+          if (!open) {
+            setModelSearchQuery("")
+          }
+        }}
+        menu={{
+          items: modelDropdownMenuItems,
+          className: "no-scrollbar",
+          activeKey: activeModelKey ?? undefined
+        }}
+        popupRender={(menu) => (
+          <div className="rounded-lg border border-border bg-surface shadow-lg">
+            {catalogControls}
+            <div className="no-scrollbar max-h-[400px] overflow-y-auto">
+              {menu}
+            </div>
+            <div className="border-t border-border p-2">
+              <Link
+                to="/docs/models"
+                className="flex items-center gap-1.5 text-xs text-primary transition-colors hover:text-primary/80"
+                onClick={() => setModelDropdownOpen(false)}
+              >
+                <HelpCircle className="h-3.5 w-3.5" />
+                <span>
+                  {t(
+                    "playground:composer.helpMeChoose",
+                    "Help me choose a model"
+                  )}
+                </span>
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            </div>
+          </div>
+        )}
+        trigger={["click"]}
+        placement={placement}
+      >
+        <Tooltip
+          title={
+            modelSelectorWarning
+              ? t(
+                  "playground:composer.selectModelTooltip",
+                  "Click to select a model"
+                )
+              : apiModelLabel
+          }
+          placement="top"
+        >
+          <button
+            type="button"
+            title={apiModelLabel}
+            aria-label={apiModelLabel}
+            aria-haspopup="listbox"
+            aria-expanded={modelDropdownOpen}
+            data-testid="model-selector"
+            onClick={() => {
+              if (!modelDropdownOpen) {
+                openDropdown()
+              }
+            }}
+            className={`inline-flex min-h-[44px] min-w-0 cursor-pointer items-center gap-1 rounded-full border px-2 text-[10px] transition-colors ${
+              modelSelectorWarning
+                ? "border-warn/50 bg-warn/10 text-warn hover:bg-warn/20"
+                : "border-border bg-surface hover:bg-surface-hover"
+            }`}
+          >
+            <ProviderIcons
+              provider={resolvedProviderKey}
+              className={`h-3 w-3 ${
+                modelSelectorWarning ? "text-warn" : "text-text-subtle"
+              }`}
+            />
+            <span className="max-w-[120px] truncate">{apiModelLabel}</span>
+            <span
+              className={`rounded-full px-1.5 py-0.5 text-[9px] ${
+                connectionStatusWarning
+                  ? "bg-warn/10 text-warn"
+                  : "bg-success/10 text-success"
+              }`}
+              title={
+                t(
+                  "playground:composer.providerStatusTooltip",
+                  "Provider status"
+                ) as string
+              }
+            >
+              {connectionStatusLabel}
+            </span>
+          </button>
+        </Tooltip>
+      </Dropdown>
+    )
+  }
+)

--- a/apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx
@@ -1,5 +1,6 @@
 import { ProviderIcons } from "@/components/Common/ProviderIcon"
 import { Dropdown, Tooltip } from "antd"
+import type { MenuProps } from "antd"
 import { ArrowRight, HelpCircle } from "lucide-react"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -11,7 +12,7 @@ type ChatModelSelectorDropdownProps = {
   catalogControls: React.ReactNode
   connectionStatusLabel: string
   connectionStatusWarning?: boolean
-  modelDropdownMenuItems: any[]
+  modelDropdownMenuItems: MenuProps["items"]
   modelDropdownOpen: boolean
   modelSelectorWarning?: boolean
   onBeforeOpen?: () => void
@@ -38,11 +39,6 @@ export const ChatModelSelectorDropdown = React.memo(
     setModelSearchQuery
   }: ChatModelSelectorDropdownProps) {
     const { t } = useTranslation(["playground", "common"])
-
-    const openDropdown = React.useCallback(() => {
-      onBeforeOpen?.()
-      setModelDropdownOpen(true)
-    }, [onBeforeOpen, setModelDropdownOpen])
 
     return (
       <Dropdown
@@ -106,11 +102,6 @@ export const ChatModelSelectorDropdown = React.memo(
             aria-haspopup="listbox"
             aria-expanded={modelDropdownOpen}
             data-testid="model-selector"
-            onClick={() => {
-              if (!modelDropdownOpen) {
-                openDropdown()
-              }
-            }}
             className={`inline-flex min-h-[44px] min-w-0 cursor-pointer items-center gap-1 rounded-full border px-2 text-[10px] transition-colors ${
               modelSelectorWarning
                 ? "border-warn/50 bg-warn/10 text-warn hover:bg-warn/20"

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -8,7 +8,6 @@ import { BetaTag } from "@/components/Common/Beta";
 // getImageBackendConfigs, normalizeImageBackendConfig, resolveImageBackendConfig moved to usePlaygroundImageGen
 import { CharacterSelect } from "@/components/Common/CharacterSelect";
 import { ChatQueuePanel } from "@/components/Common/ChatQueuePanel";
-import { ProviderIcons } from "@/components/Common/ProviderIcon";
 import { type KnowledgeTab } from "@/components/Knowledge";
 import type { SlashCommandItem } from "@/components/Sidepanel/Chat/SlashCommandMenu";
 import { isFirefoxTarget } from "@/config/platform";
@@ -134,11 +133,9 @@ import {
   Tooltip,
 } from "antd";
 import {
-  ArrowRight,
   ChevronRight,
   CornerUpLeft,
   Headphones,
-  HelpCircle,
   ImageIcon,
   X,
 } from "lucide-react";
@@ -155,6 +152,7 @@ import { useWebUI } from "~/store/webui";
 
 import { AttachedResearchContextChip } from "./AttachedResearchContextChip";
 import { AttachmentsSummary } from "./AttachmentsSummary";
+import { ChatModelSelectorDropdown } from "./ChatModelSelectorDropdown";
 // ContextFootprintPanel moved to PlaygroundContextWindowModal
 import { CompareToggle } from "./CompareToggle";
 import { ComposerTextarea } from "./ComposerTextarea";
@@ -1980,110 +1978,32 @@ export const PlaygroundForm = ({
   } = useImageBackend({ imageModels });
 
   const modelSelectButton = (
-    <Dropdown
-      open={modelDropdownOpen}
-      onOpenChange={(open) => {
-        if (open) {
-          closeComposerPopoversExcept("model");
-        }
-        setModelDropdownOpen(open);
-        if (!open) {
-          setModelSearchQuery("");
-        }
-      }}
-      menu={{
-        items: modelDropdownMenuItems,
-        className: "no-scrollbar",
-        activeKey: selectedModelKey ?? selectedModel ?? undefined,
-      }}
-      popupRender={(menu) => (
-        <div className="bg-surface rounded-lg shadow-lg border border-border">
-          <PlaygroundModelCatalogControls
-            t={t}
-            modelListScope={modelListScope}
-            setModelListScope={setModelListScope}
-            modelSearchQuery={modelSearchQuery}
-            setModelSearchQuery={setModelSearchQuery}
-            modelSortMode={modelSortMode}
-            setModelSortMode={setModelSortMode}
-          />
-          <div className="max-h-[400px] overflow-y-auto no-scrollbar">
-            {menu}
-          </div>
-          <div className="p-2 border-t border-border">
-            <Link
-              to="/docs/models"
-              className="flex items-center gap-1.5 text-xs text-primary hover:text-primary/80 transition-colors"
-              onClick={() => setModelDropdownOpen(false)}
-            >
-              <HelpCircle className="h-3.5 w-3.5" />
-              <span>
-                {t(
-                  "playground:composer.helpMeChoose",
-                  "Help me choose a model",
-                )}
-              </span>
-              <ArrowRight className="h-3 w-3" />
-            </Link>
-          </div>
-        </div>
-      )}
-      trigger={["click"]}
-      placement="topLeft"
-    >
-      <Tooltip
-        title={
-          modelSelectorWarning
-            ? t(
-                "playground:composer.selectModelTooltip",
-                "Click to select a model",
-              )
-            : apiModelLabel
-        }
-        placement="top"
-      >
-        <button
-          type="button"
-          title={apiModelLabel}
-          aria-label={apiModelLabel}
-          aria-haspopup="listbox"
-          aria-expanded={modelDropdownOpen}
-          data-testid="model-selector"
-          onClick={() => {
-            if (!modelDropdownOpen) {
-              closeComposerPopoversExcept("model");
-              setModelDropdownOpen(true);
-            }
-          }}
-          className={`inline-flex min-w-0 items-center gap-1 rounded-full border px-2 min-h-[44px] text-[10px] cursor-pointer transition-colors ${
-            modelSelectorWarning
-              ? "border-warn/50 bg-warn/10 text-warn hover:bg-warn/20"
-              : "border-border bg-surface hover:bg-surface-hover"
-          }`}
-        >
-          <ProviderIcons
-            provider={resolvedProviderKey}
-            className={`h-3 w-3 ${modelSelectorWarning ? "text-warn" : "text-text-subtle"}`}
-          />
-          <span className="truncate max-w-[120px]">{apiModelLabel}</span>
-          <span
-            className={`rounded-full px-1.5 py-0.5 text-[9px] ${
-              !isConnectionReady || connectionUxState === "connected_degraded"
-                ? "bg-warn/10 text-warn"
-                : "bg-success/10 text-success"
-            }`}
-            title={
-              t(
-                "playground:composer.providerStatusTooltip",
-                "Provider status",
-              ) as string
-            }
-          >
-            {connectionStatusLabel}
-          </span>
-        </button>
-      </Tooltip>
-    </Dropdown>
+    <ChatModelSelectorDropdown
+      activeModelKey={selectedModelKey ?? selectedModel}
+      apiModelLabel={apiModelLabel}
+      catalogControls={
+        <PlaygroundModelCatalogControls
+          t={t}
+          modelListScope={modelListScope}
+          setModelListScope={setModelListScope}
+          modelSearchQuery={modelSearchQuery}
+          setModelSearchQuery={setModelSearchQuery}
+          modelSortMode={modelSortMode}
+          setModelSortMode={setModelSortMode}
+        />
+      }
+      connectionStatusLabel={connectionStatusLabel}
+      connectionStatusWarning={
+        !isConnectionReady || connectionUxState === "connected_degraded"
+      }
+      modelDropdownMenuItems={modelDropdownMenuItems}
+      modelDropdownOpen={modelDropdownOpen}
+      modelSelectorWarning={modelSelectorWarning}
+      onBeforeOpen={() => closeComposerPopoversExcept("model")}
+      resolvedProviderKey={resolvedProviderKey}
+      setModelDropdownOpen={setModelDropdownOpen}
+      setModelSearchQuery={setModelSearchQuery}
+    />
   );
 
   const modelUsageBadge = wrapComposerProfile(

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
@@ -1543,25 +1543,33 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
     }
   }, [hasSelectedSources, showAdvancedRagSettings])
 
+  const applyComposerModels = React.useCallback(
+    (models: ChatComposerModel[]) => {
+      modelsFetchedRef.current = models.length > 0
+      setComposerModels(models)
+    },
+    []
+  )
+
   React.useEffect(() => {
     if (modelsFetchedRef.current) return
-    modelsFetchedRef.current = true
 
     let isMounted = true
     void fetchChatModels({ returnEmpty: true })
       .then((models) => {
         if (!isMounted) return
-        setComposerModels(Array.isArray(models) ? models : [])
+        applyComposerModels(models)
       })
       .catch(() => {
         if (!isMounted) return
+        modelsFetchedRef.current = false
         setComposerModels([])
       })
 
     return () => {
       isMounted = false
     }
-  }, [])
+  }, [applyComposerModels])
 
   React.useEffect(() => {
     selectedSourceIdsRef.current = selectedSourceIds
@@ -2274,6 +2282,17 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
 
     setSubmitError(null)
     await checkConnectionOnce()
+    modelsFetchedRef.current = false
+    try {
+      const models = await fetchChatModels({
+        returnEmpty: true,
+        forceRefresh: true
+      })
+      applyComposerModels(models)
+    } catch {
+      modelsFetchedRef.current = false
+      setComposerModels([])
+    }
   }
 
   const handleCitationSourceClick = React.useCallback(

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
@@ -12,7 +12,6 @@ import {
   SlidersHorizontal,
   Loader2,
   Share2,
-  Cpu,
   Plus,
   BookOpen,
   Users,
@@ -24,15 +23,17 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { buildWorkspaceChatSessionKey } from "@/store/workspace-chat-session-key"
 import { useWorkspaceStore } from "@/store/workspace"
 import { useStoreMessageOption } from "@/store/option"
-import { useStoreChatModelSettings } from "@/store/model"
 import type { Message } from "@/store/option"
 import { useMessageOption } from "@/hooks/useMessageOption"
 import { useSmartScroll } from "@/hooks/useSmartScroll"
 import { useMobile } from "@/hooks/useMediaQuery"
+import { useModelSelector } from "@/hooks/playground"
 import { useConnectionStore } from "@/store/connection"
-import { ConnectionPhase } from "@/types/connection"
+import { ConnectionPhase, deriveConnectionUxState } from "@/types/connection"
 import { DEFAULT_RAG_SETTINGS } from "@/services/rag/unified-rag"
+import { fetchChatModels } from "@/services/tldw-server"
 import { formatCost } from "@/utils/model-pricing"
+import { resolveStartupSelectedModel } from "@/utils/model-startup-selection"
 import { trackWorkspacePlaygroundTelemetry } from "@/utils/workspace-playground-telemetry"
 import type { WorkspaceSource, WorkspaceSourceType } from "@/types/workspace"
 import type { ChatScope } from "@/types/chat-scope"
@@ -44,6 +45,8 @@ import { buildConversationShareUrl } from "@/components/Layouts/chat-share-links
 import { PlaygroundMessage } from "@/components/Common/Playground/Message"
 import { Link } from "react-router-dom"
 import { EmptyState } from "@/components/ui/feedback/EmptyState"
+import { ChatModelSelectorDropdown } from "@/components/Option/Playground/ChatModelSelectorDropdown"
+import { PlaygroundModelCatalogControls } from "@/components/Option/Playground/PlaygroundModelCatalogControls"
 import { buildChatLorebookDebugPath } from "@/routes/route-paths"
 import {
   WORKSPACE_SOURCE_DRAG_TYPE,
@@ -83,11 +86,6 @@ type RetrievalDiagnostics = {
 }
 
 type ChatModePreference = "normal" | "rag"
-type ChatModelOption = {
-  id: string
-  label: string
-  provider: string
-}
 type ChatPaneContentWidthMode = "comfortable" | "expanded" | "full"
 type LorebookActivityTurn = {
   turnNumber: number
@@ -1247,6 +1245,9 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   const chatFocusTarget = useWorkspaceStore((s) => s.chatFocusTarget)
   const clearChatFocusTarget = useWorkspaceStore((s) => s.clearChatFocusTarget)
   const openAddSourceModal = useWorkspaceStore((s) => s.openAddSourceModal)
+  const openExistingSourcesModal = React.useCallback(() => {
+    openAddSourceModal("existing")
+  }, [openAddSourceModal])
   const createNewWorkspace = useWorkspaceStore((s) => s.createNewWorkspace)
   const setCurrentNote = useWorkspaceStore((s) => s.setCurrentNote)
   const switchWorkspace = useWorkspaceStore((s) => s.switchWorkspace)
@@ -1254,7 +1255,6 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   // Model settings for model badge (UX-009)
   const selectedModel = useStoreMessageOption((s) => s.selectedModel)
   const setSelectedModel = useStoreMessageOption((s) => s.setSelectedModel)
-  const chatApiProvider = useStoreChatModelSettings((s) => s.apiProvider)
   const chatScope = React.useMemo<ChatScope | undefined>(
     () =>
       workspaceId
@@ -1308,6 +1308,15 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   )
   const checkConnectionOnce = useConnectionStore((s) => s.checkOnce)
   const connectionState = useConnectionStore((s) => s.state)
+  const navigateTo = React.useCallback((path: string) => {
+    if (typeof window === "undefined") return
+    window.history.pushState({}, "", path)
+    const event =
+      typeof PopStateEvent === "function"
+        ? new PopStateEvent("popstate")
+        : new Event("popstate")
+    window.dispatchEvent(event)
+  }, [])
   const [preferredChatMode, setPreferredChatMode] = React.useState<
     ChatModePreference | null
   >(null)
@@ -1343,10 +1352,7 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   const [slashCommands, setSlashCommands] = React.useState<
     Array<{ name: string; description: string }>
   >([])
-  const [availableModels, setAvailableModels] = React.useState<ChatModelOption[]>(
-    []
-  )
-  const [loadingModels, setLoadingModels] = React.useState(false)
+  const [composerModels, setComposerModels] = React.useState<any[]>([])
   const slashCommandsFetchedRef = React.useRef(false)
   const modelsFetchedRef = React.useRef(false)
   const workspaceSessionRef = React.useRef<string | null>(null)
@@ -1529,53 +1535,16 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   React.useEffect(() => {
     if (modelsFetchedRef.current) return
     modelsFetchedRef.current = true
-    if (typeof tldwClient.getModels !== "function") return
 
     let isMounted = true
-    setLoadingModels(true)
-    void tldwClient
-      .getModels()
+    void fetchChatModels({ returnEmpty: true })
       .then((models) => {
         if (!isMounted) return
-        if (!Array.isArray(models) || models.length === 0) {
-          setAvailableModels([])
-          return
-        }
-        const uniqueById = new Map<string, ChatModelOption>()
-        for (const model of models) {
-          if (!model || typeof model !== "object") continue
-          const modelId = extractStringCandidate((model as { id?: unknown }).id)
-          if (!modelId) continue
-          const provider = extractStringCandidate(
-            (model as { provider?: unknown }).provider
-          )
-          const modelName = extractStringCandidate(
-            (model as { name?: unknown }).name
-          )
-          const label =
-            modelName && modelName !== modelId
-              ? `${modelName} (${modelId})`
-              : modelName || modelId
-          uniqueById.set(modelId, {
-            id: modelId,
-            label: provider ? `${provider} · ${label}` : label,
-            provider
-          })
-        }
-        setAvailableModels(
-          Array.from(uniqueById.values()).sort((a, b) =>
-            a.label.localeCompare(b.label, undefined, { sensitivity: "base" })
-          )
-        )
+        setComposerModels(Array.isArray(models) ? models : [])
       })
       .catch(() => {
         if (!isMounted) return
-        setAvailableModels([])
-      })
-      .finally(() => {
-        if (isMounted) {
-          setLoadingModels(false)
-        }
+        setComposerModels([])
       })
 
     return () => {
@@ -2513,12 +2482,71 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
     }
   }, [])
 
-  // Model display label (UX-009)
-  const modelDisplayLabel = React.useMemo(() => {
-    if (selectedModel) return selectedModel
-    if (chatApiProvider) return chatApiProvider
-    return null
-  }, [selectedModel, chatApiProvider])
+  const handleModelSelect = React.useCallback(
+    (model: string) => {
+      if (typeof setSelectedModel !== "function") return
+      setSelectedModel(model)
+    },
+    [setSelectedModel]
+  )
+  const {
+    modelDropdownOpen,
+    setModelDropdownOpen,
+    modelSearchQuery,
+    setModelSearchQuery,
+    modelSortMode,
+    setModelSortMode,
+    modelListScope,
+    setModelListScope,
+    selectedModelKey,
+    resolvedProviderKey,
+    apiModelLabel,
+    modelSelectorWarning,
+    favoriteModels,
+    favoriteModelsIsLoading,
+    modelDropdownMenuItems
+  } = useModelSelector({
+    composerModels,
+    selectedModel,
+    setSelectedModel: handleModelSelect,
+    navigate: navigateTo
+  })
+
+  React.useEffect(() => {
+    const nextModel = resolveStartupSelectedModel({
+      currentModel: selectedModel,
+      models: composerModels,
+      preferredModelIds: favoriteModels,
+      isCurrentModelHydrating: false,
+      arePreferencesHydrating: favoriteModelsIsLoading
+    })
+    if (nextModel && typeof setSelectedModel === "function") {
+      setSelectedModel(nextModel)
+    }
+  }, [
+    composerModels,
+    favoriteModels,
+    favoriteModelsIsLoading,
+    selectedModel,
+    setSelectedModel
+  ])
+
+  const connectionUxState = React.useMemo(
+    () => deriveConnectionUxState(connectionState),
+    [connectionState]
+  )
+  const isConnectionReady = connectionState.phase === ConnectionPhase.CONNECTED
+  const connectionStatusLabel = React.useMemo(() => {
+    if (!isConnectionReady) {
+      return t("playground:composer.providerStatusOffline", "Offline")
+    }
+    if (connectionUxState === "connected_degraded") {
+      return t("playground:composer.providerStatusDegraded", "Degraded")
+    }
+    return t("playground:composer.providerStatusReady", "Ready")
+  }, [connectionUxState, isConnectionReady, t])
+  const connectionStatusWarning =
+    !isConnectionReady || connectionUxState === "connected_degraded"
 
   // Conversation instance ID (use workspace ID or fallback)
   const conversationInstanceId = workspaceSessionId
@@ -2816,7 +2844,7 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
                   isMobile={isMobile}
                   layoutMode={contentWidthMode}
                   onExamplePromptSelect={(prompt) => setSeededPrompt(prompt)}
-                  onAddSource={openAddSourceModal}
+                  onAddSource={openExistingSourcesModal}
                   onCreateFromTemplate={handleCreateFromTemplate}
                 />
               </div>
@@ -2854,7 +2882,7 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
         onDragOver={handleDropZoneDragOver}
         onDrop={handleDropZoneDrop}
         onDragLeave={handleDropZoneDragLeave}
-        className={`sticky bottom-0 z-20 border-t border-border bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/85 transition-colors ${
+        className={`sticky bottom-0 z-20 shrink-0 border-t border-border bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/85 transition-colors ${
           dropZoneActive ? "bg-primary/5" : ""
         }`}
       >
@@ -2960,45 +2988,31 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
               </label>
             )}
             <div className="ml-auto flex flex-wrap items-center gap-1">
-              {provenanceEnabled && (loadingModels || availableModels.length > 0) && (
-                <label
-                  className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-surface/80 px-2 py-1 text-[11px] text-text-muted"
-                  title={
-                    modelDisplayLabel
-                      ? t(
-                          "playground:chat.currentModelTooltip",
-                          "Current model: {{model}}",
-                          { model: modelDisplayLabel }
-                        ).replace("{{model}}", modelDisplayLabel)
-                      : undefined
+              {provenanceEnabled && (
+                <ChatModelSelectorDropdown
+                  activeModelKey={selectedModelKey ?? selectedModel}
+                  apiModelLabel={apiModelLabel}
+                  catalogControls={
+                    <PlaygroundModelCatalogControls
+                      t={t}
+                      modelListScope={modelListScope}
+                      setModelListScope={setModelListScope}
+                      modelSearchQuery={modelSearchQuery}
+                      setModelSearchQuery={setModelSearchQuery}
+                      modelSortMode={modelSortMode}
+                      setModelSortMode={setModelSortMode}
+                    />
                   }
-                >
-                  <Cpu className="h-3 w-3" />
-                  <span>{t("playground:chat.modelPickerLabel", "Model")}</span>
-                  <select
-                    aria-label={t(
-                      "playground:chat.modelPickerAria",
-                      "Select model"
-                    )}
-                    value={selectedModel ?? ""}
-                    onChange={(event) => {
-                      if (typeof setSelectedModel !== "function") return
-                      const value = event.target.value.trim()
-                      setSelectedModel(value.length > 0 ? value : null)
-                    }}
-                    className="max-w-[180px] truncate bg-transparent text-[11px] text-text focus:outline-none"
-                    disabled={loadingModels}
-                  >
-                    <option value="">
-                      {t("playground:chat.modelPickerAuto", "Auto")}
-                    </option>
-                    {availableModels.map((model) => (
-                      <option key={model.id} value={model.id}>
-                        {model.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                  connectionStatusLabel={connectionStatusLabel}
+                  connectionStatusWarning={connectionStatusWarning}
+                  modelDropdownMenuItems={modelDropdownMenuItems}
+                  modelDropdownOpen={modelDropdownOpen}
+                  modelSelectorWarning={modelSelectorWarning}
+                  placement="topLeft"
+                  resolvedProviderKey={resolvedProviderKey}
+                  setModelDropdownOpen={setModelDropdownOpen}
+                  setModelSearchQuery={setModelSearchQuery}
+                />
               )}
               {/* Share conversation button (UX-044) */}
               {serverChatId && hasMessages && (

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/utils/message-variants"
 import { buildConversationShareUrl } from "@/components/Layouts/chat-share-links"
 import { PlaygroundMessage } from "@/components/Common/Playground/Message"
-import { Link } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { EmptyState } from "@/components/ui/feedback/EmptyState"
 import { ChatModelSelectorDropdown } from "@/components/Option/Playground/ChatModelSelectorDropdown"
 import { PlaygroundModelCatalogControls } from "@/components/Option/Playground/PlaygroundModelCatalogControls"
@@ -86,6 +86,7 @@ type RetrievalDiagnostics = {
 }
 
 type ChatModePreference = "normal" | "rag"
+type ChatComposerModel = Awaited<ReturnType<typeof fetchChatModels>>[number]
 type ChatPaneContentWidthMode = "comfortable" | "expanded" | "full"
 type LorebookActivityTurn = {
   turnNumber: number
@@ -1222,7 +1223,21 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   onRefreshResearchStudioCapabilities
 }) => {
   const { t } = useTranslation(["playground", "common"])
+  const translate = React.useCallback(
+    (
+      key: string,
+      defaultValueOrOptions?: unknown,
+      options?: unknown
+    ): string =>
+      t(
+        key,
+        defaultValueOrOptions as never,
+        options as never
+      ) as unknown as string,
+    [t]
+  )
   const isMobile = useMobile()
+  const navigate = useNavigate()
   const [messageApi, messageContextHolder] = message.useMessage()
 
   // Workspace store
@@ -1309,14 +1324,8 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   const checkConnectionOnce = useConnectionStore((s) => s.checkOnce)
   const connectionState = useConnectionStore((s) => s.state)
   const navigateTo = React.useCallback((path: string) => {
-    if (typeof window === "undefined") return
-    window.history.pushState({}, "", path)
-    const event =
-      typeof PopStateEvent === "function"
-        ? new PopStateEvent("popstate")
-        : new Event("popstate")
-    window.dispatchEvent(event)
-  }, [])
+    navigate(path)
+  }, [navigate])
   const [preferredChatMode, setPreferredChatMode] = React.useState<
     ChatModePreference | null
   >(null)
@@ -1352,7 +1361,9 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
   const [slashCommands, setSlashCommands] = React.useState<
     Array<{ name: string; description: string }>
   >([])
-  const [composerModels, setComposerModels] = React.useState<any[]>([])
+  const [composerModels, setComposerModels] = React.useState<
+    ChatComposerModel[]
+  >([])
   const slashCommandsFetchedRef = React.useRef(false)
   const modelsFetchedRef = React.useRef(false)
   const workspaceSessionRef = React.useRef<string | null>(null)
@@ -2994,7 +3005,7 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
                   apiModelLabel={apiModelLabel}
                   catalogControls={
                     <PlaygroundModelCatalogControls
-                      t={t}
+                      t={translate}
                       modelListScope={modelListScope}
                       setModelListScope={setModelListScope}
                       modelSearchQuery={modelSearchQuery}

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/AddSourceModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/AddSourceModal.tsx
@@ -101,6 +101,51 @@ type UploadProgressEntry = {
 
 type AddSourceTabUsage = Record<AddSourceTab, number>
 
+type ExistingMediaSortBy =
+  | "relevance"
+  | "date_desc"
+  | "date_asc"
+  | "title_asc"
+  | "title_desc"
+
+type ExistingMediaFilters = {
+  query: string
+  mediaType: string
+  keywords: string
+  sortBy: ExistingMediaSortBy
+}
+
+type MediaLibraryItem = Record<string, unknown>
+
+const DEFAULT_EXISTING_MEDIA_FILTERS: ExistingMediaFilters = {
+  query: "",
+  mediaType: "all",
+  keywords: "",
+  sortBy: "relevance"
+}
+
+const EXISTING_MEDIA_TYPE_FILTERS = [
+  { value: "all", label: "All types" },
+  { value: "pdf", label: "PDF" },
+  { value: "video", label: "Video" },
+  { value: "audio", label: "Audio" },
+  { value: "website", label: "Website" },
+  { value: "document", label: "Document" },
+  { value: "text", label: "Text" },
+  { value: "email", label: "Email" }
+] as const
+
+const EXISTING_MEDIA_SORT_OPTIONS: Array<{
+  value: ExistingMediaSortBy
+  label: string
+}> = [
+  { value: "relevance", label: "Relevance" },
+  { value: "date_desc", label: "Newest" },
+  { value: "date_asc", label: "Oldest" },
+  { value: "title_asc", label: "Title A-Z" },
+  { value: "title_desc", label: "Title Z-A" }
+]
+
 const buildDefaultAddSourceTabUsage = (): AddSourceTabUsage => ({
   upload: 0,
   existing: 0,
@@ -178,6 +223,80 @@ const toOptionalString = (value: unknown): string | undefined => {
   if (typeof value !== "string") return undefined
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const asMediaLibraryItem = (value: unknown): MediaLibraryItem | null =>
+  isRecord(value) ? value : null
+
+const getMediaLibraryIdNumber = (item: MediaLibraryItem): number | null =>
+  toMediaId(item.media_id ?? item.id)
+
+const getMediaLibraryTitle = (item: MediaLibraryItem): string =>
+  toOptionalString(item.title) || toOptionalString(item.name) || "Untitled"
+
+const getMediaLibraryTypeLabel = (item: MediaLibraryItem): string =>
+  toOptionalString(item.type) || toOptionalString(item.media_type) || "document"
+
+const getMediaLibraryKeywords = (item: MediaLibraryItem): string[] => {
+  const raw = item.keywords
+  if (Array.isArray(raw)) {
+    return raw
+      .map((keyword) => String(keyword).trim())
+      .filter(Boolean)
+      .slice(0, 8)
+  }
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((keyword) => keyword.trim())
+      .filter(Boolean)
+      .slice(0, 8)
+  }
+  return []
+}
+
+const parseKeywordFilterInput = (value: string): string[] =>
+  Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((keyword) => keyword.trim())
+        .filter(Boolean)
+    )
+  )
+
+const hasActiveExistingMediaFilters = (filters: ExistingMediaFilters): boolean =>
+  Boolean(filters.query.trim()) ||
+  filters.mediaType !== "all" ||
+  parseKeywordFilterInput(filters.keywords).length > 0 ||
+  filters.sortBy !== "relevance"
+
+const buildMediaSearchPayload = (filters: ExistingMediaFilters) => {
+  const payload: {
+    query?: string
+    fields: string[]
+    media_types?: string[]
+    must_have?: string[]
+    sort_by: ExistingMediaSortBy
+  } = {
+    fields: ["title", "content"],
+    sort_by: filters.sortBy
+  }
+  const trimmedQuery = filters.query.trim()
+  if (trimmedQuery) {
+    payload.query = trimmedQuery
+  }
+  if (filters.mediaType !== "all") {
+    payload.media_types = [filters.mediaType]
+  }
+  const keywords = parseKeywordFilterInput(filters.keywords)
+  if (keywords.length > 0) {
+    payload.must_have = keywords
+  }
+  return payload
 }
 
 const extractCandidateMetadata = (candidate: Record<string, unknown>) => ({
@@ -1219,7 +1338,10 @@ const ExistingTab: React.FC<{
 }> = ({ onAddSources, setProcessing, setError }) => {
   const { t } = useTranslation(["playground", "common"])
   const [searchQuery, setSearchQuery] = React.useState("")
-  const [media, setMedia] = React.useState<any[]>([])
+  const [mediaTypeFilter, setMediaTypeFilter] = React.useState("all")
+  const [keywordFilterInput, setKeywordFilterInput] = React.useState("")
+  const [sortBy, setSortBy] = React.useState<ExistingMediaSortBy>("relevance")
+  const [media, setMedia] = React.useState<MediaLibraryItem[]>([])
   const [isLoading, setIsLoading] = React.useState(false)
   const [loadError, setLoadError] = React.useState<string | null>(null)
   const [selectedMediaKeys, setSelectedMediaKeys] = React.useState<Set<string>>(
@@ -1228,7 +1350,7 @@ const ExistingTab: React.FC<{
   const [currentPage, setCurrentPage] = React.useState(1)
   const [totalCount, setTotalCount] = React.useState(0)
   const [hasMore, setHasMore] = React.useState(false)
-  const mediaRef = React.useRef<any[]>([])
+  const mediaRef = React.useRef<MediaLibraryItem[]>([])
 
   // Already added source media IDs
   const sources = useWorkspaceStore((s) => s.sources)
@@ -1237,24 +1359,26 @@ const ExistingTab: React.FC<{
     [sources]
   )
 
-  const setMediaList = React.useCallback((items: any[]) => {
+  const setMediaList = React.useCallback((items: MediaLibraryItem[]) => {
     mediaRef.current = items
     setMedia(items)
   }, [])
 
   const dedupeMediaItems = React.useCallback((items: unknown[]) => {
-    const itemMap = new Map<string, any>()
+    const itemMap = new Map<string, MediaLibraryItem>()
     for (const item of items) {
-      const key = getMediaLibraryItemKey(item)
+      const mediaItem = asMediaLibraryItem(item)
+      if (!mediaItem) continue
+      const key = getMediaLibraryItemKey(mediaItem)
       if (key == null) continue
-      itemMap.set(key, item)
+      itemMap.set(key, mediaItem)
     }
     return Array.from(itemMap.values())
   }, [])
 
   const fetchMediaFromServer = React.useCallback(
     async (
-      query?: string,
+      filters: ExistingMediaFilters,
       options?: { silent?: boolean; page?: number; append?: boolean }
     ) => {
       const shouldShowLoading = !options?.silent
@@ -1267,11 +1391,10 @@ const ExistingTab: React.FC<{
       const append = Boolean(options?.append)
 
       try {
-        const trimmedQuery = query?.trim()
         let response
-        if (trimmedQuery) {
+        if (hasActiveExistingMediaFilters(filters)) {
           response = await tldwClient.searchMedia(
-            { query: trimmedQuery },
+            buildMediaSearchPayload(filters),
             { page, results_per_page: 50 }
           )
         } else {
@@ -1303,7 +1426,8 @@ const ExistingTab: React.FC<{
         setCurrentPage(page)
         setHasMore(dedupedItems.length < normalizedTotal)
 
-      } catch {
+      } catch (err) {
+        console.error("Failed to fetch media from server:", err)
         setLoadError("Unable to load media. Please try again.")
       } finally {
         if (shouldShowLoading) {
@@ -1315,27 +1439,54 @@ const ExistingTab: React.FC<{
   )
 
   const loadMedia = React.useCallback(
-    async (query?: string) => {
-      const trimmedQuery = query?.trim()
+    async (filters?: ExistingMediaFilters) => {
+      const nextFilters =
+        filters || {
+          query: searchQuery,
+          mediaType: mediaTypeFilter,
+          keywords: keywordFilterInput,
+          sortBy
+        }
       setCurrentPage(1)
       setSelectedMediaKeys(new Set())
-      await fetchMediaFromServer(trimmedQuery, { page: 1 })
+      await fetchMediaFromServer(nextFilters, { page: 1 })
     },
-    [fetchMediaFromServer]
+    [fetchMediaFromServer, keywordFilterInput, mediaTypeFilter, searchQuery, sortBy]
   )
 
   React.useEffect(() => {
-    loadMedia()
-  }, [loadMedia])
+    void fetchMediaFromServer(DEFAULT_EXISTING_MEDIA_FILTERS, { page: 1 })
+  }, [fetchMediaFromServer])
+
+  const currentFilters = React.useMemo<ExistingMediaFilters>(
+    () => ({
+      query: searchQuery,
+      mediaType: mediaTypeFilter,
+      keywords: keywordFilterInput,
+      sortBy
+    }),
+    [keywordFilterInput, mediaTypeFilter, searchQuery, sortBy]
+  )
+  const filtersActive = hasActiveExistingMediaFilters(currentFilters)
 
   const handleSearch = () => {
     setCurrentPage(1)
-    void loadMedia(searchQuery)
+    void loadMedia(currentFilters)
+  }
+
+  const handleClearFilters = () => {
+    setSearchQuery("")
+    setMediaTypeFilter("all")
+    setKeywordFilterInput("")
+    setSortBy("relevance")
+    setCurrentPage(1)
+    setSelectedMediaKeys(new Set())
+    void fetchMediaFromServer(DEFAULT_EXISTING_MEDIA_FILTERS, { page: 1 })
   }
 
   const handleLoadMore = () => {
     if (isLoading || !hasMore) return
-    void fetchMediaFromServer(searchQuery, {
+    void fetchMediaFromServer(currentFilters, {
       page: currentPage + 1,
       append: true
     })
@@ -1344,28 +1495,30 @@ const ExistingTab: React.FC<{
   const handleAddSelected = () => {
     const selectedItems = media.filter((m) => {
       const key = getMediaLibraryItemKey(m)
-      const mediaId = Number(m.media_id ?? m.id)
+      const mediaId = getMediaLibraryIdNumber(m)
       return (
         key != null &&
-        Number.isFinite(mediaId) &&
+        mediaId != null &&
         selectedMediaKeys.has(key) &&
         !existingMediaIds.has(key)
       )
     })
 
     const newSources = selectedItems.map((m) => ({
-      mediaId: Number(m.media_id ?? m.id),
-      title: m.title || m.name || "Untitled",
-      type: getSourceTypeFromMediaType(m.type || m.media_type) as WorkspaceSourceType,
+      mediaId: getMediaLibraryIdNumber(m) as number,
+      title: getMediaLibraryTitle(m),
+      type: getSourceTypeFromMediaType(
+        toOptionalString(m.type) || toOptionalString(m.media_type) || ""
+      ) as WorkspaceSourceType,
       status: "ready" as const,
-      url: m.url || m.source_url || undefined,
-      fileSize: toOptionalNumber(m.file_size || m.filesize || m.size),
-      duration: toOptionalNumber(m.duration_seconds || m.duration),
-      pageCount: toOptionalNumber(m.page_count || m.pages),
+      url: toOptionalString(m.url) || toOptionalString(m.source_url),
+      fileSize: toOptionalNumber(m.file_size ?? m.filesize ?? m.size),
+      duration: toOptionalNumber(m.duration_seconds ?? m.duration),
+      pageCount: toOptionalNumber(m.page_count ?? m.pages),
       sourceCreatedAt:
-        parseSourceCreatedAt(m.created_at || m.createdAt || m.date_added) ||
+        parseSourceCreatedAt(m.created_at ?? m.createdAt ?? m.date_added) ||
         undefined,
-      thumbnailUrl: m.thumbnail_url || m.thumbnail || undefined
+      thumbnailUrl: toOptionalString(m.thumbnail_url) || toOptionalString(m.thumbnail)
     }))
 
     if (newSources.length > 0) {
@@ -1396,18 +1549,76 @@ const ExistingTab: React.FC<{
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2">
+      <div className="space-y-2 rounded border border-border bg-surface2/30 p-2">
+        <div className="flex gap-2">
+          <Input
+            aria-label={t("playground:sources.searchMediaLabel", "Search media")}
+            prefix={<Search className="h-4 w-4 text-text-muted" />}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onPressEnter={handleSearch}
+            placeholder={t("playground:sources.searchExisting", "Search your media library...")}
+            className="flex-1"
+          />
+          <Button
+            aria-label={t("common:search", "Search")}
+            onClick={handleSearch}
+            loading={isLoading}
+          >
+            {t("common:search", "Search")}
+          </Button>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+          <label className="min-w-0">
+            <span className="mb-1 block text-[11px] font-medium text-text-muted">
+              {t("playground:sources.mediaTypeFilter", "Media type")}
+            </span>
+            <select
+              aria-label={t("playground:sources.mediaTypeFilter", "Media type")}
+              value={mediaTypeFilter}
+              onChange={(event) => setMediaTypeFilter(event.target.value)}
+              className="h-8 w-full rounded border border-border bg-surface px-2 text-xs text-text"
+            >
+              {EXISTING_MEDIA_TYPE_FILTERS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="min-w-0">
+            <span className="mb-1 block text-[11px] font-medium text-text-muted">
+              {t("playground:sources.sortMedia", "Sort media")}
+            </span>
+            <select
+              aria-label={t("playground:sources.sortMedia", "Sort media")}
+              value={sortBy}
+              onChange={(event) => setSortBy(event.target.value as ExistingMediaSortBy)}
+              className="h-8 w-full rounded border border-border bg-surface px-2 text-xs text-text"
+            >
+              {EXISTING_MEDIA_SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {filtersActive && (
+            <Button onClick={handleClearFilters} className="self-end">
+              {t("playground:sources.clearFilters", "Clear filters")}
+            </Button>
+          )}
+        </div>
         <Input
-          prefix={<Search className="h-4 w-4 text-text-muted" />}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
+          aria-label={t("playground:sources.keywordFilter", "Keywords")}
+          value={keywordFilterInput}
+          onChange={(event) => setKeywordFilterInput(event.target.value)}
           onPressEnter={handleSearch}
-          placeholder={t("playground:sources.searchExisting", "Search your media library...")}
-          className="flex-1"
+          placeholder={t(
+            "playground:sources.keywordFilterPlaceholder",
+            "Filter keywords, comma-separated"
+          )}
         />
-        <Button onClick={handleSearch} loading={isLoading}>
-          {t("common:search", "Search")}
-        </Button>
       </div>
 
       {isLoading ? (
@@ -1451,7 +1662,8 @@ const ExistingTab: React.FC<{
               renderItem={(item) => {
                 const key = getMediaLibraryItemKey(item)
                 if (key == null) return null
-                const title = item.title || item.name || "Untitled"
+                const title = getMediaLibraryTitle(item)
+                const keywords = getMediaLibraryKeywords(item)
                 return (
                   <List.Item
                     className={`cursor-pointer transition hover:bg-surface2 ${
@@ -1475,8 +1687,20 @@ const ExistingTab: React.FC<{
                           {title}
                         </p>
                         <p className="text-xs text-text-muted capitalize">
-                          {item.type || item.media_type || "document"}
+                          {getMediaLibraryTypeLabel(item)}
                         </p>
+                        {keywords.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {keywords.map((keyword) => (
+                              <span
+                                key={keyword}
+                                className="rounded bg-surface2 px-1.5 py-0.5 text-[10px] text-text-muted"
+                              >
+                                {keyword}
+                              </span>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     </div>
                   </List.Item>

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/AddSourceModal.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/AddSourceModal.tsx
@@ -41,10 +41,13 @@ import {
   parseSourceCreatedAt,
   validateSourceUploadFile
 } from "./source-ingestion-utils"
+import {
+  getMediaLibraryItemKey,
+  normalizeMediaLibraryResponse
+} from "./media-library-normalization"
 
 const { TextArea } = Input
 const { Dragger } = Upload
-const EXISTING_MEDIA_CACHE_TTL_MS = 60_000
 const ADD_SOURCE_TAB_USAGE_STORAGE_KEY =
   "tldw:workspace-playground:add-source-tab-usage:v1"
 const DEFAULT_ADD_SOURCE_TAB_ORDER: AddSourceTab[] = [
@@ -63,9 +66,6 @@ const WORKSPACE_UPLOAD_INGEST_FIELDS = {
   overwrite: "false",
   ...WORKSPACE_RAG_INGEST_FIELDS
 } as const
-
-let existingMediaCache: { items: any[]; totalCount: number; cachedAt: number } | null =
-  null
 
 type AddSourceCandidate = {
   mediaId: number
@@ -1221,19 +1221,36 @@ const ExistingTab: React.FC<{
   const [searchQuery, setSearchQuery] = React.useState("")
   const [media, setMedia] = React.useState<any[]>([])
   const [isLoading, setIsLoading] = React.useState(false)
-  const [selectedMedia, setSelectedMedia] = React.useState<Set<number>>(
+  const [loadError, setLoadError] = React.useState<string | null>(null)
+  const [selectedMediaKeys, setSelectedMediaKeys] = React.useState<Set<string>>(
     new Set()
   )
   const [currentPage, setCurrentPage] = React.useState(1)
   const [totalCount, setTotalCount] = React.useState(0)
   const [hasMore, setHasMore] = React.useState(false)
+  const mediaRef = React.useRef<any[]>([])
 
   // Already added source media IDs
   const sources = useWorkspaceStore((s) => s.sources)
   const existingMediaIds = React.useMemo(
-    () => new Set(sources.map((s) => s.mediaId)),
+    () => new Set(sources.map((s) => String(s.mediaId))),
     [sources]
   )
+
+  const setMediaList = React.useCallback((items: any[]) => {
+    mediaRef.current = items
+    setMedia(items)
+  }, [])
+
+  const dedupeMediaItems = React.useCallback((items: unknown[]) => {
+    const itemMap = new Map<string, any>()
+    for (const item of items) {
+      const key = getMediaLibraryItemKey(item)
+      if (key == null) continue
+      itemMap.set(key, item)
+    }
+    return Array.from(itemMap.values())
+  }, [])
 
   const fetchMediaFromServer = React.useCallback(
     async (
@@ -1244,6 +1261,7 @@ const ExistingTab: React.FC<{
       if (shouldShowLoading) {
         setIsLoading(true)
       }
+      setLoadError(null)
       setError(null)
       const page = options?.page || 1
       const append = Boolean(options?.append)
@@ -1264,69 +1282,43 @@ const ExistingTab: React.FC<{
           })
         }
 
-        if (response?.media || response?.results) {
-          const items = response.media || response.results || []
-          const total = Number(
-            response.total_count ??
-              response.total ??
-              response.count ??
-              response.results_count ??
-              response.pagination?.total ??
-              (append ? media.length + items.length : items.length)
-          )
-          const normalizedTotal =
-            Number.isFinite(total) && total >= 0
-              ? total
-              : append
-                ? media.length + items.length
-                : items.length
-          const nextItems = append ? [...media, ...items] : items
-          const dedupedItems = Array.from(
-            new Map(
-              nextItems.map((item: any) => [String(item.media_id || item.id), item])
-            ).values()
-          )
+        const normalized = normalizeMediaLibraryResponse(
+          response,
+          append ? mediaRef.current.length : undefined
+        )
+        const nextItems = append
+          ? [...mediaRef.current, ...normalized.items]
+          : normalized.items
+        const dedupedItems = dedupeMediaItems(nextItems)
+        const normalizedTotal = Math.max(normalized.totalCount, dedupedItems.length)
 
-          setMedia(dedupedItems)
-          setTotalCount(normalizedTotal)
-          setCurrentPage(page)
-          setHasMore(dedupedItems.length < normalizedTotal)
+        setMediaList(dedupedItems)
+        setSelectedMediaKeys((previous) => {
+          const availableKeys = new Set(dedupedItems.map(getMediaLibraryItemKey))
+          return new Set(
+            Array.from(previous).filter((key) => availableKeys.has(key))
+          )
+        })
+        setTotalCount(normalizedTotal)
+        setCurrentPage(page)
+        setHasMore(dedupedItems.length < normalizedTotal)
 
-          if (!trimmedQuery && page === 1) {
-            existingMediaCache = {
-              items: dedupedItems,
-              totalCount: normalizedTotal,
-              cachedAt: Date.now()
-            }
-          }
-        }
-      } catch (err) {
-        setError(mapSourceIngestionError(err))
+      } catch {
+        setLoadError("Unable to load media. Please try again.")
       } finally {
         if (shouldShowLoading) {
           setIsLoading(false)
         }
       }
     },
-    [media, setError]
+    [dedupeMediaItems, setError, setMediaList]
   )
 
   const loadMedia = React.useCallback(
     async (query?: string) => {
       const trimmedQuery = query?.trim()
-      if (!trimmedQuery && existingMediaCache) {
-        const cacheIsFresh =
-          Date.now() - existingMediaCache.cachedAt < EXISTING_MEDIA_CACHE_TTL_MS
-        if (cacheIsFresh) {
-          setMedia(existingMediaCache.items)
-          setTotalCount(existingMediaCache.totalCount)
-          setCurrentPage(1)
-          setHasMore(existingMediaCache.items.length < existingMediaCache.totalCount)
-          return
-        }
-      }
-
       setCurrentPage(1)
+      setSelectedMediaKeys(new Set())
       await fetchMediaFromServer(trimmedQuery, { page: 1 })
     },
     [fetchMediaFromServer]
@@ -1350,12 +1342,19 @@ const ExistingTab: React.FC<{
   }
 
   const handleAddSelected = () => {
-    const selectedItems = media.filter(
-      (m) => selectedMedia.has(m.media_id || m.id) && !existingMediaIds.has(m.media_id || m.id)
-    )
+    const selectedItems = media.filter((m) => {
+      const key = getMediaLibraryItemKey(m)
+      const mediaId = Number(m.media_id ?? m.id)
+      return (
+        key != null &&
+        Number.isFinite(mediaId) &&
+        selectedMediaKeys.has(key) &&
+        !existingMediaIds.has(key)
+      )
+    })
 
     const newSources = selectedItems.map((m) => ({
-      mediaId: m.media_id || m.id,
+      mediaId: Number(m.media_id ?? m.id),
       title: m.title || m.name || "Untitled",
       type: getSourceTypeFromMediaType(m.type || m.media_type) as WorkspaceSourceType,
       status: "ready" as const,
@@ -1374,23 +1373,26 @@ const ExistingTab: React.FC<{
     }
   }
 
-  const toggleMedia = (id: number) => {
-    const newSelected = new Set(selectedMedia)
-    if (newSelected.has(id)) {
-      newSelected.delete(id)
+  const toggleMedia = (key: string) => {
+    const newSelected = new Set(selectedMediaKeys)
+    if (newSelected.has(key)) {
+      newSelected.delete(key)
     } else {
-      newSelected.add(id)
+      newSelected.add(key)
     }
-    setSelectedMedia(newSelected)
+    setSelectedMediaKeys(newSelected)
   }
 
-  const availableMedia = media.filter(
-    (m) => !existingMediaIds.has(m.media_id || m.id)
-  )
+  const availableMedia = media.filter((m) => {
+    const key = getMediaLibraryItemKey(m)
+    return key != null && !existingMediaIds.has(key)
+  })
   const visibleTotalCount =
     totalCount > 0
       ? Math.max(totalCount - existingMediaIds.size, availableMedia.length)
       : availableMedia.length
+  const allVisibleMediaAlreadyAdded =
+    media.length > 0 && availableMedia.length === 0
 
   return (
     <div className="space-y-4">
@@ -1412,6 +1414,16 @@ const ExistingTab: React.FC<{
         <div className="flex justify-center py-8">
           <Spin />
         </div>
+      ) : loadError ? (
+        <Alert type="error" title={loadError} showIcon />
+      ) : allVisibleMediaAlreadyAdded ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={t(
+            "playground:sources.allVisibleMediaAlreadyAdded",
+            "All visible media are already in this workspace"
+          )}
+        />
       ) : availableMedia.length === 0 ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
@@ -1437,22 +1449,30 @@ const ExistingTab: React.FC<{
               size="small"
               dataSource={availableMedia}
               renderItem={(item) => {
-                const id = item.media_id || item.id
+                const key = getMediaLibraryItemKey(item)
+                if (key == null) return null
+                const title = item.title || item.name || "Untitled"
                 return (
                   <List.Item
                     className={`cursor-pointer transition hover:bg-surface2 ${
-                      selectedMedia.has(id) ? "bg-primary/10" : ""
+                      selectedMediaKeys.has(key) ? "bg-primary/10" : ""
                     }`}
-                    onClick={() => toggleMedia(id)}
+                    onClick={() => toggleMedia(key)}
                   >
                     <div className="flex items-start gap-2">
                       <Checkbox
-                        checked={selectedMedia.has(id)}
-                        onChange={() => toggleMedia(id)}
+                        aria-label={t(
+                          "playground:sources.selectLibraryItem",
+                          "Select {{title}}",
+                          { title }
+                        )}
+                        checked={selectedMediaKeys.has(key)}
+                        onClick={(event) => event.stopPropagation()}
+                        onChange={() => toggleMedia(key)}
                       />
                       <div className="min-w-0 flex-1">
                         <p className="truncate text-sm font-medium text-text">
-                          {item.title || item.name || "Untitled"}
+                          {title}
                         </p>
                         <p className="text-xs text-text-muted capitalize">
                           {item.type || item.media_type || "document"}
@@ -1467,11 +1487,11 @@ const ExistingTab: React.FC<{
           <Button
             type="primary"
             onClick={handleAddSelected}
-            disabled={selectedMedia.size === 0}
+            disabled={selectedMediaKeys.size === 0}
             className="w-full"
           >
             {t("playground:sources.addSelected", "Add {{count}} selected", {
-              count: selectedMedia.size
+              count: selectedMediaKeys.size
             })}
           </Button>
           {hasMore && (

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/index.tsx
@@ -1363,9 +1363,9 @@ export const SourcesPane: React.FC<SourcesPaneProps> = ({
             type="primary"
             size="small"
             icon={<Plus className="h-3.5 w-3.5" />}
-            onClick={() => openAddSourceModal()}
+            onClick={() => openAddSourceModal("existing")}
           >
-            {t("playground:sources.add", "Add")}
+            {t("playground:sources.addSources", "Add Sources")}
           </Button>
           {onHide && (
             <Tooltip title={t("playground:workspace.hideSources", "Hide sources")}>
@@ -1580,7 +1580,7 @@ export const SourcesPane: React.FC<SourcesPaneProps> = ({
                   type="primary"
                   size="small"
                   icon={<Plus className="h-3.5 w-3.5" />}
-                  onClick={() => openAddSourceModal()}
+                  onClick={() => openAddSourceModal("existing")}
                 >
                   {t("playground:sources.addFirst", "Add your first source")}
                 </Button>

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/media-library-normalization.ts
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/media-library-normalization.ts
@@ -1,0 +1,107 @@
+type MediaLibraryRecord = Record<string, unknown>
+
+export type NormalizedMediaLibraryResponse = {
+  items: unknown[]
+  totalCount: number
+}
+
+const isRecord = (value: unknown): value is MediaLibraryRecord =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const normalizeId = (value: unknown): string | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value)
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  return null
+}
+
+export const getMediaLibraryItemKey = (item: unknown): string | null => {
+  if (!isRecord(item)) return null
+
+  return normalizeId(item.media_id) ?? normalizeId(item.id)
+}
+
+const firstArray = (...values: unknown[]): unknown[] | null => {
+  for (const value of values) {
+    if (Array.isArray(value)) return value
+  }
+  return null
+}
+
+const normalizeTotal = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.trunc(value)
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return Math.trunc(parsed)
+    }
+  }
+  return null
+}
+
+const firstTotal = (...values: unknown[]): number | null => {
+  for (const value of values) {
+    const total = normalizeTotal(value)
+    if (total != null) return total
+  }
+  return null
+}
+
+export const normalizeMediaLibraryResponse = (
+  response: unknown,
+  fallbackTotal?: number
+): NormalizedMediaLibraryResponse => {
+  if (Array.isArray(response)) {
+    const fallback = normalizeTotal(fallbackTotal)
+    return {
+      items: response,
+      totalCount: Math.max(response.length, fallback ?? response.length)
+    }
+  }
+
+  if (!isRecord(response)) {
+    const fallback = normalizeTotal(fallbackTotal)
+    return {
+      items: [],
+      totalCount: fallback ?? 0
+    }
+  }
+
+  const nestedData = isRecord(response.data) ? response.data : null
+  const items =
+    firstArray(response.media, response.results, response.items, response.data) ??
+    (nestedData
+      ? firstArray(nestedData.items, nestedData.media, nestedData.results)
+      : null) ??
+    []
+
+  const rootPagination = isRecord(response.pagination) ? response.pagination : null
+  const nestedPagination =
+    nestedData && isRecord(nestedData.pagination) ? nestedData.pagination : null
+  const total =
+    firstTotal(
+      response.total_count,
+      response.total,
+      response.count,
+      response.results_count,
+      rootPagination?.total,
+      rootPagination?.total_items,
+      nestedData?.total_count,
+      nestedData?.total,
+      nestedData?.count,
+      nestedData?.results_count,
+      nestedPagination?.total,
+      nestedPagination?.total_items
+    ) ?? normalizeTotal(fallbackTotal)
+
+  return {
+    items,
+    totalCount: Math.max(items.length, total ?? items.length)
+  }
+}

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx
@@ -170,13 +170,25 @@ describe("AddSourceModal Stage 2 intake and relevance", () => {
     ])
   })
 
-  it("shows a load error when My Media cannot load", async () => {
+  it("shows and logs a load error when My Media cannot load", async () => {
     workspaceStoreState.addSourceModalTab = "existing"
-    mockListMedia.mockRejectedValueOnce(new Error("offline"))
+    const loadFailure = new Error("offline")
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+    mockListMedia.mockRejectedValueOnce(loadFailure)
 
-    render(<AddSourceModal />)
+    try {
+      render(<AddSourceModal />)
 
-    expect(await screen.findByText(/unable to load media/i)).toBeInTheDocument()
+      expect(await screen.findByText(/unable to load media/i)).toBeInTheDocument()
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to fetch media from server:",
+        loadFailure
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 
   it("renders My Media items from items response shape", async () => {
@@ -214,6 +226,117 @@ describe("AddSourceModal Stage 2 intake and relevance", () => {
     expect(screen.getByText("Second Library Item")).toBeInTheDocument()
     expect(screen.getByText("Showing 2 of 125")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument()
+  })
+
+  it("searches My Media with query, content type, keywords, and sort filters", async () => {
+    workspaceStoreState.addSourceModalTab = "existing"
+    mockListMedia.mockResolvedValueOnce({ media: [], total_count: 0 })
+    mockSearchMedia.mockResolvedValueOnce({
+      items: [
+        {
+          id: 801,
+          title: "Conference Keynote",
+          type: "video",
+          keywords: ["keynote", "ai"]
+        }
+      ],
+      pagination: { total_items: 1 }
+    })
+
+    render(<AddSourceModal />)
+
+    await waitFor(() => {
+      expect(mockListMedia).toHaveBeenCalledWith({
+        page: 1,
+        results_per_page: 50,
+        include_keywords: true
+      })
+    })
+
+    fireEvent.change(screen.getByLabelText("Search media"), {
+      target: { value: "conference" }
+    })
+    fireEvent.change(screen.getByLabelText("Media type"), {
+      target: { value: "video" }
+    })
+    fireEvent.change(screen.getByLabelText("Keywords"), {
+      target: { value: "keynote, ai" }
+    })
+    fireEvent.change(screen.getByLabelText("Sort media"), {
+      target: { value: "date_desc" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Search" }))
+
+    await waitFor(() => {
+      expect(mockSearchMedia).toHaveBeenCalledWith(
+        {
+          query: "conference",
+          fields: ["title", "content"],
+          media_types: ["video"],
+          must_have: ["keynote", "ai"],
+          sort_by: "date_desc"
+        },
+        { page: 1, results_per_page: 50 }
+      )
+    })
+    expect(await screen.findByText("Conference Keynote")).toBeInTheDocument()
+    expect(screen.getByText("keynote")).toBeInTheDocument()
+    expect(screen.getByText("ai")).toBeInTheDocument()
+  })
+
+  it("clears My Media filters and returns to the default media listing", async () => {
+    workspaceStoreState.addSourceModalTab = "existing"
+    mockListMedia
+      .mockResolvedValueOnce({ media: [], total_count: 0 })
+      .mockResolvedValueOnce({
+        media: [{ id: 901, title: "Default Library Item", type: "pdf" }],
+        total_count: 1
+      })
+    mockSearchMedia.mockResolvedValueOnce({
+      items: [{ id: 902, title: "Filtered Result", type: "video" }],
+      total: 1
+    })
+
+    render(<AddSourceModal />)
+
+    await waitFor(() => {
+      expect(mockListMedia).toHaveBeenCalledWith({
+        page: 1,
+        results_per_page: 50,
+        include_keywords: true
+      })
+    })
+
+    fireEvent.change(screen.getByLabelText("Search media"), {
+      target: { value: "filtered" }
+    })
+    fireEvent.change(screen.getByLabelText("Media type"), {
+      target: { value: "video" }
+    })
+    fireEvent.change(screen.getByLabelText("Keywords"), {
+      target: { value: "demo" }
+    })
+    fireEvent.change(screen.getByLabelText("Sort media"), {
+      target: { value: "title_asc" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Search" }))
+
+    expect(await screen.findByText("Filtered Result")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear filters" }))
+
+    await waitFor(() => {
+      expect(mockListMedia).toHaveBeenLastCalledWith({
+        page: 1,
+        results_per_page: 50,
+        include_keywords: true
+      })
+    })
+    expect(screen.getByLabelText("Search media")).toHaveValue("")
+    expect(screen.getByLabelText("Media type")).toHaveValue("all")
+    expect(screen.getByLabelText("Keywords")).toHaveValue("")
+    expect(screen.getByLabelText("Sort media")).toHaveValue("relevance")
+    expect(await screen.findByText("Default Library Item")).toBeInTheDocument()
   })
 
   it("distinguishes all-added media from an empty media library", async () => {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx
@@ -143,7 +143,7 @@ describe("AddSourceModal Stage 2 intake and relevance", () => {
     ])
   })
 
-  it("reorders non-upload tabs based on prior usage frequency", async () => {
+  it("keeps visible tabs in a stable order despite prior usage frequency", async () => {
     window.localStorage.setItem(
       ADD_SOURCE_TAB_USAGE_STORAGE_KEY,
       JSON.stringify({
@@ -163,11 +163,91 @@ describe("AddSourceModal Stage 2 intake and relevance", () => {
 
     expect(tabLabels).toEqual([
       "Upload",
-      "Search Server",
-      "URL",
       "My Media",
-      "Paste"
+      "URL",
+      "Paste",
+      "Search Server"
     ])
+  })
+
+  it("shows a load error when My Media cannot load", async () => {
+    workspaceStoreState.addSourceModalTab = "existing"
+    mockListMedia.mockRejectedValueOnce(new Error("offline"))
+
+    render(<AddSourceModal />)
+
+    expect(await screen.findByText(/unable to load media/i)).toBeInTheDocument()
+  })
+
+  it("renders My Media items from items response shape", async () => {
+    workspaceStoreState.addSourceModalTab = "existing"
+    mockListMedia.mockResolvedValueOnce({
+      items: [{ id: 701, title: "Library Item", type: "pdf" }],
+      total: 1
+    })
+
+    render(<AddSourceModal />)
+
+    expect(await screen.findByText("Library Item")).toBeInTheDocument()
+    expect(screen.getByText("Showing 1 of 1")).toBeInTheDocument()
+  })
+
+  it("uses backend pagination.total_items so large media libraries can load more", async () => {
+    workspaceStoreState.addSourceModalTab = "existing"
+    mockListMedia.mockResolvedValueOnce({
+      items: [
+        { id: 701, title: "Library Item", type: "pdf" },
+        { id: 702, title: "Second Library Item", type: "video" }
+      ],
+      pagination: {
+        page: 1,
+        per_page: 2,
+        total_pages: 63,
+        results_per_page: 2,
+        total_items: 125
+      }
+    })
+
+    render(<AddSourceModal />)
+
+    expect(await screen.findByText("Library Item")).toBeInTheDocument()
+    expect(screen.getByText("Second Library Item")).toBeInTheDocument()
+    expect(screen.getByText("Showing 2 of 125")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument()
+  })
+
+  it("distinguishes all-added media from an empty media library", async () => {
+    workspaceStoreState.addSourceModalTab = "existing"
+    workspaceStoreState.sources = [{ mediaId: 701 }]
+    mockListMedia.mockResolvedValueOnce({
+      items: [{ id: 701, title: "Already Added", type: "pdf" }],
+      total: 1
+    })
+
+    render(<AddSourceModal />)
+
+    expect(
+      await screen.findByText(/already in this workspace/i)
+    ).toBeInTheDocument()
+  })
+
+  it("toggles a My Media checkbox once when clicked directly", async () => {
+    workspaceStoreState.addSourceModalTab = "existing"
+    mockListMedia.mockResolvedValueOnce({
+      items: [{ id: 701, title: "Library Item", type: "pdf" }],
+      total: 1
+    })
+
+    render(<AddSourceModal />)
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /select library item/i
+    })
+    fireEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+
+    fireEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
   })
 
   it("persists updated tab usage when switching tabs", async () => {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage1.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage1.test.tsx
@@ -320,6 +320,11 @@ describe("ChatPane Stage 1 reliability and controls", () => {
     expect((transcript as HTMLElement).className).toContain("overflow-y-auto")
     expect((transcript as HTMLElement).className).toContain("flex-1")
     expect((transcript as HTMLElement).className).toContain("min-h-0")
+
+    const composerFooter = screen.getByTestId("chat-drop-zone")
+    expect(composerFooter).toHaveClass("shrink-0")
+    expect(composerFooter).toHaveClass("sticky")
+    expect(composerFooter).toHaveClass("bottom-0")
   })
 
   it("clears chat with confirmation and persists empty session state", () => {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
@@ -8,7 +8,10 @@ import { WORKSPACE_SOURCE_DRAG_TYPE } from "../drag-source"
 
 const hoistedMocks = vi.hoisted(() => ({
   setSelectedModel: vi.fn(),
-  getModels: vi.fn()
+  getModels: vi.fn(),
+  fetchChatModels: vi.fn(),
+  setFavoriteModels: vi.fn(),
+  setModelSortMode: vi.fn()
 }))
 
 const mockCheckConnectionOnce = vi.fn()
@@ -262,6 +265,30 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   }
 }))
 
+vi.mock("@/services/tldw-server", () => ({
+  fetchChatModels: hoistedMocks.fetchChatModels
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (key: string, defaultValue: unknown) => {
+    const initialValue =
+      key === "favoriteChatModels"
+        ? ["openai:openai/gpt-4o"]
+        : key === "modelSelectSortMode"
+          ? "favorites"
+          : key === "modelListScope"
+            ? "configured"
+            : defaultValue
+    const setter =
+      key === "favoriteChatModels"
+        ? hoistedMocks.setFavoriteModels
+        : key === "modelSelectSortMode"
+          ? hoistedMocks.setModelSortMode
+          : vi.fn()
+    return [initialValue, setter, { isLoading: false }] as const
+  }
+}))
+
 vi.mock("antd", async () => {
   const actual = await vi.importActual<typeof import("antd")>("antd")
   return {
@@ -318,6 +345,10 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
     })
     mockGetWorkspaceChatSession.mockReturnValue(null)
     hoistedMocks.setSelectedModel.mockReset()
+    hoistedMocks.setFavoriteModels.mockReset()
+    hoistedMocks.setModelSortMode.mockReset()
+    hoistedMocks.fetchChatModels.mockReset()
+    hoistedMocks.fetchChatModels.mockResolvedValue([])
     hoistedMocks.getModels.mockResolvedValue([])
 
     messageOptionState.messages = []
@@ -460,29 +491,143 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
     expect(screen.getByText(/Doc A, Doc B, Doc C \+1 more/)).toBeInTheDocument()
   })
 
-  it("renders model picker options and updates selected model", async () => {
-    hoistedMocks.getModels.mockResolvedValue([
+  it("renders chat model selector options and updates selected model", async () => {
+    hoistedMocks.getModels.mockRejectedValue(new Error("legacy models unused"))
+    hoistedMocks.fetchChatModels.mockResolvedValue([
       {
-        id: "gpt-4o",
-        name: "GPT-4o",
-        provider: "openai"
+        model: "tldw:openai/gpt-4o",
+        name: "tldw:openai/gpt-4o",
+        nickname: "GPT-4o",
+        provider: "openai",
+        details: {
+          capabilities: ["vision", "tools", "streaming"],
+          price_hint: "$5/$15"
+        }
       },
       {
-        id: "claude-3-5-sonnet",
-        name: "Claude 3.5 Sonnet",
+        model: "tldw:anthropic/claude-3-5-sonnet",
+        name: "tldw:anthropic/claude-3-5-sonnet",
+        nickname: "Claude 3.5 Sonnet",
         provider: "anthropic"
       }
     ])
 
     renderChatPane()
 
-    const modelSelect = await screen.findByRole("combobox", {
-      name: "Select model"
+    await waitFor(() => {
+      expect(hoistedMocks.fetchChatModels).toHaveBeenCalledWith({
+        returnEmpty: true
+      })
     })
-    fireEvent.change(modelSelect, { target: { value: "gpt-4o" } })
+    expect(hoistedMocks.getModels).not.toHaveBeenCalled()
 
-    expect(hoistedMocks.setSelectedModel).toHaveBeenCalledWith("gpt-4o")
-    expect(screen.getByRole("option", { name: /openai/i })).toBeInTheDocument()
+    const modelSelector = await screen.findByTestId("model-selector")
+    expect(modelSelector.closest("label")).toBeNull()
+    fireEvent.click(modelSelector)
+
+    expect(
+      await screen.findByPlaceholderText("Search models")
+    ).toBeInTheDocument()
+    expect(await screen.findByText("GPT-4o")).toBeInTheDocument()
+    fireEvent.click(await screen.findByText("Claude 3.5 Sonnet"))
+
+    expect(hoistedMocks.setSelectedModel).toHaveBeenCalledWith(
+      "anthropic:anthropic/claude-3-5-sonnet"
+    )
+  })
+
+  it("uses the chat model selector menu with favorites and search", async () => {
+    hoistedMocks.getModels.mockRejectedValue(new Error("legacy models unused"))
+    hoistedMocks.fetchChatModels.mockResolvedValue([
+      {
+        model: "tldw:openai/gpt-4o",
+        name: "tldw:openai/gpt-4o",
+        nickname: "GPT-4o",
+        provider: "openai",
+        details: {
+          capabilities: ["vision", "tools", "streaming"],
+          price_hint: "$5/$15"
+        }
+      },
+      {
+        model: "tldw:anthropic/claude-3-5-sonnet",
+        name: "tldw:anthropic/claude-3-5-sonnet",
+        nickname: "Claude 3.5 Sonnet",
+        provider: "anthropic"
+      }
+    ])
+
+    renderChatPane()
+
+    await waitFor(() => {
+      expect(hoistedMocks.fetchChatModels).toHaveBeenCalledWith({
+        returnEmpty: true
+      })
+    })
+
+    const modelSelector = await screen.findByTestId("model-selector")
+    fireEvent.click(modelSelector)
+
+    expect(
+      await screen.findByPlaceholderText("Search models")
+    ).toBeInTheDocument()
+    expect(await screen.findByText("GPT-4o")).toBeInTheDocument()
+    expect(screen.getAllByText("Favorites").length).toBeGreaterThan(0)
+    expect(
+      screen.getByRole("button", { name: "Remove from favorites" })
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove from favorites" }))
+    expect(hoistedMocks.setFavoriteModels).toHaveBeenCalledWith(
+      expect.any(Function)
+    )
+
+    fireEvent.click(screen.getByText("Claude 3.5 Sonnet"))
+    expect(hoistedMocks.setSelectedModel).toHaveBeenCalledWith(
+      "anthropic:anthropic/claude-3-5-sonnet"
+    )
+  })
+
+  it("keeps the model selector usable with settings fallback when no models load", async () => {
+    hoistedMocks.getModels.mockRejectedValue(new Error("legacy models unused"))
+    hoistedMocks.fetchChatModels.mockResolvedValue([])
+
+    renderChatPane()
+
+    await waitFor(() => {
+      expect(hoistedMocks.fetchChatModels).toHaveBeenCalledWith({
+        returnEmpty: true
+      })
+    })
+
+    const modelSelector = screen.getByTestId("model-selector")
+    expect(modelSelector).not.toBeDisabled()
+    fireEvent.click(modelSelector)
+
+    expect(
+      await screen.findByText("No models available. Connect your server in Settings.")
+    ).toBeInTheDocument()
+    expect(screen.getByText("Open model settings")).toBeInTheDocument()
+  })
+
+  it("keeps the legacy model client unused", async () => {
+    hoistedMocks.getModels.mockResolvedValue([
+      {
+        id: "gpt-4o",
+        name: "GPT-4o",
+        provider: "openai"
+      }
+    ])
+
+    renderChatPane()
+
+    await waitFor(() => {
+      expect(hoistedMocks.fetchChatModels).toHaveBeenCalledWith({
+        returnEmpty: true
+      })
+    })
+
+    expect(hoistedMocks.getModels).not.toHaveBeenCalled()
   })
 
   it("handles partial retrieval metadata by inferring diagnostics from sources", () => {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
@@ -610,6 +610,43 @@ describe("ChatPane Stage 2 citation traceability and retrieval transparency", ()
     expect(screen.getByText("Open model settings")).toBeInTheDocument()
   })
 
+  it("retries chat model loading after an empty startup fetch", async () => {
+    connectionStoreState.state.phase = ConnectionPhase.ERROR
+    connectionStoreState.state.lastError = "offline"
+    hoistedMocks.getModels.mockRejectedValue(new Error("legacy models unused"))
+    hoistedMocks.fetchChatModels
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          model: "tldw:openai/gpt-4o",
+          name: "tldw:openai/gpt-4o",
+          nickname: "GPT-4o",
+          provider: "openai"
+        }
+      ])
+
+    renderChatPane()
+
+    await waitFor(() => {
+      expect(hoistedMocks.fetchChatModels).toHaveBeenCalledWith({
+        returnEmpty: true
+      })
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+
+    await waitFor(() => {
+      expect(hoistedMocks.fetchChatModels).toHaveBeenLastCalledWith({
+        returnEmpty: true,
+        forceRefresh: true
+      })
+    })
+    expect(mockCheckConnectionOnce).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId("model-selector"))
+    expect(await screen.findByText("GPT-4o")).toBeInTheDocument()
+  })
+
   it("keeps the legacy model client unused", async () => {
     hoistedMocks.getModels.mockResolvedValue([
       {

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/SourcesPane.stage2.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/SourcesPane.stage2.test.tsx
@@ -123,6 +123,14 @@ describe("SourcesPane Stage 2 source highlighting", () => {
     })
   })
 
+  it("opens Add Sources directly on My Media", () => {
+    render(<SourcesPane />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Sources" }))
+
+    expect(mockOpenAddSourceModal).toHaveBeenCalledWith("existing")
+  })
+
   it("scrolls to and highlights a focused source target", () => {
     vi.useFakeTimers()
     const scrollSpy = vi.fn()

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.desktop-layout.test.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.desktop-layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { WorkspacePlayground } from "../index"
 
@@ -63,6 +63,11 @@ vi.mock("@/hooks/useMediaQuery", () => ({
 }))
 
 vi.mock("@/store/workspace", () => ({
+  createWorkspaceStorage: () => ({
+    getItem: vi.fn().mockResolvedValue("1"),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined)
+  }),
   useWorkspaceStore: (
     selector: (state: {
       storeHydrated?: boolean
@@ -300,5 +305,44 @@ describe("WorkspacePlayground desktop layout guardrails", () => {
       "data-content-width-mode",
       "full"
     )
+  })
+
+  it("keeps collapsed sidebar restore rails persistent and associated with their panels", () => {
+    testState.leftPaneCollapsed = true
+    testState.rightPaneCollapsed = true
+
+    render(<WorkspacePlayground />)
+
+    const restoreSourcesButton = screen.getByTestId("workspace-restore-sources")
+    const restoreStudioButton = screen.getByTestId("workspace-restore-studio")
+
+    expect(restoreSourcesButton).toHaveAttribute("aria-controls", "workspace-sources-panel")
+    expect(restoreSourcesButton).toHaveAttribute("aria-expanded", "false")
+    expect(restoreSourcesButton).toHaveClass("sticky")
+    expect(restoreSourcesButton).toHaveClass("top-2")
+    expect(restoreSourcesButton).toHaveClass("self-stretch")
+    expect(restoreSourcesButton).toHaveClass("min-h-[14rem]")
+    expect(restoreSourcesButton).toHaveClass("w-11")
+
+    expect(restoreStudioButton).toHaveAttribute("aria-controls", "workspace-studio-panel")
+    expect(restoreStudioButton).toHaveAttribute("aria-expanded", "false")
+    expect(restoreStudioButton).toHaveClass("sticky")
+    expect(restoreStudioButton).toHaveClass("top-2")
+    expect(restoreStudioButton).toHaveClass("self-stretch")
+    expect(restoreStudioButton).toHaveClass("min-h-[14rem]")
+    expect(restoreStudioButton).toHaveClass("w-11")
+  })
+
+  it("restores collapsed sidebars from desktop rail buttons", () => {
+    testState.leftPaneCollapsed = true
+    testState.rightPaneCollapsed = true
+
+    render(<WorkspacePlayground />)
+
+    fireEvent.click(screen.getByTestId("workspace-restore-sources"))
+    fireEvent.click(screen.getByTestId("workspace-restore-studio"))
+
+    expect(testState.setLeftPaneCollapsed).toHaveBeenCalledWith(false)
+    expect(testState.setRightPaneCollapsed).toHaveBeenCalledWith(false)
   })
 })

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/media-library-normalization.test.ts
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/media-library-normalization.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import {
+  getMediaLibraryItemKey,
+  normalizeMediaLibraryResponse
+} from "../SourcesPane/media-library-normalization"
+
+describe("media-library-normalization", () => {
+  it.each([
+    [
+      "media",
+      { media: [{ id: 1, title: "Media" }], total_count: 9 },
+      [{ id: 1, title: "Media" }],
+      9
+    ],
+    [
+      "results",
+      { results: [{ id: 2, title: "Result" }], total: 8 },
+      [{ id: 2, title: "Result" }],
+      8
+    ],
+    [
+      "items",
+      { items: [{ id: 3, title: "Item" }], count: 7 },
+      [{ id: 3, title: "Item" }],
+      7
+    ],
+    [
+      "data",
+      { data: [{ id: 4, title: "Data" }], pagination: { total: 6 } },
+      [{ id: 4, title: "Data" }],
+      6
+    ]
+  ])("normalizes %s response shape", (_label, response, expectedItems, expectedTotal) => {
+    const normalized = normalizeMediaLibraryResponse(response)
+
+    expect(normalized.items).toEqual(expectedItems)
+    expect(normalized.totalCount).toBe(expectedTotal)
+  })
+
+  it("normalizes nested data.items response shape", () => {
+    const normalized = normalizeMediaLibraryResponse({
+      data: { items: [{ media_id: 5, title: "Nested" }], total: 5 }
+    })
+
+    expect(normalized.items).toEqual([{ media_id: 5, title: "Nested" }])
+    expect(normalized.totalCount).toBe(5)
+  })
+
+  it("reads backend pagination.total_items for large libraries", () => {
+    const normalized = normalizeMediaLibraryResponse({
+      items: [{ media_id: 5, title: "Nested" }],
+      pagination: { total_items: 918 }
+    })
+
+    expect(normalized.totalCount).toBe(918)
+  })
+
+  it("returns stable string keys for numeric and string ids", () => {
+    expect(getMediaLibraryItemKey({ media_id: 0 })).toBe("0")
+    expect(getMediaLibraryItemKey({ id: "abc" })).toBe("abc")
+    expect(getMediaLibraryItemKey({ title: "missing" })).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/index.tsx
@@ -9,7 +9,9 @@ import {
   Sparkles,
   Search,
   Command,
-  Loader2
+  Loader2,
+  PanelLeftOpen,
+  PanelRightOpen
 } from "lucide-react"
 import { createWorkspaceStorage, useWorkspaceStore } from "@/store/workspace"
 import { useTutorialStore } from "@/store/tutorials"
@@ -194,6 +196,42 @@ type WorkspaceStorageUsageState = {
   originQuotaBytes: number | null
   accountUsedBytes: number | null
   accountQuotaBytes: number | null
+}
+
+type WorkspaceRestoreRailButtonProps = {
+  side: "left" | "right"
+  label: string
+  panelId: string
+  testId: string
+  onClick: () => void
+}
+
+const WorkspaceRestoreRailButton: React.FC<WorkspaceRestoreRailButtonProps> = ({
+  side,
+  label,
+  panelId,
+  testId,
+  onClick
+}) => {
+  const Icon = side === "left" ? PanelLeftOpen : PanelRightOpen
+
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      aria-label={label}
+      aria-controls={panelId}
+      aria-expanded={false}
+      title={label}
+      onClick={onClick}
+      className="sticky top-2 z-20 hidden min-h-[14rem] w-11 shrink-0 self-stretch flex-col items-center justify-center gap-3 rounded-xl border border-border/80 bg-surface/95 px-0 py-3 text-sm font-medium text-text shadow-card transition hover:bg-surface2 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg lg:flex"
+    >
+      <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+      <span className="hidden text-xs font-medium text-muted xl:block xl:rotate-180 xl:[writing-mode:vertical-rl]">
+        {label}
+      </span>
+    </button>
+  )
 }
 
 const parseNoteKeyword = (
@@ -2148,6 +2186,14 @@ const WorkspacePlaygroundBody: React.FC = () => {
     }
   }
 
+  const handleRestoreLeftPane = () => {
+    setLeftPaneCollapsed(false)
+  }
+
+  const handleRestoreRightPane = () => {
+    setRightPaneCollapsed(false)
+  }
+
   const handleReloadWorkspaceFromSyncWarning = () => {
     if (statusGuardrailsEnabled) {
       const refreshAttempt = recordWorkspaceRefreshLoopAttempt()
@@ -2565,6 +2611,16 @@ const WorkspacePlaygroundBody: React.FC = () => {
           {tutorialPromptBanner}
 
           <div className="flex min-h-0 flex-1 gap-2 px-2 py-2">
+            {!leftPaneOpen && (
+              <WorkspaceRestoreRailButton
+                side="left"
+                label={t("playground:workspace.showSources", "Show sources")}
+                panelId="workspace-sources-panel"
+                testId="workspace-restore-sources"
+                onClick={handleRestoreLeftPane}
+              />
+            )}
+
             {leftPaneOpen && (
               <>
                 <aside
@@ -2622,6 +2678,16 @@ const WorkspacePlaygroundBody: React.FC = () => {
                 }
               />
             </main>
+
+            {!rightPaneOpen && (
+              <WorkspaceRestoreRailButton
+                side="right"
+                label={t("playground:workspace.showStudio", "Show studio")}
+                panelId="workspace-studio-panel"
+                testId="workspace-restore-studio"
+                onClick={handleRestoreRightPane}
+              />
+            )}
 
             {rightPaneOpen && (
               <>

--- a/apps/packages/ui/src/routes/option-workspace-playground.tsx
+++ b/apps/packages/ui/src/routes/option-workspace-playground.tsx
@@ -4,7 +4,7 @@ import { WorkspacePlayground } from "@/components/Option/WorkspacePlayground"
 const OptionWorkspacePlayground = () => {
   return (
     <OptionLayout>
-      <div className="w-full">
+      <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden">
         <WorkspacePlayground />
       </div>
     </OptionLayout>

--- a/apps/tldw-frontend/extension/routes/option-workspace-playground.tsx
+++ b/apps/tldw-frontend/extension/routes/option-workspace-playground.tsx
@@ -5,7 +5,7 @@ import { WorkspacePlayground } from "@/components/Option/WorkspacePlayground"
 const OptionWorkspacePlayground = () => {
   return (
     <OptionLayout>
-      <PageShell className="flex-1 min-h-0" maxWidthClassName="max-w-full">
+      <PageShell className="flex h-full min-h-0 w-full flex-1 overflow-hidden" maxWidthClassName="max-w-full">
         <WorkspacePlayground />
       </PageShell>
     </OptionLayout>

--- a/backlog/tasks/task-411 - Align-Workspace-Playground-model-selector-with-chat.md
+++ b/backlog/tasks/task-411 - Align-Workspace-Playground-model-selector-with-chat.md
@@ -1,0 +1,60 @@
+---
+id: TASK-411
+title: Align Workspace Playground model selector with chat
+status: Done
+labels:
+- webui
+- ux
+- workspace-playground
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx
+- apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the Workspace Playground chat pane's standalone model select with the same model selector behavior used by /chat so users can search, sort, and favorite saved models consistently.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace Playground uses the same model selector behavior as /chat for discovered chat models.
+- [x] #2 Saved/favorited chat models from favoriteChatModels are available and manageable from Workspace Playground.
+- [x] #3 The selector remains usable when no server models are returned, preserving the no-models/settings fallback.
+- [x] #4 Focused frontend tests cover the shared selector behavior in Workspace Playground.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused Workspace ChatPane test proving the selector opens a searchable, favorite-aware model menu and can update favoriteChatModels.
+2. Extract the /chat model selector trigger/dropdown into a reusable component that keeps useModelSelector as the behavior source.
+3. Replace Workspace ChatPane's native select with the shared selector and wire it to the same chat model query/state.
+4. Run focused Vitest and browser verification for /workspace-playground.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Extracted the /chat model selector dropdown into a shared ChatModelSelectorDropdown component and reused it from both /chat and Workspace Playground. Workspace Playground now loads discovered chat models through useModelSelector, uses favoriteChatModels/modelSelectSortMode, preserves no-models settings/help fallback behavior, and applies the same favorite-aware startup model resolution. Verification: focused Workspace ChatPane regression suite passed (6 files, 43 tests); selector-focused Workspace/useModelSelector suite passed (2 files, 17 tests); browser smoke at http://localhost:3000/workspace-playground confirmed the model selector trigger opens a searchable dropdown with settings/help fallback when no models are returned; git diff --check passed. TypeScript full project check was attempted with the frontend tsc binary and remains blocked by pre-existing repo-wide type errors outside this touched slice; filtered output showed no errors in the touched selector/ChatPane files. Bandit not applicable because the touched code is frontend TypeScript/TSX only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-412 - Fix-Workspace-Playground-Add-Sources-media-library-listing.md
+++ b/backlog/tasks/task-412 - Fix-Workspace-Playground-Add-Sources-media-library-listing.md
@@ -1,0 +1,61 @@
+---
+id: TASK-412
+title: Fix Workspace Playground Add Sources media library listing
+status: Done
+labels:
+- webui
+- ux
+- workspace-playground
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/index.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/media-library-normalization.ts
+- apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/SourcesPane.stage2.test.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure the Workspace Playground Add Sources > My Media tab exposes the user's existing media library correctly, including backend pagination totals and load-more behavior, so users with large libraries do not see an empty or truncated picker.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Add Sources entry points expose the My Media library first.
+- [x] #2 My Media handles backend pagination.total_items for large media libraries.
+- [x] #3 Focused source/add-source tests cover the media-library entry and pagination behavior.
+- [x] #4 Browser verification confirms the Workspace Playground modal opens on My Media with the local library visible.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing regression for the backend media-list response shape with pagination.total_items so My Media shows the correct total and load-more affordance.
+2. Update Workspace media-library normalization to read the backend's canonical pagination total fields.
+3. Run the AddSourceModal-focused Vitest suite and browser-check /workspace-playground Add Sources if local server state allows.
+4. Record verification and any environment limitations in the Backlog task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed Workspace Playground source entry points so the left-panel Add Sources button, empty-source CTA, and chat empty-state Add Sources CTA open the Add Sources modal directly on the My Media tab. Added regression coverage proving the primary Add Sources action requests the existing-media tab. Hardened media-library response normalization to read pagination.total_items so large backend media libraries preserve the correct total and load-more behavior even when only the backend total_items field is present. Verification: SourcesPane.stage2 passed (19 tests); AddSourceModal.stage2 plus SourcesPane.stage2 passed (32 tests); the broader focused AddSourceModal/SourcesPane/media-library-normalization suite passed (10 files, 66 tests); browser smoke at http://localhost:3000/workspace-playground confirmed Add Sources opens with My Media active, search visible, and the local media library showing 50 of 918. git diff --check passed. Full TypeScript remains blocked by pre-existing repo-wide baseline errors, but filtered compiler output for the touched Workspace source/add-source files returned no matching errors. Bandit not applicable because touched code is frontend TypeScript/TSX only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-413 - Fix-Workspace-Playground-collapsed-sidebar-restore-affordances.md
+++ b/backlog/tasks/task-413 - Fix-Workspace-Playground-collapsed-sidebar-restore-affordances.md
@@ -1,0 +1,61 @@
+---
+id: TASK-413
+title: Fix Workspace Playground collapsed sidebar restore affordances
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 16:58'
+labels:
+  - webui
+  - ux
+  - workspace-playground
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Keep the Workspace Playground Sources and Studio restore controls visible, associated with their panels, and easy to re-open after users collapse the sidebars.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Collapsed Sources and Studio restore controls remain visible as persistent desktop rails instead of disappearing into the workspace row.
+- [x] #2 Restore rails expose accessible labels and panel associations so users can understand what each control reopens.
+- [x] #3 Existing restore click behavior still expands the collapsed pane.
+- [x] #4 Focused WorkspacePlayground desktop layout verification passes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing desktop layout regression for persistent collapsed-pane restore rail affordances.
+2. Update WorkspaceRestoreRailButton styling and accessibility attributes to keep the controls visible and associated with their panels.
+3. Run focused WorkspacePlayground desktop layout tests and follow with a visual/browser check if the local app is available.
+4. Record verification and any skipped gates on the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed Workspace Playground collapsed Sources/Studio controls from small inline buttons into persistent desktop restore rails with aria labels, panel associations, visible rail sizing, and existing click-to-restore behavior preserved. Added a desktop layout regression covering the persistent rail contract. Verification: red test failed on missing aria-controls/sticky rail contract; focused desktop layout suite then passed 9 tests; broader focused WorkspacePlayground desktop + ChatPane suite passed 4 files / 47 tests; browser smoke at http://127.0.0.1:3000/workspace-playground confirmed collapsed Sources and Studio show visible restore rails and reopen. git diff --check passed. Bandit skipped because touched code is frontend TypeScript/TSX only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-413 - Fix-Workspace-Playground-collapsed-sidebar-restore-affordances.md
+++ b/backlog/tasks/task-413 - Fix-Workspace-Playground-collapsed-sidebar-restore-affordances.md
@@ -38,11 +38,9 @@ Keep the Workspace Playground Sources and Studio restore controls visible, assoc
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 

--- a/backlog/tasks/task-414 - Keep-Workspace-Playground-chat-composer-in-view.md
+++ b/backlog/tasks/task-414 - Keep-Workspace-Playground-chat-composer-in-view.md
@@ -37,11 +37,9 @@ Ensure the Workspace Playground chat composer remains inside the viewport-bounde
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 

--- a/backlog/tasks/task-414 - Keep-Workspace-Playground-chat-composer-in-view.md
+++ b/backlog/tasks/task-414 - Keep-Workspace-Playground-chat-composer-in-view.md
@@ -1,0 +1,60 @@
+---
+id: TASK-414
+title: Keep Workspace Playground chat composer in view
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 16:58'
+labels:
+  - webui
+  - ux
+  - workspace-playground
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure the Workspace Playground chat composer remains inside the viewport-bounded workspace shell so users do not need to scroll the page to reach the input.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WebUI and extension Workspace Playground route wrappers constrain height and hide page-level overflow for the workspace shell.
+- [x] #2 ChatPane keeps the composer as a non-scrolling flex footer under the transcript.
+- [x] #3 Focused WorkspacePlayground desktop layout and ChatPane tests pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for route wrapper overflow bounds and the ChatPane composer footer contract.
+2. Update the shared WebUI and extension route wrappers plus ChatPane footer classes.
+3. Run focused desktop layout and ChatPane verification.
+4. Record verification and known skips on the Backlog task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Bound the shared WebUI and extension Workspace Playground route wrappers with h-full and overflow-hidden, and made the ChatPane composer footer shrink-0 so the transcript owns internal scrolling while the composer stays in view. Added regressions for both the route shell contract and the composer footer contract. Verification: red test failed on missing wrapper h-full/overflow-hidden and missing composer shrink-0; focused desktop layout + ChatPane stage1 run then passed 2 files / 20 tests; broader focused WorkspacePlayground desktop + ChatPane suite passed 4 files / 47 tests; browser smoke at http://127.0.0.1:3000/workspace-playground confirmed the composer is visible without page scrolling. Console smoke still shows an existing AntD Modal destroyOnClose deprecation warning. git diff --check passed. Bandit skipped because touched code is frontend TypeScript/TSX only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-419 - Enhance-Workspace-Playground-Add-Sources-media-filtering.md
+++ b/backlog/tasks/task-419 - Enhance-Workspace-Playground-Add-Sources-media-filtering.md
@@ -17,6 +17,9 @@ modified_files:
 - apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx
 - apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx
 - apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx
+- backlog/tasks/task-413 - Fix-Workspace-Playground-collapsed-sidebar-restore-affordances.md
+- backlog/tasks/task-414 - Keep-Workspace-Playground-chat-composer-in-view.md
 ---
 
 ## Description
@@ -42,7 +45,7 @@ Added My Media search/content-type/keyword/sort controls in Workspace Playground
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Verification: AddSourceModal.stage2.intake.test.tsx passed 15 tests; ChatPane.stage2.test.tsx passed 17 tests; focused Workspace Playground suite passed 7 files / 90 tests; git diff --check passed. Package-wide tsc still fails on unrelated baseline errors, but filtered output for touched files is clean. Bandit skipped because this change only touches TypeScript/React and docs/backlog metadata.
+Verification: AddSourceModal.stage2.intake.test.tsx passed 15 tests; ChatPane.stage2.test.tsx passed 18 tests after adding model-load retry coverage; focused Workspace Playground suite passed 7 files / 91 tests; git diff --check passed. Package-wide tsc still fails on unrelated baseline errors, but filtered output for touched files is clean. Bandit skipped because this change only touches TypeScript/React and docs/backlog metadata. Follow-up also cleaned redundant Backlog section markers in TASK-413 and TASK-414 per PR review.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-419 - Enhance-Workspace-Playground-Add-Sources-media-filtering.md
+++ b/backlog/tasks/task-419 - Enhance-Workspace-Playground-Add-Sources-media-filtering.md
@@ -1,0 +1,56 @@
+---
+id: TASK-419
+title: Enhance Workspace Playground Add Sources media filtering
+status: Done
+references:
+- https://github.com/rmusser01/tldw_server/pull/1819
+- https://github.com/rmusser01/tldw_server/pull/1819#discussion_r3255166540
+- https://github.com/rmusser01/tldw_server/pull/1819#discussion_r3255166545
+- https://github.com/rmusser01/tldw_server/pull/1819#discussion_r3255166549
+- https://github.com/rmusser01/tldw_server/pull/1819#discussion_r3255166551
+- https://github.com/rmusser01/tldw_server/pull/1819#discussion_r3255166554
+documentation:
+- Docs/superpowers/plans/2026-05-17-workspace-playground-media-filtering-pr1819.md
+modified_files:
+- Docs/superpowers/plans/2026-05-17-workspace-playground-media-filtering-pr1819.md
+- apps/packages/ui/src/components/Option/WorkspacePlayground/SourcesPane/AddSourceModal.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx
+- apps/packages/ui/src/components/Option/Playground/ChatModelSelectorDropdown.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up for PR #1819. Add My Media search/filter/sort controls in Workspace Playground Add Sources, using existing media search APIs for query, keyword, media type, and sort filtering. Also address current PR review threads around type safety, dropdown trigger handling, router navigation, and media fetch error logging.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] My Media supports query, content type, keyword, and sort filtering.
+- [x] Filtered My Media requests use the existing media search API and default empty-filter requests preserve listMedia behavior.
+- [x] Clear filters resets controls and returns to the default media listing.
+- [x] Current PR review threads are addressed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added My Media search/content-type/keyword/sort controls in Workspace Playground Add Sources. Active filters now call searchMedia with title/content fields, media_types, must_have keyword filters, sort_by, and pagination; empty filters continue to call listMedia with include_keywords. Media load failures are logged before the user-facing error. Addressed PR #1819 review threads by typing ChatModelSelectorDropdown menu items, removing the redundant model selector trigger click path, switching ChatPane navigation to useNavigate, and typing composerModels from fetchChatModels.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verification: AddSourceModal.stage2.intake.test.tsx passed 15 tests; ChatPane.stage2.test.tsx passed 17 tests; focused Workspace Playground suite passed 7 files / 90 tests; git diff --check passed. Package-wide tsc still fails on unrelated baseline errors, but filtered output for touched files is clean. Bandit skipped because this change only touches TypeScript/React and docs/backlog metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Reuses the /chat model selector dropdown in Workspace Playground so provider grouping, search, saved/favorite models, and settings fallback behave the same way.
- Keeps Workspace Playground sidebars recoverable with visible restore rails, preserves the chat composer in view, and makes the left-panel Add Sources affordance explicit.
- Fixes My Media source intake by normalizing backend media-library response shapes, honoring pagination.total_items, removing stale module cache reuse, and distinguishing empty libraries from already-added media.

## Change summary
Human-written Change summary required before merge. Please replace this placeholder with your own explanation of what changed and why these implementation choices were made.

## Test Plan
- [x] bun run test src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.desktop-layout.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage1.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage2.test.tsx src/components/Option/WorkspacePlayground/__tests__/ChatPane.stage3.test.tsx src/components/Option/WorkspacePlayground/__tests__/SourcesPane.stage2.test.tsx src/components/Option/WorkspacePlayground/__tests__/AddSourceModal.stage2.intake.test.tsx src/components/Option/WorkspacePlayground/__tests__/media-library-normalization.test.ts --reporter=dot
- [x] git diff --check
- [x] git diff --cached --check

Tasks: TASK-411, TASK-412, TASK-413, TASK-414

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Workspace Playground with the /chat model selector, adds robust My Media filtering, and fixes layout so the composer stays in view and collapsed sidebars are easy to restore. Addresses TASK-411, TASK-412, TASK-413, TASK-414, TASK-419.

- New Features
  - My Media filtering: added query, media type, keyword, and sort controls; active filters call `searchMedia`, empty filters fall back to `listMedia`; Clear filters resets UI and data.
  - Shared /chat model selector in Playground chat with grouped providers, search, favorites, startup selection, and settings/help fallback.
  - Persistent restore rails for collapsed Sources and Studio with clear labels and proper panel associations.

- Bug Fixes
  - My Media: normalized varied backend shapes, honored `pagination.total_items`, deduped by stable keys, rendered item keywords, clarified empty vs already-added states, improved selection, and logged load failures.
  - “Add Sources” opens directly to My Media; button labels clarified.
  - Composer stays visible with a sticky, shrink-0 footer and route wrappers keep scrolling inside the workspace; model selector follow-ups: typed dropdown items, removed redundant trigger click, switched to `useNavigate`, added retry for model loading, and improved connection status labels.

<sup>Written for commit c853ff5d2839266bbcaceaf33c76ad76485ebaee. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1819?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

