### PR TITLE
Fix chat character selector background

### DIFF
--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -438,7 +438,7 @@ export const AssistantSelect: React.FC<Props> = ({
                   className={`flex min-w-0 flex-1 items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition ${
                     isActive
                       ? "border-primary bg-primary/10 text-text"
-                      : "border-border bg-bg text-text hover:bg-surface2"
+                      : "border-border bg-surface text-text hover:bg-surface2"
                   }`}
                   onClick={() => {
                     void handleSelect(entry)

--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -497,7 +497,7 @@ export const AssistantSelect: React.FC<Props> = ({
   const content = (
     <div
       data-testid="assistant-select-panel"
-      className="w-[320px] rounded-lg border border-border bg-surface shadow-lg"
+      className="w-[320px] rounded-lg border border-border bg-elevated shadow-lg"
     >
       <div className="border-b border-border p-2">
         <Input

--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -438,7 +438,7 @@ export const AssistantSelect: React.FC<Props> = ({
                   className={`flex min-w-0 flex-1 items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition ${
                     isActive
                       ? "border-primary bg-primary/10 text-text"
-                      : "border-border bg-background text-text hover:bg-surface2"
+                      : "border-border bg-bg text-text hover:bg-surface2"
                   }`}
                   onClick={() => {
                     void handleSelect(entry)
@@ -495,7 +495,10 @@ export const AssistantSelect: React.FC<Props> = ({
     )
 
   const content = (
-    <div className="w-[320px] rounded-lg border border-border bg-background shadow-lg">
+    <div
+      data-testid="assistant-select-panel"
+      className="w-[320px] rounded-lg border border-border bg-surface shadow-lg"
+    >
       <div className="border-b border-border p-2">
         <Input
           ref={searchInputRef}

--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -163,10 +163,10 @@ describe("AssistantSelect behavior", () => {
     )
 
     const panel = await screen.findByTestId("assistant-select-panel")
-    expect(panel).toHaveClass("bg-surface")
+    expect(panel).toHaveClass("bg-elevated")
     expect(panel).not.toHaveClass("bg-background")
     expect(await screen.findByRole("button", { name: "Alpha" })).toHaveClass(
-      "bg-bg"
+      "bg-surface"
     )
   })
 

--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -154,6 +154,22 @@ describe("AssistantSelect behavior", () => {
     expect(screen.queryByRole("button", { name: "Alpha" })).toBeNull()
   })
 
+  it("uses solid design-token backgrounds for the selector panel", async () => {
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    await user.click(
+      await screen.findByRole("button", { name: "Select character or persona" })
+    )
+
+    const panel = await screen.findByTestId("assistant-select-panel")
+    expect(panel).toHaveClass("bg-surface")
+    expect(panel).not.toHaveClass("bg-background")
+    expect(await screen.findByRole("button", { name: "Alpha" })).toHaveClass(
+      "bg-bg"
+    )
+  })
+
   it("does not select a character when its favorite star is clicked", async () => {
     const user = userEvent.setup()
     renderAssistantSelect()

--- a/backlog/tasks/task-424 - Fix-chat-character-selection-modal-background.md
+++ b/backlog/tasks/task-424 - Fix-chat-character-selection-modal-background.md
@@ -1,0 +1,48 @@
+---
+id: TASK-424
+title: Fix chat character selection modal background
+status: Done
+labels:
+- webui
+- chat
+- ux
+priority: High
+modified_files:
+- apps/packages/ui/src/components/Common/AssistantSelect.tsx
+- apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the /chat character/persona selection modal panel use a solid opaque background instead of a translucent/clear backing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Character/persona selection modal on /chat uses a solid opaque panel/background color.
+- [ ] #2 Fix is scoped to the modal styling and does not alter unrelated chat cockpit/sidebar behavior.
+- [ ] #3 Focused verification is run for the changed frontend scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+['User reported the character selection modal should not have a clear/opaque backing and should be a solid color.']
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated the main /chat assistant/character selector panel to use solid `bg-surface` and inactive option rows to use solid `bg-bg` instead of the unconfigured `bg-background` class. Added a focused regression test asserting the selector panel uses the solid surface token and does not regress to `bg-background`. Verification: `bunx vitest run src/components/Common/__tests__/AssistantSelect.behavior.test.tsx --maxWorkers=1 --no-file-parallelism` passed 16 tests; `git diff --check` passed. Bandit is not applicable because the touched files are TSX/Backlog task metadata only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Make the /chat assistant/character selector panel use solid design-token backgrounds instead of the unconfigured transparent-prone bg-background class.
- Add focused regression coverage for the selector panel background token.
- Track the work in TASK-424.

## Test Plan
- [x] bunx vitest run src/components/Common/__tests__/AssistantSelect.behavior.test.tsx --maxWorkers=1 --no-file-parallelism
- [x] git diff --check origin/dev...HEAD

## Change summary
Human requester to complete before merge per AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use solid background tokens for the chat character selector to remove unintended transparency, and add a focused regression test. Addresses TASK-424.

- **Bug Fixes**
  - Selector panel uses `bg-elevated` and `data-testid="assistant-select-panel"`.
  - Inactive option rows use `bg-surface` (replaces `bg-background`), with tests asserting these classes.

<sup>Written for commit 3a917a53a9ffd1dd7ce5abb6f5e31b2119df4899. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1828?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

