### PR TITLE
Add media viewer read-along TTS

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
@@ -1,0 +1,1002 @@
+# Media Viewer Read-Along TTS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build selection-initiated read-along TTS in the shared media viewer used by the WebUI and browser extension.
+
+**Architecture:** Add a focused `read-along` module under `apps/packages/ui/src/components/Media/` for pure segmentation, selection mapping, cache keys, playback session state, and compact UI controls. Integrate through `ContentViewer` only after selection mediation is in place so annotations and read-along share one selection-action path. Reuse the existing TTS provider stack and Dexie database, adding only the minimum abort/cache surface needed for read-along.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Testing Library, Dexie, Ant Design primitives already used by `ContentViewer`, lucide-react icons, existing `@tldw/ui` TTS services.
+
+---
+
+## Source Documents
+
+- Design spec: `Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md`
+- Backlog task for this plan: `TASK-416`
+- Original design task: `TASK-415`
+
+## Scope Check
+
+This plan covers one reviewable subsystem: read-along behavior inside the shared `ContentViewer` path. It deliberately excludes backend API work, new TTS providers, persistent server-side audio cache, word-level timing, and a page-level read-aloud player.
+
+## File Structure
+
+Create this directory:
+
+- `apps/packages/ui/src/components/Media/read-along/`
+
+New files:
+
+- `types.ts`
+  - Shared read-along types: segments, scopes, selection state, session state, cache signatures.
+- `media-read-along-segments.ts`
+  - Pure segmentation and scope expansion. No React imports.
+- `media-read-along-cache-key.ts`
+  - Stable content/settings signatures and request-cap subsegment helpers. No Dexie imports.
+- `media-read-along-cache.ts`
+  - Dexie-backed cache reads/writes, quota handling, LRU eviction, cache-disable fallback.
+- `media-read-along-dom.ts`
+  - DOM range helpers, nearest block lookup, segment element lookup, viewport clamping helpers.
+- `useContentSelectionActions.ts`
+  - One mediated selection path for annotation and read-along actions.
+- `useMediaReadAlongSession.ts`
+  - Playback queue, generated-audio lookahead, browser SpeechSynthesis fallback, abort/stale suppression, embedded media pause, retry/skip/stop.
+- `MediaReadAlongPopover.tsx`
+  - Compact selection action popover.
+- `MediaReadAlongTransport.tsx`
+  - Minimal inline playback transport.
+- `__tests__/media-read-along-segments.test.ts`
+- `__tests__/media-read-along-cache-key.test.ts`
+- `__tests__/media-read-along-cache.test.ts`
+- `__tests__/useContentSelectionActions.test.tsx`
+- `__tests__/useMediaReadAlongSession.test.tsx`
+
+Modify existing files:
+
+- `apps/packages/ui/src/components/Media/ContentViewer.tsx`
+  - Replace direct selection capture with mediated selection actions.
+  - Add segment wrappers for plain/transcript paths.
+  - Render read-along popover and transport.
+  - Pass `modals.mediaPlayerRef` to the session hook for embedded preview pause.
+- `apps/packages/ui/src/components/Media/hooks/useContentViewerModals.tsx`
+  - Split annotation selection capture into an explicit action callable from selection mediation.
+  - Preserve manual annotation and existing create/update/delete behavior.
+- `apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx`
+  - Keep large-content windowing intact.
+  - Expose enough rendered plain/transcript structure for segment wrappers without forcing full large-content render.
+- `apps/packages/ui/src/services/tts-provider.ts`
+  - Extend synthesis functions to accept `{ signal?: AbortSignal }`.
+  - Preserve `provider === "browser"` as a supported no-cache SpeechSynthesis path for read-along sessions.
+  - Preserve existing callers by making the options parameter optional.
+- `apps/packages/ui/src/db/dexie/types.ts`
+  - Add `MediaReadAlongAudioCacheEntry`.
+- `apps/packages/ui/src/db/dexie/schema.ts`
+  - Add a new Dexie version and `mediaReadAlongAudioCache` table.
+- Existing tests under `apps/packages/ui/src/components/Media/__tests__/`
+  - Update annotation baseline expectations.
+  - Add read-along component coverage.
+
+Do not create new backend files.
+
+## Task 1: Baseline And Guardrail Tests
+
+**Files:**
+- Read: `apps/packages/ui/src/components/Media/ContentViewer.tsx`
+- Read: `apps/packages/ui/src/components/Media/hooks/useContentViewerModals.tsx`
+- Read: `apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx`
+- Read: `apps/packages/ui/src/services/tts-provider.ts`
+- Read: `apps/packages/ui/src/db/dexie/schema.ts`
+- Read: `apps/packages/ui/src/db/dexie/types.ts`
+
+- [ ] **Step 1: Run current focused baselines**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx \
+  src/services/__tests__/tts.defaults.test.ts \
+  src/db/dexie/__tests__/stt-recordings.test.ts \
+  --maxWorkers=1
+```
+
+Expected: PASS, or document pre-existing failures before editing implementation files.
+
+- [ ] **Step 2: Inspect selection and media preview anchors**
+
+Confirm these anchors still exist:
+
+```bash
+rg -n "handleCaptureAnnotationSelection|contentBodyRef|mediaPlayerRef|embedded-audio-player|embedded-video-player" \
+  apps/packages/ui/src/components/Media
+```
+
+Expected: `ContentViewer.tsx` still binds selection events to `modals.handleCaptureAnnotationSelection`, and embedded media refs still go through `modals.mediaPlayerRef`.
+
+- [ ] **Step 3: Commit nothing**
+
+This is a read-only baseline task. Do not commit.
+
+## Task 2: Segment And Scope Primitives
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Media/read-along/types.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-segments.test.ts`
+
+- [ ] **Step 1: Write failing segmentation tests**
+
+Create `media-read-along-segments.test.ts` with tests covering timestamp lines, prose sentences, section expansion, read-from-here on full content, transient fallback, and long segment splitting.
+
+Use this shape:
+
+```ts
+import { describe, expect, it } from "vitest"
+import {
+  buildReadAlongSegments,
+  resolveReadAlongScope,
+  splitSegmentForTtsRequest
+} from "../media-read-along-segments"
+
+describe("media read-along segmentation", () => {
+  it("segments leading transcript timings as transcript lines", () => {
+    const segments = buildReadAlongSegments({
+      mediaId: "m1",
+      content: "[00:01] First line.\n[00:04] Second line.",
+      displayContent: "First line.\nSecond line.",
+      renderMode: "plain",
+      hideTranscriptTimings: true
+    })
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toMatchObject({
+      kind: "transcript-line",
+      text: "First line.",
+      timestampSeconds: 1
+    })
+    expect(segments[1].sourceStart).toBeGreaterThan(segments[0].sourceEnd)
+  })
+
+  it("resolves read-from-here against canonical full content, not a rendered window", () => {
+    const content = "Alpha one. Beta two. Gamma three. Delta four."
+    const segments = buildReadAlongSegments({
+      mediaId: "m2",
+      content,
+      displayContent: "Alpha one. Beta two.",
+      renderMode: "plain",
+      hideTranscriptTimings: false
+    })
+
+    const queue = resolveReadAlongScope({
+      scope: "from-here",
+      segments,
+      selection: {
+        selectedText: "Beta",
+        mappingConfidence: "nearest",
+        sourceStart: content.indexOf("Beta"),
+        sourceEnd: content.indexOf("Beta") + "Beta".length,
+        anchorRect: new DOMRect()
+      }
+    })
+
+    expect(queue.map((segment) => segment.text)).toEqual([
+      "Beta two.",
+      "Gamma three.",
+      "Delta four."
+    ])
+  })
+
+  it("splits overlong segments without changing the parent segment id", () => {
+    const parts = splitSegmentForTtsRequest(
+      { id: "s1", index: 0, kind: "sentence", text: "word ".repeat(80), sourceStart: 0, sourceEnd: 400 },
+      120
+    )
+
+    expect(parts.length).toBeGreaterThan(1)
+    expect(parts.every((part) => part.parentSegmentId === "s1")).toBe(true)
+    expect(parts.every((part) => part.text.length <= 120)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify red**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/media-read-along-segments.test.ts --maxWorkers=1
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement the pure types**
+
+Create `types.ts` with:
+
+```ts
+export type ReadAlongSegmentKind =
+  | "transcript-line"
+  | "sentence"
+  | "paragraph"
+  | "transient-selection"
+
+export type ReadAlongScope =
+  | "selection"
+  | "from-here"
+  | "current-section"
+  | "full-item"
+
+export interface ReadAlongSegment {
+  id: string
+  index: number
+  kind: ReadAlongSegmentKind
+  text: string
+  sourceStart: number
+  sourceEnd: number
+  displayStart?: number
+  displayEnd?: number
+  sectionId?: string
+  timestampSeconds?: number
+}
+
+export interface ReadAlongSelection {
+  selectedText: string
+  anchorRect: DOMRect
+  startSegmentId?: string
+  endSegmentId?: string
+  sourceStart?: number
+  sourceEnd?: number
+  mappingConfidence: "exact" | "nearest" | "text-only"
+}
+```
+
+- [ ] **Step 4: Implement the minimum segmentation behavior**
+
+Implement `buildReadAlongSegments`, `resolveReadAlongScope`, and `splitSegmentForTtsRequest` in `media-read-along-segments.ts`.
+
+Rules:
+
+- Detect leading transcript timings with the existing utilities from `@/utils/media-transcript-display` when possible.
+- Sentence splitting can use a conservative regex in v1, but must preserve source offsets.
+- Segment IDs must be deterministic from media id, index, kind, and source offsets.
+- Empty segments are ignored.
+- `resolveReadAlongScope("from-here")` and `resolveReadAlongScope("full-item")` must use all canonical segments from `content`, not only displayed text.
+
+- [ ] **Step 5: Run the segment tests green**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/media-read-along-segments.test.ts --maxWorkers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Media/read-along/types.ts \
+  apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts \
+  apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-segments.test.ts
+git commit -m "feat: add media read-along segmentation primitives"
+```
+
+## Task 3: Cache Keys, Dexie Store, And Provider Abort Surface
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts`
+- Modify: `apps/packages/ui/src/db/dexie/types.ts`
+- Modify: `apps/packages/ui/src/db/dexie/schema.ts`
+- Modify: `apps/packages/ui/src/services/tts-provider.ts`
+- Test: `apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts`
+
+- [ ] **Step 1: Write failing cache-key tests**
+
+Test that raw selected text is not stored in key metadata and that settings changes alter the signature:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { buildReadAlongCacheKey, buildTtsSettingsSignature } from "../media-read-along-cache-key"
+
+describe("media read-along cache keys", () => {
+  it("does not include raw segment text in the stable key", async () => {
+    const key = await buildReadAlongCacheKey({
+      serverScope: "http://127.0.0.1:8000",
+      mediaId: "42",
+      mediaKind: "media",
+      segmentId: "s1",
+      segmentText: "private transcript text",
+      sourceStart: 10,
+      sourceEnd: 33,
+      settingsSignature: "provider:tldw|voice:default"
+    })
+
+    expect(key.id).not.toContain("private transcript text")
+    expect(key.textHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it("changes settings signature when voice or speed changes", () => {
+    const a = buildTtsSettingsSignature({ provider: "tldw", model: "kokoro", voice: "af", speed: 1, format: "mp3" })
+    const b = buildTtsSettingsSignature({ provider: "tldw", model: "kokoro", voice: "bf", speed: 1, format: "mp3" })
+    const c = buildTtsSettingsSignature({ provider: "tldw", model: "kokoro", voice: "af", speed: 1.2, format: "mp3" })
+
+    expect(a).not.toEqual(b)
+    expect(a).not.toEqual(c)
+  })
+})
+```
+
+- [ ] **Step 2: Write failing cache store tests**
+
+Mock `@/db/dexie/schema` the same way `src/db/dexie/__tests__/stt-recordings.test.ts` does. Cover save/get, LRU eviction, `QuotaExceededError` retry after eviction, and disabled cache fallback.
+
+- [ ] **Step 3: Write failing provider abort test**
+
+Create `src/services/__tests__/tts-provider.read-along.test.ts`.
+
+Minimum assertion:
+
+```ts
+it("passes abort signals through tldw synthesis", async () => {
+  const signal = new AbortController().signal
+  const context = await resolveTtsProviderContext("hello", { provider: "tldw" })
+
+  await context.synthesize?.("hello", { signal })
+
+  expect(tldwClient.synthesizeSpeech).toHaveBeenCalledWith(
+    "hello",
+    expect.objectContaining({ signal })
+  )
+})
+```
+
+- [ ] **Step 4: Run tests red**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts \
+  src/components/Media/read-along/__tests__/media-read-along-cache.test.ts \
+  src/services/__tests__/tts-provider.read-along.test.ts \
+  --maxWorkers=1
+```
+
+Expected: FAIL because files/signatures do not exist.
+
+- [ ] **Step 5: Add Dexie type and schema**
+
+In `apps/packages/ui/src/db/dexie/types.ts`, add:
+
+```ts
+export type MediaReadAlongAudioCacheEntry = {
+  id: string
+  createdAt: number
+  lastUsedAt: number
+  mediaId: string
+  mediaKind: string
+  segmentId: string
+  settingsSignature: string
+  textHash: string
+  mimeType: string
+  format: string
+  blob: Blob
+  sizeBytes: number
+}
+```
+
+In `schema.ts`:
+
+- import `MediaReadAlongAudioCacheEntry`
+- add `mediaReadAlongAudioCache!: Table<MediaReadAlongAudioCacheEntry>`
+- add version 14 with all existing version 13 stores plus:
+
+```ts
+mediaReadAlongAudioCache:
+  "id, createdAt, lastUsedAt, mediaId, mediaKind, segmentId, settingsSignature, textHash"
+```
+
+- [ ] **Step 6: Implement key/store helpers**
+
+Requirements:
+
+- Use Web Crypto SHA-256 when available, with a deterministic fallback only for tests/non-secure environments.
+- Evict by `lastUsedAt` before writing when approximate total bytes exceed `MEDIA_READ_ALONG_CACHE_MAX_BYTES`.
+- Retry once after `QuotaExceededError`, then disable cache for the current session.
+- Never throw from cache read/write paths used by playback.
+
+- [ ] **Step 7: Extend provider synthesis options**
+
+Change the provider type:
+
+```ts
+export type TtsSynthesizeOptions = {
+  signal?: AbortSignal
+}
+
+export type TtsProviderContext = {
+  provider: string
+  utterance: string
+  playbackSpeed: number
+  supported: boolean
+  synthesize?: (text: string, options?: TtsSynthesizeOptions) => Promise<TtsSynthesisResult>
+  formatInfo?: TtsFormatInfo
+}
+```
+
+For `tldw`, pass `signal` into `tldwClient.synthesizeSpeech`. For OpenAI and ElevenLabs, accept the option but leave behavior unchanged unless those helpers already support abort.
+
+Do not add a fake `synthesize` function for the browser provider. Keep `supported: true` with no `synthesize`; the read-along session hook will use `window.speechSynthesis` directly for browser TTS and skip cache/lookahead for that provider.
+
+- [ ] **Step 8: Run tests green**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts \
+  src/components/Media/read-along/__tests__/media-read-along-cache.test.ts \
+  src/services/__tests__/tts-provider.read-along.test.ts \
+  src/services/__tests__/tts.defaults.test.ts \
+  src/db/dexie/__tests__/stt-recordings.test.ts \
+  --maxWorkers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts \
+  apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts \
+  apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts \
+  apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts \
+  apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts \
+  apps/packages/ui/src/db/dexie/types.ts \
+  apps/packages/ui/src/db/dexie/schema.ts \
+  apps/packages/ui/src/services/tts-provider.ts
+git commit -m "feat: add read-along audio cache primitives"
+```
+
+## Task 4: Mediated Content Selection Actions
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Media/read-along/media-read-along-dom.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx`
+- Modify: `apps/packages/ui/src/components/Media/hooks/useContentViewerModals.tsx`
+- Modify: `apps/packages/ui/src/components/Media/ContentViewer.tsx`
+- Modify: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx`
+
+- [ ] **Step 1: Write failing selection-mediation hook tests**
+
+Test:
+
+- ignores selections outside `contentBodyRef`
+- returns selected text and anchor rect for content selections
+- maps exact `data-read-along-segment-id` ancestors when present
+- falls back to `text-only` when no segment wrapper exists
+
+- [ ] **Step 2: Update annotation component test red**
+
+Change the existing "captures selected content text into annotation draft" expectation:
+
+- selection should open a selection action popover
+- annotation preview should not appear until the user clicks the annotation action
+
+Expected test shape:
+
+```ts
+fireEvent.mouseUp(contentNode)
+
+expect(screen.getByTestId("media-selection-actions-popover")).toBeInTheDocument()
+expect(screen.queryByTestId("media-annotation-selection-preview")).not.toBeInTheDocument()
+
+fireEvent.click(screen.getByTestId("media-selection-action-annotate"))
+
+await waitFor(() => {
+  expect(screen.getByTestId("media-annotation-selection-preview")).toHaveTextContent("Selected body text")
+})
+```
+
+- [ ] **Step 3: Run selection tests red**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx \
+  --maxWorkers=1
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Split annotation selection capture**
+
+In `useContentViewerModals.tsx`, replace the current event-capturing handler with an explicit draft setter:
+
+```ts
+const captureAnnotationSelection = useCallback((selectionText: string, location?: string) => {
+  const selectedText = selectionText.trim()
+  if (!selectedMediaId || isNote || !selectedText) return
+
+  setAnnotationSelectionText(selectedText.slice(0, 4000))
+  setAnnotationSelectionLocation(location || `selection:${Date.now()}`)
+  setActiveIntelligenceTab("annotations")
+  if (collapsedSections.intelligence ?? true) {
+    void setCollapsedSections((prev) => ({ ...prev, intelligence: false }))
+  }
+}, [collapsedSections.intelligence, isNote, selectedMediaId, setCollapsedSections])
+```
+
+Keep `handleCaptureAnnotationSelection` only as a backwards-compatible wrapper if any tests or callers still need it during the transition. New `ContentViewer` wiring should not call it directly from `onMouseUp`/`onKeyUp`.
+
+- [ ] **Step 5: Implement `useContentSelectionActions`**
+
+Responsibilities:
+
+- expose `selectionActionState`
+- expose `handleContentSelectionEvent`
+- expose `clearSelectionActions`
+- expose `applyAnnotationSelection`
+- never auto-open the annotation panel until `applyAnnotationSelection` is called
+
+- [ ] **Step 6: Wire `ContentViewer` to mediated selection**
+
+Replace:
+
+```tsx
+onMouseUp={modals.handleCaptureAnnotationSelection}
+onKeyUp={modals.handleCaptureAnnotationSelection}
+```
+
+with:
+
+```tsx
+onMouseUp={selectionActions.handleContentSelectionEvent}
+onKeyUp={selectionActions.handleContentSelectionEvent}
+```
+
+Render a temporary button/action popover for annotation only in this task. Read-along actions can be added in Task 6.
+
+- [ ] **Step 7: Run tests green**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx \
+  --maxWorkers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Media/read-along/media-read-along-dom.ts \
+  apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts \
+  apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx \
+  apps/packages/ui/src/components/Media/hooks/useContentViewerModals.tsx \
+  apps/packages/ui/src/components/Media/ContentViewer.tsx \
+  apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
+git commit -m "feat: mediate media content selection actions"
+```
+
+## Task 5: Read-Along Session Hook
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts`
+- Create: `apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx`
+- Modify: `apps/packages/ui/src/components/Media/read-along/types.ts`
+
+- [ ] **Step 1: Write failing session tests**
+
+Use `renderHook` from `@testing-library/react`.
+
+Cover:
+
+- `start("selection")` resolves a queue and plays cached audio before generating lookahead
+- `start("from-here")` queues beyond the rendered window
+- lookahead prefetches 3 to 5 segments, not the full item
+- browser TTS provider uses `window.speechSynthesis.speak()` and does not touch generated-audio cache
+- stop aborts current and lookahead `AbortController`s
+- stop cancels browser SpeechSynthesis when browser provider is active
+- media/content change stops and suppresses stale completions
+- settings are captured at session start and do not mutate mid-session
+- `audio.play()` rejection enters `segment-error`
+- starting read-along pauses `embeddedMediaRef.current` if it is playing
+
+- [ ] **Step 2: Run session tests red**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx --maxWorkers=1
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement state types**
+
+Add to `types.ts`:
+
+```ts
+export type ReadAlongSessionStatus =
+  | "idle"
+  | "preparing"
+  | "playing"
+  | "paused"
+  | "segment-error"
+  | "stopped"
+
+export interface ReadAlongSessionState {
+  status: ReadAlongSessionStatus
+  scope: ReadAlongScope | null
+  activeSegmentId: string | null
+  activeIndex: number
+  totalSegments: number
+  error: string | null
+  cacheDisabled: boolean
+}
+```
+
+- [ ] **Step 4: Implement session hook**
+
+Minimum API:
+
+```ts
+export function useMediaReadAlongSession(args: {
+  mediaId: string | null
+  mediaKind: string | null
+  content: string
+  displayContent: string
+  renderMode: string
+  hideTranscriptTimings: boolean
+  selection: ReadAlongSelection | null
+  contentBodyRef: React.RefObject<HTMLElement | null>
+  contentScrollContainerRef: React.RefObject<HTMLElement | null>
+  embeddedMediaRef: React.RefObject<HTMLMediaElement | null>
+}) {
+  return {
+    state,
+    start,
+    pause,
+    resume,
+    stop,
+    retry,
+    skip,
+    activeSegmentId
+  }
+}
+```
+
+Implementation requirements:
+
+- Create one session token per `start`.
+- Create an `AbortController` for current synthesis plus one for lookahead.
+- Before every state mutation from async work, check the current session token.
+- Use `resolveTtsProviderContext` once per session and freeze the settings signature.
+- Do not call `useTTS.speak()` from this hook; it performs separate segment splitting and user-visible clip saving that would break read-along cache semantics.
+- Use cache get before synthesize, and cache write after successful synthesis.
+- If the context is the browser provider with no `synthesize`, play the active segment with `SpeechSynthesisUtterance`, advance on `onend`, and skip cache/lookahead.
+- Revoke object URLs after segment playback.
+- Pause embedded media preview before the first generated audio play.
+
+- [ ] **Step 5: Run session tests green**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx \
+  src/components/Media/read-along/__tests__/media-read-along-segments.test.ts \
+  src/components/Media/read-along/__tests__/media-read-along-cache.test.ts \
+  --maxWorkers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts \
+  apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx \
+  apps/packages/ui/src/components/Media/read-along/types.ts
+git commit -m "feat: add media read-along playback session"
+```
+
+## Task 6: ContentViewer UI Integration
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx`
+- Create: `apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx`
+- Modify: `apps/packages/ui/src/components/Media/ContentViewer.tsx`
+- Modify: `apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx`
+- Test: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx`
+- Test: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx`
+- Test: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx`
+
+- [ ] **Step 1: Write failing UI tests**
+
+Create `ContentViewer.read-along.test.tsx`.
+
+Cover:
+
+- no read-along UI before selection
+- selection popover contains `Read selection`, `Read from here`, `Read current section`, `Read full item`, and `Annotate`
+- clicking `Read selection` starts playback and keeps inline transport visible after selection clears
+- active segment wrapper gets `data-read-along-active="true"`
+- stop clears read-along transient UI
+- embedded audio/video preview is paused when generated playback starts
+- markdown/html fallback starts playback without unsafe HTML mutation
+
+- [ ] **Step 2: Run UI tests red**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.read-along.test.tsx --maxWorkers=1
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement popover**
+
+Use real buttons. Test IDs:
+
+- `media-selection-actions-popover`
+- `media-selection-action-read-selection`
+- `media-selection-action-read-from-here`
+- `media-selection-action-read-current-section`
+- `media-selection-action-read-full-item`
+- `media-selection-action-annotate`
+
+Keep labels short and use `t()` fallbacks. Do not add a page-level button.
+
+- [ ] **Step 4: Implement inline transport**
+
+Use compact icon buttons from lucide-react where available:
+
+- pause/resume
+- stop
+- retry when `segment-error`
+- skip when `segment-error`
+
+Test IDs:
+
+- `media-read-along-transport`
+- `media-read-along-toggle`
+- `media-read-along-stop`
+- `media-read-along-retry`
+- `media-read-along-skip`
+- `media-read-along-progress`
+
+The transport should be anchored near the selection/active segment and clamp to the content viewport. On narrow widths, keep it compact near the active segment; do not add a sticky bottom player.
+
+- [ ] **Step 5: Wrap plain/transcript segments**
+
+For plain and transcript-line rendering, render segment wrappers with:
+
+```tsx
+<span
+  data-read-along-segment-id={segment.id}
+  data-read-along-active={segment.id === readAlong.activeSegmentId ? "true" : undefined}
+  className={segment.id === readAlong.activeSegmentId ? "rounded bg-primary/20 text-text" : undefined}
+>
+  {segment.text}
+</span>
+```
+
+Do not break existing find highlighting. If find highlighting is active, prefer find markup and skip exact read-along wrappers until the query is cleared.
+
+- [ ] **Step 6: Keep large-content rendering lazy**
+
+Use full content for queue construction inside the session hook, but only wrap the visible plain content window in the DOM. Do not force `visiblePlainContentChars = content.length` when `Read full item` starts.
+
+- [ ] **Step 7: Run UI/performance/find tests green**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/__tests__/ContentViewer.read-along.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx \
+  --maxWorkers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx \
+  apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx \
+  apps/packages/ui/src/components/Media/ContentViewer.tsx \
+  apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx \
+  apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx \
+  apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx \
+  apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx
+git commit -m "feat: wire read-along into media content viewer"
+```
+
+## Task 7: Accessibility, Route Parity, And Regression Hardening
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx`
+- Modify or create: `apps/packages/ui/src/routes/__tests__/option-media-route-guards.test.tsx`
+- Modify: `apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts`
+- Optional create: `apps/packages/ui/src/components/Review/__tests__/ViewMediaPage.read-along-parity.test.tsx`
+
+- [ ] **Step 1: Add accessibility tests**
+
+Cover:
+
+- popover actions are buttons with accessible names
+- keyboard selection path can open the selection affordance
+- active segment status uses a polite live region
+- reduced motion disables smooth auto-scroll
+- no essential controls are hover-only
+
+- [ ] **Step 2: Add route/shared import guard**
+
+The feature must stay in `apps/packages/ui`. Add or extend a guard that proves WebUI and extension media routes both use shared `ViewMediaPage`/`ContentViewer`, with no duplicate read-along implementation under `apps/tldw-frontend/extension`.
+
+- [ ] **Step 3: Add bundle/performance guard**
+
+Update the extension entry-shell performance test only if the new read-along modules change the expected static import set. Prefer lazy or local imports if static media entry cost grows unexpectedly.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx \
+  src/routes/__tests__/option-media-route-guards.test.tsx \
+  src/components/Review/__tests__/ViewMediaPage.connection.test.tsx \
+  --maxWorkers=1
+```
+
+Then from repo root:
+
+```bash
+bunx vitest run apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts --maxWorkers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx \
+  apps/packages/ui/src/routes/__tests__/option-media-route-guards.test.tsx \
+  apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts
+git commit -m "test: verify media read-along route parity"
+```
+
+## Task 8: Browser Verification And Final Cleanup
+
+**Files:**
+- Modify only if needed after browser QA:
+  - `apps/packages/ui/src/components/Media/read-along/*`
+  - `apps/packages/ui/src/components/Media/ContentViewer.tsx`
+  - focused tests touched above
+- Modify: `backlog/tasks/task-416 - Plan-media-viewer-read-along-TTS-implementation.md` only to record implementation verification if this plan task is kept as the tracking task.
+
+- [ ] **Step 1: Run the focused unit/component suite**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Media/read-along/__tests__ \
+  src/components/Media/__tests__/ContentViewer.read-along.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx \
+  src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx \
+  src/services/__tests__/tts-provider.read-along.test.ts \
+  src/db/dexie/__tests__/stt-recordings.test.ts \
+  --maxWorkers=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run design-system/openapi guards if touched imports cross those boundaries**
+
+Run:
+
+```bash
+cd apps/packages/ui && bun run verify:design-system-state
+cd apps/packages/ui && bun run verify:openapi
+```
+
+Expected: PASS, or document why a guard is unrelated and skipped.
+
+- [ ] **Step 3: Start the WebUI dev server**
+
+Use the repo's normal dev flow. If a dev server is already running, reuse it. Otherwise run the existing frontend/server command expected for this repo and record the URL.
+
+- [ ] **Step 4: Browser smoke the WebUI media viewer**
+
+Manual/browser checks:
+
+- navigate to the WebUI media viewer
+- select text in a plain/transcript item
+- verify the selection popover appears
+- click `Read selection`
+- verify active segment highlight and inline transport
+- stop playback
+- select text again and click `Annotate`
+- verify annotation draft appears only after annotation action
+
+- [ ] **Step 5: Browser smoke extension-width behavior**
+
+Use a narrow viewport comparable to the extension sidepanel. Confirm:
+
+- popover clamps within viewport
+- transport remains compact
+- text does not overlap controls
+- no sticky bottom player appears
+
+- [ ] **Step 6: Run Bandit only if Python/backend files were touched**
+
+Expected for this implementation: skipped, because the planned implementation is TypeScript UI-only. If Python files were touched despite this plan, run Bandit on the touched Python scope before completion.
+
+- [ ] **Step 7: Final commit for QA fixes**
+
+If browser QA required fixes:
+
+Stage only the focused files changed during QA, then run:
+
+```bash
+git commit -m "fix: harden media read-along browser behavior"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+## Final Verification Checklist
+
+- [ ] `ContentViewer` selection no longer automatically switches to annotations for every selection.
+- [ ] Annotation creation from selected text still works through the mediated selection action.
+- [ ] No read-along UI appears before selection or active playback.
+- [ ] Read-along actions support selection, from-here, current-section, and full-item scopes.
+- [ ] `Read from here` and `Read full item` use canonical full content, not only rendered large-content windows.
+- [ ] Large-content segmentation is lazy and cancellable.
+- [ ] Stop/media/content changes abort in-flight TTS requests and suppress stale cache writes.
+- [ ] Generated audio cache uses Dexie, LRU eviction, quota fallback, and no raw selected text metadata.
+- [ ] Existing TTS settings are reused and frozen per active session.
+- [ ] Browser TTS provider works as a no-cache SpeechSynthesis path.
+- [ ] Embedded media preview pauses when generated read-along playback starts.
+- [ ] Plain/transcript active highlighting works with find highlighting preserved.
+- [ ] Markdown/html use safe nearest-block fallback without mutating sanitized HTML.
+- [ ] WebUI and extension routes share the implementation.
+- [ ] Keyboard and reduced-motion paths are covered.
+
+## Suggested PR/Commit Stack
+
+1. `feat: add media read-along segmentation primitives`
+2. `feat: add read-along audio cache primitives`
+3. `feat: mediate media content selection actions`
+4. `feat: add media read-along playback session`
+5. `feat: wire read-along into media content viewer`
+6. `test: verify media read-along route parity`
+7. Optional browser QA fix commit
+
+## Execution Handoff
+
+Recommended execution mode: Subagent-driven, one fresh worker per task after Task 1 baseline, with parent review between commits. The tasks have mostly disjoint write scopes until `ContentViewer` integration.
+
+Inline execution is also viable if the worktree is kept narrow and each task is committed before the next begins.

--- a/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
@@ -717,6 +717,8 @@ git commit -m "feat: add media read-along playback session"
 
 ## Task 6: ContentViewer UI Integration
 
+**Status:** Complete
+
 **Files:**
 - Create: `apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx`
 - Create: `apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx`
@@ -726,7 +728,7 @@ git commit -m "feat: add media read-along playback session"
 - Test: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx`
 - Test: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx`
 
-- [ ] **Step 1: Write failing UI tests**
+- [x] **Step 1: Write failing UI tests**
 
 Create `ContentViewer.read-along.test.tsx`.
 
@@ -740,7 +742,7 @@ Cover:
 - embedded audio/video preview is paused when generated playback starts
 - markdown/html fallback starts playback without unsafe HTML mutation
 
-- [ ] **Step 2: Run UI tests red**
+- [x] **Step 2: Run UI tests red**
 
 Run:
 
@@ -750,7 +752,7 @@ cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentVie
 
 Expected: FAIL.
 
-- [ ] **Step 3: Implement popover**
+- [x] **Step 3: Implement popover**
 
 Use real buttons. Test IDs:
 
@@ -763,7 +765,7 @@ Use real buttons. Test IDs:
 
 Keep labels short and use `t()` fallbacks. Do not add a page-level button.
 
-- [ ] **Step 4: Implement inline transport**
+- [x] **Step 4: Implement inline transport**
 
 Use compact icon buttons from lucide-react where available:
 
@@ -783,7 +785,7 @@ Test IDs:
 
 The transport should be anchored near the selection/active segment and clamp to the content viewport. On narrow widths, keep it compact near the active segment; do not add a sticky bottom player.
 
-- [ ] **Step 5: Wrap plain/transcript segments**
+- [x] **Step 5: Wrap plain/transcript segments**
 
 For plain and transcript-line rendering, render segment wrappers with:
 
@@ -799,11 +801,11 @@ For plain and transcript-line rendering, render segment wrappers with:
 
 Do not break existing find highlighting. If find highlighting is active, prefer find markup and skip exact read-along wrappers until the query is cleared.
 
-- [ ] **Step 6: Keep large-content rendering lazy**
+- [x] **Step 6: Keep large-content rendering lazy**
 
 Use full content for queue construction inside the session hook, but only wrap the visible plain content window in the DOM. Do not force `visiblePlainContentChars = content.length` when `Read full item` starts.
 
-- [ ] **Step 7: Run UI/performance/find tests green**
+- [x] **Step 7: Run UI/performance/find tests green**
 
 Run:
 
@@ -818,7 +820,7 @@ cd apps/packages/ui && bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx \

--- a/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
@@ -835,13 +835,15 @@ git commit -m "feat: wire read-along into media content viewer"
 
 ## Task 7: Accessibility, Route Parity, And Regression Hardening
 
+**Status:** Complete
+
 **Files:**
 - Modify: `apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx`
 - Modify or create: `apps/packages/ui/src/routes/__tests__/option-media-route-guards.test.tsx`
 - Modify: `apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts`
 - Optional create: `apps/packages/ui/src/components/Review/__tests__/ViewMediaPage.read-along-parity.test.tsx`
 
-- [ ] **Step 1: Add accessibility tests**
+- [x] **Step 1: Add accessibility tests**
 
 Cover:
 
@@ -851,15 +853,15 @@ Cover:
 - reduced motion disables smooth auto-scroll
 - no essential controls are hover-only
 
-- [ ] **Step 2: Add route/shared import guard**
+- [x] **Step 2: Add route/shared import guard**
 
 The feature must stay in `apps/packages/ui`. Add or extend a guard that proves WebUI and extension media routes both use shared `ViewMediaPage`/`ContentViewer`, with no duplicate read-along implementation under `apps/tldw-frontend/extension`.
 
-- [ ] **Step 3: Add bundle/performance guard**
+- [x] **Step 3: Add bundle/performance guard**
 
 Update the extension entry-shell performance test only if the new read-along modules change the expected static import set. Prefer lazy or local imports if static media entry cost grows unexpectedly.
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run:
 
@@ -879,7 +881,7 @@ bunx vitest run apps/tldw-frontend/__tests__/extension/entry-shell-performance.t
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx \

--- a/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
@@ -899,7 +899,7 @@ git commit -m "test: verify media read-along route parity"
   - focused tests touched above
 - Modify: `backlog/tasks/task-416 - Plan-media-viewer-read-along-TTS-implementation.md` only to record implementation verification if this plan task is kept as the tracking task.
 
-- [ ] **Step 1: Run the focused unit/component suite**
+- [x] **Step 1: Run the focused unit/component suite**
 
 Run:
 
@@ -918,7 +918,7 @@ cd apps/packages/ui && bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 2: Run design-system/openapi guards if touched imports cross those boundaries**
+- [x] **Step 2: Run design-system/openapi guards if touched imports cross those boundaries**
 
 Run:
 
@@ -929,11 +929,11 @@ cd apps/packages/ui && bun run verify:openapi
 
 Expected: PASS, or document why a guard is unrelated and skipped.
 
-- [ ] **Step 3: Start the WebUI dev server**
+- [x] **Step 3: Start the WebUI dev server**
 
 Use the repo's normal dev flow. If a dev server is already running, reuse it. Otherwise run the existing frontend/server command expected for this repo and record the URL.
 
-- [ ] **Step 4: Browser smoke the WebUI media viewer**
+- [x] **Step 4: Browser smoke the WebUI media viewer**
 
 Manual/browser checks:
 
@@ -946,7 +946,7 @@ Manual/browser checks:
 - select text again and click `Annotate`
 - verify annotation draft appears only after annotation action
 
-- [ ] **Step 5: Browser smoke extension-width behavior**
+- [x] **Step 5: Browser smoke extension-width behavior**
 
 Use a narrow viewport comparable to the extension sidepanel. Confirm:
 
@@ -955,11 +955,11 @@ Use a narrow viewport comparable to the extension sidepanel. Confirm:
 - text does not overlap controls
 - no sticky bottom player appears
 
-- [ ] **Step 6: Run Bandit only if Python/backend files were touched**
+- [x] **Step 6: Run Bandit only if Python/backend files were touched**
 
 Expected for this implementation: skipped, because the planned implementation is TypeScript UI-only. If Python files were touched despite this plan, run Bandit on the touched Python scope before completion.
 
-- [ ] **Step 7: Final commit for QA fixes**
+- [x] **Step 7: Final commit for QA fixes**
 
 If browser QA required fixes:
 
@@ -971,23 +971,33 @@ git commit -m "fix: harden media read-along browser behavior"
 
 If no fixes were needed, do not create an empty commit.
 
+Task 8 verification notes:
+
+- Focused read-along suite rerun from `apps/packages/ui`: 12 files / 104 tests passed, including segmentation, cache, content selection, playback session, `ContentViewer.read-along`, find/performance/annotation/accessibility coverage, TTS provider mapping, and Dexie STT regression coverage.
+- Route parity rerun from `apps/packages/ui`: 2 files / 6 tests passed for shared WebUI/extension media route guards and `ViewMediaPage` connection behavior.
+- `git diff --check` passed.
+- `bun run verify:openapi` passed earlier in Task 8; `bun run verify:design-system-state` remains blocked by unrelated repo-wide baseline findings outside read-along touched files.
+- Next dev server was started at `http://127.0.0.1:8080` with quickstart deployment env. Browser render smoke passed against mocked backend responses, confirming `/media` renders a media detail in the shared content region and that the content region is explicitly text-selectable.
+- A fuller headless interaction smoke exposed real hardening issues: the content body needed explicit text selection, the selection hook needed an always-on content-scoped `selectionchange` listener, popover buttons needed pointer-down default prevention, and floating controls needed visible-window fallback when the pane rectangle is offscreen. Those fixes were added with focused regression coverage. The remaining full interaction smoke was not kept as a final gate because headless programmatic text selection stayed flaky after the product fixes; interaction behavior is covered by the focused component tests.
+- Bandit skipped because only TypeScript/React/docs/backlog files were touched.
+
 ## Final Verification Checklist
 
-- [ ] `ContentViewer` selection no longer automatically switches to annotations for every selection.
-- [ ] Annotation creation from selected text still works through the mediated selection action.
-- [ ] No read-along UI appears before selection or active playback.
-- [ ] Read-along actions support selection, from-here, current-section, and full-item scopes.
-- [ ] `Read from here` and `Read full item` use canonical full content, not only rendered large-content windows.
-- [ ] Large-content segmentation is lazy and cancellable.
-- [ ] Stop/media/content changes abort in-flight TTS requests and suppress stale cache writes.
-- [ ] Generated audio cache uses Dexie, LRU eviction, quota fallback, and no raw selected text metadata.
-- [ ] Existing TTS settings are reused and frozen per active session.
-- [ ] Browser TTS provider works as a no-cache SpeechSynthesis path.
-- [ ] Embedded media preview pauses when generated read-along playback starts.
-- [ ] Plain/transcript active highlighting works with find highlighting preserved.
-- [ ] Markdown/html use safe nearest-block fallback without mutating sanitized HTML.
-- [ ] WebUI and extension routes share the implementation.
-- [ ] Keyboard and reduced-motion paths are covered.
+- [x] `ContentViewer` selection no longer automatically switches to annotations for every selection.
+- [x] Annotation creation from selected text still works through the mediated selection action.
+- [x] No read-along UI appears before selection or active playback.
+- [x] Read-along actions support selection, from-here, current-section, and full-item scopes.
+- [x] `Read from here` and `Read full item` use canonical full content, not only rendered large-content windows.
+- [x] Large-content segmentation is lazy and cancellable.
+- [x] Stop/media/content changes abort in-flight TTS requests and suppress stale cache writes.
+- [x] Generated audio cache uses Dexie, LRU eviction, quota fallback, and no raw selected text metadata.
+- [x] Existing TTS settings are reused and frozen per active session.
+- [x] Browser TTS provider works as a no-cache SpeechSynthesis path.
+- [x] Embedded media preview pauses when generated read-along playback starts.
+- [x] Plain/transcript active highlighting works with find highlighting preserved.
+- [x] Markdown/html use safe nearest-block fallback without mutating sanitized HTML.
+- [x] WebUI and extension routes share the implementation.
+- [x] Keyboard and reduced-motion paths are covered.
 
 ## Suggested PR/Commit Stack
 

--- a/Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
+++ b/Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
@@ -38,6 +38,8 @@ The design is inspired by read-along patterns in OpenReader, especially segment-
 - browser-local audio cache keyed by content and TTS settings
 - reuse of existing TTS provider resolution and `/api/v1/audio/speech` client behavior
 - shared WebUI and extension support through `apps/packages/ui`
+- selection arbitration with the existing annotation capture flow in `ContentViewer`
+- abortable synthesis/lookahead so stop, media changes, and stale sessions do not leak playback or cache writes
 - focused tests for segmentation, selection mapping, playback session state, cache behavior, and shared route parity
 
 ### Out Of Scope
@@ -68,16 +70,22 @@ Relevant shared surfaces:
   - plain/transcript rendering helpers, find highlighting, large-content windowing, timestamp seeking
 - `apps/packages/ui/src/components/Media/hooks/useReadingProgress.tsx`
   - scroll/progress restoration and navigation-target application
+- `apps/packages/ui/src/components/Media/hooks/useContentViewerModals.tsx`
+  - currently captures any content selection for annotations and switches the intelligence tab to annotations
+  - read-along must mediate selection handling instead of adding a second independent selection listener that competes with annotations
 - `apps/packages/ui/src/hooks/useTTS.tsx`
   - existing chat/message TTS hook using provider resolution, segment splitting, and clip saving
 - `apps/packages/ui/src/hooks/document-workspace/useDocumentTTS.ts`
   - existing document TTS playback hook
 - `apps/packages/ui/src/services/tts-provider.ts`
   - provider context resolution and synthesis function construction
+  - existing resolver does not currently expose per-call abort to callers, while the lower-level `tldwClient.synthesizeSpeech` API already accepts an `AbortSignal`
 - `apps/packages/ui/src/services/tts.ts`
   - existing global TTS settings
 - `apps/packages/ui/src/services/tldw/audio-voices.ts`
   - server voice catalog fetch
+- `apps/packages/ui/src/db/dexie/schema.ts` and `apps/packages/ui/src/db/dexie/types.ts`
+  - any new read-along cache table needs an explicit Dexie version/type addition, not only a helper file
 - `apps/packages/ui/src/db/dexie/tts-clips.ts`
   - user-visible saved TTS clip history; read-along cache should not reuse this table directly
 
@@ -102,6 +110,9 @@ Relevant shared surfaces:
 12. `Read full item` segments from the canonical full media content already loaded in `ContentViewer`, not from the currently rendered large-content window.
 13. Markdown and rich HTML use nearest-block highlighting/scroll fallback in v1 unless exact rendered text-node mapping is reliable.
 14. Read-along generated audio is not saved into user-visible TTS clip history in v1.
+15. Text selection inside `ContentViewer` must have one coordinated consumer path so annotation capture and read-along actions do not both claim the same selection event unexpectedly.
+16. Segmentation and lookahead are lazy, cancellable work that starts from an explicit read action, not page render.
+17. Starting generated read-along playback pauses any embedded media preview that is already playing; v1 does not synchronize with or auto-resume that original media.
 
 ## 5. Approaches Considered
 
@@ -293,6 +304,21 @@ export interface ReadAlongSelection {
 
 The renderer should add `data-read-along-segment-id` wrappers for plain text and transcript-line modes. Markdown and rich HTML can start with nearest-block mapping and improve later.
 
+### Selection Consumer Arbitration
+
+`ContentViewer` already calls `modals.handleCaptureAnnotationSelection` on content `onMouseUp` and `onKeyUp`. That handler captures selected text, stores an annotation selection, and activates the annotations tab. Adding read-along as a separate selection listener would create surprising behavior: the same drag could open read-along controls while also switching the intelligence panel to annotations.
+
+V1 should introduce one shared selection mediation path scoped to `contentBodyRef`. That path can live in `ContentViewer` or a small `useContentSelectionActions` hook, but it should make the selection result available to both features. The user-facing result should be one compact selection affordance, not two competing popovers or an automatic tab switch plus a read-along menu.
+
+Recommended behavior:
+
+- valid content selection opens a selection action popover with read-along actions and an annotation action
+- annotation text is captured only when the user chooses the annotation action or an existing annotation-focused shortcut, not merely because a selection occurred
+- if the document intelligence panel already has an active annotation selection workflow, read-along should not clear it unless playback starts from a new selection
+- keyboard selection follows the same mediated path
+
+The implementation plan should explicitly preserve the annotation workflow while removing the current implicit "any selection opens annotations" coupling.
+
 ## 9. Playback Session Design
 
 Introduce a hook, for example:
@@ -308,6 +334,8 @@ Responsibilities:
 - maintain active segment, queued scope, loading, paused, stopped, and error states
 - expose commands for pause, resume, stop, retry failed segment, and skip failed segment
 - stop playback on media/page/content change
+- abort in-flight synthesis and lookahead on stop, media/page/content change, and explicit restart
+- suppress stale playback completions and cache writes by checking a session token before mutating state
 - auto-scroll active segment only when needed
 
 Recommended lookahead:
@@ -319,6 +347,14 @@ Recommended lookahead:
 
 The session should treat audio generation and playback as separate phases so cached audio can play immediately while future segments generate.
 
+Read-along should call the provider synthesis primitive directly, not `useTTS.speak()` as a queue driver. `useTTS` already performs its own punctuation-based segment splitting and user-visible clip saving, which would conflict with read-along's segment model and cache signature. One read-along segment should normally produce one TTS request. If a segment exceeds the provider/request cap, split it into deterministic sub-segments under that cap and keep the parent segment highlighted until all sub-segments finish.
+
+Provider/request limits should be explicit in the implementation plan. V1 can use a conservative client-side maximum character count per request, overridable later if server/provider metadata becomes available.
+
+Starting a read-along session should pause any embedded audio/video element in the media preview if it is playing. Stopping read-along should not auto-resume the original media because that would be surprising after a long generated narration session.
+
+The first audio `play()` call is user-gesture-backed through the selection action. Subsequent segment playback should still handle `HTMLMediaElement.play()` promise rejection by moving to a clear segment-error state with retry/stop actions.
+
 ## 10. Audio Generation And Cache
 
 Reuse existing TTS provider resolution instead of calling `/api/v1/audio/speech` ad hoc.
@@ -326,12 +362,19 @@ Reuse existing TTS provider resolution instead of calling `/api/v1/audio/speech`
 Preferred implementation path:
 
 - factor reusable synthesis/playback pieces out of `useTTS` or use `resolveTtsProviderContext()`
+- extend the provider synthesis path to accept `AbortSignal` because `tldwClient.synthesizeSpeech` already supports request aborts
 - keep media read-along-specific queue/session behavior in the new hook
 - do not save read-along segments into user-visible TTS clip history in v1
 
 Add a browser-local cache separate from `ttsClips`, for example:
 
 - `apps/packages/ui/src/db/dexie/media-read-along-cache.ts`
+
+The cache also needs:
+
+- a `MediaReadAlongAudioCacheEntry` type in `apps/packages/ui/src/db/dexie/types.ts`
+- a Dexie schema version bump in `apps/packages/ui/src/db/dexie/schema.ts`
+- migration-safe tests or store-helper tests that prove old databases can open and the new table can be read/written
 
 Cache key should include:
 
@@ -369,10 +412,18 @@ Eviction policy:
 
 - cap total entries and approximate bytes globally for the read-along cache
 - use a conservative v1 default of 200 entries and 250 MB approximate total cache size
+- treat 250 MB as an upper bound, not guaranteed allocation; storage estimates may force a lower effective cap
 - evict least-recently-used entries
+- evict before writes when possible, and handle `QuotaExceededError` by retrying once after eviction before disabling cache
 - tolerate Dexie/private-window failure by disabling cache for the session
 
 Cache failure must never block playback.
+
+Privacy rules:
+
+- generated audio blobs stay browser-local and are never synced by v1
+- cache metadata should not store raw selected text; use content hashes, segment IDs, media IDs, source offsets, and settings signatures
+- cache debug UI, if any, must avoid exposing private transcript text in logs or persistent records
 
 ## 11. Rendering And Highlighting
 
@@ -386,6 +437,8 @@ Plain and transcript rendering should get first-class support in v1:
 - keep find highlighting compatible with read-along highlighting
 
 Timestamp transcript lines should preserve existing timestamp seek buttons.
+
+Segmentation should be lazy. Initial page render, scroll restoration, and find-in-content should not segment an entire large item merely because read-along is available. For full-item and read-from-here scopes on large content, build the queue in cancellable chunks and yield to the browser between batches so `ContentViewer` remains scrollable.
 
 ### Markdown And Rich HTML Rendering
 
@@ -405,6 +458,8 @@ Auto-scroll rules:
 - if partly or fully outside the content viewport, scroll it into view
 - respect reduced motion preferences
 - avoid fighting user scrolling; if the user scrolls away manually, pause auto-follow until the next user action or segment boundary
+
+The popover and inline transport must clamp to the content viewport and sidepanel width. On constrained extension/mobile widths, prefer a compact anchored menu near the selection or active segment. Do not introduce a persistent bottom mini-player as a responsive fallback.
 
 ## 12. Accessibility
 
@@ -443,6 +498,7 @@ Behavior:
 - Browser cannot play generated MIME type: show a concise error and recommend changing TTS output format.
 - Cache unavailable: show no blocking error; optionally expose "cache unavailable" in debug state only.
 - Media/content changes stop playback and clear transient selection UI.
+- Media/content changes abort in-flight synthesis/lookahead and ignore late async completions from older sessions.
 - TTS settings changes create a new cache signature; old cache entries remain for eviction.
 - TTS settings changes during an active read-along session do not mutate the current queue; they apply to the next session or an explicit restart.
 
@@ -461,22 +517,26 @@ Success criteria:
 - transcript timing lines segment into transcript-line segments
 - prose segments into sentence segments with section metadata
 - cache keys change when relevant TTS settings change
+- cache table schema/type/store helpers are migration-safe
 - lookahead queue can play from cached and generated segments
+- stop and media-change paths abort in-flight generation and suppress stale completions
 
 ### Stage 2: Selection Popover And Plain/Transcript Highlighting
 
 Goal:
 
-- add selection detection in `ContentViewer`
+- replace direct annotation selection capture with mediated content selection actions in `ContentViewer`
 - add popover actions
 - add active highlighting for plain and timestamped transcript rendering
 
 Success criteria:
 
 - selecting text opens read-along actions
+- annotation selection remains available from the same selection affordance without automatic tab switching on every selection
 - `Read selection`, `Read from here`, `Read current section`, and `Read full item` queue expected scopes
 - active segment highlights and auto-scrolls correctly
 - stop clears transient UI
+- generated read-along playback pauses an active embedded media preview without auto-resuming it on stop
 
 ### Stage 3: Markdown/HTML Fallback Mapping And Polish
 
@@ -519,16 +579,23 @@ Unit tests:
 - cache LRU eviction
 - queue lookahead behavior
 - media/settings change invalidation
+- lazy large-content segmentation and cancellable queue construction
+- stale session result suppression after stop/media change
+- provider request cap fallback splitting
 
 Component tests:
 
 - popover appears only after valid content selection
+- annotation and read-along selection actions coexist without competing UI state
 - action menu queues the correct scope
 - active segment highlight applies and clears
 - pause/resume/stop update visible state
+- stop/media change aborts in-flight TTS work and prevents stale cache writes
 - TTS error exposes retry/skip/stop
 - cache failure falls back to live generation
+- storage quota failure evicts or disables cache without blocking playback
 - find highlighting and read-along highlighting coexist
+- TTS settings changed mid-session leave the active queue/cache signature stable until restart
 
 Browser/E2E tests:
 
@@ -536,6 +603,7 @@ Browser/E2E tests:
 - extension media viewer selection-to-read flow
 - transcript-line flow with timestamped content
 - long content full-item chunked generation does not request all segments upfront
+- `Read from here` on a windowed large item continues beyond the currently rendered window
 - accessibility smoke for keyboard focus and status announcements
 
 ## 16. V1 Decisions Closed For Planning
@@ -548,9 +616,12 @@ These decisions should not be reopened by the first implementation plan unless n
 - `Read full item` uses canonical full source content, not the rendered window
 - `Read from here` also continues through canonical full source content
 - very large full-item reads use chunked lookahead after segmentation
+- segmentation/lookahead starts lazily from a read action and must remain abortable
+- annotation capture and read-along selection use one mediated selection path
 - TTS settings changes apply to future sessions or explicit restarts, not mid-session mutation
 - markdown/html exact inline highlighting is best effort; nearest-block fallback is acceptable
 - cache eviction uses global LRU with default caps of 200 entries and 250 MB approximate total size
+- cache metadata avoids raw selected text and treats browser storage quota as best effort
 - generated read-along audio is not saved into user-visible TTS clip history in v1
 
 ## 17. Definition Of Done
@@ -559,12 +630,16 @@ These decisions should not be reopened by the first implementation plan unless n
 - WebUI and extension use the same implementation path
 - no persistent page-level player is introduced
 - existing TTS settings are reused
+- selection handling is mediated so existing annotation workflows and read-along do not compete
+- stop, media changes, and restarts abort in-flight TTS work and suppress stale completions
 - transcript-line and sentence segmentation are covered by tests
+- large-content segmentation is lazy and cancellable
 - active segment highlighting works for plain/transcript content
 - markdown/html have a safe fallback
-- browser-local audio cache is opportunistic and separately evicted
+- browser-local audio cache is opportunistic, separately evicted, quota-aware, and avoids raw text metadata
 - long reads use chunked lookahead
 - error states include retry, skip, and stop
+- generated read-along playback pauses active embedded media preview without v1 sync/auto-resume behavior
 - route parity and accessibility checks are documented
 
 ## 18. Deferred Follow-Ups

--- a/Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
+++ b/Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
@@ -1,0 +1,578 @@
+# Media Viewer Read-Along TTS Design
+
+- Date: 2026-05-17
+- Project: tldw_server
+- Backlog: TASK-415
+- Topic: Selection-initiated read-along in the shared media viewer
+- Mode: Design for implementation
+
+## 1. Objective
+
+Add read-along functionality to the shared media viewer used by the WebUI and browser extension. A user should be able to select text in a media item and have that selection, the surrounding section, the rest of the item, or the full item read aloud through the existing TTS stack.
+
+The v1 experience should stay content-native:
+
+- no persistent page-level read-aloud player
+- no standalone "read whole item" button
+- no UI until the user selects text
+- active text is highlighted during playback
+- playback auto-scrolls only when the active segment leaves view
+- voice, model, provider, format, and speed defaults come from existing TTS settings
+
+The design is inspired by read-along patterns in OpenReader, especially segment-aware narration, active highlight, and local reuse of generated audio:
+
+- https://github.com/richardr1126/openreader
+- https://deepwiki.com/richardr1126/OpenReader-WebUI
+
+## 2. Scope
+
+### In Scope
+
+- selection-first popover in `ContentViewer`
+- actions for `Read selection`, `Read from here`, `Read current section`, and `Read full item`
+- hybrid segmentation:
+  - timestamped transcript lines when transcript timing lines exist
+  - sentence segments for regular prose, markdown, and rich HTML
+- active segment highlighting and viewport-aware auto-scroll
+- chunked lookahead generation for long read sessions
+- browser-local audio cache keyed by content and TTS settings
+- reuse of existing TTS provider resolution and `/api/v1/audio/speech` client behavior
+- shared WebUI and extension support through `apps/packages/ui`
+- focused tests for segmentation, selection mapping, playback session state, cache behavior, and shared route parity
+
+### Out Of Scope
+
+- backend-persisted read-along audio cache
+- generated TTS synchronization with embedded original audio or video
+- word-level karaoke timing
+- a persistent page-level audio player
+- new backend TTS APIs
+- new provider or voice-management behavior
+- replacing the existing TTS playground or document workspace TTS panel
+
+## 3. Current Repo Context
+
+The feature should be implemented in the shared UI package, not separately in the Next app and extension.
+
+Relevant shared surfaces:
+
+- `apps/packages/ui/src/components/Review/ViewMediaPage.tsx`
+  - shared media page shell
+  - used by WebUI and extension routes
+- `apps/packages/ui/src/components/Media/ContentViewer.tsx`
+  - selected media detail viewer
+  - owns content rendering, metadata controls, find, embedded media preview, and action menu
+- `apps/packages/ui/src/components/Media/hooks/useContentRendering.tsx`
+  - normalizes display content, render mode, transcript timing visibility, markdown/html/plain behavior
+- `apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx`
+  - plain/transcript rendering helpers, find highlighting, large-content windowing, timestamp seeking
+- `apps/packages/ui/src/components/Media/hooks/useReadingProgress.tsx`
+  - scroll/progress restoration and navigation-target application
+- `apps/packages/ui/src/hooks/useTTS.tsx`
+  - existing chat/message TTS hook using provider resolution, segment splitting, and clip saving
+- `apps/packages/ui/src/hooks/document-workspace/useDocumentTTS.ts`
+  - existing document TTS playback hook
+- `apps/packages/ui/src/services/tts-provider.ts`
+  - provider context resolution and synthesis function construction
+- `apps/packages/ui/src/services/tts.ts`
+  - existing global TTS settings
+- `apps/packages/ui/src/services/tldw/audio-voices.ts`
+  - server voice catalog fetch
+- `apps/packages/ui/src/db/dexie/tts-clips.ts`
+  - user-visible saved TTS clip history; read-along cache should not reuse this table directly
+
+## 4. Approved Decisions
+
+1. V1 should combine basic read aloud with guided read-along.
+2. The read unit should be hybrid:
+   - transcript timestamp line for transcript-like content
+   - sentence segment for regular content
+3. The media viewer should use existing global TTS settings with compact controls only while reading.
+4. Specific selections should support both transient text selection and segment/range expansion.
+5. Generated audio should use a browser-local cache.
+6. Long full-item reads should use chunked lookahead, not all-at-once generation.
+7. None of the initial persistent placement options were acceptable:
+   - header controls
+   - sticky bottom player
+   - right-side drawer
+8. Read-along UI should be selection-initiated only.
+9. When no text is selected and no read-along session is active, no read-along UI is visible.
+10. Selecting text opens the read-along popover, including `Read full item` as an explicit scope expansion.
+11. Once playback starts, the inline transport remains visible until the session is stopped, even if the original text selection is cleared.
+12. `Read full item` segments from the canonical full media content already loaded in `ContentViewer`, not from the currently rendered large-content window.
+13. Markdown and rich HTML use nearest-block highlighting/scroll fallback in v1 unless exact rendered text-node mapping is reliable.
+14. Read-along generated audio is not saved into user-visible TTS clip history in v1.
+
+## 5. Approaches Considered
+
+### Recommended: Selection-First Popover
+
+Read-along appears only after the user selects text in the content. The popover provides scope actions, and playback highlights the active segment in place.
+
+Pros:
+
+- keeps the normal media viewer clean
+- keeps controls near the selected text
+- supports quick selection and range expansion naturally
+- avoids adding another persistent audio-player surface
+- works in WebUI and extension because the interaction is inside the shared content component
+
+Cons:
+
+- discoverability depends on text selection
+- needs careful accessibility treatment for keyboard users
+- requires robust selection-to-segment mapping
+
+### Alternative: Inline Segment Handles
+
+Each sentence, transcript line, or paragraph exposes a subtle hover/focus read handle.
+
+Pros:
+
+- clear per-segment affordance
+- direct read-from-here behavior
+
+Cons:
+
+- adds visible UI noise to dense content
+- expensive to render for large documents
+- awkward for markdown/rich HTML where generated layout may not map cleanly to source segments
+
+### Alternative: Dedicated Read Mode
+
+A user enters read mode, then content becomes explicitly segmented with range controls and a small active transport.
+
+Pros:
+
+- more discoverable once mode is active
+- stronger keyboard and range workflow
+
+Cons:
+
+- adds a mode switch before the user can act
+- feels heavier than the requested selection-first workflow
+- risks becoming a separate reader UI rather than a media viewer enhancement
+
+## 6. Interaction Design
+
+### Entry
+
+No read-along controls are visible by default.
+
+When a user selects text within the content body, `ContentViewer` opens a small popover near the selection. The popover should include:
+
+- `Read selection`
+- `Read from here`
+- `Read current section`
+- `Read full item`
+
+The popover should close when:
+
+- selection is cleared
+- user clicks outside
+- media item changes
+- playback is stopped and no selection remains
+- the content is reloaded
+
+### Scope Actions
+
+`Read selection`:
+
+- maps the selected text to intersecting segments
+- if selection cannot map precisely, reads the selected text as a transient segment
+- highlights only mapped segments when available
+
+`Read from here`:
+
+- maps the start of selection to the nearest segment
+- queues from that segment through the end of the item using canonical full media content, not only the currently rendered large-content window
+
+`Read current section`:
+
+- expands to the nearest containing section:
+  - transcript block if timestamped transcript
+  - heading-delimited section for markdown/html where detectable
+  - paragraph group fallback for plain prose
+
+`Read full item`:
+
+- queues segments from the canonical full media content using chunked lookahead
+- does not limit itself to the currently rendered large-content window
+- does not require a standalone page-level button
+
+### Playback
+
+After playback starts:
+
+- active segment receives a visible highlight in the content
+- completed segments may receive a subtle "read" state only if it does not add clutter
+- the active segment scrolls into view only when outside the viewport
+- a minimal inline transport appears near the active segment or previous selection anchor
+- the inline transport remains visible while the session is preparing, playing, paused, or in a segment-error state
+
+The inline transport should include:
+
+- pause/resume
+- stop
+- current segment count, for example `4/22`
+- cache/generation status only when useful, for example `Preparing...` or `Retry`
+
+Voice, model, provider, response format, and default speed are read from existing TTS settings. V1 should avoid a provider picker in the media viewer.
+
+## 7. Segmentation Design
+
+Introduce a small utility module, for example:
+
+- `apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts`
+
+Core shape:
+
+```ts
+export type ReadAlongSegmentKind =
+  | "transcript-line"
+  | "sentence"
+  | "paragraph"
+  | "transient-selection"
+
+export interface ReadAlongSegment {
+  id: string
+  index: number
+  kind: ReadAlongSegmentKind
+  text: string
+  sourceStart: number
+  sourceEnd: number
+  displayStart?: number
+  displayEnd?: number
+  sectionId?: string
+  timestampSeconds?: number
+}
+```
+
+Segmentation rules:
+
+1. If content has leading transcript timings, segment by timestamped line.
+2. If transcript timings are hidden in display mode, preserve mapping from original content offsets to displayed text offsets.
+3. Otherwise segment prose into sentences.
+4. Preserve paragraph and heading boundaries as section metadata for `Read current section`.
+5. Keep segment IDs deterministic for a given media ID and content version.
+6. Ignore empty or whitespace-only segments.
+7. Cap pathological segment length; split very long segments by sentence or word boundary where possible.
+8. For `Read full item`, build segments from the full source content string available to `ContentViewer`, even when the plain renderer is only showing a windowed subset.
+9. If full source content is unavailable or cannot be segmented safely, disable `Read full item` for that item and explain that the user can read the selected or current rendered section instead.
+
+The segmentation module should be independent of React so it can be unit tested heavily.
+
+## 8. Selection Mapping
+
+Introduce a hook, for example:
+
+- `apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSelection.ts`
+
+Responsibilities:
+
+- listen for selection changes scoped to `contentBodyRef`
+- ignore selections outside the media content
+- normalize selected text without losing source offsets
+- map DOM ranges to segment IDs where rendered segment markers exist
+- fall back to text search within display content when direct markers are unavailable
+- emit a stable selection object for the popover
+
+Selection shape:
+
+```ts
+export interface ReadAlongSelection {
+  selectedText: string
+  anchorRect: DOMRect
+  startSegmentId?: string
+  endSegmentId?: string
+  sourceStart?: number
+  sourceEnd?: number
+  mappingConfidence: "exact" | "nearest" | "text-only"
+}
+```
+
+The renderer should add `data-read-along-segment-id` wrappers for plain text and transcript-line modes. Markdown and rich HTML can start with nearest-block mapping and improve later.
+
+## 9. Playback Session Design
+
+Introduce a hook, for example:
+
+- `apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts`
+
+Responsibilities:
+
+- resolve selected action to a segment queue
+- generate/read audio segment-by-segment
+- prefetch a small lookahead window
+- use local cache before calling TTS
+- maintain active segment, queued scope, loading, paused, stopped, and error states
+- expose commands for pause, resume, stop, retry failed segment, and skip failed segment
+- stop playback on media/page/content change
+- auto-scroll active segment only when needed
+
+Recommended lookahead:
+
+- start with current segment immediately
+- prefetch 3 to 5 segments ahead
+- for full-item reads, generate in batches of 10 to 20 queued segments
+- never generate the entire item upfront
+
+The session should treat audio generation and playback as separate phases so cached audio can play immediately while future segments generate.
+
+## 10. Audio Generation And Cache
+
+Reuse existing TTS provider resolution instead of calling `/api/v1/audio/speech` ad hoc.
+
+Preferred implementation path:
+
+- factor reusable synthesis/playback pieces out of `useTTS` or use `resolveTtsProviderContext()`
+- keep media read-along-specific queue/session behavior in the new hook
+- do not save read-along segments into user-visible TTS clip history in v1
+
+Add a browser-local cache separate from `ttsClips`, for example:
+
+- `apps/packages/ui/src/db/dexie/media-read-along-cache.ts`
+
+Cache key should include:
+
+- server scope/base URL or connection identity
+- media ID
+- media kind
+- content hash or segment text hash
+- segment source offsets
+- provider
+- model
+- voice
+- speed
+- response format
+- normalization/SSML-relevant settings if they affect generated audio
+
+Cache record shape:
+
+```ts
+export interface MediaReadAlongAudioCacheEntry {
+  id: string
+  createdAt: number
+  lastUsedAt: number
+  mediaId: string
+  segmentId: string
+  settingsSignature: string
+  textHash: string
+  mimeType: string
+  format: string
+  blob: Blob
+  sizeBytes: number
+}
+```
+
+Eviction policy:
+
+- cap total entries and approximate bytes globally for the read-along cache
+- use a conservative v1 default of 200 entries and 250 MB approximate total cache size
+- evict least-recently-used entries
+- tolerate Dexie/private-window failure by disabling cache for the session
+
+Cache failure must never block playback.
+
+## 11. Rendering And Highlighting
+
+### Plain And Transcript Rendering
+
+Plain and transcript rendering should get first-class support in v1:
+
+- wrap segments with `data-read-along-segment-id`
+- apply active highlight class to current segment
+- optionally apply a subtle completed state
+- keep find highlighting compatible with read-along highlighting
+
+Timestamp transcript lines should preserve existing timestamp seek buttons.
+
+### Markdown And Rich HTML Rendering
+
+Markdown and rich HTML can start with a conservative fallback:
+
+- use selected text and nearest containing block for scroll
+- highlight exact rendered segment only when mapping is reliable
+- never mutate sanitized HTML with unsafe string replacement
+
+Nearest-block highlighting/scroll fallback is acceptable for v1. Future hardening can add a render plugin or text-node walker that wraps exact text nodes after sanitization/rendering.
+
+### Auto-Scroll
+
+Auto-scroll rules:
+
+- if the active segment is fully visible, do nothing
+- if partly or fully outside the content viewport, scroll it into view
+- respect reduced motion preferences
+- avoid fighting user scrolling; if the user scrolls away manually, pause auto-follow until the next user action or segment boundary
+
+## 12. Accessibility
+
+Selection-first interaction must still be keyboard reachable.
+
+Requirements:
+
+- popover opens for keyboard text selection inside content
+- popover actions are real buttons/menu items with accessible names
+- transport buttons have labels and keyboard focus states
+- active segment changes are announced politely, not on every word
+- reduced-motion users get non-smooth scrolling
+- color highlight must meet contrast against light and dark surfaces
+- no essential control appears only on hover
+
+The existing `content-selection-live-region` pattern can be extended for read-along status.
+
+## 13. Error Handling
+
+Expected states:
+
+- idle
+- selection-active
+- preparing
+- playing
+- paused
+- segment-error
+- cache-disabled
+- stopped
+
+Behavior:
+
+- TTS request failure marks the segment as failed and stops lookahead for that segment.
+- Failed segment UI offers retry, skip, and stop.
+- Unsupported response format falls back through existing TTS provider logic where possible.
+- Browser cannot play generated MIME type: show a concise error and recommend changing TTS output format.
+- Cache unavailable: show no blocking error; optionally expose "cache unavailable" in debug state only.
+- Media/content changes stop playback and clear transient selection UI.
+- TTS settings changes create a new cache signature; old cache entries remain for eviction.
+- TTS settings changes during an active read-along session do not mutate the current queue; they apply to the next session or an explicit restart.
+
+## 14. Rollout Plan
+
+### Stage 1: Segmentation, Cache, And Session Primitives
+
+Goal:
+
+- add pure segmentation utilities
+- add cache-key/cache-store helpers
+- add session state tests without visible UI
+
+Success criteria:
+
+- transcript timing lines segment into transcript-line segments
+- prose segments into sentence segments with section metadata
+- cache keys change when relevant TTS settings change
+- lookahead queue can play from cached and generated segments
+
+### Stage 2: Selection Popover And Plain/Transcript Highlighting
+
+Goal:
+
+- add selection detection in `ContentViewer`
+- add popover actions
+- add active highlighting for plain and timestamped transcript rendering
+
+Success criteria:
+
+- selecting text opens read-along actions
+- `Read selection`, `Read from here`, `Read current section`, and `Read full item` queue expected scopes
+- active segment highlights and auto-scrolls correctly
+- stop clears transient UI
+
+### Stage 3: Markdown/HTML Fallback Mapping And Polish
+
+Goal:
+
+- support selection-first read-along in markdown and rich HTML render modes without unsafe DOM mutation
+- add nearest-block scroll/highlight fallback where exact mapping is unavailable
+
+Success criteria:
+
+- playback works in markdown/html modes
+- exact highlight is used only when reliable
+- fallback behavior is understandable and non-disruptive
+
+### Stage 4: Shared Route Parity And Accessibility
+
+Goal:
+
+- verify WebUI and extension shells
+- harden keyboard and screen reader behavior
+
+Success criteria:
+
+- shared component tests pass
+- one WebUI browser workflow passes
+- one extension workflow passes
+- keyboard selection path is usable
+- reduced-motion and color contrast checks pass
+
+## 15. Testing
+
+Unit tests:
+
+- timestamp-line segmentation
+- sentence segmentation
+- heading/paragraph section expansion
+- selected text to segment mapping
+- transient text-only selection fallback
+- cache key construction
+- cache LRU eviction
+- queue lookahead behavior
+- media/settings change invalidation
+
+Component tests:
+
+- popover appears only after valid content selection
+- action menu queues the correct scope
+- active segment highlight applies and clears
+- pause/resume/stop update visible state
+- TTS error exposes retry/skip/stop
+- cache failure falls back to live generation
+- find highlighting and read-along highlighting coexist
+
+Browser/E2E tests:
+
+- WebUI media viewer selection-to-read flow
+- extension media viewer selection-to-read flow
+- transcript-line flow with timestamped content
+- long content full-item chunked generation does not request all segments upfront
+- accessibility smoke for keyboard focus and status announcements
+
+## 16. V1 Decisions Closed For Planning
+
+These decisions should not be reopened by the first implementation plan unless new repo evidence makes them impossible:
+
+- read-along entry remains selection-first
+- no persistent page-level player
+- active sessions keep a minimal inline transport visible until stopped
+- `Read full item` uses canonical full source content, not the rendered window
+- `Read from here` also continues through canonical full source content
+- very large full-item reads use chunked lookahead after segmentation
+- TTS settings changes apply to future sessions or explicit restarts, not mid-session mutation
+- markdown/html exact inline highlighting is best effort; nearest-block fallback is acceptable
+- cache eviction uses global LRU with default caps of 200 entries and 250 MB approximate total size
+- generated read-along audio is not saved into user-visible TTS clip history in v1
+
+## 17. Definition Of Done
+
+- selection-initiated read-along works in shared `ContentViewer`
+- WebUI and extension use the same implementation path
+- no persistent page-level player is introduced
+- existing TTS settings are reused
+- transcript-line and sentence segmentation are covered by tests
+- active segment highlighting works for plain/transcript content
+- markdown/html have a safe fallback
+- browser-local audio cache is opportunistic and separately evicted
+- long reads use chunked lookahead
+- error states include retry, skip, and stop
+- route parity and accessibility checks are documented
+
+## 18. Deferred Follow-Ups
+
+These are not v1 blockers:
+
+1. Expose read-along cache as clearable local data in settings.
+2. Add an explicit user action to save a read-along segment or session into user-visible TTS clips.
+3. Add exact markdown/rich HTML text-node highlighting after the fallback path is proven.
+4. Add backend-persisted read-along cache if cross-device reuse becomes important.
+5. Add word-level highlighting if provider timing metadata becomes available.

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -23,7 +23,7 @@ import {
   User,
   Download
 } from 'lucide-react'
-import React, { useState, Suspense, useMemo, useRef, useCallback } from 'react'
+import React, { useState, Suspense, useMemo, useRef, useCallback, useEffect } from 'react'
 import { Select, Dropdown, Tooltip, message, Spin } from 'antd'
 import { useTranslation } from 'react-i18next'
 import type { MenuProps } from 'antd'
@@ -272,6 +272,16 @@ export function ContentViewer({
     contentBodyRef,
     onApplyAnnotationSelection: modals.captureAnnotationSelection
   })
+
+  useEffect(() => {
+    selectionActions.clearSelectionActions()
+  }, [
+    content,
+    rendering.effectiveRenderMode,
+    selectedMedia?.kind,
+    selectedMediaId,
+    selectionActions.clearSelectionActions
+  ])
 
   // Now we have shouldShowEmbeddedPlayer from modals, re-run rendering with correct value
   // Actually, we need to use the modals result. Let's restructure:

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -1320,7 +1320,7 @@ export function ContentViewer({
                 ) : null}
                 <div
                   ref={contentBodyRef}
-                  className={`text-sm text-text leading-relaxed ${
+                  className={`select-text text-sm text-text leading-relaxed ${
                     !modals.contentExpanded && shouldShowExpandToggle ? 'max-h-64 overflow-hidden relative' : ''
                   }`}
                   tabIndex={0}

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -119,6 +119,15 @@ export const shouldShowMediaDeveloperTools = (
   return Boolean((env as Record<string, unknown>).DEV) || mode === 'development'
 }
 
+const buildContentRevisionHash = (value: string): string => {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash.toString(16).padStart(8, '0')
+}
+
 // Metadata helpers moved to useContentMetadata hook
 
 interface ContentViewerProps {
@@ -268,20 +277,26 @@ export function ContentViewer({
     t
   })
 
+  const contentSelectionIdentityKey = useMemo(
+    () => [
+      selectedMediaId || 'none',
+      selectedMedia?.kind || 'none',
+      rendering.effectiveRenderMode,
+      content.length,
+      buildContentRevisionHash(content)
+    ].join(':'),
+    [content, rendering.effectiveRenderMode, selectedMedia?.kind, selectedMediaId]
+  )
+
   const selectionActions = useContentSelectionActions({
     contentBodyRef,
+    contentIdentityKey: contentSelectionIdentityKey,
     onApplyAnnotationSelection: modals.captureAnnotationSelection
   })
 
   useEffect(() => {
     selectionActions.clearSelectionActions()
-  }, [
-    content,
-    rendering.effectiveRenderMode,
-    selectedMedia?.kind,
-    selectedMediaId,
-    selectionActions.clearSelectionActions
-  ])
+  }, [contentSelectionIdentityKey, selectionActions.clearSelectionActions])
 
   // Now we have shouldShowEmbeddedPlayer from modals, re-run rendering with correct value
   // Actually, we need to use the modals result. Let's restructure:

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -11,7 +11,6 @@ import {
   MessageSquare,
   Clock,
   FileText,
-  StickyNote,
   Edit3,
   ExternalLink,
   Expand,
@@ -59,7 +58,11 @@ import {
   LARGE_PLAIN_CONTENT_THRESHOLD_CHARS,
   LARGE_PLAIN_CONTENT_CHUNK_CHARS
 } from './hooks/useTranscriptDisplay'
+import { MediaReadAlongPopover } from './read-along/MediaReadAlongPopover'
+import { MediaReadAlongTransport } from './read-along/MediaReadAlongTransport'
 import { useContentSelectionActions } from './read-along/useContentSelectionActions'
+import { useMediaReadAlongSession } from './read-along/useMediaReadAlongSession'
+import type { ReadAlongScope } from './read-along/types'
 
 // Re-export for test compatibility
 export {
@@ -126,6 +129,13 @@ const buildContentRevisionHash = (value: string): string => {
     hash = Math.imul(hash, 0x01000193) >>> 0
   }
   return hash.toString(16).padStart(8, '0')
+}
+
+const clearDocumentSelection = (): void => {
+  if (typeof window === 'undefined' || typeof window.getSelection !== 'function') {
+    return
+  }
+  window.getSelection()?.removeAllRanges()
 }
 
 // Metadata helpers moved to useContentMetadata hook
@@ -215,6 +225,7 @@ export function ContentViewer({
   const rootContainerRef = useRef<HTMLDivElement | null>(null)
   const contentBodyRef = useRef<HTMLDivElement | null>(null)
   const contentScrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const readAlongTransportAnchorRef = useRef<DOMRect | null>(null)
   const [versionHistoryMounted, setVersionHistoryMounted] = useState(false)
 
   const selectedMediaId = selectedMedia?.id != null ? String(selectedMedia.id) : null
@@ -298,6 +309,46 @@ export function ContentViewer({
     selectionActions.clearSelectionActions()
   }, [contentSelectionIdentityKey, selectionActions.clearSelectionActions])
 
+  const readAlong = useMediaReadAlongSession({
+    mediaId: selectedMediaId,
+    mediaKind: selectedMedia?.kind || null,
+    content,
+    displayContent: rendering.displayContent,
+    renderMode: rendering.effectiveRenderMode,
+    hideTranscriptTimings: rendering.shouldHideTranscriptTimings,
+    selection: selectionActions.selectionActionState,
+    contentBodyRef,
+    contentScrollContainerRef,
+    embeddedMediaRef: modals.mediaPlayerRef
+  })
+
+  const handleStartReadAlongScope = useCallback(
+    (scope: ReadAlongScope) => {
+      const currentSelection = selectionActions.selectionActionState
+      if (!currentSelection) return
+
+      readAlongTransportAnchorRef.current = currentSelection.anchorRect
+      void readAlong.start(scope)
+      selectionActions.clearSelectionActions()
+      clearDocumentSelection()
+    },
+    [readAlong, selectionActions]
+  )
+
+  const handleStopReadAlong = useCallback(() => {
+    readAlong.stop()
+    selectionActions.clearSelectionActions()
+    clearDocumentSelection()
+  }, [readAlong, selectionActions])
+
+  const handleToggleReadAlong = useCallback(() => {
+    if (readAlong.state.status === 'paused') {
+      readAlong.resume()
+      return
+    }
+    readAlong.pause()
+  }, [readAlong])
+
   // Now we have shouldShowEmbeddedPlayer from modals, re-run rendering with correct value
   // Actually, we need to use the modals result. Let's restructure:
   // The rendering hook needs shouldShowEmbeddedPlayer which comes from modals.
@@ -318,11 +369,44 @@ export function ContentViewer({
     effectiveRenderMode: rendering.effectiveRenderMode,
     shouldHideTranscriptTimings: rendering.shouldHideTranscriptTimings,
     hasClickableTranscriptTimestamps,
+    activeReadAlongSegmentId: readAlong.activeSegmentId,
     contentScrollContainerRef,
     rootContainerRef,
     mediaPlayerRef: modals.mediaPlayerRef,
     t
   })
+
+  const transcriptReadAlongSegments = useMemo(
+    () =>
+      transcript.readAlongSegments.filter(
+        (segment) => segment.kind === 'transcript-line'
+      ),
+    [transcript.readAlongSegments]
+  )
+
+  useEffect(() => {
+    const activeSegmentId = readAlong.activeSegmentId
+    if (!activeSegmentId || transcript.normalizedFindQuery) return
+    const body = contentBodyRef.current
+    if (!body) return
+
+    const activeNode = Array.from(
+      body.querySelectorAll<HTMLElement>('[data-read-along-segment-id]')
+    ).find((node) => node.dataset.readAlongSegmentId === activeSegmentId)
+    if (!activeNode) return
+
+    const container = contentScrollContainerRef.current
+    const nodeRect = activeNode.getBoundingClientRect()
+    const viewportRect = container?.getBoundingClientRect()
+    const isOutside = viewportRect
+      ? nodeRect.top < viewportRect.top || nodeRect.bottom > viewportRect.bottom
+      : nodeRect.top < 0 ||
+        nodeRect.bottom > (typeof window !== 'undefined' ? window.innerHeight : 0)
+
+    if (isOutside && typeof activeNode.scrollIntoView === 'function') {
+      activeNode.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [readAlong.activeSegmentId, transcript.normalizedFindQuery])
 
   // --- Hook: Reading Progress ---
   const readingProgress = useReadingProgress({
@@ -1214,75 +1298,81 @@ export function ContentViewer({
                   onKeyUp={selectionActions.handleContentSelectionEvent}
                 >
                   {selectionActions.selectionActionState ? (
-                    <div
-                      className="fixed z-50 flex items-center gap-1 rounded border border-border bg-surface px-2 py-1 shadow-lg"
-                      style={{
-                        left: Math.max(
-                          8,
-                          selectionActions.selectionActionState.anchorRect.left
-                        ),
-                        top: Math.max(
-                          8,
-                          selectionActions.selectionActionState.anchorRect.top - 40
-                        )
-                      }}
-                      data-testid="media-selection-actions-popover"
-                    >
-                      <Tooltip
-                        title={t('review:mediaPage.annotateSelection', {
-                          defaultValue: 'Annotate selection'
-                        })}
-                      >
-                        <button
-                          type="button"
-                          className="inline-flex h-7 items-center gap-1 rounded px-2 text-xs font-medium text-text hover:bg-surface2"
-                          onMouseDown={(event) => event.preventDefault()}
-                          onClick={selectionActions.applyAnnotationSelection}
-                          data-testid="media-selection-action-annotate"
-                        >
-                          <StickyNote className="h-3.5 w-3.5" />
-                          <span>
-                            {t('review:mediaPage.annotate', {
-                              defaultValue: 'Annotate'
-                            })}
-                          </span>
-                        </button>
-                      </Tooltip>
-                    </div>
+                    <MediaReadAlongPopover
+                      anchorRect={selectionActions.selectionActionState.anchorRect}
+                      onReadScope={handleStartReadAlongScope}
+                      onAnnotate={selectionActions.applyAnnotationSelection}
+                      t={t}
+                    />
                   ) : null}
+                  <MediaReadAlongTransport
+                    state={readAlong.state}
+                    anchorRect={readAlongTransportAnchorRef.current}
+                    onToggle={handleToggleReadAlong}
+                    onStop={handleStopReadAlong}
+                    onRetry={readAlong.retry}
+                    onSkip={() => readAlong.skip('next')}
+                    t={t}
+                  />
                   {rendering.effectiveRenderMode === 'plain' ? (
                     transcript.shouldRenderTranscriptTimestampChips ? (
                       <div
                         className={`m-0 space-y-1 whitespace-pre-wrap text-text font-mono ${rendering.contentBodyTypographyClass}`}
                       >
-                        {rendering.transcriptLines.map((line, lineIndex) => {
-                          const parsed = parseLeadingTranscriptTiming(line)
-                          if (!parsed) {
+                        {(() => {
+                          let readAlongSegmentIndex = 0
+                          return rendering.transcriptLines.map((line, lineIndex) => {
+                            const parsed = parseLeadingTranscriptTiming(line)
+                            if (!parsed) {
+                              return (
+                                <div key={`line-${lineIndex}`}>
+                                  {line.length > 0 ? line : '\u00A0'}
+                                </div>
+                              )
+                            }
+                            const timestamp = parsed.timestamp
+                            const readAlongSegment =
+                              parsed.text.trim().length > 0
+                                ? transcriptReadAlongSegments[readAlongSegmentIndex++]
+                                : undefined
+                            const isActive =
+                              readAlongSegment?.id === readAlong.activeSegmentId
                             return (
-                              <div key={`line-${lineIndex}`}>
-                                {line.length > 0 ? line : '\u00A0'}
+                              <div key={`line-${lineIndex}`} className="flex flex-wrap items-start gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => transcript.handleTranscriptTimestampSeek(timestamp)}
+                                  className="rounded border border-border bg-surface px-1.5 py-0.5 text-[11px] text-primary hover:bg-surface2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                                  aria-label={t('review:mediaPage.seekToTimestamp', {
+                                    defaultValue: 'Seek to {{timestamp}}',
+                                    timestamp
+                                  })}
+                                >
+                                  {timestamp}
+                                </button>
+                                <span className="flex-1 whitespace-pre-wrap break-words">
+                                  {parsed.leadingWhitespace}
+                                  {parsed.separator}
+                                  {readAlongSegment ? (
+                                    <span
+                                      data-read-along-segment-id={readAlongSegment.id}
+                                      data-read-along-active={isActive ? 'true' : undefined}
+                                      className={
+                                        isActive
+                                          ? 'rounded bg-primary/20 px-0.5 text-text'
+                                          : undefined
+                                      }
+                                    >
+                                      {parsed.text}
+                                    </span>
+                                  ) : (
+                                    parsed.text
+                                  )}
+                                </span>
                               </div>
                             )
-                          }
-                          const timestamp = parsed.timestamp
-                          const tail = `${parsed.leadingWhitespace}${parsed.separator}${parsed.text}`
-                          return (
-                            <div key={`line-${lineIndex}`} className="flex flex-wrap items-start gap-2">
-                              <button
-                                type="button"
-                                onClick={() => transcript.handleTranscriptTimestampSeek(timestamp)}
-                                className="rounded border border-border bg-surface px-1.5 py-0.5 text-[11px] text-primary hover:bg-surface2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                                aria-label={t('review:mediaPage.seekToTimestamp', {
-                                  defaultValue: 'Seek to {{timestamp}}',
-                                  timestamp
-                                })}
-                              >
-                                {timestamp}
-                              </button>
-                              <span className="flex-1 whitespace-pre-wrap break-words">{tail}</span>
-                            </div>
-                          )
-                        })}
+                          })
+                        })()}
                       </div>
                     ) : (
                       <div className="space-y-2">

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -147,6 +147,13 @@ const getReadAlongScrollBehavior = (): ScrollBehavior => {
     : 'smooth'
 }
 
+const escapeCssAttributeValue = (value: string): string => {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value)
+  }
+  return value.replace(/["\\]/g, '\\$&')
+}
+
 // Metadata helpers moved to useContentMetadata hook
 
 interface ContentViewerProps {
@@ -412,9 +419,9 @@ export function ContentViewer({
     const body = contentBodyRef.current
     if (!body) return
 
-    const activeNode = Array.from(
-      body.querySelectorAll<HTMLElement>('[data-read-along-segment-id]')
-    ).find((node) => node.dataset.readAlongSegmentId === activeSegmentId)
+    const activeNode = body.querySelector<HTMLElement>(
+      `[data-read-along-segment-id="${escapeCssAttributeValue(activeSegmentId)}"]`
+    )
     if (!activeNode) return
 
     const container = contentScrollContainerRef.current

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -59,6 +59,7 @@ import {
   LARGE_PLAIN_CONTENT_THRESHOLD_CHARS,
   LARGE_PLAIN_CONTENT_CHUNK_CHARS
 } from './hooks/useTranscriptDisplay'
+import { useContentSelectionActions } from './read-along/useContentSelectionActions'
 
 // Re-export for test compatibility
 export {
@@ -265,6 +266,11 @@ export function ContentViewer({
     contentBodyRef,
     onRefreshMedia,
     t
+  })
+
+  const selectionActions = useContentSelectionActions({
+    contentBodyRef,
+    onApplyAnnotationSelection: modals.captureAnnotationSelection
   })
 
   // Now we have shouldShowEmbeddedPlayer from modals, re-run rendering with correct value
@@ -1179,9 +1185,46 @@ export function ContentViewer({
                   className={`text-sm text-text leading-relaxed ${
                     !modals.contentExpanded && shouldShowExpandToggle ? 'max-h-64 overflow-hidden relative' : ''
                   }`}
-                  onMouseUp={modals.handleCaptureAnnotationSelection}
-                  onKeyUp={modals.handleCaptureAnnotationSelection}
+                  onMouseUp={selectionActions.handleContentSelectionEvent}
+                  onKeyUp={selectionActions.handleContentSelectionEvent}
                 >
+                  {selectionActions.selectionActionState ? (
+                    <div
+                      className="fixed z-50 flex items-center gap-1 rounded border border-border bg-surface px-2 py-1 shadow-lg"
+                      style={{
+                        left: Math.max(
+                          8,
+                          selectionActions.selectionActionState.anchorRect.left
+                        ),
+                        top: Math.max(
+                          8,
+                          selectionActions.selectionActionState.anchorRect.top - 40
+                        )
+                      }}
+                      data-testid="media-selection-actions-popover"
+                    >
+                      <Tooltip
+                        title={t('review:mediaPage.annotateSelection', {
+                          defaultValue: 'Annotate selection'
+                        })}
+                      >
+                        <button
+                          type="button"
+                          className="inline-flex h-7 items-center gap-1 rounded px-2 text-xs font-medium text-text hover:bg-surface2"
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={selectionActions.applyAnnotationSelection}
+                          data-testid="media-selection-action-annotate"
+                        >
+                          <StickyNote className="h-3.5 w-3.5" />
+                          <span>
+                            {t('review:mediaPage.annotate', {
+                              defaultValue: 'Annotate'
+                            })}
+                          </span>
+                        </button>
+                      </Tooltip>
+                    </div>
+                  ) : null}
                   {rendering.effectiveRenderMode === 'plain' ? (
                     transcript.shouldRenderTranscriptTimestampChips ? (
                       <div

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -349,6 +349,19 @@ export function ContentViewer({
     readAlong.pause()
   }, [readAlong])
 
+  const supportedReadAlongScopes = useMemo<ReadAlongScope[]>(() => {
+    const selection = selectionActions.selectionActionState
+    if (
+      selection?.mappingConfidence === 'exact' &&
+      (selection.startSegmentId ||
+        selection.endSegmentId ||
+        (selection.sourceStart != null && selection.sourceEnd != null))
+    ) {
+      return ['selection', 'from-here', 'current-section', 'full-item']
+    }
+    return ['selection', 'full-item']
+  }, [selectionActions.selectionActionState])
+
   // Now we have shouldShowEmbeddedPlayer from modals, re-run rendering with correct value
   // Actually, we need to use the modals result. Let's restructure:
   // The rendering hook needs shouldShowEmbeddedPlayer which comes from modals.
@@ -406,7 +419,11 @@ export function ContentViewer({
     if (isOutside && typeof activeNode.scrollIntoView === 'function') {
       activeNode.scrollIntoView({ behavior: 'smooth', block: 'center' })
     }
-  }, [readAlong.activeSegmentId, transcript.normalizedFindQuery])
+  }, [
+    readAlong.activeSegmentId,
+    transcript.normalizedFindQuery,
+    transcript.visiblePlainContentChars
+  ])
 
   // --- Hook: Reading Progress ---
   const readingProgress = useReadingProgress({
@@ -1300,6 +1317,12 @@ export function ContentViewer({
                   {selectionActions.selectionActionState ? (
                     <MediaReadAlongPopover
                       anchorRect={selectionActions.selectionActionState.anchorRect}
+                      viewportRect={
+                        contentScrollContainerRef.current?.getBoundingClientRect() ??
+                        rootContainerRef.current?.getBoundingClientRect() ??
+                        null
+                      }
+                      supportedScopes={supportedReadAlongScopes}
                       onReadScope={handleStartReadAlongScope}
                       onAnnotate={selectionActions.applyAnnotationSelection}
                       t={t}
@@ -1308,6 +1331,11 @@ export function ContentViewer({
                   <MediaReadAlongTransport
                     state={readAlong.state}
                     anchorRect={readAlongTransportAnchorRef.current}
+                    viewportRect={
+                      contentScrollContainerRef.current?.getBoundingClientRect() ??
+                      rootContainerRef.current?.getBoundingClientRect() ??
+                      null
+                    }
                     onToggle={handleToggleReadAlong}
                     onStop={handleStopReadAlong}
                     onRetry={readAlong.retry}

--- a/apps/packages/ui/src/components/Media/ContentViewer.tsx
+++ b/apps/packages/ui/src/components/Media/ContentViewer.tsx
@@ -138,6 +138,15 @@ const clearDocumentSelection = (): void => {
   window.getSelection()?.removeAllRanges()
 }
 
+const getReadAlongScrollBehavior = (): ScrollBehavior => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'smooth'
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ? 'auto'
+    : 'smooth'
+}
+
 // Metadata helpers moved to useContentMetadata hook
 
 interface ContentViewerProps {
@@ -417,7 +426,10 @@ export function ContentViewer({
         nodeRect.bottom > (typeof window !== 'undefined' ? window.innerHeight : 0)
 
     if (isOutside && typeof activeNode.scrollIntoView === 'function') {
-      activeNode.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      activeNode.scrollIntoView({
+        behavior: getReadAlongScrollBehavior(),
+        block: 'center'
+      })
     }
   }, [
     readAlong.activeSegmentId,
@@ -1311,6 +1323,11 @@ export function ContentViewer({
                   className={`text-sm text-text leading-relaxed ${
                     !modals.contentExpanded && shouldShowExpandToggle ? 'max-h-64 overflow-hidden relative' : ''
                   }`}
+                  tabIndex={0}
+                  role="region"
+                  aria-label={t('review:mediaPage.contentRegion', {
+                    defaultValue: 'Media content'
+                  })}
                   onMouseUp={selectionActions.handleContentSelectionEvent}
                   onKeyUp={selectionActions.handleContentSelectionEvent}
                 >
@@ -1439,8 +1456,6 @@ export function ContentViewer({
                     rendering.displayContent ? (
                       <div
                         className={`${rendering.richTextTypographyClass} break-words dark:prose-invert max-w-none prose-p:leading-relaxed`}
-                        role="region"
-                        aria-label={t('review:mediaPage.contentRegion', { defaultValue: 'Media content' })}
                         dangerouslySetInnerHTML={{
                           __html: rendering.sanitizedRichContent
                         }}

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
@@ -2,7 +2,14 @@ import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ContentViewer } from '../ContentViewer'
+import {
+  ContentViewer,
+  LARGE_PLAIN_CONTENT_CHUNK_CHARS,
+  LARGE_PLAIN_CONTENT_THRESHOLD_CHARS
+} from '../ContentViewer'
+import { MediaReadAlongPopover } from '../read-along/MediaReadAlongPopover'
+import { MediaReadAlongTransport } from '../read-along/MediaReadAlongTransport'
+import * as readAlongSegmentsModule from '../read-along/media-read-along-segments'
 import { useMediaReadingProgress } from '@/hooks/useMediaReadingProgress'
 
 const mocks = vi.hoisted(() => ({
@@ -213,6 +220,51 @@ const renderViewer = (
     />
   )
 
+const makeRect = ({
+  left,
+  top,
+  width,
+  height
+}: {
+  left: number
+  top: number
+  width: number
+  height: number
+}): DOMRect =>
+  ({
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({})
+  }) as DOMRect
+
+const t = (
+  _key: string,
+  fallbackOrOptions?: string | { defaultValue?: string }
+): string => {
+  if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
+  return fallbackOrOptions?.defaultValue || _key
+}
+
+const buildLargeReadAlongContent = () => {
+  const first = `${'A'.repeat(1_000)}.`
+  const fillers = Array.from(
+    { length: 11 },
+    (_value, index) => `${String.fromCharCode(66 + index).repeat(3_000)}.`
+  )
+  const target = 'Target active sentence.'
+  const tail = `${'C'.repeat(LARGE_PLAIN_CONTENT_THRESHOLD_CHARS)}.`
+  return {
+    content: `${first} ${fillers.join(' ')} ${target} ${tail}`,
+    target
+  }
+}
+
 const selectText = (node: HTMLElement, selectedText: string) => {
   const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
   let textNode: Node | null = node.firstChild
@@ -329,6 +381,167 @@ describe('ContentViewer read-along integration', () => {
     )
     expect(screen.getByTestId('media-selection-action-annotate')).toHaveTextContent(
       'Annotate'
+    )
+  })
+
+  it('hides mapped-scope read-along actions for markdown and html text-only selections', async () => {
+    const { unmount } = renderViewer({
+      content: 'Markdown fallback sentence.',
+      contentDisplayMode: 'markdown'
+    })
+
+    selectTextInside('Markdown fallback sentence.')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('media-selection-action-read-selection')).toBeInTheDocument()
+    expect(screen.getByTestId('media-selection-action-read-full-item')).toBeInTheDocument()
+    expect(screen.getByTestId('media-selection-action-annotate')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('media-selection-action-read-from-here')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('media-selection-action-read-current-section')
+    ).not.toBeInTheDocument()
+
+    unmount()
+    window.getSelection()?.removeAllRanges()
+
+    renderViewer({
+      content: '<p>HTML fallback sentence.</p>',
+      contentDisplayMode: 'html',
+      allowRichRendering: true
+    })
+
+    selectText(screen.getByText('HTML fallback sentence.'), 'HTML fallback sentence.')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('media-selection-action-read-selection')).toBeInTheDocument()
+    expect(screen.getByTestId('media-selection-action-read-full-item')).toBeInTheDocument()
+    expect(screen.getByTestId('media-selection-action-annotate')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('media-selection-action-read-from-here')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('media-selection-action-read-current-section')
+    ).not.toBeInTheDocument()
+  })
+
+  it('segments only the visible plain-content window during lazy rendering', async () => {
+    const buildSegments = vi.spyOn(readAlongSegmentsModule, 'buildReadAlongSegments')
+    const { content } = buildLargeReadAlongContent()
+
+    renderViewer({ content, contentDisplayMode: 'plain' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('large-content-window-status')).toHaveAttribute(
+        'data-visible-chars',
+        String(LARGE_PLAIN_CONTENT_CHUNK_CHARS)
+      )
+    })
+
+    const maxSegmentedDisplayLength = Math.max(
+      ...buildSegments.mock.calls.map(([input]) =>
+        input.displayContent == null
+          ? input.content.length
+          : input.displayContent.length
+      )
+    )
+    expect(maxSegmentedDisplayLength).toBeLessThanOrEqual(
+      LARGE_PLAIN_CONTENT_CHUNK_CHARS
+    )
+  })
+
+  it('expands a large plain-content window only far enough to show the active read-along segment', async () => {
+    const { content, target } = buildLargeReadAlongContent()
+
+    renderViewer({ content, contentDisplayMode: 'plain' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('large-content-window-status')).toHaveAttribute(
+        'data-visible-chars',
+        String(LARGE_PLAIN_CONTENT_CHUNK_CHARS)
+      )
+    })
+
+    selectTextInside(`${'A'.repeat(1_000)}.`)
+    fireEvent.click(await screen.findByTestId('media-selection-action-read-full-item'))
+
+    for (let endedCount = 0; endedCount < 12; endedCount += 1) {
+      await waitFor(() => {
+        expect(audioInstances.length).toBeGreaterThanOrEqual(endedCount + 1)
+      })
+      audioInstances[audioInstances.length - 1].dispatchEvent(new Event('ended'))
+    }
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-read-along-active="true"]')).toHaveTextContent(
+        target
+      )
+    })
+
+    const status = screen.getByTestId('large-content-window-status')
+    const visibleChars = Number(status.getAttribute('data-visible-chars'))
+    expect(visibleChars).toBeGreaterThan(LARGE_PLAIN_CONTENT_CHUNK_CHARS)
+    expect(visibleChars).toBeLessThan(content.length)
+  })
+
+  it('clamps selection popover and transport to the provided viewport and exposes polite live status', () => {
+    const viewportRect = makeRect({ left: 100, top: 20, width: 320, height: 300 })
+    render(
+      <>
+        <MediaReadAlongPopover
+          anchorRect={makeRect({ left: 760, top: 32, width: 40, height: 18 })}
+          viewportRect={viewportRect}
+          onReadScope={vi.fn()}
+          onAnnotate={vi.fn()}
+          t={t}
+        />
+        <MediaReadAlongTransport
+          state={{
+            status: 'segment-error',
+            scope: 'full-item',
+            activeSegmentId: 'segment-5',
+            activeIndex: 4,
+            totalSegments: 10,
+            error: 'Generated audio playback failed',
+            cacheDisabled: false
+          }}
+          anchorRect={makeRect({ left: 900, top: 300, width: 40, height: 20 })}
+          viewportRect={makeRect({ left: 200, top: 100, width: 320, height: 240 })}
+          onToggle={vi.fn()}
+          onStop={vi.fn()}
+          onRetry={vi.fn()}
+          onSkip={vi.fn()}
+          t={t}
+        />
+      </>
+    )
+
+    expect(
+      Number(screen.getByTestId('media-selection-actions-popover').style.left.replace('px', ''))
+    ).toBeLessThanOrEqual(108)
+    const transport = screen.getByTestId('media-read-along-transport')
+    expect(Number(transport.style.left.replace('px', ''))).toBeLessThanOrEqual(252)
+    expect(Number(transport.style.top.replace('px', ''))).toBeLessThanOrEqual(288)
+    expect(screen.getByTestId('media-read-along-progress')).toHaveAttribute(
+      'role',
+      'status'
+    )
+    expect(screen.getByTestId('media-read-along-progress')).toHaveAttribute(
+      'aria-live',
+      'polite'
+    )
+    expect(screen.getByTestId('media-read-along-error')).toHaveAttribute(
+      'role',
+      'status'
+    )
+    expect(screen.getByTestId('media-read-along-error')).toHaveAttribute(
+      'aria-live',
+      'polite'
     )
   })
 

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
@@ -1,0 +1,446 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ContentViewer } from '../ContentViewer'
+import { useMediaReadingProgress } from '@/hooks/useMediaReadingProgress'
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn()
+}))
+
+const cacheEntries = new Map<string, { blob: Blob; mimeType: string; format: string }>()
+const audioInstances: MockAudio[] = []
+const originalCreateObjectUrlDescriptor = Object.getOwnPropertyDescriptor(
+  URL,
+  'createObjectURL'
+)
+const originalRevokeObjectUrlDescriptor = Object.getOwnPropertyDescriptor(
+  URL,
+  'revokeObjectURL'
+)
+
+class MockAudio extends EventTarget {
+  src: string
+  currentTime = 0
+  playbackRate = 1
+  paused = true
+  play = vi.fn(async () => {
+    this.paused = false
+  })
+  pause = vi.fn(() => {
+    this.paused = true
+  })
+
+  constructor(src = '') {
+    super()
+    this.src = src
+    audioInstances.push(this)
+  }
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+            count?: number
+            index?: number
+            total?: number
+            timestamp?: string
+          }
+    ) => {
+      if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) {
+        return fallbackOrOptions.defaultValue
+          .replace('{{count}}', String(fallbackOrOptions.count ?? ''))
+          .replace('{{index}}', String(fallbackOrOptions.index ?? ''))
+          .replace('{{total}}', String(fallbackOrOptions.total ?? ''))
+          .replace('{{timestamp}}', String(fallbackOrOptions.timestamp ?? ''))
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock('@/services/background-proxy', () => ({
+  bgRequest: mocks.bgRequest
+}))
+
+vi.mock('@/hooks/useSetting', async () => {
+  const React = await import('react')
+  return {
+    useSetting: (setting: { defaultValue: unknown }) => {
+      const [value, setValue] = React.useState(setting.defaultValue)
+      const setAsync = async (next: unknown | ((prev: unknown) => unknown)) => {
+        setValue((prev) =>
+          typeof next === 'function' ? (next as (prev: unknown) => unknown)(prev) : next
+        )
+      }
+      return [value, setAsync, { isLoading: false }] as const
+    }
+  }
+})
+
+vi.mock('@/hooks/useMediaReadingProgress', () => ({
+  useMediaReadingProgress: vi.fn()
+}))
+
+vi.mock('@/services/tts-provider', () => ({
+  applyBrowserSpeechSynthesisVoice: vi.fn(),
+  resolveTtsProviderContext: vi.fn(async () => ({
+    provider: 'tldw',
+    utterance: '',
+    cacheSettings: {
+      provider: 'tldw',
+      model: 'tts-1',
+      voice: 'alloy',
+      speed: 1,
+      format: 'mp3'
+    },
+    formatInfo: {
+      requested: 'mp3',
+      resolved: 'mp3',
+      extension: 'mp3',
+      mimeType: 'audio/mpeg'
+    },
+    playbackSpeed: 1,
+    normalizeText: (text: string) => text,
+    synthesize: vi.fn(async (text: string) => ({
+      buffer: new TextEncoder().encode(text).buffer,
+      format: 'mp3',
+      mimeType: 'audio/mpeg'
+    }))
+  }))
+}))
+
+vi.mock('@/services/tldw/TldwApiClient', () => ({
+  tldwClient: {
+    getConfig: vi.fn(async () => ({
+      serverUrl: 'http://127.0.0.1:8000/',
+      apiKey: 'test-api-key',
+      authMode: 'single-user'
+    }))
+  }
+}))
+
+vi.mock('../read-along/media-read-along-cache-key', () => ({
+  buildReadAlongCacheKey: vi.fn(async ({ segmentId, settingsSignature }) => ({
+    id: `cache:${segmentId}:${settingsSignature}`,
+    mediaId: 'media-read-along-test',
+    mediaKind: 'media',
+    segmentId,
+    settingsSignature,
+    textHash: `hash:${segmentId}`
+  })),
+  buildTtsSettingsSignature: vi.fn(() => 'mock-settings')
+}))
+
+vi.mock('../read-along/media-read-along-cache', () => ({
+  getMediaReadAlongAudioCacheEntry: vi.fn(async (id: string) => {
+    const entry = cacheEntries.get(id)
+    return entry
+      ? {
+          id,
+          createdAt: 1,
+          lastUsedAt: 1,
+          mediaId: 'media-read-along-test',
+          mediaKind: 'media',
+          segmentId: id,
+          settingsSignature: 'mock-settings',
+          textHash: 'mock',
+          blob: entry.blob,
+          mimeType: entry.mimeType,
+          format: entry.format,
+          sizeBytes: entry.blob.size
+        }
+      : undefined
+  }),
+  saveMediaReadAlongAudioCacheEntry: vi.fn(async (entry) => {
+    cacheEntries.set(entry.id, {
+      blob: entry.blob,
+      mimeType: entry.mimeType,
+      format: entry.format
+    })
+    return true
+  })
+}))
+
+vi.mock('../AnalysisModal', () => ({ AnalysisModal: () => null }))
+vi.mock('../AnalysisEditModal', () => ({ AnalysisEditModal: () => null }))
+vi.mock('../VersionHistoryPanel', () => ({ VersionHistoryPanel: () => null }))
+vi.mock('../DeveloperToolsSection', () => ({ DeveloperToolsSection: () => null }))
+vi.mock('../DiffViewModal', () => ({ DiffViewModal: () => null }))
+vi.mock('@/components/Common/MarkdownPreview', () => ({
+  MarkdownPreview: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+const selectedMedia = {
+  kind: 'media' as const,
+  id: 930,
+  title: 'Read-along target',
+  raw: {},
+  meta: {
+    type: 'document'
+  }
+}
+
+const videoMedia = {
+  ...selectedMedia,
+  id: 931,
+  title: 'Video read-along target',
+  raw: {
+    has_original_file: true
+  },
+  meta: {
+    type: 'video'
+  }
+}
+
+const renderViewer = (
+  overrides: Partial<React.ComponentProps<typeof ContentViewer>> = {}
+) =>
+  render(
+    <ContentViewer
+      selectedMedia={selectedMedia}
+      content={'First sentence. Second sentence.'}
+      mediaDetail={{ type: 'document' }}
+      contentDisplayMode="plain"
+      {...overrides}
+    />
+  )
+
+const selectText = (node: HTMLElement, selectedText: string) => {
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
+  let textNode: Node | null = node.firstChild
+  let startOffset = 0
+  while (textNode) {
+    const value = textNode.textContent || ''
+    const matchIndex = value.indexOf(selectedText)
+    if (matchIndex >= 0) {
+      startOffset = matchIndex
+      break
+    }
+    textNode = walker.nextNode()
+  }
+  expect(textNode).not.toBeNull()
+  const range = document.createRange()
+  range.setStart(textNode as Text, startOffset)
+  range.setEnd(textNode as Text, startOffset + selectedText.length)
+  const selection = window.getSelection()
+  expect(selection).not.toBeNull()
+  selection!.removeAllRanges()
+  selection!.addRange(range)
+  fireEvent.mouseUp(node)
+}
+
+const selectTextInside = (text: string) => {
+  const candidates = screen.getAllByText((_content, element) =>
+    Boolean(element?.textContent?.includes(text))
+  )
+  const node =
+    candidates.find(
+      (element) =>
+        !Array.from(element.children).some((child) =>
+          child.textContent?.includes(text)
+        )
+    ) || candidates[0]
+  selectText(node, text)
+  return node
+}
+
+const restoreUrlObjectUrlHelpers = () => {
+  if (originalCreateObjectUrlDescriptor) {
+    Object.defineProperty(URL, 'createObjectURL', originalCreateObjectUrlDescriptor)
+  } else {
+    delete (URL as any).createObjectURL
+  }
+  if (originalRevokeObjectUrlDescriptor) {
+    Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectUrlDescriptor)
+  } else {
+    delete (URL as any).revokeObjectURL
+  }
+}
+
+describe('ContentViewer read-along integration', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    cacheEntries.clear()
+    audioInstances.length = 0
+    mocks.bgRequest.mockReset()
+    mocks.bgRequest.mockImplementation(async (request: { path?: string }) => {
+      if (String(request?.path || '').endsWith('/file')) {
+        return new Uint8Array([1, 2, 3]).buffer
+      }
+      return {}
+    })
+    vi.mocked(useMediaReadingProgress).mockReturnValue({
+      saveProgress: vi.fn(),
+      clearProgress: vi.fn(),
+      progressPercent: null
+    })
+    vi.stubGlobal('Audio', MockAudio)
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:read-along-test')
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    restoreUrlObjectUrlHelpers()
+  })
+
+  it('shows no read-along UI before content selection', () => {
+    renderViewer()
+
+    expect(screen.queryByTestId('media-selection-actions-popover')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('media-read-along-transport')).not.toBeInTheDocument()
+  })
+
+  it('shows read-along and annotation actions in the selection popover', async () => {
+    renderViewer()
+
+    selectTextInside('First sentence.')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('media-selection-action-read-selection')).toHaveTextContent(
+      'Read selection'
+    )
+    expect(screen.getByTestId('media-selection-action-read-from-here')).toHaveTextContent(
+      'Read from here'
+    )
+    expect(
+      screen.getByTestId('media-selection-action-read-current-section')
+    ).toHaveTextContent('Read current section')
+    expect(screen.getByTestId('media-selection-action-read-full-item')).toHaveTextContent(
+      'Read full item'
+    )
+    expect(screen.getByTestId('media-selection-action-annotate')).toHaveTextContent(
+      'Annotate'
+    )
+  })
+
+  it('starts reading a selection and keeps the inline transport visible after selection clears', async () => {
+    renderViewer()
+
+    selectTextInside('First sentence.')
+    fireEvent.click(await screen.findByTestId('media-selection-action-read-selection'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-read-along-transport')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('media-selection-actions-popover')).not.toBeInTheDocument()
+    expect(window.getSelection()?.rangeCount).toBe(0)
+    expect(audioInstances.length).toBeGreaterThan(0)
+  })
+
+  it('marks the active readable segment in plain content', async () => {
+    renderViewer()
+
+    selectTextInside('First sentence.')
+    fireEvent.click(await screen.findByTestId('media-selection-action-read-selection'))
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-read-along-active="true"]')
+      ).toBeInTheDocument()
+    })
+    expect(document.querySelector('[data-read-along-active="true"]')).toHaveTextContent(
+      'First sentence.'
+    )
+  })
+
+  it('hides transient read-along UI after stop', async () => {
+    renderViewer()
+
+    selectTextInside('First sentence.')
+    fireEvent.click(await screen.findByTestId('media-selection-action-read-selection'))
+    await screen.findByTestId('media-read-along-transport')
+
+    fireEvent.click(screen.getByTestId('media-read-along-stop'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-read-along-transport')).not.toBeInTheDocument()
+    })
+    expect(document.querySelector('[data-read-along-active="true"]')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('media-selection-actions-popover')).not.toBeInTheDocument()
+  })
+
+  it('pauses embedded media preview when generated read-along playback starts', async () => {
+    renderViewer({
+      selectedMedia: videoMedia,
+      mediaDetail: {
+        type: 'video',
+        has_original_file: true
+      }
+    })
+
+    const video = await screen.findByTestId('embedded-video-player')
+    let paused = false
+    const pause = vi.fn(() => {
+      paused = true
+    })
+    Object.defineProperty(video, 'paused', {
+      configurable: true,
+      get: () => paused
+    })
+    Object.defineProperty(video, 'pause', {
+      configurable: true,
+      value: pause
+    })
+
+    selectTextInside('First sentence.')
+    fireEvent.click(await screen.findByTestId('media-selection-action-read-selection'))
+
+    await waitFor(() => {
+      expect(pause).toHaveBeenCalled()
+    })
+  })
+
+  it('starts markdown and html fallback playback without mutating rich HTML', async () => {
+    const { unmount } = renderViewer({
+      content: 'Markdown fallback sentence.',
+      contentDisplayMode: 'markdown'
+    })
+
+    selectTextInside('Markdown fallback sentence.')
+    fireEvent.click(await screen.findByTestId('media-selection-action-read-selection'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-read-along-transport')).toBeInTheDocument()
+    })
+
+    unmount()
+    window.getSelection()?.removeAllRanges()
+
+    renderViewer({
+      content: '<p>HTML fallback sentence.</p>',
+      contentDisplayMode: 'html',
+      allowRichRendering: true
+    })
+
+    const htmlText = screen.getByText('HTML fallback sentence.')
+    const htmlRegion = htmlText.closest('[role="region"]')
+    expect(htmlRegion?.innerHTML).not.toContain('data-read-along-segment-id')
+
+    selectText(htmlText, 'HTML fallback sentence.')
+    fireEvent.click(await screen.findByTestId('media-selection-action-read-selection'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-read-along-transport')).toBeInTheDocument()
+    })
+    expect(htmlRegion?.innerHTML).not.toContain('data-read-along-segment-id')
+  })
+})

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
@@ -609,6 +609,48 @@ describe('ContentViewer read-along integration', () => {
     )
   })
 
+  it('falls back to the visible window when the provided viewport is offscreen', () => {
+    render(
+      <>
+        <MediaReadAlongPopover
+          anchorRect={makeRect({ left: 1280, top: 40, width: 40, height: 18 })}
+          viewportRect={makeRect({ left: 1200, top: 20, width: 320, height: 300 })}
+          onReadScope={vi.fn()}
+          onAnnotate={vi.fn()}
+          t={t}
+        />
+        <MediaReadAlongTransport
+          state={{
+            status: 'playing',
+            scope: 'selection',
+            activeSegmentId: 'segment-1',
+            activeIndex: 0,
+            totalSegments: 3,
+            error: null,
+            cacheDisabled: false
+          }}
+          anchorRect={makeRect({ left: 1280, top: 100, width: 40, height: 20 })}
+          viewportRect={makeRect({ left: 1200, top: 20, width: 320, height: 300 })}
+          onToggle={vi.fn()}
+          onStop={vi.fn()}
+          onRetry={vi.fn()}
+          onSkip={vi.fn()}
+          t={t}
+        />
+      </>
+    )
+
+    const popoverLeft = Number(
+      screen.getByTestId('media-selection-actions-popover').style.left.replace('px', '')
+    )
+    const transportLeft = Number(
+      screen.getByTestId('media-read-along-transport').style.left.replace('px', '')
+    )
+
+    expect(popoverLeft).toBeLessThan(1000)
+    expect(transportLeft).toBeLessThan(1000)
+  })
+
   it('starts reading a selection and keeps the inline transport visible after selection clears', async () => {
     renderViewer()
 

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
@@ -265,6 +265,20 @@ const buildLargeReadAlongContent = () => {
   }
 }
 
+const buildLargeTimestampedTranscript = () => {
+  const lines = Array.from({ length: 1_500 }, (_value, index) => {
+    const minutes = String(Math.floor(index / 60)).padStart(2, '0')
+    const seconds = String(index % 60).padStart(2, '0')
+    const label = `Line ${String(index).padStart(4, '0')}`
+    const text = `${label} ${'transcript text '.repeat(5)}.`
+    return `${minutes}:${seconds} ${text}`
+  })
+  return {
+    content: lines.join('\n'),
+    target: 'Line 0340 transcript text transcript text transcript text transcript text transcript text .'
+  }
+}
+
 const selectText = (node: HTMLElement, selectedText: string) => {
   const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
   let textNode: Node | null = node.firstChild
@@ -486,7 +500,44 @@ describe('ContentViewer read-along integration', () => {
     const status = screen.getByTestId('large-content-window-status')
     const visibleChars = Number(status.getAttribute('data-visible-chars'))
     expect(visibleChars).toBeGreaterThan(LARGE_PLAIN_CONTENT_CHUNK_CHARS)
+    expect(visibleChars).toBe(LARGE_PLAIN_CONTENT_CHUNK_CHARS * 2)
     expect(visibleChars).toBeLessThan(content.length)
+  })
+
+  it('keeps read-along wrappers available through the visible hidden-timing transcript window', async () => {
+    const { content, target } = buildLargeTimestampedTranscript()
+
+    renderViewer({
+      selectedMedia: {
+        ...videoMedia,
+        meta: {
+          type: 'audio'
+        }
+      },
+      mediaDetail: {
+        type: 'audio',
+        has_original_file: true
+      },
+      content,
+      contentDisplayMode: 'plain'
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('large-content-window-status')).toHaveAttribute(
+        'data-visible-chars',
+        String(LARGE_PLAIN_CONTENT_CHUNK_CHARS)
+      )
+    })
+
+    selectTextInside(target)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('media-selection-action-read-from-here')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('media-selection-action-read-current-section')
+    ).toBeInTheDocument()
   })
 
   it('clamps selection popover and transport to the provided viewport and exposes polite live status', () => {
@@ -524,8 +575,21 @@ describe('ContentViewer read-along integration', () => {
     expect(
       Number(screen.getByTestId('media-selection-actions-popover').style.left.replace('px', ''))
     ).toBeLessThanOrEqual(108)
+    const popover = screen.getByTestId('media-selection-actions-popover')
+    const popoverLeft = Number(popover.style.left.replace('px', ''))
+    const popoverMaxWidth = Number(popover.style.maxWidth.replace('px', ''))
+    expect(popover.style.maxWidth).toMatch(/px$/)
+    expect(popoverMaxWidth).toBeGreaterThan(0)
+    expect(popoverMaxWidth).toBeLessThanOrEqual(
+      viewportRect.right - popoverLeft - 8
+    )
     const transport = screen.getByTestId('media-read-along-transport')
-    expect(Number(transport.style.left.replace('px', ''))).toBeLessThanOrEqual(252)
+    const transportLeft = Number(transport.style.left.replace('px', ''))
+    const transportMaxWidth = Number(transport.style.maxWidth.replace('px', ''))
+    expect(transport.style.maxWidth).toMatch(/px$/)
+    expect(transportMaxWidth).toBeGreaterThan(0)
+    expect(transportLeft).toBeLessThanOrEqual(252)
+    expect(transportMaxWidth).toBeLessThanOrEqual(520 - transportLeft - 8)
     expect(Number(transport.style.top.replace('px', ''))).toBeLessThanOrEqual(288)
     expect(screen.getByTestId('media-read-along-progress')).toHaveAttribute(
       'role',

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
@@ -279,4 +279,61 @@ describe('ContentViewer stage 14 annotations baseline', () => {
       )
     })
   })
+
+  it('clears selection actions when the selected media changes', async () => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string; method?: string; body?: any }) => {
+      const path = String(request?.path || '')
+      if (path.endsWith('/outline')) return { media_id: 777, has_outline: true, entries: [] }
+      if (path.endsWith('/insights')) return { media_id: 777, insights: [] }
+      if (path.includes('/references')) return { media_id: 777, references: [] }
+      if (path.includes('/figures')) return { media_id: 777, figures: [] }
+      if (path.endsWith('/annotations') && request?.method === 'GET') {
+        return { media_id: 777, annotations: [] }
+      }
+      return {}
+    })
+
+    const { rerender } = render(
+      <ContentViewer
+        selectedMedia={selectedMedia}
+        content={'Original selected body text'}
+        mediaDetail={{ type: 'document' }}
+      />
+    )
+
+    const contentNode = screen.getByText('Original selected body text')
+    const textNode = contentNode.firstChild
+    expect(textNode).not.toBeNull()
+
+    const selection = window.getSelection()
+    expect(selection).not.toBeNull()
+    const range = document.createRange()
+    range.setStart(textNode as Text, 0)
+    range.setEnd(textNode as Text, 'Original selected'.length)
+    selection!.removeAllRanges()
+    selection!.addRange(range)
+
+    fireEvent.mouseUp(contentNode)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeInTheDocument()
+    })
+
+    rerender(
+      <ContentViewer
+        selectedMedia={{
+          ...selectedMedia,
+          id: 778,
+          title: 'Next annotation target'
+        }}
+        content={'Next media body text'}
+        mediaDetail={{ type: 'document' }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-selection-actions-popover')).not.toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('media-annotation-selection-preview')).not.toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
@@ -336,4 +336,67 @@ describe('ContentViewer stage 14 annotations baseline', () => {
     })
     expect(screen.queryByTestId('media-annotation-selection-preview')).not.toBeInTheDocument()
   })
+
+  it('does not apply a stale selection action captured before a media change settles', async () => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string; method?: string; body?: any }) => {
+      const path = String(request?.path || '')
+      if (path.endsWith('/outline')) return { media_id: 777, has_outline: true, entries: [] }
+      if (path.endsWith('/insights')) return { media_id: 777, insights: [] }
+      if (path.includes('/references')) return { media_id: 777, references: [] }
+      if (path.includes('/figures')) return { media_id: 777, figures: [] }
+      if (path.endsWith('/annotations') && request?.method === 'GET') {
+        return { media_id: 777, annotations: [] }
+      }
+      return {}
+    })
+
+    const { rerender } = render(
+      <ContentViewer
+        selectedMedia={selectedMedia}
+        content={'Race selected body text'}
+        mediaDetail={{ type: 'document' }}
+      />
+    )
+
+    const contentNode = screen.getByText('Race selected body text')
+    const textNode = contentNode.firstChild
+    expect(textNode).not.toBeNull()
+
+    const selection = window.getSelection()
+    expect(selection).not.toBeNull()
+    const range = document.createRange()
+    range.setStart(textNode as Text, 0)
+    range.setEnd(textNode as Text, 'Race selected'.length)
+    selection!.removeAllRanges()
+    selection!.addRange(range)
+
+    fireEvent.mouseUp(contentNode)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeInTheDocument()
+    })
+    const staleAnnotateAction = screen.getByTestId('media-selection-action-annotate')
+
+    rerender(
+      <ContentViewer
+        selectedMedia={{
+          ...selectedMedia,
+          id: 779,
+          title: 'Race next annotation target'
+        }}
+        content={'Race next media body text'}
+        mediaDetail={{ type: 'document' }}
+      />
+    )
+
+    fireEvent.click(staleAnnotateAction)
+
+    expect(screen.queryByTestId('media-annotation-selection-preview')).not.toBeInTheDocument()
+    expect(mocks.bgRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/v1/media/779/annotations',
+        method: 'POST'
+      })
+    )
+  })
 })

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
@@ -153,7 +153,7 @@ describe('ContentViewer stage 14 annotations baseline', () => {
     )
 
     fireEvent.click(screen.getByTestId('media-intelligence-toggle'))
-    fireEvent.click(screen.getByTestId('media-intelligence-tab-annotations'))
+    fireEvent.click(await screen.findByTestId('media-intelligence-tab-annotations'))
 
     await waitFor(() => {
       expect(screen.getByTestId('media-annotation-manual-text')).toBeInTheDocument()
@@ -250,6 +250,13 @@ describe('ContentViewer stage 14 annotations baseline', () => {
     selection!.addRange(range)
 
     fireEvent.mouseUp(contentNode)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('media-annotation-selection-preview')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('media-selection-action-annotate'))
 
     await waitFor(() => {
       expect(screen.getByTestId('media-annotation-selection-preview')).toHaveTextContent(

--- a/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx
@@ -1,11 +1,29 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ContentViewer } from '../ContentViewer'
 
 const registryLabels = vi.hoisted(() => ({
   loading: 'Loading via registry'
+}))
+
+const mocks = vi.hoisted(() => ({
+  readAlongState: {
+    status: 'idle',
+    scope: null,
+    activeSegmentId: null,
+    activeIndex: -1,
+    totalSegments: 0,
+    error: null,
+    cacheDisabled: false
+  },
+  startReadAlong: vi.fn(),
+  pauseReadAlong: vi.fn(),
+  resumeReadAlong: vi.fn(),
+  stopReadAlong: vi.fn(),
+  retryReadAlong: vi.fn(),
+  skipReadAlong: vi.fn()
 }))
 
 vi.mock('react-i18next', () => ({
@@ -54,6 +72,19 @@ vi.mock('@/hooks/useMediaReadingProgress', () => ({
   useMediaReadingProgress: vi.fn()
 }))
 
+vi.mock('../read-along/useMediaReadAlongSession', () => ({
+  useMediaReadAlongSession: () => ({
+    state: mocks.readAlongState,
+    activeSegmentId: mocks.readAlongState.activeSegmentId,
+    start: mocks.startReadAlong,
+    pause: mocks.pauseReadAlong,
+    resume: mocks.resumeReadAlong,
+    stop: mocks.stopReadAlong,
+    retry: mocks.retryReadAlong,
+    skip: mocks.skipReadAlong
+  })
+}))
+
 vi.mock('../AnalysisModal', () => ({
   AnalysisModal: () => null
 }))
@@ -94,7 +125,73 @@ const mediaTwo = {
   meta: { type: 'document' }
 }
 
+const makeRect = ({
+  left,
+  top,
+  width,
+  height
+}: {
+  left: number
+  top: number
+  width: number
+  height: number
+}): DOMRect =>
+  ({
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({})
+  }) as DOMRect
+
+const selectText = (node: HTMLElement, selectedText: string) => {
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
+  let textNode: Node | null = node.firstChild
+  let startOffset = 0
+  while (textNode) {
+    const value = textNode.textContent || ''
+    const matchIndex = value.indexOf(selectedText)
+    if (matchIndex >= 0) {
+      startOffset = matchIndex
+      break
+    }
+    textNode = walker.nextNode()
+  }
+
+  expect(textNode).not.toBeNull()
+  const range = document.createRange()
+  range.setStart(textNode as Text, startOffset)
+  range.setEnd(textNode as Text, startOffset + selectedText.length)
+  const selection = window.getSelection()
+  expect(selection).not.toBeNull()
+  selection!.removeAllRanges()
+  selection!.addRange(range)
+}
+
 describe('ContentViewer stage 15 content announcements', () => {
+  beforeEach(() => {
+    window.getSelection()?.removeAllRanges()
+    mocks.readAlongState = {
+      status: 'idle',
+      scope: null,
+      activeSegmentId: null,
+      activeIndex: -1,
+      totalSegments: 0,
+      error: null,
+      cacheDisabled: false
+    }
+    mocks.startReadAlong.mockReset()
+    mocks.pauseReadAlong.mockReset()
+    mocks.resumeReadAlong.mockReset()
+    mocks.stopReadAlong.mockReset()
+    mocks.retryReadAlong.mockReset()
+    mocks.skipReadAlong.mockReset()
+  })
+
   it('announces loading and ready status when content state changes', async () => {
     const { rerender } = render(
       <ContentViewer
@@ -192,5 +289,108 @@ describe('ContentViewer stage 15 content announcements', () => {
       expect(liveRegion.textContent).toBe(baselineAnnouncement)
       expect(liveRegion).toHaveTextContent('Showing Accessibility Item One')
     })
+  })
+
+  it('opens named read-along and annotation actions from keyboard selection events', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ContentViewer
+        selectedMedia={mediaOne}
+        content="Keyboard selected sentence. Another sentence."
+        mediaDetail={{ type: 'document' }}
+        contentDisplayMode="plain"
+      />
+    )
+
+    const contentRegion = screen.getByRole('region', { name: 'Media content' })
+    for (let index = 0; index < 12 && document.activeElement !== contentRegion; index += 1) {
+      await user.tab()
+    }
+    expect(contentRegion).toHaveFocus()
+
+    const contentNode = screen.getByText(/Keyboard selected sentence/)
+    selectText(contentNode, 'Keyboard selected sentence.')
+    fireEvent.keyUp(contentNode)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('media-selection-actions-popover')).toBeVisible()
+    })
+    expect(
+      screen.getByRole('button', { name: 'Read selection' })
+    ).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Read from here' })).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: 'Read current section' })
+    ).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Read full item' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Annotate' })).toBeVisible()
+  })
+
+  it('uses reduced-motion scrolling for active read-along segment follow mode', async () => {
+    const scrollIntoView = vi.fn()
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+    const originalMatchMedia = window.matchMedia
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn()
+      }))
+    })
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getBoundingClientRectMock() {
+        const element = this as HTMLElement
+        if (element.dataset.readAlongSegmentId) {
+          return makeRect({ left: 0, top: 1_000, width: 100, height: 24 })
+        }
+        if (element.dataset.testid === 'content-scroll-container') {
+          return makeRect({ left: 0, top: 0, width: 320, height: 120 })
+        }
+        return makeRect({ left: 0, top: 0, width: 100, height: 24 })
+      })
+
+    mocks.readAlongState = {
+      status: 'playing',
+      scope: 'selection',
+      activeSegmentId: '1101:0:sentence:0:15',
+      activeIndex: 0,
+      totalSegments: 1,
+      error: null,
+      cacheDisabled: false
+    }
+
+    try {
+      render(
+        <ContentViewer
+          selectedMedia={mediaOne}
+          content="First sentence. Second sentence."
+          mediaDetail={{ type: 'document' }}
+          contentDisplayMode="plain"
+        />
+      )
+
+      await waitFor(() => {
+        expect(scrollIntoView).toHaveBeenCalledWith({
+          behavior: 'auto',
+          block: 'center'
+        })
+      })
+    } finally {
+      getBoundingClientRectSpy.mockRestore()
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: originalMatchMedia
+      })
+    }
   })
 })

--- a/apps/packages/ui/src/components/Media/hooks/useContentViewerModals.tsx
+++ b/apps/packages/ui/src/components/Media/hooks/useContentViewerModals.tsx
@@ -506,6 +506,21 @@ export function useContentViewerModals(deps: UseContentViewerModalsDeps) {
   ])
 
   // Annotation handlers
+  const captureAnnotationSelection = useCallback((selectionText: string, location?: string) => {
+    const selectedText = selectionText.trim()
+    if (!selectedMediaId || isNote || !selectedText) return
+
+    setAnnotationSelectionText(selectedText.slice(0, 4000))
+    setAnnotationSelectionLocation(location || `selection:${Date.now()}`)
+    setActiveIntelligenceTab('annotations')
+    if (collapsedSections.intelligence ?? true) {
+      void setCollapsedSections((prev) => ({
+        ...prev,
+        intelligence: false
+      }))
+    }
+  }, [collapsedSections.intelligence, isNote, selectedMediaId, setCollapsedSections])
+
   const handleCaptureAnnotationSelection = useCallback(() => {
     if (!selectedMediaId || isNote) return
     if (typeof window === 'undefined' || typeof window.getSelection !== 'function') {
@@ -527,16 +542,8 @@ export function useContentViewerModals(deps: UseContentViewerModalsDeps) {
     const selectedText = selection.toString().trim()
     if (!selectedText) return
 
-    setAnnotationSelectionText(selectedText.slice(0, 4000))
-    setAnnotationSelectionLocation(`selection:${Date.now()}`)
-    setActiveIntelligenceTab('annotations')
-    if (collapsedSections.intelligence ?? true) {
-      void setCollapsedSections((prev) => ({
-        ...prev,
-        intelligence: false
-      }))
-    }
-  }, [collapsedSections.intelligence, contentBodyRef, isNote, selectedMediaId, setCollapsedSections])
+    captureAnnotationSelection(selectedText)
+  }, [captureAnnotationSelection, contentBodyRef, isNote, selectedMediaId])
 
   const handleCreateAnnotation = useCallback(async () => {
     if (!selectedMediaId || isNote) return
@@ -1090,6 +1097,7 @@ export function useContentViewerModals(deps: UseContentViewerModalsDeps) {
     annotationDeletingId,
     annotationSyncing,
     annotationPanelEntries,
+    captureAnnotationSelection,
     handleCaptureAnnotationSelection,
     handleCreateAnnotation,
     handleUpdateAnnotationNote,

--- a/apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
+++ b/apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
@@ -170,6 +170,17 @@ const renderReadAlongWrappedText = (
   return <>{parts}</>
 }
 
+const getReadAlongSegmentEndOffset = (
+  segmentId: string | null | undefined
+): number | null => {
+  if (!segmentId) return null
+  const idParts = segmentId.split(':')
+  const endValue = idParts[idParts.length - 1]
+  if (!endValue) return null
+  const endOffset = Number(endValue)
+  return Number.isFinite(endOffset) && endOffset >= 0 ? endOffset : null
+}
+
 export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
   const {
     displayContent,
@@ -186,7 +197,7 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
   } = deps
 
   const [visiblePlainContentChars, setVisiblePlainContentChars] = useState(
-    () => content.length
+    () => Math.min(displayContent.length, LARGE_PLAIN_CONTENT_CHUNK_CHARS)
   )
   const [findBarOpen, setFindBarOpen] = useState(false)
   const [findQuery, setFindQuery] = useState('')
@@ -196,24 +207,6 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
   const findMatchElementRefs = useRef<Array<HTMLElement | null>>([])
 
   const normalizedFindQuery = useMemo(() => normalizeFindQuery(findQuery), [findQuery])
-
-  const readAlongSegments = useMemo(
-    () =>
-      buildReadAlongSegments({
-        mediaId: selectedMedia?.id != null ? String(selectedMedia.id) : 'unknown-media',
-        content,
-        displayContent,
-        renderMode: effectiveRenderMode,
-        hideTranscriptTimings: shouldHideTranscriptTimings
-      }),
-    [
-      content,
-      displayContent,
-      effectiveRenderMode,
-      selectedMedia?.id,
-      shouldHideTranscriptTimings
-    ]
-  )
 
   const shouldRenderTranscriptTimestampChips =
     hasClickableTranscriptTimestamps &&
@@ -242,6 +235,49 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
       Math.max(0, Math.min(displayContent.length, visiblePlainContentChars))
     )
   }, [displayContent, shouldUseChunkedPlainRendering, visiblePlainContentChars])
+
+  useEffect(() => {
+    if (!shouldUseChunkedPlainRendering) return
+    const activeEndOffset = getReadAlongSegmentEndOffset(activeReadAlongSegmentId)
+    if (activeEndOffset == null) return
+
+    setVisiblePlainContentChars((prev) => {
+      const next = Math.min(displayContent.length, Math.max(prev, activeEndOffset))
+      return next > prev ? next : prev
+    })
+  }, [
+    activeReadAlongSegmentId,
+    displayContent.length,
+    shouldUseChunkedPlainRendering
+  ])
+
+  const readAlongContentWindow = useMemo(() => {
+    if (!shouldUseChunkedPlainRendering) return content
+    const end = Math.max(0, Math.min(content.length, visiblePlainContentChars))
+    return content.slice(0, end)
+  }, [content, shouldUseChunkedPlainRendering, visiblePlainContentChars])
+
+  const readAlongDisplayContentWindow = shouldUseChunkedPlainRendering
+    ? visiblePlainContent
+    : displayContent
+
+  const readAlongSegments = useMemo(
+    () =>
+      buildReadAlongSegments({
+        mediaId: selectedMedia?.id != null ? String(selectedMedia.id) : 'unknown-media',
+        content: readAlongContentWindow,
+        displayContent: readAlongDisplayContentWindow,
+        renderMode: effectiveRenderMode,
+        hideTranscriptTimings: shouldHideTranscriptTimings
+      }),
+    [
+      effectiveRenderMode,
+      readAlongContentWindow,
+      readAlongDisplayContentWindow,
+      selectedMedia?.id,
+      shouldHideTranscriptTimings
+    ]
+  )
 
   const hasUnrenderedPlainContent =
     shouldUseChunkedPlainRendering && visiblePlainContentChars < displayContent.length

--- a/apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
+++ b/apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import type { MediaResultItem } from '../types'
+import { buildReadAlongSegments } from '../read-along/media-read-along-segments'
+import type { ReadAlongSegment } from '../read-along/types'
 
 export const LARGE_PLAIN_CONTENT_THRESHOLD_CHARS = 120_000
 export const LARGE_PLAIN_CONTENT_CHUNK_CHARS = 32_000
@@ -110,10 +112,62 @@ export interface UseTranscriptDisplayDeps {
   effectiveRenderMode: string
   shouldHideTranscriptTimings: boolean
   hasClickableTranscriptTimestamps: boolean
+  activeReadAlongSegmentId?: string | null
   contentScrollContainerRef: React.RefObject<HTMLDivElement | null>
   rootContainerRef: React.RefObject<HTMLDivElement | null>
   mediaPlayerRef: React.RefObject<HTMLMediaElement | null>
   t: (key: string, opts?: Record<string, any>) => string
+}
+
+const renderReadAlongWrappedText = (
+  text: string,
+  segments: ReadAlongSegment[],
+  activeReadAlongSegmentId: string | null | undefined
+): React.ReactNode => {
+  if (!text || segments.length === 0) return text
+
+  const visibleSegments = segments
+    .filter(
+      (segment) =>
+        segment.displayStart != null &&
+        segment.displayEnd != null &&
+        segment.displayStart >= 0 &&
+        segment.displayEnd > segment.displayStart &&
+        segment.displayStart < text.length &&
+        segment.displayEnd <= text.length
+    )
+    .sort((left, right) => left.displayStart! - right.displayStart!)
+
+  if (visibleSegments.length === 0) return text
+
+  const parts: React.ReactNode[] = []
+  let cursor = 0
+  visibleSegments.forEach((segment) => {
+    const start = segment.displayStart!
+    const end = segment.displayEnd!
+    if (start < cursor) return
+    if (start > cursor) {
+      parts.push(text.slice(cursor, start))
+    }
+    const isActive = segment.id === activeReadAlongSegmentId
+    parts.push(
+      <span
+        key={`read-along-segment-${segment.id}`}
+        data-read-along-segment-id={segment.id}
+        data-read-along-active={isActive ? 'true' : undefined}
+        className={isActive ? 'rounded bg-primary/20 px-0.5 text-text' : undefined}
+      >
+        {text.slice(start, end)}
+      </span>
+    )
+    cursor = end
+  })
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor))
+  }
+
+  return <>{parts}</>
 }
 
 export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
@@ -124,6 +178,7 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
     effectiveRenderMode,
     shouldHideTranscriptTimings,
     hasClickableTranscriptTimestamps,
+    activeReadAlongSegmentId,
     contentScrollContainerRef,
     rootContainerRef,
     mediaPlayerRef,
@@ -141,6 +196,24 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
   const findMatchElementRefs = useRef<Array<HTMLElement | null>>([])
 
   const normalizedFindQuery = useMemo(() => normalizeFindQuery(findQuery), [findQuery])
+
+  const readAlongSegments = useMemo(
+    () =>
+      buildReadAlongSegments({
+        mediaId: selectedMedia?.id != null ? String(selectedMedia.id) : 'unknown-media',
+        content,
+        displayContent,
+        renderMode: effectiveRenderMode,
+        hideTranscriptTimings: shouldHideTranscriptTimings
+      }),
+    [
+      content,
+      displayContent,
+      effectiveRenderMode,
+      selectedMedia?.id,
+      shouldHideTranscriptTimings
+    ]
+  )
 
   const shouldRenderTranscriptTimestampChips =
     hasClickableTranscriptTimestamps &&
@@ -209,8 +282,16 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
         defaultValue: 'No content available'
       })
     }
-    if (!normalizedFindQuery || findMatchOffsets.length === 0) {
-      return shouldUseChunkedPlainRendering ? visiblePlainContent : displayContent
+    const plainText = shouldUseChunkedPlainRendering ? visiblePlainContent : displayContent
+    if (!normalizedFindQuery) {
+      return renderReadAlongWrappedText(
+        plainText,
+        readAlongSegments,
+        activeReadAlongSegmentId
+      )
+    }
+    if (findMatchOffsets.length === 0) {
+      return plainText
     }
 
     const parts: React.ReactNode[] = []
@@ -250,9 +331,11 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
     return <>{parts}</>
   }, [
     activeFindMatchIndex,
+    activeReadAlongSegmentId,
     displayContent,
     findMatchOffsets,
     normalizedFindQuery,
+    readAlongSegments,
     shouldUseChunkedPlainRendering,
     t,
     visiblePlainContent
@@ -408,6 +491,7 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
     shouldUseChunkedPlainRendering,
     visiblePlainContent,
     hasUnrenderedPlainContent,
+    readAlongSegments,
     findMatchCount,
     highlightedPlainContent,
     // Callbacks

--- a/apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
+++ b/apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import type { MediaResultItem } from '../types'
 import { buildReadAlongSegments } from '../read-along/media-read-along-segments'
 import type { ReadAlongSegment } from '../read-along/types'
+import { parseLeadingTranscriptTiming } from '@/utils/media-transcript-display'
 
 export const LARGE_PLAIN_CONTENT_THRESHOLD_CHARS = 120_000
 export const LARGE_PLAIN_CONTENT_CHUNK_CHARS = 32_000
@@ -181,6 +182,93 @@ const getReadAlongSegmentEndOffset = (
   return Number.isFinite(endOffset) && endOffset >= 0 ? endOffset : null
 }
 
+const normalizeTranscriptSource = (value: string): string => value.replace(/\r\n/g, '\n')
+
+const getVisibleTranscriptLine = (line: string): string => {
+  const parsed = parseLeadingTranscriptTiming(line)
+  return parsed ? `${parsed.leadingWhitespace}${parsed.text}` : line
+}
+
+const getDisplayOffsetForSourceOffset = (
+  sourceContent: string,
+  displayContent: string,
+  sourceOffset: number
+): number => {
+  if (!Number.isFinite(sourceOffset) || sourceOffset <= 0) return 0
+  const normalizedSource = normalizeTranscriptSource(sourceContent)
+  if (normalizedSource === displayContent) {
+    return Math.min(displayContent.length, sourceOffset)
+  }
+  if (sourceOffset >= normalizedSource.length) return displayContent.length
+
+  const lines = normalizedSource.split('\n')
+  let currentSourceOffset = 0
+  let currentDisplayOffset = 0
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const hasLineBreak = index < lines.length - 1
+    const sourceLineLength = line.length + (hasLineBreak ? 1 : 0)
+    const displayLineLength =
+      getVisibleTranscriptLine(line).length + (hasLineBreak ? 1 : 0)
+    const nextSourceOffset = currentSourceOffset + sourceLineLength
+    const nextDisplayOffset = currentDisplayOffset + displayLineLength
+
+    if (sourceOffset <= nextSourceOffset) {
+      return Math.min(displayContent.length, nextDisplayOffset)
+    }
+
+    currentSourceOffset = nextSourceOffset
+    currentDisplayOffset = nextDisplayOffset
+  }
+
+  return displayContent.length
+}
+
+const getChunkBoundaryEnd = (requiredEnd: number, totalLength: number): number => {
+  const boundedEnd = Math.max(0, Math.min(totalLength, requiredEnd))
+  if (boundedEnd <= 0) return 0
+  return Math.min(
+    totalLength,
+    Math.ceil(boundedEnd / LARGE_PLAIN_CONTENT_CHUNK_CHARS) *
+      LARGE_PLAIN_CONTENT_CHUNK_CHARS
+  )
+}
+
+const getSourceWindowForDisplayWindow = (
+  sourceContent: string,
+  displayContent: string,
+  displayWindowLength: number
+): string => {
+  const normalizedSource = normalizeTranscriptSource(sourceContent)
+  const targetDisplayLength = Math.max(
+    0,
+    Math.min(displayContent.length, displayWindowLength)
+  )
+
+  if (targetDisplayLength >= displayContent.length) return normalizedSource
+  if (normalizedSource === displayContent) {
+    return normalizedSource.slice(0, targetDisplayLength)
+  }
+
+  const lines = normalizedSource.split('\n')
+  let sourceEnd = 0
+  let displayEnd = 0
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const hasLineBreak = index < lines.length - 1
+    sourceEnd += line.length + (hasLineBreak ? 1 : 0)
+    displayEnd += getVisibleTranscriptLine(line).length + (hasLineBreak ? 1 : 0)
+
+    if (displayEnd >= targetDisplayLength) {
+      return normalizedSource.slice(0, sourceEnd)
+    }
+  }
+
+  return normalizedSource
+}
+
 export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
   const {
     displayContent,
@@ -238,24 +326,40 @@ export function useTranscriptDisplay(deps: UseTranscriptDisplayDeps) {
 
   useEffect(() => {
     if (!shouldUseChunkedPlainRendering) return
-    const activeEndOffset = getReadAlongSegmentEndOffset(activeReadAlongSegmentId)
-    if (activeEndOffset == null) return
+    const activeSourceEndOffset = getReadAlongSegmentEndOffset(activeReadAlongSegmentId)
+    if (activeSourceEndOffset == null) return
+    const activeDisplayEndOffset = getDisplayOffsetForSourceOffset(
+      content,
+      displayContent,
+      activeSourceEndOffset
+    )
+    const nextVisibleEnd = getChunkBoundaryEnd(activeDisplayEndOffset, displayContent.length)
 
     setVisiblePlainContentChars((prev) => {
-      const next = Math.min(displayContent.length, Math.max(prev, activeEndOffset))
+      const next = Math.min(displayContent.length, Math.max(prev, nextVisibleEnd))
       return next > prev ? next : prev
     })
   }, [
     activeReadAlongSegmentId,
+    content,
     displayContent.length,
+    displayContent,
     shouldUseChunkedPlainRendering
   ])
 
   const readAlongContentWindow = useMemo(() => {
     if (!shouldUseChunkedPlainRendering) return content
-    const end = Math.max(0, Math.min(content.length, visiblePlainContentChars))
-    return content.slice(0, end)
-  }, [content, shouldUseChunkedPlainRendering, visiblePlainContentChars])
+    return getSourceWindowForDisplayWindow(
+      content,
+      displayContent,
+      visiblePlainContentChars
+    )
+  }, [
+    content,
+    displayContent,
+    shouldUseChunkedPlainRendering,
+    visiblePlainContentChars
+  ])
 
   const readAlongDisplayContentWindow = shouldUseChunkedPlainRendering
     ? visiblePlainContent

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { FileText, List, SkipForward, StickyNote, Volume2 } from 'lucide-react'
+import { Tooltip } from 'antd'
+
+import type { ReadAlongScope } from './types'
+
+type Translate = (key: string, opts?: Record<string, any>) => string
+
+interface MediaReadAlongPopoverProps {
+  anchorRect: DOMRect
+  onReadScope: (scope: ReadAlongScope) => void
+  onAnnotate: () => void
+  t: Translate
+}
+
+interface PopoverAction {
+  scope?: ReadAlongScope
+  testId: string
+  label: string
+  title: string
+  icon: React.ReactNode
+  onClick?: () => void
+}
+
+export function MediaReadAlongPopover({
+  anchorRect,
+  onReadScope,
+  onAnnotate,
+  t
+}: MediaReadAlongPopoverProps) {
+  const actions: PopoverAction[] = [
+    {
+      scope: 'selection',
+      testId: 'media-selection-action-read-selection',
+      label: t('review:mediaPage.readSelection', { defaultValue: 'Read selection' }),
+      title: t('review:mediaPage.readSelectionTooltip', {
+        defaultValue: 'Read the selected text'
+      }),
+      icon: <Volume2 className="h-3.5 w-3.5" />
+    },
+    {
+      scope: 'from-here',
+      testId: 'media-selection-action-read-from-here',
+      label: t('review:mediaPage.readFromHere', { defaultValue: 'Read from here' }),
+      title: t('review:mediaPage.readFromHereTooltip', {
+        defaultValue: 'Read from this point forward'
+      }),
+      icon: <SkipForward className="h-3.5 w-3.5" />
+    },
+    {
+      scope: 'current-section',
+      testId: 'media-selection-action-read-current-section',
+      label: t('review:mediaPage.readCurrentSection', {
+        defaultValue: 'Read current section'
+      }),
+      title: t('review:mediaPage.readCurrentSectionTooltip', {
+        defaultValue: 'Read the current section'
+      }),
+      icon: <List className="h-3.5 w-3.5" />
+    },
+    {
+      scope: 'full-item',
+      testId: 'media-selection-action-read-full-item',
+      label: t('review:mediaPage.readFullItem', { defaultValue: 'Read full item' }),
+      title: t('review:mediaPage.readFullItemTooltip', {
+        defaultValue: 'Read the full media item'
+      }),
+      icon: <FileText className="h-3.5 w-3.5" />
+    },
+    {
+      testId: 'media-selection-action-annotate',
+      label: t('review:mediaPage.annotate', { defaultValue: 'Annotate' }),
+      title: t('review:mediaPage.annotateSelection', {
+        defaultValue: 'Annotate selection'
+      }),
+      icon: <StickyNote className="h-3.5 w-3.5" />,
+      onClick: onAnnotate
+    }
+  ]
+
+  return (
+    <div
+      className="fixed z-50 flex max-w-[min(92vw,560px)] flex-wrap items-center gap-1 rounded border border-border bg-surface px-2 py-1 shadow-lg"
+      style={{
+        left: Math.max(8, anchorRect.left),
+        top: Math.max(8, anchorRect.top - 40)
+      }}
+      data-testid="media-selection-actions-popover"
+    >
+      {actions.map((action) => (
+        <Tooltip title={action.title} key={action.testId}>
+          <button
+            type="button"
+            className="inline-flex h-7 items-center gap-1 rounded px-2 text-xs font-medium text-text hover:bg-surface2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={action.onClick || (() => action.scope && onReadScope(action.scope))}
+            data-testid={action.testId}
+          >
+            {action.icon}
+            <span>{action.label}</span>
+          </button>
+        </Tooltip>
+      ))}
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
@@ -8,6 +8,8 @@ type Translate = (key: string, opts?: Record<string, any>) => string
 
 interface MediaReadAlongPopoverProps {
   anchorRect: DOMRect
+  viewportRect?: DOMRect | null
+  supportedScopes?: ReadAlongScope[]
   onReadScope: (scope: ReadAlongScope) => void
   onAnnotate: () => void
   t: Translate
@@ -22,12 +24,65 @@ interface PopoverAction {
   onClick?: () => void
 }
 
+const EDGE_MARGIN_PX = 8
+const ESTIMATED_POPOVER_WIDTH_PX = 560
+const ESTIMATED_POPOVER_HEIGHT_PX = 40
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(value, max))
+
+const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
+  if (viewportRect) return viewportRect
+  const width = typeof window !== 'undefined' ? window.innerWidth : 1024
+  const height = typeof window !== 'undefined' ? window.innerHeight : 768
+  return {
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    width,
+    height,
+    right: width,
+    bottom: height,
+    toJSON: () => ({})
+  } as DOMRect
+}
+
+const getPopoverPosition = (
+  anchorRect: DOMRect,
+  viewportRect?: DOMRect | null
+): { left: number; top: number } => {
+  const viewport = getViewportRect(viewportRect)
+  const viewportWidth = Math.max(0, viewport.right - viewport.left)
+  const viewportHeight = Math.max(0, viewport.bottom - viewport.top)
+  const popoverWidth = Math.min(
+    ESTIMATED_POPOVER_WIDTH_PX,
+    Math.max(0, viewportWidth - EDGE_MARGIN_PX * 2)
+  )
+  const popoverHeight = Math.min(
+    ESTIMATED_POPOVER_HEIGHT_PX,
+    Math.max(0, viewportHeight - EDGE_MARGIN_PX * 2)
+  )
+  const minLeft = viewport.left + EDGE_MARGIN_PX
+  const maxLeft = Math.max(minLeft, viewport.right - popoverWidth - EDGE_MARGIN_PX)
+  const minTop = viewport.top + EDGE_MARGIN_PX
+  const maxTop = Math.max(minTop, viewport.bottom - popoverHeight - EDGE_MARGIN_PX)
+
+  return {
+    left: clamp(anchorRect.left, minLeft, maxLeft),
+    top: clamp(anchorRect.top - ESTIMATED_POPOVER_HEIGHT_PX, minTop, maxTop)
+  }
+}
+
 export function MediaReadAlongPopover({
   anchorRect,
+  viewportRect,
+  supportedScopes = ['selection', 'from-here', 'current-section', 'full-item'],
   onReadScope,
   onAnnotate,
   t
 }: MediaReadAlongPopoverProps) {
+  const supportedScopeSet = new Set(supportedScopes)
   const actions: PopoverAction[] = [
     {
       scope: 'selection',
@@ -76,14 +131,16 @@ export function MediaReadAlongPopover({
       icon: <StickyNote className="h-3.5 w-3.5" />,
       onClick: onAnnotate
     }
-  ]
+  ].filter((action) => !action.scope || supportedScopeSet.has(action.scope))
+
+  const position = getPopoverPosition(anchorRect, viewportRect)
 
   return (
     <div
       className="fixed z-50 flex max-w-[min(92vw,560px)] flex-wrap items-center gap-1 rounded border border-border bg-surface px-2 py-1 shadow-lg"
       style={{
-        left: Math.max(8, anchorRect.left),
-        top: Math.max(8, anchorRect.top - 40)
+        left: position.left,
+        top: position.top
       }}
       data-testid="media-selection-actions-popover"
     >

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
@@ -32,10 +32,9 @@ const clamp = (value: number, min: number, max: number): number =>
   Math.max(min, Math.min(value, max))
 
 const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
-  if (viewportRect) return viewportRect
   const width = typeof window !== 'undefined' ? window.innerWidth : 1024
   const height = typeof window !== 'undefined' ? window.innerHeight : 768
-  return {
+  const windowViewport = {
     x: 0,
     y: 0,
     left: 0,
@@ -44,6 +43,27 @@ const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
     height,
     right: width,
     bottom: height,
+    toJSON: () => ({})
+  } as DOMRect
+  if (!viewportRect) return windowViewport
+
+  const left = Math.max(windowViewport.left, viewportRect.left)
+  const top = Math.max(windowViewport.top, viewportRect.top)
+  const right = Math.min(windowViewport.right, viewportRect.right)
+  const bottom = Math.min(windowViewport.bottom, viewportRect.bottom)
+  if (right - left <= EDGE_MARGIN_PX * 2 || bottom - top <= EDGE_MARGIN_PX * 2) {
+    return windowViewport
+  }
+
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width: right - left,
+    height: bottom - top,
+    right,
+    bottom,
     toJSON: () => ({})
   } as DOMRect
 }
@@ -153,6 +173,7 @@ export function MediaReadAlongPopover({
           <button
             type="button"
             className="inline-flex h-7 items-center gap-1 rounded px-2 text-xs font-medium text-text hover:bg-surface2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            onPointerDown={(event) => event.preventDefault()}
             onMouseDown={(event) => event.preventDefault()}
             onClick={action.onClick || (() => action.scope && onReadScope(action.scope))}
             data-testid={action.testId}

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
@@ -51,7 +51,7 @@ const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
 const getPopoverPosition = (
   anchorRect: DOMRect,
   viewportRect?: DOMRect | null
-): { left: number; top: number } => {
+): { left: number; maxWidth: number; top: number } => {
   const viewport = getViewportRect(viewportRect)
   const viewportWidth = Math.max(0, viewport.right - viewport.left)
   const viewportHeight = Math.max(0, viewport.bottom - viewport.top)
@@ -68,8 +68,11 @@ const getPopoverPosition = (
   const minTop = viewport.top + EDGE_MARGIN_PX
   const maxTop = Math.max(minTop, viewport.bottom - popoverHeight - EDGE_MARGIN_PX)
 
+  const left = clamp(anchorRect.left, minLeft, maxLeft)
+
   return {
-    left: clamp(anchorRect.left, minLeft, maxLeft),
+    left,
+    maxWidth: Math.max(0, viewport.right - left - EDGE_MARGIN_PX),
     top: clamp(anchorRect.top - ESTIMATED_POPOVER_HEIGHT_PX, minTop, maxTop)
   }
 }
@@ -137,9 +140,10 @@ export function MediaReadAlongPopover({
 
   return (
     <div
-      className="fixed z-50 flex max-w-[min(92vw,560px)] flex-wrap items-center gap-1 rounded border border-border bg-surface px-2 py-1 shadow-lg"
+      className="fixed z-50 flex flex-wrap items-center gap-1 rounded border border-border bg-surface px-2 py-1 shadow-lg"
       style={{
         left: position.left,
+        maxWidth: position.maxWidth,
         top: position.top
       }}
       data-testid="media-selection-actions-popover"

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
@@ -58,21 +58,28 @@ const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
 const getTransportPosition = (
   anchorRect: DOMRect | null,
   viewportRect?: DOMRect | null
-): { left: number; top: number } => {
+): { left: number; maxWidth: number; top: number } => {
   const viewport = getViewportRect(viewportRect)
+  const viewportWidth = Math.max(0, viewport.right - viewport.left)
+  const transportWidth = Math.min(
+    ESTIMATED_TRANSPORT_WIDTH_PX,
+    Math.max(0, viewportWidth - EDGE_MARGIN_PX * 2)
+  )
   const minLeft = viewport.left + EDGE_MARGIN_PX
   const maxLeft = Math.max(
     minLeft,
-    viewport.right - ESTIMATED_TRANSPORT_WIDTH_PX - EDGE_MARGIN_PX
+    viewport.right - transportWidth - EDGE_MARGIN_PX
   )
   const minTop = viewport.top + EDGE_MARGIN_PX
   const maxTop = Math.max(
     minTop,
     viewport.bottom - ESTIMATED_TRANSPORT_HEIGHT_PX - EDGE_MARGIN_PX
   )
+  const left = clamp(anchorRect?.left ?? minLeft, minLeft, maxLeft)
 
   return {
-    left: clamp(anchorRect?.left ?? minLeft, minLeft, maxLeft),
+    left,
+    maxWidth: Math.max(0, viewport.right - left - EDGE_MARGIN_PX),
     top: clamp((anchorRect?.bottom ?? minTop + 72) + EDGE_MARGIN_PX, minTop, maxTop)
   }
 }
@@ -102,9 +109,10 @@ export function MediaReadAlongTransport({
 
   return (
     <div
-      className="fixed z-40 inline-flex max-w-[calc(100vw-16px)] items-center gap-1 rounded border border-border bg-surface px-2 py-1 text-xs text-text shadow-lg"
+      className="fixed z-40 flex flex-wrap items-center gap-1 overflow-hidden rounded border border-border bg-surface px-2 py-1 text-xs text-text shadow-lg"
       style={{
         left: position.left,
+        maxWidth: position.maxWidth,
         top: position.top
       }}
       data-testid="media-read-along-transport"

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import {
+  AlertCircle,
+  Pause,
+  Play,
+  RefreshCw,
+  SkipForward,
+  Square
+} from 'lucide-react'
+import { Tooltip } from 'antd'
+
+import type { ReadAlongSessionState } from './types'
+
+type Translate = (key: string, opts?: Record<string, any>) => string
+
+interface MediaReadAlongTransportProps {
+  state: ReadAlongSessionState
+  anchorRect: DOMRect | null
+  onToggle: () => void
+  onStop: () => void
+  onRetry: () => void
+  onSkip: () => void
+  t: Translate
+}
+
+const visibleStatuses = new Set([
+  'preparing',
+  'playing',
+  'paused',
+  'segment-error'
+])
+
+export function MediaReadAlongTransport({
+  state,
+  anchorRect,
+  onToggle,
+  onStop,
+  onRetry,
+  onSkip,
+  t
+}: MediaReadAlongTransportProps) {
+  if (!visibleStatuses.has(state.status)) return null
+
+  const isPaused = state.status === 'paused'
+  const isPreparing = state.status === 'preparing'
+  const hasError = state.status === 'segment-error'
+  const progress =
+    state.totalSegments > 0 && state.activeIndex >= 0
+      ? `${state.activeIndex + 1}/${state.totalSegments}`
+      : isPreparing
+        ? t('review:mediaPage.readAlongPreparing', { defaultValue: 'Preparing' })
+        : '0/0'
+  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024
+
+  return (
+    <div
+      className="fixed z-40 inline-flex max-w-[calc(100vw-16px)] items-center gap-1 rounded border border-border bg-surface px-2 py-1 text-xs text-text shadow-lg"
+      style={{
+        left: Math.max(8, Math.min(anchorRect?.left ?? 16, viewportWidth - 260)),
+        top: Math.max(8, (anchorRect?.bottom ?? 88) + 8)
+      }}
+      data-testid="media-read-along-transport"
+      role="group"
+      aria-label={t('review:mediaPage.readAlongTransport', {
+        defaultValue: 'Read-along controls'
+      })}
+    >
+      <Tooltip
+        title={
+          isPaused
+            ? t('review:mediaPage.readAlongResume', { defaultValue: 'Resume' })
+            : t('review:mediaPage.readAlongPause', { defaultValue: 'Pause' })
+        }
+      >
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded text-text-muted hover:bg-surface2 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onToggle}
+          disabled={isPreparing || hasError}
+          aria-label={
+            isPaused
+              ? t('review:mediaPage.readAlongResume', { defaultValue: 'Resume' })
+              : t('review:mediaPage.readAlongPause', { defaultValue: 'Pause' })
+          }
+          data-testid="media-read-along-toggle"
+        >
+          {isPaused ? <Play className="h-3.5 w-3.5" /> : <Pause className="h-3.5 w-3.5" />}
+        </button>
+      </Tooltip>
+      <Tooltip title={t('review:mediaPage.readAlongStop', { defaultValue: 'Stop' })}>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded text-text-muted hover:bg-surface2 hover:text-text"
+          onClick={onStop}
+          aria-label={t('review:mediaPage.readAlongStop', { defaultValue: 'Stop' })}
+          data-testid="media-read-along-stop"
+        >
+          <Square className="h-3.5 w-3.5" />
+        </button>
+      </Tooltip>
+      <span
+        className="min-w-[44px] rounded bg-surface2 px-1.5 py-0.5 text-center tabular-nums text-text-muted"
+        data-testid="media-read-along-progress"
+      >
+        {progress}
+      </span>
+      <Tooltip title={t('review:mediaPage.readAlongRetry', { defaultValue: 'Retry' })}>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded text-text-muted hover:bg-surface2 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onRetry}
+          disabled={!hasError}
+          aria-label={t('review:mediaPage.readAlongRetry', { defaultValue: 'Retry' })}
+          data-testid="media-read-along-retry"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+        </button>
+      </Tooltip>
+      <Tooltip title={t('review:mediaPage.readAlongSkip', { defaultValue: 'Skip' })}>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded text-text-muted hover:bg-surface2 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onSkip}
+          disabled={!hasError}
+          aria-label={t('review:mediaPage.readAlongSkip', { defaultValue: 'Skip' })}
+          data-testid="media-read-along-skip"
+        >
+          <SkipForward className="h-3.5 w-3.5" />
+        </button>
+      </Tooltip>
+      {hasError ? (
+        <span className="inline-flex max-w-[180px] items-center gap-1 truncate text-warn">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{state.error || 'Playback failed'}</span>
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
@@ -16,6 +16,7 @@ type Translate = (key: string, opts?: Record<string, any>) => string
 interface MediaReadAlongTransportProps {
   state: ReadAlongSessionState
   anchorRect: DOMRect | null
+  viewportRect?: DOMRect | null
   onToggle: () => void
   onStop: () => void
   onRetry: () => void
@@ -30,9 +31,56 @@ const visibleStatuses = new Set([
   'segment-error'
 ])
 
+const EDGE_MARGIN_PX = 8
+const ESTIMATED_TRANSPORT_WIDTH_PX = 260
+const ESTIMATED_TRANSPORT_HEIGHT_PX = 44
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(value, max))
+
+const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
+  if (viewportRect) return viewportRect
+  const width = typeof window !== 'undefined' ? window.innerWidth : 1024
+  const height = typeof window !== 'undefined' ? window.innerHeight : 768
+  return {
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    width,
+    height,
+    right: width,
+    bottom: height,
+    toJSON: () => ({})
+  } as DOMRect
+}
+
+const getTransportPosition = (
+  anchorRect: DOMRect | null,
+  viewportRect?: DOMRect | null
+): { left: number; top: number } => {
+  const viewport = getViewportRect(viewportRect)
+  const minLeft = viewport.left + EDGE_MARGIN_PX
+  const maxLeft = Math.max(
+    minLeft,
+    viewport.right - ESTIMATED_TRANSPORT_WIDTH_PX - EDGE_MARGIN_PX
+  )
+  const minTop = viewport.top + EDGE_MARGIN_PX
+  const maxTop = Math.max(
+    minTop,
+    viewport.bottom - ESTIMATED_TRANSPORT_HEIGHT_PX - EDGE_MARGIN_PX
+  )
+
+  return {
+    left: clamp(anchorRect?.left ?? minLeft, minLeft, maxLeft),
+    top: clamp((anchorRect?.bottom ?? minTop + 72) + EDGE_MARGIN_PX, minTop, maxTop)
+  }
+}
+
 export function MediaReadAlongTransport({
   state,
   anchorRect,
+  viewportRect,
   onToggle,
   onStop,
   onRetry,
@@ -50,14 +98,14 @@ export function MediaReadAlongTransport({
       : isPreparing
         ? t('review:mediaPage.readAlongPreparing', { defaultValue: 'Preparing' })
         : '0/0'
-  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024
+  const position = getTransportPosition(anchorRect, viewportRect)
 
   return (
     <div
       className="fixed z-40 inline-flex max-w-[calc(100vw-16px)] items-center gap-1 rounded border border-border bg-surface px-2 py-1 text-xs text-text shadow-lg"
       style={{
-        left: Math.max(8, Math.min(anchorRect?.left ?? 16, viewportWidth - 260)),
-        top: Math.max(8, (anchorRect?.bottom ?? 88) + 8)
+        left: position.left,
+        top: position.top
       }}
       data-testid="media-read-along-transport"
       role="group"
@@ -101,6 +149,9 @@ export function MediaReadAlongTransport({
       <span
         className="min-w-[44px] rounded bg-surface2 px-1.5 py-0.5 text-center tabular-nums text-text-muted"
         data-testid="media-read-along-progress"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
       >
         {progress}
       </span>
@@ -129,7 +180,13 @@ export function MediaReadAlongTransport({
         </button>
       </Tooltip>
       {hasError ? (
-        <span className="inline-flex max-w-[180px] items-center gap-1 truncate text-warn">
+        <span
+          className="inline-flex max-w-[180px] items-center gap-1 truncate text-warn"
+          data-testid="media-read-along-error"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">{state.error || 'Playback failed'}</span>
         </span>

--- a/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
@@ -39,10 +39,9 @@ const clamp = (value: number, min: number, max: number): number =>
   Math.max(min, Math.min(value, max))
 
 const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
-  if (viewportRect) return viewportRect
   const width = typeof window !== 'undefined' ? window.innerWidth : 1024
   const height = typeof window !== 'undefined' ? window.innerHeight : 768
-  return {
+  const windowViewport = {
     x: 0,
     y: 0,
     left: 0,
@@ -51,6 +50,27 @@ const getViewportRect = (viewportRect?: DOMRect | null): DOMRect => {
     height,
     right: width,
     bottom: height,
+    toJSON: () => ({})
+  } as DOMRect
+  if (!viewportRect) return windowViewport
+
+  const left = Math.max(windowViewport.left, viewportRect.left)
+  const top = Math.max(windowViewport.top, viewportRect.top)
+  const right = Math.min(windowViewport.right, viewportRect.right)
+  const bottom = Math.min(windowViewport.bottom, viewportRect.bottom)
+  if (right - left <= EDGE_MARGIN_PX * 2 || bottom - top <= EDGE_MARGIN_PX * 2) {
+    return windowViewport
+  }
+
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width: right - left,
+    height: bottom - top,
+    right,
+    bottom,
     toJSON: () => ({})
   } as DOMRect
 }

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildReadAlongCacheKey,
+  buildTtsSettingsSignature
+} from '../media-read-along-cache-key'
+
+describe('media read-along cache keys', () => {
+  it('does not include raw segment text in the stable key metadata', async () => {
+    const key = await buildReadAlongCacheKey({
+      serverScope: 'http://127.0.0.1:8000',
+      mediaId: '42',
+      mediaKind: 'media',
+      segmentId: 's1',
+      segmentText: 'private transcript text',
+      sourceStart: 10,
+      sourceEnd: 33,
+      settingsSignature: 'provider:tldw|voice:default'
+    })
+
+    expect(key.id).not.toContain('private transcript text')
+    expect(JSON.stringify(key)).not.toContain('private transcript text')
+  })
+
+  it('hashes segment text with a lowercase SHA-256 hex digest', async () => {
+    const key = await buildReadAlongCacheKey({
+      serverScope: 'http://127.0.0.1:8000',
+      mediaId: '42',
+      mediaKind: 'media',
+      segmentId: 's1',
+      segmentText: 'private transcript text',
+      sourceStart: 10,
+      sourceEnd: 33,
+      settingsSignature: 'provider:tldw|voice:default'
+    })
+
+    expect(key.textHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('changes settings signature when voice or speed changes', () => {
+    const base = buildTtsSettingsSignature({
+      provider: 'tldw',
+      model: 'kokoro',
+      voice: 'af',
+      speed: 1,
+      format: 'mp3'
+    })
+    const changedVoice = buildTtsSettingsSignature({
+      provider: 'tldw',
+      model: 'kokoro',
+      voice: 'bf',
+      speed: 1,
+      format: 'mp3'
+    })
+    const changedSpeed = buildTtsSettingsSignature({
+      provider: 'tldw',
+      model: 'kokoro',
+      voice: 'af',
+      speed: 1.2,
+      format: 'mp3'
+    })
+
+    expect(base).not.toEqual(changedVoice)
+    expect(base).not.toEqual(changedSpeed)
+  })
+})

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts
@@ -87,4 +87,30 @@ describe('media read-along cache keys', () => {
     expect(base).not.toEqual(changedVoice)
     expect(base).not.toEqual(changedSpeed)
   })
+
+  it('preserves opaque model and voice id casing in settings signatures', () => {
+    const mixedCase = buildTtsSettingsSignature({
+      provider: ' OpenAI ',
+      model: ' TTS-Model-A ',
+      voice: ' Voice-ID-A ',
+      speed: 1,
+      format: ' MP3 ',
+      language: ' EN-US '
+    })
+    const lowerCaseIds = buildTtsSettingsSignature({
+      provider: 'openai',
+      model: 'tts-model-a',
+      voice: 'voice-id-a',
+      speed: 1,
+      format: 'mp3',
+      language: 'en-us'
+    })
+
+    expect(mixedCase).toContain('provider:openai')
+    expect(mixedCase).toContain('model:TTS-Model-A')
+    expect(mixedCase).toContain('voice:Voice-ID-A')
+    expect(mixedCase).toContain('format:mp3')
+    expect(mixedCase).toContain('language:en-us')
+    expect(mixedCase).not.toEqual(lowerCaseIds)
+  })
 })

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildReadAlongCacheKey,
-  buildTtsSettingsSignature
+  buildTtsSettingsSignature,
+  sha256Hex
 } from '../media-read-along-cache-key'
 
 describe('media read-along cache keys', () => {
@@ -35,6 +36,29 @@ describe('media read-along cache keys', () => {
     })
 
     expect(key.textHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('matches the known SHA-256 digest for abc', async () => {
+    await expect(sha256Hex('abc')).resolves.toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    )
+  })
+
+  it('fails closed instead of producing a fake SHA-256 digest when Web Crypto is unavailable', async () => {
+    const originalCrypto = globalThis.crypto
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: undefined
+    })
+
+    try {
+      await expect(sha256Hex('abc')).rejects.toThrow(/SHA-256/)
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        configurable: true,
+        value: originalCrypto
+      })
+    }
   })
 
   it('changes settings signature when voice or speed changes', () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
@@ -8,8 +8,12 @@ const { rows, mockTable, putState, tableState } = vi.hoisted(() => {
     afterCommit: undefined as ((row: any) => void) | undefined
   }
   const tableState = {
-    afterToArray: undefined as (() => void) | undefined
+    afterListMetadata: undefined as (() => void) | undefined,
+    failUpdateForId: undefined as string | undefined
   }
+  const collectionToArray = vi.fn(async () => {
+    throw new Error('metadata listing should not load cache rows')
+  })
 
   const mockTable = {
     put: vi.fn(async (row: any) => {
@@ -26,6 +30,9 @@ const { rows, mockTable, putState, tableState } = vi.hoisted(() => {
     }),
     get: vi.fn(async (id: string) => rows.get(id)),
     update: vi.fn(async (id: string, changes: Record<string, unknown>) => {
+      if (tableState.failUpdateForId === id) {
+        throw new Error('IndexedDB metadata update failed')
+      }
       const current = rows.get(id)
       if (!current) return 0
       rows.set(id, { ...current, ...changes })
@@ -38,17 +45,24 @@ const { rows, mockTable, putState, tableState } = vi.hoisted(() => {
       for (const id of ids) rows.delete(id)
     }),
     toArray: vi.fn(async () => {
-      const values = Array.from(rows.values())
-      tableState.afterToArray?.()
-      return values
+      throw new Error('metadata listing should not load cache rows')
     }),
     orderBy: vi.fn((field: string) => ({
-      toArray: vi.fn(async () => {
-        const all = Array.from(rows.values())
-        all.sort((a, b) => a[field] - b[field])
-        tableState.afterToArray?.()
-        return all
-      })
+      keys: vi.fn(async () => {
+        expect(field).toBe('[lastUsedAt+sizeBytes+id]')
+        const keys = Array.from(rows.values())
+          .sort((a, b) => {
+            const lastUsedDelta = a.lastUsedAt - b.lastUsedAt
+            if (lastUsedDelta !== 0) return lastUsedDelta
+            const sizeDelta = a.sizeBytes - b.sizeBytes
+            if (sizeDelta !== 0) return sizeDelta
+            return String(a.id).localeCompare(String(b.id))
+          })
+          .map((row) => [row.lastUsedAt, row.sizeBytes, row.id])
+        tableState.afterListMetadata?.()
+        return keys
+      }),
+      toArray: collectionToArray
     }))
   }
 
@@ -97,7 +111,8 @@ describe('media read-along audio cache', () => {
     putState.throwQuotaTimes = 0
     putState.beforeCommit = undefined
     putState.afterCommit = undefined
-    tableState.afterToArray = undefined
+    tableState.afterListMetadata = undefined
+    tableState.failUpdateForId = undefined
     vi.clearAllMocks()
     resetMediaReadAlongAudioCacheSessionForTests()
   })
@@ -127,6 +142,20 @@ describe('media read-along audio cache', () => {
     )
   })
 
+  it('returns a cached entry when the best-effort last-used update fails', async () => {
+    const entry = cacheEntry({ id: 'update-fails' })
+    rows.set(entry.id, entry)
+    tableState.failUpdateForId = entry.id
+
+    const result = await getMediaReadAlongAudioCacheEntry(entry.id)
+
+    expect(result).toBe(entry)
+    expect(mockTable.update).toHaveBeenCalledWith(
+      entry.id,
+      expect.objectContaining({ lastUsedAt: expect.any(Number) })
+    )
+  })
+
   it('evicts least recently used entries before writes that exceed the byte cap', async () => {
     rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 700 }))
     rows.set('middle', cacheEntry({ id: 'middle', lastUsedAt: 20, sizeBytes: 200 }))
@@ -138,6 +167,21 @@ describe('media read-along audio cache', () => {
     )
 
     expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
+    expect(rows.has('oldest')).toBe(false)
+    expect(rows.has('incoming')).toBe(true)
+  })
+
+  it('uses metadata index keys for eviction without loading cached blobs', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 700 }))
+    rows.set('newest', cacheEntry({ id: 'newest', lastUsedAt: 30, sizeBytes: 100 }))
+
+    await saveMediaReadAlongAudioCacheEntry(
+      cacheEntry({ id: 'incoming', sizeBytes: 250 }),
+      { maxBytes: 1000 }
+    )
+
+    expect(mockTable.orderBy).toHaveBeenCalledWith('[lastUsedAt+sizeBytes+id]')
+    expect(mockTable.toArray).not.toHaveBeenCalled()
     expect(rows.has('oldest')).toBe(false)
     expect(rows.has('incoming')).toBe(true)
   })
@@ -193,7 +237,7 @@ describe('media read-along audio cache', () => {
     rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 900 }))
     const entry = cacheEntry({ id: 'guarded-before-delete', sizeBytes: 200 })
     let allowSave = true
-    tableState.afterToArray = () => {
+    tableState.afterListMetadata = () => {
       allowSave = false
     }
 
@@ -277,7 +321,7 @@ describe('media read-along audio cache', () => {
     putState.throwQuotaTimes = 1
     let allowSave = true
     let reads = 0
-    tableState.afterToArray = () => {
+    tableState.afterListMetadata = () => {
       reads += 1
       if (reads === 2) {
         allowSave = false

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
@@ -135,6 +135,22 @@ describe('media read-along audio cache', () => {
     expect(rows.has('oversized')).toBe(false)
   })
 
+  it('does not write when the save guard fails after eviction and before put', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 900 }))
+    const entry = cacheEntry({ id: 'guarded', sizeBytes: 200 })
+    let checks = 0
+
+    const saved = await saveMediaReadAlongAudioCacheEntry(entry, {
+      maxBytes: 1000,
+      shouldContinue: () => checks++ === 0
+    })
+
+    expect(saved).toBe(false)
+    expect(mockTable.put).not.toHaveBeenCalled()
+    expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
+    expect(rows.has('guarded')).toBe(false)
+  })
+
   it('retries once after QuotaExceededError by evicting LRU entries', async () => {
     rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 500 }))
     rows.set('newest', cacheEntry({ id: 'newest', lastUsedAt: 20, sizeBytes: 100 }))

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
@@ -62,6 +62,8 @@ vi.mock('@/db/dexie/schema', () => ({
 }))
 
 import {
+  MEDIA_READ_ALONG_CACHE_MAX_BYTES,
+  MEDIA_READ_ALONG_CACHE_MAX_ENTRIES,
   getMediaReadAlongAudioCacheEntry,
   resetMediaReadAlongAudioCacheSessionForTests,
   saveMediaReadAlongAudioCacheEntry
@@ -100,6 +102,11 @@ describe('media read-along audio cache', () => {
     resetMediaReadAlongAudioCacheSessionForTests()
   })
 
+  it('uses the spec default entry and byte caps', () => {
+    expect(MEDIA_READ_ALONG_CACHE_MAX_ENTRIES).toBe(200)
+    expect(MEDIA_READ_ALONG_CACHE_MAX_BYTES).toBe(250 * 1024 * 1024)
+  })
+
   it('saves and retrieves cache entries by id', async () => {
     const entry = cacheEntry()
 
@@ -132,6 +139,21 @@ describe('media read-along audio cache', () => {
 
     expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
     expect(rows.has('oldest')).toBe(false)
+    expect(rows.has('incoming')).toBe(true)
+  })
+
+  it('evicts least recently used entries before writes that exceed the entry cap', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 100 }))
+    rows.set('newest', cacheEntry({ id: 'newest', lastUsedAt: 20, sizeBytes: 100 }))
+
+    await saveMediaReadAlongAudioCacheEntry(
+      cacheEntry({ id: 'incoming', sizeBytes: 100 }),
+      { maxBytes: 1000, maxEntries: 2 }
+    )
+
+    expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
+    expect(rows.has('oldest')).toBe(false)
+    expect(rows.has('newest')).toBe(true)
     expect(rows.has('incoming')).toBe(true)
   })
 

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { rows, mockTable, putState } = vi.hoisted(() => {
+  const rows = new Map<string, any>()
+  const putState = {
+    throwQuotaTimes: 0
+  }
+
+  const mockTable = {
+    put: vi.fn(async (row: any) => {
+      if (putState.throwQuotaTimes > 0) {
+        putState.throwQuotaTimes -= 1
+        const error = new Error('Quota exceeded')
+        error.name = 'QuotaExceededError'
+        throw error
+      }
+      rows.set(row.id, row)
+      return row.id
+    }),
+    get: vi.fn(async (id: string) => rows.get(id)),
+    update: vi.fn(async (id: string, changes: Record<string, unknown>) => {
+      const current = rows.get(id)
+      if (!current) return 0
+      rows.set(id, { ...current, ...changes })
+      return 1
+    }),
+    delete: vi.fn(async (id: string) => {
+      rows.delete(id)
+    }),
+    bulkDelete: vi.fn(async (ids: string[]) => {
+      for (const id of ids) rows.delete(id)
+    }),
+    toArray: vi.fn(async () => Array.from(rows.values())),
+    orderBy: vi.fn((field: string) => ({
+      toArray: vi.fn(async () => {
+        const all = Array.from(rows.values())
+        all.sort((a, b) => a[field] - b[field])
+        return all
+      })
+    }))
+  }
+
+  return { rows, mockTable, putState }
+})
+
+vi.mock('@/db/dexie/schema', () => ({
+  db: {
+    mediaReadAlongAudioCache: mockTable
+  }
+}))
+
+import {
+  getMediaReadAlongAudioCacheEntry,
+  resetMediaReadAlongAudioCacheSessionForTests,
+  saveMediaReadAlongAudioCacheEntry
+} from '../media-read-along-cache'
+
+function fakeBlob(size = 1024): Blob {
+  return new Blob([new Uint8Array(size)], { type: 'audio/mpeg' })
+}
+
+function cacheEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cache-1',
+    createdAt: 1000,
+    lastUsedAt: 1000,
+    mediaId: 'media-1',
+    mediaKind: 'media',
+    segmentId: 'segment-1',
+    settingsSignature: 'provider:tldw|voice:af',
+    textHash: 'a'.repeat(64),
+    mimeType: 'audio/mpeg',
+    format: 'mp3',
+    blob: fakeBlob(),
+    sizeBytes: 1024,
+    ...overrides
+  }
+}
+
+describe('media read-along audio cache', () => {
+  beforeEach(() => {
+    rows.clear()
+    putState.throwQuotaTimes = 0
+    vi.clearAllMocks()
+    resetMediaReadAlongAudioCacheSessionForTests()
+  })
+
+  it('saves and retrieves cache entries by id', async () => {
+    const entry = cacheEntry()
+
+    const saved = await saveMediaReadAlongAudioCacheEntry(entry)
+    const result = await getMediaReadAlongAudioCacheEntry(entry.id)
+
+    expect(saved).toBe(true)
+    expect(mockTable.put).toHaveBeenCalledWith(entry)
+    expect(result).toMatchObject({
+      id: entry.id,
+      mediaId: entry.mediaId,
+      segmentId: entry.segmentId,
+      textHash: entry.textHash
+    })
+    expect(mockTable.update).toHaveBeenCalledWith(
+      entry.id,
+      expect.objectContaining({ lastUsedAt: expect.any(Number) })
+    )
+  })
+
+  it('evicts least recently used entries before writes that exceed the byte cap', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 700 }))
+    rows.set('middle', cacheEntry({ id: 'middle', lastUsedAt: 20, sizeBytes: 200 }))
+    rows.set('newest', cacheEntry({ id: 'newest', lastUsedAt: 30, sizeBytes: 100 }))
+
+    await saveMediaReadAlongAudioCacheEntry(
+      cacheEntry({ id: 'incoming', sizeBytes: 250 }),
+      { maxBytes: 1000 }
+    )
+
+    expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
+    expect(rows.has('oldest')).toBe(false)
+    expect(rows.has('incoming')).toBe(true)
+  })
+
+  it('retries once after QuotaExceededError by evicting LRU entries', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 500 }))
+    rows.set('newest', cacheEntry({ id: 'newest', lastUsedAt: 20, sizeBytes: 100 }))
+    putState.throwQuotaTimes = 1
+
+    const saved = await saveMediaReadAlongAudioCacheEntry(
+      cacheEntry({ id: 'incoming', sizeBytes: 100 }),
+      { maxBytes: 1000 }
+    )
+
+    expect(saved).toBe(true)
+    expect(mockTable.put).toHaveBeenCalledTimes(2)
+    expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
+    expect(rows.has('incoming')).toBe(true)
+  })
+
+  it('disables cache for the session after repeated quota failures', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 500 }))
+    putState.throwQuotaTimes = 2
+
+    const saved = await saveMediaReadAlongAudioCacheEntry(
+      cacheEntry({ id: 'incoming', sizeBytes: 100 }),
+      { maxBytes: 1000 }
+    )
+    const result = await getMediaReadAlongAudioCacheEntry('oldest')
+    const skipped = await saveMediaReadAlongAudioCacheEntry(cacheEntry({ id: 'skipped' }))
+
+    expect(saved).toBe(false)
+    expect(result).toBeUndefined()
+    expect(skipped).toBe(false)
+    expect(mockTable.put).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { rows, mockTable, putState } = vi.hoisted(() => {
   const rows = new Map<string, any>()
   const putState = {
-    throwQuotaTimes: 0
+    throwQuotaTimes: 0,
+    beforeCommit: undefined as Promise<void> | undefined,
+    afterCommit: undefined as ((row: any) => void) | undefined
   }
 
   const mockTable = {
@@ -14,7 +16,9 @@ const { rows, mockTable, putState } = vi.hoisted(() => {
         error.name = 'QuotaExceededError'
         throw error
       }
+      await putState.beforeCommit
       rows.set(row.id, row)
+      putState.afterCommit?.(row)
       return row.id
     }),
     get: vi.fn(async (id: string) => rows.get(id)),
@@ -81,6 +85,8 @@ describe('media read-along audio cache', () => {
   beforeEach(() => {
     rows.clear()
     putState.throwQuotaTimes = 0
+    putState.beforeCommit = undefined
+    putState.afterCommit = undefined
     vi.clearAllMocks()
     resetMediaReadAlongAudioCacheSessionForTests()
   })
@@ -151,6 +157,52 @@ describe('media read-along audio cache', () => {
     expect(rows.has('guarded')).toBe(false)
   })
 
+  it('removes a row when the save guard fails after a delayed put commits', async () => {
+    const entry = cacheEntry({ id: 'stale-after-put' })
+    let allowSave = true
+    let releasePut!: () => void
+    putState.beforeCommit = new Promise<void>((resolve) => {
+      releasePut = resolve
+    })
+
+    const savePromise = saveMediaReadAlongAudioCacheEntry(entry, {
+      shouldContinue: () => allowSave
+    })
+
+    await vi.waitFor(() => expect(mockTable.put).toHaveBeenCalledWith(entry))
+    allowSave = false
+    releasePut()
+
+    await expect(savePromise).resolves.toBe(false)
+    expect(mockTable.delete).toHaveBeenCalledWith(entry.id)
+    expect(rows.has(entry.id)).toBe(false)
+  })
+
+  it('does not remove a newer matching-key write when cleaning up a stale delayed put', async () => {
+    const entry = cacheEntry({ id: 'shared-key' })
+    const newerEntry = cacheEntry({ id: entry.id, createdAt: 2000, lastUsedAt: 2000 })
+    let allowSave = true
+    let releasePut!: () => void
+    putState.beforeCommit = new Promise<void>((resolve) => {
+      releasePut = resolve
+    })
+    putState.afterCommit = () => {
+      rows.set(entry.id, newerEntry)
+    }
+
+    const savePromise = saveMediaReadAlongAudioCacheEntry(entry, {
+      shouldContinue: () => allowSave
+    })
+
+    await vi.waitFor(() => expect(mockTable.put).toHaveBeenCalledWith(entry))
+    allowSave = false
+    releasePut()
+
+    await expect(savePromise).resolves.toBe(false)
+    expect(mockTable.delete).not.toHaveBeenCalled()
+    expect(rows.get(entry.id)).toBe(newerEntry)
+  })
+
   it('retries once after QuotaExceededError by evicting LRU entries', async () => {
     rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 500 }))
     rows.set('newest', cacheEntry({ id: 'newest', lastUsedAt: 20, sizeBytes: 100 }))
@@ -165,6 +217,31 @@ describe('media read-along audio cache', () => {
     expect(mockTable.put).toHaveBeenCalledTimes(2)
     expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
     expect(rows.has('incoming')).toBe(true)
+  })
+
+  it('removes a row when the save guard fails after a delayed quota retry put commits', async () => {
+    const entry = cacheEntry({ id: 'stale-retry-after-put', sizeBytes: 100 })
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 500 }))
+    putState.throwQuotaTimes = 1
+    let allowSave = true
+    let releasePut!: () => void
+    putState.beforeCommit = new Promise<void>((resolve) => {
+      releasePut = resolve
+    })
+
+    const savePromise = saveMediaReadAlongAudioCacheEntry(entry, {
+      maxBytes: 1000,
+      shouldContinue: () => allowSave
+    })
+
+    await vi.waitFor(() => expect(mockTable.put).toHaveBeenCalledTimes(2))
+    allowSave = false
+    releasePut()
+
+    await expect(savePromise).resolves.toBe(false)
+    expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
+    expect(mockTable.delete).toHaveBeenCalledWith(entry.id)
+    expect(rows.has(entry.id)).toBe(false)
   })
 
   it('disables cache for the session after repeated quota failures', async () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
@@ -120,6 +120,21 @@ describe('media read-along audio cache', () => {
     expect(rows.has('incoming')).toBe(true)
   })
 
+  it('skips oversized entries without evicting or writing', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 700 }))
+
+    const saved = await saveMediaReadAlongAudioCacheEntry(
+      cacheEntry({ id: 'oversized', sizeBytes: 1200 }),
+      { maxBytes: 1000 }
+    )
+
+    expect(saved).toBe(false)
+    expect(mockTable.put).not.toHaveBeenCalled()
+    expect(mockTable.bulkDelete).not.toHaveBeenCalled()
+    expect(rows.has('oldest')).toBe(true)
+    expect(rows.has('oversized')).toBe(false)
+  })
+
   it('retries once after QuotaExceededError by evicting LRU entries', async () => {
     rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 500 }))
     rows.set('newest', cacheEntry({ id: 'newest', lastUsedAt: 20, sizeBytes: 100 }))

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { rows, mockTable, putState } = vi.hoisted(() => {
+const { rows, mockTable, putState, tableState } = vi.hoisted(() => {
   const rows = new Map<string, any>()
   const putState = {
     throwQuotaTimes: 0,
     beforeCommit: undefined as Promise<void> | undefined,
     afterCommit: undefined as ((row: any) => void) | undefined
+  }
+  const tableState = {
+    afterToArray: undefined as (() => void) | undefined
   }
 
   const mockTable = {
@@ -34,17 +37,22 @@ const { rows, mockTable, putState } = vi.hoisted(() => {
     bulkDelete: vi.fn(async (ids: string[]) => {
       for (const id of ids) rows.delete(id)
     }),
-    toArray: vi.fn(async () => Array.from(rows.values())),
+    toArray: vi.fn(async () => {
+      const values = Array.from(rows.values())
+      tableState.afterToArray?.()
+      return values
+    }),
     orderBy: vi.fn((field: string) => ({
       toArray: vi.fn(async () => {
         const all = Array.from(rows.values())
         all.sort((a, b) => a[field] - b[field])
+        tableState.afterToArray?.()
         return all
       })
     }))
   }
 
-  return { rows, mockTable, putState }
+  return { rows, mockTable, putState, tableState }
 })
 
 vi.mock('@/db/dexie/schema', () => ({
@@ -87,6 +95,7 @@ describe('media read-along audio cache', () => {
     putState.throwQuotaTimes = 0
     putState.beforeCommit = undefined
     putState.afterCommit = undefined
+    tableState.afterToArray = undefined
     vi.clearAllMocks()
     resetMediaReadAlongAudioCacheSessionForTests()
   })
@@ -141,7 +150,7 @@ describe('media read-along audio cache', () => {
     expect(rows.has('oversized')).toBe(false)
   })
 
-  it('does not write when the save guard fails after eviction and before put', async () => {
+  it('does not evict or write when the save guard fails after preflight', async () => {
     rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 900 }))
     const entry = cacheEntry({ id: 'guarded', sizeBytes: 200 })
     let checks = 0
@@ -153,8 +162,29 @@ describe('media read-along audio cache', () => {
 
     expect(saved).toBe(false)
     expect(mockTable.put).not.toHaveBeenCalled()
-    expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
+    expect(mockTable.bulkDelete).not.toHaveBeenCalled()
+    expect(rows.has('oldest')).toBe(true)
     expect(rows.has('guarded')).toBe(false)
+  })
+
+  it('does not evict entries when the save guard fails immediately before bulk delete', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 900 }))
+    const entry = cacheEntry({ id: 'guarded-before-delete', sizeBytes: 200 })
+    let allowSave = true
+    tableState.afterToArray = () => {
+      allowSave = false
+    }
+
+    const saved = await saveMediaReadAlongAudioCacheEntry(entry, {
+      maxBytes: 1000,
+      shouldContinue: () => allowSave
+    })
+
+    expect(saved).toBe(false)
+    expect(mockTable.bulkDelete).not.toHaveBeenCalled()
+    expect(mockTable.put).not.toHaveBeenCalled()
+    expect(rows.has('oldest')).toBe(true)
+    expect(rows.has(entry.id)).toBe(false)
   })
 
   it('removes a row when the save guard fails after a delayed put commits', async () => {
@@ -217,6 +247,31 @@ describe('media read-along audio cache', () => {
     expect(mockTable.put).toHaveBeenCalledTimes(2)
     expect(mockTable.bulkDelete).toHaveBeenCalledWith(['oldest'])
     expect(rows.has('incoming')).toBe(true)
+  })
+
+  it('does not retry-evict entries when the save guard fails before quota bulk delete', async () => {
+    rows.set('oldest', cacheEntry({ id: 'oldest', lastUsedAt: 10, sizeBytes: 100 }))
+    const entry = cacheEntry({ id: 'stale-before-retry-delete', sizeBytes: 100 })
+    putState.throwQuotaTimes = 1
+    let allowSave = true
+    let reads = 0
+    tableState.afterToArray = () => {
+      reads += 1
+      if (reads === 2) {
+        allowSave = false
+      }
+    }
+
+    const saved = await saveMediaReadAlongAudioCacheEntry(entry, {
+      maxBytes: 1000,
+      shouldContinue: () => allowSave
+    })
+
+    expect(saved).toBe(false)
+    expect(mockTable.put).toHaveBeenCalledTimes(1)
+    expect(mockTable.bulkDelete).not.toHaveBeenCalled()
+    expect(rows.has('oldest')).toBe(true)
+    expect(rows.has(entry.id)).toBe(false)
   })
 
   it('removes a row when the save guard fails after a delayed quota retry put commits', async () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-segments.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-segments.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildReadAlongSegments,
+  resolveReadAlongScope,
+  splitSegmentForTtsRequest
+} from '../media-read-along-segments'
+
+describe('media read-along segmentation', () => {
+  it('segments leading transcript timings as transcript lines with timestamps', () => {
+    const content = '[00:01] First line.\n[00:04] Second line.'
+
+    const segments = buildReadAlongSegments({
+      mediaId: 'm1',
+      content,
+      displayContent: 'First line.\nSecond line.',
+      renderMode: 'plain',
+      hideTranscriptTimings: true
+    })
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toMatchObject({
+      id: 'm1:0:transcript-line:8:19',
+      index: 0,
+      kind: 'transcript-line',
+      text: 'First line.',
+      sourceStart: 8,
+      sourceEnd: 19,
+      timestampSeconds: 1
+    })
+    expect(segments[1]).toMatchObject({
+      id: 'm1:1:transcript-line:28:40',
+      kind: 'transcript-line',
+      text: 'Second line.',
+      timestampSeconds: 4
+    })
+    expect(segments[1].sourceStart).toBeGreaterThan(segments[0].sourceEnd)
+  })
+
+  it('segments prose sentences with deterministic offsets', () => {
+    const content = 'Alpha one. Beta two!\n\nGamma three? Delta four.'
+
+    const segments = buildReadAlongSegments({
+      mediaId: 'm2',
+      content,
+      displayContent: 'Alpha one. Beta two!',
+      renderMode: 'plain',
+      hideTranscriptTimings: false
+    })
+
+    expect(segments.map((segment) => segment.text)).toEqual([
+      'Alpha one.',
+      'Beta two!',
+      'Gamma three?',
+      'Delta four.'
+    ])
+    expect(
+      segments.map((segment) => ({
+        id: segment.id,
+        sourceStart: segment.sourceStart,
+        sourceEnd: segment.sourceEnd
+      }))
+    ).toEqual([
+      { id: 'm2:0:sentence:0:10', sourceStart: 0, sourceEnd: 10 },
+      { id: 'm2:1:sentence:11:20', sourceStart: 11, sourceEnd: 20 },
+      { id: 'm2:2:sentence:22:34', sourceStart: 22, sourceEnd: 34 },
+      { id: 'm2:3:sentence:35:46', sourceStart: 35, sourceEnd: 46 }
+    ])
+  })
+
+  it('resolves read-from-here against canonical full content, not a rendered window', () => {
+    const content = 'Alpha one. Beta two. Gamma three. Delta four.'
+    const segments = buildReadAlongSegments({
+      mediaId: 'm3',
+      content,
+      displayContent: 'Alpha one. Beta two.',
+      renderMode: 'plain',
+      hideTranscriptTimings: false
+    })
+
+    const queue = resolveReadAlongScope({
+      scope: 'from-here',
+      segments,
+      selection: {
+        selectedText: 'Beta',
+        mappingConfidence: 'nearest',
+        sourceStart: content.indexOf('Beta'),
+        sourceEnd: content.indexOf('Beta') + 'Beta'.length,
+        anchorRect: new DOMRect()
+      }
+    })
+
+    expect(queue.map((segment) => segment.text)).toEqual([
+      'Beta two.',
+      'Gamma three.',
+      'Delta four.'
+    ])
+  })
+
+  it('returns every canonical segment for full-item scope', () => {
+    const content = 'Alpha one. Beta two. Gamma three.'
+    const segments = buildReadAlongSegments({
+      mediaId: 'm4',
+      content,
+      displayContent: 'Alpha one.',
+      renderMode: 'plain',
+      hideTranscriptTimings: false
+    })
+
+    const queue = resolveReadAlongScope({
+      scope: 'full-item',
+      segments,
+      selection: {
+        selectedText: 'Alpha',
+        mappingConfidence: 'exact',
+        sourceStart: 0,
+        sourceEnd: 5,
+        anchorRect: new DOMRect()
+      }
+    })
+
+    expect(queue.map((segment) => segment.text)).toEqual([
+      'Alpha one.',
+      'Beta two.',
+      'Gamma three.'
+    ])
+  })
+
+  it('expands current-section using heading and paragraph metadata', () => {
+    const content = '# Intro\nAlpha one. Beta two.\n\n# Details\nGamma three. Delta four.'
+    const segments = buildReadAlongSegments({
+      mediaId: 'm5',
+      content,
+      displayContent: content,
+      renderMode: 'markdown',
+      hideTranscriptTimings: false
+    })
+
+    const queue = resolveReadAlongScope({
+      scope: 'current-section',
+      segments,
+      selection: {
+        selectedText: 'Gamma',
+        mappingConfidence: 'nearest',
+        sourceStart: content.indexOf('Gamma'),
+        sourceEnd: content.indexOf('Gamma') + 'Gamma'.length,
+        anchorRect: new DOMRect()
+      }
+    })
+
+    expect(queue.map((segment) => segment.text)).toEqual([
+      'Gamma three.',
+      'Delta four.'
+    ])
+    expect(new Set(queue.map((segment) => segment.sectionId))).toEqual(
+      new Set(['section-1'])
+    )
+  })
+
+  it('falls back to a transient selection when selection cannot map to source segments', () => {
+    const segments = buildReadAlongSegments({
+      mediaId: 'm6',
+      content: 'Alpha one. Beta two.',
+      displayContent: 'Alpha one. Beta two.',
+      renderMode: 'plain',
+      hideTranscriptTimings: false
+    })
+
+    const queue = resolveReadAlongScope({
+      scope: 'selection',
+      segments,
+      selection: {
+        selectedText: 'Detached rendered text',
+        mappingConfidence: 'text-only',
+        anchorRect: new DOMRect()
+      }
+    })
+
+    expect(queue).toEqual([
+      expect.objectContaining({
+        id: 'transient-selection:0:22',
+        index: 0,
+        kind: 'transient-selection',
+        text: 'Detached rendered text',
+        sourceStart: 0,
+        sourceEnd: 22
+      })
+    ])
+  })
+
+  it('splits overlong segment requests and preserves parent segment id', () => {
+    const parts = splitSegmentForTtsRequest(
+      {
+        id: 's1',
+        index: 0,
+        kind: 'sentence',
+        text: 'word '.repeat(80).trim(),
+        sourceStart: 0,
+        sourceEnd: 399
+      },
+      120
+    )
+
+    expect(parts.length).toBeGreaterThan(1)
+    expect(parts.every((part) => part.parentSegmentId === 's1')).toBe(true)
+    expect(parts.every((part) => part.text.length <= 120)).toBe(true)
+    expect(parts.map((part) => part.text).join(' ')).toBe('word '.repeat(80).trim())
+  })
+})

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-segments.test.ts
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-segments.test.ts
@@ -178,7 +178,7 @@ describe('media read-along segmentation', () => {
 
     expect(queue).toEqual([
       expect.objectContaining({
-        id: 'transient-selection:0:22',
+        id: 'm6:0:transient-selection:text-0babd90f:0:22',
         index: 0,
         kind: 'transient-selection',
         text: 'Detached rendered text',
@@ -186,6 +186,104 @@ describe('media read-along segmentation', () => {
         sourceEnd: 22
       })
     ])
+  })
+
+  it('builds deterministic non-colliding transient fallback ids', () => {
+    const firstSegments = buildReadAlongSegments({
+      mediaId: 'media-a',
+      content: 'Alpha one.',
+      displayContent: 'Alpha one.',
+      renderMode: 'plain',
+      hideTranscriptTimings: false
+    })
+    const secondSegments = buildReadAlongSegments({
+      mediaId: 'media-b',
+      content: 'Alpha one.',
+      displayContent: 'Alpha one.',
+      renderMode: 'plain',
+      hideTranscriptTimings: false
+    })
+
+    const firstOffsetQueue = resolveReadAlongScope({
+      scope: 'selection',
+      segments: firstSegments,
+      selection: {
+        selectedText: 'Same',
+        mappingConfidence: 'text-only',
+        sourceStart: 50,
+        sourceEnd: 54,
+        anchorRect: new DOMRect()
+      }
+    })
+    const secondOffsetQueue = resolveReadAlongScope({
+      scope: 'selection',
+      segments: firstSegments,
+      selection: {
+        selectedText: 'Same',
+        mappingConfidence: 'text-only',
+        sourceStart: 60,
+        sourceEnd: 64,
+        anchorRect: new DOMRect()
+      }
+    })
+    const secondMediaQueue = resolveReadAlongScope({
+      scope: 'selection',
+      segments: secondSegments,
+      selection: {
+        selectedText: 'Same',
+        mappingConfidence: 'text-only',
+        sourceStart: 50,
+        sourceEnd: 54,
+        anchorRect: new DOMRect()
+      }
+    })
+    const firstTextOnlyQueue = resolveReadAlongScope({
+      scope: 'selection',
+      segments: firstSegments,
+      selection: {
+        selectedText: 'WXYZ',
+        mappingConfidence: 'text-only',
+        anchorRect: new DOMRect()
+      }
+    })
+    const secondTextOnlyQueue = resolveReadAlongScope({
+      scope: 'selection',
+      segments: firstSegments,
+      selection: {
+        selectedText: 'ABCD',
+        mappingConfidence: 'text-only',
+        anchorRect: new DOMRect()
+      }
+    })
+    const repeatTextOnlyQueue = resolveReadAlongScope({
+      scope: 'selection',
+      segments: firstSegments,
+      selection: {
+        selectedText: 'WXYZ',
+        mappingConfidence: 'text-only',
+        anchorRect: new DOMRect()
+      }
+    })
+
+    expect(firstOffsetQueue[0].id).toBe('media-a:0:transient-selection:50:54')
+    expect(secondOffsetQueue[0].id).toBe('media-a:0:transient-selection:60:64')
+    expect(secondMediaQueue[0].id).toBe('media-b:0:transient-selection:50:54')
+    expect(firstTextOnlyQueue[0].id).toMatch(
+      /^media-a:0:transient-selection:text-[a-f0-9]+:0:4$/
+    )
+    expect(secondTextOnlyQueue[0].id).toMatch(
+      /^media-a:0:transient-selection:text-[a-f0-9]+:0:4$/
+    )
+    expect(firstTextOnlyQueue[0].id).toBe(repeatTextOnlyQueue[0].id)
+    expect(
+      new Set([
+        firstOffsetQueue[0].id,
+        secondOffsetQueue[0].id,
+        secondMediaQueue[0].id,
+        firstTextOnlyQueue[0].id,
+        secondTextOnlyQueue[0].id
+      ]).size
+    ).toBe(5)
   })
 
   it('splits overlong segment requests and preserves parent segment id', () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useContentSelectionActions } from '../useContentSelectionActions'
@@ -147,7 +147,34 @@ describe('useContentSelectionActions', () => {
     expect(result.current.selectionActionState?.endSegmentId).toBeUndefined()
   })
 
-  it('clears open selection actions when the document selection is cleared', () => {
+  it('opens selection actions from document selectionchange before explicit mouseup', async () => {
+    const contentBody = document.createElement('div')
+    contentBody.textContent = 'Selectionchange selected text'
+    document.body.append(contentBody)
+    setSelectionRange(contentBody.firstChild as Text, 0, contentBody.firstChild as Text, 15)
+
+    const ref = { current: contentBody } as React.RefObject<HTMLDivElement | null>
+    const { result } = renderHook(() =>
+      useContentSelectionActions({
+        contentBodyRef: ref,
+        contentIdentityKey: 'media:777:plain:a',
+        onApplyAnnotationSelection: vi.fn()
+      })
+    )
+
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'))
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectionActionState).toMatchObject({
+        selectedText: 'Selectionchange',
+        mappingConfidence: 'text-only'
+      })
+    })
+  })
+
+  it('clears open selection actions when the document selection is cleared', async () => {
     const onApplyAnnotationSelection = vi.fn()
     const contentBody = document.createElement('div')
     contentBody.textContent = 'Clearable selected text'
@@ -173,7 +200,9 @@ describe('useContentSelectionActions', () => {
       document.dispatchEvent(new Event('selectionchange'))
     })
 
-    expect(result.current.selectionActionState).toBeNull()
+    await waitFor(() => {
+      expect(result.current.selectionActionState).toBeNull()
+    })
 
     act(() => {
       result.current.applyAnnotationSelection()

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
@@ -142,4 +142,37 @@ describe('useContentSelectionActions', () => {
     expect(result.current.selectionActionState?.startSegmentId).toBeUndefined()
     expect(result.current.selectionActionState?.endSegmentId).toBeUndefined()
   })
+
+  it('clears open selection actions when the document selection is cleared', () => {
+    const onApplyAnnotationSelection = vi.fn()
+    const contentBody = document.createElement('div')
+    contentBody.textContent = 'Clearable selected text'
+    document.body.append(contentBody)
+    setSelectionRange(contentBody.firstChild as Text, 0, contentBody.firstChild as Text, 9)
+
+    const ref = { current: contentBody } as React.RefObject<HTMLDivElement | null>
+    const { result } = renderHook(() =>
+      useContentSelectionActions({
+        contentBodyRef: ref,
+        onApplyAnnotationSelection
+      })
+    )
+
+    act(() => {
+      result.current.handleContentSelectionEvent()
+    })
+    expect(result.current.selectionActionState?.selectedText).toBe('Clearable')
+
+    act(() => {
+      window.getSelection()?.removeAllRanges()
+      document.dispatchEvent(new Event('selectionchange'))
+    })
+
+    expect(result.current.selectionActionState).toBeNull()
+
+    act(() => {
+      result.current.applyAnnotationSelection()
+    })
+    expect(onApplyAnnotationSelection).not.toHaveBeenCalled()
+  })
 })

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useContentSelectionActions } from '../useContentSelectionActions'
+
+function setSelectionRange(startNode: Node, startOffset: number, endNode: Node, endOffset: number) {
+  const selection = window.getSelection()
+  expect(selection).not.toBeNull()
+
+  const range = document.createRange()
+  range.setStart(startNode, startOffset)
+  range.setEnd(endNode, endOffset)
+  Object.defineProperty(range, 'getBoundingClientRect', {
+    configurable: true,
+    value: vi.fn(() => new DOMRect(10, 20, 120, 18))
+  })
+
+  selection!.removeAllRanges()
+  selection!.addRange(range)
+}
+
+describe('useContentSelectionActions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    window.getSelection()?.removeAllRanges()
+    vi.restoreAllMocks()
+  })
+
+  it('ignores selections outside contentBodyRef', () => {
+    const contentBody = document.createElement('div')
+    contentBody.textContent = 'Inside content'
+    const outside = document.createElement('p')
+    outside.textContent = 'Outside content'
+    document.body.append(contentBody, outside)
+
+    setSelectionRange(outside.firstChild as Text, 0, outside.firstChild as Text, 7)
+
+    const ref = { current: contentBody } as React.RefObject<HTMLDivElement | null>
+    const { result } = renderHook(() =>
+      useContentSelectionActions({
+        contentBodyRef: ref,
+        onApplyAnnotationSelection: vi.fn()
+      })
+    )
+
+    act(() => {
+      result.current.handleContentSelectionEvent()
+    })
+
+    expect(result.current.selectionActionState).toBeNull()
+  })
+
+  it('returns selected text and anchor rect for content selections', () => {
+    const contentBody = document.createElement('div')
+    contentBody.textContent = 'Selected content text'
+    document.body.append(contentBody)
+    setSelectionRange(contentBody.firstChild as Text, 0, contentBody.firstChild as Text, 8)
+
+    const ref = { current: contentBody } as React.RefObject<HTMLDivElement | null>
+    const { result } = renderHook(() =>
+      useContentSelectionActions({
+        contentBodyRef: ref,
+        onApplyAnnotationSelection: vi.fn()
+      })
+    )
+
+    act(() => {
+      result.current.handleContentSelectionEvent()
+    })
+
+    expect(result.current.selectionActionState).toMatchObject({
+      selectedText: 'Selected',
+      mappingConfidence: 'text-only'
+    })
+    expect(result.current.selectionActionState?.anchorRect).toMatchObject({
+      x: 10,
+      y: 20,
+      width: 120,
+      height: 18
+    })
+  })
+
+  it('maps exact data-read-along-segment-id ancestors when present', () => {
+    const contentBody = document.createElement('div')
+    const startSegment = document.createElement('span')
+    startSegment.dataset.readAlongSegmentId = 'segment-start'
+    startSegment.textContent = 'Start segment'
+    const endSegment = document.createElement('span')
+    endSegment.dataset.readAlongSegmentId = 'segment-end'
+    endSegment.textContent = 'End segment'
+    contentBody.append(startSegment, endSegment)
+    document.body.append(contentBody)
+    setSelectionRange(
+      startSegment.firstChild as Text,
+      0,
+      endSegment.firstChild as Text,
+      'End'.length
+    )
+
+    const ref = { current: contentBody } as React.RefObject<HTMLDivElement | null>
+    const { result } = renderHook(() =>
+      useContentSelectionActions({
+        contentBodyRef: ref,
+        onApplyAnnotationSelection: vi.fn()
+      })
+    )
+
+    act(() => {
+      result.current.handleContentSelectionEvent()
+    })
+
+    expect(result.current.selectionActionState).toMatchObject({
+      startSegmentId: 'segment-start',
+      endSegmentId: 'segment-end',
+      mappingConfidence: 'exact'
+    })
+  })
+
+  it('falls back to text-only when no segment wrapper exists', () => {
+    const contentBody = document.createElement('div')
+    contentBody.textContent = 'Plain selected text'
+    document.body.append(contentBody)
+    setSelectionRange(contentBody.firstChild as Text, 0, contentBody.firstChild as Text, 5)
+
+    const ref = { current: contentBody } as React.RefObject<HTMLDivElement | null>
+    const { result } = renderHook(() =>
+      useContentSelectionActions({
+        contentBodyRef: ref,
+        onApplyAnnotationSelection: vi.fn()
+      })
+    )
+
+    act(() => {
+      result.current.handleContentSelectionEvent()
+    })
+
+    expect(result.current.selectionActionState).toMatchObject({
+      selectedText: 'Plain',
+      mappingConfidence: 'text-only'
+    })
+    expect(result.current.selectionActionState?.startSegmentId).toBeUndefined()
+    expect(result.current.selectionActionState?.endSegmentId).toBeUndefined()
+  })
+})

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
@@ -40,6 +40,7 @@ describe('useContentSelectionActions', () => {
     const { result } = renderHook(() =>
       useContentSelectionActions({
         contentBodyRef: ref,
+        contentIdentityKey: 'media:777:plain:a',
         onApplyAnnotationSelection: vi.fn()
       })
     )
@@ -61,6 +62,7 @@ describe('useContentSelectionActions', () => {
     const { result } = renderHook(() =>
       useContentSelectionActions({
         contentBodyRef: ref,
+        contentIdentityKey: 'media:777:plain:a',
         onApplyAnnotationSelection: vi.fn()
       })
     )
@@ -102,6 +104,7 @@ describe('useContentSelectionActions', () => {
     const { result } = renderHook(() =>
       useContentSelectionActions({
         contentBodyRef: ref,
+        contentIdentityKey: 'media:777:plain:a',
         onApplyAnnotationSelection: vi.fn()
       })
     )
@@ -127,6 +130,7 @@ describe('useContentSelectionActions', () => {
     const { result } = renderHook(() =>
       useContentSelectionActions({
         contentBodyRef: ref,
+        contentIdentityKey: 'media:777:plain:a',
         onApplyAnnotationSelection: vi.fn()
       })
     )
@@ -154,6 +158,7 @@ describe('useContentSelectionActions', () => {
     const { result } = renderHook(() =>
       useContentSelectionActions({
         contentBodyRef: ref,
+        contentIdentityKey: 'media:777:plain:a',
         onApplyAnnotationSelection
       })
     )
@@ -174,5 +179,40 @@ describe('useContentSelectionActions', () => {
       result.current.applyAnnotationSelection()
     })
     expect(onApplyAnnotationSelection).not.toHaveBeenCalled()
+  })
+
+  it('refuses to apply a selection opened under a previous content identity key', () => {
+    const onApplyAnnotationSelection = vi.fn()
+    const contentBody = document.createElement('div')
+    contentBody.textContent = 'Identity guarded text'
+    document.body.append(contentBody)
+    setSelectionRange(contentBody.firstChild as Text, 0, contentBody.firstChild as Text, 8)
+
+    const ref = { current: contentBody } as React.RefObject<HTMLDivElement | null>
+    const { result, rerender } = renderHook(
+      ({ contentIdentityKey }: { contentIdentityKey: string }) =>
+        useContentSelectionActions({
+          contentBodyRef: ref,
+          contentIdentityKey,
+          onApplyAnnotationSelection
+        }),
+      {
+        initialProps: { contentIdentityKey: 'media:777:plain:a' }
+      }
+    )
+
+    act(() => {
+      result.current.handleContentSelectionEvent()
+    })
+    expect(result.current.selectionActionState?.selectedText).toBe('Identity')
+
+    rerender({ contentIdentityKey: 'media:778:plain:b' })
+
+    act(() => {
+      result.current.applyAnnotationSelection()
+    })
+
+    expect(onApplyAnnotationSelection).not.toHaveBeenCalled()
+    expect(result.current.selectionActionState).toBeNull()
   })
 })

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -427,6 +427,66 @@ describe('useMediaReadAlongSession', () => {
     expect(eventLog.some((entry) => entry.includes('tldw|||1|wav|'))).toBe(false)
   })
 
+  it('uses effective model and voice in generated-audio cache signatures', async () => {
+    providerContext = {
+      provider: 'openai',
+      utterance: '',
+      playbackSpeed: 1,
+      supported: true,
+      cacheSettings: {
+        provider: 'openai',
+        model: 'tts-model-a',
+        voice: 'voice-a',
+        speed: 1,
+        format: 'mp3'
+      },
+      synthesize: vi.fn(async (text: string) => ({
+        buffer: new TextEncoder().encode(text).buffer,
+        format: 'mp3',
+        mimeType: 'audio/mpeg'
+      }))
+    }
+    const first = setupHook()
+
+    await act(async () => {
+      await first.result.current.start('selection')
+    })
+    first.unmount()
+
+    providerContext = {
+      provider: 'openai',
+      utterance: '',
+      playbackSpeed: 1,
+      supported: true,
+      cacheSettings: {
+        provider: 'openai',
+        model: 'tts-model-b',
+        voice: 'voice-b',
+        speed: 1,
+        format: 'mp3'
+      },
+      synthesize: vi.fn(async (text: string) => ({
+        buffer: new TextEncoder().encode(text).buffer,
+        format: 'mp3',
+        mimeType: 'audio/mpeg'
+      }))
+    }
+    const second = setupHook()
+
+    await act(async () => {
+      await second.result.current.start('selection')
+    })
+
+    expect(eventLog).toContain('settings:openai|tts-model-a|voice-a|1|mp3|')
+    expect(eventLog).toContain('settings:openai|tts-model-b|voice-b|1|mp3|')
+    expect(eventLog).toContain(
+      'cache-key:media-1:0:sentence:0:15:openai|tts-model-a|voice-a|1|mp3|'
+    )
+    expect(eventLog).toContain(
+      'cache-key:media-1:0:sentence:0:15:openai|tts-model-b|voice-b|1|mp3|'
+    )
+  })
+
   it('audio.play() rejection enters segment-error', async () => {
     playRejects = true
     const { result } = setupHook()

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -90,14 +90,32 @@ class MockSpeechSynthesisUtterance extends EventTarget {
 }
 
 vi.mock('@/services/tts-provider', () => ({
+  applyBrowserSpeechSynthesisVoice: vi.fn(),
   resolveTtsProviderContext: vi.fn(async () => {
     eventLog.push(`provider:resolve:${providerContext.provider}`)
     return providerContext
   })
 }))
 
+vi.mock('@/services/tldw/TldwApiClient', () => ({
+  tldwClient: {
+    getConfig: vi.fn(async () => ({
+      serverUrl: 'http://127.0.0.1:8000/',
+      apiKey: 'secret-api-key',
+      authMode: 'single-user'
+    }))
+  }
+}))
+
 vi.mock('../media-read-along-cache-key', () => ({
-  buildReadAlongCacheKey: vi.fn(async ({ segmentId, settingsSignature }) => {
+  buildReadAlongCacheKey: vi.fn(async ({
+    segmentId,
+    segmentText,
+    serverScope,
+    settingsSignature
+  }) => {
+    eventLog.push(`cache-scope:${serverScope}`)
+    eventLog.push(`cache-text:${segmentId}:${segmentText}`)
     eventLog.push(`cache-key:${segmentId}:${settingsSignature}`)
     return {
       id: `cache:${segmentId}:${settingsSignature}`,
@@ -162,6 +180,7 @@ vi.mock('../media-read-along-cache', () => ({
 }))
 
 import { resolveTtsProviderContext } from '@/services/tts-provider'
+import { tldwClient } from '@/services/tldw/TldwApiClient'
 import {
   getMediaReadAlongAudioCacheEntry,
   saveMediaReadAlongAudioCacheEntry
@@ -239,6 +258,7 @@ describe('useMediaReadAlongSession', () => {
       playbackSpeed: 1,
       supported: true,
       formatInfo: { requested: 'mp3', resolved: 'mp3', isFallback: false },
+      normalizeText: (text: string) => text,
       synthesize: vi.fn(async (text: string) => {
         eventLog.push(`synthesize:${text}`)
         return {
@@ -249,6 +269,11 @@ describe('useMediaReadAlongSession', () => {
       })
     }
     vi.clearAllMocks()
+    vi.mocked(tldwClient.getConfig).mockResolvedValue({
+      serverUrl: 'http://127.0.0.1:8000/',
+      apiKey: 'secret-api-key',
+      authMode: 'single-user'
+    })
     vi.stubGlobal('AbortController', TrackingAbortController)
     vi.stubGlobal('Audio', MockAudio)
     vi.stubGlobal('SpeechSynthesisUtterance', MockSpeechSynthesisUtterance)
@@ -344,7 +369,8 @@ describe('useMediaReadAlongSession', () => {
       provider: 'browser',
       utterance: 'First sentence.',
       playbackSpeed: 1.25,
-      supported: true
+      supported: true,
+      normalizeText: (text: string) => text
     }
     const { result } = setupHook()
 
@@ -356,6 +382,168 @@ describe('useMediaReadAlongSession', () => {
     expect(getMediaReadAlongAudioCacheEntry).not.toHaveBeenCalled()
     expect(saveMediaReadAlongAudioCacheEntry).not.toHaveBeenCalled()
     expect(buildReadAlongCacheKey).not.toHaveBeenCalled()
+  })
+
+  it('targets retry and skip from the segment that failed while loading', async () => {
+    providerContext.synthesize = vi.fn(async (text: string) => {
+      eventLog.push(`synthesize:${text}`)
+      if (text === 'Second sentence.') {
+        throw new Error('second segment failed')
+      }
+      return audioResult(text)
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    await completeCurrentAudio()
+
+    await waitFor(() => expect(result.current.state.status).toBe('segment-error'))
+    expect(result.current.state).toMatchObject({
+      activeSegmentId: 'media-1:1:sentence:16:32',
+      activeIndex: 1,
+      error: 'second segment failed'
+    })
+
+    providerContext.synthesize = vi.fn(async (text: string) => {
+      eventLog.push(`synthesize:${text}`)
+      return audioResult(text)
+    })
+    act(() => {
+      result.current.skip()
+    })
+
+    await waitFor(() =>
+      expect(result.current.state.activeSegmentId).toBe('media-1:2:sentence:33:48')
+    )
+  })
+
+  it('reuses an in-flight lookahead request when that segment becomes current', async () => {
+    const pending = new Map<string, DeferredAudio>()
+    providerContext.synthesize = vi.fn((text: string) => {
+      eventLog.push(`synthesize:${text}`)
+      if (text === 'Second sentence.') {
+        const deferred = deferredAudio()
+        pending.set(text, deferred)
+        return deferred.promise
+      }
+      return Promise.resolve(audioResult(text))
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    await waitFor(() => expect(pending.has('Second sentence.')).toBe(true))
+    await completeCurrentAudio()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const secondCalls = vi
+      .mocked(providerContext.synthesize)
+      .mock.calls
+      .filter(([text]) => text === 'Second sentence.')
+    expect(secondCalls).toHaveLength(1)
+
+    await act(async () => {
+      pending.get('Second sentence.')!.resolve(audioResult('second'))
+    })
+    await waitFor(() =>
+      expect(result.current.state.activeSegmentId).toBe('media-1:1:sentence:16:32')
+    )
+  })
+
+  it('aborts stale lookahead work when retry restarts the current segment', async () => {
+    const lookaheadSignals: AbortSignal[] = []
+    const pending = new Map<string, DeferredAudio>()
+    providerContext.synthesize = vi.fn((text: string, options?: { signal?: AbortSignal }) => {
+      eventLog.push(`synthesize:${text}`)
+      if (text === 'Second sentence.') {
+        if (options?.signal) lookaheadSignals.push(options.signal)
+        const deferred = deferredAudio()
+        pending.set(text, deferred)
+        return deferred.promise
+      }
+      return Promise.resolve(audioResult(text))
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    await waitFor(() => expect(pending.has('Second sentence.')).toBe(true))
+
+    act(() => {
+      result.current.retry()
+    })
+
+    expect(lookaheadSignals[0]?.aborted).toBe(true)
+  })
+
+  it('splits over-cap provider requests while keeping the parent segment active', async () => {
+    const longText = Array.from({ length: 900 }, (_, index) => `word${index}`).join(' ')
+    providerContext.synthesize = vi.fn(async (text: string) => {
+      eventLog.push(`synthesize:${text.length}`)
+      return audioResult(text)
+    })
+    const { result } = setupHook({
+      content: longText,
+      displayContent: longText,
+      selection: makeSelection({
+        selectedText: longText,
+        startSegmentId: `media-1:0:sentence:0:${longText.length}`,
+        endSegmentId: `media-1:0:sentence:0:${longText.length}`,
+        sourceStart: 0,
+        sourceEnd: longText.length
+      })
+    })
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    const synthesizeCalls = vi.mocked(providerContext.synthesize).mock.calls
+    expect(synthesizeCalls.length).toBeGreaterThan(1)
+    expect(synthesizeCalls.every(([text]) => String(text).length <= 4000)).toBe(true)
+    expect(result.current.state).toMatchObject({
+      status: 'playing',
+      activeSegmentId: `media-1:0:sentence:0:${longText.length}`,
+      activeIndex: 0,
+      totalSegments: 1
+    })
+  })
+
+  it('uses session-normalized text for generated synthesis and cache hashing', async () => {
+    providerContext.normalizeText = vi.fn((text: string) => `normalized:${text}`)
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    expect(providerContext.normalizeText).toHaveBeenCalledWith('First sentence.')
+    expect(providerContext.synthesize).toHaveBeenCalledWith(
+      'normalized:First sentence.',
+      expect.any(Object)
+    )
+    expect(eventLog).toContain(
+      'cache-text:media-1:0:sentence:0:15:normalized:First sentence.'
+    )
+  })
+
+  it('uses active server identity in generated-audio cache scope without secrets', async () => {
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    const scopeEntries = eventLog.filter((entry) => entry.startsWith('cache-scope:'))
+    expect(scopeEntries[0]).toContain('http://127.0.0.1:8000')
+    expect(scopeEntries[0]).not.toContain('secret-api-key')
+    expect(scopeEntries[0]).not.toBe('cache-scope:media-read-along')
   })
 
   it('stop aborts current and lookahead AbortControllers', async () => {
@@ -379,7 +567,8 @@ describe('useMediaReadAlongSession', () => {
       provider: 'browser',
       utterance: 'First sentence.',
       playbackSpeed: 1,
-      supported: true
+      supported: true,
+      normalizeText: (text: string) => text
     }
     const { result } = setupHook()
 
@@ -525,6 +714,7 @@ describe('useMediaReadAlongSession', () => {
       playbackSpeed: 1,
       supported: true,
       formatInfo: { requested: 'mp3', resolved: 'mp3', isFallback: false },
+      normalizeText: (text: string) => text,
       synthesize: firstSynthesize
     }
     const { result } = setupHook()
@@ -538,6 +728,7 @@ describe('useMediaReadAlongSession', () => {
       playbackSpeed: 1,
       supported: true,
       formatInfo: { requested: 'wav', resolved: 'wav', isFallback: false },
+      normalizeText: (text: string) => text,
       synthesize: secondSynthesize
     }
     await completeCurrentAudio()
@@ -562,6 +753,7 @@ describe('useMediaReadAlongSession', () => {
         speed: 1,
         format: 'mp3'
       },
+      normalizeText: (text: string) => text,
       synthesize: vi.fn(async (text: string) => ({
         buffer: new TextEncoder().encode(text).buffer,
         format: 'mp3',
@@ -587,6 +779,7 @@ describe('useMediaReadAlongSession', () => {
         speed: 1,
         format: 'mp3'
       },
+      normalizeText: (text: string) => text,
       synthesize: vi.fn(async (text: string) => ({
         buffer: new TextEncoder().encode(text).buffer,
         format: 'mp3',
@@ -626,7 +819,8 @@ describe('useMediaReadAlongSession', () => {
       provider: 'browser',
       utterance: 'First sentence.',
       playbackSpeed: 1,
-      supported: true
+      supported: true,
+      normalizeText: (text: string) => text
     }
     const spoken: MockSpeechSynthesisUtterance[] = []
     Object.defineProperty(window, 'speechSynthesis', {
@@ -671,7 +865,8 @@ describe('useMediaReadAlongSession', () => {
       provider: 'browser',
       utterance: 'First sentence.',
       playbackSpeed: 1,
-      supported: true
+      supported: true,
+      normalizeText: (text: string) => text
     }
     const spoken: MockSpeechSynthesisUtterance[] = []
     Object.defineProperty(window, 'speechSynthesis', {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -368,6 +368,33 @@ describe('useMediaReadAlongSession', () => {
       .toBeLessThan(8)
   })
 
+  it('contains background lookahead failures without changing current playback state', async () => {
+    providerContext.synthesize = vi.fn(async (text: string) => {
+      eventLog.push(`synthesize:${text}`)
+      if (text === 'Second sentence.') {
+        throw new Error('lookahead failed')
+      }
+      return audioResult(text)
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    await waitFor(() =>
+      expect(providerContext.synthesize).toHaveBeenCalledWith(
+        'Second sentence.',
+        expect.any(Object)
+      )
+    )
+
+    expect(result.current.state).toMatchObject({
+      status: 'playing',
+      activeSegmentId: 'media-1:0:sentence:0:15',
+      error: null
+    })
+  })
+
   it('browser TTS provider uses window.speechSynthesis.speak() and does not touch generated-audio cache', async () => {
     providerContext = {
       provider: 'browser',

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -14,6 +14,7 @@ const eventLog: string[] = []
 let providerContext: TtsProviderContext
 let objectUrlCounter = 0
 let playRejects = false
+let cacheSaveGate: Promise<void> | null = null
 
 type DeferredAudio = {
   promise: Promise<{
@@ -142,8 +143,15 @@ vi.mock('../media-read-along-cache', () => ({
         }
       : undefined
   }),
-  saveMediaReadAlongAudioCacheEntry: vi.fn(async (entry) => {
+  saveMediaReadAlongAudioCacheEntry: vi.fn(async (entry, options) => {
     eventLog.push(`cache:save:${entry.id}`)
+    if (cacheSaveGate) {
+      await cacheSaveGate
+    }
+    if (options?.signal?.aborted || options?.shouldContinue?.() === false) {
+      eventLog.push(`cache:skip:${entry.id}`)
+      return false
+    }
     cacheEntries.set(entry.id, {
       blob: entry.blob,
       mimeType: entry.mimeType,
@@ -224,6 +232,7 @@ describe('useMediaReadAlongSession', () => {
     eventLog.length = 0
     objectUrlCounter = 0
     playRejects = false
+    cacheSaveGate = null
     providerContext = {
       provider: 'tldw',
       utterance: '',
@@ -473,6 +482,32 @@ describe('useMediaReadAlongSession', () => {
     expect(result.current.state.status).toBe('stopped')
   })
 
+  it('rejects a generated cache save that is cancelled while the write is pending', async () => {
+    let releaseSave!: () => void
+    cacheSaveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve
+    })
+    const { result } = setupHook()
+
+    act(() => {
+      void result.current.start('selection')
+    })
+    await waitFor(() => expect(saveMediaReadAlongAudioCacheEntry).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.stop()
+    })
+    await act(async () => {
+      releaseSave()
+      await cacheSaveGate
+    })
+
+    expect(cacheEntries.size).toBe(0)
+    expect(eventLog).toContain('cache:skip:cache:media-1:0:sentence:0:15:tldw|||1|mp3|')
+    expect(audioInstances).toHaveLength(0)
+    expect(result.current.state.status).toBe('stopped')
+  })
+
   it('settings are captured at session start and do not mutate mid-session', async () => {
     const firstSynthesize = vi.fn(async (text: string) => ({
       buffer: new TextEncoder().encode(`first:${text}`).buffer,
@@ -629,6 +664,51 @@ describe('useMediaReadAlongSession', () => {
       error: null
     })
     expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates browser utterance callbacks before synchronous cancel during skip', async () => {
+    providerContext = {
+      provider: 'browser',
+      utterance: 'First sentence.',
+      playbackSpeed: 1,
+      supported: true
+    }
+    const spoken: MockSpeechSynthesisUtterance[] = []
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        speak: vi.fn((utterance: MockSpeechSynthesisUtterance) => {
+          spoken.push(utterance)
+          eventLog.push(`speech:speak:${utterance.text}`)
+        }),
+        cancel: vi.fn(() => {
+          spoken[0]?.onerror?.()
+          spoken[0]?.onend?.()
+        }),
+        pause: vi.fn(),
+        resume: vi.fn()
+      }
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+
+    act(() => {
+      result.current.skip()
+    })
+
+    expect(result.current.state).toMatchObject({
+      status: 'playing',
+      activeSegmentId: 'media-1:1:sentence:16:32',
+      error: null
+    })
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(2)
+    expect(spoken.map((utterance) => utterance.text)).toEqual([
+      'First sentence.',
+      'Second sentence.'
+    ])
   })
 
   it('starting read-along pauses embeddedMediaRef.current if it is playing', async () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -15,6 +15,37 @@ let providerContext: TtsProviderContext
 let objectUrlCounter = 0
 let playRejects = false
 
+type DeferredAudio = {
+  promise: Promise<{
+    buffer: ArrayBuffer
+    format: string
+    mimeType: string
+  }>
+  resolve: (value: {
+    buffer: ArrayBuffer
+    format: string
+    mimeType: string
+  }) => void
+}
+
+const deferredAudio = (): DeferredAudio => {
+  let resolve!: DeferredAudio['resolve']
+  const promise = new Promise<{
+    buffer: ArrayBuffer
+    format: string
+    mimeType: string
+  }>((resolver) => {
+    resolve = resolver
+  })
+  return { promise, resolve }
+}
+
+const audioResult = (text: string) => ({
+  buffer: new TextEncoder().encode(text).buffer,
+  format: 'mp3',
+  mimeType: 'audio/mpeg'
+})
+
 class TrackingAbortController extends AbortController {
   constructor() {
     super()
@@ -386,6 +417,62 @@ describe('useMediaReadAlongSession', () => {
     })
   })
 
+  it('ignores a pending generated segment when skip starts the next segment', async () => {
+    const pending = new Map<string, DeferredAudio>()
+    providerContext.synthesize = vi.fn((text: string) => {
+      const deferred = deferredAudio()
+      pending.set(text, deferred)
+      return deferred.promise
+    })
+    const { result } = setupHook()
+
+    act(() => {
+      void result.current.start('full-item')
+    })
+    await waitFor(() => expect(pending.has('First sentence.')).toBe(true))
+
+    act(() => {
+      result.current.skip()
+    })
+    await waitFor(() => expect(pending.has('Second sentence.')).toBe(true))
+    await act(async () => {
+      pending.get('Second sentence.')!.resolve(audioResult('second'))
+    })
+    await waitFor(() =>
+      expect(result.current.state.activeSegmentId).toBe('media-1:1:sentence:16:32')
+    )
+
+    await act(async () => {
+      pending.get('First sentence.')!.resolve(audioResult('first'))
+    })
+
+    expect(result.current.state.activeSegmentId).toBe('media-1:1:sentence:16:32')
+    expect(audioInstances).toHaveLength(1)
+    expect(audioInstances[0]?.src).toBe('blob:read-along-0')
+  })
+
+  it('does not cache or play generated audio that resolves after stop', async () => {
+    const deferred = deferredAudio()
+    providerContext.synthesize = vi.fn(() => deferred.promise)
+    const { result } = setupHook()
+
+    act(() => {
+      void result.current.start('selection')
+    })
+    await waitFor(() => expect(providerContext.synthesize).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.stop()
+    })
+    await act(async () => {
+      deferred.resolve(audioResult('stopped'))
+    })
+
+    expect(saveMediaReadAlongAudioCacheEntry).not.toHaveBeenCalled()
+    expect(audioInstances).toHaveLength(0)
+    expect(result.current.state.status).toBe('stopped')
+  })
+
   it('settings are captured at session start and do not mutate mid-session', async () => {
     const firstSynthesize = vi.fn(async (text: string) => ({
       buffer: new TextEncoder().encode(`first:${text}`).buffer,
@@ -497,6 +584,51 @@ describe('useMediaReadAlongSession', () => {
 
     await waitFor(() => expect(result.current.state.status).toBe('segment-error'))
     expect(result.current.state.error).toContain('autoplay blocked')
+  })
+
+  it('ignores old browser utterance callbacks after skip cancels speech', async () => {
+    providerContext = {
+      provider: 'browser',
+      utterance: 'First sentence.',
+      playbackSpeed: 1,
+      supported: true
+    }
+    const spoken: MockSpeechSynthesisUtterance[] = []
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        speak: vi.fn((utterance: MockSpeechSynthesisUtterance) => {
+          spoken.push(utterance)
+          eventLog.push(`speech:speak:${utterance.text}`)
+        }),
+        cancel: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn()
+      }
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    expect(spoken[0]?.text).toBe('First sentence.')
+
+    act(() => {
+      result.current.skip()
+    })
+    expect(spoken[1]?.text).toBe('Second sentence.')
+
+    act(() => {
+      spoken[0]!.onend?.()
+      spoken[0]!.onerror?.()
+    })
+
+    expect(result.current.state).toMatchObject({
+      status: 'playing',
+      activeSegmentId: 'media-1:1:sentence:16:32',
+      error: null
+    })
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(2)
   })
 
   it('starting read-along pauses embeddedMediaRef.current if it is playing', async () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -9,6 +9,10 @@ import type { ReadAlongSelection } from '../types'
 const cacheEntries = new Map<string, { blob: Blob; mimeType: string; format: string }>()
 const abortControllers: AbortController[] = []
 const audioInstances: MockAudio[] = []
+const audioListenerOptions: Array<{
+  type: string
+  options: boolean | AddEventListenerOptions | undefined
+}> = []
 const eventLog: string[] = []
 
 let providerContext: TtsProviderContext
@@ -74,6 +78,15 @@ class MockAudio extends EventTarget {
     super()
     this.src = src
     audioInstances.push(this)
+  }
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    audioListenerOptions.push({ type, options })
+    super.addEventListener(type, listener, options)
   }
 }
 
@@ -251,6 +264,7 @@ describe('useMediaReadAlongSession', () => {
     cacheEntries.clear()
     abortControllers.length = 0
     audioInstances.length = 0
+    audioListenerOptions.length = 0
     eventLog.length = 0
     objectUrlCounter = 0
     playRejects = false
@@ -326,6 +340,22 @@ describe('useMediaReadAlongSession', () => {
       eventLog.indexOf('cache:get:cache:media-1:0:sentence:0:15:tldw|||1|mp3|')
     )
     expect(eventLog.findIndex((entry) => entry.startsWith('synthesize:'))).toBe(-1)
+  })
+
+  it('registers generated audio terminal listeners as one-shot handlers', async () => {
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    await waitFor(() => expect(audioInstances[0]?.play).toHaveBeenCalledTimes(1))
+    expect(audioListenerOptions).toEqual(
+      expect.arrayContaining([
+        { type: 'ended', options: { once: true } },
+        { type: 'error', options: { once: true } }
+      ])
+    )
   })
 
   it('start("from-here") queues beyond the rendered window', async () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -179,7 +179,10 @@ vi.mock('../media-read-along-cache', () => ({
   })
 }))
 
-import { resolveTtsProviderContext } from '@/services/tts-provider'
+import {
+  applyBrowserSpeechSynthesisVoice,
+  resolveTtsProviderContext
+} from '@/services/tts-provider'
 import { tldwClient } from '@/services/tldw/TldwApiClient'
 import {
   getMediaReadAlongAudioCacheEntry,
@@ -269,6 +272,7 @@ describe('useMediaReadAlongSession', () => {
       })
     }
     vi.clearAllMocks()
+    vi.mocked(applyBrowserSpeechSynthesisVoice).mockReset()
     vi.mocked(tldwClient.getConfig).mockResolvedValue({
       serverUrl: 'http://127.0.0.1:8000/',
       apiKey: 'secret-api-key',
@@ -382,6 +386,50 @@ describe('useMediaReadAlongSession', () => {
     expect(getMediaReadAlongAudioCacheEntry).not.toHaveBeenCalled()
     expect(saveMediaReadAlongAudioCacheEntry).not.toHaveBeenCalled()
     expect(buildReadAlongCacheKey).not.toHaveBeenCalled()
+  })
+
+  it('cleans up browser voice listeners when browser segments are replaced', async () => {
+    providerContext = {
+      provider: 'browser',
+      utterance: 'First sentence.',
+      playbackSpeed: 1,
+      supported: true,
+      browserVoiceName: 'Browser Voice',
+      normalizeText: (text: string) => text
+    }
+    const cleanups: Array<ReturnType<typeof vi.fn>> = []
+    vi.mocked(applyBrowserSpeechSynthesisVoice).mockImplementation(() => {
+      const cleanup = vi.fn()
+      cleanups.push(cleanup)
+      return cleanup
+    })
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        speak: vi.fn((utterance: MockSpeechSynthesisUtterance) => {
+          eventLog.push(`speech:speak:${utterance.text}`)
+        }),
+        cancel: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn()
+      }
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    act(() => {
+      result.current.skip()
+    })
+    act(() => {
+      result.current.stop()
+    })
+
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(2)
+    expect(cleanups).toHaveLength(2)
+    expect(cleanups[0]).toHaveBeenCalledTimes(1)
+    expect(cleanups[1]).toHaveBeenCalledTimes(1)
   })
 
   it('targets retry and skip from the segment that failed while loading', async () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -275,6 +275,11 @@ describe('useMediaReadAlongSession', () => {
       playbackSpeed: 1,
       supported: true,
       formatInfo: { requested: 'mp3', resolved: 'mp3', isFallback: false },
+      cacheSettings: {
+        provider: 'tldw',
+        speed: 1,
+        format: 'mp3'
+      },
       normalizeText: (text: string) => text,
       synthesize: vi.fn(async (text: string) => {
         eventLog.push(`synthesize:${text}`)
@@ -819,6 +824,11 @@ describe('useMediaReadAlongSession', () => {
       playbackSpeed: 1,
       supported: true,
       formatInfo: { requested: 'mp3', resolved: 'mp3', isFallback: false },
+      cacheSettings: {
+        provider: 'tldw',
+        speed: 1,
+        format: 'mp3'
+      },
       normalizeText: (text: string) => text,
       synthesize: firstSynthesize
     }
@@ -833,6 +843,11 @@ describe('useMediaReadAlongSession', () => {
       playbackSpeed: 1,
       supported: true,
       formatInfo: { requested: 'wav', resolved: 'wav', isFallback: false },
+      cacheSettings: {
+        provider: 'tldw',
+        speed: 1,
+        format: 'wav'
+      },
       normalizeText: (text: string) => text,
       synthesize: secondSynthesize
     }
@@ -907,6 +922,38 @@ describe('useMediaReadAlongSession', () => {
     )
   })
 
+  it('does not include playback-only speed in generated-audio cache signatures', async () => {
+    providerContext = {
+      provider: 'openai',
+      utterance: '',
+      playbackSpeed: 1.75,
+      supported: true,
+      cacheSettings: {
+        provider: 'openai',
+        model: 'tts-model-a',
+        voice: 'voice-a',
+        format: 'mp3'
+      },
+      normalizeText: (text: string) => text,
+      synthesize: vi.fn(async (text: string) => ({
+        buffer: new TextEncoder().encode(text).buffer,
+        format: 'mp3',
+        mimeType: 'audio/mpeg'
+      }))
+    }
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    expect(eventLog).toContain('settings:openai|tts-model-a|voice-a||mp3|')
+    expect(eventLog).not.toContain('settings:openai|tts-model-a|voice-a|1.75|mp3|')
+    expect(eventLog).toContain(
+      'cache-key:media-1:0:sentence:0:15:openai|tts-model-a|voice-a||mp3|'
+    )
+  })
+
   it('audio.play() rejection enters segment-error', async () => {
     playRejects = true
     const { result } = setupHook()
@@ -917,6 +964,24 @@ describe('useMediaReadAlongSession', () => {
 
     await waitFor(() => expect(result.current.state.status).toBe('segment-error'))
     expect(result.current.state.error).toContain('autoplay blocked')
+  })
+
+  it('resume safely no-ops when generated audio is unavailable after an error', async () => {
+    providerContext.synthesize = vi.fn(async () => {
+      throw new Error('synthesis failed')
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    await waitFor(() => expect(result.current.state.status).toBe('segment-error'))
+    expect(() => result.current.resume()).not.toThrow()
+    expect(result.current.state).toMatchObject({
+      status: 'segment-error',
+      error: 'synthesis failed'
+    })
   })
 
   it('ignores old browser utterance callbacks after skip cancels speech', async () => {

--- a/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+++ b/apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
@@ -1,0 +1,463 @@
+import React from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TtsProviderContext } from '@/services/tts-provider'
+
+import type { ReadAlongSelection } from '../types'
+
+const cacheEntries = new Map<string, { blob: Blob; mimeType: string; format: string }>()
+const abortControllers: AbortController[] = []
+const audioInstances: MockAudio[] = []
+const eventLog: string[] = []
+
+let providerContext: TtsProviderContext
+let objectUrlCounter = 0
+let playRejects = false
+
+class TrackingAbortController extends AbortController {
+  constructor() {
+    super()
+    abortControllers.push(this)
+  }
+}
+
+class MockAudio extends EventTarget {
+  src: string
+  currentTime = 0
+  playbackRate = 1
+  paused = true
+  play = vi.fn(async () => {
+    eventLog.push(`audio:play:${this.src}`)
+    if (playRejects) {
+      throw new Error('autoplay blocked')
+    }
+    this.paused = false
+  })
+  pause = vi.fn(() => {
+    this.paused = true
+  })
+
+  constructor(src = '') {
+    super()
+    this.src = src
+    audioInstances.push(this)
+  }
+}
+
+class MockSpeechSynthesisUtterance extends EventTarget {
+  text: string
+  rate = 1
+  onend: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(text: string) {
+    super()
+    this.text = text
+  }
+}
+
+vi.mock('@/services/tts-provider', () => ({
+  resolveTtsProviderContext: vi.fn(async () => {
+    eventLog.push(`provider:resolve:${providerContext.provider}`)
+    return providerContext
+  })
+}))
+
+vi.mock('../media-read-along-cache-key', () => ({
+  buildReadAlongCacheKey: vi.fn(async ({ segmentId, settingsSignature }) => {
+    eventLog.push(`cache-key:${segmentId}:${settingsSignature}`)
+    return {
+      id: `cache:${segmentId}:${settingsSignature}`,
+      mediaId: 'media-1',
+      mediaKind: 'video',
+      segmentId,
+      settingsSignature,
+      textHash: `hash:${segmentId}`
+    }
+  }),
+  buildTtsSettingsSignature: vi.fn((settings) => {
+    const signature = [
+      settings.provider,
+      settings.model ?? '',
+      settings.voice ?? '',
+      settings.speed ?? '',
+      settings.format ?? '',
+      settings.language ?? ''
+    ].join('|')
+    eventLog.push(`settings:${signature}`)
+    return signature
+  })
+}))
+
+vi.mock('../media-read-along-cache', () => ({
+  getMediaReadAlongAudioCacheEntry: vi.fn(async (id: string) => {
+    eventLog.push(`cache:get:${id}`)
+    const entry = cacheEntries.get(id)
+    return entry
+      ? {
+          id,
+          createdAt: 1,
+          lastUsedAt: 1,
+          mediaId: 'media-1',
+          mediaKind: 'video',
+          segmentId: id,
+          settingsSignature: 'mock',
+          textHash: 'mock',
+          blob: entry.blob,
+          mimeType: entry.mimeType,
+          format: entry.format,
+          sizeBytes: entry.blob.size
+        }
+      : undefined
+  }),
+  saveMediaReadAlongAudioCacheEntry: vi.fn(async (entry) => {
+    eventLog.push(`cache:save:${entry.id}`)
+    cacheEntries.set(entry.id, {
+      blob: entry.blob,
+      mimeType: entry.mimeType,
+      format: entry.format
+    })
+    return true
+  })
+}))
+
+import { resolveTtsProviderContext } from '@/services/tts-provider'
+import {
+  getMediaReadAlongAudioCacheEntry,
+  saveMediaReadAlongAudioCacheEntry
+} from '../media-read-along-cache'
+import { buildReadAlongCacheKey } from '../media-read-along-cache-key'
+import { useMediaReadAlongSession } from '../useMediaReadAlongSession'
+
+const makeSelection = (overrides: Partial<ReadAlongSelection> = {}): ReadAlongSelection => ({
+  selectedText: 'First sentence.',
+  anchorRect: new DOMRect(0, 0, 10, 10),
+  startSegmentId: 'media-1:0:sentence:0:15',
+  endSegmentId: 'media-1:0:sentence:0:15',
+  sourceStart: 0,
+  sourceEnd: 15,
+  mappingConfidence: 'exact',
+  ...overrides
+})
+
+const content = [
+  'First sentence.',
+  'Second sentence.',
+  'Third sentence.',
+  'Fourth sentence.',
+  'Fifth sentence.',
+  'Sixth sentence.',
+  'Seventh sentence.',
+  'Eighth sentence.'
+].join(' ')
+
+const setupHook = (overrides: Partial<Parameters<typeof useMediaReadAlongSession>[0]> = {}) => {
+  const contentBody = document.createElement('div')
+  const scrollContainer = document.createElement('div')
+  const embeddedMedia = document.createElement('video')
+  document.body.append(contentBody, scrollContainer, embeddedMedia)
+
+  return renderHook((props: Partial<Parameters<typeof useMediaReadAlongSession>[0]>) =>
+    useMediaReadAlongSession({
+      mediaId: 'media-1',
+      mediaKind: 'video',
+      content,
+      displayContent: 'First sentence. Second sentence.',
+      renderMode: 'plain',
+      hideTranscriptTimings: false,
+      selection: makeSelection(),
+      contentBodyRef: { current: contentBody },
+      contentScrollContainerRef: { current: scrollContainer },
+      embeddedMediaRef: { current: embeddedMedia },
+      ...overrides,
+      ...props
+    })
+  )
+}
+
+const completeCurrentAudio = async () => {
+  const audio = audioInstances.at(-1)
+  expect(audio).toBeDefined()
+  await act(async () => {
+    audio!.dispatchEvent(new Event('ended'))
+  })
+}
+
+describe('useMediaReadAlongSession', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    cacheEntries.clear()
+    abortControllers.length = 0
+    audioInstances.length = 0
+    eventLog.length = 0
+    objectUrlCounter = 0
+    playRejects = false
+    providerContext = {
+      provider: 'tldw',
+      utterance: '',
+      playbackSpeed: 1,
+      supported: true,
+      formatInfo: { requested: 'mp3', resolved: 'mp3', isFallback: false },
+      synthesize: vi.fn(async (text: string) => {
+        eventLog.push(`synthesize:${text}`)
+        return {
+          buffer: new TextEncoder().encode(text).buffer,
+          format: 'mp3',
+          mimeType: 'audio/mpeg'
+        }
+      })
+    }
+    vi.clearAllMocks()
+    vi.stubGlobal('AbortController', TrackingAbortController)
+    vi.stubGlobal('Audio', MockAudio)
+    vi.stubGlobal('SpeechSynthesisUtterance', MockSpeechSynthesisUtterance)
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => `blob:read-along-${objectUrlCounter++}`)
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn()
+    })
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        speak: vi.fn((utterance: MockSpeechSynthesisUtterance) => {
+          eventLog.push(`speech:speak:${utterance.text}`)
+        }),
+        cancel: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn()
+      }
+    })
+  })
+
+  it('start("selection") resolves a queue and plays cached audio before generating lookahead', async () => {
+    cacheEntries.set('cache:media-1:0:sentence:0:15:tldw|||1|mp3|', {
+      blob: new Blob(['cached'], { type: 'audio/mpeg' }),
+      mimeType: 'audio/mpeg',
+      format: 'mp3'
+    })
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    await waitFor(() => expect(audioInstances[0]?.play).toHaveBeenCalledTimes(1))
+    expect(result.current.state).toMatchObject({
+      status: 'playing',
+      scope: 'selection',
+      activeSegmentId: 'media-1:0:sentence:0:15',
+      activeIndex: 0,
+      totalSegments: 1
+    })
+    expect(eventLog.indexOf('audio:play:blob:read-along-0')).toBeGreaterThan(
+      eventLog.indexOf('cache:get:cache:media-1:0:sentence:0:15:tldw|||1|mp3|')
+    )
+    expect(eventLog.findIndex((entry) => entry.startsWith('synthesize:'))).toBe(-1)
+  })
+
+  it('start("from-here") queues beyond the rendered window', async () => {
+    const { result } = setupHook({
+      selection: makeSelection({
+        selectedText: 'Third sentence.',
+        startSegmentId: 'media-1:2:sentence:33:48',
+        endSegmentId: 'media-1:2:sentence:33:48',
+        sourceStart: 33,
+        sourceEnd: 48
+      })
+    })
+
+    await act(async () => {
+      await result.current.start('from-here')
+    })
+
+    await waitFor(() => expect(result.current.state.totalSegments).toBe(6))
+    expect(result.current.state.activeSegmentId).toBe('media-1:2:sentence:33:48')
+    expect(providerContext.synthesize).toHaveBeenCalledWith(
+      'Third sentence.',
+      expect.any(Object)
+    )
+  })
+
+  it('lookahead prefetches 3 to 5 segments, not the full item', async () => {
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+
+    await waitFor(() =>
+      expect((providerContext.synthesize as ReturnType<typeof vi.fn>).mock.calls.length)
+        .toBeGreaterThanOrEqual(4)
+    )
+    expect((providerContext.synthesize as ReturnType<typeof vi.fn>).mock.calls.length)
+      .toBeLessThanOrEqual(6)
+    expect((providerContext.synthesize as ReturnType<typeof vi.fn>).mock.calls.length)
+      .toBeLessThan(8)
+  })
+
+  it('browser TTS provider uses window.speechSynthesis.speak() and does not touch generated-audio cache', async () => {
+    providerContext = {
+      provider: 'browser',
+      utterance: 'First sentence.',
+      playbackSpeed: 1.25,
+      supported: true
+    }
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1)
+    expect(getMediaReadAlongAudioCacheEntry).not.toHaveBeenCalled()
+    expect(saveMediaReadAlongAudioCacheEntry).not.toHaveBeenCalled()
+    expect(buildReadAlongCacheKey).not.toHaveBeenCalled()
+  })
+
+  it('stop aborts current and lookahead AbortControllers', async () => {
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    await waitFor(() => expect(abortControllers.length).toBeGreaterThanOrEqual(2))
+
+    act(() => {
+      result.current.stop()
+    })
+
+    expect(abortControllers.every((controller) => controller.signal.aborted)).toBe(true)
+    expect(result.current.state.status).toBe('stopped')
+  })
+
+  it('stop cancels browser SpeechSynthesis when browser provider is active', async () => {
+    providerContext = {
+      provider: 'browser',
+      utterance: 'First sentence.',
+      playbackSpeed: 1,
+      supported: true
+    }
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+    act(() => {
+      result.current.stop()
+    })
+
+    expect(window.speechSynthesis.cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('media/content change stops and suppresses stale completions', async () => {
+    let finishSynthesis!: (value: {
+      buffer: ArrayBuffer
+      format: string
+      mimeType: string
+    }) => void
+    providerContext.synthesize = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          finishSynthesis = resolve
+        })
+    )
+    const { result, rerender } = setupHook()
+
+    await act(async () => {
+      void result.current.start('selection')
+    })
+    rerender({ mediaId: 'media-2' })
+    await act(async () => {
+      finishSynthesis({
+        buffer: new ArrayBuffer(8),
+        format: 'mp3',
+        mimeType: 'audio/mpeg'
+      })
+    })
+
+    expect(audioInstances).toHaveLength(0)
+    expect(result.current.state).toMatchObject({
+      status: 'stopped',
+      activeSegmentId: null
+    })
+  })
+
+  it('settings are captured at session start and do not mutate mid-session', async () => {
+    const firstSynthesize = vi.fn(async (text: string) => ({
+      buffer: new TextEncoder().encode(`first:${text}`).buffer,
+      format: 'mp3',
+      mimeType: 'audio/mpeg'
+    }))
+    const secondSynthesize = vi.fn(async (text: string) => ({
+      buffer: new TextEncoder().encode(`second:${text}`).buffer,
+      format: 'wav',
+      mimeType: 'audio/wav'
+    }))
+    providerContext = {
+      provider: 'tldw',
+      utterance: '',
+      playbackSpeed: 1,
+      supported: true,
+      formatInfo: { requested: 'mp3', resolved: 'mp3', isFallback: false },
+      synthesize: firstSynthesize
+    }
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('full-item')
+    })
+    providerContext = {
+      provider: 'tldw',
+      utterance: '',
+      playbackSpeed: 1,
+      supported: true,
+      formatInfo: { requested: 'wav', resolved: 'wav', isFallback: false },
+      synthesize: secondSynthesize
+    }
+    await completeCurrentAudio()
+
+    await waitFor(() => expect(firstSynthesize.mock.calls.length).toBeGreaterThan(1))
+    expect(resolveTtsProviderContext).toHaveBeenCalledTimes(1)
+    expect(secondSynthesize).not.toHaveBeenCalled()
+    expect(eventLog.some((entry) => entry.includes('tldw|||1|mp3|'))).toBe(true)
+    expect(eventLog.some((entry) => entry.includes('tldw|||1|wav|'))).toBe(false)
+  })
+
+  it('audio.play() rejection enters segment-error', async () => {
+    playRejects = true
+    const { result } = setupHook()
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    await waitFor(() => expect(result.current.state.status).toBe('segment-error'))
+    expect(result.current.state.error).toContain('autoplay blocked')
+  })
+
+  it('starting read-along pauses embeddedMediaRef.current if it is playing', async () => {
+    const embeddedMedia = document.createElement('video')
+    const pause = vi.fn()
+    Object.defineProperty(embeddedMedia, 'paused', {
+      configurable: true,
+      value: false
+    })
+    Object.defineProperty(embeddedMedia, 'pause', {
+      configurable: true,
+      value: pause
+    })
+    const { result } = setupHook({
+      embeddedMediaRef: { current: embeddedMedia }
+    })
+
+    await act(async () => {
+      await result.current.start('selection')
+    })
+
+    expect(pause).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts
@@ -44,8 +44,11 @@ export const sha256Hex = async (text: string): Promise<string> => {
   return toHex(new Uint8Array(digest))
 }
 
-const normalizeSignaturePart = (value: unknown): string =>
+const normalizeCaseInsensitiveSignaturePart = (value: unknown): string =>
   value == null ? '' : String(value).trim().toLowerCase()
+
+const normalizeOpaqueIdSignaturePart = (value: unknown): string =>
+  value == null ? '' : String(value).trim()
 
 export const buildTtsSettingsSignature = ({
   provider,
@@ -59,12 +62,12 @@ export const buildTtsSettingsSignature = ({
     typeof speed === 'number' && Number.isFinite(speed) ? String(speed) : ''
 
   return [
-    `provider:${normalizeSignaturePart(provider)}`,
-    `model:${normalizeSignaturePart(model)}`,
-    `voice:${normalizeSignaturePart(voice)}`,
+    `provider:${normalizeCaseInsensitiveSignaturePart(provider)}`,
+    `model:${normalizeOpaqueIdSignaturePart(model)}`,
+    `voice:${normalizeOpaqueIdSignaturePart(voice)}`,
     `speed:${normalizedSpeed}`,
-    `format:${normalizeSignaturePart(format)}`,
-    `language:${normalizeSignaturePart(language)}`
+    `format:${normalizeCaseInsensitiveSignaturePart(format)}`,
+    `language:${normalizeCaseInsensitiveSignaturePart(language)}`
   ].join('|')
 }
 

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts
@@ -34,40 +34,14 @@ const toHex = (bytes: Uint8Array): string =>
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join('')
 
-const fallbackHash64 = (text: string): string => {
-  let first = 0x811c9dc5
-  let second = 0x01000193
-
-  for (let index = 0; index < text.length; index += 1) {
-    const code = text.charCodeAt(index)
-    first ^= code
-    first = Math.imul(first, 0x01000193) >>> 0
-    second ^= code + index
-    second = Math.imul(second, 0x85ebca6b) >>> 0
-  }
-
-  const chunks = [
-    first,
-    second,
-    Math.imul(first ^ second, 0xc2b2ae35) >>> 0,
-    Math.imul(first + second, 0x27d4eb2f) >>> 0,
-    Math.imul(first ^ text.length, 0x165667b1) >>> 0,
-    Math.imul(second ^ text.length, 0xd3a2646c) >>> 0,
-    Math.imul(first + text.length, 0x9e3779b1) >>> 0,
-    Math.imul(second + text.length, 0x85ebca77) >>> 0
-  ]
-
-  return chunks.map((chunk) => chunk.toString(16).padStart(8, '0')).join('')
-}
-
 export const sha256Hex = async (text: string): Promise<string> => {
   const subtle = globalThis.crypto?.subtle
-  if (subtle) {
-    const digest = await subtle.digest('SHA-256', textEncoder.encode(text))
-    return toHex(new Uint8Array(digest))
+  if (!subtle) {
+    throw new Error('Web Crypto SHA-256 is required for read-along audio cache keys')
   }
 
-  return fallbackHash64(text)
+  const digest = await subtle.digest('SHA-256', textEncoder.encode(text))
+  return toHex(new Uint8Array(digest))
 }
 
 const normalizeSignaturePart = (value: unknown): string =>

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts
@@ -1,0 +1,129 @@
+export type ReadAlongCacheKeyInput = {
+  serverScope: string
+  mediaId: string
+  mediaKind: string
+  segmentId: string
+  segmentText: string
+  sourceStart: number
+  sourceEnd: number
+  settingsSignature: string
+}
+
+export type ReadAlongCacheKey = {
+  id: string
+  mediaId: string
+  mediaKind: string
+  segmentId: string
+  settingsSignature: string
+  textHash: string
+}
+
+export type TtsSettingsSignatureInput = {
+  provider: string
+  model?: string | null
+  voice?: string | null
+  speed?: number | null
+  format?: string | null
+  language?: string | null
+}
+
+const textEncoder = new TextEncoder()
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+
+const fallbackHash64 = (text: string): string => {
+  let first = 0x811c9dc5
+  let second = 0x01000193
+
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index)
+    first ^= code
+    first = Math.imul(first, 0x01000193) >>> 0
+    second ^= code + index
+    second = Math.imul(second, 0x85ebca6b) >>> 0
+  }
+
+  const chunks = [
+    first,
+    second,
+    Math.imul(first ^ second, 0xc2b2ae35) >>> 0,
+    Math.imul(first + second, 0x27d4eb2f) >>> 0,
+    Math.imul(first ^ text.length, 0x165667b1) >>> 0,
+    Math.imul(second ^ text.length, 0xd3a2646c) >>> 0,
+    Math.imul(first + text.length, 0x9e3779b1) >>> 0,
+    Math.imul(second + text.length, 0x85ebca77) >>> 0
+  ]
+
+  return chunks.map((chunk) => chunk.toString(16).padStart(8, '0')).join('')
+}
+
+export const sha256Hex = async (text: string): Promise<string> => {
+  const subtle = globalThis.crypto?.subtle
+  if (subtle) {
+    const digest = await subtle.digest('SHA-256', textEncoder.encode(text))
+    return toHex(new Uint8Array(digest))
+  }
+
+  return fallbackHash64(text)
+}
+
+const normalizeSignaturePart = (value: unknown): string =>
+  value == null ? '' : String(value).trim().toLowerCase()
+
+export const buildTtsSettingsSignature = ({
+  provider,
+  model,
+  voice,
+  speed,
+  format,
+  language
+}: TtsSettingsSignatureInput): string => {
+  const normalizedSpeed =
+    typeof speed === 'number' && Number.isFinite(speed) ? String(speed) : ''
+
+  return [
+    `provider:${normalizeSignaturePart(provider)}`,
+    `model:${normalizeSignaturePart(model)}`,
+    `voice:${normalizeSignaturePart(voice)}`,
+    `speed:${normalizedSpeed}`,
+    `format:${normalizeSignaturePart(format)}`,
+    `language:${normalizeSignaturePart(language)}`
+  ].join('|')
+}
+
+export const buildReadAlongCacheKey = async ({
+  serverScope,
+  mediaId,
+  mediaKind,
+  segmentId,
+  segmentText,
+  sourceStart,
+  sourceEnd,
+  settingsSignature
+}: ReadAlongCacheKeyInput): Promise<ReadAlongCacheKey> => {
+  const textHash = await sha256Hex(segmentText)
+  const stableScope = await sha256Hex(
+    [
+      serverScope,
+      mediaId,
+      mediaKind,
+      segmentId,
+      sourceStart,
+      sourceEnd,
+      settingsSignature,
+      textHash
+    ].join('\n')
+  )
+
+  return {
+    id: `read-along:${stableScope}`,
+    mediaId,
+    mediaKind,
+    segmentId,
+    settingsSignature,
+    textHash
+  }
+}

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
@@ -35,8 +35,9 @@ const listEntries = async (): Promise<MediaReadAlongAudioCacheEntry[]> => {
 const evictLeastRecentlyUsed = async (
   incomingSizeBytes: number,
   maxBytes: number,
+  options: SaveOptions,
   forceOne = false
-): Promise<void> => {
+): Promise<boolean> => {
   const entries = await listEntries()
   const sorted = [...entries].sort((a, b) => a.lastUsedAt - b.lastUsedAt)
   const idsToDelete: string[] = []
@@ -50,8 +51,10 @@ const evictLeastRecentlyUsed = async (
   }
 
   if (idsToDelete.length > 0) {
+    if (!canContinueSave(options)) return false
     await table().bulkDelete(idsToDelete)
   }
+  return canContinueSave(options)
 }
 
 const matchesAttemptedWrite = (
@@ -120,15 +123,17 @@ export const saveMediaReadAlongAudioCacheEntry = async (
   if (!canContinueSave(options)) return false
 
   try {
-    await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes)
-    if (!canContinueSave(options)) return false
+    if (!(await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, options))) {
+      return false
+    }
     return await putEntryIfCurrent(entry, options)
   } catch (error) {
     if (!isQuotaExceededError(error)) return false
 
     try {
-      await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, true)
-      if (!canContinueSave(options)) return false
+      if (!(await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, options, true))) {
+        return false
+      }
       return await putEntryIfCurrent(entry, options)
     } catch (retryError) {
       if (isQuotaExceededError(retryError)) {

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
@@ -73,6 +73,7 @@ export const saveMediaReadAlongAudioCacheEntry = async (
   if (cacheDisabledForSession) return false
 
   const maxBytes = options.maxBytes ?? MEDIA_READ_ALONG_CACHE_MAX_BYTES
+  if (entry.sizeBytes > maxBytes) return false
 
   try {
     await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes)

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
@@ -1,0 +1,95 @@
+import { db } from '@/db/dexie/schema'
+import type { MediaReadAlongAudioCacheEntry } from '@/db/dexie/types'
+
+export const MEDIA_READ_ALONG_CACHE_MAX_BYTES = 50 * 1024 * 1024
+
+type SaveOptions = {
+  maxBytes?: number
+}
+
+let cacheDisabledForSession = false
+
+const isQuotaExceededError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false
+  const name = 'name' in error ? String(error.name) : ''
+  return name === 'QuotaExceededError'
+}
+
+const table = () => db.mediaReadAlongAudioCache
+
+const listEntries = async (): Promise<MediaReadAlongAudioCacheEntry[]> => {
+  if (typeof table().toArray === 'function') {
+    return await table().toArray()
+  }
+  return await table().orderBy('lastUsedAt').toArray()
+}
+
+const evictLeastRecentlyUsed = async (
+  incomingSizeBytes: number,
+  maxBytes: number,
+  forceOne = false
+): Promise<void> => {
+  const entries = await listEntries()
+  const sorted = [...entries].sort((a, b) => a.lastUsedAt - b.lastUsedAt)
+  const idsToDelete: string[] = []
+  let totalBytes = sorted.reduce((sum, entry) => sum + (entry.sizeBytes || 0), 0)
+
+  for (const entry of sorted) {
+    if (!forceOne && totalBytes + incomingSizeBytes <= maxBytes) break
+    idsToDelete.push(entry.id)
+    totalBytes -= entry.sizeBytes || 0
+    if (forceOne) break
+  }
+
+  if (idsToDelete.length > 0) {
+    await table().bulkDelete(idsToDelete)
+  }
+}
+
+export const resetMediaReadAlongAudioCacheSessionForTests = (): void => {
+  cacheDisabledForSession = false
+}
+
+export const getMediaReadAlongAudioCacheEntry = async (
+  id: string
+): Promise<MediaReadAlongAudioCacheEntry | undefined> => {
+  if (cacheDisabledForSession) return undefined
+
+  try {
+    const entry = await table().get(id)
+    if (!entry) return undefined
+
+    await table().update(id, { lastUsedAt: Date.now() })
+    return entry
+  } catch {
+    return undefined
+  }
+}
+
+export const saveMediaReadAlongAudioCacheEntry = async (
+  entry: MediaReadAlongAudioCacheEntry,
+  options: SaveOptions = {}
+): Promise<boolean> => {
+  if (cacheDisabledForSession) return false
+
+  const maxBytes = options.maxBytes ?? MEDIA_READ_ALONG_CACHE_MAX_BYTES
+
+  try {
+    await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes)
+    await table().put(entry)
+    return true
+  } catch (error) {
+    if (!isQuotaExceededError(error)) return false
+
+    try {
+      await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, true)
+      await table().put(entry)
+      return true
+    } catch (retryError) {
+      if (isQuotaExceededError(retryError)) {
+        cacheDisabledForSession = true
+      }
+      return false
+    }
+  }
+}

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
@@ -54,6 +54,41 @@ const evictLeastRecentlyUsed = async (
   }
 }
 
+const matchesAttemptedWrite = (
+  current: MediaReadAlongAudioCacheEntry | undefined,
+  entry: MediaReadAlongAudioCacheEntry
+): boolean => {
+  return Boolean(
+    current &&
+      current.createdAt === entry.createdAt &&
+      current.lastUsedAt === entry.lastUsedAt &&
+      current.textHash === entry.textHash &&
+      current.settingsSignature === entry.settingsSignature &&
+      current.segmentId === entry.segmentId &&
+      current.sizeBytes === entry.sizeBytes
+  )
+}
+
+const removeAttemptedWriteIfCurrent = async (
+  entry: MediaReadAlongAudioCacheEntry
+): Promise<void> => {
+  const current = await table().get(entry.id)
+  if (matchesAttemptedWrite(current, entry)) {
+    await table().delete(entry.id)
+  }
+}
+
+const putEntryIfCurrent = async (
+  entry: MediaReadAlongAudioCacheEntry,
+  options: SaveOptions
+): Promise<boolean> => {
+  await table().put(entry)
+  if (canContinueSave(options)) return true
+
+  await removeAttemptedWriteIfCurrent(entry)
+  return false
+}
+
 export const resetMediaReadAlongAudioCacheSessionForTests = (): void => {
   cacheDisabledForSession = false
 }
@@ -87,16 +122,14 @@ export const saveMediaReadAlongAudioCacheEntry = async (
   try {
     await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes)
     if (!canContinueSave(options)) return false
-    await table().put(entry)
-    return true
+    return await putEntryIfCurrent(entry, options)
   } catch (error) {
     if (!isQuotaExceededError(error)) return false
 
     try {
       await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, true)
       if (!canContinueSave(options)) return false
-      await table().put(entry)
-      return true
+      return await putEntryIfCurrent(entry, options)
     } catch (retryError) {
       if (isQuotaExceededError(retryError)) {
         cacheDisabledForSession = true

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
@@ -5,6 +5,8 @@ export const MEDIA_READ_ALONG_CACHE_MAX_BYTES = 50 * 1024 * 1024
 
 type SaveOptions = {
   maxBytes?: number
+  signal?: AbortSignal
+  shouldContinue?: () => boolean
 }
 
 let cacheDisabledForSession = false
@@ -16,6 +18,12 @@ const isQuotaExceededError = (error: unknown): boolean => {
 }
 
 const table = () => db.mediaReadAlongAudioCache
+
+const canContinueSave = (options: SaveOptions): boolean => {
+  if (options.signal?.aborted) return false
+  if (options.shouldContinue && !options.shouldContinue()) return false
+  return true
+}
 
 const listEntries = async (): Promise<MediaReadAlongAudioCacheEntry[]> => {
   if (typeof table().toArray === 'function') {
@@ -74,9 +82,11 @@ export const saveMediaReadAlongAudioCacheEntry = async (
 
   const maxBytes = options.maxBytes ?? MEDIA_READ_ALONG_CACHE_MAX_BYTES
   if (entry.sizeBytes > maxBytes) return false
+  if (!canContinueSave(options)) return false
 
   try {
     await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes)
+    if (!canContinueSave(options)) return false
     await table().put(entry)
     return true
   } catch (error) {
@@ -84,6 +94,7 @@ export const saveMediaReadAlongAudioCacheEntry = async (
 
     try {
       await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, true)
+      if (!canContinueSave(options)) return false
       await table().put(entry)
       return true
     } catch (retryError) {

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
@@ -1,10 +1,12 @@
 import { db } from '@/db/dexie/schema'
 import type { MediaReadAlongAudioCacheEntry } from '@/db/dexie/types'
 
-export const MEDIA_READ_ALONG_CACHE_MAX_BYTES = 50 * 1024 * 1024
+export const MEDIA_READ_ALONG_CACHE_MAX_ENTRIES = 200
+export const MEDIA_READ_ALONG_CACHE_MAX_BYTES = 250 * 1024 * 1024
 
 type SaveOptions = {
   maxBytes?: number
+  maxEntries?: number
   signal?: AbortSignal
   shouldContinue?: () => boolean
 }
@@ -32,21 +34,42 @@ const listEntries = async (): Promise<MediaReadAlongAudioCacheEntry[]> => {
   return await table().orderBy('lastUsedAt').toArray()
 }
 
+const resolveMaxEntries = (maxEntries: number): number => {
+  if (!Number.isFinite(maxEntries)) return MEDIA_READ_ALONG_CACHE_MAX_ENTRIES
+  return Math.max(0, Math.floor(maxEntries))
+}
+
 const evictLeastRecentlyUsed = async (
-  incomingSizeBytes: number,
+  incomingEntry: MediaReadAlongAudioCacheEntry,
   maxBytes: number,
+  maxEntries: number,
   options: SaveOptions,
   forceOne = false
 ): Promise<boolean> => {
   const entries = await listEntries()
   const sorted = [...entries].sort((a, b) => a.lastUsedAt - b.lastUsedAt)
   const idsToDelete: string[] = []
-  let totalBytes = sorted.reduce((sum, entry) => sum + (entry.sizeBytes || 0), 0)
+  const existingEntry = sorted.find((entry) => entry.id === incomingEntry.id)
+  let totalBytesAfterWrite =
+    sorted.reduce((sum, entry) => sum + (entry.sizeBytes || 0), 0) -
+    (existingEntry?.sizeBytes || 0) +
+    incomingEntry.sizeBytes
+  let entryCountAfterWrite = sorted.length + (existingEntry ? 0 : 1)
 
   for (const entry of sorted) {
-    if (!forceOne && totalBytes + incomingSizeBytes <= maxBytes) break
+    if (
+      !forceOne &&
+      totalBytesAfterWrite <= maxBytes &&
+      entryCountAfterWrite <= maxEntries
+    ) {
+      break
+    }
+    if (entry.id === incomingEntry.id && !forceOne) {
+      continue
+    }
     idsToDelete.push(entry.id)
-    totalBytes -= entry.sizeBytes || 0
+    totalBytesAfterWrite -= entry.sizeBytes || 0
+    entryCountAfterWrite -= 1
     if (forceOne) break
   }
 
@@ -85,6 +108,7 @@ const putEntryIfCurrent = async (
   entry: MediaReadAlongAudioCacheEntry,
   options: SaveOptions
 ): Promise<boolean> => {
+  if (!canContinueSave(options)) return false
   await table().put(entry)
   if (canContinueSave(options)) return true
 
@@ -119,11 +143,15 @@ export const saveMediaReadAlongAudioCacheEntry = async (
   if (cacheDisabledForSession) return false
 
   const maxBytes = options.maxBytes ?? MEDIA_READ_ALONG_CACHE_MAX_BYTES
+  const maxEntries = resolveMaxEntries(
+    options.maxEntries ?? MEDIA_READ_ALONG_CACHE_MAX_ENTRIES
+  )
   if (entry.sizeBytes > maxBytes) return false
+  if (maxEntries < 1) return false
   if (!canContinueSave(options)) return false
 
   try {
-    if (!(await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, options))) {
+    if (!(await evictLeastRecentlyUsed(entry, maxBytes, maxEntries, options))) {
       return false
     }
     return await putEntryIfCurrent(entry, options)
@@ -131,7 +159,7 @@ export const saveMediaReadAlongAudioCacheEntry = async (
     if (!isQuotaExceededError(error)) return false
 
     try {
-      if (!(await evictLeastRecentlyUsed(entry.sizeBytes, maxBytes, options, true))) {
+      if (!(await evictLeastRecentlyUsed(entry, maxBytes, maxEntries, options, true))) {
         return false
       }
       return await putEntryIfCurrent(entry, options)

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
@@ -11,6 +11,13 @@ type SaveOptions = {
   shouldContinue?: () => boolean
 }
 
+type CacheEntryMetadata = Pick<
+  MediaReadAlongAudioCacheEntry,
+  'id' | 'lastUsedAt' | 'sizeBytes'
+>
+
+const CACHE_METADATA_INDEX = '[lastUsedAt+sizeBytes+id]'
+
 let cacheDisabledForSession = false
 
 const isQuotaExceededError = (error: unknown): boolean => {
@@ -27,11 +34,23 @@ const canContinueSave = (options: SaveOptions): boolean => {
   return true
 }
 
-const listEntries = async (): Promise<MediaReadAlongAudioCacheEntry[]> => {
-  if (typeof table().toArray === 'function') {
-    return await table().toArray()
+const toCacheEntryMetadata = (key: unknown): CacheEntryMetadata | null => {
+  if (!Array.isArray(key) || key.length < 3) return null
+  const [lastUsedAt, sizeBytes, id] = key
+  if (typeof id !== 'string') return null
+
+  return {
+    id,
+    lastUsedAt: Number(lastUsedAt) || 0,
+    sizeBytes: Number(sizeBytes) || 0
   }
-  return await table().orderBy('lastUsedAt').toArray()
+}
+
+const listEntryMetadata = async (): Promise<CacheEntryMetadata[]> => {
+  const keys = await table().orderBy(CACHE_METADATA_INDEX).keys()
+  return keys
+    .map(toCacheEntryMetadata)
+    .filter((entry): entry is CacheEntryMetadata => entry !== null)
 }
 
 const resolveMaxEntries = (maxEntries: number): number => {
@@ -46,8 +65,7 @@ const evictLeastRecentlyUsed = async (
   options: SaveOptions,
   forceOne = false
 ): Promise<boolean> => {
-  const entries = await listEntries()
-  const sorted = [...entries].sort((a, b) => a.lastUsedAt - b.lastUsedAt)
+  const sorted = await listEntryMetadata()
   const idsToDelete: string[] = []
   const existingEntry = sorted.find((entry) => entry.id === incomingEntry.id)
   let totalBytesAfterWrite =
@@ -125,15 +143,20 @@ export const getMediaReadAlongAudioCacheEntry = async (
 ): Promise<MediaReadAlongAudioCacheEntry | undefined> => {
   if (cacheDisabledForSession) return undefined
 
+  let entry: MediaReadAlongAudioCacheEntry | undefined
   try {
-    const entry = await table().get(id)
-    if (!entry) return undefined
-
-    await table().update(id, { lastUsedAt: Date.now() })
-    return entry
+    entry = await table().get(id)
   } catch {
     return undefined
   }
+  if (!entry) return undefined
+
+  try {
+    await table().update(id, { lastUsedAt: Date.now() })
+  } catch {
+    // Metadata updates are best effort; do not discard a valid cached blob.
+  }
+  return entry
 }
 
 export const saveMediaReadAlongAudioCacheEntry = async (

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-dom.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-dom.ts
@@ -1,0 +1,112 @@
+import type { ReadAlongSelection } from './types'
+
+const isNodeInside = (container: HTMLElement, node: Node | null): boolean => {
+  if (!node) return false
+  if (node === container) return true
+  return container.contains(node)
+}
+
+const makeEmptyDomRect = (): DOMRect => {
+  if (typeof DOMRect !== 'undefined') {
+    return new DOMRect()
+  }
+  return {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    toJSON: () => ({})
+  } as DOMRect
+}
+
+export const isRangeInsideContentBody = (
+  range: Range | null | undefined,
+  contentBody: HTMLElement | null | undefined
+): boolean => {
+  if (!range || !contentBody) return false
+  return (
+    isNodeInside(contentBody, range.commonAncestorContainer) &&
+    isNodeInside(contentBody, range.startContainer) &&
+    isNodeInside(contentBody, range.endContainer)
+  )
+}
+
+export const getRangeAnchorRect = (range: Range | null | undefined): DOMRect => {
+  if (!range) return makeEmptyDomRect()
+
+  if (typeof range.getBoundingClientRect === 'function') {
+    const rect = range.getBoundingClientRect()
+    if (rect.width > 0 || rect.height > 0) {
+      return rect
+    }
+  }
+
+  if (typeof range.getClientRects === 'function') {
+    const firstRect = range.getClientRects()[0]
+    if (firstRect) {
+      return firstRect as DOMRect
+    }
+  }
+
+  return makeEmptyDomRect()
+}
+
+export const findNearestReadAlongSegmentId = (
+  node: Node | null | undefined,
+  contentBody?: HTMLElement | null
+): string | undefined => {
+  let current: Node | null = node ?? null
+  while (current && current !== contentBody) {
+    if (typeof HTMLElement !== 'undefined' && current instanceof HTMLElement) {
+      const segmentId = current.dataset.readAlongSegmentId
+      if (segmentId) return segmentId
+    }
+    current = current.parentNode
+  }
+
+  if (contentBody?.dataset.readAlongSegmentId) {
+    return contentBody.dataset.readAlongSegmentId
+  }
+
+  return undefined
+}
+
+export const getContentSelectionFromDom = (
+  contentBody: HTMLElement | null | undefined
+): ReadAlongSelection | null => {
+  if (
+    !contentBody ||
+    typeof window === 'undefined' ||
+    typeof window.getSelection !== 'function'
+  ) {
+    return null
+  }
+
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return null
+  }
+
+  const range = selection.getRangeAt(0)
+  if (!isRangeInsideContentBody(range, contentBody)) {
+    return null
+  }
+
+  const selectedText = selection.toString().trim()
+  if (!selectedText) return null
+
+  const startSegmentId = findNearestReadAlongSegmentId(range.startContainer, contentBody)
+  const endSegmentId = findNearestReadAlongSegmentId(range.endContainer, contentBody)
+
+  return {
+    selectedText,
+    anchorRect: getRangeAnchorRect(range),
+    startSegmentId,
+    endSegmentId,
+    mappingConfidence: startSegmentId || endSegmentId ? 'exact' : 'text-only'
+  }
+}

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts
@@ -24,6 +24,25 @@ const buildSegmentId = (
   sourceEnd: number
 ): string => `${mediaId}:${index}:${kind}:${sourceStart}:${sourceEnd}`
 
+const getMediaIdFromSegments = (segments: ReadAlongSegment[]): string => {
+  const firstSegmentId = segments[0]?.id
+  if (!firstSegmentId) return 'unknown-media'
+
+  const match = firstSegmentId.match(
+    /^(.*):\d+:(?:transcript-line|sentence|paragraph|transient-selection):/
+  )
+  return match?.[1] || 'unknown-media'
+}
+
+const stableTextHash = (text: string): string => {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash.toString(16).padStart(8, '0')
+}
+
 const parseTimestampSeconds = (timestamp: string): number | undefined => {
   const parts = timestamp.split(':').map((part) => Number.parseInt(part, 10))
   if (parts.some((part) => Number.isNaN(part))) return undefined
@@ -212,19 +231,29 @@ export const buildReadAlongSegments = (
 }
 
 const buildTransientSelectionSegment = (
+  segments: ReadAlongSegment[],
   selection: ReadAlongSelection
 ): ReadAlongSegment[] => {
   const text = selection.selectedText.trim()
   if (!text) return []
 
+  const mediaId = getMediaIdFromSegments(segments)
+  const hasSourceOffsets =
+    selection.sourceStart != null && selection.sourceEnd != null
+  const sourceStart = hasSourceOffsets ? selection.sourceStart! : 0
+  const sourceEnd = hasSourceOffsets ? selection.sourceEnd! : text.length
+  const id = hasSourceOffsets
+    ? buildSegmentId(mediaId, 0, 'transient-selection', sourceStart, sourceEnd)
+    : `${mediaId}:0:transient-selection:text-${stableTextHash(text)}:0:${text.length}`
+
   return [
     {
-      id: `transient-selection:0:${text.length}`,
+      id,
       index: 0,
       kind: 'transient-selection',
       text,
-      sourceStart: 0,
-      sourceEnd: text.length
+      sourceStart,
+      sourceEnd
     }
   ]
 }
@@ -292,12 +321,12 @@ export const resolveReadAlongScope = ({
     const selectedSegments = findSelectedSegments(segments, selection)
     return selectedSegments.length > 0
       ? selectedSegments
-      : buildTransientSelectionSegment(selection)
+      : buildTransientSelectionSegment(segments, selection)
   }
 
   const startIndex = findSegmentIndexForSelection(segments, selection)
   if (startIndex < 0) {
-    return buildTransientSelectionSegment(selection)
+    return buildTransientSelectionSegment(segments, selection)
   }
 
   if (scope === 'from-here') {

--- a/apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts
+++ b/apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts
@@ -1,0 +1,390 @@
+import {
+  hasLeadingTranscriptTimings,
+  parseLeadingTranscriptTiming
+} from '@/utils/media-transcript-display'
+
+import type {
+  BuildReadAlongSegmentsInput,
+  ReadAlongSegment,
+  ReadAlongSelection,
+  ReadAlongTtsRequestSegment,
+  ResolveReadAlongScopeInput
+} from './types'
+
+const SENTENCE_BOUNDARY_PATTERN = /[^.!?\n]+[.!?]+(?=\s|$)|[^.!?\n]+$/g
+const MARKDOWN_HEADING_PATTERN = /^\s{0,3}#{1,6}\s+\S/
+
+const normalizeNewlines = (value: string): string => value.replace(/\r\n/g, '\n')
+
+const buildSegmentId = (
+  mediaId: string,
+  index: number,
+  kind: ReadAlongSegment['kind'],
+  sourceStart: number,
+  sourceEnd: number
+): string => `${mediaId}:${index}:${kind}:${sourceStart}:${sourceEnd}`
+
+const parseTimestampSeconds = (timestamp: string): number | undefined => {
+  const parts = timestamp.split(':').map((part) => Number.parseInt(part, 10))
+  if (parts.some((part) => Number.isNaN(part))) return undefined
+
+  if (parts.length === 2) {
+    const [minutes, seconds] = parts
+    return minutes * 60 + seconds
+  }
+
+  if (parts.length === 3) {
+    const [hours, minutes, seconds] = parts
+    return hours * 3600 + minutes * 60 + seconds
+  }
+
+  return undefined
+}
+
+const findDisplayOffset = (
+  displayContent: string | undefined,
+  text: string,
+  after: number
+): number | undefined => {
+  if (!displayContent) return undefined
+  const offset = displayContent.indexOf(text, Math.max(0, after))
+  return offset >= 0 ? offset : undefined
+}
+
+const buildTranscriptSegments = ({
+  mediaId,
+  content,
+  displayContent
+}: BuildReadAlongSegmentsInput): ReadAlongSegment[] => {
+  const normalized = normalizeNewlines(content)
+  const segments: ReadAlongSegment[] = []
+  let sourceOffset = 0
+  let nextDisplayStart = 0
+
+  for (const line of normalized.split('\n')) {
+    const parsed = parseLeadingTranscriptTiming(line)
+    if (parsed) {
+      const prefixLength =
+        parsed.leadingWhitespace.length +
+        parsed.timestamp.length +
+        parsed.separator.length +
+        (line.includes(`[${parsed.timestamp}]`) ? 2 : 0)
+      const rawTextStart = sourceOffset + prefixLength
+      const textLeadingTrim = parsed.text.length - parsed.text.trimStart().length
+      const text = parsed.text.trim()
+      const sourceStart = rawTextStart + textLeadingTrim
+      const sourceEnd = sourceStart + text.length
+
+      if (text.length > 0) {
+        const displayStart = findDisplayOffset(displayContent, text, nextDisplayStart)
+        if (displayStart != null) {
+          nextDisplayStart = displayStart + text.length
+        }
+
+        segments.push({
+          id: buildSegmentId(
+            mediaId,
+            segments.length,
+            'transcript-line',
+            sourceStart,
+            sourceEnd
+          ),
+          index: segments.length,
+          kind: 'transcript-line',
+          text,
+          sourceStart,
+          sourceEnd,
+          displayStart,
+          displayEnd: displayStart == null ? undefined : displayStart + text.length,
+          sectionId: 'transcript',
+          timestampSeconds: parseTimestampSeconds(parsed.timestamp)
+        })
+      }
+    }
+
+    sourceOffset += line.length + 1
+  }
+
+  return segments
+}
+
+const splitSentences = (
+  text: string,
+  sourceOffset: number
+): Array<{ text: string; sourceStart: number; sourceEnd: number }> => {
+  const sentences: Array<{ text: string; sourceStart: number; sourceEnd: number }> = []
+
+  for (const match of text.matchAll(SENTENCE_BOUNDARY_PATTERN)) {
+    const matchedText = match[0]
+    const localStart = match.index ?? 0
+    const leadingTrim = matchedText.length - matchedText.trimStart().length
+    const trimmed = matchedText.trim()
+    if (!trimmed) continue
+
+    const sourceStart = sourceOffset + localStart + leadingTrim
+    sentences.push({
+      text: trimmed,
+      sourceStart,
+      sourceEnd: sourceStart + trimmed.length
+    })
+  }
+
+  return sentences
+}
+
+const buildProseSegments = ({
+  mediaId,
+  content,
+  displayContent,
+  renderMode
+}: BuildReadAlongSegmentsInput): ReadAlongSegment[] => {
+  const normalized = normalizeNewlines(content)
+  const lines = normalized.split('\n')
+  const segments: ReadAlongSegment[] = []
+  let sourceOffset = 0
+  let sectionIndex = 0
+  let paragraphIndex = 0
+  let nextDisplayStart = 0
+
+  for (const line of lines) {
+    const isHeading = renderMode === 'markdown' && MARKDOWN_HEADING_PATTERN.test(line)
+    if (isHeading) {
+      sectionIndex += segments.length === 0 && sectionIndex === 0 ? 0 : 1
+      sourceOffset += line.length + 1
+      continue
+    }
+
+    if (line.trim().length === 0) {
+      paragraphIndex += 1
+      sourceOffset += line.length + 1
+      continue
+    }
+
+    const sectionId =
+      renderMode === 'markdown' ? `section-${sectionIndex}` : `paragraph-${paragraphIndex}`
+
+    for (const sentence of splitSentences(line, sourceOffset)) {
+      const displayStart = findDisplayOffset(
+        displayContent,
+        sentence.text,
+        nextDisplayStart
+      )
+      if (displayStart != null) {
+        nextDisplayStart = displayStart + sentence.text.length
+      }
+
+      segments.push({
+        id: buildSegmentId(
+          mediaId,
+          segments.length,
+          'sentence',
+          sentence.sourceStart,
+          sentence.sourceEnd
+        ),
+        index: segments.length,
+        kind: 'sentence',
+        text: sentence.text,
+        sourceStart: sentence.sourceStart,
+        sourceEnd: sentence.sourceEnd,
+        displayStart,
+        displayEnd:
+          displayStart == null ? undefined : displayStart + sentence.text.length,
+        sectionId
+      })
+    }
+
+    sourceOffset += line.length + 1
+  }
+
+  return segments
+}
+
+export const buildReadAlongSegments = (
+  input: BuildReadAlongSegmentsInput
+): ReadAlongSegment[] => {
+  if (!input.content.trim()) return []
+
+  if (hasLeadingTranscriptTimings(input.content)) {
+    return buildTranscriptSegments(input)
+  }
+
+  return buildProseSegments(input)
+}
+
+const buildTransientSelectionSegment = (
+  selection: ReadAlongSelection
+): ReadAlongSegment[] => {
+  const text = selection.selectedText.trim()
+  if (!text) return []
+
+  return [
+    {
+      id: `transient-selection:0:${text.length}`,
+      index: 0,
+      kind: 'transient-selection',
+      text,
+      sourceStart: 0,
+      sourceEnd: text.length
+    }
+  ]
+}
+
+const findSegmentIndexForSelection = (
+  segments: ReadAlongSegment[],
+  selection: ReadAlongSelection
+): number => {
+  const idIndex = selection.startSegmentId
+    ? segments.findIndex((segment) => segment.id === selection.startSegmentId)
+    : -1
+  if (idIndex >= 0) return idIndex
+
+  if (selection.sourceStart == null) return -1
+
+  const containingIndex = segments.findIndex(
+    (segment) =>
+      selection.sourceStart != null &&
+      selection.sourceStart >= segment.sourceStart &&
+      selection.sourceStart < segment.sourceEnd
+  )
+  if (containingIndex >= 0) return containingIndex
+
+  return segments.findIndex((segment) => selection.sourceStart! < segment.sourceStart)
+}
+
+const findSelectedSegments = (
+  segments: ReadAlongSegment[],
+  selection: ReadAlongSelection
+): ReadAlongSegment[] => {
+  if (selection.startSegmentId || selection.endSegmentId) {
+    const startIndex = findSegmentIndexForSelection(segments, selection)
+    const endIndex = selection.endSegmentId
+      ? segments.findIndex((segment) => segment.id === selection.endSegmentId)
+      : startIndex
+    if (startIndex >= 0 && endIndex >= 0) {
+      return segments.slice(
+        Math.min(startIndex, endIndex),
+        Math.max(startIndex, endIndex) + 1
+      )
+    }
+  }
+
+  if (selection.sourceStart == null || selection.sourceEnd == null) {
+    return []
+  }
+
+  return segments.filter(
+    (segment) =>
+      segment.sourceEnd > selection.sourceStart! &&
+      segment.sourceStart < selection.sourceEnd!
+  )
+}
+
+export const resolveReadAlongScope = ({
+  scope,
+  segments,
+  selection
+}: ResolveReadAlongScopeInput): ReadAlongSegment[] => {
+  if (scope === 'full-item') {
+    return segments
+  }
+
+  if (scope === 'selection') {
+    const selectedSegments = findSelectedSegments(segments, selection)
+    return selectedSegments.length > 0
+      ? selectedSegments
+      : buildTransientSelectionSegment(selection)
+  }
+
+  const startIndex = findSegmentIndexForSelection(segments, selection)
+  if (startIndex < 0) {
+    return buildTransientSelectionSegment(selection)
+  }
+
+  if (scope === 'from-here') {
+    return segments.slice(startIndex)
+  }
+
+  const sectionId = segments[startIndex]?.sectionId
+  if (!sectionId) {
+    return [segments[startIndex]]
+  }
+
+  return segments.filter((segment) => segment.sectionId === sectionId)
+}
+
+export const splitSegmentForTtsRequest = (
+  segment: ReadAlongSegment,
+  maxLength: number
+): ReadAlongTtsRequestSegment[] => {
+  const normalizedMaxLength = Math.max(1, maxLength)
+  if (segment.text.length <= normalizedMaxLength) {
+    return [
+      {
+        id: `${segment.id}:part:0:${segment.sourceStart}:${segment.sourceEnd}`,
+        parentSegmentId: segment.id,
+        index: 0,
+        text: segment.text,
+        sourceStart: segment.sourceStart,
+        sourceEnd: segment.sourceEnd
+      }
+    ]
+  }
+
+  const parts: ReadAlongTtsRequestSegment[] = []
+  let current = ''
+  let currentStartOffset = 0
+  let cursor = 0
+
+  const flush = () => {
+    const text = current.trim()
+    if (!text) return
+    const sourceStart = segment.sourceStart + currentStartOffset
+    const sourceEnd = sourceStart + text.length
+    parts.push({
+      id: `${segment.id}:part:${parts.length}:${sourceStart}:${sourceEnd}`,
+      parentSegmentId: segment.id,
+      index: parts.length,
+      text,
+      sourceStart,
+      sourceEnd
+    })
+  }
+
+  for (const wordMatch of segment.text.matchAll(/\S+\s*/g)) {
+    const token = wordMatch[0]
+    const tokenStart = wordMatch.index ?? cursor
+
+    if (!current) {
+      current = token
+      currentStartOffset = tokenStart
+    } else if ((current + token).trim().length <= normalizedMaxLength) {
+      current += token
+    } else {
+      flush()
+      current = token
+      currentStartOffset = tokenStart
+    }
+
+    while (current.trim().length > normalizedMaxLength) {
+      const text = current.trim().slice(0, normalizedMaxLength)
+      const sourceStart = segment.sourceStart + currentStartOffset
+      const sourceEnd = sourceStart + text.length
+      parts.push({
+        id: `${segment.id}:part:${parts.length}:${sourceStart}:${sourceEnd}`,
+        parentSegmentId: segment.id,
+        index: parts.length,
+        text,
+        sourceStart,
+        sourceEnd
+      })
+      current = current.trim().slice(normalizedMaxLength)
+      currentStartOffset += normalizedMaxLength
+    }
+
+    cursor = tokenStart + token.length
+  }
+
+  flush()
+
+  return parts
+}

--- a/apps/packages/ui/src/components/Media/read-along/types.ts
+++ b/apps/packages/ui/src/components/Media/read-along/types.ts
@@ -10,6 +10,14 @@ export type ReadAlongScope =
   | 'current-section'
   | 'full-item'
 
+export type ReadAlongSessionStatus =
+  | 'idle'
+  | 'preparing'
+  | 'playing'
+  | 'paused'
+  | 'segment-error'
+  | 'stopped'
+
 export interface ReadAlongSegment {
   id: string
   index: number
@@ -31,6 +39,16 @@ export interface ReadAlongSelection {
   sourceStart?: number
   sourceEnd?: number
   mappingConfidence: 'exact' | 'nearest' | 'text-only'
+}
+
+export interface ReadAlongSessionState {
+  status: ReadAlongSessionStatus
+  scope: ReadAlongScope | null
+  activeSegmentId: string | null
+  activeIndex: number
+  totalSegments: number
+  error: string | null
+  cacheDisabled: boolean
 }
 
 export interface BuildReadAlongSegmentsInput {

--- a/apps/packages/ui/src/components/Media/read-along/types.ts
+++ b/apps/packages/ui/src/components/Media/read-along/types.ts
@@ -1,0 +1,57 @@
+export type ReadAlongSegmentKind =
+  | 'transcript-line'
+  | 'sentence'
+  | 'paragraph'
+  | 'transient-selection'
+
+export type ReadAlongScope =
+  | 'selection'
+  | 'from-here'
+  | 'current-section'
+  | 'full-item'
+
+export interface ReadAlongSegment {
+  id: string
+  index: number
+  kind: ReadAlongSegmentKind
+  text: string
+  sourceStart: number
+  sourceEnd: number
+  displayStart?: number
+  displayEnd?: number
+  sectionId?: string
+  timestampSeconds?: number
+}
+
+export interface ReadAlongSelection {
+  selectedText: string
+  anchorRect: DOMRect
+  startSegmentId?: string
+  endSegmentId?: string
+  sourceStart?: number
+  sourceEnd?: number
+  mappingConfidence: 'exact' | 'nearest' | 'text-only'
+}
+
+export interface BuildReadAlongSegmentsInput {
+  mediaId: string
+  content: string
+  displayContent?: string
+  renderMode?: 'plain' | 'markdown' | 'html' | string
+  hideTranscriptTimings?: boolean
+}
+
+export interface ResolveReadAlongScopeInput {
+  scope: ReadAlongScope
+  segments: ReadAlongSegment[]
+  selection: ReadAlongSelection
+}
+
+export interface ReadAlongTtsRequestSegment {
+  id: string
+  parentSegmentId: string
+  index: number
+  text: string
+  sourceStart: number
+  sourceEnd: number
+}

--- a/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
@@ -79,9 +79,11 @@ export const useContentSelectionActions = ({
   ])
 
   useEffect(() => {
-    if (!selectionActionState || typeof document === 'undefined') return
+    if (typeof document === 'undefined' || typeof window === 'undefined') return
 
-    const handleSelectionChange = () => {
+    let selectionChangeTimer: number | null = null
+    const updateSelectionFromDocument = () => {
+      selectionChangeTimer = null
       const selection = getContentSelectionFromDom(contentBodyRef.current)
       if (!selection) {
         clearSelectionActions()
@@ -89,12 +91,21 @@ export const useContentSelectionActions = ({
       }
       setSelectionActionState(toActionState(selection, contentIdentityKey))
     }
+    const handleSelectionChange = () => {
+      if (selectionChangeTimer != null) {
+        window.clearTimeout(selectionChangeTimer)
+      }
+      selectionChangeTimer = window.setTimeout(updateSelectionFromDocument, 0)
+    }
 
     document.addEventListener('selectionchange', handleSelectionChange)
     return () => {
+      if (selectionChangeTimer != null) {
+        window.clearTimeout(selectionChangeTimer)
+      }
       document.removeEventListener('selectionchange', handleSelectionChange)
     }
-  }, [clearSelectionActions, contentBodyRef, contentIdentityKey, selectionActionState])
+  }, [clearSelectionActions, contentBodyRef, contentIdentityKey])
 
   useEffect(() => {
     if (

--- a/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { RefObject } from 'react'
 
 import { getContentSelectionFromDom } from './media-read-along-dom'
@@ -21,6 +21,11 @@ const buildSelectionLocation = (selection: ReadAlongSelection): string | undefin
   return `read-along-segment:${selection.startSegmentId}..${selection.endSegmentId}`
 }
 
+const toActionState = (selection: ReadAlongSelection): ContentSelectionActionState => ({
+  ...selection,
+  location: buildSelectionLocation(selection)
+})
+
 export const useContentSelectionActions = ({
   contentBodyRef,
   onApplyAnnotationSelection
@@ -39,20 +44,40 @@ export const useContentSelectionActions = ({
       return
     }
 
-    setSelectionActionState({
-      ...selection,
-      location: buildSelectionLocation(selection)
-    })
+    setSelectionActionState(toActionState(selection))
   }, [clearSelectionActions, contentBodyRef])
 
   const applyAnnotationSelection = useCallback(() => {
     if (!selectionActionState) return
-    onApplyAnnotationSelection(
-      selectionActionState.selectedText,
-      selectionActionState.location
-    )
+
+    const currentSelection = getContentSelectionFromDom(contentBodyRef.current)
+    if (!currentSelection) {
+      clearSelectionActions()
+      return
+    }
+
+    const currentActionState = toActionState(currentSelection)
+    onApplyAnnotationSelection(currentActionState.selectedText, currentActionState.location)
     clearSelectionActions()
-  }, [clearSelectionActions, onApplyAnnotationSelection, selectionActionState])
+  }, [clearSelectionActions, contentBodyRef, onApplyAnnotationSelection, selectionActionState])
+
+  useEffect(() => {
+    if (!selectionActionState || typeof document === 'undefined') return
+
+    const handleSelectionChange = () => {
+      const selection = getContentSelectionFromDom(contentBodyRef.current)
+      if (!selection) {
+        clearSelectionActions()
+        return
+      }
+      setSelectionActionState(toActionState(selection))
+    }
+
+    document.addEventListener('selectionchange', handleSelectionChange)
+    return () => {
+      document.removeEventListener('selectionchange', handleSelectionChange)
+    }
+  }, [clearSelectionActions, contentBodyRef, selectionActionState])
 
   return {
     selectionActionState,

--- a/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
@@ -1,0 +1,63 @@
+import { useCallback, useState } from 'react'
+import type { RefObject } from 'react'
+
+import { getContentSelectionFromDom } from './media-read-along-dom'
+import type { ReadAlongSelection } from './types'
+
+export interface UseContentSelectionActionsOptions {
+  contentBodyRef: RefObject<HTMLElement | null>
+  onApplyAnnotationSelection: (selectionText: string, location?: string) => void
+}
+
+export interface ContentSelectionActionState extends ReadAlongSelection {
+  location?: string
+}
+
+const buildSelectionLocation = (selection: ReadAlongSelection): string | undefined => {
+  if (!selection.startSegmentId) return undefined
+  if (!selection.endSegmentId || selection.endSegmentId === selection.startSegmentId) {
+    return `read-along-segment:${selection.startSegmentId}`
+  }
+  return `read-along-segment:${selection.startSegmentId}..${selection.endSegmentId}`
+}
+
+export const useContentSelectionActions = ({
+  contentBodyRef,
+  onApplyAnnotationSelection
+}: UseContentSelectionActionsOptions) => {
+  const [selectionActionState, setSelectionActionState] =
+    useState<ContentSelectionActionState | null>(null)
+
+  const clearSelectionActions = useCallback(() => {
+    setSelectionActionState(null)
+  }, [])
+
+  const handleContentSelectionEvent = useCallback(() => {
+    const selection = getContentSelectionFromDom(contentBodyRef.current)
+    if (!selection) {
+      clearSelectionActions()
+      return
+    }
+
+    setSelectionActionState({
+      ...selection,
+      location: buildSelectionLocation(selection)
+    })
+  }, [clearSelectionActions, contentBodyRef])
+
+  const applyAnnotationSelection = useCallback(() => {
+    if (!selectionActionState) return
+    onApplyAnnotationSelection(
+      selectionActionState.selectedText,
+      selectionActionState.location
+    )
+    clearSelectionActions()
+  }, [clearSelectionActions, onApplyAnnotationSelection, selectionActionState])
+
+  return {
+    selectionActionState,
+    handleContentSelectionEvent,
+    clearSelectionActions,
+    applyAnnotationSelection
+  }
+}

--- a/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
@@ -6,10 +6,12 @@ import type { ReadAlongSelection } from './types'
 
 export interface UseContentSelectionActionsOptions {
   contentBodyRef: RefObject<HTMLElement | null>
+  contentIdentityKey: string
   onApplyAnnotationSelection: (selectionText: string, location?: string) => void
 }
 
 export interface ContentSelectionActionState extends ReadAlongSelection {
+  contentIdentityKey: string
   location?: string
 }
 
@@ -21,13 +23,18 @@ const buildSelectionLocation = (selection: ReadAlongSelection): string | undefin
   return `read-along-segment:${selection.startSegmentId}..${selection.endSegmentId}`
 }
 
-const toActionState = (selection: ReadAlongSelection): ContentSelectionActionState => ({
+const toActionState = (
+  selection: ReadAlongSelection,
+  contentIdentityKey: string
+): ContentSelectionActionState => ({
   ...selection,
+  contentIdentityKey,
   location: buildSelectionLocation(selection)
 })
 
 export const useContentSelectionActions = ({
   contentBodyRef,
+  contentIdentityKey,
   onApplyAnnotationSelection
 }: UseContentSelectionActionsOptions) => {
   const [selectionActionState, setSelectionActionState] =
@@ -44,11 +51,15 @@ export const useContentSelectionActions = ({
       return
     }
 
-    setSelectionActionState(toActionState(selection))
-  }, [clearSelectionActions, contentBodyRef])
+    setSelectionActionState(toActionState(selection, contentIdentityKey))
+  }, [clearSelectionActions, contentBodyRef, contentIdentityKey])
 
   const applyAnnotationSelection = useCallback(() => {
     if (!selectionActionState) return
+    if (selectionActionState.contentIdentityKey !== contentIdentityKey) {
+      clearSelectionActions()
+      return
+    }
 
     const currentSelection = getContentSelectionFromDom(contentBodyRef.current)
     if (!currentSelection) {
@@ -56,10 +67,16 @@ export const useContentSelectionActions = ({
       return
     }
 
-    const currentActionState = toActionState(currentSelection)
+    const currentActionState = toActionState(currentSelection, contentIdentityKey)
     onApplyAnnotationSelection(currentActionState.selectedText, currentActionState.location)
     clearSelectionActions()
-  }, [clearSelectionActions, contentBodyRef, onApplyAnnotationSelection, selectionActionState])
+  }, [
+    clearSelectionActions,
+    contentBodyRef,
+    contentIdentityKey,
+    onApplyAnnotationSelection,
+    selectionActionState
+  ])
 
   useEffect(() => {
     if (!selectionActionState || typeof document === 'undefined') return
@@ -70,17 +87,31 @@ export const useContentSelectionActions = ({
         clearSelectionActions()
         return
       }
-      setSelectionActionState(toActionState(selection))
+      setSelectionActionState(toActionState(selection, contentIdentityKey))
     }
 
     document.addEventListener('selectionchange', handleSelectionChange)
     return () => {
       document.removeEventListener('selectionchange', handleSelectionChange)
     }
-  }, [clearSelectionActions, contentBodyRef, selectionActionState])
+  }, [clearSelectionActions, contentBodyRef, contentIdentityKey, selectionActionState])
+
+  useEffect(() => {
+    if (
+      selectionActionState &&
+      selectionActionState.contentIdentityKey !== contentIdentityKey
+    ) {
+      clearSelectionActions()
+    }
+  }, [clearSelectionActions, contentIdentityKey, selectionActionState])
+
+  const currentSelectionActionState =
+    selectionActionState?.contentIdentityKey === contentIdentityKey
+      ? selectionActionState
+      : null
 
   return {
-    selectionActionState,
+    selectionActionState: currentSelectionActionState,
     handleContentSelectionEvent,
     clearSelectionActions,
     applyAnnotationSelection

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -424,8 +424,9 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       if (!isCurrentSession(token)) return
       const settingsSignature = buildTtsSettingsSignature({
         provider: providerContext.provider,
-        speed: providerContext.playbackSpeed,
-        format: providerContext.formatInfo?.resolved
+        ...providerContext.cacheSettings,
+        speed: providerContext.cacheSettings?.speed ?? providerContext.playbackSpeed,
+        format: providerContext.cacheSettings?.format ?? providerContext.formatInfo?.resolved
       })
       const session: ReadAlongSession = {
         token,

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -768,7 +768,6 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       const settingsSignature = buildTtsSettingsSignature({
         provider: providerContext.provider,
         ...providerContext.cacheSettings,
-        speed: providerContext.cacheSettings?.speed ?? providerContext.playbackSpeed,
         format: providerContext.cacheSettings?.format ?? providerContext.formatInfo?.resolved
       })
       const session: ReadAlongSession = {
@@ -849,7 +848,10 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       return
     }
 
-    void session.audio?.play().then(() => {
+    const playPromise = session.audio?.play()
+    if (!playPromise) return
+
+    void playPromise.then(() => {
       if (!isCurrentSession(session.token)) return
       setState((previous) => ({
         ...previous,

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -1,0 +1,567 @@
+import * as React from 'react'
+
+import {
+  resolveTtsProviderContext,
+  type TtsProviderContext
+} from '@/services/tts-provider'
+
+import {
+  buildReadAlongCacheKey,
+  buildTtsSettingsSignature
+} from './media-read-along-cache-key'
+import {
+  getMediaReadAlongAudioCacheEntry,
+  saveMediaReadAlongAudioCacheEntry
+} from './media-read-along-cache'
+import {
+  buildReadAlongSegments,
+  resolveReadAlongScope
+} from './media-read-along-segments'
+import type {
+  ReadAlongScope,
+  ReadAlongSegment,
+  ReadAlongSelection,
+  ReadAlongSessionState
+} from './types'
+
+const LOOKAHEAD_SEGMENT_COUNT = 4
+
+type SessionToken = symbol
+
+type AudioSource = {
+  blob: Blob
+  format: string
+  mimeType: string
+}
+
+type ReadAlongSession = {
+  token: SessionToken
+  scope: ReadAlongScope
+  queue: ReadAlongSegment[]
+  providerContext: TtsProviderContext
+  settingsSignature: string
+  currentController: AbortController
+  lookaheadController: AbortController
+  audio: HTMLAudioElement | null
+  objectUrl: string | null
+  browserUtterance: SpeechSynthesisUtterance | null
+  prefetched: Map<string, AudioSource>
+  cacheDisabled: boolean
+}
+
+type UseMediaReadAlongSessionArgs = {
+  mediaId: string | null
+  mediaKind: string | null
+  content: string
+  displayContent: string
+  renderMode: string
+  hideTranscriptTimings: boolean
+  selection: ReadAlongSelection | null
+  contentBodyRef: React.RefObject<HTMLElement | null>
+  contentScrollContainerRef: React.RefObject<HTMLElement | null>
+  embeddedMediaRef: React.RefObject<HTMLMediaElement | null>
+}
+
+const idleState: ReadAlongSessionState = {
+  status: 'idle',
+  scope: null,
+  activeSegmentId: null,
+  activeIndex: -1,
+  totalSegments: 0,
+  error: null,
+  cacheDisabled: false
+}
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error || 'Unknown read-along error')
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof DOMException
+    ? error.name === 'AbortError'
+    : error instanceof Error && error.name === 'AbortError'
+
+const revokeObjectUrl = (url: string | null): void => {
+  if (!url || typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
+    return
+  }
+  URL.revokeObjectURL(url)
+}
+
+const createBlob = (source: AudioSource): Blob =>
+  source.blob instanceof Blob
+    ? source.blob
+    : new Blob([source.blob], { type: source.mimeType })
+
+export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
+  const {
+    mediaId,
+    mediaKind,
+    content,
+    displayContent,
+    renderMode,
+    hideTranscriptTimings,
+    selection,
+    embeddedMediaRef
+  } = args
+
+  const [state, setState] = React.useState<ReadAlongSessionState>(idleState)
+  const sessionRef = React.useRef<ReadAlongSession | null>(null)
+  const activeTokenRef = React.useRef<SessionToken | null>(null)
+
+  const isCurrentSession = React.useCallback((token: SessionToken): boolean => {
+    return activeTokenRef.current === token
+  }, [])
+
+  const mutateState = React.useCallback(
+    (
+      token: SessionToken,
+      update:
+        | ReadAlongSessionState
+        | ((previous: ReadAlongSessionState) => ReadAlongSessionState)
+    ): void => {
+      if (!isCurrentSession(token)) return
+      setState(update)
+    },
+    [isCurrentSession]
+  )
+
+  const cleanupSession = React.useCallback(
+    (session: ReadAlongSession | null, cancelBrowserSpeech = true): void => {
+      if (!session) return
+      session.currentController.abort()
+      session.lookaheadController.abort()
+      session.audio?.pause()
+      session.audio = null
+      revokeObjectUrl(session.objectUrl)
+      session.objectUrl = null
+      session.browserUtterance = null
+      if (
+        cancelBrowserSpeech &&
+        session.providerContext.provider === 'browser' &&
+        typeof window !== 'undefined' &&
+        window.speechSynthesis
+      ) {
+        window.speechSynthesis.cancel()
+      }
+    },
+    []
+  )
+
+  const stop = React.useCallback((): void => {
+    const session = sessionRef.current
+    activeTokenRef.current = null
+    cleanupSession(session)
+    sessionRef.current = null
+    setState({
+      ...idleState,
+      status: 'stopped'
+    })
+  }, [cleanupSession])
+
+  const loadSegmentAudio = React.useCallback(
+    async (
+      session: ReadAlongSession,
+      segment: ReadAlongSegment,
+      signal: AbortSignal
+    ): Promise<AudioSource> => {
+      const key = await buildReadAlongCacheKey({
+        serverScope: 'media-read-along',
+        mediaId: mediaId || 'unknown-media',
+        mediaKind: mediaKind || 'unknown',
+        segmentId: segment.id,
+        segmentText: segment.text,
+        sourceStart: segment.sourceStart,
+        sourceEnd: segment.sourceEnd,
+        settingsSignature: session.settingsSignature
+      })
+
+      const cached = await getMediaReadAlongAudioCacheEntry(key.id)
+      if (cached) {
+        return {
+          blob: cached.blob,
+          format: cached.format,
+          mimeType: cached.mimeType
+        }
+      }
+
+      if (!session.providerContext.synthesize) {
+        throw new Error('The selected TTS provider cannot synthesize generated audio')
+      }
+
+      const generated = await session.providerContext.synthesize(segment.text, { signal })
+      const blob = new Blob([generated.buffer], { type: generated.mimeType })
+      const saved = await saveMediaReadAlongAudioCacheEntry({
+        id: key.id,
+        createdAt: Date.now(),
+        lastUsedAt: Date.now(),
+        mediaId: key.mediaId,
+        mediaKind: key.mediaKind,
+        segmentId: key.segmentId,
+        settingsSignature: key.settingsSignature,
+        textHash: key.textHash,
+        blob,
+        mimeType: generated.mimeType,
+        format: generated.format,
+        sizeBytes: blob.size
+      })
+      if (!saved) {
+        session.cacheDisabled = true
+        mutateState(session.token, (previous) => ({
+          ...previous,
+          cacheDisabled: true
+        }))
+      }
+
+      return {
+        blob,
+        format: generated.format,
+        mimeType: generated.mimeType
+      }
+    },
+    [mediaId, mediaKind, mutateState]
+  )
+
+  const prefetchLookahead = React.useCallback(
+    async (session: ReadAlongSession, activeIndex: number): Promise<void> => {
+      const lookahead = session.queue.slice(
+        activeIndex + 1,
+        activeIndex + 1 + LOOKAHEAD_SEGMENT_COUNT
+      )
+      for (const segment of lookahead) {
+        if (!isCurrentSession(session.token)) return
+        if (session.lookaheadController.signal.aborted) return
+        if (session.prefetched.has(segment.id)) continue
+
+        try {
+          const source = await loadSegmentAudio(
+            session,
+            segment,
+            session.lookaheadController.signal
+          )
+          if (!isCurrentSession(session.token)) return
+          session.prefetched.set(segment.id, source)
+        } catch (error) {
+          if (isAbortError(error)) return
+        }
+      }
+    },
+    [isCurrentSession, loadSegmentAudio]
+  )
+
+  const playBrowserSegment = React.useCallback(
+    (session: ReadAlongSession, index: number): void => {
+      const segment = session.queue[index]
+      if (!segment || typeof window === 'undefined' || !window.speechSynthesis) {
+        mutateState(session.token, (previous) => ({
+          ...previous,
+          status: 'segment-error',
+          error: 'Browser speech synthesis is unavailable'
+        }))
+        return
+      }
+
+      const utterance = new SpeechSynthesisUtterance(segment.text)
+      utterance.rate = session.providerContext.playbackSpeed || 1
+      utterance.onend = () => {
+        if (!isCurrentSession(session.token)) return
+        void playSegment(session, index + 1)
+      }
+      utterance.onerror = () => {
+        mutateState(session.token, (previous) => ({
+          ...previous,
+          status: 'segment-error',
+          error: 'Browser speech synthesis failed'
+        }))
+      }
+
+      session.browserUtterance = utterance
+      mutateState(session.token, {
+        status: 'playing',
+        scope: session.scope,
+        activeSegmentId: segment.id,
+        activeIndex: index,
+        totalSegments: session.queue.length,
+        error: null,
+        cacheDisabled: session.cacheDisabled
+      })
+      window.speechSynthesis.speak(utterance)
+    },
+    [isCurrentSession, mutateState]
+  )
+
+  const playGeneratedSegment = React.useCallback(
+    async (session: ReadAlongSession, index: number): Promise<void> => {
+      const segment = session.queue[index]
+      if (!segment) return
+
+      try {
+        const source =
+          session.prefetched.get(segment.id) ||
+          (await loadSegmentAudio(session, segment, session.currentController.signal))
+        if (!isCurrentSession(session.token)) return
+
+        session.prefetched.delete(segment.id)
+        revokeObjectUrl(session.objectUrl)
+        const objectUrl = URL.createObjectURL(createBlob(source))
+        const audio = new Audio(objectUrl)
+        audio.playbackRate = session.providerContext.playbackSpeed || 1
+        session.objectUrl = objectUrl
+        session.audio = audio
+
+        audio.addEventListener('ended', () => {
+          revokeObjectUrl(objectUrl)
+          if (session.objectUrl === objectUrl) {
+            session.objectUrl = null
+          }
+          if (!isCurrentSession(session.token)) return
+          void playSegment(session, index + 1)
+        })
+        audio.addEventListener('error', () => {
+          revokeObjectUrl(objectUrl)
+          if (!isCurrentSession(session.token)) return
+          mutateState(session.token, (previous) => ({
+            ...previous,
+            status: 'segment-error',
+            error: 'Generated audio playback failed'
+          }))
+        })
+
+        mutateState(session.token, {
+          status: 'playing',
+          scope: session.scope,
+          activeSegmentId: segment.id,
+          activeIndex: index,
+          totalSegments: session.queue.length,
+          error: null,
+          cacheDisabled: session.cacheDisabled
+        })
+        await audio.play()
+        if (!isCurrentSession(session.token)) return
+        void prefetchLookahead(session, index)
+      } catch (error) {
+        if (!isCurrentSession(session.token) || isAbortError(error)) return
+        mutateState(session.token, (previous) => ({
+          ...previous,
+          status: 'segment-error',
+          error: errorMessage(error)
+        }))
+      }
+    },
+    [isCurrentSession, loadSegmentAudio, mutateState, prefetchLookahead]
+  )
+
+  const playSegment = React.useCallback(
+    async (session: ReadAlongSession, index: number): Promise<void> => {
+      if (!isCurrentSession(session.token)) return
+      if (index >= session.queue.length) {
+        cleanupSession(session, false)
+        sessionRef.current = null
+        activeTokenRef.current = null
+        setState({
+          ...idleState,
+          status: 'stopped',
+          scope: session.scope,
+          totalSegments: session.queue.length,
+          cacheDisabled: session.cacheDisabled
+        })
+        return
+      }
+
+      if (session.providerContext.provider === 'browser' && !session.providerContext.synthesize) {
+        playBrowserSegment(session, index)
+        return
+      }
+
+      await playGeneratedSegment(session, index)
+    },
+    [cleanupSession, isCurrentSession, playBrowserSegment, playGeneratedSegment]
+  )
+
+  const start = React.useCallback(
+    async (scope: ReadAlongScope): Promise<void> => {
+      if (!mediaId || !mediaKind || !selection) return
+
+      const token = Symbol('media-read-along-session')
+      cleanupSession(sessionRef.current)
+      activeTokenRef.current = token
+      const segments = buildReadAlongSegments({
+        mediaId,
+        content,
+        displayContent,
+        renderMode,
+        hideTranscriptTimings
+      })
+      const queue = resolveReadAlongScope({ scope, segments, selection })
+      if (queue.length === 0) {
+        sessionRef.current = null
+        activeTokenRef.current = null
+        setState({
+          ...idleState,
+          status: 'segment-error',
+          scope,
+          error: 'No readable content found for the selected read-along scope'
+        })
+        return
+      }
+
+      const currentController = new AbortController()
+      const lookaheadController = new AbortController()
+      let providerContext: TtsProviderContext
+      try {
+        providerContext = await resolveTtsProviderContext(queue[0].text)
+      } catch (error) {
+        if (!isCurrentSession(token)) return
+        activeTokenRef.current = null
+        setState({
+          ...idleState,
+          status: 'segment-error',
+          scope,
+          totalSegments: queue.length,
+          error: errorMessage(error)
+        })
+        return
+      }
+      if (!isCurrentSession(token)) return
+      const settingsSignature = buildTtsSettingsSignature({
+        provider: providerContext.provider,
+        speed: providerContext.playbackSpeed,
+        format: providerContext.formatInfo?.resolved
+      })
+      const session: ReadAlongSession = {
+        token,
+        scope,
+        queue,
+        providerContext,
+        settingsSignature,
+        currentController,
+        lookaheadController,
+        audio: null,
+        objectUrl: null,
+        browserUtterance: null,
+        prefetched: new Map(),
+        cacheDisabled: false
+      }
+
+      sessionRef.current = session
+      setState({
+        status: 'preparing',
+        scope,
+        activeSegmentId: null,
+        activeIndex: -1,
+        totalSegments: queue.length,
+        error: null,
+        cacheDisabled: false
+      })
+
+      const embeddedMedia = embeddedMediaRef.current
+      if (embeddedMedia && !embeddedMedia.paused) {
+        embeddedMedia.pause()
+      }
+
+      await playSegment(session, 0)
+    },
+    [
+      cleanupSession,
+      content,
+      displayContent,
+      embeddedMediaRef,
+      hideTranscriptTimings,
+      mediaId,
+      mediaKind,
+      playSegment,
+      renderMode,
+      selection
+    ]
+  )
+
+  const pause = React.useCallback((): void => {
+    const session = sessionRef.current
+    if (!session) return
+    if (session.providerContext.provider === 'browser' && typeof window !== 'undefined') {
+      window.speechSynthesis?.pause()
+    } else {
+      session.audio?.pause()
+    }
+    setState((previous) => ({
+      ...previous,
+      status: previous.status === 'playing' ? 'paused' : previous.status
+    }))
+  }, [])
+
+  const resume = React.useCallback((): void => {
+    const session = sessionRef.current
+    if (!session) return
+    if (session.providerContext.provider === 'browser' && typeof window !== 'undefined') {
+      window.speechSynthesis?.resume()
+      setState((previous) => ({
+        ...previous,
+        status: previous.status === 'paused' ? 'playing' : previous.status
+      }))
+      return
+    }
+
+    void session.audio?.play().then(() => {
+      if (!isCurrentSession(session.token)) return
+      setState((previous) => ({
+        ...previous,
+        status: previous.status === 'paused' ? 'playing' : previous.status
+      }))
+    }).catch((error) => {
+      if (!isCurrentSession(session.token)) return
+      setState((previous) => ({
+        ...previous,
+        status: 'segment-error',
+        error: errorMessage(error)
+      }))
+    })
+  }, [isCurrentSession])
+
+  const retry = React.useCallback((): void => {
+    const session = sessionRef.current
+    if (!session) return
+    const index = Math.max(0, state.activeIndex)
+    void playSegment(session, index)
+  }, [playSegment, state.activeIndex])
+
+  const skip = React.useCallback(
+    (direction: 'next' | 'previous' = 'next'): void => {
+      const session = sessionRef.current
+      if (!session) return
+      const offset = direction === 'previous' ? -1 : 1
+      const nextIndex = Math.min(
+        session.queue.length,
+        Math.max(0, state.activeIndex + offset)
+      )
+      session.audio?.pause()
+      if (session.providerContext.provider === 'browser' && typeof window !== 'undefined') {
+        window.speechSynthesis?.cancel()
+      }
+      void playSegment(session, nextIndex)
+    },
+    [playSegment, state.activeIndex]
+  )
+
+  React.useEffect(() => {
+    if (!activeTokenRef.current) return
+    stop()
+  }, [mediaId, mediaKind, content, displayContent, renderMode, hideTranscriptTimings, stop])
+
+  React.useEffect(() => {
+    return () => {
+      cleanupSession(sessionRef.current)
+      sessionRef.current = null
+      activeTokenRef.current = null
+    }
+  }, [cleanupSession])
+
+  return {
+    state,
+    start,
+    pause,
+    resume,
+    stop,
+    retry,
+    skip,
+    activeSegmentId: state.activeSegmentId
+  }
+}

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -60,6 +60,7 @@ type ReadAlongSession = {
   audio: HTMLAudioElement | null
   objectUrl: string | null
   browserUtterance: SpeechSynthesisUtterance | null
+  browserVoiceCleanup: (() => void) | null
   prefetched: Map<string, AudioSource[]>
   inFlight: Map<string, InFlightSegmentAudio>
   cacheDisabled: boolean
@@ -181,6 +182,11 @@ const linkAbortSignal = (
   return () => signal.removeEventListener('abort', abort)
 }
 
+const cleanupBrowserVoiceListener = (session: ReadAlongSession): void => {
+  session.browserVoiceCleanup?.()
+  session.browserVoiceCleanup = null
+}
+
 export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
   const {
     mediaId,
@@ -238,6 +244,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       session.audio = null
       revokeObjectUrl(session.objectUrl)
       session.objectUrl = null
+      cleanupBrowserVoiceListener(session)
       session.browserUtterance = null
       session.playAttemptToken = null
       if (
@@ -486,11 +493,11 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       const utterance = new SpeechSynthesisUtterance(
         session.providerContext.normalizeText(segment.text)
       )
-      applyBrowserSpeechSynthesisVoice(
+      session.browserVoiceCleanup = applyBrowserSpeechSynthesisVoice(
         utterance,
         window.speechSynthesis,
         session.providerContext.browserVoiceName
-      )
+      ) ?? null
       utterance.rate = session.providerContext.playbackSpeed || 1
       utterance.onend = () => {
         if (
@@ -499,6 +506,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         ) {
           return
         }
+        cleanupBrowserVoiceListener(session)
         void playSegmentRef.current(session, index + 1)
       }
       utterance.onerror = () => {
@@ -508,6 +516,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         ) {
           return
         }
+        cleanupBrowserVoiceListener(session)
         mutateState(session.token, {
           status: 'segment-error',
           scope: session.scope,
@@ -643,6 +652,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       session.currentController.abort()
       session.currentController = new AbortController()
       session.audio?.pause()
+      cleanupBrowserVoiceListener(session)
       session.browserUtterance = null
       session.pendingIndex = index
       const playToken = Symbol('read-along-play-attempt')
@@ -764,6 +774,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         audio: null,
         objectUrl: null,
         browserUtterance: null,
+        browserVoiceCleanup: null,
         prefetched: new Map(),
         inFlight: new Map(),
         playAttemptToken: null,
@@ -864,6 +875,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       )
       session.audio?.pause()
       if (session.providerContext.provider === 'browser' && typeof window !== 'undefined') {
+        cleanupBrowserVoiceListener(session)
         session.browserUtterance = null
         session.playAttemptToken = null
         window.speechSynthesis?.cancel()

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -1,9 +1,11 @@
 import * as React from 'react'
 
 import {
+  applyBrowserSpeechSynthesisVoice,
   resolveTtsProviderContext,
   type TtsProviderContext
 } from '@/services/tts-provider'
+import { tldwClient } from '@/services/tldw/TldwApiClient'
 
 import {
   buildReadAlongCacheKey,
@@ -15,16 +17,19 @@ import {
 } from './media-read-along-cache'
 import {
   buildReadAlongSegments,
-  resolveReadAlongScope
+  resolveReadAlongScope,
+  splitSegmentForTtsRequest
 } from './media-read-along-segments'
 import type {
   ReadAlongScope,
   ReadAlongSegment,
   ReadAlongSelection,
-  ReadAlongSessionState
+  ReadAlongSessionState,
+  ReadAlongTtsRequestSegment
 } from './types'
 
 const LOOKAHEAD_SEGMENT_COUNT = 4
+const TTS_REQUEST_MAX_TEXT_LENGTH = 4000
 
 type SessionToken = symbol
 type PlayAttemptToken = symbol
@@ -35,12 +40,19 @@ type AudioSource = {
   mimeType: string
 }
 
+type InFlightSegmentAudio = {
+  controller: AbortController
+  promise: Promise<AudioSource[]>
+  unlinkAbort: () => void
+}
+
 type ReadAlongSession = {
   token: SessionToken
   scope: ReadAlongScope
   queue: ReadAlongSegment[]
   providerContext: TtsProviderContext
   settingsSignature: string
+  serverScope: string
   currentController: AbortController
   lookaheadController: AbortController
   playAttemptToken: PlayAttemptToken | null
@@ -48,7 +60,8 @@ type ReadAlongSession = {
   audio: HTMLAudioElement | null
   objectUrl: string | null
   browserUtterance: SpeechSynthesisUtterance | null
-  prefetched: Map<string, AudioSource>
+  prefetched: Map<string, AudioSource[]>
+  inFlight: Map<string, InFlightSegmentAudio>
   cacheDisabled: boolean
 }
 
@@ -98,6 +111,76 @@ const createBlob = (source: AudioSource): Blob =>
     ? source.blob
     : new Blob([source.blob], { type: source.mimeType })
 
+const normalizeServerUrlForScope = (serverUrl: unknown): string => {
+  const value = String(serverUrl || '').trim()
+  if (!value) return 'unknown-server'
+
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.hash = ''
+    url.search = ''
+    return url.toString().replace(/\/$/, '').toLowerCase()
+  } catch {
+    return value
+      .replace(/\/\/[^/@]+@/, '//')
+      .replace(/[?#].*$/, '')
+      .replace(/\/+$/, '')
+      .toLowerCase()
+  }
+}
+
+const resolveReadAlongServerScope = async (): Promise<string> => {
+  const config = await tldwClient.getConfig().catch(() => null)
+  const serverUrl = normalizeServerUrlForScope(config?.serverUrl)
+  const authMode = String(config?.authMode || 'unknown')
+  const credentialScope = config?.accessToken
+    ? 'access-token'
+    : config?.apiKey
+      ? 'api-key'
+      : 'none'
+  const orgId = config?.orgId == null ? 'none' : String(config.orgId)
+
+  return [
+    `server:${serverUrl}`,
+    `auth:${authMode}`,
+    `credential:${credentialScope}`,
+    `org:${orgId}`
+  ].join('|')
+}
+
+const toRequestParts = (segment: ReadAlongSegment): ReadAlongTtsRequestSegment[] => {
+  if (segment.text.length <= TTS_REQUEST_MAX_TEXT_LENGTH) {
+    return [
+      {
+        id: segment.id,
+        parentSegmentId: segment.id,
+        index: 0,
+        text: segment.text,
+        sourceStart: segment.sourceStart,
+        sourceEnd: segment.sourceEnd
+      }
+    ]
+  }
+
+  return splitSegmentForTtsRequest(segment, TTS_REQUEST_MAX_TEXT_LENGTH)
+}
+
+const linkAbortSignal = (
+  signal: AbortSignal,
+  controller: AbortController
+): (() => void) => {
+  if (signal.aborted) {
+    controller.abort()
+    return () => undefined
+  }
+
+  const abort = () => controller.abort()
+  signal.addEventListener('abort', abort, { once: true })
+  return () => signal.removeEventListener('abort', abort)
+}
+
 export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
   const {
     mediaId,
@@ -113,6 +196,9 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
   const [state, setState] = React.useState<ReadAlongSessionState>(idleState)
   const sessionRef = React.useRef<ReadAlongSession | null>(null)
   const activeTokenRef = React.useRef<SessionToken | null>(null)
+  const playSegmentRef = React.useRef<
+    (session: ReadAlongSession, index: number) => Promise<void>
+  >(async () => undefined)
 
   const isCurrentSession = React.useCallback((token: SessionToken): boolean => {
     return activeTokenRef.current === token
@@ -143,6 +229,11 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       if (!session) return
       session.currentController.abort()
       session.lookaheadController.abort()
+      session.inFlight.forEach((entry) => {
+        entry.unlinkAbort()
+        entry.controller.abort()
+      })
+      session.inFlight.clear()
       session.audio?.pause()
       session.audio = null
       revokeObjectUrl(session.objectUrl)
@@ -172,21 +263,22 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
     })
   }, [cleanupSession])
 
-  const loadSegmentAudio = React.useCallback(
+  const loadRequestPartAudio = React.useCallback(
     async (
       session: ReadAlongSession,
-      segment: ReadAlongSegment,
+      part: ReadAlongTtsRequestSegment,
       signal: AbortSignal,
       isCurrentLoad: () => boolean
     ): Promise<AudioSource> => {
+      const requestText = session.providerContext.normalizeText(part.text)
       const key = await buildReadAlongCacheKey({
-        serverScope: 'media-read-along',
+        serverScope: session.serverScope,
         mediaId: mediaId || 'unknown-media',
         mediaKind: mediaKind || 'unknown',
-        segmentId: segment.id,
-        segmentText: segment.text,
-        sourceStart: segment.sourceStart,
-        sourceEnd: segment.sourceEnd,
+        segmentId: part.id,
+        segmentText: requestText,
+        sourceStart: part.sourceStart,
+        sourceEnd: part.sourceEnd,
         settingsSignature: session.settingsSignature
       })
 
@@ -206,7 +298,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         throw new Error('The selected TTS provider cannot synthesize generated audio')
       }
 
-      const generated = await session.providerContext.synthesize(segment.text, { signal })
+      const generated = await session.providerContext.synthesize(requestText, { signal })
       if (signal.aborted || !isCurrentLoad()) {
         throw readAlongAbortError()
       }
@@ -251,6 +343,73 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
     [mediaId, mediaKind, mutateState]
   )
 
+  const fetchSegmentAudioSources = React.useCallback(
+    async (
+      session: ReadAlongSession,
+      segment: ReadAlongSegment,
+      signal: AbortSignal,
+      isCurrentLoad: () => boolean
+    ): Promise<AudioSource[]> => {
+      const parts = toRequestParts(segment)
+      const sources: AudioSource[] = []
+      for (const part of parts) {
+        if (signal.aborted || !isCurrentLoad()) {
+          throw readAlongAbortError()
+        }
+        sources.push(
+          await loadRequestPartAudio(session, part, signal, isCurrentLoad)
+        )
+      }
+      return sources
+    },
+    [loadRequestPartAudio]
+  )
+
+  const getSegmentAudioSources = React.useCallback(
+    async (
+      session: ReadAlongSession,
+      segment: ReadAlongSegment,
+      signal: AbortSignal,
+      isCurrentLoad: () => boolean
+    ): Promise<AudioSource[]> => {
+      const prefetched = session.prefetched.get(segment.id)
+      if (prefetched) {
+        return prefetched
+      }
+
+      const inFlight = session.inFlight.get(segment.id)
+      if (inFlight) {
+        const sources = await inFlight.promise
+        if (signal.aborted || !isCurrentLoad()) {
+          throw readAlongAbortError()
+        }
+        return sources
+      }
+
+      return fetchSegmentAudioSources(session, segment, signal, isCurrentLoad)
+    },
+    [fetchSegmentAudioSources]
+  )
+
+  const resetLookahead = React.useCallback(
+    (session: ReadAlongSession, preserveSegmentId?: string): void => {
+      const preserved = preserveSegmentId
+        ? session.inFlight.get(preserveSegmentId)
+        : undefined
+      preserved?.unlinkAbort()
+
+      session.lookaheadController.abort()
+      session.lookaheadController = new AbortController()
+      session.inFlight.forEach((entry, segmentId) => {
+        if (segmentId === preserveSegmentId) return
+        entry.unlinkAbort()
+        entry.controller.abort()
+        session.inFlight.delete(segmentId)
+      })
+    },
+    []
+  )
+
   const prefetchLookahead = React.useCallback(
     async (session: ReadAlongSession, activeIndex: number): Promise<void> => {
       const lookahead = session.queue.slice(
@@ -260,23 +419,48 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       for (const segment of lookahead) {
         if (!isCurrentSession(session.token)) return
         if (session.lookaheadController.signal.aborted) return
-        if (session.prefetched.has(segment.id)) continue
+        if (session.prefetched.has(segment.id) || session.inFlight.has(segment.id)) {
+          continue
+        }
 
-        try {
-          const source = await loadSegmentAudio(
+        const controller = new AbortController()
+        const unlinkAbort = linkAbortSignal(
+          session.lookaheadController.signal,
+          controller
+        )
+        const inFlight: InFlightSegmentAudio = {
+          controller,
+          unlinkAbort,
+          promise: fetchSegmentAudioSources(
             session,
             segment,
-            session.lookaheadController.signal,
-            () => isCurrentSession(session.token) && !session.lookaheadController.signal.aborted
+            controller.signal,
+            () => isCurrentSession(session.token) && !controller.signal.aborted
           )
-          if (!isCurrentSession(session.token)) return
-          session.prefetched.set(segment.id, source)
+            .then((sources) => {
+              if (isCurrentSession(session.token) && !controller.signal.aborted) {
+                session.prefetched.set(segment.id, sources)
+              }
+              return sources
+            })
+            .finally(() => {
+              unlinkAbort()
+              controller.abort()
+              if (session.inFlight.get(segment.id) === inFlight) {
+                session.inFlight.delete(segment.id)
+              }
+            })
+        }
+        session.inFlight.set(segment.id, inFlight)
+
+        try {
+          await inFlight.promise
         } catch (error) {
           if (isAbortError(error)) return
         }
       }
     },
-    [isCurrentSession, loadSegmentAudio]
+    [fetchSegmentAudioSources, isCurrentSession]
   )
 
   const playBrowserSegment = React.useCallback(
@@ -287,15 +471,26 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
     ): void => {
       const segment = session.queue[index]
       if (!segment || typeof window === 'undefined' || !window.speechSynthesis) {
-        mutateState(session.token, (previous) => ({
-          ...previous,
+        mutateState(session.token, {
           status: 'segment-error',
-          error: 'Browser speech synthesis is unavailable'
-        }))
+          scope: session.scope,
+          activeSegmentId: segment?.id ?? null,
+          activeIndex: segment ? index : -1,
+          totalSegments: session.queue.length,
+          error: 'Browser speech synthesis is unavailable',
+          cacheDisabled: session.cacheDisabled
+        })
         return
       }
 
-      const utterance = new SpeechSynthesisUtterance(segment.text)
+      const utterance = new SpeechSynthesisUtterance(
+        session.providerContext.normalizeText(segment.text)
+      )
+      applyBrowserSpeechSynthesisVoice(
+        utterance,
+        window.speechSynthesis,
+        session.providerContext.browserVoiceName
+      )
       utterance.rate = session.providerContext.playbackSpeed || 1
       utterance.onend = () => {
         if (
@@ -304,7 +499,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         ) {
           return
         }
-        void playSegment(session, index + 1)
+        void playSegmentRef.current(session, index + 1)
       }
       utterance.onerror = () => {
         if (
@@ -313,11 +508,15 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         ) {
           return
         }
-        mutateState(session.token, (previous) => ({
-          ...previous,
+        mutateState(session.token, {
           status: 'segment-error',
-          error: 'Browser speech synthesis failed'
-        }))
+          scope: session.scope,
+          activeSegmentId: segment.id,
+          activeIndex: index,
+          totalSegments: session.queue.length,
+          error: 'Browser speech synthesis failed',
+          cacheDisabled: session.cacheDisabled
+        })
       }
 
       session.browserUtterance = utterance
@@ -345,54 +544,78 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       if (!segment) return
 
       try {
-        const source =
-          session.prefetched.get(segment.id) ||
-          (await loadSegmentAudio(
-            session,
-            segment,
-            session.currentController.signal,
-            () => isCurrentPlayAttempt(session, playToken)
-          ))
+        const sources = await getSegmentAudioSources(
+          session,
+          segment,
+          session.currentController.signal,
+          () => isCurrentPlayAttempt(session, playToken)
+        )
         if (!isCurrentPlayAttempt(session, playToken)) return
 
         session.prefetched.delete(segment.id)
-        revokeObjectUrl(session.objectUrl)
-        const objectUrl = URL.createObjectURL(createBlob(source))
-        const audio = new Audio(objectUrl)
-        audio.playbackRate = session.providerContext.playbackSpeed || 1
-        session.objectUrl = objectUrl
-        session.audio = audio
-
-        audio.addEventListener('ended', () => {
-          revokeObjectUrl(objectUrl)
-          if (session.objectUrl === objectUrl) {
-            session.objectUrl = null
-          }
-          if (!isCurrentPlayAttempt(session, playToken)) return
-          void playSegment(session, index + 1)
-        })
-        audio.addEventListener('error', () => {
-          revokeObjectUrl(objectUrl)
-          if (!isCurrentPlayAttempt(session, playToken)) return
-          mutateState(session.token, (previous) => ({
-            ...previous,
+        const markSegmentError = (message: string) => {
+          mutateState(session.token, {
             status: 'segment-error',
-            error: 'Generated audio playback failed'
-          }))
-        })
+            scope: session.scope,
+            activeSegmentId: segment.id,
+            activeIndex: index,
+            totalSegments: session.queue.length,
+            error: message,
+            cacheDisabled: session.cacheDisabled
+          })
+        }
 
-        mutateState(session.token, {
-          status: 'playing',
-          scope: session.scope,
-          activeSegmentId: segment.id,
-          activeIndex: index,
-          totalSegments: session.queue.length,
-          error: null,
-          cacheDisabled: session.cacheDisabled
-        })
-        await audio.play()
-        if (!isCurrentPlayAttempt(session, playToken)) return
-        void prefetchLookahead(session, index)
+        const playSourceAt = async (sourceIndex: number): Promise<void> => {
+          const source = sources[sourceIndex]
+          if (!source || !isCurrentPlayAttempt(session, playToken)) return
+
+          revokeObjectUrl(session.objectUrl)
+          const objectUrl = URL.createObjectURL(createBlob(source))
+          const audio = new Audio(objectUrl)
+          audio.playbackRate = session.providerContext.playbackSpeed || 1
+          session.objectUrl = objectUrl
+          session.audio = audio
+
+          audio.addEventListener('ended', () => {
+            revokeObjectUrl(objectUrl)
+            if (session.objectUrl === objectUrl) {
+              session.objectUrl = null
+            }
+            if (!isCurrentPlayAttempt(session, playToken)) return
+            if (sourceIndex < sources.length - 1) {
+              void playSourceAt(sourceIndex + 1).catch((error) => {
+                if (!isCurrentPlayAttempt(session, playToken) || isAbortError(error)) {
+                  return
+                }
+                markSegmentError(errorMessage(error))
+              })
+              return
+            }
+            void playSegmentRef.current(session, index + 1)
+          })
+          audio.addEventListener('error', () => {
+            revokeObjectUrl(objectUrl)
+            if (!isCurrentPlayAttempt(session, playToken)) return
+            markSegmentError('Generated audio playback failed')
+          })
+
+          mutateState(session.token, {
+            status: 'playing',
+            scope: session.scope,
+            activeSegmentId: segment.id,
+            activeIndex: index,
+            totalSegments: session.queue.length,
+            error: null,
+            cacheDisabled: session.cacheDisabled
+          })
+          await audio.play()
+          if (!isCurrentPlayAttempt(session, playToken)) return
+          if (sourceIndex === 0) {
+            void prefetchLookahead(session, index)
+          }
+        }
+
+        await playSourceAt(0)
       } catch (error) {
         if (!isCurrentPlayAttempt(session, playToken) || isAbortError(error)) return
         if (session.objectUrl) {
@@ -400,14 +623,18 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           session.objectUrl = null
         }
         session.audio = null
-        mutateState(session.token, (previous) => ({
-          ...previous,
+        mutateState(session.token, {
           status: 'segment-error',
-          error: errorMessage(error)
-        }))
+          scope: session.scope,
+          activeSegmentId: segment.id,
+          activeIndex: index,
+          totalSegments: session.queue.length,
+          error: errorMessage(error),
+          cacheDisabled: session.cacheDisabled
+        })
       }
     },
-    [isCurrentPlayAttempt, loadSegmentAudio, mutateState, prefetchLookahead]
+    [getSegmentAudioSources, isCurrentPlayAttempt, mutateState, prefetchLookahead]
   )
 
   const playSegment = React.useCallback(
@@ -435,6 +662,18 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         return
       }
 
+      const segment = session.queue[index]
+      resetLookahead(session, segment?.id)
+      mutateState(session.token, {
+        status: 'preparing',
+        scope: session.scope,
+        activeSegmentId: segment?.id ?? null,
+        activeIndex: segment ? index : -1,
+        totalSegments: session.queue.length,
+        error: null,
+        cacheDisabled: session.cacheDisabled
+      })
+
       if (session.providerContext.provider === 'browser' && !session.providerContext.synthesize) {
         playBrowserSegment(session, index, playToken)
         return
@@ -442,8 +681,19 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
 
       await playGeneratedSegment(session, index, playToken)
     },
-    [cleanupSession, isCurrentSession, playBrowserSegment, playGeneratedSegment]
+    [
+      cleanupSession,
+      isCurrentSession,
+      mutateState,
+      playBrowserSegment,
+      playGeneratedSegment,
+      resetLookahead
+    ]
   )
+
+  React.useEffect(() => {
+    playSegmentRef.current = playSegment
+  }, [playSegment])
 
   const start = React.useCallback(
     async (scope: ReadAlongScope): Promise<void> => {
@@ -475,8 +725,14 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       const currentController = new AbortController()
       const lookaheadController = new AbortController()
       let providerContext: TtsProviderContext
+      let serverScope = 'server:unknown-server'
       try {
-        providerContext = await resolveTtsProviderContext(queue[0].text)
+        const resolved = await Promise.all([
+          resolveTtsProviderContext(queue[0].text),
+          resolveReadAlongServerScope()
+        ])
+        providerContext = resolved[0]
+        serverScope = resolved[1]
       } catch (error) {
         if (!isCurrentSession(token)) return
         activeTokenRef.current = null
@@ -502,12 +758,14 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         queue,
         providerContext,
         settingsSignature,
+        serverScope,
         currentController,
         lookaheadController,
         audio: null,
         objectUrl: null,
         browserUtterance: null,
         prefetched: new Map(),
+        inFlight: new Map(),
         playAttemptToken: null,
         pendingIndex: -1,
         cacheDisabled: false

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -27,6 +27,7 @@ import type {
 const LOOKAHEAD_SEGMENT_COUNT = 4
 
 type SessionToken = symbol
+type PlayAttemptToken = symbol
 
 type AudioSource = {
   blob: Blob
@@ -42,6 +43,8 @@ type ReadAlongSession = {
   settingsSignature: string
   currentController: AbortController
   lookaheadController: AbortController
+  playAttemptToken: PlayAttemptToken | null
+  pendingIndex: number
   audio: HTMLAudioElement | null
   objectUrl: string | null
   browserUtterance: SpeechSynthesisUtterance | null
@@ -80,6 +83,9 @@ const isAbortError = (error: unknown): boolean =>
     ? error.name === 'AbortError'
     : error instanceof Error && error.name === 'AbortError'
 
+const readAlongAbortError = (): DOMException =>
+  new DOMException('Read-along playback cancelled', 'AbortError')
+
 const revokeObjectUrl = (url: string | null): void => {
   if (!url || typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
     return
@@ -112,6 +118,13 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
     return activeTokenRef.current === token
   }, [])
 
+  const isCurrentPlayAttempt = React.useCallback(
+    (session: ReadAlongSession, playToken: PlayAttemptToken): boolean => {
+      return isCurrentSession(session.token) && session.playAttemptToken === playToken
+    },
+    [isCurrentSession]
+  )
+
   const mutateState = React.useCallback(
     (
       token: SessionToken,
@@ -135,6 +148,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       revokeObjectUrl(session.objectUrl)
       session.objectUrl = null
       session.browserUtterance = null
+      session.playAttemptToken = null
       if (
         cancelBrowserSpeech &&
         session.providerContext.provider === 'browser' &&
@@ -162,7 +176,8 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
     async (
       session: ReadAlongSession,
       segment: ReadAlongSegment,
-      signal: AbortSignal
+      signal: AbortSignal,
+      isCurrentLoad: () => boolean
     ): Promise<AudioSource> => {
       const key = await buildReadAlongCacheKey({
         serverScope: 'media-read-along',
@@ -176,6 +191,9 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       })
 
       const cached = await getMediaReadAlongAudioCacheEntry(key.id)
+      if (signal.aborted || !isCurrentLoad()) {
+        throw readAlongAbortError()
+      }
       if (cached) {
         return {
           blob: cached.blob,
@@ -189,6 +207,9 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       }
 
       const generated = await session.providerContext.synthesize(segment.text, { signal })
+      if (signal.aborted || !isCurrentLoad()) {
+        throw readAlongAbortError()
+      }
       const blob = new Blob([generated.buffer], { type: generated.mimeType })
       const saved = await saveMediaReadAlongAudioCacheEntry({
         id: key.id,
@@ -210,6 +231,9 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           ...previous,
           cacheDisabled: true
         }))
+      }
+      if (signal.aborted || !isCurrentLoad()) {
+        throw readAlongAbortError()
       }
 
       return {
@@ -236,7 +260,8 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           const source = await loadSegmentAudio(
             session,
             segment,
-            session.lookaheadController.signal
+            session.lookaheadController.signal,
+            () => isCurrentSession(session.token) && !session.lookaheadController.signal.aborted
           )
           if (!isCurrentSession(session.token)) return
           session.prefetched.set(segment.id, source)
@@ -249,7 +274,11 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
   )
 
   const playBrowserSegment = React.useCallback(
-    (session: ReadAlongSession, index: number): void => {
+    (
+      session: ReadAlongSession,
+      index: number,
+      playToken: PlayAttemptToken
+    ): void => {
       const segment = session.queue[index]
       if (!segment || typeof window === 'undefined' || !window.speechSynthesis) {
         mutateState(session.token, (previous) => ({
@@ -263,10 +292,21 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       const utterance = new SpeechSynthesisUtterance(segment.text)
       utterance.rate = session.providerContext.playbackSpeed || 1
       utterance.onend = () => {
-        if (!isCurrentSession(session.token)) return
+        if (
+          !isCurrentPlayAttempt(session, playToken) ||
+          session.browserUtterance !== utterance
+        ) {
+          return
+        }
         void playSegment(session, index + 1)
       }
       utterance.onerror = () => {
+        if (
+          !isCurrentPlayAttempt(session, playToken) ||
+          session.browserUtterance !== utterance
+        ) {
+          return
+        }
         mutateState(session.token, (previous) => ({
           ...previous,
           status: 'segment-error',
@@ -286,19 +326,28 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       })
       window.speechSynthesis.speak(utterance)
     },
-    [isCurrentSession, mutateState]
+    [isCurrentPlayAttempt, mutateState]
   )
 
   const playGeneratedSegment = React.useCallback(
-    async (session: ReadAlongSession, index: number): Promise<void> => {
+    async (
+      session: ReadAlongSession,
+      index: number,
+      playToken: PlayAttemptToken
+    ): Promise<void> => {
       const segment = session.queue[index]
       if (!segment) return
 
       try {
         const source =
           session.prefetched.get(segment.id) ||
-          (await loadSegmentAudio(session, segment, session.currentController.signal))
-        if (!isCurrentSession(session.token)) return
+          (await loadSegmentAudio(
+            session,
+            segment,
+            session.currentController.signal,
+            () => isCurrentPlayAttempt(session, playToken)
+          ))
+        if (!isCurrentPlayAttempt(session, playToken)) return
 
         session.prefetched.delete(segment.id)
         revokeObjectUrl(session.objectUrl)
@@ -313,12 +362,12 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           if (session.objectUrl === objectUrl) {
             session.objectUrl = null
           }
-          if (!isCurrentSession(session.token)) return
+          if (!isCurrentPlayAttempt(session, playToken)) return
           void playSegment(session, index + 1)
         })
         audio.addEventListener('error', () => {
           revokeObjectUrl(objectUrl)
-          if (!isCurrentSession(session.token)) return
+          if (!isCurrentPlayAttempt(session, playToken)) return
           mutateState(session.token, (previous) => ({
             ...previous,
             status: 'segment-error',
@@ -336,10 +385,10 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           cacheDisabled: session.cacheDisabled
         })
         await audio.play()
-        if (!isCurrentSession(session.token)) return
+        if (!isCurrentPlayAttempt(session, playToken)) return
         void prefetchLookahead(session, index)
       } catch (error) {
-        if (!isCurrentSession(session.token) || isAbortError(error)) return
+        if (!isCurrentPlayAttempt(session, playToken) || isAbortError(error)) return
         mutateState(session.token, (previous) => ({
           ...previous,
           status: 'segment-error',
@@ -347,12 +396,20 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         }))
       }
     },
-    [isCurrentSession, loadSegmentAudio, mutateState, prefetchLookahead]
+    [isCurrentPlayAttempt, loadSegmentAudio, mutateState, prefetchLookahead]
   )
 
   const playSegment = React.useCallback(
     async (session: ReadAlongSession, index: number): Promise<void> => {
       if (!isCurrentSession(session.token)) return
+      session.currentController.abort()
+      session.currentController = new AbortController()
+      session.audio?.pause()
+      session.browserUtterance = null
+      session.pendingIndex = index
+      const playToken = Symbol('read-along-play-attempt')
+      session.playAttemptToken = playToken
+
       if (index >= session.queue.length) {
         cleanupSession(session, false)
         sessionRef.current = null
@@ -368,11 +425,11 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       }
 
       if (session.providerContext.provider === 'browser' && !session.providerContext.synthesize) {
-        playBrowserSegment(session, index)
+        playBrowserSegment(session, index, playToken)
         return
       }
 
-      await playGeneratedSegment(session, index)
+      await playGeneratedSegment(session, index, playToken)
     },
     [cleanupSession, isCurrentSession, playBrowserSegment, playGeneratedSegment]
   )
@@ -440,6 +497,8 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         objectUrl: null,
         browserUtterance: null,
         prefetched: new Map(),
+        playAttemptToken: null,
+        pendingIndex: -1,
         cacheDisabled: false
       }
 
@@ -529,9 +588,10 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       const session = sessionRef.current
       if (!session) return
       const offset = direction === 'previous' ? -1 : 1
+      const baseIndex = state.activeIndex >= 0 ? state.activeIndex : session.pendingIndex
       const nextIndex = Math.min(
         session.queue.length,
-        Math.max(0, state.activeIndex + offset)
+        Math.max(0, baseIndex + offset)
       )
       session.audio?.pause()
       if (session.providerContext.provider === 'browser' && typeof window !== 'undefined') {

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -586,28 +586,36 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           session.objectUrl = objectUrl
           session.audio = audio
 
-          audio.addEventListener('ended', () => {
-            revokeObjectUrl(objectUrl)
-            if (session.objectUrl === objectUrl) {
-              session.objectUrl = null
-            }
-            if (!isCurrentPlayAttempt(session, playToken)) return
-            if (sourceIndex < sources.length - 1) {
-              void playSourceAt(sourceIndex + 1).catch((error) => {
-                if (!isCurrentPlayAttempt(session, playToken) || isAbortError(error)) {
-                  return
-                }
-                markSegmentError(errorMessage(error))
-              })
-              return
-            }
-            void playSegmentRef.current(session, index + 1)
-          })
-          audio.addEventListener('error', () => {
-            revokeObjectUrl(objectUrl)
-            if (!isCurrentPlayAttempt(session, playToken)) return
-            markSegmentError('Generated audio playback failed')
-          })
+          audio.addEventListener(
+            'ended',
+            () => {
+              revokeObjectUrl(objectUrl)
+              if (session.objectUrl === objectUrl) {
+                session.objectUrl = null
+              }
+              if (!isCurrentPlayAttempt(session, playToken)) return
+              if (sourceIndex < sources.length - 1) {
+                void playSourceAt(sourceIndex + 1).catch((error) => {
+                  if (!isCurrentPlayAttempt(session, playToken) || isAbortError(error)) {
+                    return
+                  }
+                  markSegmentError(errorMessage(error))
+                })
+                return
+              }
+              void playSegmentRef.current(session, index + 1)
+            },
+            { once: true }
+          )
+          audio.addEventListener(
+            'error',
+            () => {
+              revokeObjectUrl(objectUrl)
+              if (!isCurrentPlayAttempt(session, playToken)) return
+              markSegmentError('Generated audio playback failed')
+            },
+            { once: true }
+          )
 
           mutateState(session.token, {
             status: 'playing',

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -211,29 +211,35 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         throw readAlongAbortError()
       }
       const blob = new Blob([generated.buffer], { type: generated.mimeType })
-      const saved = await saveMediaReadAlongAudioCacheEntry({
-        id: key.id,
-        createdAt: Date.now(),
-        lastUsedAt: Date.now(),
-        mediaId: key.mediaId,
-        mediaKind: key.mediaKind,
-        segmentId: key.segmentId,
-        settingsSignature: key.settingsSignature,
-        textHash: key.textHash,
-        blob,
-        mimeType: generated.mimeType,
-        format: generated.format,
-        sizeBytes: blob.size
-      })
+      const saved = await saveMediaReadAlongAudioCacheEntry(
+        {
+          id: key.id,
+          createdAt: Date.now(),
+          lastUsedAt: Date.now(),
+          mediaId: key.mediaId,
+          mediaKind: key.mediaKind,
+          segmentId: key.segmentId,
+          settingsSignature: key.settingsSignature,
+          textHash: key.textHash,
+          blob,
+          mimeType: generated.mimeType,
+          format: generated.format,
+          sizeBytes: blob.size
+        },
+        {
+          signal,
+          shouldContinue: isCurrentLoad
+        }
+      )
+      if (signal.aborted || !isCurrentLoad()) {
+        throw readAlongAbortError()
+      }
       if (!saved) {
         session.cacheDisabled = true
         mutateState(session.token, (previous) => ({
           ...previous,
           cacheDisabled: true
         }))
-      }
-      if (signal.aborted || !isCurrentLoad()) {
-        throw readAlongAbortError()
       }
 
       return {
@@ -389,6 +395,11 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
         void prefetchLookahead(session, index)
       } catch (error) {
         if (!isCurrentPlayAttempt(session, playToken) || isAbortError(error)) return
+        if (session.objectUrl) {
+          revokeObjectUrl(session.objectUrl)
+          session.objectUrl = null
+        }
+        session.audio = null
         mutateState(session.token, (previous) => ({
           ...previous,
           status: 'segment-error',
@@ -595,6 +606,8 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
       )
       session.audio?.pause()
       if (session.providerContext.provider === 'browser' && typeof window !== 'undefined') {
+        session.browserUtterance = null
+        session.playAttemptToken = null
         window.speechSynthesis?.cancel()
       }
       void playSegment(session, nextIndex)

--- a/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+++ b/apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
@@ -464,6 +464,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           await inFlight.promise
         } catch (error) {
           if (isAbortError(error)) return
+          continue
         }
       }
     },
@@ -620,7 +621,7 @@ export function useMediaReadAlongSession(args: UseMediaReadAlongSessionArgs) {
           await audio.play()
           if (!isCurrentPlayAttempt(session, playToken)) return
           if (sourceIndex === 0) {
-            void prefetchLookahead(session, index)
+            void prefetchLookahead(session, index).catch(() => undefined)
           }
         }
 

--- a/apps/packages/ui/src/db/dexie/schema.ts
+++ b/apps/packages/ui/src/db/dexie/schema.ts
@@ -390,7 +390,7 @@ export class PageAssistDexieDB extends Dexie {
       audiobookChapterAssets: 'id, projectId, chapterId, createdAt',
       ttsClips: 'id, createdAt, historyId, serverChatId, messageId, serverMessageId, provider',
       sttRecordings: 'id, createdAt',
-      mediaReadAlongAudioCache: 'id, createdAt, lastUsedAt, mediaId, mediaKind, segmentId, settingsSignature, textHash'
+      mediaReadAlongAudioCache: 'id, createdAt, lastUsedAt, [lastUsedAt+sizeBytes+id], mediaId, mediaKind, segmentId, settingsSignature, textHash'
     });
   }
 }

--- a/apps/packages/ui/src/db/dexie/schema.ts
+++ b/apps/packages/ui/src/db/dexie/schema.ts
@@ -21,7 +21,8 @@ import {
   AudiobookProject,
   AudiobookChapterAsset,
   TtsClip,
-  SttRecordingRow
+  SttRecordingRow,
+  MediaReadAlongAudioCacheEntry
 } from "./types"
 
 export class PageAssistDexieDB extends Dexie {
@@ -53,6 +54,9 @@ export class PageAssistDexieDB extends Dexie {
 
   // STT recordings
   sttRecordings!: Table<SttRecordingRow>
+
+  // Media read-along generated audio cache
+  mediaReadAlongAudioCache!: Table<MediaReadAlongAudioCacheEntry>
 
   constructor() {
     super('PageAssistDatabase');
@@ -361,6 +365,32 @@ export class PageAssistDexieDB extends Dexie {
           prompt.syncPayloadVersion = 1;
         }
       });
+    });
+
+    // Version 14: Media read-along generated audio cache
+    this.version(14).stores({
+      chatHistories: 'id, title, is_rag, message_source, is_pinned, createdAt, doc_id, last_used_prompt, model_id, root_id, parent_conversation_id, server_chat_id',
+      messages: 'id, history_id, name, role, content, createdAt, messageType, modelName, clusterId, modelId, parent_message_id',
+      prompts: 'id, title, content, is_system, createdBy, createdAt, deletedAt, serverId, studioProjectId, syncStatus, sourceSystem, usageCount, lastUsedAt',
+      webshares: 'id, title, url, api_url, share_id, createdAt',
+      sessionFiles: 'sessionId, retrievalEnabled, createdAt',
+      userSettings: 'id, user_id',
+      customModels: 'id, model_id, name, model_name, model_image, provider_id, lookup, model_type, db_type',
+      modelNickname: 'id, model_id, model_name, model_avatar',
+      processedMedia: 'id, url, createdAt',
+      folders: 'id, name, parent_id, deleted',
+      keywords: 'id, keyword, deleted',
+      folderKeywordLinks: '[folder_id+keyword_id], folder_id, keyword_id',
+      conversationKeywordLinks: '[conversation_id+keyword_id], conversation_id, keyword_id',
+      compareStates: 'history_id',
+      contentDrafts: 'id, batchId, status, mediaType, createdAt, updatedAt, expiresAt',
+      draftBatches: 'id, createdAt, updatedAt',
+      draftAssets: 'id, draftId, createdAt',
+      audiobookProjects: 'id, title, status, createdAt, updatedAt, lastOpenedAt',
+      audiobookChapterAssets: 'id, projectId, chapterId, createdAt',
+      ttsClips: 'id, createdAt, historyId, serverChatId, messageId, serverMessageId, provider',
+      sttRecordings: 'id, createdAt',
+      mediaReadAlongAudioCache: 'id, createdAt, lastUsedAt, mediaId, mediaKind, segmentId, settingsSignature, textHash'
     });
   }
 }

--- a/apps/packages/ui/src/db/dexie/types.ts
+++ b/apps/packages/ui/src/db/dexie/types.ts
@@ -433,6 +433,25 @@ export type SttRecordingRow = {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Media Read-Along Audio Cache Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type MediaReadAlongAudioCacheEntry = {
+  id: string
+  createdAt: number
+  lastUsedAt: number
+  mediaId: string
+  mediaKind: string
+  segmentId: string
+  settingsSignature: string
+  textHash: string
+  mimeType: string
+  format: string
+  blob: Blob
+  sizeBytes: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // TTS Clip Types
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/apps/packages/ui/src/routes/__tests__/option-media-route-guards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-media-route-guards.test.tsx
@@ -1,8 +1,17 @@
+import { existsSync, readFileSync } from "node:fs"
 import React from "react"
 import { describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import OptionMediaMulti from "../option-media-multi"
 import OptionMediaTrash from "../option-media-trash"
+
+const readFirstExisting = (candidates: string[]): string => {
+  const path = candidates.find((candidate) => existsSync(candidate))
+  if (!path) {
+    throw new Error(`Unable to locate any route source candidate: ${candidates.join(", ")}`)
+  }
+  return readFileSync(path, "utf8")
+}
 
 vi.mock("~/components/Layouts/Layout", () => ({
   __esModule: true,
@@ -86,5 +95,36 @@ describe("media option route guards", () => {
     render(<OptionMediaTrash />)
     expect(screen.getByTestId("route-boundary-media-trash")).toBeVisible()
     expect(screen.getByTestId("media-trash-page")).toBeVisible()
+  })
+
+  it("keeps WebUI and extension media routes on the shared ViewMediaPage implementation", () => {
+    const sharedOptionMediaSource = readFirstExisting([
+      "src/routes/option-media.tsx",
+      "apps/packages/ui/src/routes/option-media.tsx"
+    ])
+    const extensionOptionMediaSource = readFirstExisting([
+      "../../tldw-frontend/extension/routes/option-media.tsx",
+      "apps/tldw-frontend/extension/routes/option-media.tsx"
+    ])
+    const extensionMediaRouteSources = [
+      extensionOptionMediaSource,
+      readFirstExisting([
+        "../../tldw-frontend/extension/routes/option-media-multi.tsx",
+        "apps/tldw-frontend/extension/routes/option-media-multi.tsx"
+      ]),
+      readFirstExisting([
+        "../../tldw-frontend/extension/routes/option-media-trash.tsx",
+        "apps/tldw-frontend/extension/routes/option-media-trash.tsx"
+      ])
+    ]
+
+    expect(sharedOptionMediaSource).toContain(
+      'import ViewMediaPage from "@/components/Review/ViewMediaPage"'
+    )
+    expect(extensionOptionMediaSource).toContain(
+      'import ViewMediaPage from "@/components/Review/ViewMediaPage"'
+    )
+    expect(extensionMediaRouteSources.join("\n")).not.toContain("read-along")
+    expect(extensionMediaRouteSources.join("\n")).not.toContain("ContentViewer")
   })
 })

--- a/apps/packages/ui/src/services/__tests__/elevenlabs.test.ts
+++ b/apps/packages/ui/src/services/__tests__/elevenlabs.test.ts
@@ -116,6 +116,47 @@ describe("ElevenLabs fetch service", () => {
     await expect(request).rejects.toThrow("Aborted")
   })
 
+  it("keeps caller abort active while generated speech response bodies are read", async () => {
+    const callerAbort = new AbortController()
+    let resolveBody!: (value: ArrayBuffer) => void
+    let bodyStarted!: () => void
+    const bodyStartedPromise = new Promise<void>((resolve) => {
+      bodyStarted = resolve
+    })
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: vi.fn(() => {
+          bodyStarted()
+          return new Promise<ArrayBuffer>((resolve, reject) => {
+            resolveBody = resolve
+            init?.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true }
+            )
+          })
+        })
+      } as Response)
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const request = generateSpeech(
+      "eleven-key",
+      "hello",
+      "voice-1",
+      "model-1",
+      undefined,
+      { signal: callerAbort.signal, timeoutMs: 10_000 }
+    )
+    await bodyStartedPromise
+
+    callerAbort.abort()
+    resolveBody(new ArrayBuffer(1))
+
+    await expect(request).rejects.toThrow("Aborted")
+  })
+
   it("rejects failed ElevenLabs responses with a descriptive status error", async () => {
     const fetchMock = vi
       .fn()
@@ -143,6 +184,49 @@ describe("ElevenLabs fetch service", () => {
       "ElevenLabs request timed out"
     )
     await vi.advanceTimersByTimeAsync(5)
+
+    await requestAssertion
+  })
+
+  it("keeps timeouts active while generated speech response bodies are read", async () => {
+    vi.useFakeTimers()
+    let resolveBody!: (value: ArrayBuffer) => void
+    let bodyStarted!: () => void
+    const bodyStartedPromise = new Promise<void>((resolve) => {
+      bodyStarted = resolve
+    })
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: vi.fn(() => {
+          bodyStarted()
+          return new Promise<ArrayBuffer>((resolve, reject) => {
+            resolveBody = resolve
+            init?.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true }
+            )
+          })
+        })
+      } as Response)
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const request = generateSpeech(
+      "eleven-key",
+      "hello",
+      "voice-1",
+      "model-1",
+      undefined,
+      { timeoutMs: 5 }
+    )
+    await bodyStartedPromise
+    const requestAssertion = expect(request).rejects.toThrow(
+      "ElevenLabs request timed out"
+    )
+    await vi.advanceTimersByTimeAsync(5)
+    resolveBody(new ArrayBuffer(1))
 
     await requestAssertion
   })

--- a/apps/packages/ui/src/services/__tests__/elevenlabs.test.ts
+++ b/apps/packages/ui/src/services/__tests__/elevenlabs.test.ts
@@ -86,6 +86,36 @@ describe("ElevenLabs fetch service", () => {
     })
   })
 
+  it("aborts generated speech with the caller-provided signal without reporting a timeout", async () => {
+    vi.useFakeTimers()
+    const callerAbort = new AbortController()
+    let fetchSignal: AbortSignal | undefined
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      fetchSignal = init?.signal ?? undefined
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"))
+        })
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const request = generateSpeech(
+      "eleven-key",
+      "hello",
+      "voice-1",
+      "model-1",
+      undefined,
+      { signal: callerAbort.signal, timeoutMs: 10_000 }
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    callerAbort.abort()
+
+    expect(fetchSignal?.aborted).toBe(true)
+    await expect(request).rejects.toThrow("Aborted")
+  })
+
   it("rejects failed ElevenLabs responses with a descriptive status error", async () => {
     const fetchMock = vi
       .fn()

--- a/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('@/services/tts', () => ({
   getOpenAITTSModel: vi.fn(async () => 'tts-1'),
   getOpenAITTSVoice: vi.fn(async () => 'alloy'),
+  getVoice: vi.fn(async () => 'Browser Voice'),
   getElevenLabsApiKey: vi.fn(async () => ''),
   getElevenLabsModel: vi.fn(async () => ''),
   getElevenLabsVoiceId: vi.fn(async () => ''),
@@ -54,7 +55,13 @@ vi.mock('@/services/tldw/TldwApiClient', () => ({
 
 import { tldwClient } from '@/services/tldw/TldwApiClient'
 import { generateOpenAITTS } from '@/services/openai-tts'
-import { getOpenAITTSModel, getOpenAITTSVoice } from '@/services/tts'
+import { markdownToText } from '@/utils/markdown-to-text'
+import {
+  getOpenAITTSModel,
+  getOpenAITTSVoice,
+  getVoice,
+  isSSMLEnabled
+} from '@/services/tts'
 import { resolveTtsProviderContext } from '../tts-provider'
 
 describe('tts provider read-along synthesis', () => {
@@ -104,5 +111,23 @@ describe('tts provider read-along synthesis', () => {
     expect(generateOpenAITTS).toHaveBeenCalledWith(
       expect.objectContaining({ signal })
     )
+  })
+
+  it('captures reusable text normalization at provider resolution time', async () => {
+    vi.mocked(markdownToText).mockImplementation((text: string) => `plain:${text}`)
+
+    const context = await resolveTtsProviderContext('hello', { provider: 'browser' })
+    vi.mocked(isSSMLEnabled).mockResolvedValue(true)
+
+    expect(context.utterance).toBe('plain:hello')
+    expect(context.normalizeText?.('next')).toBe('plain:next')
+  })
+
+  it('captures the configured browser voice name for read-along playback', async () => {
+    vi.mocked(getVoice).mockResolvedValueOnce('Voice A')
+
+    const context = await resolveTtsProviderContext('hello', { provider: 'browser' })
+
+    expect(context.browserVoiceName).toBe('Voice A')
   })
 })

--- a/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
@@ -89,7 +89,20 @@ describe('tts provider read-along synthesis', () => {
       text: 'next segment',
       model: 'model-a',
       voice: 'voice-a',
-      speed: undefined
+      speed: undefined,
+      signal: undefined
     })
+  })
+
+  it('passes abort signals through OpenAI synthesis', async () => {
+    const signal = new AbortController().signal
+    vi.mocked(generateOpenAITTS).mockResolvedValueOnce(new ArrayBuffer(8))
+    const context = await resolveTtsProviderContext('hello', { provider: 'openai' })
+
+    await context.synthesize?.('hello', { signal })
+
+    expect(generateOpenAITTS).toHaveBeenCalledWith(
+      expect.objectContaining({ signal })
+    )
   })
 })

--- a/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/services/tts', () => ({
+  getElevenLabsApiKey: vi.fn(async () => ''),
+  getElevenLabsModel: vi.fn(async () => ''),
+  getElevenLabsVoiceId: vi.fn(async () => ''),
+  getRemoveReasoningTagTTS: vi.fn(async () => false),
+  getSpeechPlaybackSpeed: vi.fn(async () => 1),
+  getTTSProvider: vi.fn(async () => 'browser'),
+  getTldwTTSModel: vi.fn(async () => 'kokoro'),
+  getTldwTTSResponseFormat: vi.fn(async () => 'mp3'),
+  getTldwTTSSpeed: vi.fn(async () => 1),
+  getTldwTTSVoice: vi.fn(async () => 'af_heart'),
+  isSSMLEnabled: vi.fn(async () => false),
+  isSupportedTldwTtsResponseFormat: vi.fn(() => true),
+  normalizeTldwTtsResponseFormat: vi.fn((format: string) => format)
+}))
+
+vi.mock('@/services/tts-providers', () => ({
+  TTS_PROVIDER_VALUES: ['browser', 'elevenlabs', 'openai', 'tldw']
+}))
+
+vi.mock('@/utils/markdown-to-ssml', () => ({
+  markdownToSSML: vi.fn((text: string) => text)
+}))
+
+vi.mock('@/libs/reasoning', () => ({
+  removeReasoning: vi.fn((text: string) => text)
+}))
+
+vi.mock('@/utils/markdown-to-text', () => ({
+  markdownToText: vi.fn((text: string) => text)
+}))
+
+vi.mock('@/services/elevenlabs', () => ({
+  generateSpeech: vi.fn()
+}))
+
+vi.mock('@/services/openai-tts', () => ({
+  generateOpenAITTS: vi.fn()
+}))
+
+vi.mock('@/utils/provider-registry', () => ({
+  inferProviderFromModel: vi.fn(() => 'kokoro')
+}))
+
+vi.mock('@/services/tldw/TldwApiClient', () => ({
+  tldwClient: {
+    synthesizeSpeech: vi.fn(async () => new ArrayBuffer(8))
+  }
+}))
+
+import { tldwClient } from '@/services/tldw/TldwApiClient'
+import { resolveTtsProviderContext } from '../tts-provider'
+
+describe('tts provider read-along synthesis', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes abort signals through tldw synthesis', async () => {
+    const signal = new AbortController().signal
+    const context = await resolveTtsProviderContext('hello', { provider: 'tldw' })
+
+    await context.synthesize?.('hello', { signal })
+
+    expect(tldwClient.synthesizeSpeech).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({ signal })
+    )
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/services/tts', () => ({
+  getOpenAITTSModel: vi.fn(async () => 'tts-1'),
+  getOpenAITTSVoice: vi.fn(async () => 'alloy'),
   getElevenLabsApiKey: vi.fn(async () => ''),
   getElevenLabsModel: vi.fn(async () => ''),
   getElevenLabsVoiceId: vi.fn(async () => ''),
@@ -51,6 +53,8 @@ vi.mock('@/services/tldw/TldwApiClient', () => ({
 }))
 
 import { tldwClient } from '@/services/tldw/TldwApiClient'
+import { generateOpenAITTS } from '@/services/openai-tts'
+import { getOpenAITTSModel, getOpenAITTSVoice } from '@/services/tts'
 import { resolveTtsProviderContext } from '../tts-provider'
 
 describe('tts provider read-along synthesis', () => {
@@ -68,5 +72,24 @@ describe('tts provider read-along synthesis', () => {
       'hello',
       expect.objectContaining({ signal })
     )
+  })
+
+  it('captures OpenAI model and voice when provider context is resolved', async () => {
+    vi.mocked(getOpenAITTSModel).mockResolvedValueOnce('model-a')
+    vi.mocked(getOpenAITTSVoice).mockResolvedValueOnce('voice-a')
+    vi.mocked(generateOpenAITTS).mockResolvedValueOnce(new ArrayBuffer(8))
+
+    const context = await resolveTtsProviderContext('hello', { provider: 'openai' })
+    vi.mocked(getOpenAITTSModel).mockResolvedValue('model-b')
+    vi.mocked(getOpenAITTSVoice).mockResolvedValue('voice-b')
+
+    await context.synthesize?.('next segment')
+
+    expect(generateOpenAITTS).toHaveBeenCalledWith({
+      text: 'next segment',
+      model: 'model-a',
+      voice: 'voice-a',
+      speed: undefined
+    })
   })
 })

--- a/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
@@ -120,6 +120,27 @@ describe('tts provider read-along synthesis', () => {
     )
   })
 
+  it('normalizes mixed-case provider overrides before provider support checks', async () => {
+    vi.mocked(generateOpenAITTS).mockResolvedValueOnce(new ArrayBuffer(8))
+
+    const context = await resolveTtsProviderContext('hello', {
+      provider: ' OpenAI ',
+      openAiModel: 'model-a',
+      openAiVoice: 'voice-a'
+    })
+    await context.synthesize?.('hello')
+
+    expect(context.provider).toBe('openai')
+    expect(context.supported).toBe(true)
+    expect(generateOpenAITTS).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'hello',
+        model: 'model-a',
+        voice: 'voice-a'
+      })
+    )
+  })
+
   it('passes abort signals through ElevenLabs synthesis', async () => {
     const signal = new AbortController().signal
     vi.mocked(getElevenLabsApiKey).mockResolvedValueOnce('eleven-key')

--- a/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
@@ -54,15 +54,22 @@ vi.mock('@/services/tldw/TldwApiClient', () => ({
 }))
 
 import { tldwClient } from '@/services/tldw/TldwApiClient'
+import { generateSpeech } from '@/services/elevenlabs'
 import { generateOpenAITTS } from '@/services/openai-tts'
 import { markdownToText } from '@/utils/markdown-to-text'
 import {
+  getElevenLabsApiKey,
+  getElevenLabsModel,
+  getElevenLabsVoiceId,
   getOpenAITTSModel,
   getOpenAITTSVoice,
   getVoice,
   isSSMLEnabled
 } from '@/services/tts'
-import { resolveTtsProviderContext } from '../tts-provider'
+import {
+  applyBrowserSpeechSynthesisVoice,
+  resolveTtsProviderContext
+} from '../tts-provider'
 
 describe('tts provider read-along synthesis', () => {
   beforeEach(() => {
@@ -110,6 +117,74 @@ describe('tts provider read-along synthesis', () => {
 
     expect(generateOpenAITTS).toHaveBeenCalledWith(
       expect.objectContaining({ signal })
+    )
+  })
+
+  it('passes abort signals through ElevenLabs synthesis', async () => {
+    const signal = new AbortController().signal
+    vi.mocked(getElevenLabsApiKey).mockResolvedValueOnce('eleven-key')
+    vi.mocked(getElevenLabsModel).mockResolvedValueOnce('model-a')
+    vi.mocked(getElevenLabsVoiceId).mockResolvedValueOnce('voice-a')
+    vi.mocked(generateSpeech).mockResolvedValueOnce(new ArrayBuffer(8))
+    const context = await resolveTtsProviderContext('hello', { provider: 'elevenlabs' })
+
+    await context.synthesize?.('hello', { signal })
+
+    expect(generateSpeech).toHaveBeenCalledWith(
+      'eleven-key',
+      'hello',
+      'voice-a',
+      'model-a',
+      undefined,
+      { signal }
+    )
+  })
+
+  it('uses scoped browser voice listeners without overwriting global handlers', () => {
+    const originalHandler = vi.fn()
+    let voices: SpeechSynthesisVoice[] = []
+    const listeners: EventListener[] = []
+    const synthesis = {
+      onvoiceschanged: originalHandler,
+      getVoices: vi.fn(() => voices),
+      addEventListener: vi.fn((_eventName: string, listener: EventListener) => {
+        listeners.push(listener)
+      }),
+      removeEventListener: vi.fn()
+    } as unknown as SpeechSynthesis
+    const firstUtterance = {} as SpeechSynthesisUtterance
+    const secondUtterance = {} as SpeechSynthesisUtterance
+    const voice = { name: 'Browser Voice' } as SpeechSynthesisVoice
+
+    const cleanupFirst = applyBrowserSpeechSynthesisVoice(
+      firstUtterance,
+      synthesis,
+      'Browser Voice'
+    )
+    const cleanupSecond = applyBrowserSpeechSynthesisVoice(
+      secondUtterance,
+      synthesis,
+      'Browser Voice'
+    )
+    voices = [voice]
+    listeners.forEach((listener) => listener(new Event('voiceschanged')))
+
+    expect(synthesis.onvoiceschanged).toBe(originalHandler)
+    expect(synthesis.addEventListener).toHaveBeenCalledTimes(2)
+    expect(firstUtterance.voice).toBe(voice)
+    expect(secondUtterance.voice).toBe(voice)
+
+    cleanupFirst()
+    cleanupSecond()
+
+    expect(synthesis.removeEventListener).toHaveBeenCalledTimes(2)
+    expect(synthesis.removeEventListener).toHaveBeenCalledWith(
+      'voiceschanged',
+      listeners[0]
+    )
+    expect(synthesis.removeEventListener).toHaveBeenCalledWith(
+      'voiceschanged',
+      listeners[1]
     )
   })
 

--- a/apps/packages/ui/src/services/elevenlabs.ts
+++ b/apps/packages/ui/src/services/elevenlabs.ts
@@ -13,6 +13,7 @@ const DEFAULT_ELEVENLABS_TIMEOUT_MS = 10_000;
 
 type ElevenLabsRequestOptions = {
   timeoutMs?: number;
+  signal?: AbortSignal;
   responseType?: 'json' | 'text' | 'arrayBuffer' | 'arraybuffer';
   includeBrowserTransportFailure?: boolean;
 };
@@ -33,6 +34,55 @@ function createTimeoutSignal(timeoutMs: number): {
     signal: controller.signal,
     cleanup: () => clearTimeout(timeoutId),
     didTimeout: () => timedOut,
+  };
+}
+
+function createRequestSignal(options?: ElevenLabsRequestOptions): {
+  signal: AbortSignal;
+  cleanup: () => void;
+  didTimeout: () => boolean;
+  didCallerAbort: () => boolean;
+} {
+  const timeout = createTimeoutSignal(
+    options?.timeoutMs ?? DEFAULT_ELEVENLABS_TIMEOUT_MS
+  );
+  const callerSignal = options?.signal;
+  if (!callerSignal) {
+    return {
+      ...timeout,
+      didCallerAbort: () => false,
+    };
+  }
+
+  const controller = new AbortController();
+  let callerAborted = callerSignal.aborted;
+
+  const abortFromTimeout = () => {
+    controller.abort(timeout.signal.reason);
+  };
+  const abortFromCaller = () => {
+    if (timeout.didTimeout()) return;
+    callerAborted = true;
+    timeout.cleanup();
+    controller.abort(callerSignal.reason);
+  };
+
+  timeout.signal.addEventListener('abort', abortFromTimeout, { once: true });
+  if (callerSignal.aborted) {
+    abortFromCaller();
+  } else {
+    callerSignal.addEventListener('abort', abortFromCaller, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      timeout.cleanup();
+      timeout.signal.removeEventListener('abort', abortFromTimeout);
+      callerSignal.removeEventListener('abort', abortFromCaller);
+    },
+    didTimeout: timeout.didTimeout,
+    didCallerAbort: () => callerAborted,
   };
 }
 
@@ -67,9 +117,7 @@ async function fetchElevenLabs<T>(
   init: RequestInit = {},
   options?: ElevenLabsRequestOptions
 ): Promise<T> {
-  const timeout = createTimeoutSignal(
-    options?.timeoutMs ?? DEFAULT_ELEVENLABS_TIMEOUT_MS
-  );
+  const requestSignal = createRequestSignal(options);
   const headers = new Headers(init.headers);
   headers.set('xi-api-key', apiKey);
 
@@ -78,14 +126,16 @@ async function fetchElevenLabs<T>(
     response = await fetch(`${BASE_URL}${path}`, {
       ...init,
       headers,
-      signal: timeout.signal,
+      signal: requestSignal.signal,
     });
   } catch (error) {
-    timeout.cleanup();
+    requestSignal.cleanup();
+    const callerAbort = requestSignal.didCallerAbort();
     if (
+      !callerAbort &&
       isTimeoutLikeFetchFailure(
         error,
-        timeout.didTimeout(),
+        requestSignal.didTimeout(),
         options?.includeBrowserTransportFailure ?? true
       )
     ) {
@@ -93,7 +143,7 @@ async function fetchElevenLabs<T>(
     }
     throw error;
   }
-  timeout.cleanup();
+  requestSignal.cleanup();
 
   if (!response.ok) {
     throw new Error(`ElevenLabs request failed with status ${response.status}`);
@@ -141,7 +191,8 @@ export const generateSpeech = async (
   text: string,
   voiceId: string,
   modelId: string,
-  speed?: number
+  speed?: number,
+  options?: ElevenLabsRequestOptions
 ): Promise<ArrayBuffer> => {
   const payload: Record<string, unknown> = {
     text,
@@ -163,6 +214,7 @@ export const generateSpeech = async (
       body: JSON.stringify(payload),
     },
     {
+      ...options,
       responseType: 'arrayBuffer',
       includeBrowserTransportFailure: false,
     }

--- a/apps/packages/ui/src/services/elevenlabs.ts
+++ b/apps/packages/ui/src/services/elevenlabs.ts
@@ -121,15 +121,28 @@ async function fetchElevenLabs<T>(
   const headers = new Headers(init.headers);
   headers.set('xi-api-key', apiKey);
 
-  let response: Response;
   try {
-    response = await fetch(`${BASE_URL}${path}`, {
+    const response = await fetch(`${BASE_URL}${path}`, {
       ...init,
       headers,
       signal: requestSignal.signal,
     });
+
+    if (!response.ok) {
+      throw new Error(`ElevenLabs request failed with status ${response.status}`);
+    }
+
+    switch (options?.responseType ?? 'json') {
+      case 'arrayBuffer':
+      case 'arraybuffer':
+        return (await response.arrayBuffer()) as T;
+      case 'text':
+        return (await response.text()) as T;
+      case 'json':
+      default:
+        return (await response.json()) as T;
+    }
   } catch (error) {
-    requestSignal.cleanup();
     const callerAbort = requestSignal.didCallerAbort();
     if (
       !callerAbort &&
@@ -142,22 +155,8 @@ async function fetchElevenLabs<T>(
       throw new Error('ElevenLabs request timed out');
     }
     throw error;
-  }
-  requestSignal.cleanup();
-
-  if (!response.ok) {
-    throw new Error(`ElevenLabs request failed with status ${response.status}`);
-  }
-
-  switch (options?.responseType ?? 'json') {
-    case 'arrayBuffer':
-    case 'arraybuffer':
-      return response.arrayBuffer() as Promise<T>;
-    case 'text':
-      return response.text() as Promise<T>;
-    case 'json':
-    default:
-      return response.json() as Promise<T>;
+  } finally {
+    requestSignal.cleanup();
   }
 }
 

--- a/apps/packages/ui/src/services/openai-tts.ts
+++ b/apps/packages/ui/src/services/openai-tts.ts
@@ -6,11 +6,13 @@ export const generateOpenAITTS: (params: {
   model?: string
   voice?: string
   speed?: number
+  signal?: AbortSignal
 }) => Promise<ArrayBuffer> = async ({
   text,
   model: overrideModel,
   voice: overrideVoice,
-  speed
+  speed,
+  signal
 }) => {
   const model = overrideModel || (await getOpenAITTSModel())
   const voice = overrideVoice || (await getOpenAITTSVoice())
@@ -18,7 +20,8 @@ export const generateOpenAITTS: (params: {
   const audio = await tldwClient.synthesizeSpeech(text, {
     model,
     voice,
-    speed
+    speed,
+    signal
   })
 
   return audio

--- a/apps/packages/ui/src/services/tts-provider.ts
+++ b/apps/packages/ui/src/services/tts-provider.ts
@@ -2,6 +2,8 @@ import {
   getElevenLabsApiKey,
   getElevenLabsModel,
   getElevenLabsVoiceId,
+  getOpenAITTSModel,
+  getOpenAITTSVoice,
   getRemoveReasoningTagTTS,
   getSpeechPlaybackSpeed,
   getTTSProvider,
@@ -67,6 +69,15 @@ export type TtsFormatInfo = {
   isFallback: boolean
 }
 
+export type TtsCacheSettings = {
+  provider: string
+  model?: string | null
+  voice?: string | null
+  speed?: number | null
+  format?: string | null
+  language?: string | null
+}
+
 export type TtsProviderContext = {
   provider: string
   utterance: string
@@ -77,6 +88,7 @@ export type TtsProviderContext = {
     options?: TtsSynthesizeOptions
   ) => Promise<TtsSynthesisResult>
   formatInfo?: TtsFormatInfo
+  cacheSettings?: TtsCacheSettings
 }
 
 const SUPPORTED_TTS_PROVIDERS = new Set<TtsProviderKey>(TTS_PROVIDER_VALUES)
@@ -169,6 +181,13 @@ export const resolveTtsProviderContext = async (
       utterance,
       playbackSpeed,
       supported: true,
+      cacheSettings: {
+        provider,
+        model: modelId,
+        voice: voiceId,
+        speed,
+        format: "mp3"
+      },
       synthesize: async (segment: string, _options?: TtsSynthesizeOptions) => ({
         buffer: await generateSpeech(apiKey, segment, voiceId, modelId, speed),
         format: "mp3",
@@ -178,17 +197,30 @@ export const resolveTtsProviderContext = async (
   }
 
   if (provider === "openai") {
+    const baseModel = await getOpenAITTSModel()
+    const baseVoice = await getOpenAITTSVoice()
+    const model = overrides?.openAiModel || baseModel
+    const voice = overrides?.openAiVoice || baseVoice
+    const speed = overrides?.openAiSpeed
+
     return {
       provider,
       utterance,
       playbackSpeed,
       supported: true,
+      cacheSettings: {
+        provider,
+        model,
+        voice,
+        speed,
+        format: "mp3"
+      },
       synthesize: async (segment: string, _options?: TtsSynthesizeOptions) => ({
         buffer: await generateOpenAITTS({
           text: segment,
-          model: overrides?.openAiModel,
-          voice: overrides?.openAiVoice,
-          speed: overrides?.openAiSpeed
+          model,
+          voice,
+          speed
         }),
         format: "mp3",
         mimeType: "audio/mpeg"
@@ -224,6 +256,14 @@ export const resolveTtsProviderContext = async (
     playbackSpeed,
     supported: true,
     formatInfo,
+    cacheSettings: {
+      provider,
+      model,
+      voice,
+      speed,
+      format: responseFormat,
+      language
+    },
     synthesize: async (segment: string, options?: TtsSynthesizeOptions) => ({
       buffer: await tldwClient.synthesizeSpeech(segment, {
         model,

--- a/apps/packages/ui/src/services/tts-provider.ts
+++ b/apps/packages/ui/src/services/tts-provider.ts
@@ -11,6 +11,7 @@ import {
   getTldwTTSResponseFormat,
   getTldwTTSSpeed,
   getTldwTTSVoice,
+  getVoice,
   isSSMLEnabled,
   isSupportedTldwTtsResponseFormat,
   normalizeTldwTtsResponseFormat
@@ -78,11 +79,15 @@ export type TtsCacheSettings = {
   language?: string | null
 }
 
+export type TtsTextNormalizer = (text: string) => string
+
 export type TtsProviderContext = {
   provider: string
   utterance: string
+  normalizeText: TtsTextNormalizer
   playbackSpeed: number
   supported: boolean
+  browserVoiceName?: string | null
   synthesize?: (
     text: string,
     options?: TtsSynthesizeOptions
@@ -117,11 +122,17 @@ const formatToMimeType = (format: string): string => {
   }
 }
 
-const normalizeUtterance = async (text: string): Promise<string> => {
+const normalizeUtteranceWithSettings = (
+  text: string,
+  {
+    shouldRemoveReasoning,
+    ssmlEnabled
+  }: {
+    shouldRemoveReasoning: boolean
+    ssmlEnabled: boolean
+  }
+): string => {
   let utterance = text
-  const shouldRemoveReasoning = await getRemoveReasoningTagTTS()
-  const ssmlEnabled = await isSSMLEnabled()
-
   if (shouldRemoveReasoning) {
     utterance = removeReasoning(utterance)
   }
@@ -133,6 +144,50 @@ const normalizeUtterance = async (text: string): Promise<string> => {
   return markdownToText(utterance)
 }
 
+export const resolveTtsTextNormalizer = async (): Promise<TtsTextNormalizer> => {
+  const [shouldRemoveReasoning, ssmlEnabled] = await Promise.all([
+    getRemoveReasoningTagTTS(),
+    isSSMLEnabled()
+  ])
+
+  return (text: string) =>
+    normalizeUtteranceWithSettings(text, { shouldRemoveReasoning, ssmlEnabled })
+}
+
+export const applyBrowserSpeechSynthesisVoice = (
+  utterance: SpeechSynthesisUtterance,
+  synthesis: SpeechSynthesis | null | undefined,
+  voiceName?: string | null
+): void => {
+  const targetVoiceName = String(voiceName || "").trim()
+  if (
+    !targetVoiceName ||
+    !synthesis ||
+    typeof synthesis.getVoices !== "function"
+  ) {
+    return
+  }
+
+  const applyVoice = () => {
+    const selectedVoice = synthesis
+      .getVoices()
+      .find((voice) => voice.name === targetVoiceName)
+    if (selectedVoice) {
+      utterance.voice = selectedVoice
+    }
+  }
+
+  applyVoice()
+  if (utterance.voice) return
+
+  const previousHandler = synthesis.onvoiceschanged
+  synthesis.onvoiceschanged = function onvoiceschanged(event: Event) {
+    applyVoice()
+    if (typeof previousHandler === "function") {
+      previousHandler.call(this, event)
+    }
+  }
+}
 
 export const inferTldwProviderFromModel = (
   model?: string | null
@@ -143,24 +198,29 @@ export const resolveTtsProviderContext = async (
   overrides?: TtsProviderOverrides
 ): Promise<TtsProviderContext> => {
   const provider = overrides?.provider || (await getTTSProvider())
-  const utterance = await normalizeUtterance(text)
+  const normalizeText = await resolveTtsTextNormalizer()
+  const utterance = normalizeText(text)
   const playbackSpeed = await getSpeechPlaybackSpeed()
 
   if (!SUPPORTED_TTS_PROVIDERS.has(provider as TtsProviderKey)) {
     return {
       provider,
       utterance,
+      normalizeText,
       playbackSpeed,
       supported: false
     }
   }
 
   if (provider === "browser") {
+    const browserVoiceName = await getVoice()
     return {
       provider,
       utterance,
+      normalizeText,
       playbackSpeed,
-      supported: true
+      supported: true,
+      browserVoiceName
     }
   }
 
@@ -179,6 +239,7 @@ export const resolveTtsProviderContext = async (
     return {
       provider,
       utterance,
+      normalizeText,
       playbackSpeed,
       supported: true,
       cacheSettings: {
@@ -206,6 +267,7 @@ export const resolveTtsProviderContext = async (
     return {
       provider,
       utterance,
+      normalizeText,
       playbackSpeed,
       supported: true,
       cacheSettings: {
@@ -254,6 +316,7 @@ export const resolveTtsProviderContext = async (
   return {
     provider,
     utterance,
+    normalizeText,
     playbackSpeed,
     supported: true,
     formatInfo,

--- a/apps/packages/ui/src/services/tts-provider.ts
+++ b/apps/packages/ui/src/services/tts-provider.ts
@@ -57,6 +57,10 @@ export type TtsSynthesisResult = {
   mimeType: string
 }
 
+export type TtsSynthesizeOptions = {
+  signal?: AbortSignal
+}
+
 export type TtsFormatInfo = {
   requested?: string | null
   resolved: string
@@ -68,7 +72,10 @@ export type TtsProviderContext = {
   utterance: string
   playbackSpeed: number
   supported: boolean
-  synthesize?: (text: string) => Promise<TtsSynthesisResult>
+  synthesize?: (
+    text: string,
+    options?: TtsSynthesizeOptions
+  ) => Promise<TtsSynthesisResult>
   formatInfo?: TtsFormatInfo
 }
 
@@ -162,7 +169,7 @@ export const resolveTtsProviderContext = async (
       utterance,
       playbackSpeed,
       supported: true,
-      synthesize: async (segment: string) => ({
+      synthesize: async (segment: string, _options?: TtsSynthesizeOptions) => ({
         buffer: await generateSpeech(apiKey, segment, voiceId, modelId, speed),
         format: "mp3",
         mimeType: "audio/mpeg"
@@ -176,7 +183,7 @@ export const resolveTtsProviderContext = async (
       utterance,
       playbackSpeed,
       supported: true,
-      synthesize: async (segment: string) => ({
+      synthesize: async (segment: string, _options?: TtsSynthesizeOptions) => ({
         buffer: await generateOpenAITTS({
           text: segment,
           model: overrides?.openAiModel,
@@ -217,7 +224,7 @@ export const resolveTtsProviderContext = async (
     playbackSpeed,
     supported: true,
     formatInfo,
-    synthesize: async (segment: string) => ({
+    synthesize: async (segment: string, options?: TtsSynthesizeOptions) => ({
       buffer: await tldwClient.synthesizeSpeech(segment, {
         model,
         voice,
@@ -226,7 +233,8 @@ export const resolveTtsProviderContext = async (
         language,
         normalizationOptions,
         extraParams,
-        stream: false
+        stream: false,
+        signal: options?.signal
       }),
       format: responseFormat,
       mimeType

--- a/apps/packages/ui/src/services/tts-provider.ts
+++ b/apps/packages/ui/src/services/tts-provider.ts
@@ -158,17 +158,21 @@ export const applyBrowserSpeechSynthesisVoice = (
   utterance: SpeechSynthesisUtterance,
   synthesis: SpeechSynthesis | null | undefined,
   voiceName?: string | null
-): void => {
+): (() => void) => {
+  const noop = () => undefined
   const targetVoiceName = String(voiceName || "").trim()
   if (
     !targetVoiceName ||
     !synthesis ||
     typeof synthesis.getVoices !== "function"
   ) {
-    return
+    return noop
   }
 
+  let cleanup: () => void = noop
+  let cleanedUp = false
   const applyVoice = () => {
+    if (cleanedUp) return
     const selectedVoice = synthesis
       .getVoices()
       .find((voice) => voice.name === targetVoiceName)
@@ -178,15 +182,29 @@ export const applyBrowserSpeechSynthesisVoice = (
   }
 
   applyVoice()
-  if (utterance.voice) return
+  if (utterance.voice) return noop
 
-  const previousHandler = synthesis.onvoiceschanged
-  synthesis.onvoiceschanged = function onvoiceschanged(event: Event) {
+  if (
+    typeof synthesis.addEventListener !== "function" ||
+    typeof synthesis.removeEventListener !== "function"
+  ) {
+    return noop
+  }
+
+  const handleVoicesChanged = () => {
     applyVoice()
-    if (typeof previousHandler === "function") {
-      previousHandler.call(this, event)
+    if (utterance.voice) {
+      cleanup()
     }
   }
+
+  cleanup = () => {
+    if (cleanedUp) return
+    cleanedUp = true
+    synthesis.removeEventListener("voiceschanged", handleVoicesChanged)
+  }
+  synthesis.addEventListener("voiceschanged", handleVoicesChanged)
+  return cleanup
 }
 
 export const inferTldwProviderFromModel = (
@@ -250,7 +268,9 @@ export const resolveTtsProviderContext = async (
         format: "mp3"
       },
       synthesize: async (segment: string, _options?: TtsSynthesizeOptions) => ({
-        buffer: await generateSpeech(apiKey, segment, voiceId, modelId, speed),
+        buffer: await generateSpeech(apiKey, segment, voiceId, modelId, speed, {
+          signal: _options?.signal
+        }),
         format: "mp3",
         mimeType: "audio/mpeg"
       })

--- a/apps/packages/ui/src/services/tts-provider.ts
+++ b/apps/packages/ui/src/services/tts-provider.ts
@@ -215,7 +215,8 @@ export const resolveTtsProviderContext = async (
   text: string,
   overrides?: TtsProviderOverrides
 ): Promise<TtsProviderContext> => {
-  const provider = overrides?.provider || (await getTTSProvider())
+  const rawProvider = overrides?.provider ?? (await getTTSProvider())
+  const provider = String(rawProvider || '').trim().toLowerCase()
   const normalizeText = await resolveTtsTextNormalizer()
   const utterance = normalizeText(text)
   const playbackSpeed = await getSpeechPlaybackSpeed()

--- a/apps/packages/ui/src/services/tts-provider.ts
+++ b/apps/packages/ui/src/services/tts-provider.ts
@@ -220,7 +220,8 @@ export const resolveTtsProviderContext = async (
           text: segment,
           model,
           voice,
-          speed
+          speed,
+          signal: _options?.signal
         }),
         format: "mp3",
         mimeType: "audio/mpeg"

--- a/apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts
+++ b/apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts
@@ -881,7 +881,10 @@ describe("extension entry shell performance contracts", () => {
     )
     expect(documentWorkspacePageSource).toContain('import("./DocumentViewer")')
     expect(documentWorkspacePageSource).toContain(
-      'import("./LeftSidebar/FiguresTab")',
+      'import("./LeftSidebar/PagesTab")',
+    )
+    expect(documentWorkspacePageSource).toContain(
+      'import("./LeftSidebar/ReferencesTab")',
     )
     expect(documentWorkspacePageSource).toContain(
       'import("./RightPanel/DocumentChat")',

--- a/backlog/completed/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/completed/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-417
 title: Implement media viewer read-along TTS
-status: In Progress
+status: Done
 labels:
 - implementation
 - webui
@@ -12,12 +12,16 @@ references:
 - Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
 - Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
 modified_files:
-- apps/packages/ui/src/services/elevenlabs.ts
-- apps/packages/ui/src/services/__tests__/elevenlabs.test.ts
 - apps/packages/ui/src/services/tts-provider.ts
 - apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+- apps/packages/ui/src/components/Media/read-along/media-read-along-segments.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-segments.test.ts
+- apps/packages/ui/src/components/Media/read-along/media-read-along-cache-key.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts
 - apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
 - apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+- apps/packages/ui/src/components/Media/read-along/useContentSelectionActions.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx
 - apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
 - apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
 - apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
@@ -25,6 +29,7 @@ modified_files:
 - apps/packages/ui/src/components/Media/ContentViewer.tsx
 - apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
 - apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
+- apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx
 - apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx
 - apps/packages/ui/src/routes/__tests__/option-media-route-guards.test.tsx
 - apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts
@@ -150,7 +155,7 @@ Task 6 review findings fixed:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented shared WebUI/extension media-viewer read-along TTS. The feature adds selectable read-along scopes, explicit annotation mediation, TTS-provider reuse including browser SpeechSynthesis, generated-audio caching, cancellation/race hardening, active segment rendering, route parity coverage, accessibility coverage, and browser-discovered selection/viewport hardening. Final verification recorded: focused read-along Vitest suite passed (12 files, 104 tests), route parity/connection suite passed (2 files, 6 tests), browser render smoke passed, and git diff --check passed. OpenAPI passed earlier in Task 8; design-system verification remains blocked by unrelated baseline findings outside the touched read-along files; Bandit skipped because no Python files were touched.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-415 - Design-media-viewer-read-along-TTS-interaction.md
+++ b/backlog/tasks/task-415 - Design-media-viewer-read-along-TTS-interaction.md
@@ -1,0 +1,64 @@
+---
+id: TASK-415
+title: Design media viewer read-along TTS interaction
+status: In Progress
+labels:
+- design
+- webui
+- extension
+- tts
+- media
+modified_files:
+- Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a design spec for selection-initiated read-along functionality in the shared media viewer, covering WebUI and extension behavior, TTS reuse, segmentation, highlighting, local audio cache, error states, testing, and rollout boundaries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Spec documents the approved selection-first interaction model.
+- [ ] #2 Spec anchors the design to shared ContentViewer/WebUI/extension paths and existing TTS services.
+- [ ] #3 Spec covers hybrid transcript-line/sentence segmentation, range expansion actions, active highlighting, chunked lookahead, browser-local cache, error handling, and v1 exclusions.
+- [ ] #4 Spec includes testing and staged rollout guidance.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design spec drafted at Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md.
+
+Spec review loop:
+- Pass 1 found planning conflicts around active transport visibility, full-item large-content behavior, and markdown/html fallback.
+- Pass 2 approved after those fixes.
+- Pass 3 approved after advisory clarifications for canonical Read from here behavior and mid-session TTS settings behavior.
+
+Verification:
+- rg found no TODO/TBD/placeholders in the spec.
+- Bandit is not applicable because this change is docs/task tracking only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-415 - Design-media-viewer-read-along-TTS-interaction.md
+++ b/backlog/tasks/task-415 - Design-media-viewer-read-along-TTS-interaction.md
@@ -36,8 +36,14 @@ Spec review loop:
 - Pass 2 approved after those fixes.
 - Pass 3 approved after advisory clarifications for canonical Read from here behavior and mid-session TTS settings behavior.
 
+Human-requested critique pass:
+- Hardened the spec around the existing annotation selection capture path in ContentViewer so read-along and annotations share mediated selection actions instead of competing listeners.
+- Added lazy/cancellable segmentation requirements for large media items and explicit abort/stale-result suppression for in-flight TTS lookahead.
+- Clarified provider synthesis reuse, request cap splitting, Dexie schema/type migration requirements, storage quota/privacy constraints, autoplay rejection handling, and embedded media preview pause behavior.
+
 Verification:
-- rg found no TODO/TBD/placeholders in the spec.
+- Marker scan found no unfinished-work markers in the spec or task after the critique patch.
+- git diff --check passed for the spec and task files.
 - Bandit is not applicable because this change is docs/task tracking only.
 <!-- SECTION:PLAN:END -->
 

--- a/backlog/tasks/task-416 - Plan-media-viewer-read-along-TTS-implementation.md
+++ b/backlog/tasks/task-416 - Plan-media-viewer-read-along-TTS-implementation.md
@@ -1,0 +1,80 @@
+---
+id: TASK-416
+title: Plan media viewer read-along TTS implementation
+status: Done
+labels:
+- plan
+- webui
+- extension
+- tts
+- media
+modified_files:
+- Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+references:
+- Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a detailed implementation plan for the approved media viewer read-along TTS design, including file ownership, TDD steps, staged tasks, verification commands, and execution handoff.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan starts with the required superpowers writing-plans header and references the approved design spec.
+- [x] #2 Plan maps concrete shared UI files, new read-along modules, Dexie cache files, provider changes, tests, and verification commands.
+- [x] #3 Plan decomposes implementation into TDD-first tasks that can be executed independently with frequent commits.
+- [x] #4 Plan calls out critical risks: annotation selection mediation, large-content lazy segmentation, abort/stale suppression, cache privacy/quota, embedded media overlap, route parity, and accessibility.
+- [x] #5 Plan includes execution handoff options.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan saved at Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md.
+
+The plan decomposes the approved design into eight staged tasks:
+- Baseline and guardrail tests.
+- Segment and scope primitives.
+- Cache keys, Dexie store, and provider abort surface.
+- Mediated content selection actions.
+- Read-along playback session hook.
+- ContentViewer UI integration.
+- Accessibility, route parity, and regression hardening.
+- Browser verification and final cleanup.
+
+Critical risks covered:
+- Existing annotation selection behavior must move to a mediated selection action path before read-along UI lands.
+- Browser TTS provider must use a no-cache SpeechSynthesis path.
+- Large-content read-from-here/full-item behavior must segment canonical content lazily without forcing full rendering.
+- Stop/media/content changes must abort in-flight TTS work and suppress stale async completions.
+- Cache metadata must avoid raw selected text and handle browser quota failures.
+
+Verification:
+- Marker scan found no unfinished-work markers in the plan or task.
+- git diff --check passed for the plan and task files.
+- Bandit is not applicable because this task changes documentation/task tracking only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the media viewer read-along TTS implementation plan at Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md. The plan is TDD-first, scoped to shared apps/packages/ui surfaces, and includes file ownership, focused test commands, staged commits, final verification, and execution handoff options. Plan-review subagent dispatch was not performed in this turn because active tool policy requires explicit user authorization for subagents.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -25,6 +25,7 @@ modified_files:
 - apps/packages/ui/src/components/Media/ContentViewer.tsx
 - apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
 - apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
+- Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
 ---
 
 ## Description

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -20,6 +20,11 @@ modified_files:
 - apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
 - apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
 - apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+- apps/packages/ui/src/components/Media/read-along/MediaReadAlongPopover.tsx
+- apps/packages/ui/src/components/Media/read-along/MediaReadAlongTransport.tsx
+- apps/packages/ui/src/components/Media/ContentViewer.tsx
+- apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
+- apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
 ---
 
 ## Description
@@ -116,6 +121,16 @@ Verification:
 - cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx src/services/__tests__/tts-provider.read-along.test.ts --maxWorkers=1 -> passed, 2 files / 27 tests.
 - git diff --check -> passed.
 - Bandit not run because this review-fix slice touched TypeScript frontend files only.
+
+Task 6 completed:
+- Added ContentViewer read-along UI integration with selection popover actions, inline transport, read-along session wiring, and active segment wrappers for plain/timestamped transcript rendering.
+- Preserved mediated annotation selection; Annotate remains explicit, and read-along actions clear the popover/document selection after starting.
+- Markdown/html fallback starts playback through the existing session without mutating rich HTML; full-item playback uses the session hook and does not expand the lazy plain-content window.
+- Red verification: `cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.read-along.test.tsx --maxWorkers=1` failed before implementation because `media-selection-action-read-selection` was missing.
+- Green verification: same command passed 1 file / 7 tests.
+- Regression verification: `cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.read-along.test.tsx src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx --maxWorkers=1` passed 4 files / 20 tests.
+- `git diff --check` passed.
+- Bandit skipped for Task 6 because the touched slice is TypeScript/React frontend code only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -12,10 +12,14 @@ references:
 - Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
 - Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
 modified_files:
-- apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+- apps/packages/ui/src/services/elevenlabs.ts
+- apps/packages/ui/src/services/__tests__/elevenlabs.test.ts
 - apps/packages/ui/src/services/tts-provider.ts
-- apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
 - apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
+- apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+- apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
 ---
 
 ## Description

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -86,6 +86,14 @@ Task 4 completed:
 - Green verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx --maxWorkers=1` passed 3 files / 9 tests.
 - `git diff --check` passed for the Task 4 files.
 - Bandit skipped for Task 4 because the touched slice is TypeScript/React frontend code only.
+
+Task 5 completed:
+- Added `useMediaReadAlongSession` with session-token guarded async state, frozen TTS provider context/signature, generated-audio cache read/write, browser SpeechSynthesis fallback, current/lookahead abort controllers, media-preview pause, object URL cleanup, stop/retry/skip/pause/resume controls, and media/content-change stale completion suppression.
+- Added focused renderHook coverage for cached selection playback, full-content from-here queueing beyond rendered windows, bounded 4-segment lookahead, browser provider no-cache behavior, abort/cancel stop behavior, stale completion suppression, frozen settings, audio.play errors, and embedded media pause.
+- Red verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx --maxWorkers=1` failed before implementation because `../useMediaReadAlongSession` did not exist.
+- Green verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx src/components/Media/read-along/__tests__/media-read-along-segments.test.ts src/components/Media/read-along/__tests__/media-read-along-cache.test.ts --maxWorkers=1` passed 3 files / 23 tests.
+- `git diff --check` passed.
+- Bandit skipped for Task 5 because the touched slice is TypeScript/React frontend code only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -76,6 +76,16 @@ Task 3 completed:
 - `git diff --check` passed for the Task 3 files.
 - Task 3 spec and code-quality re-reviews approved after the fix.
 - Bandit skipped for Task 3 because the touched slice is TypeScript frontend/Dexie code only.
+
+Task 4 completed:
+- Added DOM-safe content-selection helpers, a mediated `useContentSelectionActions` hook, and a temporary annotation-only selection action popover in `ContentViewer`.
+- Split annotation capture into explicit `captureAnnotationSelection(selectionText, location)` while preserving `handleCaptureAnnotationSelection` as a backwards-compatible wrapper.
+- Updated the stage 14 annotation test so text selection opens `media-selection-actions-popover`, keeps `media-annotation-selection-preview` absent until `media-selection-action-annotate` is clicked, then saves the selected highlight.
+- Fixed the pre-existing stage 14 lazy intelligence-tab timing failure by waiting for `media-intelligence-tab-annotations` after expanding the section.
+- Red verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx --maxWorkers=1` failed before implementation because `../useContentSelectionActions` was missing and the popover was absent.
+- Green verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useContentSelectionActions.test.tsx src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx --maxWorkers=1` passed 3 files / 9 tests.
+- `git diff --check` passed for the Task 4 files.
+- Bandit skipped for Task 4 because the touched slice is TypeScript/React frontend code only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -11,6 +11,11 @@ labels:
 references:
 - Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
 - Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+- apps/packages/ui/src/services/tts-provider.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+- apps/packages/ui/src/services/__tests__/tts-provider.read-along.test.ts
 ---
 
 ## Description
@@ -94,6 +99,19 @@ Task 5 completed:
 - Green verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx src/components/Media/read-along/__tests__/media-read-along-segments.test.ts src/components/Media/read-along/__tests__/media-read-along-cache.test.ts --maxWorkers=1` passed 3 files / 23 tests.
 - `git diff --check` passed.
 - Bandit skipped for Task 5 because the touched slice is TypeScript/React frontend code only.
+Task 5 review findings fixed:
+- Segment load/play failures now mark the failed pending segment as active so retry and skip target the correct parent segment.
+- Lookahead tracks in-flight segment audio, reuses a pending lookahead request when it becomes current, and aborts stale lookahead on retry/skip/current changes while preserving the bounded window.
+- Provider synthesis now splits over-cap parent segments into deterministic TTS request parts, plays all parts sequentially under the same highlighted/counting parent segment, and keeps lookahead bounded.
+- Read-along uses the session-captured TTS text normalizer for provider/browser synthesis and cache text hashes; browser provider contexts also capture the configured browser voice name.
+- Generated-audio cache keys now include a sanitized active server/auth-scope identity from tldwClient.getConfig() instead of the hard-coded media-read-along scope.
+- Recursive play-next calls now go through a playSegment ref to avoid stale hook callback dependencies.
+
+Verification:
+- cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx src/components/Media/read-along/__tests__/media-read-along-segments.test.ts src/components/Media/read-along/__tests__/media-read-along-cache.test.ts src/services/__tests__/tts-provider.read-along.test.ts --maxWorkers=1 -> passed, 4 files / 44 tests.
+- cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx src/services/__tests__/tts-provider.read-along.test.ts --maxWorkers=1 -> passed, 2 files / 27 tests.
+- git diff --check -> passed.
+- Bandit not run because this review-fix slice touched TypeScript frontend files only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -64,6 +64,18 @@ Task 2 completed:
 - Red verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/media-read-along-segments.test.ts --maxWorkers=1` failed because `../media-read-along-segments` did not exist.
 - Green verification: same command passed with 7 tests after implementation.
 - `git diff --check` passed for the Task 2 files.
+- Spec review found transient fallback segment IDs were too collision-prone; fixed in `be51074a4` by including derived media/source identity or a stable text hash.
+- Task 2 spec and code-quality re-reviews approved after the fix.
+
+Task 3 completed:
+- Added read-along cache-key helpers, Dexie-backed audio cache helpers, Dexie schema/type support, and TTS provider abort-signal surface.
+- Red verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts src/components/Media/read-along/__tests__/media-read-along-cache.test.ts src/services/__tests__/tts-provider.read-along.test.ts --maxWorkers=1` failed before implementation because cache modules/signatures were missing and `tldw` synthesis did not forward `signal`.
+- Initial green verification passed 5 files / 18 tests, then code-quality review found two issues: weak fake SHA fallback and oversized cache writes exceeding the cap.
+- Fixed in `31180c28` by making `sha256Hex` fail closed without Web Crypto and skipping oversized cache writes before eviction/write attempts.
+- Final green verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/media-read-along-cache-key.test.ts src/components/Media/read-along/__tests__/media-read-along-cache.test.ts src/services/__tests__/tts-provider.read-along.test.ts src/services/__tests__/tts.defaults.test.ts src/db/dexie/__tests__/stt-recordings.test.ts --maxWorkers=1` passed 5 files / 21 tests.
+- `git diff --check` passed for the Task 3 files.
+- Task 3 spec and code-quality re-reviews approved after the fix.
+- Bandit skipped for Task 3 because the touched slice is TypeScript frontend/Dexie code only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -1,0 +1,60 @@
+---
+id: TASK-417
+title: Implement media viewer read-along TTS
+status: To Do
+labels:
+- implementation
+- webui
+- extension
+- tts
+- media
+references:
+- Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
+- Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved selection-initiated media viewer read-along TTS feature in shared apps/packages/ui surfaces using the committed design spec and implementation plan.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md with subagent-driven development.
+
+Implementation constraints:
+- Stay in the isolated worktree at .worktrees/media-read-along-tts on branch codex/media-read-along-tts.
+- Follow TDD: write focused failing tests, verify red, implement, verify green, commit per task.
+- Preserve existing annotation workflows through mediated selection actions.
+- Keep work scoped to shared apps/packages/ui surfaces unless the plan explicitly says otherwise.
+- Do not introduce backend APIs or duplicate extension-specific implementations.
+- Record verification and known skips before final completion.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -131,6 +131,16 @@ Task 6 completed:
 - Regression verification: `cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.read-along.test.tsx src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx --maxWorkers=1` passed 4 files / 20 tests.
 - `git diff --check` passed.
 - Bandit skipped for Task 6 because the touched slice is TypeScript/React frontend code only.
+
+Task 6 review findings fixed:
+- Lazy plain rendering now builds highlight wrappers only from the currently visible plain-content window and initializes large plain content at the first chunk instead of the full item.
+- Full-item/from-here playback no longer forces the lazy plain-content window to the full content. When the active segment advances outside the rendered chunk, the visible window expands only through that active segment so highlight and scroll can catch up.
+- Markdown/html text-only selections now hide unsupported mapped-scope actions (`Read from here`, `Read current section`) while preserving `Read selection`, `Read full item`, and `Annotate`; exact plain selections still expose all scopes.
+- Selection popover and read-along transport are clamped to the content viewport when available, including right-edge placement, and transport progress/error text uses polite status live regions.
+- Red verification: `cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.read-along.test.tsx --maxWorkers=1` failed with 4 expected review-regression failures: unsupported markdown/html scopes visible, full display content segmented during lazy rendering, active large-content highlight missing after playback advanced, and right-edge popover unclamped.
+- Green verification: `cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.read-along.test.tsx --maxWorkers=1` passed 1 file / 11 tests.
+- Regression verification: `cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.read-along.test.tsx src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx --maxWorkers=1` passed 4 files / 24 tests.
+- `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-417
 title: Implement media viewer read-along TTS
-status: To Do
+status: In Progress
 labels:
 - implementation
 - webui
@@ -40,7 +40,24 @@ Implementation constraints:
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Task 1 baseline completed.
 
+Dependency setup:
+- Initial worker baseline could not run because the clean worktree had broken node_modules symlinks for Vitest.
+- Ran `bun install` from `apps/` to restore dependencies. The command populated `apps/node_modules` enough for Vitest to run, but the install session did not exit cleanly through the tool after dependency resolution. Subsequent Vitest commands are usable.
+
+Focused baseline results before read-along code edits:
+- Command: `cd apps/packages/ui && bunx vitest run src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx src/services/__tests__/tts.defaults.test.ts src/db/dexie/__tests__/stt-recordings.test.ts --maxWorkers=1`
+- Result: 17 passed, 1 failed.
+- Reproduced with: `bunx vitest run src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx --maxWorkers=1`
+- Pre-existing failure: `ContentViewer.stage14.annotations.test.tsx` first test cannot find `data-testid="media-intelligence-tab-annotations"` immediately after clicking `media-intelligence-toggle`. The selected-content annotation test passes.
+
+Guardrail anchors:
+- `rg` confirmed `ContentViewer` still binds `onMouseUp`/`onKeyUp` to `modals.handleCaptureAnnotationSelection`.
+- `rg` confirmed embedded audio/video elements still assign through `modals.mediaPlayerRef`.
+
+Known baseline concern:
+- The annotation panel create/update/sync/delete test is already failing before implementation changes. Task 4 will intentionally update this annotation-selection surface, so keep this failure visible in verification until the mediated selection task replaces or fixes the expectation.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -58,6 +58,12 @@ Guardrail anchors:
 
 Known baseline concern:
 - The annotation panel create/update/sync/delete test is already failing before implementation changes. Task 4 will intentionally update this annotation-selection surface, so keep this failure visible in verification until the mediated selection task replaces or fixes the expectation.
+
+Task 2 completed:
+- Added pure read-along segment types, canonical segmentation/scope helpers, and focused tests under `apps/packages/ui/src/components/Media/read-along/`.
+- Red verification: `cd apps/packages/ui && bunx vitest run src/components/Media/read-along/__tests__/media-read-along-segments.test.ts --maxWorkers=1` failed because `../media-read-along-segments` did not exist.
+- Green verification: same command passed with 7 tests after implementation.
+- `git diff --check` passed for the Task 2 files.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
+++ b/backlog/tasks/task-417 - Implement-media-viewer-read-along-TTS.md
@@ -25,6 +25,9 @@ modified_files:
 - apps/packages/ui/src/components/Media/ContentViewer.tsx
 - apps/packages/ui/src/components/Media/hooks/useTranscriptDisplay.tsx
 - apps/packages/ui/src/components/Media/__tests__/ContentViewer.read-along.test.tsx
+- apps/packages/ui/src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx
+- apps/packages/ui/src/routes/__tests__/option-media-route-guards.test.tsx
+- apps/tldw-frontend/__tests__/extension/entry-shell-performance.test.ts
 - Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
 ---
 

--- a/backlog/tasks/task-425 - Address-media-read-along-PR-review-feedback.md
+++ b/backlog/tasks/task-425 - Address-media-read-along-PR-review-feedback.md
@@ -37,7 +37,7 @@ Address the four live PR #1835 review findings: avoid blob-heavy cache eviction 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Verified live PR surface via gh pr view, gh pr checks, and GraphQL review threads. CodeRabbit skipped; actionable comments came from Gemini/Qodo. Local checks: targeted review-fix tests passed 45 tests; broader read-along suite passed 107 tests; route parity passed 6 tests; git diff --check passed. Bandit not applicable because only frontend TypeScript/backlog files changed.
+Second live-thread pass found Qodo #1 and #2: resume null-audio crash and playback-only speed in cache signatures. Fixed resume to no-op when no generated audio is available; removed playbackSpeed fallback from generated-audio cache signatures while retaining synthesis-specific cacheSettings.speed. Regression checks: targeted session/cache tests passed 42 tests; broader read-along suite passed 109 tests; route parity passed 6 tests; git diff --check passed. Bandit not applicable because only frontend TypeScript/backlog files changed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-425 - Address-media-read-along-PR-review-feedback.md
+++ b/backlog/tasks/task-425 - Address-media-read-along-PR-review-feedback.md
@@ -1,0 +1,57 @@
+---
+id: TASK-425
+title: Address media read-along PR review feedback
+status: In Progress
+labels:
+- pr-review
+- media
+- read-along
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/1835
+modified_files:
+- apps/packages/ui/src/components/Media/ContentViewer.tsx
+- apps/packages/ui/src/components/Media/read-along/media-read-along-cache.ts
+- apps/packages/ui/src/components/Media/read-along/useMediaReadAlongSession.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/media-read-along-cache.test.ts
+- apps/packages/ui/src/components/Media/read-along/__tests__/useMediaReadAlongSession.test.tsx
+- apps/packages/ui/src/db/dexie/schema.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Evaluate and address live GitHub PR #1835 review comments/check failures for the media viewer read-along TTS branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Address the four live PR #1835 review findings: avoid blob-heavy cache eviction reads, keep cache hits valid when lastUsedAt updates fail, use targeted active-segment DOM lookup, and register generated-audio terminal listeners as one-shot handlers.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verified live PR surface via gh pr view, gh pr checks, and GraphQL review threads. CodeRabbit skipped; actionable comments came from Gemini/Qodo. Local checks: targeted review-fix tests passed 45 tests; broader read-along suite passed 107 tests; route parity passed 6 tests; git diff --check passed. Bandit not applicable because only frontend TypeScript/backlog files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: adds shared media viewer read-along TTS for full media, current section, from-here, and selected text scopes, with playback state, highlighting, and generated-audio caching.
- Why: lets users listen to media content directly in the media viewer while reusing existing TTS providers and keeping annotation actions explicit.

## Human Change Summary

Required before merge: replace this section with a human-authored explanation of what changed and why these implementation choices were made.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated with design and implementation plan artifacts

Focused local checks:

- [x] `cd apps/packages/ui && ./node_modules/.bin/vitest run src/components/Media/read-along/__tests__ src/components/Media/__tests__/ContentViewer.read-along.test.tsx src/components/Media/__tests__/ContentViewer.stage10.findBar.test.tsx src/components/Media/__tests__/ContentViewer.stage12.performance.test.tsx src/components/Media/__tests__/ContentViewer.stage14.annotations.test.tsx src/components/Media/__tests__/ContentViewer.stage15.accessibility.test.tsx src/services/__tests__/tts-provider.read-along.test.ts src/db/dexie/__tests__/stt-recordings.test.ts --maxWorkers=1`
- [x] `cd apps/packages/ui && ./node_modules/.bin/vitest run src/routes/__tests__/option-media-route-guards.test.ts src/components/Review/__tests__/ViewMediaPage.connection.test.tsx --maxWorkers=1`
- [x] `git diff --check origin/dev...HEAD`

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [x] WebUI/extension parity validated for shared UI fixes

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable; no Watchlists UI behavior changed

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable; no Watchlists scale behavior changed

## Risk & Rollback

- Risk level: Medium
- Rollback plan: revert this PR to remove the media read-along UI/session/cache integration and restore prior selection/annotation behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds selection-first read-along TTS to the media viewer with scoped playback, inline controls, active highlighting, and a local audio cache. Hardens resume behavior and cache signatures, with viewport-safe popovers/transport, mediated annotation integration, and robust TTS cancellation; fulfills TASK-417 and follows TASK-415.

- New Features
  - Read-along actions in a selection popover; annotate still available.
  - Compact transport near the selection with play/pause/stop/skip/retry.
  - Hybrid segmentation (transcript line + sentence), scope resolution, and auto-scroll highlighting.
  - Browser-local audio cache in Dexie with size/entry limits and SHA‑256 keys; works in WebUI and extension.

- Bug Fixes
  - Abort-safe TTS with reliable pause/resume: `AbortSignal` through `elevenlabs` and `openai-tts`; caller abort vs timeout handled.
  - Session-frozen settings signature and text normalization in `tts-provider` for stable cache keys across resume/retry.
  - Hardened selection mediation (shared with annotate) and viewport anchoring for popover/transport.
  - Dexie v14 adds a safe cache table with quota handling, LRU pruning, and guarded writes.

<sup>Written for commit 91407f3fe382835c2c85b90ac07209a356b17b62. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1835?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

