### PR TITLE
Harden local-directory source entitlements

### DIFF
--- a/backlog/tasks/task-422 - Tighten-local-directory-source-entitlement-follow-up.md
+++ b/backlog/tasks/task-422 - Tighten-local-directory-source-entitlement-follow-up.md
@@ -1,0 +1,50 @@
+---
+id: TASK-422
+title: Tighten local-directory source entitlement follow-up
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 19:02'
+labels:
+  - review
+  - ingestion-sources
+  - security
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address post-merge code-review feedback for local-directory ingestion source entitlements. Multi-user deployments must not enable local-directory source creation via a global flag, and malformed persisted rollout percentages should fail closed through the real feature-flag service path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Local-directory ingestion source creation is not authorized by a global feature flag in multi-user mode.
+- [x] #2 User/org-scoped feature flags still authorize eligible users according to existing targeting rules.
+- [x] #3 Malformed persisted rollout_percent values fail closed through the feature-flag service path used by the access policy.
+- [x] #4 Focused backend tests cover the changed entitlement behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented post-review entitlement hardening. Local-directory ingestion source access no longer accepts global feature flags in multi-user mode. Persisted malformed or out-of-range rollout_percent values now normalize to 0 for fail-closed behavior in feature-flag reads. Verification: focused Ingestion Sources access-policy tests, admin system-ops feature-flag test, git diff --check, and Bandit on touched backend files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Local-directory source entitlement review fixes are implemented and verified. User/org-scoped flags still authorize access; global flags now report false; malformed persisted rollout_percent values fail closed before the access policy can authorize.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Ingestion_Sources/access_policy.py
+++ b/tldw_Server_API/app/core/Ingestion_Sources/access_policy.py
@@ -40,6 +40,9 @@ def _enabled_flag_applies(flag: dict[str, Any], *, user_id: int, org_ids: set[in
     """Return whether one enabled feature flag grants access for a user."""
     if not bool(flag.get("enabled")):
         return False
+    scope = str(flag.get("scope") or "global").strip().lower()
+    if scope == "global":
+        return False
     target_user_ids = {_coerce_int(value) for value in flag.get("target_user_ids") or []}
     target_user_ids.discard(None)
     if target_user_ids and user_id not in target_user_ids:
@@ -54,9 +57,6 @@ def _enabled_flag_applies(flag: dict[str, Any], *, user_id: int, org_ids: set[in
     ):
         return False
 
-    scope = str(flag.get("scope") or "global").strip().lower()
-    if scope == "global":
-        return True
     if scope == "user":
         return _coerce_int(flag.get("user_id")) == user_id
     if scope == "org":

--- a/tldw_Server_API/app/services/admin_system_ops_service.py
+++ b/tldw_Server_API/app/services/admin_system_ops_service.py
@@ -259,12 +259,12 @@ def _normalize_rollout_percent(value: Any, *, strict: bool) -> int:
     except (TypeError, ValueError):
         if strict:
             raise ValueError("invalid_rollout_percent") from None
-        return 100
+        return 0
     if 0 <= parsed <= 100:
         return parsed
     if strict:
         raise ValueError("invalid_rollout_percent")
-    return 100
+    return 0
 
 
 def _normalize_allowlist_ids(values: list[int] | None) -> list[int]:

--- a/tldw_Server_API/tests/Ingestion_Sources/integration/test_ingestion_sources_access_policy.py
+++ b/tldw_Server_API/tests/Ingestion_Sources/integration/test_ingestion_sources_access_policy.py
@@ -397,12 +397,11 @@ def test_patch_existing_local_directory_same_normalized_config_without_entitleme
 @pytest.mark.parametrize(
     "feature_flags",
     [
-        [_flag(scope="global")],
         [_flag(scope="user", user_id=7)],
         [_flag(scope="org", org_id=42)],
     ],
 )
-def test_capabilities_reports_applicable_user_org_and_global_flags(
+def test_capabilities_reports_applicable_user_and_org_flags(
     ingestion_sources_policy_client,
     feature_flags,
 ):
@@ -412,6 +411,18 @@ def test_capabilities_reports_applicable_user_org_and_global_flags(
 
     assert response.status_code == 200, response.text
     assert response.json() == {"can_create_local_directory": True}
+
+
+@pytest.mark.integration
+def test_capabilities_reports_false_for_global_flag(
+    ingestion_sources_policy_client,
+):
+    ingestion_sources_policy_client["feature_flags"].append(_flag(scope="global"))
+
+    response = ingestion_sources_policy_client["client"].get("/api/v1/ingestion-sources/capabilities")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"can_create_local_directory": False}
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/Ingestion_Sources/unit/test_access_policy.py
+++ b/tldw_Server_API/tests/Ingestion_Sources/unit/test_access_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 
@@ -100,14 +102,17 @@ def test_disabled_flags_do_not_allow(access_policy, monkeypatch):
     ) is False
 
 
-def test_target_user_ids_narrows_global_flags(access_policy, monkeypatch):
+def test_global_flags_do_not_allow_local_directory_creation(access_policy, monkeypatch):
     monkeypatch.setattr(
         access_policy,
         "list_feature_flags",
-        lambda: [_flag(scope="global", target_user_ids=[7])],
+        lambda: [
+            _flag(scope="global"),
+            _flag(scope="global", target_user_ids=[7]),
+        ],
     )
 
-    assert access_policy.can_create_local_directory_ingestion_source(FakeUser(7)) is True
+    assert access_policy.can_create_local_directory_ingestion_source(FakeUser(7)) is False
     assert access_policy.can_create_local_directory_ingestion_source(FakeUser(8)) is False
 
 
@@ -140,7 +145,7 @@ def test_rollout_percent_is_deterministic_per_user(access_policy, monkeypatch):
     monkeypatch.setattr(
         access_policy,
         "list_feature_flags",
-        lambda: [_flag(scope="global", rollout_percent=50)],
+        lambda: [_flag(scope="user", user_id=7, rollout_percent=50)],
     )
 
     first = access_policy.can_create_local_directory_ingestion_source(FakeUser(7))
@@ -153,7 +158,7 @@ def test_missing_rollout_percent_defaults_to_full_rollout(access_policy, monkeyp
     monkeypatch.setattr(
         access_policy,
         "list_feature_flags",
-        lambda: [_flag(scope="global", rollout_percent=None)],
+        lambda: [_flag(scope="user", user_id=7, rollout_percent=None)],
     )
 
     assert access_policy.can_create_local_directory_ingestion_source(FakeUser(7)) is True
@@ -163,7 +168,31 @@ def test_malformed_rollout_percent_fails_closed(access_policy, monkeypatch):
     monkeypatch.setattr(
         access_policy,
         "list_feature_flags",
-        lambda: [_flag(scope="global", rollout_percent="not-a-number")],
+        lambda: [_flag(scope="user", user_id=7, rollout_percent="not-a-number")],
     )
+
+    assert access_policy.can_create_local_directory_ingestion_source(FakeUser(7)) is False
+
+
+def test_malformed_persisted_rollout_percent_from_feature_flag_service_fails_closed(
+    access_policy,
+    monkeypatch,
+    tmp_path,
+):
+    from tldw_Server_API.app.services import admin_system_ops_service
+
+    store_path = tmp_path / "system_ops.json"
+    store_path.write_text(
+        json.dumps(
+            {
+                "feature_flags": [
+                    _flag(scope="user", user_id=7, rollout_percent="not-a-number")
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(admin_system_ops_service, "_STORE_PATH", store_path)
+    monkeypatch.setattr(access_policy, "list_feature_flags", admin_system_ops_service.list_feature_flags)
 
     assert access_policy.can_create_local_directory_ingestion_source(FakeUser(7)) is False


### PR DESCRIPTION
## Change summary

<!-- Human-owned summary required before merge. Please replace this section with the maintainer's explanation of what changed and why. -->

## What changed

- Tightened local-directory ingestion source entitlement checks so `scope=global` feature flags no longer grant access in multi-user mode.
- Normalized malformed or out-of-range persisted `rollout_percent` values to `0` on feature-flag reads so corrupted records fail closed.
- Added regression coverage for global local-directory flag denial and malformed persisted rollout data through the admin feature-flag service path.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Ingestion_Sources/unit/test_access_policy.py tldw_Server_API/tests/Ingestion_Sources/integration/test_ingestion_sources_access_policy.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Admin/test_system_ops.py -q`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Ingestion_Sources/access_policy.py tldw_Server_API/app/services/admin_system_ops_service.py -f json -o /tmp/bandit_sources_entitlement_followup.json`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened local-directory ingestion source entitlements so `scope=global` flags no longer grant access in multi-user mode (TASK-422). Malformed or out-of-range `rollout_percent` now normalizes to 0 to fail closed, with regression tests through the admin feature-flag service.

- **Bug Fixes**
  - Deny global flags for local-directory creation; only user/org-scoped flags apply.
  - Normalize invalid `rollout_percent` to 0 on reads (was 100), ensuring fail-closed behavior.
  - Added unit and integration tests for global flag denial and persisted rollout normalization.

<sup>Written for commit 0d191513dc8c292eb65276921acb259fb5b12e7c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1822?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

