### PR TITLE
Migrate LocaleJsonDiagnostics alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1,16 +1,5 @@
 [
   {
-    "id": "antd-product-state-import:src/components/Common/LocaleJsonDiagnostics.tsx:Alert",
-    "path": "src/components/Common/LocaleJsonDiagnostics.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/LocaleJsonDiagnostics.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Common/PromptInsertModal.tsx:Alert",
     "path": "src/components/Common/PromptInsertModal.tsx",
     "rule": "antd-product-state-import",
@@ -3054,50 +3043,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Empty product-state UI in src/components/Option/SharedWithMe/index.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Sources/SourceForm.tsx:Alert#antd-alert-sourceform-type-error-line-230-1953zxe",
-    "path": "src/components/Option/Sources/SourceForm.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Sources/SourceForm.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Sources/SourceForm.tsx:Alert#antd-alert-sourceform-type-info-line-457-1avu05z",
-    "path": "src/components/Option/Sources/SourceForm.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Sources/SourceForm.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Sources/SourceForm.tsx:Alert#antd-alert-sourceform-type-info-line-462-17tv81b",
-    "path": "src/components/Option/Sources/SourceForm.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Sources/SourceForm.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Sources/SourceForm.tsx:Alert#antd-alert-sourceform-type-info-locked-after-first-succe-10k3a9g",
-    "path": "src/components/Option/Sources/SourceForm.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Sources/SourceForm.tsx before the stable duplicate-id guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/assets/locale/en/sources.json
+++ b/apps/packages/ui/src/assets/locale/en/sources.json
@@ -6,7 +6,8 @@
     "new": "New source",
     "sync": "Sync now",
     "uploadArchive": "Upload archive",
-    "reattach": "Reattach"
+    "reattach": "Reattach",
+    "showRoots": "Show roots"
   },
   "states": {
     "unsupported": "This server does not advertise ingestion source support.",
@@ -18,6 +19,11 @@
     "archiveSnapshot": "Archive snapshot",
     "path": "Server directory path",
     "pathHelp": "This is a path on the tldw server host, not a local browser or extension folder.",
-    "archiveHint": "Upload archive after creation"
+    "archiveHint": "Upload archive after creation",
+    "checkingFolderSync": "Checking whether this server allows folder sync.",
+    "currentDestination": "Current destination",
+    "folderSyncDisabledDescription": "The administrator must enable server folder sync before you can create a local directory source.",
+    "lockedAfterSync": "Locked after first successful sync",
+    "serverFolderSyncDisabled": "Server folder sync is disabled"
   }
 }

