### PR TITLE
Preview llama.cpp asset folder imports

### DIFF
--- a/backlog/tasks/task-416.1 - Implement-llama.cpp-local-import-preview-contract.md
+++ b/backlog/tasks/task-416.1 - Implement-llama.cpp-local-import-preview-contract.md
@@ -43,13 +43,13 @@ Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-pl
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Added `LlamaCppAssetImportPreviewResponse` plus `preview_import_asset_folder()` using the existing canonicalization, config safety, allowlist, asset classification, mmproj pairing, warning, and bounded scan helpers. Added `POST /api/v1/llamacpp/assets/import-folder/preview` as an admin-only, rate-limited endpoint that runs inventory work in the threadpool and maps `ServerError` to HTTP 400. Added service/API/AuthNZ coverage for non-mutating preview behavior, fail-closed path handling, endpoint auth, and threadpool offload.
+Added `LlamaCppAssetImportPreviewResponse` plus `preview_import_asset_folder()` using the existing canonicalization, config safety, allowlist, asset classification, mmproj pairing, warning, and bounded scan helpers. Added `POST /api/v1/llamacpp/assets/import-folder/preview` as an admin-only, rate-limited endpoint that runs inventory work in the threadpool and maps `ServerError` to HTTP 400. Added service/API/AuthNZ coverage for non-mutating preview behavior, fail-closed path handling, endpoint auth, and threadpool offload. Review follow-up reused `_validate_allowed_asset_path()`, removed the redundant limit cast and unused endpoint parameter, added the endpoint docstring/style cleanup, and deduplicated preview assets by `asset_id`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the local asset-folder import preview contract for llama.cpp without changing the existing persistent import path. Verification: focused pytest set passed (60 passed); git diff --check passed; Bandit on touched production Python scope passed with zero findings. Known skips/blockers: none.
+Implemented the local asset-folder import preview contract for llama.cpp and addressed PR #1826 review comments. Review follow-up added endpoint docstring/style cleanup, reused the existing allowed-path validator, removed the redundant limit cast and unused endpoint parameter, and deduplicated preview assets by resolved asset_id. Verification: focused pytest set passed (61 passed); git diff --check passed; Bandit on touched production Python scope passed with zero findings. Known skips/blockers: none.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-416.1 - Implement-llama.cpp-local-import-preview-contract.md
+++ b/backlog/tasks/task-416.1 - Implement-llama.cpp-local-import-preview-contract.md
@@ -1,0 +1,63 @@
+---
+id: TASK-416.1
+title: Implement llama.cpp local import preview contract
+status: Done
+labels:
+- llamacpp
+- backend
+- local-llm
+priority: high
+parent_task_id: TASK-416
+documentation:
+- Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+modified_files:
+- tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
+- tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+- tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
+- tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 1 from the llama.cpp model acquisition/import workflow plan: add a non-mutating local asset-folder import preview service/API, richer preview result contract, and permission coverage without changing profile creation/start/use-in-chat behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Service preview summarizes GGUF/mmproj/folder assets, warnings, counts, and scan-limit state without persisting imported folders.
+- [x] #2 Preview fails closed for non-existent paths, file paths, and folders outside allowed llama.cpp paths.
+- [x] #3 API endpoint POST /api/v1/llamacpp/assets/import-folder/preview returns the preview response, maps ServerError to HTTP 400, and does not mutate config.
+- [x] #4 AuthNZ permission coverage includes the new admin-only preview endpoint.
+- [x] #5 Focused inventory service/API/AuthNZ tests, git diff checks, and Bandit on touched Python scope are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `LlamaCppAssetImportPreviewResponse` plus `preview_import_asset_folder()` using the existing canonicalization, config safety, allowlist, asset classification, mmproj pairing, warning, and bounded scan helpers. Added `POST /api/v1/llamacpp/assets/import-folder/preview` as an admin-only, rate-limited endpoint that runs inventory work in the threadpool and maps `ServerError` to HTTP 400. Added service/API/AuthNZ coverage for non-mutating preview behavior, fail-closed path handling, endpoint auth, and threadpool offload.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the local asset-folder import preview contract for llama.cpp without changing the existing persistent import path. Verification: focused pytest set passed (60 passed); git diff --check passed; Bandit on touched production Python scope passed with zero findings. Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -427,15 +427,21 @@ async def import_llamacpp_asset_folder_endpoint(
     "/llamacpp/assets/import-folder/preview",
     summary="Preview a llama.cpp Asset Folder Import",
     response_model=LlamaCppAssetImportPreviewResponse,
