### PR TITLE
Add llama.cpp acquisition workflow UI

### DIFF
--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
@@ -124,6 +124,7 @@ export const LlamacppAdminPage: React.FC = () => {
   const initialLoadRef = React.useRef(false)
   const presetFileInputRef = React.useRef<HTMLInputElement | null>(null)
   const refreshedDownloadJobIdsRef = React.useRef<Set<string>>(new Set())
+  const downloadsInitializedRef = React.useRef(false)
 
   const [config, setConfig] = React.useState<LlamacppConfigResponse | null>(null)
   const [status, setStatus] = React.useState<LlamacppStatus | null>(null)
@@ -232,17 +233,19 @@ export const LlamacppAdminPage: React.FC = () => {
     }
   }, [markAdminGuardFromError])
 
-  const loadAssets = React.useCallback(async () => {
+  const loadAssets = React.useCallback(async (): Promise<boolean> => {
     try {
       setLoadingAssets(true)
       setAssetError(null)
       const data = await tldwClient.getLlamacppAssets()
       setAssets(data)
+      return true
     } catch (error: unknown) {
       setAssets(null)
       setAssetError(
         sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp assets.")
       )
+      return false
     } finally {
       setLoadingAssets(false)
     }
@@ -265,6 +268,7 @@ export const LlamacppAdminPage: React.FC = () => {
   const loadAssetDownloads = React.useCallback(async () => {
     try {
       setLoadingAssetDownloads(true)
+      setAssetError(null)
       const data = await tldwClient.listLlamacppAssetDownloads()
       setAssetDownloads(data)
       const completedJobs = (data.jobs || []).filter((job) =>
@@ -274,12 +278,22 @@ export const LlamacppAdminPage: React.FC = () => {
         (job) => !refreshedDownloadJobIdsRef.current.has(job.job_id)
       )
       if (newlyCompleted.length > 0) {
-        newlyCompleted.forEach((job) => {
-          refreshedDownloadJobIdsRef.current.add(job.job_id)
-        })
-        await loadAssets()
+        if (downloadsInitializedRef.current) {
+          const refreshed = await loadAssets()
+          if (refreshed) {
+            newlyCompleted.forEach((job) => {
+              refreshedDownloadJobIdsRef.current.add(job.job_id)
+            })
+          }
+        } else {
+          newlyCompleted.forEach((job) => {
+            refreshedDownloadJobIdsRef.current.add(job.job_id)
+          })
+        }
       }
+      downloadsInitializedRef.current = true
     } catch (error: unknown) {
+      downloadsInitializedRef.current = true
       setAssetError(
         sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp asset downloads.")
       )
@@ -844,6 +858,7 @@ export const LlamacppAdminPage: React.FC = () => {
               error={assetError}
               onRegisterPath={handleRegisterAssetPath}
               onPreviewImportFolder={handlePreviewAssetFolder}
+              onClearImportPreview={() => setAssetImportPreview(null)}
               onImportFolder={handleImportAssetFolder}
               onStartDownload={handleStartAssetDownload}
               onCancelDownload={handleCancelAssetDownload}

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
@@ -5,6 +5,9 @@ import { PageShell } from "@/components/Common/PageShell"
 import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import type {
+  LlamacppAcquisitionJobListResponse,
+  LlamacppAssetDownloadRequest,
+  LlamacppAssetImportPreviewResponse,
   LlamacppAssetsResponse,
   LlamacppConfigResponse,
   LlamacppHardwareSnapshotResponse,
@@ -120,11 +123,16 @@ export const LlamacppAdminPage: React.FC = () => {
   const { t } = useTranslation(["option", "settings", "common"])
   const initialLoadRef = React.useRef(false)
   const presetFileInputRef = React.useRef<HTMLInputElement | null>(null)
+  const refreshedDownloadJobIdsRef = React.useRef<Set<string>>(new Set())
 
   const [config, setConfig] = React.useState<LlamacppConfigResponse | null>(null)
   const [status, setStatus] = React.useState<LlamacppStatus | null>(null)
   const [inventory, setInventory] = React.useState<LlamacppInventoryResponse | null>(null)
   const [assets, setAssets] = React.useState<LlamacppAssetsResponse | null>(null)
+  const [assetImportPreview, setAssetImportPreview] =
+    React.useState<LlamacppAssetImportPreviewResponse | null>(null)
+  const [assetDownloads, setAssetDownloads] =
+    React.useState<LlamacppAcquisitionJobListResponse | null>(null)
   const [hardware, setHardware] = React.useState<LlamacppHardwareSnapshotResponse | null>(null)
   const [runtimeProfiles, setRuntimeProfiles] = React.useState<LlamacppProfile[]>([])
   const [runtimeInstances, setRuntimeInstances] = React.useState<LlamacppRuntime[]>([])
@@ -136,7 +144,11 @@ export const LlamacppAdminPage: React.FC = () => {
   const [loadingRuntimes, setLoadingRuntimes] = React.useState(true)
   const [registeringPath, setRegisteringPath] = React.useState(false)
   const [registeringAssetPath, setRegisteringAssetPath] = React.useState(false)
+  const [previewingAssetFolder, setPreviewingAssetFolder] = React.useState(false)
   const [importingAssetFolder, setImportingAssetFolder] = React.useState(false)
+  const [loadingAssetDownloads, setLoadingAssetDownloads] = React.useState(false)
+  const [startingAssetDownload, setStartingAssetDownload] = React.useState(false)
+  const [cancelingAssetDownloadId, setCancelingAssetDownloadId] = React.useState<string | null>(null)
 
   const [statusError, setStatusError] = React.useState<string | null>(null)
   const [inventoryError, setInventoryError] = React.useState<string | null>(null)
@@ -250,6 +262,32 @@ export const LlamacppAdminPage: React.FC = () => {
     }
   }, [])
 
+  const loadAssetDownloads = React.useCallback(async () => {
+    try {
+      setLoadingAssetDownloads(true)
+      const data = await tldwClient.listLlamacppAssetDownloads()
+      setAssetDownloads(data)
+      const completedJobs = (data.jobs || []).filter((job) =>
+        ["completed", "succeeded", "done"].includes(job.status.toLowerCase())
+      )
+      const newlyCompleted = completedJobs.filter(
+        (job) => !refreshedDownloadJobIdsRef.current.has(job.job_id)
+      )
+      if (newlyCompleted.length > 0) {
+        newlyCompleted.forEach((job) => {
+          refreshedDownloadJobIdsRef.current.add(job.job_id)
+        })
+        await loadAssets()
+      }
+    } catch (error: unknown) {
+      setAssetError(
+        sanitizeAdminErrorMessage(error, "Failed to load Llama.cpp asset downloads.")
+      )
+    } finally {
+      setLoadingAssetDownloads(false)
+    }
+  }, [loadAssets])
+
   const loadRuntimePlane = React.useCallback(async () => {
     try {
       setLoadingRuntimes(true)
@@ -292,11 +330,13 @@ export const LlamacppAdminPage: React.FC = () => {
       loadStatus(),
       loadInventory(),
       loadAssets(),
+      loadAssetDownloads(),
       loadHardware(),
       loadRuntimePlane()
     ])
   }, [
     loadAssets,
+    loadAssetDownloads,
     loadConfig,
     loadHardware,
     loadInventory,
@@ -368,11 +408,30 @@ export const LlamacppAdminPage: React.FC = () => {
     }
   }
 
+  const handlePreviewAssetFolder = async (path: string): Promise<boolean> => {
+    try {
+      setPreviewingAssetFolder(true)
+      setAssetError(null)
+      const preview = await tldwClient.previewLlamacppAssetFolder(path)
+      setAssetImportPreview(preview)
+      return true
+    } catch (error: unknown) {
+      setAssetImportPreview(null)
+      setAssetError(
+        sanitizeAdminErrorMessage(error, "Failed to preview Llama.cpp asset folder.")
+      )
+      return false
+    } finally {
+      setPreviewingAssetFolder(false)
+    }
+  }
+
   const handleImportAssetFolder = async (path: string): Promise<boolean> => {
     try {
       setImportingAssetFolder(true)
       setAssetError(null)
       await tldwClient.importLlamacppAssetFolder(path)
+      setAssetImportPreview(null)
       await loadAssets()
       return true
     } catch (error: unknown) {
@@ -382,6 +441,42 @@ export const LlamacppAdminPage: React.FC = () => {
       return false
     } finally {
       setImportingAssetFolder(false)
+    }
+  }
+
+  const handleStartAssetDownload = async (
+    payload: LlamacppAssetDownloadRequest
+  ): Promise<boolean> => {
+    try {
+      setStartingAssetDownload(true)
+      setAssetError(null)
+      await tldwClient.startLlamacppAssetDownload(payload)
+      await loadAssetDownloads()
+      return true
+    } catch (error: unknown) {
+      setAssetError(
+        sanitizeAdminErrorMessage(error, "Failed to queue Llama.cpp asset download.")
+      )
+      return false
+    } finally {
+      setStartingAssetDownload(false)
+    }
+  }
+
+  const handleCancelAssetDownload = async (jobId: string): Promise<boolean> => {
+    try {
+      setCancelingAssetDownloadId(jobId)
+      setAssetError(null)
+      await tldwClient.cancelLlamacppAssetDownload(jobId)
+      await loadAssetDownloads()
+      return true
+    } catch (error: unknown) {
+      setAssetError(
+        sanitizeAdminErrorMessage(error, "Failed to cancel Llama.cpp asset download.")
+      )
+      return false
+    } finally {
+      setCancelingAssetDownloadId(null)
     }
   }
 
@@ -739,10 +834,20 @@ export const LlamacppAdminPage: React.FC = () => {
               assets={assets}
               loading={loadingAssets}
               registeringPath={registeringAssetPath}
+              previewingFolder={previewingAssetFolder}
               importingFolder={importingAssetFolder}
+              importPreview={assetImportPreview}
+              downloads={assetDownloads}
+              loadingDownloads={loadingAssetDownloads}
+              startingDownload={startingAssetDownload}
+              cancelingDownloadId={cancelingAssetDownloadId}
               error={assetError}
               onRegisterPath={handleRegisterAssetPath}
+              onPreviewImportFolder={handlePreviewAssetFolder}
               onImportFolder={handleImportAssetFolder}
+              onStartDownload={handleStartAssetDownload}
+              onCancelDownload={handleCancelAssetDownload}
+              onReloadDownloads={loadAssetDownloads}
               onReload={loadAssets}
             />
 

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
@@ -3,7 +3,11 @@ import { Button, Card, Input, List, Space, Tag, Typography } from "antd"
 import { RefreshCw } from "lucide-react"
 import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import type {
+  LlamacppAcquisitionJobListResponse,
+  LlamacppAcquisitionJobResponse,
   LlamacppAsset,
+  LlamacppAssetDownloadRequest,
+  LlamacppAssetImportPreviewResponse,
   LlamacppAssetKind,
   LlamacppAssetsResponse
 } from "@/types/llamacpp-admin"
@@ -19,9 +23,19 @@ interface LlamacppAssetsPanelProps {
   loading?: boolean
   registeringPath?: boolean
   importingFolder?: boolean
+  previewingFolder?: boolean
+  importPreview?: LlamacppAssetImportPreviewResponse | null
+  downloads?: LlamacppAcquisitionJobListResponse | null
+  loadingDownloads?: boolean
+  startingDownload?: boolean
+  cancelingDownloadId?: string | null
   error?: string | null
   onRegisterPath: (path: string) => boolean | Promise<boolean>
   onImportFolder: (path: string) => boolean | Promise<boolean>
+  onPreviewImportFolder?: (path: string) => boolean | Promise<boolean>
+  onStartDownload?: (payload: LlamacppAssetDownloadRequest) => boolean | Promise<boolean>
+  onCancelDownload?: (jobId: string) => boolean | Promise<boolean>
+  onReloadDownloads?: () => void
   onReload: () => void
 }
 
@@ -54,6 +68,44 @@ const toAssetGroups = (assetList: LlamacppAsset[]) =>
       items: assetList.filter((asset) => asset.kind === kind)
     }))
     .filter((group) => group.items.length > 0)
+
+const acquisitionStatusColors: Record<string, string> = {
+  queued: "blue",
+  pending: "blue",
+  running: "processing",
+  processing: "processing",
+  completed: "green",
+  succeeded: "green",
+  done: "green",
+  failed: "red",
+  canceled: "default",
+  cancelled: "default"
+}
+
+const cancelableDownloadStatuses = new Set([
+  "queued",
+  "pending",
+  "running",
+  "processing",
+  "downloading"
+])
+
+const previewCountLabel = (kind: string) => (kind === "gguf" ? "GGUF" : kind)
+
+const progressPercent = (job: LlamacppAcquisitionJobResponse): number | null => {
+  const raw = job.progress?.progress_percent
+  const value =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string"
+        ? Number(raw)
+        : NaN
+  if (!Number.isFinite(value)) return null
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+const downloadLabel = (job: LlamacppAcquisitionJobResponse) =>
+  job.source_label || job.destination_path || `Download ${job.job_id}`
 
 const renderMetadataTags = (asset: LlamacppAsset) => (
   <>
@@ -88,15 +140,32 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
   loading = false,
   registeringPath = false,
   importingFolder = false,
+  previewingFolder = false,
+  importPreview = null,
+  downloads = null,
+  loadingDownloads = false,
+  startingDownload = false,
+  cancelingDownloadId = null,
   error,
   onRegisterPath,
   onImportFolder,
+  onPreviewImportFolder,
+  onStartDownload,
+  onCancelDownload,
+  onReloadDownloads,
   onReload
 }) => {
   const [assetPath, setAssetPath] = React.useState("")
   const [folderPath, setFolderPath] = React.useState("")
+  const [previewedFolderPath, setPreviewedFolderPath] = React.useState("")
+  const [downloadUrl, setDownloadUrl] = React.useState("")
+  const [downloadDestinationDir, setDownloadDestinationDir] = React.useState("")
+  const [downloadFilename, setDownloadFilename] = React.useState("")
   const assetList = assets?.assets || []
   const assetGroups = toAssetGroups(assetList)
+  const downloadJobs = downloads?.jobs || []
+  const showDownloadWorkflow = Boolean(onStartDownload) || downloadJobs.length > 0
+  const importUsesPreview = Boolean(onPreviewImportFolder)
 
   const handleRegisterPath = async () => {
     const trimmed = assetPath.trim()
@@ -107,12 +176,48 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
     }
   }
 
-  const handleImportFolder = async () => {
+  const handlePreviewFolder = async () => {
     const trimmed = folderPath.trim()
+    if (!trimmed || !onPreviewImportFolder) return
+    const previewed = await onPreviewImportFolder(trimmed)
+    if (previewed) {
+      setPreviewedFolderPath(trimmed)
+    }
+  }
+
+  const handleImportFolder = async () => {
+    const trimmed = importUsesPreview
+      ? previewedFolderPath || folderPath.trim()
+      : folderPath.trim()
     if (!trimmed) return
     const imported = await onImportFolder(trimmed)
     if (imported) {
       setFolderPath("")
+      setPreviewedFolderPath("")
+    }
+  }
+
+  const handleStartDownload = async () => {
+    if (!onStartDownload) return
+    const trimmedUrl = downloadUrl.trim()
+    if (!trimmedUrl) return
+    const payload: LlamacppAssetDownloadRequest = {
+      url: trimmedUrl
+    }
+    const trimmedDestinationDir = downloadDestinationDir.trim()
+    const trimmedFilename = downloadFilename.trim()
+    if (trimmedDestinationDir) {
+      payload.destination_dir = trimmedDestinationDir
+    }
+    if (trimmedFilename) {
+      payload.filename = trimmedFilename
+    }
+
+    const started = await onStartDownload(payload)
+    if (started) {
+      setDownloadUrl("")
+      setDownloadDestinationDir("")
+      setDownloadFilename("")
     }
   }
 
@@ -150,18 +255,178 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
           <Input
             aria-label="Import local asset folder"
             value={folderPath}
-            onChange={(event) => setFolderPath(event.target.value)}
+            onChange={(event) => {
+              setFolderPath(event.target.value)
+              setPreviewedFolderPath("")
+            }}
             placeholder="/absolute/path/to/model-folder"
-            disabled={importingFolder}
+            disabled={importingFolder || previewingFolder}
           />
-          <Button
-            onClick={handleImportFolder}
-            loading={importingFolder}
-            disabled={!folderPath.trim()}
-          >
-            Import folder
-          </Button>
+          {importUsesPreview ? (
+            <Button
+              onClick={handlePreviewFolder}
+              loading={previewingFolder}
+              disabled={!folderPath.trim()}
+            >
+              Preview folder
+            </Button>
+          ) : (
+            <Button
+              onClick={handleImportFolder}
+              loading={importingFolder}
+              disabled={!folderPath.trim()}
+            >
+              Import folder
+            </Button>
+          )}
         </Space.Compact>
+
+        {importUsesPreview && importPreview && (
+          <section aria-label="Import preview">
+            <Space orientation="vertical" size="small" className="w-full">
+              <Space wrap size="small">
+                <Text strong>Import preview</Text>
+                <Text type="secondary" className="break-all">
+                  {importPreview.folder.path}
+                </Text>
+                {Object.entries(importPreview.asset_counts).map(([kind, count]) => (
+                  <Tag key={kind}>
+                    {previewCountLabel(kind)}: {count}
+                  </Tag>
+                ))}
+                {importPreview.scan_limited && <Tag color="orange">scan limited</Tag>}
+              </Space>
+              {importPreview.warnings.map((warning) => (
+                <DesignSystemAlert
+                  key={warning}
+                  variant="warning"
+                  {...passiveAlertProps}
+                  title={warning}
+                />
+              ))}
+              <Button
+                size="small"
+                onClick={handleImportFolder}
+                loading={importingFolder}
+                disabled={!previewedFolderPath && !folderPath.trim()}
+              >
+                Confirm import
+              </Button>
+            </Space>
+          </section>
+        )}
+
+        {showDownloadWorkflow && (
+          <section aria-label="Asset downloads">
+            <Space orientation="vertical" size="small" className="w-full">
+              <Space wrap className="w-full" size="small">
+                <Input
+                  aria-label="Download source URL"
+                  value={downloadUrl}
+                  onChange={(event) => setDownloadUrl(event.target.value)}
+                  placeholder="https://example.com/model.gguf"
+                  disabled={startingDownload}
+                  className="min-w-[260px] flex-1"
+                />
+                <Input
+                  aria-label="Download destination directory"
+                  value={downloadDestinationDir}
+                  onChange={(event) => setDownloadDestinationDir(event.target.value)}
+                  placeholder="/absolute/path/to/models"
+                  disabled={startingDownload}
+                  className="min-w-[220px] flex-1"
+                />
+                <Input
+                  aria-label="Download filename"
+                  value={downloadFilename}
+                  onChange={(event) => setDownloadFilename(event.target.value)}
+                  placeholder="model.gguf"
+                  disabled={startingDownload}
+                  className="min-w-[160px] flex-1"
+                />
+                <Button
+                  onClick={handleStartDownload}
+                  loading={startingDownload}
+                  disabled={!downloadUrl.trim() || !onStartDownload}
+                >
+                  Queue download
+                </Button>
+                {onReloadDownloads && (
+                  <Button size="small" onClick={onReloadDownloads} loading={loadingDownloads}>
+                    Refresh downloads
+                  </Button>
+                )}
+              </Space>
+
+              {downloadJobs.length > 0 && (
+                <List
+                  size="small"
+                  bordered
+                  loading={loadingDownloads}
+                  rowKey="job_id"
+                  dataSource={downloadJobs}
+                  renderItem={(job) => {
+                    const status = job.status.toLowerCase()
+                    const percent = progressPercent(job)
+                    const canCancel = cancelableDownloadStatuses.has(status)
+                    return (
+                      <List.Item
+                        actions={
+                          canCancel && onCancelDownload
+                            ? [
+                                <Button
+                                  key="cancel"
+                                  size="small"
+                                  danger
+                                  loading={cancelingDownloadId === job.job_id}
+                                  onClick={() => {
+                                    void onCancelDownload(job.job_id)
+                                  }}
+                                >
+                                  Cancel download {job.job_id}
+                                </Button>
+                              ]
+                            : undefined
+                        }
+                      >
+                        <Space orientation="vertical" size={4} className="w-full">
+                          <Space wrap size="small">
+                            <Text strong>{downloadLabel(job)}</Text>
+                            <Tag color={acquisitionStatusColors[status] || "default"}>
+                              {job.status}
+                            </Tag>
+                            {percent !== null && <Tag>{percent}%</Tag>}
+                            {job.asset_id && <Tag>{job.asset_id}</Tag>}
+                          </Space>
+                          {job.destination_path && (
+                            <Text type="secondary" className="break-all">
+                              {job.destination_path}
+                            </Text>
+                          )}
+                          {job.error_message && (
+                            <DesignSystemAlert
+                              variant="error"
+                              {...passiveAlertProps}
+                              title={job.error_message}
+                            />
+                          )}
+                          {job.warnings.map((warning) => (
+                            <DesignSystemAlert
+                              key={warning}
+                              variant="warning"
+                              {...passiveAlertProps}
+                              title={warning}
+                            />
+                          ))}
+                        </Space>
+                      </List.Item>
+                    )
+                  }}
+                />
+              )}
+            </Space>
+          </section>
+        )}
 
         {assets?.warnings.map((warning) => (
           <DesignSystemAlert

--- a/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
@@ -33,6 +33,7 @@ interface LlamacppAssetsPanelProps {
   onRegisterPath: (path: string) => boolean | Promise<boolean>
   onImportFolder: (path: string) => boolean | Promise<boolean>
   onPreviewImportFolder?: (path: string) => boolean | Promise<boolean>
+  onClearImportPreview?: () => void
   onStartDownload?: (payload: LlamacppAssetDownloadRequest) => boolean | Promise<boolean>
   onCancelDownload?: (jobId: string) => boolean | Promise<boolean>
   onReloadDownloads?: () => void
@@ -150,6 +151,7 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
   onRegisterPath,
   onImportFolder,
   onPreviewImportFolder,
+  onClearImportPreview,
   onStartDownload,
   onCancelDownload,
   onReloadDownloads,
@@ -166,6 +168,13 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
   const downloadJobs = downloads?.jobs || []
   const showDownloadWorkflow = Boolean(onStartDownload) || downloadJobs.length > 0
   const importUsesPreview = Boolean(onPreviewImportFolder)
+  const trimmedFolderPath = folderPath.trim()
+  const previewMatchesCurrentFolder =
+    importUsesPreview &&
+    Boolean(importPreview) &&
+    Boolean(previewedFolderPath) &&
+    trimmedFolderPath === previewedFolderPath &&
+    importPreview?.folder.path === previewedFolderPath
 
   const handleRegisterPath = async () => {
     const trimmed = assetPath.trim()
@@ -187,7 +196,7 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
 
   const handleImportFolder = async () => {
     const trimmed = importUsesPreview
-      ? previewedFolderPath || folderPath.trim()
+      ? previewedFolderPath
       : folderPath.trim()
     if (!trimmed) return
     const imported = await onImportFolder(trimmed)
@@ -257,7 +266,10 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
             value={folderPath}
             onChange={(event) => {
               setFolderPath(event.target.value)
-              setPreviewedFolderPath("")
+              if (importUsesPreview) {
+                setPreviewedFolderPath("")
+                onClearImportPreview?.()
+              }
             }}
             placeholder="/absolute/path/to/model-folder"
             disabled={importingFolder || previewingFolder}
@@ -281,7 +293,7 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
           )}
         </Space.Compact>
 
-        {importUsesPreview && importPreview && (
+        {previewMatchesCurrentFolder && importPreview && (
           <section aria-label="Import preview">
             <Space orientation="vertical" size="small" className="w-full">
               <Space wrap size="small">
@@ -296,9 +308,9 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
                 ))}
                 {importPreview.scan_limited && <Tag color="orange">scan limited</Tag>}
               </Space>
-              {importPreview.warnings.map((warning) => (
+              {importPreview.warnings.map((warning, index) => (
                 <DesignSystemAlert
-                  key={warning}
+                  key={`import-preview-warning-${index}`}
                   variant="warning"
                   {...passiveAlertProps}
                   title={warning}
@@ -308,7 +320,7 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
                 size="small"
                 onClick={handleImportFolder}
                 loading={importingFolder}
-                disabled={!previewedFolderPath && !folderPath.trim()}
+                disabled={!previewedFolderPath || trimmedFolderPath !== previewedFolderPath}
               >
                 Confirm import
               </Button>
@@ -410,9 +422,9 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
                               title={job.error_message}
                             />
                           )}
-                          {job.warnings.map((warning) => (
+                          {job.warnings.map((warning, index) => (
                             <DesignSystemAlert
-                              key={warning}
+                              key={`${job.job_id}-warning-${index}`}
                               variant="warning"
                               {...passiveAlertProps}
                               title={warning}
@@ -428,9 +440,9 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
           </section>
         )}
 
-        {assets?.warnings.map((warning) => (
+        {assets?.warnings.map((warning, index) => (
           <DesignSystemAlert
-            key={warning}
+            key={`assets-warning-${index}`}
             variant="warning"
             {...passiveAlertProps}
             title={warning}
@@ -478,8 +490,8 @@ export const LlamacppAssetsPanel: React.FC<LlamacppAssetsPanelProps> = ({
                           <CandidateLabels asset={asset} />
                           {asset.warnings.length > 0 && (
                             <Space wrap size="small">
-                              {asset.warnings.map((warning) => (
-                                <Tag key={warning} color="orange">
+                              {asset.warnings.map((warning, index) => (
+                                <Tag key={`${asset.asset_id}-warning-${index}`} color="orange">
                                   {warning}
                                 </Tag>
                               ))}

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
@@ -437,6 +437,21 @@ const mockRuntimes = {
   ]
 }
 
+const completedDownloadJob = {
+  job_id: "99",
+  status: "completed",
+  operation: "download",
+  queue: "acquisition",
+  source_label: "Done model",
+  destination_path: "/srv/models/done.gguf",
+  asset_id: "gguf:done",
+  progress: {
+    progress_percent: 100
+  },
+  warnings: [],
+  error_message: null
+}
+
 describe("LlamacppAdminPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -895,24 +910,9 @@ describe("LlamacppAdminPage", () => {
     expect(apiMock.useLlamacppInChat).not.toHaveBeenCalled()
   })
 
-  it("refreshes assets when a download completes without profile side effects", async () => {
+  it("does not duplicate asset scans for completed downloads during initial load", async () => {
     apiMock.listLlamacppAssetDownloads.mockResolvedValueOnce({
-      jobs: [
-        {
-          job_id: "99",
-          status: "completed",
-          operation: "download",
-          queue: "acquisition",
-          source_label: "Done model",
-          destination_path: "/srv/models/done.gguf",
-          asset_id: "gguf:done",
-          progress: {
-            progress_percent: 100
-          },
-          warnings: [],
-          error_message: null
-        }
-      ]
+      jobs: [completedDownloadJob]
     })
 
     render(<LlamacppAdminPage />)
@@ -920,11 +920,100 @@ describe("LlamacppAdminPage", () => {
     expect(await screen.findByText("Done model")).toBeTruthy()
 
     await waitFor(() => {
-      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(2)
+      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(1)
     })
     expect(apiMock.createLlamacppProfile).not.toHaveBeenCalled()
     expect(apiMock.startLlamacppProfile).not.toHaveBeenCalled()
     expect(apiMock.useLlamacppInChat).not.toHaveBeenCalled()
+  })
+
+  it("refreshes assets when a download completes after initial load without profile side effects", async () => {
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByText("Assets")).toBeTruthy()
+
+    await waitFor(() => {
+      expect(apiMock.listLlamacppAssetDownloads).toHaveBeenCalledTimes(1)
+    })
+
+    apiMock.getLlamacppAssets.mockClear()
+    apiMock.listLlamacppAssetDownloads.mockResolvedValueOnce({
+      jobs: [completedDownloadJob]
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh downloads/ }))
+
+    await waitFor(() => {
+      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(1)
+    })
+    expect(apiMock.createLlamacppProfile).not.toHaveBeenCalled()
+    expect(apiMock.startLlamacppProfile).not.toHaveBeenCalled()
+    expect(apiMock.useLlamacppInChat).not.toHaveBeenCalled()
+  })
+
+  it("retries asset refresh for completed downloads after a failed refresh", async () => {
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByText("Assets")).toBeTruthy()
+
+    await waitFor(() => {
+      expect(apiMock.listLlamacppAssetDownloads).toHaveBeenCalledTimes(1)
+    })
+
+    apiMock.getLlamacppAssets.mockClear()
+    apiMock.getLlamacppAssets
+      .mockRejectedValueOnce(new Error("asset refresh failed"))
+      .mockResolvedValue(mockAssets)
+    apiMock.listLlamacppAssetDownloads.mockResolvedValueOnce({
+      jobs: [completedDownloadJob]
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh downloads/ }))
+
+    expect(await screen.findByText("asset refresh failed")).toBeTruthy()
+    expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(1)
+
+    apiMock.listLlamacppAssetDownloads.mockResolvedValueOnce({
+      jobs: [completedDownloadJob]
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh downloads/ }))
+
+    await waitFor(() => {
+      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(screen.queryByText("asset refresh failed")).toBeNull()
+    })
+  })
+
+  it("clears a stale download-list error after a successful downloads refresh", async () => {
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByText("Assets")).toBeTruthy()
+
+    await waitFor(() => {
+      expect(apiMock.listLlamacppAssetDownloads).toHaveBeenCalledTimes(1)
+    })
+
+    apiMock.listLlamacppAssetDownloads.mockRejectedValueOnce(
+      new Error("download list failed")
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh downloads/ }))
+
+    expect(await screen.findByText("download list failed")).toBeTruthy()
+
+    apiMock.listLlamacppAssetDownloads.mockResolvedValueOnce({ jobs: [] })
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh downloads/ }))
+
+    await waitFor(() => {
+      expect(apiMock.listLlamacppAssetDownloads).toHaveBeenCalledTimes(3)
+    })
+    await waitFor(() => {
+      expect(screen.queryByText("download list failed")).toBeNull()
+    })
   })
 
   it("shows asset load failure without hiding legacy inventory", async () => {

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
@@ -26,7 +26,12 @@ const apiMock = vi.hoisted(() => ({
   useLlamacppInChat: vi.fn(),
   registerLlamacppModelPath: vi.fn(),
   registerLlamacppAssetPath: vi.fn(),
-  importLlamacppAssetFolder: vi.fn()
+  importLlamacppAssetFolder: vi.fn(),
+  previewLlamacppAssetFolder: vi.fn(),
+  startLlamacppAssetDownload: vi.fn(),
+  listLlamacppAssetDownloads: vi.fn(),
+  getLlamacppAssetDownload: vi.fn(),
+  cancelLlamacppAssetDownload: vi.fn()
 }))
 
 vi.mock("react-i18next", () => ({
@@ -531,6 +536,56 @@ describe("LlamacppAdminPage", () => {
     apiMock.registerLlamacppModelPath.mockResolvedValue(mockInventory.models[0])
     apiMock.registerLlamacppAssetPath.mockResolvedValue(mockAssets.assets[0])
     apiMock.importLlamacppAssetFolder.mockResolvedValue(mockAssets.assets[2])
+    apiMock.previewLlamacppAssetFolder.mockResolvedValue({
+      folder: mockAssets.assets[2],
+      assets: [mockAssets.assets[0], mockAssets.assets[1]],
+      asset_counts: {
+        gguf: 1,
+        mmproj: 1
+      },
+      warnings: ["Preview skipped unreadable sidecar file."],
+      scan_limited: false,
+      will_persist: false
+    })
+    apiMock.startLlamacppAssetDownload.mockResolvedValue({
+      job_id: "42",
+      status: "queued",
+      operation: "download",
+      queue: "acquisition",
+      source_label: "Toy model",
+      destination_path: "/srv/models/toy.gguf",
+      asset_id: null,
+      progress: {},
+      warnings: [],
+      error_message: null
+    })
+    apiMock.listLlamacppAssetDownloads.mockResolvedValue({ jobs: [] })
+    apiMock.getLlamacppAssetDownload.mockResolvedValue({
+      job_id: "42",
+      status: "running",
+      operation: "download",
+      queue: "acquisition",
+      source_label: "Toy model",
+      destination_path: "/srv/models/toy.gguf",
+      asset_id: null,
+      progress: {
+        progress_percent: 25
+      },
+      warnings: [],
+      error_message: null
+    })
+    apiMock.cancelLlamacppAssetDownload.mockResolvedValue({
+      job_id: "42",
+      status: "canceled",
+      operation: "download",
+      queue: "acquisition",
+      source_label: "Toy model",
+      destination_path: "/srv/models/toy.gguf",
+      asset_id: null,
+      progress: {},
+      warnings: [],
+      error_message: null
+    })
   })
 
   it("renders readiness from saved config and restart-required state", async () => {
@@ -791,12 +846,85 @@ describe("LlamacppAdminPage", () => {
     fireEvent.change(await screen.findByLabelText("Import local asset folder"), {
       target: { value: "/srv/models/imported" }
     })
-    fireEvent.click(screen.getByRole("button", { name: "Import folder" }))
+    fireEvent.click(screen.getByRole("button", { name: "Preview folder" }))
+
+    await waitFor(() => {
+      expect(apiMock.previewLlamacppAssetFolder).toHaveBeenCalledWith("/srv/models/imported")
+    })
+
+    expect(screen.getByText("Import preview")).toBeTruthy()
+    expect(screen.getByText("GGUF: 1")).toBeTruthy()
+    expect(screen.getByText("mmproj: 1")).toBeTruthy()
+    expect(screen.getByText("Preview skipped unreadable sidecar file.")).toBeTruthy()
+    expect(apiMock.importLlamacppAssetFolder).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm import" }))
 
     await waitFor(() => {
       expect(apiMock.importLlamacppAssetFolder).toHaveBeenCalledWith("/srv/models/imported")
       expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(2)
     })
+  })
+
+  it("queues asset downloads without creating profiles or wiring chat", async () => {
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByText("Assets")).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText("Download source URL"), {
+      target: { value: "https://example.com/toy.gguf" }
+    })
+    fireEvent.change(screen.getByLabelText("Download destination directory"), {
+      target: { value: "/srv/models" }
+    })
+    fireEvent.change(screen.getByLabelText("Download filename"), {
+      target: { value: "toy.gguf" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Queue download" }))
+
+    await waitFor(() => {
+      expect(apiMock.startLlamacppAssetDownload).toHaveBeenCalledWith({
+        url: "https://example.com/toy.gguf",
+        destination_dir: "/srv/models",
+        filename: "toy.gguf"
+      })
+      expect(apiMock.listLlamacppAssetDownloads).toHaveBeenCalledTimes(2)
+    })
+    expect(apiMock.createLlamacppProfile).not.toHaveBeenCalled()
+    expect(apiMock.startLlamacppProfile).not.toHaveBeenCalled()
+    expect(apiMock.useLlamacppInChat).not.toHaveBeenCalled()
+  })
+
+  it("refreshes assets when a download completes without profile side effects", async () => {
+    apiMock.listLlamacppAssetDownloads.mockResolvedValueOnce({
+      jobs: [
+        {
+          job_id: "99",
+          status: "completed",
+          operation: "download",
+          queue: "acquisition",
+          source_label: "Done model",
+          destination_path: "/srv/models/done.gguf",
+          asset_id: "gguf:done",
+          progress: {
+            progress_percent: 100
+          },
+          warnings: [],
+          error_message: null
+        }
+      ]
+    })
+
+    render(<LlamacppAdminPage />)
+
+    expect(await screen.findByText("Done model")).toBeTruthy()
+
+    await waitFor(() => {
+      expect(apiMock.getLlamacppAssets).toHaveBeenCalledTimes(2)
+    })
+    expect(apiMock.createLlamacppProfile).not.toHaveBeenCalled()
+    expect(apiMock.startLlamacppProfile).not.toHaveBeenCalled()
+    expect(apiMock.useLlamacppInChat).not.toHaveBeenCalled()
   })
 
   it("shows asset load failure without hiding legacy inventory", async () => {
@@ -824,6 +952,7 @@ describe("LlamacppAdminPage", () => {
       expect(apiMock.getLlamacppHardware).toHaveBeenCalledTimes(1)
       expect(apiMock.listLlamacppProfiles).toHaveBeenCalledTimes(1)
       expect(apiMock.listLlamacppInstances).toHaveBeenCalledTimes(1)
+      expect(apiMock.listLlamacppAssetDownloads).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
@@ -2,7 +2,12 @@ import React from "react"
 import { describe, expect, it, vi } from "vitest"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { LlamacppAssetsPanel } from "../LlamacppAssetsPanel"
-import type { LlamacppAssetsResponse } from "@/types/llamacpp-admin"
+import type {
+  LlamacppAcquisitionJobListResponse,
+  LlamacppAssetImportPreviewResponse,
+  LlamacppAssetDownloadRequest,
+  LlamacppAssetsResponse
+} from "@/types/llamacpp-admin"
 
 const mockAssets: LlamacppAssetsResponse = {
   assets: [
@@ -62,6 +67,53 @@ const mockAssets: LlamacppAssetsResponse = {
   ],
   warnings: ["One imported folder could not be read."],
   scan_limited: false
+}
+
+const mockImportPreview: LlamacppAssetImportPreviewResponse = {
+  folder: {
+    asset_id: "folder:preview",
+    kind: "folder",
+    identity_basis: "resolved_path",
+    path: "/external/models",
+    resolved_path: "/external/models",
+    display_name: "models",
+    source: "imported_folder",
+    size_bytes: null,
+    modified_at: null,
+    metadata: {},
+    capabilities: ["asset_folder"],
+    mmproj_asset_ids: [],
+    base_model_asset_ids: [],
+    warnings: []
+  },
+  assets: [mockAssets.assets[0]!, mockAssets.assets[1]!],
+  asset_counts: {
+    gguf: 1,
+    mmproj: 1
+  },
+  warnings: ["Preview skipped unreadable sidecar file."],
+  scan_limited: false,
+  will_persist: false
+}
+
+const mockDownloads: LlamacppAcquisitionJobListResponse = {
+  jobs: [
+    {
+      job_id: "42",
+      status: "running",
+      operation: "download",
+      queue: "acquisition",
+      source_label: "Toy model",
+      destination_path: "/models/toy.gguf",
+      asset_id: null,
+      progress: {
+        progress_percent: 25,
+        progress_message: "downloading"
+      },
+      warnings: ["Checksum will be verified after download."],
+      error_message: null
+    }
+  ]
 }
 
 describe("LlamacppAssetsPanel", () => {
@@ -160,5 +212,103 @@ describe("LlamacppAssetsPanel", () => {
       expect(onImportFolder).toHaveBeenCalledWith("/external/models")
     })
     expect(folderInput.value).toBe("/external/models")
+  })
+
+  it("previews local folder imports before confirming persistence", async () => {
+    const onPreviewImportFolder = vi.fn().mockResolvedValue(true)
+    const onImportFolder = vi.fn().mockResolvedValue(true)
+
+    render(
+      <LlamacppAssetsPanel
+        assets={{ assets: [], warnings: [], scan_limited: false }}
+        loading={false}
+        registeringPath={false}
+        importingFolder={false}
+        previewingFolder={false}
+        importPreview={mockImportPreview}
+        error={null}
+        onRegisterPath={vi.fn()}
+        onPreviewImportFolder={onPreviewImportFolder}
+        onImportFolder={onImportFolder}
+        onReload={vi.fn()}
+      />
+    )
+
+    const folderInput = screen.getByLabelText("Import local asset folder") as HTMLInputElement
+    fireEvent.change(folderInput, { target: { value: "/external/models" } })
+    fireEvent.click(screen.getByRole("button", { name: "Preview folder" }))
+
+    await waitFor(() => {
+      expect(onPreviewImportFolder).toHaveBeenCalledWith("/external/models")
+    })
+
+    expect(screen.getByText("Import preview")).toBeTruthy()
+    expect(screen.getByText("GGUF: 1")).toBeTruthy()
+    expect(screen.getByText("mmproj: 1")).toBeTruthy()
+    expect(screen.getByText("Preview skipped unreadable sidecar file.")).toBeTruthy()
+    expect(onImportFolder).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm import" }))
+
+    await waitFor(() => {
+      expect(onImportFolder).toHaveBeenCalledWith("/external/models")
+    })
+  })
+
+  it("queues downloads and renders cancellable acquisition status", async () => {
+    const onStartDownload =
+      vi.fn<(payload: LlamacppAssetDownloadRequest) => Promise<boolean>>()
+        .mockResolvedValue(true)
+    const onCancelDownload = vi.fn().mockResolvedValue(true)
+
+    render(
+      <LlamacppAssetsPanel
+        assets={{ assets: [], warnings: [], scan_limited: false }}
+        loading={false}
+        registeringPath={false}
+        importingFolder={false}
+        error={null}
+        downloads={mockDownloads}
+        startingDownload={false}
+        cancelingDownloadId={null}
+        onRegisterPath={vi.fn()}
+        onImportFolder={vi.fn()}
+        onStartDownload={onStartDownload}
+        onCancelDownload={onCancelDownload}
+        onReload={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Queue download" })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText("Download source URL"), {
+      target: { value: "https://example.com/toy.gguf" }
+    })
+    fireEvent.change(screen.getByLabelText("Download destination directory"), {
+      target: { value: "/models" }
+    })
+    fireEvent.change(screen.getByLabelText("Download filename"), {
+      target: { value: "toy.gguf" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Queue download" }))
+
+    await waitFor(() => {
+      expect(onStartDownload).toHaveBeenCalledWith({
+        url: "https://example.com/toy.gguf",
+        destination_dir: "/models",
+        filename: "toy.gguf"
+      } satisfies Partial<LlamacppAssetDownloadRequest>)
+    })
+
+    expect(screen.getByText("Toy model")).toBeTruthy()
+    expect(screen.getByText("running")).toBeTruthy()
+    expect(screen.getByText("25%")).toBeTruthy()
+    expect(screen.getByText("Checksum will be verified after download.")).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel download 42" }))
+
+    await waitFor(() => {
+      expect(onCancelDownload).toHaveBeenCalledWith("42")
+    })
   })
 })

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
@@ -255,6 +255,88 @@ describe("LlamacppAssetsPanel", () => {
     })
   })
 
+  it("clears stale import previews when the folder path changes", async () => {
+    const onClearImportPreview = vi.fn()
+    const onPreviewImportFolder = vi.fn().mockResolvedValue(true)
+    const onImportFolder = vi.fn().mockResolvedValue(true)
+
+    render(
+      <LlamacppAssetsPanel
+        assets={{ assets: [], warnings: [], scan_limited: false }}
+        loading={false}
+        registeringPath={false}
+        importingFolder={false}
+        previewingFolder={false}
+        importPreview={mockImportPreview}
+        error={null}
+        onRegisterPath={vi.fn()}
+        onPreviewImportFolder={onPreviewImportFolder}
+        onClearImportPreview={onClearImportPreview}
+        onImportFolder={onImportFolder}
+        onReload={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("Import local asset folder"), {
+      target: { value: "/external/other-models" }
+    })
+
+    expect(onClearImportPreview).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText("Import preview")).toBeNull()
+    expect(screen.queryByRole("button", { name: "Confirm import" })).toBeNull()
+    expect(onImportFolder).not.toHaveBeenCalled()
+  })
+
+  it("renders duplicate warning strings without React key collisions", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    try {
+      render(
+        <LlamacppAssetsPanel
+          assets={{
+            ...mockAssets,
+            warnings: ["Repeated warning.", "Repeated warning."],
+            assets: [
+              {
+                ...mockAssets.assets[0]!,
+                warnings: ["Repeated asset warning.", "Repeated asset warning."]
+              }
+            ]
+          }}
+          loading={false}
+          registeringPath={false}
+          importingFolder={false}
+          previewingFolder={false}
+          importPreview={{
+            ...mockImportPreview,
+            warnings: ["Repeated preview warning.", "Repeated preview warning."]
+          }}
+          downloads={{
+            jobs: [
+              {
+                ...mockDownloads.jobs[0]!,
+                warnings: ["Repeated job warning.", "Repeated job warning."]
+              }
+            ]
+          }}
+          error={null}
+          onRegisterPath={vi.fn()}
+          onPreviewImportFolder={vi.fn()}
+          onImportFolder={vi.fn()}
+          onStartDownload={vi.fn()}
+          onReload={vi.fn()}
+        />
+      )
+
+      const duplicateKeyWarnings = consoleError.mock.calls.filter((call) =>
+        String(call[0]).includes("Encountered two children with the same key")
+      )
+      expect(duplicateKeyWarnings).toHaveLength(0)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("queues downloads and renders cancellable acquisition status", async () => {
     const onStartDownload =
       vi.fn<(payload: LlamacppAssetDownloadRequest) => Promise<boolean>>()

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
@@ -123,4 +123,69 @@ describe("TldwApiClient getModels normalization", () => {
     expect(requests[1]?.body).toEqual({ name: "Default", model_id: "gguf:default" })
     expect(requests[2]?.body).toEqual({ name: "Updated" })
   })
+
+  it("routes llama.cpp acquisition workflow methods", async () => {
+    const requests: Array<{ path?: string; method?: string; body?: unknown }> = []
+    mocks.bgRequest.mockImplementation(
+      async (request: { path?: string; method?: string; body?: unknown }) => {
+        requests.push(request)
+        if (request.path === "/api/v1/llamacpp/assets/import-folder/preview") {
+          return {
+            folder: {},
+            assets: [],
+            asset_counts: {},
+            warnings: [],
+            scan_limited: false,
+            will_persist: false
+          }
+        }
+        if (request.path === "/api/v1/llamacpp/assets/downloads") {
+          return request.method === "GET"
+            ? { jobs: [] }
+            : {
+                job_id: "42",
+                status: "queued",
+                operation: "download",
+                queue: "acquisition",
+                progress: {},
+                warnings: []
+              }
+        }
+        return {
+          job_id: "42",
+          status: request.method === "DELETE" ? "canceled" : "running",
+          operation: "download",
+          queue: "acquisition",
+          progress: {},
+          warnings: []
+        }
+      }
+    )
+
+    const client = new TldwApiClient()
+
+    await client.previewLlamacppAssetFolder("/models")
+    await client.startLlamacppAssetDownload({
+      url: "https://example.com/model.gguf",
+      destination_dir: "/models",
+      filename: "model.gguf"
+    })
+    await client.listLlamacppAssetDownloads()
+    await client.getLlamacppAssetDownload("42")
+    await client.cancelLlamacppAssetDownload("42")
+
+    expect(requests.map((request) => [request.method, request.path])).toEqual([
+      ["POST", "/api/v1/llamacpp/assets/import-folder/preview"],
+      ["POST", "/api/v1/llamacpp/assets/downloads"],
+      ["GET", "/api/v1/llamacpp/assets/downloads"],
+      ["GET", "/api/v1/llamacpp/assets/downloads/42"],
+      ["DELETE", "/api/v1/llamacpp/assets/downloads/42"]
+    ])
+    expect(requests[0]?.body).toEqual({ path: "/models" })
+    expect(requests[1]?.body).toEqual({
+      url: "https://example.com/model.gguf",
+      destination_dir: "/models",
+      filename: "model.gguf"
+    })
+  })
 })

--- a/apps/packages/ui/src/services/tldw/domains/models-audio.ts
+++ b/apps/packages/ui/src/services/tldw/domains/models-audio.ts
@@ -3,6 +3,10 @@ import { buildQuery } from "../client-utils"
 import { appendPathQuery } from "../path-utils"
 import type {
   LlamacppAsset,
+  LlamacppAcquisitionJobListResponse,
+  LlamacppAcquisitionJobResponse,
+  LlamacppAssetDownloadRequest,
+  LlamacppAssetImportPreviewResponse,
   LlamacppAssetsResponse,
   LlamacppConfigResponse,
   LlamacppConfigUpdateRequest,
@@ -384,6 +388,53 @@ export const modelsAudioMethods = {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: { path }
+    })
+  },
+
+  async previewLlamacppAssetFolder(
+    path: string
+  ): Promise<LlamacppAssetImportPreviewResponse> {
+    return await bgRequest<LlamacppAssetImportPreviewResponse>({
+      path: "/api/v1/llamacpp/assets/import-folder/preview",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { path }
+    })
+  },
+
+  async startLlamacppAssetDownload(
+    payload: LlamacppAssetDownloadRequest
+  ): Promise<LlamacppAcquisitionJobResponse> {
+    return await bgRequest<LlamacppAcquisitionJobResponse>({
+      path: "/api/v1/llamacpp/assets/downloads",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload
+    })
+  },
+
+  async listLlamacppAssetDownloads(): Promise<LlamacppAcquisitionJobListResponse> {
+    return await bgRequest<LlamacppAcquisitionJobListResponse>({
+      path: "/api/v1/llamacpp/assets/downloads",
+      method: "GET"
+    })
+  },
+
+  async getLlamacppAssetDownload(
+    jobId: string | number
+  ): Promise<LlamacppAcquisitionJobResponse> {
+    return await bgRequest<LlamacppAcquisitionJobResponse>({
+      path: `/api/v1/llamacpp/assets/downloads/${encodeURIComponent(String(jobId))}`,
+      method: "GET"
+    })
+  },
+
+  async cancelLlamacppAssetDownload(
+    jobId: string | number
+  ): Promise<LlamacppAcquisitionJobResponse> {
+    return await bgRequest<LlamacppAcquisitionJobResponse>({
+      path: `/api/v1/llamacpp/assets/downloads/${encodeURIComponent(String(jobId))}`,
+      method: "DELETE"
     })
   },
 

--- a/apps/packages/ui/src/types/llamacpp-admin.ts
+++ b/apps/packages/ui/src/types/llamacpp-admin.ts
@@ -132,6 +132,43 @@ export interface LlamacppAssetsResponse {
   scan_limited: boolean
 }
 
+export interface LlamacppAssetImportPreviewResponse {
+  folder: LlamacppAsset
+  assets: LlamacppAsset[]
+  asset_counts: Record<string, number>
+  warnings: string[]
+  scan_limited: boolean
+  will_persist: boolean
+}
+
+export interface LlamacppAssetDownloadRequest {
+  url: string
+  destination_dir?: string | null
+  filename?: string | null
+  expected_sha256?: string | null
+  expected_size_bytes?: number | null
+  source_label?: string | null
+  overwrite?: boolean
+  register_asset?: boolean
+}
+
+export interface LlamacppAcquisitionJobResponse {
+  job_id: string
+  status: string
+  operation: "download"
+  queue: string
+  source_label?: string | null
+  destination_path?: string | null
+  asset_id?: string | null
+  progress: Record<string, unknown>
+  warnings: string[]
+  error_message?: string | null
+}
+
+export interface LlamacppAcquisitionJobListResponse {
+  jobs: LlamacppAcquisitionJobResponse[]
+}
+
 export interface LlamacppUseInChatResponse {
   provider: string
   endpoint: string

--- a/backlog/tasks/task-416.4 - Implement-llama.cpp-acquisition-workflow-UI.md
+++ b/backlog/tasks/task-416.4 - Implement-llama.cpp-acquisition-workflow-UI.md
@@ -1,0 +1,71 @@
+---
+id: TASK-416.4
+title: Implement llama.cpp acquisition workflow UI
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-18 04:07
+labels:
+- llamacpp
+- webui
+- local-llm
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/pull/1833
+- https://github.com/rmusser01/tldw_server/pull/1836
+documentation:
+- Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+parent_task_id: TASK-416
+priority: high
+modified_files:
+- apps/packages/ui/src/types/llamacpp-admin.ts
+- apps/packages/ui/src/services/tldw/domains/models-audio.ts
+- apps/packages/ui/src/components/Option/Admin/LlamacppAssetsPanel.tsx
+- apps/packages/ui/src/components/Option/Admin/LlamacppAdminPage.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx
+- apps/packages/ui/src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx
+- apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 4 from the llama.cpp model acquisition/import workflow plan: expose local import preview, confirmed folder import, remote asset download queue/status/cancel, and asset refresh in the existing Admin assets WebUI without creating or starting profiles.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Local import preview renders counts/warnings and requires an explicit import action before mutation.
+- [x] #2 Download form prevents empty submissions and queues Jobs-backed asset downloads through the shared API client.
+- [x] #3 Queued/running/completed/failed downloads render as a compact status list with progress and cancel where applicable.
+- [x] #4 Completed downloads refresh the normal llama.cpp asset inventory and do not create/start/wire profiles.
+- [x] #5 Focused shared UI client/component tests cover the workflow.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Task 4 in Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md. Use TDD: add failing Vitest/client tests, implement client types/methods and compact LlamacppAssetsPanel workflow, then verify focused tests and diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added llama.cpp acquisition API client types and methods, converted Admin asset folder import to preview then explicit confirm, added a compact remote download queue/status/cancel workflow, and refresh asset inventory once per newly completed download job. Download handling deliberately does not create saved profiles, start runtime profiles, or wire Chat. Verification: focused Vitest passed 28 tests; git diff --check passed; broad tsc remains blocked by unrelated repo-wide baseline type errors; Bandit not run because this slice touches only TypeScript/TSX and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the llama.cpp acquisition workflow UI for Admin assets: local folder preview/confirm import, remote download queue/status/cancel, API client routing, focused regression coverage, and PR https://github.com/rmusser01/tldw_server/pull/1836.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-416.4 - Implement-llama.cpp-acquisition-workflow-UI.md
+++ b/backlog/tasks/task-416.4 - Implement-llama.cpp-acquisition-workflow-UI.md
@@ -15,6 +15,12 @@ references:
 - https://github.com/rmusser01/tldw_server/pull/1836
 documentation:
 - Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+- 'PR #1836 review thread sweep: verifying and fixing current review findings for
+  acquisition workflow UI.'
+- 'PR #1836 review fix verification: focused Vitest passed 33 tests; git diff --check
+  passed; broad bunx tsc remains blocked by pre-existing repo-wide TypeScript baseline
+  outside this touched slice; Bandit not run because review fix touches only TypeScript/TSX
+  and Backlog metadata.'
 parent_task_id: TASK-416
 priority: high
 modified_files:
@@ -57,7 +63,7 @@ Added llama.cpp acquisition API client types and methods, converted Admin asset 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the llama.cpp acquisition workflow UI for Admin assets: local folder preview/confirm import, remote download queue/status/cancel, API client routing, focused regression coverage, and PR https://github.com/rmusser01/tldw_server/pull/1836.
+Implemented the llama.cpp acquisition workflow UI and addressed PR #1836 review feedback: preview confirmations now require the current previewed folder, stale previews are cleared on input changes, completed download refreshes avoid redundant initial scans and retry after failed asset refreshes, download-list errors clear after successful reloads, and duplicate warning strings render with unique keys.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Add shared UI client types and methods for llama.cpp import-preview and asset download jobs.
- Add Admin assets UI for preview-then-confirm folder imports plus compact download queue/status/cancel handling.
- Refresh asset inventory when completed downloads appear without creating profiles, starting runtimes, or wiring Chat.

## Test Plan
- [x] ./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx src/services/__tests__/tldw-api-client.models-normalization.test.ts
- [x] git diff --check
- [ ] ./node_modules/.bin/tsc --noEmit --project tsconfig.json (not clean: existing unrelated package-wide type errors; no errors reported in touched llama.cpp acquisition files)

Change summary: Human reviewer should replace this placeholder before merge per the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the llama.cpp acquisition workflow to the Admin Assets UI: preview-then-confirm local folder imports and a compact remote download queue with status/progress/cancel, with automatic asset inventory refresh on completed downloads. Aligns with TASK-416.4 and intentionally avoids creating profiles, starting runtimes, or wiring Chat.

- **New Features**
  - Admin Assets: preview local folder imports (counts and warnings), then confirm to persist.
  - Admin Assets: queue remote downloads (URL, destination dir, filename), list jobs with status/progress, and cancel running jobs; manual “Refresh downloads” button.
  - Auto-refresh assets once per newly completed download after initial load; no profile side-effects.
  - Client/types: added `LlamacppAssetImportPreviewResponse`, `LlamacppAssetDownloadRequest`, `LlamacppAcquisitionJobResponse`, `LlamacppAcquisitionJobListResponse`; new `tldwClient` methods `previewLlamacppAssetFolder`, `startLlamacppAssetDownload`, `listLlamacppAssetDownloads`, `getLlamacppAssetDownload`, `cancelLlamacppAssetDownload`.

- **Bug Fixes**
  - Import preview: clear stale previews when the folder path changes; confirm only the currently previewed path.
  - Downloads: avoid redundant asset scans on initial load; retry asset refresh after failures; clear stale download-list errors after a successful refresh.
  - UI robustness: consistent progress percent and cancel status; unique keys for repeated warnings to prevent React key collisions.

<sup>Written for commit e507c7f6afd472afd9d61b3a48eeae48be1507a9. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1836?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

