### PR TITLE
Add llama.cpp acquisition job API

### DIFF
--- a/backlog/tasks/task-416.2 - Implement-llama.cpp-acquisition-job-API-contract.md
+++ b/backlog/tasks/task-416.2 - Implement-llama.cpp-acquisition-job-API-contract.md
@@ -1,0 +1,69 @@
+---
+id: TASK-416.2
+title: Implement llama.cpp acquisition job API contract
+status: Done
+labels:
+- llamacpp
+- backend
+- local-llm
+- jobs
+priority: high
+parent_task_id: TASK-416
+documentation:
+- Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+modified_files:
+- tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
+- tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+- tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_jobs.py
+- tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+- tldw_Server_API/app/core/Jobs/manager.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py
+- tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 2 from the llama.cpp model acquisition/import workflow plan: add safe remote download request validation plus admin-only Jobs-backed acquisition API/status/cancel endpoints without adding the download worker yet.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Acquisition service rejects unsupported schemes, unsafe local/private sources by default, traversal/delimiter destinations, and unsafe filenames.
+- [ ] #2 Acquisition service redacts credentials/secrets from source labels and resolves destinations only under configured models_dir or allowed_paths.
+- [ ] #3 Acquisition service exposes partial-path, completed-download validation, and completed asset registration helpers for the later worker slice.
+- [ ] #4 Acquisition job helper creates/list/status/cancel mappings for domain llama.cpp acquisition jobs without storing raw credentials.
+- [ ] #5 Admin-only API endpoints create/list/status/cancel acquisition jobs and AuthNZ permission coverage includes all new endpoints.
+- [ ] #6 Focused acquisition service/API/AuthNZ tests, git diff checks, and Bandit on touched Python scope are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the llama.cpp asset acquisition job API contract without adding a download worker. Remote acquisition requests now validate allowed schemes, private/local host policy, destination allowlists, filename safety, size/checksum metadata, and credential redaction before creating a Jobs row. Admin endpoints can create, list, inspect, and cancel acquisition jobs, and tests cover service validation, API job storage, credential hygiene, and admin-only access.
+
+Verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short (55 passed, 5 warnings); git diff --check; Bandit on touched production paths wrote /tmp/bandit_llamacpp_acquisition_job_api.json with 0 results.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-416.2 - Implement-llama.cpp-acquisition-job-API-contract.md
+++ b/backlog/tasks/task-416.2 - Implement-llama.cpp-acquisition-job-API-contract.md
@@ -2,15 +2,19 @@
 id: TASK-416.2
 title: Implement llama.cpp acquisition job API contract
 status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-17 21:56
 labels:
 - llamacpp
 - backend
 - local-llm
 - jobs
-priority: high
-parent_task_id: TASK-416
+dependencies: []
 documentation:
 - Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+parent_task_id: TASK-416
+priority: high
 modified_files:
 - tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
 - tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
@@ -20,6 +24,7 @@ modified_files:
 - tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
 - tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py
 - tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
+- backlog/tasks/task-416.2 - Implement-llama.cpp-acquisition-job-API-contract.md
 ---
 
 ## Description
@@ -30,12 +35,12 @@ Implement Task 2 from the llama.cpp model acquisition/import workflow plan: add 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Acquisition service rejects unsupported schemes, unsafe local/private sources by default, traversal/delimiter destinations, and unsafe filenames.
-- [ ] #2 Acquisition service redacts credentials/secrets from source labels and resolves destinations only under configured models_dir or allowed_paths.
-- [ ] #3 Acquisition service exposes partial-path, completed-download validation, and completed asset registration helpers for the later worker slice.
-- [ ] #4 Acquisition job helper creates/list/status/cancel mappings for domain llama.cpp acquisition jobs without storing raw credentials.
-- [ ] #5 Admin-only API endpoints create/list/status/cancel acquisition jobs and AuthNZ permission coverage includes all new endpoints.
-- [ ] #6 Focused acquisition service/API/AuthNZ tests, git diff checks, and Bandit on touched Python scope are recorded.
+- [x] #1 Acquisition service rejects unsupported schemes, unsafe local/private sources by default, traversal/delimiter destinations, and unsafe filenames.
+- [x] #2 Acquisition service redacts credentials/secrets from source labels and resolves destinations only under configured models_dir or allowed_paths.
+- [x] #3 Acquisition service exposes partial-path, completed-download validation, and completed asset registration helpers for the later worker slice.
+- [x] #4 Acquisition job helper creates/list/status/cancel mappings for domain llama.cpp acquisition jobs without storing raw credentials.
+- [x] #5 Admin-only API endpoints create/list/status/cancel acquisition jobs and AuthNZ permission coverage includes all new endpoints.
+- [x] #6 Focused acquisition service/API/AuthNZ tests, git diff checks, and Bandit on touched Python scope are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -46,24 +51,26 @@ Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-pl
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added the llama.cpp asset acquisition job API contract without adding a download worker. Remote acquisition requests now validate allowed schemes, private/local host policy, destination allowlists, filename safety, size/checksum metadata, and credential redaction before creating a Jobs row. Admin endpoints can create, list, inspect, and cancel acquisition jobs, and tests cover service validation, API job storage, credential hygiene, and admin-only access.
+Added the llama.cpp asset acquisition job API contract without adding a download worker. Remote acquisition requests now validate allowed schemes, private/local host policy, destination allowlists, filename safety, size/checksum metadata, and credential/secret URL policy before creating a Jobs row. Admin endpoints can create, list, inspect, and cancel acquisition jobs, and tests cover service validation, API job storage, credential hygiene, and admin-only access.
 
-Verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short (55 passed, 5 warnings); git diff --check; Bandit on touched production paths wrote /tmp/bandit_llamacpp_acquisition_job_api.json with 0 results.
+Verification: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short (61 passed, 5 warnings); git diff --check; Bandit on touched production paths wrote /tmp/bandit_llamacpp_acquisition_review_fix.json with 0 results.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-416.2.1 - Address-PR-1829-acquisition-job-API-review-comments.md
+++ b/backlog/tasks/task-416.2.1 - Address-PR-1829-acquisition-job-API-review-comments.md
@@ -4,16 +4,23 @@ title: Address PR 1829 acquisition job API review comments
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-17 21:54'
+updated_date: 2026-05-17 21:54
 labels:
-  - llamacpp
-  - backend
-  - review-fix
+- llamacpp
+- backend
+- review-fix
 dependencies: []
 documentation:
-  - 'https://github.com/rmusser01/tldw_server/pull/1829'
+- https://github.com/rmusser01/tldw_server/pull/1829
 parent_task_id: TASK-416.2
 priority: high
+modified_files:
+- backlog/tasks/task-416.2.1 - Address-PR-1829-acquisition-job-API-review-comments.md
+- backlog/tasks/task-416.2 - Implement-llama.cpp-acquisition-job-API-contract.md
+- tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+- tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py
 ---
 
 ## Description
@@ -37,9 +44,9 @@ Verify and address still-valid PR #1829 review comments for the llama.cpp acquis
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed all current PR #1829 review comments. No findings were skipped.
+Addressed all current PR #1829 review comments. No findings were skipped. Follow-up CodeRabbit task-file comments were handled by checking TASK-416.2 Acceptance Criteria/Definition of Done and replacing the absolute venv verification command with a repo-relative command.
 
-Verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short (61 passed, 5 warnings); git diff --check; Bandit wrote /tmp/bandit_llamacpp_acquisition_review_fix.json with 0 results.
+Verification: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short (61 passed, 5 warnings); git diff --check; Bandit wrote /tmp/bandit_llamacpp_acquisition_review_fix.json with 0 results.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-416.2.1 - Address-PR-1829-acquisition-job-API-review-comments.md
+++ b/backlog/tasks/task-416.2.1 - Address-PR-1829-acquisition-job-API-review-comments.md
@@ -1,0 +1,53 @@
+---
+id: TASK-416.2.1
+title: Address PR 1829 acquisition job API review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-17 21:54'
+labels:
+  - llamacpp
+  - backend
+  - review-fix
+dependencies: []
+documentation:
+  - 'https://github.com/rmusser01/tldw_server/pull/1829'
+parent_task_id: TASK-416.2
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address still-valid PR #1829 review comments for the llama.cpp acquisition job API: secret URL policy, DNS fail-closed handling, endpoint formatting, and redundant size cast.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all current PR #1829 review comments. No findings were skipped.
+
+Verification: source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short (61 passed, 5 warnings); git diff --check; Bandit wrote /tmp/bandit_llamacpp_acquisition_review_fix.json with 0 results.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -500,7 +500,11 @@ async def list_llamacpp_asset_downloads_endpoint(
     limit: int = Query(default=100, ge=1, le=500),
     job_manager: JobManager = Depends(get_job_manager),
 ) -> LlamaCppAcquisitionJobListResponse:
-    return await run_in_threadpool(llamacpp_acquisition_jobs.list_download_jobs, job_manager, limit=limit)
+    return await run_in_threadpool(
+        llamacpp_acquisition_jobs.list_download_jobs,
+        job_manager,
+        limit=limit,
+    )
 
 
 @router.get(
@@ -517,7 +521,11 @@ async def get_llamacpp_asset_download_endpoint(
     job_id: int,
     job_manager: JobManager = Depends(get_job_manager),
 ) -> LlamaCppAcquisitionJobResponse:
-    response = await run_in_threadpool(llamacpp_acquisition_jobs.get_download_job, job_manager, job_id)
+    response = await run_in_threadpool(
+        llamacpp_acquisition_jobs.get_download_job,
+        job_manager,
+        job_id,
+    )
     if response is None:
         raise HTTPException(status_code=404, detail="Llama.cpp acquisition job was not found.")
     return response
@@ -537,7 +545,11 @@ async def cancel_llamacpp_asset_download_endpoint(
     job_id: int,
     job_manager: JobManager = Depends(get_job_manager),
 ) -> LlamaCppAcquisitionJobResponse:
-    response = await run_in_threadpool(llamacpp_acquisition_jobs.cancel_download_job, job_manager, job_id)
+    response = await run_in_threadpool(
+        llamacpp_acquisition_jobs.cancel_download_job,
+        job_manager,
+        job_id,
+    )
     if response is None:
         raise HTTPException(status_code=404, detail="Llama.cpp acquisition job was not found.")
     return response

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -12,8 +12,12 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from starlette.concurrency import run_in_threadpool
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, RequireRole, User
+from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
+    LlamaCppAcquisitionJobListResponse,
+    LlamaCppAcquisitionJobResponse,
     LlamaCppAsset,
+    LlamaCppAssetDownloadRequest,
     LlamaCppAssetImportPreviewResponse,
     LlamaCppAssetsResponse,
     LlamaCppConfigResponse,
@@ -44,10 +48,12 @@ from tldw_Server_API.app.core.Local_LLM.LlamaCpp_Handler import LlamaCppHandler
 
 #
 # Local Imports
+from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import InferenceError, ModelNotFoundError, ServerError
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Manager import LLMInferenceManager
 from tldw_Server_API.app.core.Local_LLM import (
     http_utils,
+    llamacpp_acquisition_jobs,
     llamacpp_config_service,
     llamacpp_hardware_service,
     llamacpp_inventory_service,
@@ -151,6 +157,13 @@ def _profile_response(profile: LlamaCppProfile) -> LlamaCppProfileResponse:
 
 def _runtime_response(runtime: LlamaCppRuntime) -> LlamaCppRuntimeResponse:
     return LlamaCppRuntimeResponse.model_validate(runtime.model_dump(mode="python"))
+
+
+def _owner_user_id_from_request(request: Request) -> str | None:
+    auth_context = getattr(request.state, "auth", None)
+    principal = getattr(auth_context, "principal", None)
+    user_id = getattr(principal, "user_id", None)
+    return str(user_id) if user_id is not None else None
 
 
 def _get_profile_or_404(supervisor: LlamaCppSupervisor, profile_id: str) -> LlamaCppProfile:
@@ -444,6 +457,90 @@ async def preview_llamacpp_asset_folder_endpoint(
         )
     except ServerError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post(
+    "/llamacpp/assets/downloads",
+    summary="Queue a llama.cpp Asset Download",
+    response_model=LlamaCppAcquisitionJobResponse,
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(RequireRole("admin")),
+        Depends(_resolve_llm_manager),
+    ],
+)
+async def create_llamacpp_asset_download_endpoint(
+    payload: LlamaCppAssetDownloadRequest,
+    request: Request,
+    job_manager: JobManager = Depends(get_job_manager),
+) -> LlamaCppAcquisitionJobResponse:
+    """Create a sanitized Jobs row for a future llama.cpp asset download worker."""
+    try:
+        return await run_in_threadpool(
+            llamacpp_acquisition_jobs.create_download_job,
+            job_manager,
+            payload,
+            owner_user_id=_owner_user_id_from_request(request),
+        )
+    except (ServerError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get(
+    "/llamacpp/assets/downloads",
+    summary="List llama.cpp Asset Download Jobs",
+    response_model=LlamaCppAcquisitionJobListResponse,
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(RequireRole("admin")),
+        Depends(_resolve_llm_manager),
+    ],
+)
+async def list_llamacpp_asset_downloads_endpoint(
+    limit: int = Query(default=100, ge=1, le=500),
+    job_manager: JobManager = Depends(get_job_manager),
+) -> LlamaCppAcquisitionJobListResponse:
+    return await run_in_threadpool(llamacpp_acquisition_jobs.list_download_jobs, job_manager, limit=limit)
+
+
+@router.get(
+    "/llamacpp/assets/downloads/{job_id}",
+    summary="Get a llama.cpp Asset Download Job",
+    response_model=LlamaCppAcquisitionJobResponse,
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(RequireRole("admin")),
+        Depends(_resolve_llm_manager),
+    ],
+)
+async def get_llamacpp_asset_download_endpoint(
+    job_id: int,
+    job_manager: JobManager = Depends(get_job_manager),
+) -> LlamaCppAcquisitionJobResponse:
+    response = await run_in_threadpool(llamacpp_acquisition_jobs.get_download_job, job_manager, job_id)
+    if response is None:
+        raise HTTPException(status_code=404, detail="Llama.cpp acquisition job was not found.")
+    return response
+
+
+@router.delete(
+    "/llamacpp/assets/downloads/{job_id}",
+    summary="Cancel a llama.cpp Asset Download Job",
+    response_model=LlamaCppAcquisitionJobResponse,
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(RequireRole("admin")),
+        Depends(_resolve_llm_manager),
+    ],
+)
+async def cancel_llamacpp_asset_download_endpoint(
+    job_id: int,
+    job_manager: JobManager = Depends(get_job_manager),
+) -> LlamaCppAcquisitionJobResponse:
+    response = await run_in_threadpool(llamacpp_acquisition_jobs.cancel_download_job, job_manager, job_id)
+    if response is None:
+        raise HTTPException(status_code=404, detail="Llama.cpp acquisition job was not found.")
+    return response
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py
@@ -187,6 +187,42 @@ class LlamaCppAssetImportPreviewResponse(BaseModel):
     will_persist: bool = False
 
 