-    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(RequireRole("admin")),
+        Depends(_resolve_llm_manager),
+    ],
 )
 async def preview_llamacpp_asset_folder_endpoint(
     payload: LlamaCppImportAssetFolderRequest,
-    llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager),
 ) -> LlamaCppAssetImportPreviewResponse:
-    _ = llm_manager
+    """Preview an allowlisted local asset folder without persisting config changes."""
     try:
-        return await run_in_threadpool(llamacpp_inventory_service.preview_import_asset_folder, Path(payload.path))
+        return await run_in_threadpool(
+            llamacpp_inventory_service.preview_import_asset_folder,
+            Path(payload.path),
+        )
     except ServerError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -14,6 +14,7 @@ from starlette.concurrency import run_in_threadpool
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, RequireRole, User
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppAsset,
+    LlamaCppAssetImportPreviewResponse,
     LlamaCppAssetsResponse,
     LlamaCppConfigResponse,
     LlamaCppConfigUpdateRequest,
@@ -418,6 +419,23 @@ async def import_llamacpp_asset_folder_endpoint(
     _ = llm_manager
     try:
         return await run_in_threadpool(llamacpp_inventory_service.import_asset_folder, Path(payload.path))
+    except ServerError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post(
+    "/llamacpp/assets/import-folder/preview",
+    summary="Preview a llama.cpp Asset Folder Import",
+    response_model=LlamaCppAssetImportPreviewResponse,
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
+)
+async def preview_llamacpp_asset_folder_endpoint(
+    payload: LlamaCppImportAssetFolderRequest,
+    llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager),
+) -> LlamaCppAssetImportPreviewResponse:
+    _ = llm_manager
+    try:
+        return await run_in_threadpool(llamacpp_inventory_service.preview_import_asset_folder, Path(payload.path))
     except ServerError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
@@ -176,6 +176,17 @@ class LlamaCppImportAssetFolderRequest(BaseModel):
     path: str = Field(..., min_length=1)
 
 
+class LlamaCppAssetImportPreviewResponse(BaseModel):
+    """Non-mutating preview of an allowlisted local asset folder import."""
+
+    folder: LlamaCppAsset
+    assets: list[LlamaCppAsset] = Field(default_factory=list)
+    asset_counts: dict[str, int] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+    scan_limited: bool = False
+    will_persist: bool = False
+
+
 class LlamaCppInventoryItem(BaseModel):
     """A single model inventory entry from models_dir or registered paths."""
 

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -309,29 +309,30 @@ def preview_import_asset_folder(path: Path, *, limit: int = 500) -> LlamaCppAsse
     if not canonical.is_dir():
         raise ServerError("Imported asset path is not a folder.")
 
-    saved_config = _read_saved_config()
-    allowed_bases = _allowed_bases_for_config(saved_config)
-    if not allowed_bases or not handler_utils.is_path_allowed(canonical, allowed_bases):
-        raise ServerError("Imported asset folder is outside allowed llama.cpp paths.")
+    allowed_bases = _allowed_bases_for_config(_read_saved_config())
+    _validate_allowed_asset_path(canonical, allowed_bases, "Imported asset folder")
 
     warnings: list[str] = []
     assets: list[LlamaCppAsset] = []
+    seen_ids: set[str] = set()
     scan_limited = False
-    asset_limit = max(int(limit), 0)
+    asset_limit = max(limit, 0)
     folder_asset = _folder_asset_for_path(canonical, allowed_bases=allowed_bases)
 
     for candidate in _iter_asset_files(canonical, warnings, max(asset_limit + 1, 1)):
-        if len(assets) >= asset_limit:
-            scan_limited = True
-            break
         asset = _asset_for_path(
             candidate,
             source="imported_folder",
             allowed_bases=allowed_bases,
             warnings=warnings,
         )
