### PR TITLE
fix: harden llama.cpp profile launch validation

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
@@ -167,7 +167,7 @@ git commit -m "feat: reconcile llama.cpp runtime profiles"
 - Test: `tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py`
 - Test: `tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py`
 
-- [ ] **Step 1: Write failing validation tests**
+- [x] **Step 1: Write failing validation tests**
 
 Cover:
 - duplicate explicit host/port conflicts across enabled profiles, including wildcard host conflicts;
@@ -177,7 +177,7 @@ Cover:
 - raw args cannot override reserved structured flags such as host, port, model, and mmproj unless the backend explicitly allows it;
 - path-like args such as `grammar_file`, `chat_template_file`, `prompt_cache`, and `lora_base` are resolved through the same allowlist policy or rejected.
 
-- [ ] **Step 2: Run validation tests to verify failure**
+- [x] **Step 2: Run validation tests to verify failure**
 
 ```bash
 python -m pytest \
@@ -190,15 +190,15 @@ python -m pytest \
 
 Expected: FAIL for the new cases.
 
-- [ ] **Step 3: Centralize validation**
+- [x] **Step 3: Centralize validation**
 
 Add helper functions near the runtime/profile modules rather than duplicating validation across endpoints and UI. The supervisor should call the helper before persisting and before starting, because persisted state and current asset state can diverge.
 
-- [ ] **Step 4: Preserve advisory warnings**
+- [x] **Step 4: Preserve advisory warnings**
 
 Keep hardware/resource fit warnings in response/runtime warning lists. Only hard-fail unsafe paths, invalid ports, reserved flag conflicts, missing required assets, or incompatible mode/asset combinations.
 
-- [ ] **Step 5: Run focused backend tests**
+- [x] **Step 5: Run focused backend tests**
 
 ```bash
 python -m pytest \