--- a/apps/packages/ui/src/components/Common/LocaleJsonDiagnostics.tsx
+++ b/apps/packages/ui/src/components/Common/LocaleJsonDiagnostics.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Alert } from "antd"
+import { Alert } from "@/components/ui/primitives"
 
 // Cross-platform dev mode detection (Vite and Next.js compatible)
 const isDevMode = typeof import.meta !== "undefined" && (
@@ -8,12 +8,37 @@ const isDevMode = typeof import.meta !== "undefined" && (
   (typeof process !== "undefined" && process.env.NODE_ENV === "development")
 )
 
-type LocaleIssue = {
+export type LocaleIssue = {
   path: string
   message: string
   line?: number
   column?: number
 }
+
+export interface LocaleJsonDiagnosticsPanelProps {
+  issues: LocaleIssue[]
+}
+
+export const LocaleJsonDiagnosticsPanel: React.FC<
+  LocaleJsonDiagnosticsPanelProps
+> = ({ issues }) => (
+  <div className="mb-4">
+    <Alert variant="error" title="Locale JSON errors detected">
+      <div className="space-y-1 text-xs">
+        {issues.map((issue) => (
+          <div key={issue.path} className="break-all">
+            <span className="font-mono">{issue.path}</span>
+            {issue.line != null && issue.column != null
+              ? ` (line ${issue.line}, col ${issue.column})`
+              : ""}
+            {": "}
+            {issue.message}
+          </div>
+        ))}
+      </div>
+    </Alert>
+  </div>
+)
 
 const findErrorPosition = (message: string): number | null => {
   const match = message.match(/position (\d+)/i)
@@ -66,29 +91,7 @@ export const LocaleJsonDiagnostics: React.FC = () => {
 
   if (!isDevMode || issues.length === 0) return null
 
-  return (
-    <div className="mb-4">
-      <Alert
-        type="error"
-        showIcon
-        title="Locale JSON errors detected"
-        description={
-          <div className="space-y-1 text-xs">
-            {issues.map((issue) => (
-              <div key={issue.path} className="break-all">
-                <span className="font-mono">{issue.path}</span>
-                {issue.line != null && issue.column != null
-                  ? ` (line ${issue.line}, col ${issue.column})`
-                  : ""}
-                {": "}
-                {issue.message}
-              </div>
-            ))}
-          </div>
-        }
-      />
-    </div>
-  )
+  return <LocaleJsonDiagnosticsPanel issues={issues} />
 }
 
 export default LocaleJsonDiagnostics

--- a/apps/packages/ui/src/components/Common/LocaleJsonDiagnostics.tsx
+++ b/apps/packages/ui/src/components/Common/LocaleJsonDiagnostics.tsx
@@ -25,8 +25,15 @@ export const LocaleJsonDiagnosticsPanel: React.FC<
   <div className="mb-4">
     <Alert variant="error" title="Locale JSON errors detected">
       <div className="space-y-1 text-xs">
-        {issues.map((issue) => (
-          <div key={issue.path} className="break-all">
+        {issues.map((issue, index) => (
+          <div
+            key={[
+              issue.path,
+              issue.line ?? "unknown",
+              issue.column ?? "unknown",
+              index,
+            ].join(":")}
+            className="break-all">
             <span className="font-mono">{issue.path}</span>
             {issue.line != null && issue.column != null
               ? ` (line ${issue.line}, col ${issue.column})`

--- a/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Alert, Button, Checkbox, List, Radio, Tag, Typography } from "antd"
+import { Button, Checkbox, List, Radio, Typography } from "antd"
 import { ListVideo, Plus, RefreshCw } from "lucide-react"
+import { Alert, Badge } from "@/components/ui/primitives"
 import type { PlaylistPreflightResult } from "@/services/tldw/playlist-preflight"
 import type { ConferenceDuplicatePolicy } from "./types"
 
@@ -61,20 +62,19 @@ export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
       </div>
 
       {error && (
-        <Alert
-          className="mt-2"
-          type="warning"
-          showIcon
-          message={error}
-        />
+        <Alert className="mt-2" variant="warning">
+          {error}
+        </Alert>
       )}
 
       {result && (
         <div className="mt-2">
           <div className="flex flex-wrap items-center gap-1.5">
-            <Tag color="blue">{result.itemCount} items</Tag>
-            <Tag color="green">{selectedCount} selected</Tag>
-            {duplicateCount > 0 && <Tag color="warning">{duplicateCount} duplicates</Tag>}
+            <Badge variant="info">{result.itemCount} items</Badge>
+            <Badge variant="success">{selectedCount} selected</Badge>
+            {duplicateCount > 0 && (
+              <Badge variant="warning">{duplicateCount} duplicates</Badge>
+            )}
           </div>
 
           {duplicateCount > 0 && (
@@ -123,9 +123,9 @@ export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
                   </Typography.Text>
                 </div>
                 {isDuplicatePreflightStatus(item.duplicateStatus) && (
-                  <Tag color="warning" className="!mr-0">
+                  <Badge variant="warning" className="!mr-0">
                     duplicate
-                  </Tag>
+                  </Badge>
                 )}
               </List.Item>
             )}

--- a/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
@@ -62,9 +62,7 @@ export const PlaylistPreflightPanel: React.FC<PlaylistPreflightPanelProps> = ({
       </div>
 
       {error && (
-        <Alert className="mt-2" variant="warning">
-          {error}
-        </Alert>
+        <Alert className="mt-2" variant="warning" title={error} />
       )}
 
       {result && (

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
@@ -99,6 +99,7 @@ describe("PlaylistPreflightPanel", () => {
 
     const warning = screen.getByText("Unable to preview playlist metadata")
     expect(warning.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expect(warning).toHaveClass("font-medium")
 
     const duplicateSummary = screen.getByText("1 duplicates")
     expect(

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
@@ -76,4 +76,36 @@ describe("PlaylistPreflightPanel", () => {
 
     expect(onDuplicatePolicyChange).toHaveBeenCalledWith("include_existing")
   })
+
+  it("renders playlist preflight state indicators through design-system primitives", () => {
+    const result = buildResult()
+    result.duplicateCount = 1
+    result.items[1] = {
+      ...result.items[1],
+      duplicateStatus: "duplicate_existing",
+      selected: false
+    }
+
+    render(
+      <PlaylistPreflightPanel
+        candidateUrl="https://www.youtube.com/playlist?list=PLtest"
+        error="Unable to preview playlist metadata"
+        result={result}
+        duplicatePolicy="skip"
+        onPreview={vi.fn()}
+        onAddItems={vi.fn()}
+      />
+    )
+
+    const warning = screen.getByText("Unable to preview playlist metadata")
+    expect(warning.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
+    const duplicateSummary = screen.getByText("1 duplicates")
+    expect(
+      duplicateSummary.closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+
+    const duplicateItem = screen.getByText("duplicate")
+    expect(duplicateItem.closest('[data-ds-component="Badge"]')).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Common/__tests__/LocaleJsonDiagnostics.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/LocaleJsonDiagnostics.design-system.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import * as LocaleDiagnostics from "../LocaleJsonDiagnostics"
+
+describe("LocaleJsonDiagnostics design-system contract", () => {
+  it("renders locale JSON parse errors through the design-system Alert primitive", () => {
+    expect(LocaleDiagnostics.LocaleJsonDiagnosticsPanel).toBeTypeOf("function")
+
+    render(
+      <LocaleDiagnostics.LocaleJsonDiagnosticsPanel
+        issues={[
+          {
+            path: "../../assets/locale/en/common.json",
+            message: "Expected property name or '}' in JSON at position 42",
+            line: 3,
+            column: 12,
+          },
+        ]}
+      />
+    )
+
+    const title = screen.getByText("Locale JSON errors detected")
+    const alert = title.closest('[data-ds-component="Alert"]')
+
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveAttribute("role", "alert")
+    expect(screen.getByText("../../assets/locale/en/common.json")).toBeInTheDocument()
+    expect(screen.getByText(/line 3, col 12/)).toBeInTheDocument()
+    expect(screen.getByText(/Expected property name/)).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Common/__tests__/LocaleJsonDiagnostics.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/LocaleJsonDiagnostics.design-system.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import * as LocaleDiagnostics from "../LocaleJsonDiagnostics"
 
 describe("LocaleJsonDiagnostics design-system contract", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("renders locale JSON parse errors through the design-system Alert primitive", () => {
     expect(LocaleDiagnostics.LocaleJsonDiagnosticsPanel).toBeTypeOf("function")
 
@@ -27,5 +31,38 @@ describe("LocaleJsonDiagnostics design-system contract", () => {
     expect(screen.getByText("../../assets/locale/en/common.json")).toBeInTheDocument()
     expect(screen.getByText(/line 3, col 12/)).toBeInTheDocument()
     expect(screen.getByText(/Expected property name/)).toBeInTheDocument()
+  })
+
+  it("keeps issue keys unique when one locale file reports multiple parse errors", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    render(
+      <LocaleDiagnostics.LocaleJsonDiagnosticsPanel
+        issues={[
+          {
+            path: "../../assets/locale/en/common.json",
+            message: "Expected property name or '}' in JSON at position 42",
+            line: 3,
+            column: 12,
+          },
+          {
+            path: "../../assets/locale/en/common.json",
+            message: "Expected ',' or '}' after property value in JSON at position 48",
+            line: 3,
+            column: 18,
+          },
+        ]}
+      />
+    )
+
+    expect(
+      consoleError.mock.calls.some((call) =>
+        call.some(
+          (value) =>
+            typeof value === "string" &&
+            value.includes("Encountered two children with the same key")
+        )
+      )
+    ).toBe(false)
   })
 })

--- a/apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
+++ b/apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
@@ -162,8 +162,14 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
     effectiveSourceType === "local_directory" &&
     (capabilitiesLoading || localDirectoryCreateKnownFalse)
   const localDirectoryCapabilityMessage = capabilitiesLoading
-    ? "Checking whether this server allows folder sync."
-    : "The administrator must enable server folder sync before you can create a local directory source."
+    ? t(
+        "sources:form.checkingFolderSync",
+        "Checking whether this server allows folder sync."
+      )
+    : t(
+        "sources:form.folderSyncDisabledDescription",
+        "The administrator must enable server folder sync before you can create a local directory source."
+      )
   const directoryBrowseQuery = useIngestionSourceDirectoryBrowseQuery(
     browsePath,
     undefined,
@@ -373,7 +379,7 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
               variant="warning"
               title={browseErrorMessage}
               action={{
-                label: "Show roots",
+                label: t("sources:actions.showRoots", "Show roots"),
                 onClick: () => setBrowsePath(null)
               }}
             />
@@ -449,7 +455,12 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
           void handleFinish(values)
         }}>
         {identityLocked && source ? (
-          <DesignSystemAlert variant="info" title="Locked after first successful sync">
+          <DesignSystemAlert
+            variant="info"
+            title={t(
+              "sources:form.lockedAfterSync",
+              "Locked after first successful sync"
+            )}>
             <div className="space-y-2">
               <div>
                 <Typography.Text strong>
@@ -458,7 +469,9 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
                 <div>{getSourceTypeLabel(source.source_type)}</div>
               </div>
               <div>
-                <Typography.Text strong>Current destination</Typography.Text>
+                <Typography.Text strong>
+                  {t("sources:form.currentDestination", "Current destination")}
+                </Typography.Text>
                 <div>{getSinkTypeLabel(source.sink_type)}</div>
               </div>
               {typeof source.config?.path === "string" && source.config.path.trim().length > 0 ? (
@@ -533,7 +546,10 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
             {mode === "create" && !capabilitiesLoading && localDirectoryCreateKnownFalse ? (
               <DesignSystemAlert
                 variant="warning"
-                title="Server folder sync is disabled"
+                title={t(
+                  "sources:form.serverFolderSyncDisabled",
+                  "Server folder sync is disabled"
+                )}
               >
                 {localDirectoryCapabilityMessage}
               </DesignSystemAlert>

--- a/apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
+++ b/apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { Alert, Button, Empty, Form, Input, Modal, Radio, Select, Space, Spin, Switch, Typography } from "antd"
+import { Button, Empty, Form, Input, Modal, Radio, Select, Space, Spin, Switch, Typography } from "antd"
 import { ArrowUp, Check, FolderOpen } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 
 import {
   useCreateIngestionSourceMutation,
@@ -327,7 +328,9 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
 
   return (
     <div className="space-y-4">
-      {submitError ? <Alert type="error" title={submitError} /> : null}
+      {submitError ? (
+        <DesignSystemAlert variant="error" title={submitError} />
+      ) : null}
 
       <Modal
         destroyOnHidden
@@ -366,15 +369,13 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
           ) : null}
 
           {browseErrorMessage ? (
-            <Alert
-              showIcon
-              type="warning"
+            <DesignSystemAlert
+              variant="warning"
               title={browseErrorMessage}
-              action={
-                <Button size="small" onClick={() => setBrowsePath(null)}>
-                  Show roots
-                </Button>
-              }
+              action={{
+                label: "Show roots",
+                onClick: () => setBrowsePath(null)
+              }}
             />
           ) : null}
 
@@ -448,40 +449,36 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
           void handleFinish(values)
         }}>
         {identityLocked && source ? (
-          <Alert
-            type="info"
-            title="Locked after first successful sync"
-            description={
-              <div className="space-y-2">
+          <DesignSystemAlert variant="info" title="Locked after first successful sync">
+            <div className="space-y-2">
+              <div>
+                <Typography.Text strong>
+                  {t("sources:form.sourceType", "Source type")}
+                </Typography.Text>
+                <div>{getSourceTypeLabel(source.source_type)}</div>
+              </div>
+              <div>
+                <Typography.Text strong>Current destination</Typography.Text>
+                <div>{getSinkTypeLabel(source.sink_type)}</div>
+              </div>
+              {typeof source.config?.path === "string" && source.config.path.trim().length > 0 ? (
                 <div>
                   <Typography.Text strong>
-                    {t("sources:form.sourceType", "Source type")}
+                    {t("sources:form.path", "Server directory path")}
                   </Typography.Text>
-                  <div>{getSourceTypeLabel(source.source_type)}</div>
+                  <div>{source.config.path}</div>
                 </div>
+              ) : null}
+              {source.source_type === "git_repository" && typeof source.config?.repo_url === "string" ? (
                 <div>
-                  <Typography.Text strong>Current destination</Typography.Text>
-                  <div>{getSinkTypeLabel(source.sink_type)}</div>
+                  <Typography.Text strong>
+                    {t("sources:form.repoUrl", "GitHub repository URL")}
+                  </Typography.Text>
+                  <div>{source.config.repo_url}</div>
                 </div>
-                {typeof source.config?.path === "string" && source.config.path.trim().length > 0 ? (
-                  <div>
-                    <Typography.Text strong>
-                      {t("sources:form.path", "Server directory path")}
-                    </Typography.Text>
-                    <div>{source.config.path}</div>
-                  </div>
-                ) : null}
-                {source.source_type === "git_repository" && typeof source.config?.repo_url === "string" ? (
-                  <div>
-                    <Typography.Text strong>
-                      {t("sources:form.repoUrl", "GitHub repository URL")}
-                    </Typography.Text>
-                    <div>{source.config.repo_url}</div>
-                  </div>
-                ) : null}
-              </div>
-            }
-          />
+              ) : null}
+            </div>
+          </DesignSystemAlert>
         ) : (
           <>
             <Form.Item
@@ -534,14 +531,17 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
         {effectiveSourceType === "local_directory" && !identityLocked ? (
           <>
             {mode === "create" && !capabilitiesLoading && localDirectoryCreateKnownFalse ? (
-              <Alert
-                type="warning"
-                showIcon
+              <DesignSystemAlert
+                variant="warning"
                 title="Server folder sync is disabled"
-                description={localDirectoryCapabilityMessage}
-              />
+              >
+                {localDirectoryCapabilityMessage}
+              </DesignSystemAlert>
             ) : mode === "create" && capabilitiesLoading ? (
-              <Alert type="info" showIcon title={localDirectoryCapabilityMessage} />
+              <DesignSystemAlert
+                variant="info"
+                title={localDirectoryCapabilityMessage}
+              />
             ) : null}
             <Form.Item
               label={t("sources:form.path", "Server directory path")}
@@ -666,14 +666,17 @@ export const SourceForm: React.FC<SourceFormProps> = ({ mode, source, preset }) 
             </Form.Item>
           </>
         ) : effectiveSourceType === "archive_snapshot" ? (
-          <Alert
-            type="info"
+          <DesignSystemAlert
+            variant="info"
             title={t("sources:form.archiveHint", "Upload archive after creation")}
           />
         ) : (
-          <Alert
-            type="info"
-            title={t("sources:form.gitRepositoryHint", "Git repository details are configured below.")}
+          <DesignSystemAlert
+            variant="info"
+            title={t(
+              "sources:form.gitRepositoryHint",
+              "Git repository details are configured below."
+            )}
           />
         )}
 

--- a/apps/packages/ui/src/components/Option/Sources/__tests__/SourceForm.test.tsx
+++ b/apps/packages/ui/src/components/Option/Sources/__tests__/SourceForm.test.tsx
@@ -16,18 +16,22 @@ const routerMocks = vi.hoisted(() => ({
   navigate: vi.fn()
 }))
 
+const translationMocks = vi.hoisted(() => ({
+  t: vi.fn((
+    key: string,
+    fallbackOrOptions?: string | { defaultValue?: string }
+  ) => {
+    if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+    if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+      return fallbackOrOptions.defaultValue || key
+    }
+    return key
+  })
+}))
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (
-      key: string,
-      fallbackOrOptions?: string | { defaultValue?: string }
-    ) => {
-      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
-      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
-        return fallbackOrOptions.defaultValue || key
-      }
-      return key
-    }
+    t: translationMocks.t
   })
 }))
 
@@ -422,6 +426,14 @@ describe("SourceForm", () => {
     expect(
       screen.getByText("Locked after first successful sync")
     ).toBeInTheDocument()
+    expect(translationMocks.t).toHaveBeenCalledWith(
+      "sources:form.lockedAfterSync",
+      "Locked after first successful sync"
+    )
+    expect(translationMocks.t).toHaveBeenCalledWith(
+      "sources:form.currentDestination",
+      "Current destination"
+    )
     expect(screen.getByText("/srv/tldw/notes")).toBeInTheDocument()
     expect(screen.queryByRole("radio", { name: "Archive snapshot" })).not.toBeInTheDocument()
     expect(screen.queryByLabelText("Server directory path")).not.toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
@@ -45,6 +45,7 @@ import { buildConversationShareUrl } from "@/components/Layouts/chat-share-links
 import { PlaygroundMessage } from "@/components/Common/Playground/Message"
 import { Link, useNavigate } from "react-router-dom"
 import { EmptyState } from "@/components/ui/feedback/EmptyState"
+import { DEGRADED_STATE_LABEL, READY_STATE_LABEL } from "@/design-system"
 import { ChatModelSelectorDropdown } from "@/components/Option/Playground/ChatModelSelectorDropdown"
 import { PlaygroundModelCatalogControls } from "@/components/Option/Playground/PlaygroundModelCatalogControls"
 import { buildChatLorebookDebugPath } from "@/routes/route-paths"
@@ -2571,9 +2572,9 @@ export const ChatPane: React.FC<ChatPaneProps> = ({
       return t("playground:composer.providerStatusOffline", "Offline")
     }
     if (connectionUxState === "connected_degraded") {
-      return t("playground:composer.providerStatusDegraded", "Degraded")
+      return t("playground:composer.providerStatusDegraded", DEGRADED_STATE_LABEL)
     }
-    return t("playground:composer.providerStatusReady", "Ready")
+    return t("playground:composer.providerStatusReady", READY_STATE_LABEL)
   }, [connectionUxState, isConnectionReady, t])
   const connectionStatusWarning =
     !isConnectionReady || connectionUxState === "connected_degraded"

--- a/backlog/tasks/task-45.44.13.4 - Migrate-LocaleJsonDiagnostics-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.13.4 - Migrate-LocaleJsonDiagnostics-alert-to-design-system-Alert.md
@@ -1,0 +1,70 @@
+---
+id: TASK-45.44.13.4
+title: Migrate LocaleJsonDiagnostics alert to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.13
+references:
+- apps/packages/ui/src/components/Common/LocaleJsonDiagnostics.tsx
+- apps/packages/ui/src/components/Common/__tests__/LocaleJsonDiagnostics.design-system.test.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
+- apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+modified_files:
+- apps/packages/ui/src/components/Common/LocaleJsonDiagnostics.tsx
+- apps/packages/ui/src/components/Common/__tests__/LocaleJsonDiagnostics.design-system.test.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
+- apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
+- apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace LocaleJsonDiagnostics' remaining AntD Alert product-state usage with the shared design-system Alert primitive while preserving dev-only locale JSON error diagnostics and line/column details. Current dev also had product-state verifier drift in PlaylistPreflightPanel, SourceForm, and WorkspacePlayground ChatPane; resolve that drift in this slice so the verifier can pass without adding new baseline debt.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 LocaleJsonDiagnostics renders locale JSON parse failures through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused coverage proves the dev diagnostics banner uses data-ds-component="Alert" and retains error details.
+- [x] #3 The design-system product-state baseline no longer contains the LocaleJsonDiagnostics AntD Alert exception or migrated SourceForm stale Alert exceptions.
+- [x] #4 Focused tests, design-system verifier, git diff check, and TypeScript/Bandit applicability are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented via TDD for LocaleJsonDiagnostics and PlaylistPreflightPanel.
+
+Added a focused LocaleJsonDiagnostics panel regression, migrated the dev-only locale parse error banner from AntD Alert to the shared design-system Alert, and removed its baseline exception.
+
+During verifier proof, current dev had product-state drift outside LocaleJsonDiagnostics: PlaylistPreflightPanel AntD Alert/Tag findings, SourceForm stale/new Alert findings, and WorkspacePlayground ChatPane Ready/Degraded canonical labels. Resolved that drift by migrating PlaylistPreflightPanel state indicators to Alert/Badge, migrating SourceForm product-state alerts to the design-system Alert, routing ChatPane Ready/Degraded fallbacks through the state registry exports, and removing the resolved SourceForm stale baseline entries instead of adding new debt.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated LocaleJsonDiagnostics to the shared design-system Alert and resolved current-dev product-state verifier drift in PlaylistPreflightPanel, SourceForm, and WorkspacePlayground ChatPane. Verification: focused red test failed before LocaleJsonDiagnostics panel existed; PlaylistPreflightPanel red test failed before DS primitives; focused LocaleJsonDiagnostics + PlaylistPreflightPanel + SourceForm + product-state guard Vitest passed (71 tests); bun run verify:design-system-state passed with 399 remaining allowed baseline exceptions; baseline JSON parse passed; git diff --check passed; bunx tsc --noEmit still exits 2 on existing package-wide type debt with no touched-file matches. Bandit is not applicable because this slice touched frontend TypeScript/JSON/backlog files only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.13.4 - Migrate-LocaleJsonDiagnostics-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.13.4 - Migrate-LocaleJsonDiagnostics-alert-to-design-system-Alert.md
@@ -17,6 +17,7 @@ references:
 - apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
 - apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1823
 documentation:
 - Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
 modified_files:
@@ -56,7 +57,7 @@ During verifier proof, current dev had product-state drift outside LocaleJsonDia
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated LocaleJsonDiagnostics to the shared design-system Alert and resolved current-dev product-state verifier drift in PlaylistPreflightPanel, SourceForm, and WorkspacePlayground ChatPane. Verification: focused red test failed before LocaleJsonDiagnostics panel existed; PlaylistPreflightPanel red test failed before DS primitives; focused LocaleJsonDiagnostics + PlaylistPreflightPanel + SourceForm + product-state guard Vitest passed (71 tests); bun run verify:design-system-state passed with 399 remaining allowed baseline exceptions; baseline JSON parse passed; git diff --check passed; bunx tsc --noEmit still exits 2 on existing package-wide type debt with no touched-file matches. Bandit is not applicable because this slice touched frontend TypeScript/JSON/backlog files only.
+Migrated LocaleJsonDiagnostics to the shared design-system Alert and resolved current-dev product-state verifier drift in PlaylistPreflightPanel, SourceForm, and WorkspacePlayground ChatPane. PR opened: https://github.com/rmusser01/tldw_server/pull/1823. Verification: focused red test failed before LocaleJsonDiagnostics panel existed; PlaylistPreflightPanel red test failed before DS primitives; focused LocaleJsonDiagnostics + PlaylistPreflightPanel + SourceForm + product-state guard Vitest passed (71 tests); bun run verify:design-system-state passed with 399 remaining allowed baseline exceptions; baseline JSON parse passed; git diff --check passed; bunx tsc --noEmit still exits 2 on existing package-wide type debt with no touched-file matches. Bandit is not applicable because this slice touched frontend TypeScript/JSON/backlog files only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.13.4 - Migrate-LocaleJsonDiagnostics-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.13.4 - Migrate-LocaleJsonDiagnostics-alert-to-design-system-Alert.md
@@ -18,6 +18,8 @@ references:
 - apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - https://github.com/rmusser01/tldw_server/pull/1823
+- apps/packages/ui/src/components/Option/Sources/__tests__/SourceForm.test.tsx
+- apps/packages/ui/src/assets/locale/en/sources.json
 documentation:
 - Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
 modified_files:
@@ -26,7 +28,9 @@ modified_files:
 - apps/packages/ui/src/components/Common/QuickIngest/PlaylistPreflightPanel.tsx
 - apps/packages/ui/src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx
 - apps/packages/ui/src/components/Option/Sources/SourceForm.tsx
+- apps/packages/ui/src/components/Option/Sources/__tests__/SourceForm.test.tsx
 - apps/packages/ui/src/components/Option/WorkspacePlayground/ChatPane/index.tsx
+- apps/packages/ui/src/assets/locale/en/sources.json
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 ---
 
@@ -57,7 +61,7 @@ During verifier proof, current dev had product-state drift outside LocaleJsonDia
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated LocaleJsonDiagnostics to the shared design-system Alert and resolved current-dev product-state verifier drift in PlaylistPreflightPanel, SourceForm, and WorkspacePlayground ChatPane. PR opened: https://github.com/rmusser01/tldw_server/pull/1823. Verification: focused red test failed before LocaleJsonDiagnostics panel existed; PlaylistPreflightPanel red test failed before DS primitives; focused LocaleJsonDiagnostics + PlaylistPreflightPanel + SourceForm + product-state guard Vitest passed (71 tests); bun run verify:design-system-state passed with 399 remaining allowed baseline exceptions; baseline JSON parse passed; git diff --check passed; bunx tsc --noEmit still exits 2 on existing package-wide type debt with no touched-file matches. Bandit is not applicable because this slice touched frontend TypeScript/JSON/backlog files only.
+Migrated LocaleJsonDiagnostics to the shared design-system Alert and resolved current-dev product-state verifier drift in PlaylistPreflightPanel, SourceForm, and WorkspacePlayground ChatPane. PR opened: https://github.com/rmusser01/tldw_server/pull/1823. Follow-up review comments addressed duplicate LocaleJsonDiagnostics keys, PlaylistPreflightPanel Alert title usage, and SourceForm i18n for the changed locked/source-sync alert strings. Verification: focused red tests failed for all three review findings before the fixes; focused LocaleJsonDiagnostics + PlaylistPreflightPanel + SourceForm + product-state guard + sources locale Vitest passed (73 tests); bun run verify:design-system-state passed with 399 remaining allowed baseline exceptions; touched JSON parse passed; git diff --check passed; bunx tsc --noEmit still exits 2 on existing package-wide type debt, with no touched-file matches in /tmp/ds-locale-tsc.log. Bandit is not applicable because this slice touched frontend TypeScript/JSON/backlog files only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Migrates `LocaleJsonDiagnostics` locale parse errors from AntD `Alert` to the shared design-system `Alert`.
- Resolves current-dev product-state drift by migrating `PlaylistPreflightPanel` state indicators to `Alert`/`Badge`, migrating `SourceForm` state alerts to the design-system `Alert`, and routing Workspace ChatPane Ready/Degraded labels through the state registry.
- Removes resolved product-state baseline exceptions and tracks the slice in `TASK-45.44.13.4`.

## Verification
- `bunx vitest run src/components/Common/__tests__/LocaleJsonDiagnostics.design-system.test.tsx src/components/Common/QuickIngest/__tests__/PlaylistPreflightPanel.test.tsx src/components/Option/Sources/__tests__/SourceForm.test.tsx src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism`
- `bun run verify:design-system-state`
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"`
- `git diff --check`
- `bunx tsc --noEmit --pretty false` exits 2 on existing package-wide TypeScript debt; `/tmp/ds-locale-tsc.log` has no touched-file matches for this slice.

## Change summary
Human-authored change summary required before merge: explain what changed and why these design-system migration choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Locale JSON diagnostics and related state indicators to design-system `Alert`/`Badge` for consistent UI and product-state compliance. Fulfills Linear TASK-45.44.13.4, adds i18n for SourceForm messages, and removes related baseline exceptions; tests assert the DS primitives.

- **Refactors**
  - `LocaleJsonDiagnostics`: replaced `antd` `Alert` with design-system `Alert`; introduced `LocaleJsonDiagnosticsPanel` for isolated rendering/tests and fixed duplicate key handling.
  - `PlaylistPreflightPanel`: switched error banner to design-system `Alert` and counts/duplicate markers to `Badge`; tests assert `[data-ds-component]` markers.
  - `SourceForm`: migrated submit and inline banners from `antd` `Alert` to design-system `Alert`, including action as `{ label, onClick }`; added/used i18n strings in `en/sources.json` for folder sync and actions; updated tests.
  - `WorkspacePlayground/ChatPane`: routed status labels through `READY_STATE_LABEL` and `DEGRADED_STATE_LABEL` from `@/design-system`.
  - Baseline: removed obsolete exceptions from `design-system-product-state-baseline.json`.

<sup>Written for commit 9d5bf7fd32ec97a71ae1b17258b5561234246f24. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1823?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