+class LlamaCppAssetDownloadRequest(BaseModel):
+    """Request to queue a safe llama.cpp asset download job."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str
+    destination_dir: str | None = None
+    filename: str | None = None
+    expected_sha256: str | None = None
+    expected_size_bytes: int | None = Field(default=None, ge=1)
+    source_label: str | None = None
+    overwrite: bool = False
+    register_asset: bool = True
+
+
+class LlamaCppAcquisitionJobResponse(BaseModel):
+    """Normalized llama.cpp acquisition job state for admin clients."""
+
+    job_id: str
+    status: str
+    operation: Literal["download"]
+    queue: str
+    source_label: str | None = None
+    destination_path: str | None = None
+    asset_id: str | None = None
+    progress: dict[str, object] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+    error_message: str | None = None
+
+
+class LlamaCppAcquisitionJobListResponse(BaseModel):
+    """Recent llama.cpp acquisition jobs."""
+
+    jobs: list[LlamaCppAcquisitionJobResponse] = Field(default_factory=list)
+
+
 class LlamaCppInventoryItem(BaseModel):
     """A single model inventory entry from models_dir or registered paths."""
 

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -254,6 +254,7 @@ class JobManager:
     # Standard queues across domains
     STANDARD_QUEUES = ("default", "high", "low")
     DOMAIN_ALLOWED_QUEUES: ClassVar[dict[str, tuple[str, ...]]] = {
+        "llamacpp": ("acquisition",),
         "reading": ("reading-digest",),
         "vn_assets": ("generation",),
         "persona_visuals": ("generation",),

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_jobs.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_jobs.py
@@ -1,0 +1,130 @@
+"""Jobs-backed contract helpers for llama.cpp asset acquisition."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
+    LlamaCppAcquisitionJobListResponse,
+    LlamaCppAcquisitionJobResponse,
+    LlamaCppAssetDownloadRequest,
+)
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+
+LLAMACPP_ACQUISITION_DOMAIN = "llamacpp"
+LLAMACPP_ACQUISITION_QUEUE = "acquisition"
+LLAMACPP_DOWNLOAD_JOB_TYPE = "llamacpp_asset_download"
+
+
+def create_download_job(
+    job_manager: JobManager,
+    payload: LlamaCppAssetDownloadRequest,
+    *,
+    owner_user_id: str | None,
+) -> LlamaCppAcquisitionJobResponse:
+    """Validate a download request and create a sanitized llama.cpp acquisition job."""
+    validated = llamacpp_acquisition_service.validate_download_request(payload)
+    job_payload = {
+        "operation": "download",
+        "source_url": validated.source_url,
+        "source_label": validated.source_label,
+        "destination_path": str(validated.destination_path),
+        "expected_sha256": validated.expected_sha256,
+        "expected_size_bytes": validated.expected_size_bytes,
+        "overwrite": validated.overwrite,
+        "register_asset": validated.register_asset,
+        "warnings": list(validated.warnings),
+    }
+    job = job_manager.create_job(
+        domain=LLAMACPP_ACQUISITION_DOMAIN,
+        queue=LLAMACPP_ACQUISITION_QUEUE,
+        job_type=LLAMACPP_DOWNLOAD_JOB_TYPE,
+        payload=job_payload,
+        owner_user_id=owner_user_id,
+        priority=5,
+        max_retries=3,
+    )
+    job_id = job.get("id")
+    if job_id is not None:
+        refreshed = job_manager.get_job(int(job_id))
+        if refreshed is not None:
+            job = refreshed
+    return job_to_response(job)
+
+
+def get_download_job(job_manager: JobManager, job_id: int) -> LlamaCppAcquisitionJobResponse | None:
+    """Return one llama.cpp acquisition job if it belongs to the acquisition domain."""
+    job = job_manager.get_job(int(job_id))
+    if not _is_llamacpp_download_job(job):
+        return None
+    return job_to_response(job)
+
+
+def list_download_jobs(job_manager: JobManager, *, limit: int = 100) -> LlamaCppAcquisitionJobListResponse:
+    """Return recent llama.cpp acquisition download jobs."""
+    jobs = job_manager.list_jobs(
+        domain=LLAMACPP_ACQUISITION_DOMAIN,
+        queue=LLAMACPP_ACQUISITION_QUEUE,
+        job_type=LLAMACPP_DOWNLOAD_JOB_TYPE,
+        limit=limit,
+    )
+    return LlamaCppAcquisitionJobListResponse(jobs=[job_to_response(job) for job in jobs])
+
+
+def cancel_download_job(job_manager: JobManager, job_id: int) -> LlamaCppAcquisitionJobResponse | None:
+    """Request cancellation for a llama.cpp acquisition job and return its new state."""
+    job = job_manager.get_job(int(job_id))
+    if not _is_llamacpp_download_job(job):
+        return None
+    job_manager.cancel_job(int(job_id), reason="cancelled_by_admin")
+    return get_download_job(job_manager, int(job_id))
+
+
+def job_to_response(job: dict[str, Any]) -> LlamaCppAcquisitionJobResponse:
+    """Map a raw Jobs row into the llama.cpp acquisition API response."""
+    payload = _dict_value(job.get("payload"))
+    result = _dict_value(job.get("result"))
+    progress = _dict_value(payload.get("progress"))
+    if result:
+        progress.update(_dict_value(result.get("progress")))
+    warnings = _string_list(payload.get("warnings")) + _string_list(result.get("warnings") if result else None)
+    return LlamaCppAcquisitionJobResponse(
+        job_id=str(job.get("id") or ""),
+        status=str(job.get("status") or "unknown"),
+        operation="download",
+        queue=str(job.get("queue") or LLAMACPP_ACQUISITION_QUEUE),
+        source_label=_optional_str(payload.get("source_label")),
+        destination_path=_optional_str(payload.get("destination_path")),
+        asset_id=_optional_str(result.get("asset_id") if result else None),
+        progress=progress,
+        warnings=warnings,
+        error_message=_optional_str(job.get("last_error") or job.get("error_message")),
+    )
+
+
+def _is_llamacpp_download_job(job: dict[str, Any] | None) -> bool:
+    return bool(
+        job
+        and job.get("domain") == LLAMACPP_ACQUISITION_DOMAIN
+        and job.get("queue") == LLAMACPP_ACQUISITION_QUEUE
+        and job.get("job_type") == LLAMACPP_DOWNLOAD_JOB_TYPE
+    )
+
+
+def _dict_value(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
@@ -10,7 +10,7 @@ import socket
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, unquote, urlencode, urlsplit, urlunsplit
+from urllib.parse import SplitResult, parse_qsl, unquote, urlencode, urlsplit, urlunsplit
 
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppAsset,
@@ -141,7 +141,7 @@ def validate_completed_download(
         raise ServerError("Downloaded file does not exist.")
     if not path.is_file():
         raise ServerError("Downloaded path is not a file.")
-    if expected_size_bytes is not None and path.stat().st_size != int(expected_size_bytes):
+    if expected_size_bytes is not None and path.stat().st_size != expected_size_bytes:
         raise ServerError("Downloaded file size did not match expected size.")
     expected_digest = _normalize_sha256(expected_sha256)
     if expected_digest is not None and _sha256_file(path) != expected_digest:
@@ -179,12 +179,27 @@ def _validate_source_url(url: str, saved_config: dict[str, Any], warnings: list[
         raise ServerError("Download URL scheme must be http or https.")
     if not parsed.hostname:
         raise ServerError("Download URL host is required.")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ServerError("Download URL is invalid.") from exc
+    if parsed.username is not None or parsed.password is not None:
+        raise ServerError("Download URL credentials are not supported.")
+    secret_keys = sorted(
+        {
+            key
+            for key, _val in parse_qsl(parsed.query, keep_blank_values=True)
+            if _is_secret_query_key(key)
+        }
+    )
+    if secret_keys:
+        raise ServerError(f"Download URL query contains secret parameters: {', '.join(secret_keys)}.")
     allow_private = bool(_config_bool(saved_config.get("allow_private_downloads")))
     host = parsed.hostname.strip().lower()
     if _is_local_hostname(host) and not allow_private:
         raise ServerError("Download URL host resolves to a local or private network address.")
     _validate_host_addresses(host, allow_private=allow_private, warnings=warnings)
-    return redacted_source_label(raw_url)
+    return _normalized_source_url(parsed, port=port)
 
 
 def _validate_host_addresses(host: str, *, allow_private: bool, warnings: list[str]) -> None:
@@ -195,6 +210,8 @@ def _validate_host_addresses(host: str, *, allow_private: bool, warnings: list[s
     try:
         resolved = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
     except OSError as exc:
+        if not allow_private:
+            raise ServerError(f"Could not resolve download host '{host}' to verify network safety.") from exc
         warnings.append(f"Could not resolve download host '{host}': {exc.__class__.__name__}.")
         return
     for result in resolved:
@@ -227,6 +244,16 @@ def _ip_address_or_none(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Addr
 
 def _is_local_hostname(host: str) -> bool:
     return host in {"localhost"} or host.endswith(".localhost")
+
+
+def _normalized_source_url(parsed: SplitResult, *, port: int | None) -> str:
+    host = parsed.hostname or ""
+    netloc = host
+    if ":" in host and not host.startswith("["):
+        netloc = f"[{host}]"
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path, parsed.query, ""))
 
 
 def _source_label_for_payload(payload: LlamaCppAssetDownloadRequest) -> str:

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
@@ -1,0 +1,360 @@
+"""Safe request validation helpers for llama.cpp asset acquisition."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import os
+import re
+import socket
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, unquote, urlencode, urlsplit, urlunsplit
+
+from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
+    LlamaCppAsset,
+    LlamaCppAssetDownloadRequest,
+)
+from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+from tldw_Server_API.app.core.Setup import setup_manager
+from tldw_Server_API.app.core.config import load_comprehensive_config
+
+
+_DOWNLOAD_SCHEMES = {"http", "https"}
+_FILENAME_DELIMITERS = {",", os.pathsep}
+_SECRET_QUERY_KEYS = {
+    "access_token",
+    "apikey",
+    "api_key",
+    "auth",
+    "authorization",
+    "key",
+    "password",
+    "secret",
+    "sig",
+    "signature",
+    "token",
+    "x-amz-credential",
+    "x-amz-security-token",
+    "x-amz-signature",
+}
+_SAFE_JOB_ID_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+@dataclass(frozen=True)
+class LlamaCppValidatedDownload:
+    """Sanitized llama.cpp download request ready for job creation."""
+
+    source_url: str
+    source_label: str
+    destination_path: Path
+    expected_sha256: str | None = None
+    expected_size_bytes: int | None = None
+    overwrite: bool = False
+    register_asset: bool = True
+    warnings: list[str] = field(default_factory=list)
+
+
+def validate_download_request(
+    payload: LlamaCppAssetDownloadRequest,
+    saved_config: dict[str, Any] | None = None,
+) -> LlamaCppValidatedDownload:
+    """Validate a remote asset download request without performing network I/O."""
+    config = saved_config if saved_config is not None else _read_saved_config()
+    warnings: list[str] = []
+    source_url = _validate_source_url(payload.url, config, warnings)
+    expected_sha256 = _normalize_sha256(payload.expected_sha256)
+    destination_path = resolve_download_destination(payload, config)
+    if destination_path.exists() and not payload.overwrite:
+        raise ServerError("Destination file already exists; set overwrite=true to replace it.")
+    return LlamaCppValidatedDownload(
+        source_url=source_url,
+        source_label=_source_label_for_payload(payload),
+        destination_path=destination_path,
+        expected_sha256=expected_sha256,
+        expected_size_bytes=payload.expected_size_bytes,
+        overwrite=payload.overwrite,
+        register_asset=payload.register_asset,
+        warnings=warnings,
+    )
+
+
+def redacted_source_label(url: str) -> str:
+    """Return a display-safe URL label without userinfo or secret query values."""
+    value = str(url or "").strip()
+    if not value:
+        return ""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return _sanitize_freeform_label(value)
+    if not parsed.scheme or not parsed.netloc:
+        return _sanitize_freeform_label(value)
+
+    host = parsed.hostname or ""
+    netloc = host
+    if ":" in host and not host.startswith("["):
+        netloc = f"[{host}]"
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    query = urlencode(
+        [
+            (key, val)
+            for key, val in parse_qsl(parsed.query, keep_blank_values=True)
+            if not _is_secret_query_key(key)
+        ],
+        doseq=True,
+    )
+    return urlunsplit((parsed.scheme, netloc, parsed.path, query, ""))
+
+
+def resolve_download_destination(payload: LlamaCppAssetDownloadRequest, saved_config: dict[str, Any]) -> Path:
+    """Resolve a requested download destination under configured llama.cpp roots."""
+    filename = _resolve_filename(payload)
+    destination_dir = _destination_dir(payload, saved_config)
+    _validate_destination_dir(destination_dir, saved_config)
+    destination = destination_dir / filename
+    _validate_path_value(destination, "Download destination")
+    allowed_bases = _allowed_bases(saved_config)
+    if not allowed_bases or not handler_utils.is_path_allowed(destination, allowed_bases):
+        raise ServerError("Download destination is outside allowed llama.cpp paths.")
+    return destination
+
+
+def partial_download_path(final_path: Path, job_id: str) -> Path:
+    """Return the partial-file path colocated with the final destination."""
+    safe_job_id = _SAFE_JOB_ID_RE.sub("-", str(job_id or "").strip()).strip("-._")
+    if not safe_job_id:
+        safe_job_id = hashlib.sha256(str(job_id).encode("utf-8")).hexdigest()[:12]
+    return final_path.with_name(f"{final_path.name}.{safe_job_id}.partial")
+
+
+def validate_completed_download(
+    path: Path,
+    expected_sha256: str | None = None,
+    expected_size_bytes: int | None = None,
+) -> list[str]:
+    """Validate a completed local download before asset registration."""
+    if not path.exists():
+        raise ServerError("Downloaded file does not exist.")
+    if not path.is_file():
+        raise ServerError("Downloaded path is not a file.")
+    if expected_size_bytes is not None and path.stat().st_size != int(expected_size_bytes):
+        raise ServerError("Downloaded file size did not match expected size.")
+    expected_digest = _normalize_sha256(expected_sha256)
+    if expected_digest is not None and _sha256_file(path) != expected_digest:
+        raise ServerError("Downloaded file checksum did not match expected sha256.")
+    return []
+
+
+def register_completed_download(path: Path) -> LlamaCppAsset:
+    """Register a completed asset through the llama.cpp inventory service."""
+    return LlamaCppAsset.model_validate(llamacpp_inventory_service.register_asset_path(path))
+
+
+def _read_saved_config() -> dict[str, Any]:
+    parser = load_comprehensive_config()
+    section = parser["LlamaCpp"] if parser and parser.has_section("LlamaCpp") else None
+    if section is None:
+        return {"allowed_paths": []}
+    return {
+        "models_dir": _str_or_none(section.get("models_dir", fallback=None)),
+        "allowed_paths": _split_list(section.get("allowed_paths", fallback="")),
+        "allow_private_downloads": _config_bool(section.get("allow_private_downloads", fallback=None)),
+    }
+
+
+def _validate_source_url(url: str, saved_config: dict[str, Any], warnings: list[str]) -> str:
+    raw_url = str(url or "").strip()
+    if not raw_url:
+        raise ServerError("Download URL is required.")
+    try:
+        parsed = urlsplit(raw_url)
+    except ValueError as exc:
+        raise ServerError("Download URL is invalid.") from exc
+    scheme = parsed.scheme.lower()
+    if scheme not in _DOWNLOAD_SCHEMES:
+        raise ServerError("Download URL scheme must be http or https.")
+    if not parsed.hostname:
+        raise ServerError("Download URL host is required.")
+    allow_private = bool(_config_bool(saved_config.get("allow_private_downloads")))
+    host = parsed.hostname.strip().lower()
+    if _is_local_hostname(host) and not allow_private:
+        raise ServerError("Download URL host resolves to a local or private network address.")
+    _validate_host_addresses(host, allow_private=allow_private, warnings=warnings)
+    return redacted_source_label(raw_url)
+
+
+def _validate_host_addresses(host: str, *, allow_private: bool, warnings: list[str]) -> None:
+    literal = _ip_address_or_none(host)
+    if literal is not None:
+        _reject_private_address(literal, allow_private=allow_private)
+        return
+    try:
+        resolved = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        warnings.append(f"Could not resolve download host '{host}': {exc.__class__.__name__}.")
+        return
+    for result in resolved:
+        address = result[4][0]
+        candidate = _ip_address_or_none(address)
+        if candidate is not None:
+            _reject_private_address(candidate, allow_private=allow_private)
+
+
+def _reject_private_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address, *, allow_private: bool) -> None:
+    if allow_private:
+        return
+    if (
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address.is_unspecified
+        or address.is_multicast
+        or address.is_reserved
+    ):
+        raise ServerError("Download URL host resolves to a local or private network address.")
+
+
+def _ip_address_or_none(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(host)
+    except ValueError:
+        return None
+
+
+def _is_local_hostname(host: str) -> bool:
+    return host in {"localhost"} or host.endswith(".localhost")
+
+
+def _source_label_for_payload(payload: LlamaCppAssetDownloadRequest) -> str:
+    if payload.source_label:
+        return _sanitize_freeform_label(payload.source_label)
+    return redacted_source_label(payload.url)
+
+
+def _sanitize_freeform_label(label: str) -> str:
+    value = re.sub(r"//[^/@\s]+@", "//", str(label or "").strip())
+    return re.sub(r"(?i)(token|secret|password|signature|api[_-]?key)=\S+", r"\1=<redacted>", value)
+
+
+def _is_secret_query_key(key: str) -> bool:
+    normalized = str(key or "").strip().lower().replace("-", "_")
+    compact = normalized.replace("_", "")
+    return (
+        normalized in _SECRET_QUERY_KEYS
+        or compact in _SECRET_QUERY_KEYS
+        or any(token in normalized for token in ("token", "secret", "signature", "password", "credential"))
+    )
+
+
+def _resolve_filename(payload: LlamaCppAssetDownloadRequest) -> str:
+    raw_filename = payload.filename
+    if raw_filename is None:
+        raw_filename = unquote(Path(urlsplit(payload.url).path).name)
+    filename = str(raw_filename or "").strip()
+    if not filename:
+        raise ServerError("Download filename is required.")
+    if filename in {".", ".."} or filename != Path(filename).name or "/" in filename or "\\" in filename:
+        raise ServerError("Download filename must be a simple filename.")
+    if any(delimiter in filename for delimiter in _FILENAME_DELIMITERS):
+        raise ServerError("Download filename contains unsupported delimiter characters.")
+    if "\x00" in filename or "\n" in filename or "\r" in filename:
+        raise ServerError("Download filename contains unsupported characters.")
+    if not filename.lower().endswith(".gguf"):
+        raise ServerError("Download filename must end with .gguf.")
+    return filename
+
+
+def _destination_dir(payload: LlamaCppAssetDownloadRequest, saved_config: dict[str, Any]) -> Path:
+    raw_destination = payload.destination_dir or saved_config.get("models_dir")
+    if not raw_destination:
+        raise ServerError("Download destination_dir is required when models_dir is not configured.")
+    destination_dir = Path(str(raw_destination)).expanduser().resolve()
+    _validate_path_value(destination_dir, "Download destination directory")
+    if not destination_dir.exists():
+        raise ServerError("Download destination directory does not exist.")
+    if not destination_dir.is_dir():
+        raise ServerError("Download destination is not a directory.")
+    return destination_dir
+
+
+def _validate_destination_dir(destination_dir: Path, saved_config: dict[str, Any]) -> None:
+    allowed_bases = _allowed_bases(saved_config)
+    if not allowed_bases or not handler_utils.is_path_allowed(destination_dir, allowed_bases):
+        raise ServerError("Download destination directory is outside allowed llama.cpp paths.")
+
+
+def _validate_path_value(path: Path, label: str) -> None:
+    text = str(path)
+    try:
+        setup_manager.validate_config_value_single_line("LlamaCpp", "models_dir", text)
+    except ValueError as exc:
+        raise ServerError(f"{label} contains unsupported config characters.") from exc
+    if any(delimiter in text for delimiter in _FILENAME_DELIMITERS):
+        raise ServerError(f"{label} contains unsupported delimiter characters.")
+
+
+def _allowed_bases(saved_config: dict[str, Any]) -> list[Path]:
+    models_dir = _optional_path(saved_config.get("models_dir"))
+    allowed_paths = _path_list(saved_config.get("allowed_paths"))
+    return handler_utils.build_allowed_paths(models_dir, allowed_paths) if models_dir else allowed_paths
+
+
+def _normalize_sha256(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+        raise ServerError("expected_sha256 must be a 64-character hexadecimal sha256 digest.")
+    return normalized
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _optional_path(value: Any) -> Path | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return Path(text).expanduser() if text else None
+
+
+def _path_list(value: Any) -> list[Path]:
+    if not value:
+        return []
+    if isinstance(value, str):
+        values = _split_list(value)
+    else:
+        values = [str(item).strip() for item in value if str(item).strip()]
+    return [Path(item).expanduser() for item in values]
+
+
+def _split_list(raw: str | None) -> list[str]:
+    if raw is None:
+        return []
+    return [part.strip() for part in str(raw).replace(os.pathsep, ",").split(",") if part.strip()]
+
+
+def _str_or_none(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    return value or None
+
+
+def _config_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
@@ -129,6 +129,7 @@ def _build_app_with_overrides(
     app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
     app.dependency_overrides[auth_deps.check_rate_limit] = _fake_check_rate_limit
     app.dependency_overrides[llamacpp_mod.check_rate_limit] = _fake_check_rate_limit
+    app.dependency_overrides[llamacpp_mod.get_job_manager] = lambda: object()
 
     return app
 
@@ -173,6 +174,38 @@ def _patch_provider_config_writes(monkeypatch) -> None:  # noqa: ANN001
             "will_persist": False,
         },
     )
+    acquisition_job = {
+        "job_id": "1",
+        "status": "queued",
+        "operation": "download",
+        "queue": "acquisition",
+        "source_label": "https://example.com/model.gguf",
+        "destination_path": "/models/model.gguf",
+        "asset_id": None,
+        "progress": {},
+        "warnings": [],
+        "error_message": None,
+    }
+    monkeypatch.setattr(
+        llamacpp_mod.llamacpp_acquisition_jobs,
+        "create_download_job",
+        lambda job_manager, payload, *, owner_user_id: acquisition_job,
+    )
+    monkeypatch.setattr(
+        llamacpp_mod.llamacpp_acquisition_jobs,
+        "get_download_job",
+        lambda job_manager, job_id: acquisition_job,
+    )
+    monkeypatch.setattr(
+        llamacpp_mod.llamacpp_acquisition_jobs,
+        "list_download_jobs",
+        lambda job_manager, *, limit=100: {"jobs": [acquisition_job]},
+    )
+    monkeypatch.setattr(
+        llamacpp_mod.llamacpp_acquisition_jobs,
+        "cancel_download_job",
+        lambda job_manager, job_id: acquisition_job | {"status": "cancelled"},
+    )
 
 
 @pytest.mark.unit
@@ -188,6 +221,10 @@ def _patch_provider_config_writes(monkeypatch) -> None:  # noqa: ANN001
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
         ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
+        ("post", "/api/v1/llamacpp/assets/downloads", {"url": "https://example.com/model.gguf"}),
+        ("get", "/api/v1/llamacpp/assets/downloads", None),
+        ("get", "/api/v1/llamacpp/assets/downloads/1", None),
+        ("delete", "/api/v1/llamacpp/assets/downloads/1", None),
     ],
 )
 def test_llamacpp_lifecycle_401_when_principal_unavailable(
@@ -202,6 +239,8 @@ def test_llamacpp_lifecycle_401_when_principal_unavailable(
     with TestClient(app) as client:
         if method == "post":
             resp = client.post(path, json=payload or {})
+        elif method == "delete":
+            resp = client.delete(path)
         else:
             resp = client.get(path)
 
@@ -222,6 +261,10 @@ def test_llamacpp_lifecycle_401_when_principal_unavailable(
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
         ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
+        ("post", "/api/v1/llamacpp/assets/downloads", {"url": "https://example.com/model.gguf"}),
+        ("get", "/api/v1/llamacpp/assets/downloads", None),
+        ("get", "/api/v1/llamacpp/assets/downloads/1", None),
+        ("delete", "/api/v1/llamacpp/assets/downloads/1", None),
     ],
 )
 def test_llamacpp_lifecycle_403_when_missing_admin_role(
@@ -241,6 +284,8 @@ def test_llamacpp_lifecycle_403_when_missing_admin_role(
     with TestClient(app) as client:
         if method == "post":
             resp = client.post(path, json=payload or {})
+        elif method == "delete":
+            resp = client.delete(path)
         else:
             resp = client.get(path)
 
@@ -260,6 +305,10 @@ def test_llamacpp_lifecycle_403_when_missing_admin_role(
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
         ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
+        ("post", "/api/v1/llamacpp/assets/downloads", {"url": "https://example.com/model.gguf"}),
+        ("get", "/api/v1/llamacpp/assets/downloads", None),
+        ("get", "/api/v1/llamacpp/assets/downloads/1", None),
+        ("delete", "/api/v1/llamacpp/assets/downloads/1", None),
     ],
 )
 def test_llamacpp_lifecycle_200_for_admin_principal(
@@ -279,6 +328,8 @@ def test_llamacpp_lifecycle_200_for_admin_principal(
     with TestClient(app) as client:
         if method == "post":
             resp = client.post(path, json=payload or {})
+        elif method == "delete":
+            resp = client.delete(path)
         else:
             resp = client.get(path)
 

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import llamacpp as lp
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+
+def _admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        api_key_id=None,
+        subject=None,
+        token_type="access",
+        jti=None,
+        roles=["admin"],
+        permissions=[],
+        is_admin=True,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+class _Logger:
+    def error(self, *args: Any, **kwargs: Any) -> None:
+        return
+
+
+class _Manager:
+    logger = _Logger()
+
+
+def _make_app(job_manager: JobManager) -> FastAPI:
+    app = FastAPI()
+    app.include_router(lp.router, prefix="/api/v1")
+    app.state.llm_manager = _Manager()
+
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:  # type: ignore[override]
+        principal = _admin_principal()
+        ip = request.client.host if getattr(request, "client", None) else None
+        ua = request.headers.get("User-Agent") if getattr(request, "headers", None) else None
+        request_id = request.headers.get("X-Request-ID") if getattr(request, "headers", None) else None
+        request.state.auth = AuthContext(principal=principal, ip=ip, user_agent=ua, request_id=request_id)
+        return principal
+
+    async def _fake_check_rate_limit() -> None:
+        return
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[auth_deps.check_rate_limit] = _fake_check_rate_limit
+    app.dependency_overrides[lp.check_rate_limit] = _fake_check_rate_limit
+    app.dependency_overrides[lp.get_job_manager] = lambda: job_manager
+    return app
+
+
+def _llamacpp_parser(models_dir: Path, **overrides: str) -> ConfigParser:
+    parser = ConfigParser()
+    parser.add_section("LlamaCpp")
+    values = {
+        "enabled": "true",
+        "models_dir": str(models_dir),
+        "allowed_paths": "",
+        "registered_model_paths": "",
+        "imported_asset_folders": "",
+    }
+    values.update(overrides)
+    parser["LlamaCpp"] = values
+    return parser
+
+
+@pytest.mark.unit
+def test_download_endpoint_creates_redacted_llamacpp_acquisition_job(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    monkeypatch.setattr(
+        llamacpp_acquisition_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+    job_manager = JobManager(db_path=tmp_path / "jobs.db")
+    app = _make_app(job_manager)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/llamacpp/assets/downloads",
+            json={
+                "url": "https://user:pass@example.com/releases/model.gguf?token=secret&download=1",
+                "expected_size_bytes": 11,
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "queued"
+    assert body["operation"] == "download"
+    assert body["queue"] == "acquisition"
+    assert "secret" not in body["source_label"]
+    assert "user:pass" not in body["source_label"]
+    job = job_manager.get_job(int(body["job_id"]))
+    assert job is not None
+    assert job["domain"] == "llamacpp"
+    assert job["queue"] == "acquisition"
+    assert job["job_type"] == "llamacpp_asset_download"
+    assert "secret" not in str(job["payload"])
+    assert "user:pass" not in str(job["payload"])
+    assert job["payload"]["source_url"] == "https://example.com/releases/model.gguf?download=1"
+    assert job["payload"]["destination_path"] == str(models_dir / "model.gguf")
+
+
+@pytest.mark.unit
+def test_download_job_status_list_and_cancel_endpoints(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    monkeypatch.setattr(
+        llamacpp_acquisition_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+    job_manager = JobManager(db_path=tmp_path / "jobs.db")
+    app = _make_app(job_manager)
+
+    with TestClient(app) as client:
+        create_response = client.post(
+            "/api/v1/llamacpp/assets/downloads",
+            json={"url": "https://example.com/releases/model.gguf"},
+        )
+        job_id = create_response.json()["job_id"]
+        status_response = client.get(f"/api/v1/llamacpp/assets/downloads/{job_id}")
+        list_response = client.get("/api/v1/llamacpp/assets/downloads")
+        cancel_response = client.delete(f"/api/v1/llamacpp/assets/downloads/{job_id}")
+
+    assert create_response.status_code == 200, create_response.text
+    assert status_response.status_code == 200, status_response.text
+    assert status_response.json()["job_id"] == job_id
+    assert list_response.status_code == 200, list_response.text
+    assert [job["job_id"] for job in list_response.json()["jobs"]] == [job_id]
+    assert cancel_response.status_code == 200, cancel_response.text
+    assert cancel_response.json()["status"] == "cancelled"
+
+
+@pytest.mark.unit
+def test_download_endpoint_rejects_invalid_request(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    monkeypatch.setattr(
+        llamacpp_acquisition_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+    app = _make_app(JobManager(db_path=tmp_path / "jobs.db"))
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/llamacpp/assets/downloads", json={"url": "file:///tmp/model.gguf"})
+
+    assert response.status_code == 400
+    assert "scheme" in response.json()["detail"].lower()

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py
@@ -78,6 +78,14 @@ def _llamacpp_parser(models_dir: Path, **overrides: str) -> ConfigParser:
     return parser
 
 
+def _allow_public_dns(monkeypatch: pytest.MonkeyPatch, llamacpp_acquisition_service: Any) -> None:
+    monkeypatch.setattr(
+        llamacpp_acquisition_service.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, ("93.184.216.34", 0))],
+    )
+
+
 @pytest.mark.unit
 def test_download_endpoint_creates_redacted_llamacpp_acquisition_job(monkeypatch, tmp_path: Path) -> None:
     from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
@@ -89,6 +97,7 @@ def test_download_endpoint_creates_redacted_llamacpp_acquisition_job(monkeypatch
         "load_comprehensive_config",
         lambda: _llamacpp_parser(models_dir),
     )
+    _allow_public_dns(monkeypatch, llamacpp_acquisition_service)
     job_manager = JobManager(db_path=tmp_path / "jobs.db")
     app = _make_app(job_manager)
 
@@ -96,7 +105,7 @@ def test_download_endpoint_creates_redacted_llamacpp_acquisition_job(monkeypatch
         response = client.post(
             "/api/v1/llamacpp/assets/downloads",
             json={
-                "url": "https://user:pass@example.com/releases/model.gguf?token=secret&download=1",
+                "url": "https://example.com/releases/model.gguf?download=1",
                 "expected_size_bytes": 11,
             },
         )
@@ -106,15 +115,12 @@ def test_download_endpoint_creates_redacted_llamacpp_acquisition_job(monkeypatch
     assert body["status"] == "queued"
     assert body["operation"] == "download"
     assert body["queue"] == "acquisition"
-    assert "secret" not in body["source_label"]
-    assert "user:pass" not in body["source_label"]
+    assert body["source_label"] == "https://example.com/releases/model.gguf?download=1"
     job = job_manager.get_job(int(body["job_id"]))
     assert job is not None
     assert job["domain"] == "llamacpp"
     assert job["queue"] == "acquisition"
     assert job["job_type"] == "llamacpp_asset_download"
-    assert "secret" not in str(job["payload"])
-    assert "user:pass" not in str(job["payload"])
     assert job["payload"]["source_url"] == "https://example.com/releases/model.gguf?download=1"
     assert job["payload"]["destination_path"] == str(models_dir / "model.gguf")
 
@@ -130,6 +136,7 @@ def test_download_job_status_list_and_cancel_endpoints(monkeypatch, tmp_path: Pa
         "load_comprehensive_config",
         lambda: _llamacpp_parser(models_dir),
     )
+    _allow_public_dns(monkeypatch, llamacpp_acquisition_service)
     job_manager = JobManager(db_path=tmp_path / "jobs.db")
     app = _make_app(job_manager)
 
@@ -170,3 +177,30 @@ def test_download_endpoint_rejects_invalid_request(monkeypatch, tmp_path: Path) 
 
     assert response.status_code == 400
     assert "scheme" in response.json()["detail"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:pass@example.com/releases/model.gguf",
+        "https://example.com/releases/model.gguf?token=secret&download=1",
+    ],
+)
+def test_download_endpoint_rejects_credentialed_or_secret_urls(monkeypatch, tmp_path: Path, url: str) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    monkeypatch.setattr(
+        llamacpp_acquisition_service,
+        "load_comprehensive_config",
+        lambda: _llamacpp_parser(models_dir),
+    )
+    app = _make_app(JobManager(db_path=tmp_path / "jobs.db"))
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/llamacpp/assets/downloads", json={"url": url})
+
+    assert response.status_code == 400
+    assert "credential" in response.json()["detail"].lower() or "secret" in response.json()["detail"].lower()

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+
+def _saved_config(models_dir: Path, **overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "models_dir": str(models_dir),
+        "allowed_paths": [],
+    }
+    values.update(overrides)
+    return values
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("url", ["", "file:///tmp/model.gguf", "ftp://example.com/model.gguf"])
+def test_validate_download_request_rejects_empty_and_unsupported_urls(tmp_path: Path, url: str) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    payload = LlamaCppAssetDownloadRequest(url=url, filename="model.gguf")
+
+    with pytest.raises(ServerError):
+        llamacpp_acquisition_service.validate_download_request(payload, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/model.gguf",
+        "http://127.0.0.1/model.gguf",
+        "http://10.0.0.1/model.gguf",
+        "http://169.254.1.1/model.gguf",
+    ],
+)
+def test_validate_download_request_rejects_private_network_sources_by_default(tmp_path: Path, url: str) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    payload = LlamaCppAssetDownloadRequest(url=url, filename="model.gguf")
+
+    with pytest.raises(ServerError, match="private|local|loopback|link-local"):
+        llamacpp_acquisition_service.validate_download_request(payload, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+def test_validate_download_request_allows_private_network_when_explicitly_enabled(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    payload = LlamaCppAssetDownloadRequest(url="http://10.0.0.1/model.gguf", filename="model.gguf")
+
+    validated = llamacpp_acquisition_service.validate_download_request(
+        payload,
+        _saved_config(models_dir, allow_private_downloads=True),
+    )
+
+    assert validated.destination_path == models_dir / "model.gguf"
+    assert validated.source_url.startswith("http://10.0.0.1/")
+
+
+@pytest.mark.unit
+def test_redacted_source_label_removes_credentials_and_secret_queries() -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    label = llamacpp_acquisition_service.redacted_source_label(
+        "https://user:pass@example.com/models/model.gguf?token=secret&download=1"
+    )
+
+    assert "user" not in label
+    assert "pass" not in label
+    assert "secret" not in label
+    assert "token=" not in label
+    assert "download=1" in label
+
+
+@pytest.mark.unit
+def test_resolve_download_destination_uses_allowlisted_models_dir_and_blocks_traversal(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    payload = LlamaCppAssetDownloadRequest(url="https://example.com/releases/model.gguf")
+
+    destination = llamacpp_acquisition_service.resolve_download_destination(payload, _saved_config(models_dir))
+
+    assert destination == models_dir / "model.gguf"
+
+    traversal = LlamaCppAssetDownloadRequest(url="https://example.com/releases/model.gguf", filename="../model.gguf")
+    with pytest.raises(ServerError, match="filename"):
+        llamacpp_acquisition_service.resolve_download_destination(traversal, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+def test_resolve_download_destination_rejects_delimiters_and_outside_allowed_paths(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    outside_dir = tmp_path / "outside"
+    models_dir.mkdir()
+    outside_dir.mkdir()
+
+    bad_name = LlamaCppAssetDownloadRequest(url="https://example.com/model.gguf", filename="bad,name.gguf")
+    with pytest.raises(ServerError, match="delimiter"):
+        llamacpp_acquisition_service.resolve_download_destination(bad_name, _saved_config(models_dir))
+
+    outside = LlamaCppAssetDownloadRequest(
+        url="https://example.com/model.gguf",
+        destination_dir=str(outside_dir),
+        filename="model.gguf",
+    )
+    with pytest.raises(ServerError, match="allowed"):
+        llamacpp_acquisition_service.resolve_download_destination(outside, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+def test_partial_path_and_completed_download_validation(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    final_path.write_bytes(b"model-bytes")
+    digest = hashlib.sha256(b"model-bytes").hexdigest()
+
+    partial = llamacpp_acquisition_service.partial_download_path(final_path, "job-123")
+    assert partial.parent == final_path.parent
+    assert partial.name.endswith(".job-123.partial")
+
+    warnings = llamacpp_acquisition_service.validate_completed_download(final_path, digest, len(b"model-bytes"))
+    assert warnings == []
+
+    with pytest.raises(ServerError, match="checksum"):
+        llamacpp_acquisition_service.validate_completed_download(final_path, "0" * 64, len(b"model-bytes"))
+
+
+@pytest.mark.unit
+def test_register_completed_download_delegates_to_inventory_registration(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    registered: list[Path] = []
+    model_path = tmp_path / "models" / "model.gguf"
+    model_path.parent.mkdir()
+    model_path.write_text("model")
+
+    def fake_register_asset_path(path: Path) -> dict[str, object]:
+        registered.append(path)
+        return {
+            "asset_id": "gguf:registered",
+            "kind": "gguf",
+            "identity_basis": "resolved_path",
+            "path": str(path),
+            "resolved_path": str(path),
+            "display_name": "model",
+            "source": "registered_path",
+            "metadata": {},
+            "capabilities": ["unknown"],
+            "mmproj_asset_ids": [],
+            "base_model_asset_ids": [],
+            "warnings": [],
+        }
+
+    monkeypatch.setattr(
+        llamacpp_acquisition_service.llamacpp_inventory_service,
+        "register_asset_path",
+        fake_register_asset_path,
+    )
+
+    asset = llamacpp_acquisition_service.register_completed_download(model_path)
+
+    assert asset.asset_id == "gguf:registered"
+    assert registered == [model_path]

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
@@ -72,6 +72,65 @@ def test_validate_download_request_allows_private_network_when_explicitly_enable
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:pass@example.com/releases/model.gguf",
+        "https://example.com/releases/model.gguf?token=secret&download=1",
+    ],
+)
+def test_validate_download_request_rejects_credentialed_or_secret_urls(tmp_path: Path, url: str) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    payload = LlamaCppAssetDownloadRequest(url=url, filename="model.gguf")
+
+    with pytest.raises(ServerError, match="credentials|secret"):
+        llamacpp_acquisition_service.validate_download_request(payload, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+def test_validate_download_request_fails_closed_when_dns_cannot_be_verified(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    payload = LlamaCppAssetDownloadRequest(url="https://unresolved.example/model.gguf")
+    monkeypatch.setattr(
+        llamacpp_acquisition_service.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("dns unavailable")),
+    )
+
+    with pytest.raises(ServerError, match="resolve|verify"):
+        llamacpp_acquisition_service.validate_download_request(payload, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+def test_validate_download_request_rejects_malformed_port(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import LlamaCppAssetDownloadRequest
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    payload = LlamaCppAssetDownloadRequest(url="https://example.com:bad/model.gguf", filename="model.gguf")
+    monkeypatch.setattr(
+        llamacpp_acquisition_service.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, ("93.184.216.34", 0))],
+    )
+
+    with pytest.raises(ServerError, match="invalid"):
+        llamacpp_acquisition_service.validate_download_request(payload, _saved_config(models_dir))
+
+
+@pytest.mark.unit
 def test_redacted_source_label_removes_credentials_and_secret_queries() -> None:
     from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
 


### PR DESCRIPTION
## Summary
- Add safe llama.cpp asset download request schemas, validation helpers, and sanitized Jobs payload mapping.
- Add admin-only create/list/status/cancel endpoints for llama.cpp acquisition jobs.
- Add focused service/API/AuthNZ coverage and Backlog task TASK-416.2.

## Verification
- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -q --tb=short
- git diff --check
- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/llamacpp_admin_schemas.py tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_jobs.py tldw_Server_API/app/api/v1/endpoints/llamacpp.py tldw_Server_API/app/core/Jobs/manager.py -f json -o /tmp/bandit_llamacpp_acquisition_job_api.json

## Change summary
Human-authored summary required before merge.