### PR TITLE
Add llama.cpp acquisition download worker

### DIFF
--- a/backlog/tasks/task-416.3 - Implement-llama.cpp-acquisition-download-worker.md
+++ b/backlog/tasks/task-416.3 - Implement-llama.cpp-acquisition-download-worker.md
@@ -3,8 +3,8 @@ id: TASK-416.3
 title: Implement llama.cpp acquisition download worker
 status: Done
 assignee: []
-created_date: ''
-updated_date: 2026-05-17 22:22
+created_date: '2026-05-17T22:22:00Z'
+updated_date: 2026-05-18 03:22
 labels:
 - llamacpp
 - backend
@@ -44,7 +44,7 @@ Implement Task 3 from the llama.cpp model acquisition/import workflow plan: add 
 
 <!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Verification: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -q --tb=short (82 passed, 5 warnings); source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -v (21 passed, 5 warnings); source .venv/bin/activate && python -m bandit -r touched service paths -f json -o /tmp/bandit_llamacpp_acquisition_worker.json (0 findings); git diff --check (clean). Docs skip: Task 3 is worker/startup code only; docs are Task 5.
+Verification: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -q --tb=short (85 passed, 5 warnings); source .venv/bin/activate && python -m ruff check tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py tldw_Server_API/app/services/startup_content_jobs_pollers.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py (passed); source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py tldw_Server_API/app/services/startup_content_jobs_pollers.py -f json -o /tmp/bandit_llamacpp_acquisition_worker.json (0 findings); git diff --check (clean). Docs skip: Task 3 is worker/startup code only; docs are Task 5.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
 

--- a/backlog/tasks/task-416.3 - Implement-llama.cpp-acquisition-download-worker.md
+++ b/backlog/tasks/task-416.3 - Implement-llama.cpp-acquisition-download-worker.md
@@ -1,0 +1,65 @@
+---
+id: TASK-416.3
+title: Implement llama.cpp acquisition download worker
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-17 22:22
+labels:
+- llamacpp
+- backend
+- local-llm
+- jobs
+dependencies: []
+documentation:
+- Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+parent_task_id: TASK-416
+priority: high
+modified_files:
+- backlog/tasks/task-416.3 - Implement-llama.cpp-acquisition-download-worker.md
+- tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+- tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py
+- tldw_Server_API/app/services/startup_content_jobs_pollers.py
+- tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py
+- tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/1833
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 3 from the llama.cpp model acquisition/import workflow plan: add the Jobs-backed download worker, startup wiring, progress/cancel/cleanup behavior, and focused worker/startup tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Worker streams downloads to partial files, validates size/checksum, promotes atomically, and registers assets only after validation.
+- [x] #2 Worker handles cancellation and validation failures by cleaning partial files and avoiding asset registration.
+- [x] #3 Startup content jobs pollers can start/register the worker behind LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED with label llamacpp-acquisition.
+- [x] #4 Focused worker/startup tests cover the Task 3 behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -q --tb=short (82 passed, 5 warnings); source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -v (21 passed, 5 warnings); source .venv/bin/activate && python -m bandit -r touched service paths -f json -o /tmp/bandit_llamacpp_acquisition_worker.json (0 findings); git diff --check (clean). Docs skip: Task 3 is worker/startup code only; docs are Task 5.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the llama.cpp acquisition download worker and wired it into content jobs startup. Covered successful download/register flow, checksum cleanup, cancellation cleanup, overwrite conflict handling, progress metadata, credential-safe errors, and worker inventory startup registration.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import inspect
 import ipaddress
 import os
 import re
 import socket
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -20,11 +21,10 @@ from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppAsset,
     LlamaCppAssetDownloadRequest,
 )
+from tldw_Server_API.app.core.config import load_comprehensive_config
 from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
 from tldw_Server_API.app.core.Setup import setup_manager
-from tldw_Server_API.app.core.config import load_comprehensive_config
-
 
 _DOWNLOAD_SCHEMES = {"http", "https"}
 _FILENAME_DELIMITERS = {",", os.pathsep}