@@ -210,7 +210,7 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit Task 2**
+- [x] **Step 6: Commit Task 2**
 
 ```bash
 git add \

--- a/backlog/tasks/task-423 - Harden-llama.cpp-profile-launch-validation.md
+++ b/backlog/tasks/task-423 - Harden-llama.cpp-profile-launch-validation.md
@@ -33,12 +33,13 @@ Implement Task 2 from the llama.cpp managed runtime closeout plan: fail closed f
 - Existing profile-store/profile-capability/process-runner coverage already covered duplicate explicit ports, wildcard conflicts, disabled duplicate ports, and launch-time mmproj/path validation.
 - Added supervisor persistence-time regression coverage for vision profiles without mmproj, conflicting `mmproj_model_id`/`server_args["mmproj"]` selections, path-like server args outside allowlist, reserved model arg overrides even when unvalidated args are allowed, and invalid server_args updates preserving the stored profile.
 - Shared server-arg validation now runs before supervisor create/update/default persistence and before launch.
+- PR review follow-up: fixed persistence-time validation for core numeric server args such as `ctx_size`, and added clearer rejection for malformed `lora_scaled` sequences.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Centralized llama.cpp profile launch validation before supervisor persistence and start by reusing launch asset resolution plus shared server_arg validation. The shared validation now rejects reserved structured args, unsupported args when unvalidated args are disabled, denylisted secret flags, invalid formatter values, and path-bearing args outside allowed paths. Focused backend tests pass; production Bandit scope passes. Full touched-scope Bandit including pytest files only reports the repository-standard B101 assert warnings in tests.
+Centralized llama.cpp profile launch validation before supervisor persistence and start by reusing launch asset resolution plus shared server_arg validation. The shared validation now rejects reserved structured args, unsupported args when unvalidated args are disabled, denylisted secret flags, invalid formatter values including core numeric aliases, malformed `lora_scaled` pairs, and path-bearing args outside allowed paths. Focused backend tests pass; production Bandit scope passes. Full touched-scope Bandit including pytest files only reports the repository-standard B101 assert warnings in tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-423 - Harden-llama.cpp-profile-launch-validation.md
+++ b/backlog/tasks/task-423 - Harden-llama.cpp-profile-launch-validation.md
@@ -1,0 +1,52 @@
+---
+id: TASK-423
+title: Harden llama.cpp profile launch validation
+status: Done
+labels:
+- llamacpp
+- local-llm
+- backend
+priority: medium
+documentation:
+- Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 2 from the llama.cpp managed runtime closeout plan: fail closed for unsafe or internally conflicting launch definitions while preserving advisory warnings for hardware/resource risks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Add or verify tests covering duplicate explicit host/port conflicts, wildcard host conflicts, and disabled-profile non-conflicts.
+- [x] #2 Add or verify tests covering vision mmproj requirements and server_args/mmproj_model_id consistency.
+- [x] #3 Add or verify tests covering reserved structured raw-arg rejection.
+- [x] #4 Add or verify tests covering allowlist validation for path-like launch args.
+- [x] #5 Centralize or reuse backend validation before profile persistence and launch.
+- [x] #6 Run focused backend tests, diff checks, and Bandit on touched Python paths before PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Existing profile-store/profile-capability/process-runner coverage already covered duplicate explicit ports, wildcard conflicts, disabled duplicate ports, and launch-time mmproj/path validation.
+- Added supervisor persistence-time regression coverage for vision profiles without mmproj, conflicting `mmproj_model_id`/`server_args["mmproj"]` selections, path-like server args outside allowlist, reserved model arg overrides even when unvalidated args are allowed, and invalid server_args updates preserving the stored profile.
+- Shared server-arg validation now runs before supervisor create/update/default persistence and before launch.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Centralized llama.cpp profile launch validation before supervisor persistence and start by reusing launch asset resolution plus shared server_arg validation. The shared validation now rejects reserved structured args, unsupported args when unvalidated args are disabled, denylisted secret flags, invalid formatter values, and path-bearing args outside allowed paths. Focused backend tests pass; production Bandit scope passes. Full touched-scope Bandit including pytest files only reports the repository-standard B101 assert warnings in tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py
@@ -250,16 +250,18 @@ def validate_profile_server_args(
         raise ServerError(f"Unsupported llama.cpp server args: {sorted(invalid)}")
 
     for key, value in args.items():
-        if key in core_keys:
+        if key in allowed_structured_args:
             continue
         formatter = formatters.get(key)
-        if formatter is None:
+        if formatter is not None:
+            _validate_config_arg_path(config, key, value)
+            try:
+                formatter(value)
+            except (IndexError, TypeError, ValueError) as exc:
+                raise ServerError(f"Invalid value for llama.cpp server arg '{key}'.") from exc
             continue
-        _validate_config_arg_path(config, key, value)
-        try:
-            formatter(value)
-        except (IndexError, TypeError, ValueError) as exc:
-            raise ServerError(f"Invalid value for llama.cpp server arg '{key}'.") from exc
+        if key in core_keys:
+            continue
 
 
 def _clean_server_args(server_args: dict[str, Any]) -> dict[str, Any]:
@@ -283,10 +285,18 @@ def _validate_config_arg_path(config: LlamaCppConfig, key: str, value: Any) -> N
             if not _is_config_path_allowed(config, _coerce_path_arg(key, item)):
                 raise ServerError("LoRA path must be under allowed directories.")
     if key == "lora_scaled":
-        paths = [value[0]] if isinstance(value, (list, tuple)) and value else [value]
+        paths = _lora_scaled_path_values(value)
         for item in paths:
             if item is not None and not _is_config_path_allowed(config, _coerce_path_arg(key, item)):
                 raise ServerError("LoRA path must be under allowed directories.")
+
+
+def _lora_scaled_path_values(value: Any) -> list[Any]:
+    if isinstance(value, (list, tuple)):
+        if len(value) != 2:
+            raise ServerError("lora_scaled must be a path/scale pair.")
+        return [value[0]]
+    return [value]
 
 
 def _coerce_path_arg(key: str, value: Any) -> Path:

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py
@@ -39,6 +39,17 @@ _PATH_ARG_KEYS = {
     "mmproj",
     "model_draft",
 }
+_CORE_SERVER_ARG_KEYS = {
+    "threads",
+    "t",
+    "ctx_size",
+    "c",
+    "n_ctx",
+    "n_gpu_layers",
+    "ngl",
+    "gpu_layers",
+}
+_RESERVED_STRUCTURED_ARG_KEYS = {"host", "port", "model", "m"}
 
 
 async def wait_for_http_ready(*args: Any, **kwargs: Any) -> bool:
@@ -204,6 +215,89 @@ def _server_arg_formatters() -> dict[str, Callable[[Any], list[str]]]:
     }
 
 
+def validate_profile_server_args(
+    config: LlamaCppConfig,
+    profile: LlamaCppProfile,
+    *,
+    allowed_structured_args: set[str] | None = None,
+) -> None:
+    """Validate user-supplied llama-server args before persistence or launch."""
+    args = _clean_server_args(profile.server_args)
+    try:
+        handler_utils.check_denylist(
+            args,
+            allow_secrets=getattr(config, "allow_cli_secrets", False),
+        )
+    except ValueError as exc:
+        raise ServerError(str(exc)) from exc
+
+    allowed_structured_args = allowed_structured_args or set()
+    reserved = sorted(
+        key
+        for key in args
+        if key in _RESERVED_STRUCTURED_ARG_KEYS and key not in allowed_structured_args
+    )
+    if reserved:
+        raise ServerError(
+            "Reserved llama.cpp server args must be set through profile fields, "
+            f"not server_args: {reserved}"
+        )
+
+    formatters = _server_arg_formatters()
+    core_keys = _CORE_SERVER_ARG_KEYS | allowed_structured_args
+    invalid = [key for key in args if key not in formatters and key not in core_keys]
+    if invalid and not getattr(config, "allow_unvalidated_args", False):
+        raise ServerError(f"Unsupported llama.cpp server args: {sorted(invalid)}")
+
+    for key, value in args.items():
+        if key in core_keys:
+            continue
+        formatter = formatters.get(key)
+        if formatter is None:
+            continue
+        _validate_config_arg_path(config, key, value)
+        try:
+            formatter(value)
+        except (IndexError, TypeError, ValueError) as exc:
+            raise ServerError(f"Invalid value for llama.cpp server arg '{key}'.") from exc
+
+
+def _clean_server_args(server_args: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in server_args.items() if value is not None and value != ""}
+
+
+def _is_config_path_allowed(config: LlamaCppConfig, path: Path) -> bool:
+    allowed_paths = handler_utils.build_allowed_paths(
+        Path(config.models_dir),
+        getattr(config, "allowed_paths", None),
+    )
+    return handler_utils.is_path_allowed(path, allowed_paths)
+
+
+def _validate_config_arg_path(config: LlamaCppConfig, key: str, value: Any) -> None:
+    if key in _PATH_ARG_KEYS and not _is_config_path_allowed(config, _coerce_path_arg(key, value)):
+        raise ServerError(f"File path for '{key}' must be under allowed directories.")
+    if key == "lora":
+        values = value if isinstance(value, (list, tuple)) else [value]
+        for item in values:
+            if not _is_config_path_allowed(config, _coerce_path_arg(key, item)):
+                raise ServerError("LoRA path must be under allowed directories.")
+    if key == "lora_scaled":
+        paths = [value[0]] if isinstance(value, (list, tuple)) and value else [value]
+        for item in paths:
+            if item is not None and not _is_config_path_allowed(config, _coerce_path_arg(key, item)):
+                raise ServerError("LoRA path must be under allowed directories.")
+
+
+def _coerce_path_arg(key: str, value: Any) -> Path:
+    if not isinstance(value, (str, os.PathLike)):
+        raise ServerError(f"File path for '{key}' must be a string or path-like value.")
+    try:
+        return Path(value)
+    except (TypeError, ValueError) as exc:
+        raise ServerError(f"File path for '{key}' could not be resolved.") from exc
+
+
 class LlamaCppProcessRunner:
     """Owns one llama.cpp server process for one managed profile."""
 
@@ -235,11 +329,7 @@ class LlamaCppProcessRunner:
         return handler_utils.is_port_free(host, port)
 
     def _is_path_allowed(self, path: Path) -> bool:
-        allowed_paths = handler_utils.build_allowed_paths(
-            self.models_dir,
-            getattr(self.config, "allowed_paths", None),
-        )
-        return handler_utils.is_path_allowed(path, allowed_paths)
+        return _is_config_path_allowed(self.config, path)
 
     async def start(self, model_path: Path, profile: LlamaCppProfile) -> LlamaCppRuntime:
         """Start this runner's process for the supplied profile and model."""
@@ -251,7 +341,7 @@ class LlamaCppProcessRunner:
         if not executable_path.is_file():
             raise ServerError(f"Llama.cpp server executable not found at {self.config.executable_path}")
 
-        args = {key: value for key, value in profile.server_args.items() if value is not None and value != ""}
+        args = _clean_server_args(profile.server_args)
         self._check_denylist(args)
         host = handler_utils.strip_host_brackets(profile.host or self.config.default_host or "127.0.0.1")
         port = self._resolve_port(host, profile)
@@ -540,7 +630,7 @@ class LlamaCppProcessRunner:
         if threads is not None:
             command.extend(["-t", str(int(threads))])
 
-        core_keys = {"port", "host", "threads", "t", "ctx_size", "c", "n_ctx", "n_gpu_layers", "ngl", "gpu_layers"}
+        core_keys = {"port", "host", *_CORE_SERVER_ARG_KEYS}
         formatters = _server_arg_formatters()
         invalid = [key for key in args if key not in formatters and key not in core_keys]
         if invalid and not getattr(self.config, "allow_unvalidated_args", False):
@@ -587,27 +677,11 @@ class LlamaCppProcessRunner:
             raise ServerError(f"{label} must be an integer.") from exc
 
     def _validate_arg_path(self, key: str, value: Any) -> None:
-        if key in _PATH_ARG_KEYS and not self._is_path_allowed(self._coerce_path_arg(key, value)):
-            raise ServerError(f"File path for '{key}' must be under allowed directories.")
-        if key == "lora":
-            values = value if isinstance(value, (list, tuple)) else [value]
-            for item in values:
-                if not self._is_path_allowed(self._coerce_path_arg(key, item)):
-                    raise ServerError("LoRA path must be under allowed directories.")
-        if key == "lora_scaled":
-            paths = [value[0]] if isinstance(value, (list, tuple)) and value else [value]
-            for item in paths:
-                if item is not None and not self._is_path_allowed(self._coerce_path_arg(key, item)):
-                    raise ServerError("LoRA path must be under allowed directories.")
+        _validate_config_arg_path(self.config, key, value)
 
     @staticmethod
     def _coerce_path_arg(key: str, value: Any) -> Path:
-        if not isinstance(value, (str, os.PathLike)):
-            raise ServerError(f"File path for '{key}' must be a string or path-like value.")
-        try:
-            return Path(value)
-        except (TypeError, ValueError) as exc:
-            raise ServerError(f"File path for '{key}' could not be resolved.") from exc
+        return _coerce_path_arg(key, value)
 
     def _open_log_targets(self) -> tuple[Any, Any, Any | None, Path | None]:
         log_file = getattr(self.config, "log_output_file", None)

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
@@ -13,8 +13,14 @@ from uuid import uuid4
 from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Schemas import LlamaCppConfig
-from tldw_Server_API.app.core.Local_LLM.llamacpp_process_runner import LlamaCppProcessRunner
-from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import resolve_profile_launch
+from tldw_Server_API.app.core.Local_LLM.llamacpp_process_runner import (
+    LlamaCppProcessRunner,
+    validate_profile_server_args,
+)
+from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_capabilities import (
+    LlamaCppResolvedProfileLaunch,
+    resolve_profile_launch,
+)
 from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_store import (
     DEFAULT_PROFILE_ID,
     DEFAULT_PROFILE_NAME,
@@ -133,6 +139,7 @@ class LlamaCppSupervisor:
             provider_alias=request.provider_alias,
             tags=list(request.tags),
         )
+        self._validate_profile_launch_definition(profile)
         self._validate_runtime_port_available(profile)
         return await self._store_upsert(profile)
 
@@ -154,6 +161,7 @@ class LlamaCppSupervisor:
         if "tags" in updates and updates["tags"] is not None:
             updates["tags"] = list(updates["tags"])
         profile = LlamaCppProfile.model_validate(existing.model_dump(mode="python") | updates)
+        self._validate_profile_launch_definition(profile)
         self._validate_runtime_port_available(profile)
         return await self._store_upsert(profile)
 
@@ -186,11 +194,7 @@ class LlamaCppSupervisor:
                     return status
                 await runner.stop()
             self._validate_runtime_port_available(profile)
-            resolution_profile = self._profile_for_launch_resolution(profile)
-            resolved = resolve_profile_launch(
-                resolution_profile,
-                path_resolver=self._resolve_launch_asset_path,
-            )
+            resolved = self._validate_profile_launch_definition(profile)
             launch_profile = profile.model_copy(update={"server_args": resolved.server_args})
             runtime = await runner.start(resolved.model_path, launch_profile)
             if profile.last_runtime_failure:
@@ -359,6 +363,7 @@ class LlamaCppSupervisor:
                     "server_args": dict(server_args),
                 }
             )
+        self._validate_profile_launch_definition(profile)
         self._validate_runtime_port_available(profile)
         return await self._store_upsert(profile)
 
@@ -414,6 +419,7 @@ class LlamaCppSupervisor:
                     "server_args": dict(server_args),
                 }
             )
+        self._validate_profile_launch_definition(profile)
         self._validate_runtime_port_available(profile)
         return await self._store_upsert(profile)
 
@@ -509,6 +515,25 @@ class LlamaCppSupervisor:
         if profile.profile_id == DEFAULT_PROFILE_ID and profile.model_path:
             return profile.model_copy(update={"model_id": None})
         return profile
+
+    def _validate_profile_launch_definition(self, profile: LlamaCppProfile) -> LlamaCppResolvedProfileLaunch:
+        """Resolve and validate launch assets and server args for a profile."""
+        resolved = resolve_profile_launch(
+            self._profile_for_launch_resolution(profile),
+            path_resolver=self._resolve_launch_asset_path,
+        )
+        validate_profile_server_args(
+            self.config,
+            profile.model_copy(update={"server_args": resolved.server_args}),
+            allowed_structured_args=self._allowed_structured_server_args(profile),
+        )
+        return resolved
+
+    @staticmethod
+    def _allowed_structured_server_args(profile: LlamaCppProfile) -> set[str]:
+        if profile.profile_id == DEFAULT_PROFILE_ID:
+            return {"host", "port"}
+        return set()
 
     def _resolve_launch_asset_path(self, raw_path: str | Path, expected_kind: str, label: str) -> Path:
         """Resolve a launch asset path using the inventory service contract.

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
@@ -296,14 +296,125 @@ async def test_supervisor_starts_vision_profile_with_resolved_mmproj(
 
 
 @pytest.mark.asyncio
+async def test_supervisor_rejects_vision_profile_without_mmproj_before_persisting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    supervisor, config, factory = make_supervisor(tmp_path)
+    _base_path, _mmproj_path, base_asset_id, _mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
+
+    with pytest.raises(ServerError, match="mmproj"):
+        await supervisor.create_profile(
+            LlamaCppProfileCreateRequest(
+                profile_id="vision",
+                name="Vision",
+                mode=LlamaCppProfileMode.VISION,
+                model_id=base_asset_id,
+                server_args={"ctx_size": 4096},
+            )
+        )
+
+    assert supervisor.store.get("vision") is None
+    assert "vision" not in factory.runners
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_conflicting_mmproj_selection_before_persisting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    supervisor, config, _factory = make_supervisor(tmp_path)
+    _base_path, _mmproj_path, base_asset_id, mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
+    other_mmproj_path = config.models_dir / "mmproj-other.gguf"
+    other_mmproj_path.write_text("other projector", encoding="utf-8")
+
+    with pytest.raises(ServerError, match="conflicts"):
+        await supervisor.create_profile(
+            LlamaCppProfileCreateRequest(
+                profile_id="vision",
+                name="Vision",
+                mode=LlamaCppProfileMode.VISION,
+                model_id=base_asset_id,
+                mmproj_model_id=mmproj_asset_id,
+                server_args={"mmproj": str(other_mmproj_path)},
+            )
+        )
+
+    assert supervisor.store.get("vision") is None
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_path_arg_outside_allowlist_before_persisting(tmp_path: Path):
+    supervisor, config, _factory = make_supervisor(tmp_path)
+    model_path = make_model(config)
+    grammar_path = tmp_path / "outside" / "grammar.gbnf"
+    grammar_path.parent.mkdir()
+    grammar_path.write_text("root ::= \"ok\"", encoding="utf-8")
+
+    with pytest.raises(ServerError, match="grammar_file"):
+        await supervisor.create_profile(
+            LlamaCppProfileCreateRequest(
+                profile_id="grammar",
+                name="Grammar",
+                model_path=str(model_path),
+                server_args={"grammar_file": str(grammar_path)},
+            )
+        )
+
+    assert supervisor.store.get("grammar") is None
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_reserved_model_arg_before_persisting_even_when_unvalidated_args_allowed(
+    tmp_path: Path,
+):
+    supervisor, config, _factory = make_supervisor(tmp_path)
+    config.allow_unvalidated_args = True
+    model_path = make_model(config)
+    other_model_path = make_model(config, "other.gguf")
+
+    with pytest.raises(ServerError, match="Reserved"):
+        await supervisor.create_profile(
+            LlamaCppProfileCreateRequest(
+                profile_id="reserved",
+                name="Reserved",
+                model_path=str(model_path),
+                server_args={"model": str(other_model_path)},
+            )
+        )
+
+    assert supervisor.store.get("reserved") is None
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_invalid_server_args_update_without_persisting(tmp_path: Path):
+    supervisor, config, _factory = make_supervisor(tmp_path)
+    model_path = make_model(config)
+    outside_model = tmp_path / "outside" / "draft.gguf"
+    outside_model.parent.mkdir()
+    outside_model.write_text("draft", encoding="utf-8")
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(profile_id="one", name="One", model_path=str(model_path), port=8181)
+    )
+
+    with pytest.raises(ServerError, match="model_draft"):
+        await supervisor.update_profile(
+            "one",
+            LlamaCppProfileUpdateRequest(server_args={"model_draft": str(outside_model)}),
+        )
+
+    assert supervisor.store.get("one").server_args == {}
+
+
+@pytest.mark.asyncio
 async def test_supervisor_rejects_vision_profile_without_mmproj_before_runner_spawn(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
     supervisor, config, factory = make_supervisor(tmp_path)
     _base_path, _mmproj_path, base_asset_id, _mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
-    await supervisor.create_profile(
-        LlamaCppProfileCreateRequest(
+    supervisor.store.upsert(
+        LlamaCppProfile(
             profile_id="vision",
             name="Vision",
             mode=LlamaCppProfileMode.VISION,
@@ -325,8 +436,8 @@ async def test_supervisor_rejects_wrong_kind_mmproj_asset_before_runner_spawn(
 ):
     supervisor, config, factory = make_supervisor(tmp_path)
     _base_path, _mmproj_path, base_asset_id, _mmproj_asset_id = configure_supervisor_assets(monkeypatch, config)
-    await supervisor.create_profile(
-        LlamaCppProfileCreateRequest(
+    supervisor.store.upsert(
+        LlamaCppProfile(
             profile_id="vision",
             name="Vision",
             mode=LlamaCppProfileMode.VISION,
@@ -351,8 +462,8 @@ async def test_supervisor_rejects_manual_mmproj_path_outside_allowlist_before_ru
     outside = tmp_path / "outside" / "mmproj-other.gguf"
     outside.parent.mkdir()
     outside.write_text("outside projector", encoding="utf-8")
-    await supervisor.create_profile(
-        LlamaCppProfileCreateRequest(
+    supervisor.store.upsert(
+        LlamaCppProfile(
             profile_id="vision",
             name="Vision",
             mode=LlamaCppProfileMode.VISION,

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
@@ -365,6 +365,44 @@ async def test_supervisor_rejects_path_arg_outside_allowlist_before_persisting(t
 
 
 @pytest.mark.asyncio
+async def test_supervisor_rejects_invalid_core_numeric_arg_before_persisting(tmp_path: Path):
+    supervisor, config, _factory = make_supervisor(tmp_path)
+    model_path = make_model(config)
+
+    with pytest.raises(ServerError, match="ctx_size"):
+        await supervisor.create_profile(
+            LlamaCppProfileCreateRequest(
+                profile_id="bad-core",
+                name="Bad Core",
+                model_path=str(model_path),
+                server_args={"ctx_size": "not-an-int"},
+            )
+        )
+
+    assert supervisor.store.get("bad-core") is None
+
+
+@pytest.mark.asyncio
+async def test_supervisor_rejects_malformed_lora_scaled_before_persisting(tmp_path: Path):
+    supervisor, config, _factory = make_supervisor(tmp_path)
+    model_path = make_model(config)
+    lora_path = config.models_dir / "adapter.gguf"
+    lora_path.write_text("adapter", encoding="utf-8")
+
+    with pytest.raises(ServerError, match="lora_scaled"):
+        await supervisor.create_profile(
+            LlamaCppProfileCreateRequest(
+                profile_id="bad-lora-scaled",
+                name="Bad LoRA",
+                model_path=str(model_path),
+                server_args={"lora_scaled": [str(lora_path)]},
+            )
+        )
+
+    assert supervisor.store.get("bad-lora-scaled") is None
+
+
+@pytest.mark.asyncio
 async def test_supervisor_rejects_reserved_model_arg_before_persisting_even_when_unvalidated_args_allowed(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Summary
- validate managed llama.cpp profile launch definitions before create/update/default persistence and before start
- share server-arg validation for reserved structured flags, denylisted secret flags, unsupported args, invalid formatter values, and path allowlist enforcement
- add persistence-time regression coverage for mmproj requirements/conflicts, reserved model overrides, path-like arg allowlists, and update rollback

## Verification
- `python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_store.py tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py -q --tb=short`
- `git diff --check`
- `python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py -f json -o /tmp/bandit_llamacpp_profile_validation_runtime.json`
- `python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py -s B101 -f json -o /tmp/bandit_llamacpp_profile_validation_skip_b101.json`

## Change summary
Human maintainer to fill before merge: explain what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `llama.cpp` profile launch validation by centralizing server-arg and asset checks. Profiles are validated before persistence and start to block unsafe args, invalid paths, bad core numeric values, and vision asset mismatches. Completes Linear TASK-423.

- Bug Fixes
  - Validate `server_args` before create/update/default and launch via `validate_profile_server_args`; reject reserved flags (`host`, `port`, `model`/`m`) in `server_args` (allow `host`/`port` only on the default profile).
  - Enforce path allowlists for file args (e.g., `grammar_file`, `chat_template_file`, `prompt_cache`, `lora*`); denylisted secret flags; unsupported args when `allow_unvalidated_args` is false; invalid formatter values; validate core numeric aliases (`threads`/`t`, `ctx_size`/`c`/`n_ctx`, `gpu_layers`/`n_gpu_layers`/`ngl`) and reject malformed `lora_scaled` pairs.
  - Verify vision `mmproj` requirements and conflicts between `mmproj_model_id` and `server_args["mmproj"]`; reject wrong-kind assets and out-of-allowlist paths.
  - Prevent persisting invalid updates; stored profiles are unchanged on failed `server_args` edits.

- Refactors
  - Shared arg cleaning, path allowlist helpers, and core-arg sets live in `llamacpp_process_runner.py`; supervisor resolves launch assets and reuses shared validation before persistence and start, enforcing allowed structured args per profile (only `host`/`port` on default).
  - Added focused tests for persistence-time and start-time checks; updated plan docs and added `backlog/tasks/task-423 - Harden-llama.cpp-profile-launch-validation.md`.

<sup>Written for commit c4a7d5d923a4c2a96624621b0e420786c9fbaf93. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1824?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