-        if asset is not None:
-            assets.append(asset)
+        if asset is None or asset.asset_id in seen_ids:
+            continue
+        if len(assets) >= asset_limit:
+            scan_limited = True
+            break
+        seen_ids.add(asset.asset_id)
+        assets.append(asset)
 
     _attach_mmproj_candidates(assets)
     assets.sort(

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppAsset,
+    LlamaCppAssetImportPreviewResponse,
     LlamaCppAssetMetadata,
     LlamaCppAssetsResponse,
     LlamaCppInventoryItem,
@@ -297,6 +298,57 @@ def import_asset_folder(path: Path) -> LlamaCppAsset:
     saved_config["imported_asset_folders"] = [imported_value]
     allowed_bases = _allowed_bases_for_config(saved_config)
     return _folder_asset_for_path(canonical, allowed_bases=allowed_bases)
+
+
+def preview_import_asset_folder(path: Path, *, limit: int = 500) -> LlamaCppAssetImportPreviewResponse:
+    """Return a bounded, non-mutating preview for an allowlisted asset folder."""
+    canonical = _canonical_path(path, "Imported asset folder")
+    _validate_path_for_config(canonical, "imported_asset_folders", "Imported asset folder")
+    if not canonical.exists():
+        raise ServerError("Imported asset folder does not exist.")
+    if not canonical.is_dir():
+        raise ServerError("Imported asset path is not a folder.")
+
+    saved_config = _read_saved_config()
+    allowed_bases = _allowed_bases_for_config(saved_config)
+    if not allowed_bases or not handler_utils.is_path_allowed(canonical, allowed_bases):
+        raise ServerError("Imported asset folder is outside allowed llama.cpp paths.")
+
+    warnings: list[str] = []
+    assets: list[LlamaCppAsset] = []
+    scan_limited = False
+    asset_limit = max(int(limit), 0)
+    folder_asset = _folder_asset_for_path(canonical, allowed_bases=allowed_bases)
+
+    for candidate in _iter_asset_files(canonical, warnings, max(asset_limit + 1, 1)):
+        if len(assets) >= asset_limit:
+            scan_limited = True
+            break
+        asset = _asset_for_path(
+            candidate,
+            source="imported_folder",
+            allowed_bases=allowed_bases,
+            warnings=warnings,
+        )
+        if asset is not None:
+            assets.append(asset)
+
+    _attach_mmproj_candidates(assets)
+    assets.sort(
+        key=lambda asset: (
+            _ASSET_KIND_ORDER.get(asset.kind, 99),
+            asset.display_name.lower(),
+            asset.resolved_path or asset.path,
+        )
+    )
+    return LlamaCppAssetImportPreviewResponse(
+        folder=folder_asset,
+        assets=assets,
+        asset_counts=_asset_counts(assets),
+        warnings=warnings,
+        scan_limited=scan_limited,
+        will_persist=False,
+    )
 
 
 def _validate_registered_path_for_config(path: Path) -> None:
@@ -642,6 +694,13 @@ def _pairing_tokens(value: str) -> set[str]:
 def _append_unique_warning(warnings: list[str], warning: str) -> None:
     if warning not in warnings:
         warnings.append(warning)
+
+
+def _asset_counts(assets: list[LlamaCppAsset]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for asset in assets:
+        counts[asset.kind] = counts.get(asset.kind, 0) + 1
+    return counts
 
 
 def _item_for_path(

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
@@ -148,6 +148,31 @@ def _patch_provider_config_writes(monkeypatch) -> None:  # noqa: ANN001
     )
     monkeypatch.setattr(llamacpp_mod.llamacpp_provider_service, "refresh_config_cache", lambda: None)
     monkeypatch.setattr(llamacpp_mod.llamacpp_provider_service, "llamacpp_config_write_lock", lambda: FakeLock())
+    monkeypatch.setattr(
+        llamacpp_mod.llamacpp_inventory_service,
+        "preview_import_asset_folder",
+        lambda path: {
+            "folder": {
+                "asset_id": "folder:authz",
+                "kind": "folder",
+                "identity_basis": "resolved_path",
+                "path": str(path),
+                "resolved_path": str(path),
+                "display_name": "models",
+                "source": "imported_folder",
+                "metadata": {},
+                "capabilities": ["asset_folder"],
+                "mmproj_asset_ids": [],
+                "base_model_asset_ids": [],
+                "warnings": [],
+            },
+            "assets": [],
+            "asset_counts": {},
+            "warnings": [],
+            "scan_limited": False,
+            "will_persist": False,
+        },
+    )
 
 
 @pytest.mark.unit
@@ -162,6 +187,7 @@ def _patch_provider_config_writes(monkeypatch) -> None:  # noqa: ANN001
         ("get", "/api/v1/llamacpp/metrics", None),
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
+        ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
     ],
 )
 def test_llamacpp_lifecycle_401_when_principal_unavailable(
@@ -195,6 +221,7 @@ def test_llamacpp_lifecycle_401_when_principal_unavailable(
         ("get", "/api/v1/llamacpp/metrics", None),
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
+        ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
     ],
 )
 def test_llamacpp_lifecycle_403_when_missing_admin_role(
@@ -232,6 +259,7 @@ def test_llamacpp_lifecycle_403_when_missing_admin_role(
         ("get", "/api/v1/llamacpp/metrics", None),
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
+        ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
     ],
 )
 def test_llamacpp_lifecycle_200_for_admin_principal(

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
@@ -73,6 +73,80 @@ def test_scan_assets_discovers_gguf_mmproj_and_folder(monkeypatch, tmp_path: Pat
 
 
 @pytest.mark.unit
+def test_preview_import_asset_folder_summarizes_assets_without_persisting(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    (imported / "chat.Q4_K_M.gguf").write_text("base")
+    (imported / "mmproj-chat-f16.gguf").write_text("projector")
+    updates: list[dict[str, dict[str, str]]] = []
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(
+            models_dir,
+            allowed_paths=str(imported),
+            imported_asset_folders="",
+        ),
+    )
+    monkeypatch.setattr(llamacpp_inventory_service.setup_manager, "update_config", updates.append)
+
+    preview = llamacpp_inventory_service.preview_import_asset_folder(imported, limit=500)
+
+    assert preview.folder.kind == "folder"
+    assert preview.folder.display_name == "imported"
+    assert preview.asset_counts == {"gguf": 1, "mmproj": 1}
+    assert {asset.kind for asset in preview.assets} == {"gguf", "mmproj"}
+    assert preview.assets[0].source == "imported_folder"
+    assert preview.scan_limited is False
+    assert preview.will_persist is False
+    assert updates == []
+
+
+@pytest.mark.unit
+def test_preview_import_asset_folder_fails_for_file_path(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    file_path = imported / "chat.gguf"
+    file_path.write_text("base")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, allowed_paths=str(imported)),
+    )
+
+    with pytest.raises(ServerError, match="not a folder"):
+        llamacpp_inventory_service.preview_import_asset_folder(file_path)
+
+
+@pytest.mark.unit
+def test_preview_import_asset_folder_fails_closed_outside_allowed_paths(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, allowed_paths=""),
+    )
+
+    with pytest.raises(ServerError, match="outside allowed"):
+        llamacpp_inventory_service.preview_import_asset_folder(imported)
+
+
+@pytest.mark.unit
 def test_scan_assets_reports_stale_imported_folder_without_failing(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
 

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py
@@ -107,6 +107,33 @@ def test_preview_import_asset_folder_summarizes_assets_without_persisting(monkey
 
 
 @pytest.mark.unit
+def test_preview_import_asset_folder_deduplicates_resolved_asset_ids(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    model_path = imported / "chat.Q4_K_M.gguf"
+    model_path.write_text("base")
+    symlink_path = imported / "chat-link.Q4_K_M.gguf"
+    try:
+        symlink_path.symlink_to(model_path)
+    except OSError as exc:
+        pytest.skip(f"Symlinks are unavailable in this environment: {exc}")
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, allowed_paths=str(imported)),
+    )
+
+    preview = llamacpp_inventory_service.preview_import_asset_folder(imported, limit=500)
+
+    assert [asset.kind for asset in preview.assets] == ["gguf"]
+    assert preview.asset_counts == {"gguf": 1}
+
+
+@pytest.mark.unit
 def test_preview_import_asset_folder_fails_for_file_path(monkeypatch, tmp_path: Path):
     from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
     from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py
@@ -294,6 +294,38 @@ def test_import_folder_persists_allowlisted_folder_and_returns_folder_asset(monk
 
 
 @pytest.mark.unit
+def test_import_folder_preview_returns_summary_without_persisting(monkeypatch, tmp_path: Path):
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_inventory_service
+
+    models_dir = tmp_path / "models"
+    imported = tmp_path / "imported"
+    models_dir.mkdir()
+    imported.mkdir()
+    (imported / "chat.Q4_K_M.gguf").write_text("base")
+    (imported / "mmproj-chat-f16.gguf").write_text("projector")
+    updates: list[dict[str, dict[str, str]]] = []
+    monkeypatch.setattr(
+        llamacpp_inventory_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir, allowed_paths=str(imported), imported_asset_folders=""),
+    )
+    monkeypatch.setattr(llamacpp_inventory_service.setup_manager, "update_config", updates.append)
+    monkeypatch.setattr(llamacpp_inventory_service, "refresh_config_cache", lambda: None)
+    app = _make_app_with_manager(_Manager())
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/llamacpp/assets/import-folder/preview", json={"path": str(imported)})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["folder"]["kind"] == "folder"
+    assert body["asset_counts"] == {"gguf": 1, "mmproj": 1}
+    assert {asset["kind"] for asset in body["assets"]} == {"gguf", "mmproj"}
+    assert body["will_persist"] is False
+    assert updates == []
+
+
+@pytest.mark.unit
 def test_asset_endpoints_offload_blocking_inventory_work_to_threadpool(monkeypatch):
     calls: list[tuple[Any, tuple[Any, ...], dict[str, Any]]] = []
     config_state = {
@@ -342,6 +374,17 @@ def test_asset_endpoints_offload_blocking_inventory_work_to_threadpool(monkeypat
         assert path == Path("/models")
         return asset_payload
 
+    def fake_preview_import_asset_folder(path: Path) -> dict[str, Any]:
+        assert path == Path("/models")
+        return {
+            "folder": asset_payload,
+            "assets": [],
+            "asset_counts": {},
+            "warnings": [],
+            "scan_limited": False,
+            "will_persist": False,
+        }
+
     async def fake_run_in_threadpool(func: Any, *args: Any, **kwargs: Any) -> Any:
         calls.append((func, args, kwargs))
         return func(*args, **kwargs)
@@ -351,20 +394,28 @@ def test_asset_endpoints_offload_blocking_inventory_work_to_threadpool(monkeypat
     monkeypatch.setattr(lp.llamacpp_inventory_service, "scan_assets", fake_scan_assets)
     monkeypatch.setattr(lp.llamacpp_inventory_service, "register_asset_path", fake_register_asset_path)
     monkeypatch.setattr(lp.llamacpp_inventory_service, "import_asset_folder", fake_import_asset_folder)
+    monkeypatch.setattr(
+        lp.llamacpp_inventory_service,
+        "preview_import_asset_folder",
+        fake_preview_import_asset_folder,
+    )
     app = _make_app_with_manager(_Manager())
 
     with TestClient(app) as client:
         list_response = client.get("/api/v1/llamacpp/assets")
         register_response = client.post("/api/v1/llamacpp/assets/register-path", json={"path": "/models/base.gguf"})
+        preview_response = client.post("/api/v1/llamacpp/assets/import-folder/preview", json={"path": "/models"})
         import_response = client.post("/api/v1/llamacpp/assets/import-folder", json={"path": "/models"})
 
     assert list_response.status_code == 200, list_response.text
     assert register_response.status_code == 200, register_response.text
+    assert preview_response.status_code == 200, preview_response.text
     assert import_response.status_code == 200, import_response.text
     assert [call[0] for call in calls] == [
         fake_get_config_state,
         fake_scan_assets,
         fake_register_asset_path,
+        fake_preview_import_asset_folder,
         fake_import_asset_folder,
     ]
 


### PR DESCRIPTION
## Summary
- Add an admin-only non-mutating asset-folder import preview endpoint for llama.cpp.
- Reuse inventory allowlist/canonicalization helpers to summarize folder, GGUF, and mmproj assets without config writes.
- Add focused service/API/AuthNZ tests and Backlog task TASK-416.1.

## Change summary
TODO: Human-authored change summary required before merge.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short
- [x] git diff --check
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py tldw_Server_API/app/core/Local_LLM/llamacpp_inventory_service.py tldw_Server_API/app/api/v1/endpoints/llamacpp.py -f json -o /tmp/bandit_llamacpp_import_preview.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an admin-only, non-mutating preview for llama.cpp asset-folder imports. It summarizes folder, GGUF, and mmproj assets with counts and warnings without writing config, aligning with TASK-416.1.

- New Features
  - POST /api/v1/llamacpp/assets/import-folder/preview returns LlamaCppAssetImportPreviewResponse with counts, warnings, scan_limited, and will_persist=false.
  - Validates allowlisted folders; returns HTTP 400 for non-existent paths, file paths, or folders outside allowed bases.
  - Offloads scanning to the threadpool; endpoint is rate-limited and requires admin.
  - Deduplicates assets by asset_id, pairs mmproj candidates, and sorts results.
  - Added focused service, API, and AuthNZ tests, including threadpool offload, failure cases, and symlink deduplication.

<sup>Written for commit 89b49bdf0066117c95d0910bb53078baf71bdf9d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1826?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