@@ -237,7 +237,7 @@ async def download_to_partial(
                     bytes_written += len(chunk)
                     if byte_limit is not None and bytes_written > byte_limit:
                         raise ServerError("Downloaded file exceeded the configured maximum size.")
-                    handle.write(chunk)
+                    await asyncio.to_thread(handle.write, chunk)
                     await _emit_progress(
                         progress_callback,
                         bytes_downloaded=bytes_written,
@@ -323,6 +323,8 @@ def _validate_source_url(url: str, saved_config: dict[str, Any], warnings: list[
 
 
 def _validate_payload_source_url(url: str, saved_config: dict[str, Any]) -> str:
+    """Validate a queued download URL without DNS lookups and return its sanitized form."""
+
     raw_url = str(url or "").strip()
     if not raw_url:
         raise ServerError("Download URL is required.")
@@ -635,7 +637,7 @@ class _HttpxDownloadStream:
         self._response: httpx.Response | None = None
         self.total_bytes: int | None = None
 
-    async def __aenter__(self) -> "_HttpxDownloadStream":
+    async def __aenter__(self) -> _HttpxDownloadStream:
         self._client = httpx.AsyncClient(timeout=self._timeout_seconds, follow_redirects=True)
         self._response_cm = self._client.stream("GET", self._url)
         self._response = await self._response_cm.__aenter__()
@@ -650,7 +652,7 @@ class _HttpxDownloadStream:
             await self._client.aclose()
         return False
 
-    async def aiter_bytes(self):
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
         if self._response is None:
             raise LlamaCppDownloadError("Download stream was not opened.")
         async for chunk in self._response.aiter_bytes():
@@ -681,7 +683,7 @@ def _cancel_requested(cancel_check: CancelCheck | None) -> bool:
         return False
     try:
         return bool(cancel_check())
-    except Exception:
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
         return False
 
 

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import ipaddress
 import os
 import re
 import socket
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import SplitResult, parse_qsl, unquote, urlencode, urlsplit, urlunsplit
+
+import httpx
 
 from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppAsset,
@@ -41,6 +45,20 @@ _SECRET_QUERY_KEYS = {
     "x-amz-signature",
 }
 _SAFE_JOB_ID_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+_DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 60.0
+_DEFAULT_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024 * 1024
+
+ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
+CancelCheck = Callable[[], bool]
+DownloadStreamFactory = Callable[..., Any]
+
+
+class LlamaCppDownloadCancelled(Exception):
+    """Raised when a llama.cpp acquisition download observes cancellation."""
+
+
+class LlamaCppDownloadError(ServerError):
+    """Retryable download transport failure for llama.cpp acquisition jobs."""
 
 
 @dataclass(frozen=True)
@@ -61,7 +79,7 @@ def validate_download_request(
     payload: LlamaCppAssetDownloadRequest,
     saved_config: dict[str, Any] | None = None,
 ) -> LlamaCppValidatedDownload:
-    """Validate a remote asset download request without performing network I/O."""
+    """Validate a remote asset download request before queueing a download job."""
     config = saved_config if saved_config is not None else _read_saved_config()
     warnings: list[str] = []
     source_url = _validate_source_url(payload.url, config, warnings)
@@ -77,6 +95,36 @@ def validate_download_request(
         expected_size_bytes=payload.expected_size_bytes,
         overwrite=payload.overwrite,
         register_asset=payload.register_asset,
+        warnings=warnings,
+    )
+
+
+def validate_download_payload(
+    payload: dict[str, Any],
+    saved_config: dict[str, Any] | None = None,
+) -> LlamaCppValidatedDownload:
+    """Validate a stored acquisition job payload before the worker downloads it."""
+    if not isinstance(payload, dict):
+        raise ServerError("Invalid llama.cpp acquisition job payload.")
+    config = saved_config if saved_config is not None else _read_saved_config()
+    warnings = _string_list(payload.get("warnings"))
+    source_url = _validate_payload_source_url(str(payload.get("source_url") or ""), config)
+    destination_raw = str(payload.get("destination_path") or "").strip()
+    if not destination_raw:
+        raise ServerError("Download destination path is required.")
+    destination_path = Path(destination_raw).expanduser().resolve()
+    _validate_download_destination_path(destination_path, config)
+    expected_size_bytes = _positive_int_or_none(payload.get("expected_size_bytes"))
+    return LlamaCppValidatedDownload(
+        source_url=source_url,
+        source_label=_sanitize_freeform_label(
+            str(payload.get("source_label") or redacted_source_label(source_url))
+        ),
+        destination_path=destination_path,
+        expected_sha256=_normalize_sha256(_optional_str(payload.get("expected_sha256"))),
+        expected_size_bytes=expected_size_bytes,
+        overwrite=bool(payload.get("overwrite")),
+        register_asset=bool(payload.get("register_asset", True)),
         warnings=warnings,
     )
 
@@ -154,6 +202,78 @@ def register_completed_download(path: Path) -> LlamaCppAsset:
     return LlamaCppAsset.model_validate(llamacpp_inventory_service.register_asset_path(path))
 
 
+async def download_to_partial(
+    validated: LlamaCppValidatedDownload,
+    partial_path: Path,
+    *,
+    progress_callback: ProgressCallback | None = None,
+    cancel_check: CancelCheck | None = None,
+    timeout_seconds: float | None = None,
+    max_bytes: int | None = None,
+    stream_factory: DownloadStreamFactory | None = None,
+) -> int:
+    """Stream a remote asset into a partial file with progress and size bounds."""
+    partial_path.parent.mkdir(parents=True, exist_ok=True)
+    cleanup_partial_if_needed(partial_path)
+    timeout = _coerce_positive_float(timeout_seconds, _download_timeout_seconds())
+    byte_limit = _download_byte_limit(validated.expected_size_bytes, max_bytes=max_bytes)
+    bytes_written = 0
+    total_bytes: int | None = None
+
+    try:
+        stream = await _open_download_stream(
+            validated.source_url,
+            timeout_seconds=timeout,
+            stream_factory=stream_factory,
+        )
+        async with stream:
+            total_bytes = _stream_total_bytes(stream) or validated.expected_size_bytes
+            with partial_path.open("wb") as handle:
+                async for chunk in stream.aiter_bytes():
+                    if _cancel_requested(cancel_check):
+                        raise LlamaCppDownloadCancelled()
+                    if not chunk:
+                        continue
+                    bytes_written += len(chunk)
+                    if byte_limit is not None and bytes_written > byte_limit:
+                        raise ServerError("Downloaded file exceeded the configured maximum size.")
+                    handle.write(chunk)
+                    await _emit_progress(
+                        progress_callback,
+                        bytes_downloaded=bytes_written,
+                        total_bytes=total_bytes,
+                    )
+        if _cancel_requested(cancel_check):
+            raise LlamaCppDownloadCancelled()
+        return bytes_written
+    except LlamaCppDownloadCancelled:
+        raise
+    except ServerError:
+        raise
+    except (httpx.HTTPError, OSError, TimeoutError) as exc:
+        raise LlamaCppDownloadError("Download failed while reading remote asset.") from exc
+
+
+def promote_partial_download(partial_path: Path, final_path: Path, *, overwrite: bool = False) -> Path:
+    """Atomically move a validated partial file into its final destination path."""
+    if not partial_path.exists():
+        raise ServerError("Partial download file does not exist.")
+    if final_path.exists() and not overwrite:
+        raise ServerError("Destination file already exists; set overwrite=true to replace it.")
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    partial_path.replace(final_path)
+    return final_path
+
+
+def cleanup_partial_if_needed(partial_path: Path) -> None:
+    """Remove a leftover partial download file if it exists."""
+    try:
+        if partial_path.exists():
+            partial_path.unlink()
+    except OSError:
+        return
+
+
 def _read_saved_config() -> dict[str, Any]:
     parser = load_comprehensive_config()
     section = parser["LlamaCpp"] if parser and parser.has_section("LlamaCpp") else None
@@ -199,6 +319,34 @@ def _validate_source_url(url: str, saved_config: dict[str, Any], warnings: list[
     if _is_local_hostname(host) and not allow_private:
         raise ServerError("Download URL host resolves to a local or private network address.")
     _validate_host_addresses(host, allow_private=allow_private, warnings=warnings)
+    return _normalized_source_url(parsed, port=port)
+
+
+def _validate_payload_source_url(url: str, saved_config: dict[str, Any]) -> str:
+    raw_url = str(url or "").strip()
+    if not raw_url:
+        raise ServerError("Download URL is required.")
+    try:
+        parsed = urlsplit(raw_url)
+        port = parsed.port
+    except ValueError as exc:
+        raise ServerError("Download URL is invalid.") from exc
+    scheme = parsed.scheme.lower()
+    if scheme not in _DOWNLOAD_SCHEMES:
+        raise ServerError("Download URL scheme must be http or https.")
+    if not parsed.hostname:
+        raise ServerError("Download URL host is required.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ServerError("Download URL credentials are not supported.")
+    if any(_is_secret_query_key(key) for key, _val in parse_qsl(parsed.query, keep_blank_values=True)):
+        raise ServerError("Download URL contains unsupported sensitive query parameters.")
+    allow_private = bool(_config_bool(saved_config.get("allow_private_downloads")))
+    host = parsed.hostname.strip().lower()
+    if _is_local_hostname(host) and not allow_private:
+        raise ServerError("Download URL host resolves to a local or private network address.")
+    literal = _ip_address_or_none(host)
+    if literal is not None:
+        _reject_private_address(literal, allow_private=allow_private)
     return _normalized_source_url(parsed, port=port)
 
 
@@ -314,6 +462,21 @@ def _validate_destination_dir(destination_dir: Path, saved_config: dict[str, Any
         raise ServerError("Download destination directory is outside allowed llama.cpp paths.")
 
 
+def _validate_download_destination_path(destination: Path, saved_config: dict[str, Any]) -> None:
+    if not destination.name:
+        raise ServerError("Download destination path is required.")
+    if not destination.name.lower().endswith(".gguf"):
+        raise ServerError("Download destination filename must end with .gguf.")
+    _validate_path_value(destination, "Download destination")
+    if not destination.parent.exists():
+        raise ServerError("Download destination directory does not exist.")
+    if not destination.parent.is_dir():
+        raise ServerError("Download destination parent is not a directory.")
+    allowed_bases = _allowed_bases(saved_config)
+    if not allowed_bases or not handler_utils.is_path_allowed(destination, allowed_bases):
+        raise ServerError("Download destination is outside allowed llama.cpp paths.")
+
+
 def _validate_path_value(path: Path, label: str) -> None:
     text = str(path)
     try:
@@ -339,6 +502,31 @@ def _normalize_sha256(value: str | None) -> str | None:
     if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
         raise ServerError("expected_sha256 must be a 64-character hexadecimal sha256 digest.")
     return normalized
+
+
+def _positive_int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ServerError("expected_size_bytes must be a positive integer.") from None
+    if parsed <= 0:
+        raise ServerError("expected_size_bytes must be a positive integer.")
+    return parsed
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
 
 
 def _sha256_file(path: Path) -> str:
@@ -385,3 +573,136 @@ def _config_bool(value: Any) -> bool:
     if value is None:
         return False
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _download_timeout_seconds() -> float:
+    return _coerce_positive_float(
+        os.getenv("LLAMACPP_ACQUISITION_DOWNLOAD_TIMEOUT_SECONDS"),
+        _DEFAULT_DOWNLOAD_TIMEOUT_SECONDS,
+    )
+
+
+def _download_byte_limit(expected_size_bytes: int | None, *, max_bytes: int | None = None) -> int | None:
+    configured = max_bytes
+    if configured is None:
+        configured = _positive_int_env("LLAMACPP_ACQUISITION_MAX_DOWNLOAD_BYTES")
+    if configured is None:
+        configured = _DEFAULT_MAX_DOWNLOAD_BYTES
+    if expected_size_bytes is not None:
+        return min(int(configured), int(expected_size_bytes))
+    return int(configured) if configured else None
+
+
+def _positive_int_env(name: str) -> int | None:
+    value = os.getenv(name)
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _coerce_positive_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    return parsed if parsed > 0 else float(default)
+
+
+async def _open_download_stream(
+    url: str,
+    *,
+    timeout_seconds: float,
+    stream_factory: DownloadStreamFactory | None,
+) -> Any:
+    if stream_factory is not None:
+        stream = stream_factory(url, timeout_seconds=timeout_seconds)
+        if inspect.isawaitable(stream):
+            stream = await stream
+        return stream
+    return _HttpxDownloadStream(url, timeout_seconds=timeout_seconds)
+
+
+class _HttpxDownloadStream:
+    def __init__(self, url: str, *, timeout_seconds: float) -> None:
+        self._url = url
+        self._timeout_seconds = timeout_seconds
+        self._client: httpx.AsyncClient | None = None
+        self._response_cm: Any | None = None
+        self._response: httpx.Response | None = None
+        self.total_bytes: int | None = None
+
+    async def __aenter__(self) -> "_HttpxDownloadStream":
+        self._client = httpx.AsyncClient(timeout=self._timeout_seconds, follow_redirects=True)
+        self._response_cm = self._client.stream("GET", self._url)
+        self._response = await self._response_cm.__aenter__()
+        self._response.raise_for_status()
+        self.total_bytes = _content_length(self._response.headers.get("content-length"))
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        if self._response_cm is not None:
+            await self._response_cm.__aexit__(exc_type, exc, tb)
+        if self._client is not None:
+            await self._client.aclose()
+        return False
+
+    async def aiter_bytes(self):
+        if self._response is None:
+            raise LlamaCppDownloadError("Download stream was not opened.")
+        async for chunk in self._response.aiter_bytes():
+            yield chunk
+
+
+def _content_length(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _stream_total_bytes(stream: Any) -> int | None:
+    value = getattr(stream, "total_bytes", None)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _cancel_requested(cancel_check: CancelCheck | None) -> bool:
+    if cancel_check is None:
+        return False
+    try:
+        return bool(cancel_check())
+    except Exception:
+        return False
+
+
+async def _emit_progress(
+    progress_callback: ProgressCallback | None,
+    *,
+    bytes_downloaded: int,
+    total_bytes: int | None,
+) -> None:
+    if progress_callback is None:
+        return
+    progress_percent = None
+    if total_bytes:
+        progress_percent = min(95.0, max(0.0, (bytes_downloaded / total_bytes) * 95.0))
+    result = progress_callback(
+        {
+            "bytes_downloaded": bytes_downloaded,
+            "total_bytes": total_bytes,
+            "progress_percent": progress_percent,
+            "progress_message": "downloading",
+        }
+    )
+    if inspect.isawaitable(result):
+        await result

--- a/tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py
+++ b/tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py
@@ -1,0 +1,343 @@
+"""Jobs worker for safe llama.cpp asset acquisition downloads."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
+from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
+from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
+from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service as acquisition_service
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+from tldw_Server_API.app.core.Local_LLM.llamacpp_acquisition_jobs import (
+    LLAMACPP_ACQUISITION_DOMAIN,
+    LLAMACPP_ACQUISITION_QUEUE,
+    LLAMACPP_DOWNLOAD_JOB_TYPE,
+)
+
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b((?:bearer|token|api[_-]?key|password|secret|signature)\s*[:=]\s*)[^\s,;]+"
+)
+_URL_USERINFO_RE = re.compile(r"(?i)(https?://)[^/@\s]+@")
+
+
+@dataclass
+class _ProgressState:
+    """Mutable progress snapshot reported back to the Jobs worker SDK."""
+
+    percent: float | None = None
+    message: str | None = None
+    bytes_downloaded: int = 0
+    total_bytes: int | None = None
+
+
+class LlamaCppAcquisitionJobError(RuntimeError):
+    """Normalized worker error with retry metadata for llama.cpp acquisition."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retryable: bool = False,
+        backoff_seconds: int | None = None,
+        failure_code: str = "llamacpp_acquisition_failed",
+    ) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+        self.failure_code = failure_code
+        if backoff_seconds is not None:
+            self.backoff_seconds = backoff_seconds
+
+
+def _build_worker_config(*, worker_id: str, queue: str) -> WorkerConfig:
+    """Build the worker SDK configuration for llama.cpp acquisition jobs."""
+
+    return WorkerConfig(
+        domain=LLAMACPP_ACQUISITION_DOMAIN,
+        queue=queue,
+        worker_id=worker_id,
+        lease_seconds=_coerce_int(os.getenv("LLAMACPP_ACQUISITION_JOBS_LEASE_SECONDS"), 120),
+        renew_jitter_seconds=_coerce_int(
+            os.getenv("LLAMACPP_ACQUISITION_JOBS_RENEW_JITTER_SECONDS"),
+            5,
+        ),
+        renew_threshold_seconds=_coerce_int(
+            os.getenv("LLAMACPP_ACQUISITION_JOBS_RENEW_THRESHOLD_SECONDS"),
+            15,
+        ),
+        backoff_base_seconds=_coerce_int(
+            os.getenv("LLAMACPP_ACQUISITION_JOBS_BACKOFF_BASE_SECONDS"),
+            2,
+        ),
+        backoff_max_seconds=_coerce_int(
+            os.getenv("LLAMACPP_ACQUISITION_JOBS_BACKOFF_MAX_SECONDS"),
+            30,
+        ),
+        retry_on_exception=True,
+        retry_backoff_seconds=_coerce_int(
+            os.getenv("LLAMACPP_ACQUISITION_JOBS_RETRY_BACKOFF_SECONDS"),
+            10,
+        ),
+    )
+
+
+def _resolve_queue_name() -> str:
+    """Return the configured acquisition queue name."""
+
+    return (os.getenv("LLAMACPP_ACQUISITION_JOBS_QUEUE") or LLAMACPP_ACQUISITION_QUEUE).strip() or (
+        LLAMACPP_ACQUISITION_QUEUE
+    )
+
+
+def _normalize_payload(value: Any) -> dict[str, Any]:
+    """Normalize stored job payloads into a dictionary."""
+
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _should_cancel(job_manager: Any, job_id: int, cancel_check: acquisition_service.CancelCheck | None) -> bool:
+    """Return whether the current job has been cancelled."""
+
+    if cancel_check is not None:
+        try:
+            if bool(cancel_check()):
+                return True
+        except Exception:
+            return False
+    try:
+        current = job_manager.get_job(int(job_id)) or {}
+    except Exception:
+        return False
+    return str(current.get("status") or "").lower() == "cancelled"
+
+
+def _finalize_cancelled(job_manager: Any, job_id: int, *, reason: str) -> None:
+    with contextlib.suppress(Exception):
+        job_manager.finalize_cancelled(int(job_id), reason=reason)
+
+
+def _safe_error_message(value: Any) -> str:
+    """Redact URL credentials and secret-looking assignments from worker errors."""
+
+    text = str(value or "llama.cpp acquisition job failed")
+    text = _URL_USERINFO_RE.sub(r"\1", text)
+    text = _SECRET_ASSIGNMENT_RE.sub(r"\1[redacted]", text)
+    return " ".join(text.split())[:1000]
+
+
+async def process_llamacpp_acquisition_job(
+    job: dict[str, Any],
+    *,
+    job_manager: JobManager,
+    worker_id: str = "llamacpp-acquisition-worker",
+    progress: _ProgressState | None = None,
+    stream_factory: acquisition_service.DownloadStreamFactory | None = None,
+    cancel_check: acquisition_service.CancelCheck | None = None,
+) -> dict[str, Any]:
+    """Download, validate, promote, and optionally register one llama.cpp asset job."""
+
+    del worker_id
+    try:
+        job_id = int(job.get("id"))
+    except (TypeError, ValueError) as exc:
+        raise LlamaCppAcquisitionJobError("invalid job id", retryable=False) from exc
+    if str(job.get("job_type") or "").lower() != LLAMACPP_DOWNLOAD_JOB_TYPE:
+        raise LlamaCppAcquisitionJobError("unsupported job_type", retryable=False)
+
+    payload = _normalize_payload(job.get("payload"))
+    partial_path = None
+    try:
+        validated = acquisition_service.validate_download_payload(payload)
+        final_path = validated.destination_path
+        if final_path.exists() and not validated.overwrite:
+            raise ServerError("Destination file already exists; set overwrite=true to replace it.")
+        partial_path = acquisition_service.partial_download_path(final_path, str(job_id))
+
+        if _should_cancel(job_manager, job_id, cancel_check):
+            acquisition_service.cleanup_partial_if_needed(partial_path)
+            _finalize_cancelled(job_manager, job_id, reason="cancel requested before download")
+            return {}
+
+        if progress is not None:
+            progress.percent = 0.0
+            progress.message = "queued"
+
+        async def _progress_callback(update: dict[str, Any]) -> None:
+            if progress is not None:
+                progress.bytes_downloaded = int(update.get("bytes_downloaded") or 0)
+                total = update.get("total_bytes")
+                progress.total_bytes = int(total) if total is not None else None
+                percent = update.get("progress_percent")
+                progress.percent = float(percent) if percent is not None else progress.percent
+                progress.message = str(update.get("progress_message") or "downloading")
+            job_manager.update_job_progress(
+                job_id,
+                progress_percent=(progress.percent if progress is not None else update.get("progress_percent")),
+                progress_message=str(update.get("progress_message") or "downloading"),
+            )
+
+        bytes_written = await acquisition_service.download_to_partial(
+            validated,
+            partial_path,
+            progress_callback=_progress_callback,
+            cancel_check=lambda: _should_cancel(job_manager, job_id, cancel_check),
+            stream_factory=stream_factory,
+        )
+
+        if _should_cancel(job_manager, job_id, cancel_check):
+            acquisition_service.cleanup_partial_if_needed(partial_path)
+            _finalize_cancelled(job_manager, job_id, reason="cancel requested during download")
+            return {}
+
+        warnings = list(validated.warnings)
+        warnings.extend(
+            acquisition_service.validate_completed_download(
+                partial_path,
+                validated.expected_sha256,
+                validated.expected_size_bytes,
+            )
+        )
+        final_path = acquisition_service.promote_partial_download(
+            partial_path,
+            final_path,
+            overwrite=validated.overwrite,
+        )
+        partial_path = None
+
+        asset_id = None
+        if validated.register_asset:
+            asset = acquisition_service.register_completed_download(final_path)
+            asset_id = _asset_value(asset, "asset_id")
+            warnings.extend(_asset_warnings(asset))
+
+        if progress is not None:
+            progress.percent = 100.0
+            progress.message = "completed"
+            progress.bytes_downloaded = bytes_written
+            progress.total_bytes = progress.total_bytes or validated.expected_size_bytes
+        job_manager.update_job_progress(
+            job_id,
+            progress_percent=100.0,
+            progress_message="completed",
+        )
+        result_progress: dict[str, Any] = {
+            "bytes_downloaded": bytes_written,
+            "progress_percent": 100.0,
+            "progress_message": "completed",
+        }
+        total_bytes = progress.total_bytes if progress is not None else validated.expected_size_bytes
+        if total_bytes is not None:
+            result_progress["total_bytes"] = total_bytes
+        return {
+            "status": "ready",
+            "asset_id": asset_id,
+            "destination_path": str(final_path),
+            "bytes": bytes_written,
+            "warnings": warnings,
+            "progress": result_progress,
+        }
+    except acquisition_service.LlamaCppDownloadCancelled:
+        if partial_path is not None:
+            acquisition_service.cleanup_partial_if_needed(partial_path)
+        _finalize_cancelled(job_manager, job_id, reason="cancel requested during download")
+        return {}
+    except acquisition_service.LlamaCppDownloadError as exc:
+        if partial_path is not None:
+            acquisition_service.cleanup_partial_if_needed(partial_path)
+        raise LlamaCppAcquisitionJobError(
+            _safe_error_message(exc),
+            retryable=True,
+            failure_code="download_failed",
+        ) from exc
+    except ServerError as exc:
+        if partial_path is not None:
+            acquisition_service.cleanup_partial_if_needed(partial_path)
+        raise LlamaCppAcquisitionJobError(
+            _safe_error_message(exc),
+            retryable=False,
+            failure_code="validation_failed",
+        ) from exc
+
+
+def _asset_value(asset: Any, key: str) -> str | None:
+    if isinstance(asset, dict):
+        value = asset.get(key)
+    else:
+        value = getattr(asset, key, None)
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+def _asset_warnings(asset: Any) -> list[str]:
+    if isinstance(asset, dict):
+        value = asset.get("warnings")
+    else:
+        value = getattr(asset, "warnings", None)
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+async def run_llamacpp_acquisition_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
+    """Run the long-lived llama.cpp acquisition download worker until stopped."""
+
+    queue_name = _resolve_queue_name()
+    worker_id = (
+        os.getenv("LLAMACPP_ACQUISITION_JOBS_WORKER_ID")
+        or f"llamacpp-acquisition-worker-{os.getpid()}"
+    ).strip()
+    jm = _jobs_manager()
+    sdk = WorkerSDK(jm, _build_worker_config(worker_id=worker_id, queue=queue_name))
+    progress = _ProgressState()
+
+    async def _handler(job: dict[str, Any]) -> dict[str, Any]:
+        return await process_llamacpp_acquisition_job(
+            job,
+            job_manager=jm,
+            worker_id=worker_id,
+            progress=progress,
+        )
+
+    async def _cancel_check(job: dict[str, Any]) -> bool:
+        try:
+            return _should_cancel(jm, int(job.get("id")), None)
+        except (TypeError, ValueError):
+            return False
+
+    def _progress_cb() -> dict[str, Any]:
+        update: dict[str, Any] = {}
+        if progress.percent is not None:
+            update["progress_percent"] = progress.percent
+        if progress.message is not None:
+            update["progress_message"] = progress.message
+        return update
+
+    async def _watch_stop() -> None:
+        if stop_event is None:
+            return
+        await stop_event.wait()
+        sdk.stop()
+
+    logger.info("Starting llama.cpp Acquisition Jobs worker (queue={})", queue_name)
+    watcher = asyncio.create_task(_watch_stop())
+    try:
+        await sdk.run(handler=_handler, cancel_check=_cancel_check, progress_cb=_progress_cb)
+    finally:
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(run_llamacpp_acquisition_jobs_worker())

--- a/tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py
+++ b/tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import os
 import re
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -16,17 +17,28 @@ from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
 from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
 from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service as acquisition_service
-from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
 from tldw_Server_API.app.core.Local_LLM.llamacpp_acquisition_jobs import (
     LLAMACPP_ACQUISITION_DOMAIN,
     LLAMACPP_ACQUISITION_QUEUE,
     LLAMACPP_DOWNLOAD_JOB_TYPE,
 )
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
 
 _SECRET_ASSIGNMENT_RE = re.compile(
     r"(?i)\b((?:bearer|token|api[_-]?key|password|secret|signature)\s*[:=]\s*)[^\s,;]+"
 )
 _URL_USERINFO_RE = re.compile(r"(?i)(https?://)[^/@\s]+@")
+_CANCEL_CHECK_EXCEPTIONS = (
+    AttributeError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+_PROGRESS_DB_UPDATE_INTERVAL_SECONDS = 1.0
+_PROGRESS_DB_UPDATE_PERCENT_DELTA = 1.0
+_PROGRESS_DB_UPDATE_BYTES_DELTA = 5 * 1024 * 1024
+_CANCELLATION_DB_POLL_INTERVAL_SECONDS = 1.0
 
 
 @dataclass
@@ -37,6 +49,77 @@ class _ProgressState:
     message: str | None = None
     bytes_downloaded: int = 0
     total_bytes: int | None = None
+
+
+@dataclass
+class _ProgressUpdateThrottle:
+    """Rate-limit persisted progress updates while keeping in-memory progress fresh."""
+
+    interval_seconds: float = _PROGRESS_DB_UPDATE_INTERVAL_SECONDS
+    percent_delta: float = _PROGRESS_DB_UPDATE_PERCENT_DELTA
+    bytes_delta: int = _PROGRESS_DB_UPDATE_BYTES_DELTA
+    _last_updated_at: float | None = None
+    _last_percent: float | None = None
+    _last_bytes: int = 0
+    _last_message: str | None = None
+
+    def should_update(self, *, bytes_downloaded: int, percent: float | None, message: str) -> bool:
+        """Return whether a progress row should be persisted for this update."""
+
+        now = time.monotonic()
+        if self._last_updated_at is None:
+            self._record(now=now, bytes_downloaded=bytes_downloaded, percent=percent, message=message)
+            return True
+        if message != self._last_message:
+            self._record(now=now, bytes_downloaded=bytes_downloaded, percent=percent, message=message)
+            return True
+        if percent is not None and self._last_percent is not None:
+            if abs(percent - self._last_percent) >= self.percent_delta:
+                self._record(now=now, bytes_downloaded=bytes_downloaded, percent=percent, message=message)
+                return True
+        if bytes_downloaded - self._last_bytes >= self.bytes_delta:
+            self._record(now=now, bytes_downloaded=bytes_downloaded, percent=percent, message=message)
+            return True
+        if now - self._last_updated_at >= self.interval_seconds:
+            self._record(now=now, bytes_downloaded=bytes_downloaded, percent=percent, message=message)
+            return True
+        return False
+
+    def _record(self, *, now: float, bytes_downloaded: int, percent: float | None, message: str) -> None:
+        self._last_updated_at = now
+        self._last_percent = percent
+        self._last_bytes = bytes_downloaded
+        self._last_message = message
+
+
+@dataclass
+class _CancellationPoller:
+    """Poll injected cancellation each chunk and Jobs status at a bounded rate."""
+
+    job_manager: Any
+    job_id: int
+    cancel_check: acquisition_service.CancelCheck | None
+    interval_seconds: float = _CANCELLATION_DB_POLL_INTERVAL_SECONDS
+    _last_status_poll_at: float | None = None
+
+    def __call__(self) -> bool:
+        if self._cancel_check_requested():
+            return True
+        now = time.monotonic()
+        if self._last_status_poll_at is not None and now - self._last_status_poll_at < self.interval_seconds:
+            return False
+        self._last_status_poll_at = now
+        return _job_status_cancelled(self.job_manager, self.job_id)
+
+    def _cancel_check_requested(self) -> bool:
+        if self.cancel_check is None:
+            return False
+        try:
+            return bool(self.cancel_check())
+        except _CANCEL_CHECK_EXCEPTIONS as exc:
+            logger.debug(f"llama.cpp acquisition cancel_check failed for job {self.job_id}: {exc}")
+            self._last_status_poll_at = time.monotonic()
+            return _job_status_cancelled(self.job_manager, self.job_id)
 
 
 class LlamaCppAcquisitionJobError(RuntimeError):
@@ -110,11 +193,16 @@ def _should_cancel(job_manager: Any, job_id: int, cancel_check: acquisition_serv
         try:
             if bool(cancel_check()):
                 return True
-        except Exception:
-            return False
+        except _CANCEL_CHECK_EXCEPTIONS as exc:
+            logger.debug(f"llama.cpp acquisition cancel_check failed for job {job_id}: {exc}")
+    return _job_status_cancelled(job_manager, job_id)
+
+
+def _job_status_cancelled(job_manager: Any, job_id: int) -> bool:
     try:
         current = job_manager.get_job(int(job_id)) or {}
-    except Exception:
+    except _CANCEL_CHECK_EXCEPTIONS as exc:
+        logger.debug(f"llama.cpp acquisition Jobs status check failed for job {job_id}: {exc}")
         return False
     return str(current.get("status") or "").lower() == "cancelled"
 
@@ -170,25 +258,38 @@ async def process_llamacpp_acquisition_job(
             progress.percent = 0.0
             progress.message = "queued"
 
+        progress_throttle = _ProgressUpdateThrottle()
+
         async def _progress_callback(update: dict[str, Any]) -> None:
+            bytes_downloaded = int(update.get("bytes_downloaded") or 0)
+            percent_value = update.get("progress_percent")
+            percent = float(percent_value) if percent_value is not None else None
+            message = str(update.get("progress_message") or "downloading")
             if progress is not None:
-                progress.bytes_downloaded = int(update.get("bytes_downloaded") or 0)
+                progress.bytes_downloaded = bytes_downloaded
                 total = update.get("total_bytes")
                 progress.total_bytes = int(total) if total is not None else None
-                percent = update.get("progress_percent")
-                progress.percent = float(percent) if percent is not None else progress.percent
-                progress.message = str(update.get("progress_message") or "downloading")
+                progress.percent = percent if percent is not None else progress.percent
+                progress.message = message
+            persisted_percent = progress.percent if progress is not None else percent
+            if not progress_throttle.should_update(
+                bytes_downloaded=bytes_downloaded,
+                percent=persisted_percent,
+                message=message,
+            ):
+                return
             job_manager.update_job_progress(
                 job_id,
-                progress_percent=(progress.percent if progress is not None else update.get("progress_percent")),
-                progress_message=str(update.get("progress_message") or "downloading"),
+                progress_percent=persisted_percent,
+                progress_message=message,
             )
 
+        cancellation_poller = _CancellationPoller(job_manager, job_id, cancel_check)
         bytes_written = await acquisition_service.download_to_partial(
             validated,
             partial_path,
             progress_callback=_progress_callback,
-            cancel_check=lambda: _should_cancel(job_manager, job_id, cancel_check),
+            cancel_check=cancellation_poller,
             stream_factory=stream_factory,
         )
 

--- a/tldw_Server_API/app/services/startup_content_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_content_jobs_pollers.py
@@ -457,6 +457,7 @@ async def _start_llamacpp_acquisition_jobs_worker(
 ) -> tuple[Any | None, Any | None]:
     """Start the llama.cpp acquisition jobs poller and return its shutdown handles."""
 
+    task = None
     try:
         enabled = should_start_worker(
             "LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED",
@@ -490,6 +491,7 @@ async def _start_llamacpp_acquisition_jobs_worker(
         )
         return stop_event, task
     except _STARTUP_GUARD_EXCEPTIONS as exc:
+        _safe_cancel_task(task)
         logger.warning(f"Failed to start llama.cpp Acquisition Jobs worker: {exc}")
         return None, None
 

--- a/tldw_Server_API/app/services/startup_content_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_content_jobs_pollers.py
@@ -37,6 +37,8 @@ class ContentJobsPollerHandles:
     media_ingest_heavy_jobs_task: Any | None = None
     reading_digest_jobs_stop_event: Any | None = None
     reading_digest_jobs_task: Any | None = None
+    llamacpp_acquisition_jobs_stop_event: Any | None = None
+    llamacpp_acquisition_jobs_task: Any | None = None
     vn_asset_jobs_stop_event: Any | None = None
     vn_asset_jobs_task: Any | None = None
     vn_asset_generation_jobs_stop_event: Any | None = None
@@ -97,6 +99,15 @@ async def start_content_jobs_pollers(
         should_start_worker=should_start_worker,
         worker_inventory=worker_inventory,
     )
+    llamacpp_acquisition_jobs_stop_event, llamacpp_acquisition_jobs_task = (
+        await _start_llamacpp_acquisition_jobs_worker(
+            app=app,
+            owned_job_pollers=owned_job_pollers,
+            register_owned_job_poller=register_owned_job_poller,
+            should_start_worker=should_start_worker,
+            worker_inventory=worker_inventory,
+        )
+    )
     (
         vn_asset_jobs_stop_event,
         vn_asset_jobs_task,
@@ -131,6 +142,8 @@ async def start_content_jobs_pollers(
         media_ingest_heavy_jobs_task=media_ingest_heavy_jobs_task,
         reading_digest_jobs_stop_event=reading_digest_jobs_stop_event,
         reading_digest_jobs_task=reading_digest_jobs_task,
+        llamacpp_acquisition_jobs_stop_event=llamacpp_acquisition_jobs_stop_event,
+        llamacpp_acquisition_jobs_task=llamacpp_acquisition_jobs_task,
         vn_asset_jobs_stop_event=vn_asset_jobs_stop_event,
         vn_asset_jobs_task=vn_asset_jobs_task,
         vn_asset_generation_jobs_stop_event=vn_asset_generation_jobs_stop_event,
@@ -434,6 +447,53 @@ async def _start_reading_digest_jobs_worker(
         return None, None
 
 
+async def _start_llamacpp_acquisition_jobs_worker(
+    *,
+    app: Any,
+    owned_job_pollers: list[Any],
+    register_owned_job_poller: Callable[..., None],
+    should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
+) -> tuple[Any | None, Any | None]:
+    """Start the llama.cpp acquisition jobs poller and return its shutdown handles."""
+
+    try:
+        enabled = should_start_worker(
+            "LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED",
+            "llamacpp-acquisition",
+        )
+        if not enabled:
+            logger.info(
+                "llama.cpp Acquisition Jobs worker disabled by flag "
+                "(LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED)"
+            )
+            return None, None
+
+        if worker_inventory is not None:
+            stop_event, task = await _register_jobs_worker_with_inventory(
+                worker_inventory,
+                name="llamacpp_acquisition_jobs_task",
+                coroutine_factory=_run_llamacpp_acquisition_jobs_worker_service,
+            )
+            logger.info("llama.cpp Acquisition Jobs worker started with explicit stop_event signal")
+            return stop_event, task
+
+        stop_event = _make_event()
+        task = _create_task(_run_llamacpp_acquisition_jobs_worker_service(stop_event))
+        logger.info("llama.cpp Acquisition Jobs worker started with explicit stop_event signal")
+        register_owned_job_poller(
+            app,
+            owned_job_pollers,
+            name="llamacpp_acquisition_jobs_task",
+            task=task,
+            stop_event=stop_event,
+        )
+        return stop_event, task
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.warning(f"Failed to start llama.cpp Acquisition Jobs worker: {exc}")
+        return None, None
+
+
 async def _start_vn_asset_jobs_workers(
     *,
     app: Any,
@@ -622,6 +682,14 @@ def _run_reading_digest_jobs_worker_service(stop_event: Any) -> Any:
     )
 
     return _run_reading_digest_jobs_worker(stop_event)
+
+
+def _run_llamacpp_acquisition_jobs_worker_service(stop_event: Any) -> Any:
+    from tldw_Server_API.app.services.llamacpp_acquisition_jobs_worker import (
+        run_llamacpp_acquisition_jobs_worker as _run_llamacpp_acquisition_jobs_worker,
+    )
+
+    return _run_llamacpp_acquisition_jobs_worker(stop_event)
 
 
 def _run_vn_asset_jobs_worker_service(stop_event: Any) -> Any:

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Local_LLM.llamacpp_acquisition_jobs import (
+    LLAMACPP_DOWNLOAD_JOB_TYPE,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeDownloadStream:
+    def __init__(self, chunks: list[bytes], *, total_bytes: int | None = None) -> None:
+        self._chunks = chunks
+        self.total_bytes = total_bytes
+
+    async def __aenter__(self) -> "_FakeDownloadStream":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _RecordingJobManager:
+    def __init__(self, *, status: str = "processing") -> None:
+        self.status = status
+        self.progress_updates: list[dict[str, Any]] = []
+        self.cancelled: list[dict[str, Any]] = []
+
+    def update_job_progress(
+        self,
+        job_id: int,
+        *,
+        progress_percent: float | None = None,
+        progress_message: str | None = None,
+    ) -> bool:
+        self.progress_updates.append(
+            {
+                "job_id": job_id,
+                "progress_percent": progress_percent,
+                "progress_message": progress_message,
+            }
+        )
+        return True
+
+    def get_job(self, job_id: int) -> dict[str, Any]:
+        return {"id": job_id, "status": self.status}
+
+    def finalize_cancelled(self, job_id: int, *, reason: str | None = None) -> bool:
+        self.cancelled.append({"job_id": job_id, "reason": reason})
+        self.status = "cancelled"
+        return True
+
+
+def _job_for(final_path: Path, *, payload_overrides: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "operation": "download",
+        "source_url": "https://example.com/releases/model.gguf",
+        "source_label": "Example model",
+        "destination_path": str(final_path),
+        "expected_sha256": None,
+        "expected_size_bytes": None,
+        "overwrite": False,
+        "register_asset": True,
+        "warnings": ["dns warning"],
+    }
+    if payload_overrides:
+        payload.update(payload_overrides)
+    return {
+        "id": 41,
+        "job_type": LLAMACPP_DOWNLOAD_JOB_TYPE,
+        "payload": payload,
+        "status": "processing",
+    }
+
+
+def _asset_payload(path: Path) -> dict[str, object]:
+    return {
+        "asset_id": "gguf:registered",
+        "kind": "gguf",
+        "identity_basis": "resolved_path",
+        "path": str(path),
+        "resolved_path": str(path),
+        "display_name": path.name,
+        "source": "registered_path",
+        "metadata": {},
+        "capabilities": ["unknown"],
+        "mmproj_asset_ids": [],
+        "base_model_asset_ids": [],
+        "warnings": [],
+    }
+
+
+def _allow_destination(monkeypatch: pytest.MonkeyPatch, worker: Any, models_dir: Path) -> None:
+    monkeypatch.setattr(
+        worker.acquisition_service,
+        "_read_saved_config",
+        lambda: {"models_dir": str(models_dir), "allowed_paths": []},
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_downloads_validates_promotes_registers_and_reports_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services import llamacpp_acquisition_jobs_worker as worker
+
+    content = b"llama-bytes"
+    digest = hashlib.sha256(content).hexdigest()
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    _allow_destination(monkeypatch, worker, final_path.parent)
+    registered: list[Path] = []
+
+    def _register(path: Path):
+        registered.append(path)
+        return _asset_payload(path)
+
+    monkeypatch.setattr(worker.acquisition_service, "register_completed_download", _register)
+
+    def _stream_factory(url: str, *, timeout_seconds: float):
+        assert url == "https://example.com/releases/model.gguf"
+        assert timeout_seconds > 0
+        return _FakeDownloadStream([content[:5], content[5:]], total_bytes=len(content))
+
+    job_manager = _RecordingJobManager()
+    progress = worker._ProgressState()
+
+    result = await worker.process_llamacpp_acquisition_job(
+        _job_for(
+            final_path,
+            payload_overrides={
+                "expected_sha256": digest,
+                "expected_size_bytes": len(content),
+            },
+        ),
+        job_manager=job_manager,
+        progress=progress,
+        stream_factory=_stream_factory,
+    )
+
+    assert final_path.read_bytes() == content
+    assert list(final_path.parent.glob("*.partial")) == []
+    assert registered == [final_path]
+    assert result["status"] == "ready"
+    assert result["asset_id"] == "gguf:registered"
+    assert result["bytes"] == len(content)
+    assert result["warnings"] == ["dns warning"]
+    assert result["progress"]["bytes_downloaded"] == len(content)
+    assert result["progress"]["total_bytes"] == len(content)
+    assert "source_url" not in result
+    assert progress.bytes_downloaded == len(content)
+    assert progress.total_bytes == len(content)
+    assert any(update["progress_message"] == "downloading" for update in job_manager.progress_updates)
+
+
+@pytest.mark.asyncio
+async def test_worker_checksum_mismatch_removes_partial_and_final_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services import llamacpp_acquisition_jobs_worker as worker
+
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    _allow_destination(monkeypatch, worker, final_path.parent)
+    registered: list[Path] = []
+    monkeypatch.setattr(
+        worker.acquisition_service,
+        "register_completed_download",
+        lambda path: registered.append(path) or _asset_payload(path),
+    )
+
+    def _stream_factory(_url: str, *, timeout_seconds: float):
+        del timeout_seconds
+        return _FakeDownloadStream([b"wrong-bytes"], total_bytes=len(b"wrong-bytes"))
+
+    with pytest.raises(worker.LlamaCppAcquisitionJobError) as exc_info:
+        await worker.process_llamacpp_acquisition_job(
+            _job_for(final_path, payload_overrides={"expected_sha256": "0" * 64}),
+            job_manager=_RecordingJobManager(),
+            progress=worker._ProgressState(),
+            stream_factory=_stream_factory,
+        )
+
+    assert exc_info.value.retryable is False
+    assert "checksum" in str(exc_info.value).lower()
+    assert not final_path.exists()
+    assert list(final_path.parent.glob("*.partial")) == []
+    assert registered == []
+
+
+@pytest.mark.asyncio
+async def test_worker_cancellation_deletes_partial_and_skips_registration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services import llamacpp_acquisition_jobs_worker as worker
+
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    _allow_destination(monkeypatch, worker, final_path.parent)
+    registered: list[Path] = []
+    monkeypatch.setattr(
+        worker.acquisition_service,
+        "register_completed_download",
+        lambda path: registered.append(path) or _asset_payload(path),
+    )
+
+    def _stream_factory(_url: str, *, timeout_seconds: float):
+        del timeout_seconds
+        return _FakeDownloadStream([b"first", b"second"], total_bytes=len(b"firstsecond"))
+
+    calls = 0
+
+    def _cancel_check() -> bool:
+        nonlocal calls
+        calls += 1
+        return calls > 1
+
+    job_manager = _RecordingJobManager()
+    result = await worker.process_llamacpp_acquisition_job(
+        _job_for(final_path),
+        job_manager=job_manager,
+        progress=worker._ProgressState(),
+        stream_factory=_stream_factory,
+        cancel_check=_cancel_check,
+    )
+
+    assert result == {}
+    assert not final_path.exists()
+    assert list(final_path.parent.glob("*.partial")) == []
+    assert registered == []
+    assert job_manager.cancelled == [{"job_id": 41, "reason": "cancel requested during download"}]
+
+
+@pytest.mark.asyncio
+async def test_worker_existing_destination_without_overwrite_fails_terminally(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services import llamacpp_acquisition_jobs_worker as worker
+
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    _allow_destination(monkeypatch, worker, final_path.parent)
+    final_path.write_bytes(b"existing")
+
+    def _stream_factory(_url: str, *, timeout_seconds: float):
+        del timeout_seconds
+        raise AssertionError("download should not start when destination exists")
+
+    with pytest.raises(worker.LlamaCppAcquisitionJobError) as exc_info:
+        await worker.process_llamacpp_acquisition_job(
+            _job_for(final_path),
+            job_manager=_RecordingJobManager(),
+            progress=worker._ProgressState(),
+            stream_factory=_stream_factory,
+        )
+
+    assert exc_info.value.retryable is False
+    assert "already exists" in str(exc_info.value).lower()
+    assert final_path.read_bytes() == b"existing"
+    assert list(final_path.parent.glob("*.partial")) == []
+
+
+@pytest.mark.asyncio
+async def test_worker_errors_never_echo_source_url_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services import llamacpp_acquisition_jobs_worker as worker
+
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    _allow_destination(monkeypatch, worker, final_path.parent)
+
+    with pytest.raises(worker.LlamaCppAcquisitionJobError) as exc_info:
+        await worker.process_llamacpp_acquisition_job(
+            _job_for(
+                final_path,
+                payload_overrides={
+                    "source_url": "https://user:pass@example.com/releases/model.gguf?token=secret",
+                    "source_label": "bad source",
+                },
+            ),
+            job_manager=_RecordingJobManager(),
+            progress=worker._ProgressState(),
+            stream_factory=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("download should not start")
+            ),
+        )
+
+    message = str(exc_info.value)
+    assert "user" not in message
+    assert "pass" not in message
+    assert "secret" not in message
+    assert "token=secret" not in message
+    assert not final_path.exists()
+    assert list(final_path.parent.glob("*.partial")) == []

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py
@@ -18,7 +18,7 @@ class _FakeDownloadStream:
         self._chunks = chunks
         self.total_bytes = total_bytes
 
-    async def __aenter__(self) -> "_FakeDownloadStream":
+    async def __aenter__(self) -> _FakeDownloadStream:
         return self
 
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
@@ -241,6 +241,73 @@ async def test_worker_cancellation_deletes_partial_and_skips_registration(
     assert list(final_path.parent.glob("*.partial")) == []
     assert registered == []
     assert job_manager.cancelled == [{"job_id": 41, "reason": "cancel requested during download"}]
+
+
+@pytest.mark.asyncio
+async def test_worker_cancel_check_error_falls_back_to_jobs_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services import llamacpp_acquisition_jobs_worker as worker
+
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    _allow_destination(monkeypatch, worker, final_path.parent)
+
+    def _stream_factory(_url: str, *, timeout_seconds: float):
+        del timeout_seconds
+        raise AssertionError("download should not start when Jobs status is cancelled")
+
+    def _cancel_check() -> bool:
+        raise RuntimeError("transient cancel callback failure")
+
+    job_manager = _RecordingJobManager(status="cancelled")
+    result = await worker.process_llamacpp_acquisition_job(
+        _job_for(final_path),
+        job_manager=job_manager,
+        progress=worker._ProgressState(),
+        stream_factory=_stream_factory,
+        cancel_check=_cancel_check,
+    )
+
+    assert result == {}
+    assert not final_path.exists()
+    assert list(final_path.parent.glob("*.partial")) == []
+    assert job_manager.cancelled == [{"job_id": 41, "reason": "cancel requested before download"}]
+
+
+@pytest.mark.asyncio
+async def test_worker_throttles_small_chunk_progress_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services import llamacpp_acquisition_jobs_worker as worker
+
+    final_path = tmp_path / "models" / "model.gguf"
+    final_path.parent.mkdir()
+    _allow_destination(monkeypatch, worker, final_path.parent)
+    chunks = [b"x"] * 20
+
+    def _stream_factory(_url: str, *, timeout_seconds: float):
+        del timeout_seconds
+        return _FakeDownloadStream(chunks, total_bytes=1_000_000_000)
+
+    job_manager = _RecordingJobManager()
+    progress = worker._ProgressState()
+    result = await worker.process_llamacpp_acquisition_job(
+        _job_for(final_path, payload_overrides={"register_asset": False}),
+        job_manager=job_manager,
+        progress=progress,
+        stream_factory=_stream_factory,
+    )
+
+    downloading_updates = [
+        update for update in job_manager.progress_updates if update["progress_message"] == "downloading"
+    ]
+    assert len(downloading_updates) == 1
+    assert job_manager.progress_updates[-1]["progress_message"] == "completed"
+    assert progress.bytes_downloaded == len(chunks)
+    assert result["bytes"] == len(chunks)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
@@ -46,6 +46,11 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
         calls.append("reading-digest")
         return ("reading-stop", "reading-task")
 
+    async def _record_llamacpp_acquisition(**kwargs):
+        del kwargs
+        calls.append("llamacpp-acquisition")
+        return ("llamacpp-stop", "llamacpp-task")
+
     async def _record_vn_asset(**kwargs: object) -> tuple[str, str, str, str]:
         """Record that the VN asset worker starter ran."""
 
@@ -63,6 +68,11 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
     monkeypatch.setattr(startup_pollers, "_start_presentation_render_jobs_worker", _record_presentation)
     monkeypatch.setattr(startup_pollers, "_start_media_ingest_jobs_workers", _record_media_ingest)
     monkeypatch.setattr(startup_pollers, "_start_reading_digest_jobs_worker", _record_reading_digest)
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_llamacpp_acquisition_jobs_worker",
+        _record_llamacpp_acquisition,
+    )
     monkeypatch.setattr(startup_pollers, "_start_vn_asset_jobs_workers", _record_vn_asset)
     monkeypatch.setattr(startup_pollers, "_start_companion_reflection_jobs_worker", _record_companion)
 
@@ -79,6 +89,7 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
         "presentation",
         "media-ingest",
         "reading-digest",
+        "llamacpp-acquisition",
         "vn-asset",
         "companion",
     ]
@@ -94,6 +105,8 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
     assert handles.media_ingest_heavy_jobs_task == "media-heavy-task"
     assert handles.reading_digest_jobs_stop_event == "reading-stop"
     assert handles.reading_digest_jobs_task == "reading-task"
+    assert handles.llamacpp_acquisition_jobs_stop_event == "llamacpp-stop"
+    assert handles.llamacpp_acquisition_jobs_task == "llamacpp-task"
     assert handles.vn_asset_jobs_stop_event == "vn-asset-stop"
     assert handles.vn_asset_jobs_task == "vn-asset-task"
     assert handles.vn_asset_generation_jobs_stop_event == "vn-generation-stop"
@@ -148,6 +161,11 @@ async def test_start_content_jobs_pollers_passes_inventory_to_workers(
     )
     monkeypatch.setattr(
         startup_pollers,
+        "_start_llamacpp_acquisition_jobs_worker",
+        _record_worker("llamacpp-acquisition", ("llamacpp-stop", "llamacpp-task")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
         "_start_vn_asset_jobs_workers",
         _record_worker("vn-asset", ("vn-asset-stop", "vn-asset-task", "vn-generation-stop", "vn-generation-task")),
     )
@@ -174,6 +192,7 @@ async def test_start_content_jobs_pollers_passes_inventory_to_workers(
         "presentation": worker_inventory,
         "media-ingest": worker_inventory,
         "reading-digest": worker_inventory,
+        "llamacpp-acquisition": worker_inventory,
         "vn-asset": worker_inventory,
         "companion": worker_inventory,
     }
@@ -215,6 +234,13 @@ async def test_start_content_jobs_pollers_passes_inventory_to_workers(
             "reading",
             "reading_digest_jobs_task",
             "_run_reading_digest_jobs_worker_service",
+        ),
+        (
+            "_start_llamacpp_acquisition_jobs_worker",
+            "LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED",
+            "llamacpp-acquisition",
+            "llamacpp_acquisition_jobs_task",
+            "_run_llamacpp_acquisition_jobs_worker_service",
         ),
         (
             "_start_companion_reflection_jobs_worker",
@@ -467,6 +493,65 @@ async def test_start_audio_jobs_worker_registers_owned_poller_when_enabled(
             "name": "audio_jobs_task",
             "task": "audio-task",
             "stop_event": "audio-stop",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_llamacpp_acquisition_jobs_worker_registers_owned_poller_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_content_jobs_pollers()
+    captured_stop_events: list[object] = []
+    created_coroutines: list[object] = []
+    registrations: list[dict[str, object]] = []
+
+    monkeypatch.setattr(startup_pollers, "_make_event", lambda: "llamacpp-stop")
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: created_coroutines.append(coro) or "llamacpp-task",
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_run_llamacpp_acquisition_jobs_worker_service",
+        lambda stop_event: captured_stop_events.append(stop_event) or "llamacpp-coro",
+    )
+
+    def _register_owned_job_poller(app, owned_job_pollers, *, name, task, stop_event):
+        registrations.append(
+            {
+                "app": app,
+                "owned_job_pollers": owned_job_pollers,
+                "name": name,
+                "task": task,
+                "stop_event": stop_event,
+            }
+        )
+
+    owned_job_pollers: list[object] = []
+    stop_event, task = await startup_pollers._start_llamacpp_acquisition_jobs_worker(
+        app="app",
+        owned_job_pollers=owned_job_pollers,
+        register_owned_job_poller=_register_owned_job_poller,
+        should_start_worker=lambda flag, route, **kwargs: (flag, route, kwargs) == (
+            "LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED",
+            "llamacpp-acquisition",
+            {},
+        ),
+    )
+
+    assert stop_event == "llamacpp-stop"
+    assert task == "llamacpp-task"
+    assert captured_stop_events == ["llamacpp-stop"]
+    assert created_coroutines == ["llamacpp-coro"]
+    assert registrations == [
+        {
+            "app": "app",
+            "owned_job_pollers": owned_job_pollers,
+            "name": "llamacpp_acquisition_jobs_task",
+            "task": "llamacpp-task",
+            "stop_event": "llamacpp-stop",
         }
     ]
 

--- a/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
@@ -557,6 +557,54 @@ async def test_start_llamacpp_acquisition_jobs_worker_registers_owned_poller_whe
 
 
 @pytest.mark.asyncio
+async def test_start_llamacpp_acquisition_jobs_worker_cancels_task_when_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_content_jobs_pollers()
+    created_coroutines: list[object] = []
+
+    class _FakeTask:
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    task = _FakeTask()
+    monkeypatch.setattr(startup_pollers, "_make_event", lambda: "llamacpp-stop")
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: created_coroutines.append(coro) or task,
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_run_llamacpp_acquisition_jobs_worker_service",
+        lambda stop_event: f"llamacpp-coro:{stop_event}",
+    )
+
+    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise RuntimeError("registration failed")
+
+    stop_event, returned_task = await startup_pollers._start_llamacpp_acquisition_jobs_worker(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        should_start_worker=lambda flag, route, **kwargs: (flag, route, kwargs) == (
+            "LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED",
+            "llamacpp-acquisition",
+            {},
+        ),
+    )
+
+    assert stop_event is None
+    assert returned_task is None
+    assert created_coroutines == ["llamacpp-coro:llamacpp-stop"]
+    assert task.cancelled is True
+
+
+@pytest.mark.asyncio
 async def test_start_vn_asset_jobs_workers_use_stable_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- What changed:
  - Added a Jobs-backed llama.cpp acquisition download worker.
  - Added bounded httpx streaming to `.partial` files, cancellation cleanup, checksum/size validation, atomic promotion, optional asset registration, and progress metadata.
  - Wired the worker into content jobs startup behind `LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED` with the `llamacpp-acquisition` label.
  - Added focused worker and startup tests plus Backlog task tracking.
- Why:
  - Implements Task 3 of the llama.cpp acquisition/import workflow plan so queued download jobs can be processed safely before the Admin WebUI surface is added.

## Change Summary (human-owned, required before merge)

TODO: Human requester to summarize what changed and why these implementation choices are appropriate.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [ ] Docs updated (if behavior, routes, or config changed)

Commands:

- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -q --tb=short`
  - `82 passed, 5 warnings`
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py -v`
  - `21 passed, 5 warnings`
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py tldw_Server_API/app/services/llamacpp_acquisition_jobs_worker.py tldw_Server_API/app/services/startup_content_jobs_pollers.py -f json -o /tmp/bandit_llamacpp_acquisition_worker.json`
  - `0 findings`
- `git diff --check`
  - clean

Docs note: this PR is Task 3 worker/startup code. Workflow docs are planned for Task 5.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [ ] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [ ] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [ ] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [ ] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [ ] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

## Risk & Rollback

- Risk level: Medium
- Rollback plan: revert this PR to remove the worker startup hook and download worker; queued acquisition job API rows remain inert without the worker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Jobs-backed llama.cpp acquisition download worker that streams .gguf model files to `.partial` with bounded `httpx` I/O, validates checksum/size, promotes atomically, reports throttled progress, and optionally registers the asset. Wired into content jobs startup behind LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED with the llamacpp-acquisition label (Backlog TASK-416.3).

- **New Features**
  - Worker: streaming to `.partial`, env-bound timeout/max-bytes, SHA-256/size checks, atomic promotion, overwrite control, throttled progress, optional asset registration.
  - Safety: cleans partials on cancel/failure, finalizes cancelled jobs, falls back to Jobs status when cancel callback fails, and redacts URL credentials/secret-like tokens in errors.
  - Validation: job payload validation, URL/host checks, allowed destination enforcement, and required `.gguf` filename.
  - Startup/Tests: worker registered in content jobs (supports worker inventory); tests cover success, checksum mismatch, cancellation, cancel-fallback behavior, overwrite conflicts, progress throttling, redaction, and startup wiring.

- **Migration**
  - Enable: set LLAMACPP_ACQUISITION_JOBS_WORKER_ENABLED=true.
  - Optional: LLAMACPP_ACQUISITION_JOBS_QUEUE, LLAMACPP_ACQUISITION_DOWNLOAD_TIMEOUT_SECONDS, LLAMACPP_ACQUISITION_MAX_DOWNLOAD_BYTES, plus standard lease/backoff envs.

<sup>Written for commit 36f4d633774328c6aaa3a9178fb3e72fbe4cf2b7. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1833?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

