### PR TITLE
Implement watchlists digest/audio PR1 contracts

### DIFF
--- a/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
@@ -1,0 +1,962 @@
+# Watchlists Digest And Audio Briefing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `/watchlists` digest/newsletter and optional 1-4 speaker audio briefing workflow from the hardened PRD without removing existing watchlists, OSINT, CTI, or power-user flows.
+
+**Architecture:** Reuse the existing Watchlists WebUI, shared UI package, Watchlists API, Scheduler pipeline, output artifacts, notifications service, and audio briefing workflow. Start with contract alignment and observable states, then add guided source/monitor/digest/audio setup inside `/watchlists`, then add reuse, batch operations, and operator recovery.
+
+**Tech Stack:** Next.js route wrapper, shared React/Ant Design UI in `apps/packages/ui`, TypeScript service/types, FastAPI/Pydantic Watchlists endpoints, SQLite-backed Watchlists DB, Scheduler/Workflow audio tasks, Vitest, Pytest, Playwright.
+
+---
+
+## Source Documents
+
+- PRD: `Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md`
+- Backlog: `TASK-425`
+- Key WebUI route: `apps/tldw-frontend/pages/watchlists.tsx`
+- Shared route/component entry: `apps/packages/ui/src/routes/option-watchlists.tsx`
+- Watchlists shell: `apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx`
+- Watchlists API: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Watchlists schemas: `tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py`
+- Watchlists pipeline: `tldw_Server_API/app/core/Watchlists/pipeline.py`
+- Audio workflow bridge: `tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py`
+
+## File Structure And Ownership
+
+### Frontend Contract And Services
+
+- Modify: `apps/packages/ui/src/types/watchlists.ts`
+  - Add typed source settings/scrape rules.
+  - Add output audio fields missing from `WatchlistOutputCreate`.
+  - Add `auto_output` job output preference typing.
+  - Add run audio status/artifact typing.
+  - Add structured `audio_cast` typing while preserving `voice_map`.
+- Modify: `apps/packages/ui/src/services/watchlists.ts`
+  - Add `getWatchlistRunAudio(runId)`.
+  - Keep existing source/job/output functions stable.
+  - Optionally add `validateWatchlistSourceDraftRules` only if the backend route is added.
+- Test: `apps/packages/ui/src/services/__tests__/watchlists-overview.test.ts` or new `apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts`.
+
+### Source Setup
+
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx`
+  - Preserve and submit `settings`.
+  - Pass draft `settings` to source test.
+  - Accept capability-driven forum enablement instead of hard-coded disabled forum UI.
+  - Add typed website extraction/discovery controls behind advanced disclosure.
+  - Show validation diagnostics returned by backend.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx`
+  - Load `/watchlists/settings` capability data and pass `forums_enabled` into `SourceFormModal`.
+- Create: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts`
+  - Pure helpers for parsing, normalizing, merging, and serializing source settings without deleting unknown keys.
+- Test: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts`
+- Backend modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+  - Return selector validation diagnostics from draft/saved source test, or add a specific validation endpoint.
+- Backend test: `tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_preview_endpoint.py`
+
+### Monitor Cadence, Output, Delivery
+
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts`
+  - Support every N minutes and every N hours as first-class presets.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-frequency.ts`
+  - Preserve minimum interval validation.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx`
+  - Replace fixed hourly/every-6-hour-only UI with variable interval controls.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx`
+  - Surface `auto_output.enabled`.
+  - Explain scheduled output/delivery behavior before save.
+  - Keep raw cron and existing advanced controls.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts`
+  - Ensure scheduled pipeline payloads set `output_prefs.auto_output.enabled`.
+  - Keep manual/test run output creation explicit.
+- Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py`
+
+### Run, Output, Audio Artifacts
+
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx`
+  - Show output, delivery, audio pending, audio failed, fallback, and final artifact states.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx`
+  - Add compact audio/output status indicator.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputPreviewDrawer.tsx`
+  - Show delivery result, script, per-speaker artifacts, fallback reason, and final player when metadata exists.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts`
+  - Add pure metadata extraction helpers for delivery/audio status.
+- Backend modify: `tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py`
+  - Add typed response schema for run audio status.
+  - Add typed output metadata structures where practical.
+- Backend modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+  - Return script/per-speaker/final audio artifacts, not just one final audio candidate.
+- Backend modify: `tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py`
+  - Accept structured speaker config.
+  - Persist script, per-speaker artifacts, final mix, and fallback reason as workflow/watchlist output metadata.
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputPreviewDrawer.audio.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_audio_output_delivery.py`
+
+### Guided Pipeline MVP
+
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx`
+  - Replace partial quick setup with a full additive guided entry point.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts`
+  - Extend draft model to include source settings preview, output/delivery expectations, and audio cast.
+- Create: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx`
+  - Source, Monitor, Digest, Optional Audio, Review steps.
+- Create: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts`
+  - Pure state transitions and validation helpers.
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts`
+- Regression test: `apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.experimental-ia.test.tsx`
+
+### Power-User Throughput
+
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx`
+  - Clone monitor.
+  - Batch activation/schedule/output changes.
+  - Batch retry entry points if backend supports them.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx`
+  - Clone source rules.
+  - Batch source rule test.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsCommandPalette.tsx`
+  - Commands for create pipeline, clone, validate, run, retry, export.
+- Backend modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+  - Add safe batch endpoints only where existing single-operation APIs are insufficient.
+- Test: existing source/jobs batch tests plus new focused clone/batch tests.
+
+### Operator/Admin Reliability
+
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx`
+  - Surface source/scheduler/delivery/audio health.
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx`
+  - Diagnostic bundle export and stage-specific retry controls.
+- Backend modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+  - Add delivery-only retry and audio-only retry if existing workflow APIs are too generic.
+  - Add diagnostic bundle endpoint if not already available through run logs/exports.
+- Backend test: `tldw_Server_API/tests/Watchlists/test_delivery_integrations.py`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_runs_csv_export.py`
+- Backend test: new `tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py`
+
+---
+
+## Stage Gates
+
+- Stage 0 is complete when types/services can represent existing backend capability without changing the user journey.
+- Stage 1A is complete when users can save source settings and variable cadence without raw JSON or cron.
+- Stage 1B is complete when scheduled monitors can produce digest/newsletter output through `auto_output.enabled` and show delivery state.
+- Stage 1C is complete when optional audio shows script, per-speaker artifacts, final mix, fallback reason, and final player inside `/watchlists`.
+- Stage 2 is complete when expert users can clone/reuse/batch the core workflow.
+- Stage 3 is complete when operators can diagnose and retry delivery/audio without rerunning ingestion.
+
+## Recommended PR Slices
+
+- PR 1: Tasks 1-3. Contract alignment, variable cadence, source settings preservation, and forum capability gating. This creates immediate user value without backend artifact changes.
+- PR 2: Tasks 4-5. Source validation diagnostics plus scheduled output/delivery contract.
+- PR 3: Tasks 6-7. Audio status display plus backend script/per-speaker/final artifact persistence.
+- PR 4: Task 8. Guided pipeline MVP, built only after the contracts it promises are present.
+- PR 5: Tasks 9-10. Power-user reuse/batch operations and operator recovery.
+- PR 6: Task 11. End-to-end verification, browser QA, and release hardening.
+
+---
+
+## Task 1: Frontend Watchlists Contract Alignment
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/watchlists.ts`
+- Modify: `apps/packages/ui/src/services/watchlists.ts`
+- Test: `apps/packages/ui/src/services/__tests__/watchlists-overview.test.ts`
+- Test: new `apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts`
+
+- [ ] **Step 1: Write failing type/service tests**
+
+Add service tests proving `getWatchlistRunAudio(123)` calls `/api/v1/watchlists/runs/123/audio`, and compile-time fixtures proving `WatchlistOutputCreate` accepts backend-supported audio fields.
+
+Representative fixture:
+
+```ts
+const output: WatchlistOutputCreate = {
+  run_id: 10,
+  generate_audio: true,
+  target_audio_minutes: 12,
+  audio_model: "kokoro",
+  audio_voice: "af_heart",
+  audio_speed: 1.05,
+  background_audio_uri: "file:///tmp/bed.mp3",
+  background_volume: 0.15,
+  audio_language: "en",
+  llm_provider: "openai",
+  llm_model: "gpt-4.1-mini",
+  persona_summarize: true,
+  voice_map: { HOST: "af_bella", ANALYST: "am_adam" }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/services/__tests__/watchlists-audio.test.ts src/components/Option/Watchlists/__tests__/watchlists-static-guard.typecheck.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: FAIL because the service helper and several output audio fields are missing or incomplete.
+
+- [ ] **Step 3: Add types and service helper**
+
+Add these types to `watchlists.ts`:
+
+```ts
+export interface WatchlistAudioCastSpeaker {
+  id: string
+  label: string
+  role?: string
+  voice: string
+  persona?: string
+}
+
+export interface WatchlistAudioCast {
+  speaker_count: 1 | 2 | 3 | 4
+  speakers: WatchlistAudioCastSpeaker[]
+}
+
+export interface WatchlistRunAudioStatus {
+  run_id: number
+  task_id?: string | null
+  status: "pending" | "running" | "completed" | "failed" | "unknown" | string
+  audio_uri?: string | null
+  download_url?: string | null
+  artifact_id?: string | number | null
+  size_bytes?: number | null
+  mime_type?: string | null
+  script_artifact?: Record<string, unknown> | null
+  speaker_artifacts?: Array<Record<string, unknown>>
+  final_artifact?: Record<string, unknown> | null
+  fallback_reason?: string | null
+  error?: string | null
+}
+```
+
+Extend `JobOutputPrefs` and `WatchlistOutputCreate` with backend-supported audio fields and `auto_output`.
+
+Add this helper in `watchlists.ts` service:
+
+```ts
+export const getWatchlistRunAudio = async (
+  runId: number
+): Promise<WatchlistRunAudioStatus> => {
+  return bgRequest<WatchlistRunAudioStatus>({
+    path: `/api/v1/watchlists/runs/${runId}/audio` as any,
+    method: "GET"
+  })
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/types/watchlists.ts apps/packages/ui/src/services/watchlists.ts apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts
+git commit -m "feat: align watchlists audio contracts"
+```
+
+---
+
+## Task 2: Variable Cadence Controls
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-frequency.ts`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx`
+
+- [ ] **Step 1: Write failing schedule tests**
+
+Add coverage for:
+
+- Every 5 hours -> `0 */5 * * *`
+- Every 15 minutes -> `*/15 * * * *`
+- Every 4 minutes blocked by existing minimum interval
+- Existing `0 */6 * * *` parses back to every 6 hours
+- Weekly still works
+- Raw cron still available
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: FAIL because presets are fixed to hourly/every6/daily/weekly.
+
+- [ ] **Step 3: Implement interval preset state**
+
+Update `SchedulePresetKey` and state:
+
+```ts
+export type SchedulePresetKey = "interval" | "daily" | "weekdays" | "weekly"
+export type ScheduleIntervalUnit = "minutes" | "hours"
+
+export interface PresetScheduleState {
+  preset: SchedulePresetKey
+  intervalValue: number
+  intervalUnit: ScheduleIntervalUnit
+  hour: number
+  minute: number
+  weekday: WeekdayToken
+}
+```
+
+Build cron as:
+
+```ts
+if (state.preset === "interval" && state.intervalUnit === "minutes") {
+  return `*/${clampInteger(state.intervalValue, 5, 59)} * * * *`
+}
+if (state.preset === "interval" && state.intervalUnit === "hours") {
+  return `${minute} */${clampInteger(state.intervalValue, 1, 23)} * * *`
+}
+```
+
+Keep custom cron as the escape hatch for schedules cron can express but the preset UI cannot safely model.
+
+Update `parsePresetFromCron` so existing `*/6` schedules map into the interval model instead of appearing as raw cron after upgrade.
+
+- [ ] **Step 4: Update UI copy and controls**
+
+In `SchedulePicker.tsx`, use segmented/select controls for:
+
+- Manual/no schedule via existing clear/null behavior.
+- Every N minutes.
+- Every N hours.
+- Daily.
+- Weekdays.
+- Weekly.
+- Advanced cron.
+
+Always show generated cron and a human-readable preview via `CronDisplay`.
+
+- [ ] **Step 5: Run focused tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-frequency.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx
+git commit -m "feat: add variable watchlist cadence controls"
+```
+
+---
+
+## Task 3: Source Settings Preservation And Rule Preview
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx`
+- Test: new `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx`
+
+- [ ] **Step 1: Write failing source settings tests**
+
+Cover:
+
+- Editing a source preserves unknown `settings` keys.
+- Website scrape rules are serialized under `settings.scrape_rules`.
+- Draft source test sends `settings`.
+- Empty advanced fields do not create noisy settings.
+- Forum source option is enabled only when watchlists settings report `forums_enabled`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: FAIL because settings are not exposed or submitted.
+
+- [ ] **Step 3: Implement pure merge helpers**
+
+Add helpers:
+
+```ts
+export const mergeSourceSettings = (
+  existing: Record<string, unknown> | null | undefined,
+  patch: Record<string, unknown>
+): Record<string, unknown> => ({
+  ...(existing || {}),
+  ...patch
+})
+```
+
+Use more specific functions for scrape rules, so fields can be deleted intentionally without wiping unrelated advanced settings.
+
+- [ ] **Step 4: Update `SourceFormModal`**
+
+Change `onSubmit` values to include `settings`.
+
+Load `initialValues.settings` into form state.
+
+Add a `forumsEnabled` prop to `SourceFormModal`, defaulting to `false`, and pass it from `SourcesTab` using the existing settings endpoint/service. Keep the disabled explanatory copy when the capability is false.
+
+For saved and draft tests, pass settings:
+
+```ts
+await testWatchlistSourceDraft(
+  {
+    url: draftUrl,
+    source_type: draftType as SourceType,
+    settings: buildSourceSettingsPayload(initialValues?.settings, values)
+  },
+  { limit: 10 }
+)
+```
+
+- [ ] **Step 5: Add validation display placeholders**
+
+Show a compact diagnostics block when preview response includes:
+
+- fetch mode
+- selector errors
+- no-match warnings
+- non-unique warnings
+- fragile selector warnings
+- dedupe preview key
+
+Do not invent those fields in the UI if the backend does not return them yet; render only when present.
+
+- [ ] **Step 6: Run focused tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx
+git commit -m "feat: preserve watchlist source settings"
+```
+
+---
+
+## Task 4: Source Validation Diagnostics API
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_preview_endpoint.py`
+
+- [ ] **Step 1: Write failing backend tests**
+
+Add tests proving draft/saved source test returns diagnostics for site sources with scrape rules:
+
+```python
+assert response.json()["diagnostics"]["fetch_mode"] == "scrape_rules"
+assert "selector_warnings" in response.json()["diagnostics"]
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q
+```
+
+Expected: FAIL because preview result currently exposes only item counts/items to the frontend contract.
+
+- [ ] **Step 3: Add response schema**
+
+Extend preview response schema with optional diagnostics:
+
+```python
+class SourcePreviewDiagnostics(BaseModel):
+    fetch_mode: str | None = None
+    selector_errors: list[str] = Field(default_factory=list)
+    selector_warnings: list[str] = Field(default_factory=list)
+    dedupe_preview_key: str | None = None
+```
+
+Keep fields optional to avoid breaking existing callers.
+
+- [ ] **Step 4: Populate diagnostics**
+
+Reuse existing `validate_selector_rules` output for site/forum scrape rules. For RSS and discovery fallback, report `fetch_mode` only if no selector diagnostics exist.
+
+- [ ] **Step 5: Run backend tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+git commit -m "feat: expose watchlist source validation diagnostics"
+```
+
+---
+
+## Task 5: Auto-Output And Delivery Contract
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/watchlists.ts`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py`
+- Backend test: `tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py`
+
+- [ ] **Step 1: Write failing frontend tests**
+
+Cover:
+
+- Scheduled monitor payload includes `output_prefs.auto_output.enabled: true`.
+- Manual/test output creation remains explicit.
+- Delivery status helper distinguishes `sent`, `skipped`, `failed`, and `pending`.
+
+- [ ] **Step 2: Run frontend tests to verify failure**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+- [ ] **Step 3: Add `auto_output` type and UI**
+
+Add to `JobOutputPrefs`:
+
+```ts
+auto_output?: {
+  enabled?: boolean
+  type?: string
+  format?: "md" | "html"
+  template_name?: string
+  template_version?: number
+}
+```
+
+In `JobFormModal`, make scheduled output explicit: when delivery or audio is enabled for recurring monitors, require or default `auto_output.enabled` and show review copy that output artifacts will be generated each run.
+
+- [ ] **Step 4: Update pipeline payload helpers**
+
+In `pipeline-contract.ts`, set `auto_output.enabled` when the user chooses scheduled digest/newsletter output. Do not set it for manual/test-only flows.
+
+- [ ] **Step 5: Confirm backend roundtrip**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py -q
+```
+
+Expected: PASS or only frontend-driven behavior needs update. If backend drops the field, fix schema/persistence before proceeding.
+
+- [ ] **Step 6: Run focused frontend tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/packages/ui/src/types/watchlists.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+git commit -m "feat: make watchlist scheduled outputs explicit"
+```
+
+---
+
+## Task 6: Run Audio Status In Activity And Reports
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/watchlists.ts`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputPreviewDrawer.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputPreviewDrawer.audio.test.tsx`
+
+- [ ] **Step 1: Write failing UI tests**
+
+Cover:
+
+- Run drawer polls or loads audio status when `stats.audio_briefing_task_id` exists.
+- Pending status is visible.
+- Final audio renders a player/download link.
+- Output preview shows fallback reason when metadata has fallback.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/OutputPreviewDrawer.audio.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+- [ ] **Step 3: Implement status helpers**
+
+Add pure helpers in `outputMetadata.ts` for:
+
+- delivery status summary
+- audio requested/pending/final/failed/fallback summary
+- script/per-speaker/final artifact extraction
+
+- [ ] **Step 4: Render states**
+
+In run/output surfaces, distinguish:
+
+- audio not requested
+- audio queued/pending
+- audio running
+- final audio available
+- failed audio
+- fallback single-voice audio
+- status unknown
+
+- [ ] **Step 5: Run focused tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/services/watchlists.ts apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputPreviewDrawer.tsx apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputPreviewDrawer.audio.test.tsx
+git commit -m "feat: surface watchlist audio run status"
+```
+
+---
+
+## Task 7: Backend Audio Artifact Persistence
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Modify: `tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_audio_output_delivery.py`
+
+- [ ] **Step 1: Write failing backend tests**
+
+Add tests for `GET /runs/{run_id}/audio` returning:
+
+- script artifact
+- per-speaker artifacts
+- final artifact
+- fallback reason when multi-voice fails
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py tldw_Server_API/tests/Watchlists/test_audio_output_delivery.py -q
+```
+
+Expected: FAIL because the endpoint currently chooses a final audio candidate and does not expose the full artifact graph.
+
+- [ ] **Step 3: Add structured audio cast schema**
+
+Add optional `audio_cast` to output create/job prefs schemas. Preserve `voice_map` compatibility.
+
+```python
+class WatchlistAudioCastSpeaker(BaseModel):
+    id: str
+    label: str
+    role: str | None = None
+    voice: str
+    persona: str | None = None
+
+class WatchlistAudioCast(BaseModel):
+    speaker_count: int = Field(..., ge=1, le=4)
+    speakers: list[WatchlistAudioCastSpeaker]
+```
+
+- [ ] **Step 4: Persist intermediate artifacts**
+
+Extend workflow metadata/artifact naming so script, per-speaker clips, final mix, and fallback reason can be retrieved by run ID. Do not create a new podcast job system.
+
+- [ ] **Step 5: Expand run audio endpoint**
+
+Return a stable shape:
+
+```python
+{
+    "run_id": run_id,
+    "task_id": task_id,
+    "status": matching_run_status,
+    "script_artifact": script_artifact,
+    "speaker_artifacts": speaker_artifacts,
+    "final_artifact": final_artifact,
+    "fallback_reason": fallback_reason,
+    "download_url": final_download_url,
+}
+```
+
+- [ ] **Step 6: Run backend tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py tldw_Server_API/tests/Watchlists/test_audio_output_delivery.py
+git commit -m "feat: persist watchlist audio briefing artifacts"
+```
+
+---
+
+## Task 8: Guided Pipeline MVP
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/quick-setup.ts`
+- Create: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx`
+- Create: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts`
+- Test: new `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx`
+- Test: new `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts`
+- Test: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts`
+- Regression: `apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.experimental-ia.test.tsx`
+
+- [ ] **Step 1: Write failing wizard state tests**
+
+Cover:
+
+- Requires at least one source.
+- Requires monitor name.
+- Supports manual/every-N-hours/daily/weekly schedule.
+- Requires template for digest/newsletter.
+- Optional audio supports 0-4 speakers.
+- Review summary names source, cadence, filters, output, delivery, and audio.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+- [ ] **Step 3: Implement wizard state helpers**
+
+Keep state pure. Use existing service calls from the component, not from helper files.
+
+- [ ] **Step 4: Implement additive `PipelineWizard`**
+
+Wizard steps:
+
+1. Sources.
+2. Monitor.
+3. Digest.
+4. Optional Audio.
+5. Review.
+
+The wizard should call existing `createWatchlistSource`, `createWatchlistJob`, `triggerWatchlistRun`, and `createWatchlistOutput` helpers. It must not bypass existing API contracts.
+
+- [ ] **Step 5: Wire into overview without removing full controls**
+
+Add "Create briefing pipeline" as an entry point. Preserve current Sources/Items/Outputs primary tabs and "Show all views".
+
+- [ ] **Step 6: Run focused tests**
+
+Run the command from Step 2 again.
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/quick-setup.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.experimental-ia.test.tsx
+git commit -m "feat: add watchlists briefing pipeline wizard"
+```
+
+---
+
+## Task 9: Power-User Reuse And Batch Operations
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsCommandPalette.tsx`
+- Modify as needed: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test: existing Jobs/Sources batch tests plus new focused tests.
+
+- [ ] **Step 1: Write failing clone/reuse tests**
+
+Cover:
+
+- Clone monitor preserves scope, schedule, filters, output prefs, delivery, audio cast.
+- Clone source rules preserves settings but resets status/seen state.
+- Command palette exposes create, clone, run, preview, retry, export.
+
+- [ ] **Step 2: Implement frontend-only clone where possible**
+
+Prefer composing existing create APIs with copied payloads. Add backend batch APIs only where frontend composition is unsafe or inefficient.
+
+- [ ] **Step 3: Add batch test/validation actions**
+
+Source batch rule test can reuse `checkWatchlistSourcesNow` initially, then move to a richer validation endpoint when Task 4 exists.
+
+- [ ] **Step 4: Run watchlists scale and batch tests**
+
+```bash
+cd apps/packages/ui
+bun run test:watchlists:scale
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsCommandPalette.tsx
+git commit -m "feat: add watchlists reuse and batch controls"
+```
+
+---
+
+## Task 10: Operator Recovery And Diagnostics
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test: new `tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_delivery_integrations.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_runs_csv_export.py`
+
+- [ ] **Step 1: Write failing operator tests**
+
+Cover:
+
+- Delivery-only retry does not rerun ingestion.
+- Audio-only retry does not rerun ingestion.
+- Diagnostic bundle contains source statuses, filter tallies, output metadata, delivery statuses, audio task metadata, and logs.
+
+- [ ] **Step 2: Run backend tests to verify failure**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py tldw_Server_API/tests/Watchlists/test_delivery_integrations.py tldw_Server_API/tests/Watchlists/test_runs_csv_export.py -q
+```
+
+- [ ] **Step 3: Add backend retry and diagnostics endpoints**
+
+Only add endpoints that cannot safely be represented with existing APIs. Keep them stage-specific:
+
+- output delivery retry
+- audio retry
+- diagnostic bundle export
+
+- [ ] **Step 4: Render operator controls**
+
+Controls must show confirmation copy that names what will and will not rerun.
+
+- [ ] **Step 5: Run backend and frontend focused tests**
+
+Run backend command from Step 2 and focused `RunsTab` Vitest tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py tldw_Server_API/tests/Watchlists/test_delivery_integrations.py tldw_Server_API/tests/Watchlists/test_runs_csv_export.py apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsHealthBar.tsx apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx
+git commit -m "feat: add watchlists operator recovery controls"
+```
+
+---
+
+## Task 11: End-To-End Verification And Browser QA
+
+**Files:**
+- Create or modify: `apps/tldw-frontend/e2e/...` only if an existing watchlists workflow spec is present and suitable.
+- Otherwise rely on component/API tests plus browser-observed manual QA.
+
+- [ ] **Step 1: Run focused frontend verification**
+
+```bash
+cd apps/packages/ui
+bun run test:watchlists:a11y
+bun run test:watchlists:scale
+bun run test:watchlists:typecheck
+```
+
+- [ ] **Step 2: Run focused backend verification**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_api.py tldw_Server_API/tests/Watchlists/test_full_pipeline_integration.py tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py tldw_Server_API/tests/Watchlists/test_audio_output_delivery.py -q
+```
+
+- [ ] **Step 3: Run Bandit on touched backend code**
+
+```bash
+source .venv/bin/activate
+python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py tldw_Server_API/app/core/Watchlists -f json -o /tmp/bandit_watchlists_digest_audio.json
+```
+
+- [ ] **Step 4: Browser QA `/watchlists`**
+
+Start local services per repo conventions, then verify:
+
+- First-time empty/near-empty state offers guided pipeline and full controls.
+- Source test displays RSS/site mode, preview counts, and diagnostics.
+- Every 5 hours can be selected without raw cron.
+- Weekly can be selected.
+- Scheduled digest shows `auto_output` expectation before save.
+- Email delivery setup distinguishes configured/unavailable/skipped states.
+- Optional audio supports no audio and 1-4 speakers.
+- Run detail shows pending/final/failed audio state.
+- Output preview shows digest, delivery status, final audio, and fallback when applicable.
+- Full tab workflow and "Show all views" still work.
+
+- [ ] **Step 5: Final regression sweep**
+
+```bash
+git diff --check
+```
+
+If frontend and backend tests are too expensive for the final patch, document exact skipped commands and why in the Backlog task and PR body.
+
+---
+
+## Deferred Or Explicitly Non-MVP Work
+
+- True every-N-weeks recurrence beyond cron-supported weekly patterns. Use custom cron or add a backend recurrence abstraction later.
+- Full podcast studio outside `/watchlists`.
+- Removing raw cron, raw `voice_map`, OPML, templates, item review, or advanced tabs.
+- Forum source default enablement before backend settings report `forums_enabled`.
+- Large IA redesign outside `/watchlists`.
+
+## Plan Review Notes
+
+- This plan intentionally starts with contract work because the current UI cannot honestly promise scheduled digest delivery or multi-speaker artifact recovery until the frontend/backend contracts can represent those states.
+- The first implementation PR should stop after Tasks 1-3 or Tasks 1-5. Shipping all tasks in one PR would create review risk and make regression source hard to isolate.
+- A plan-document-reviewer subagent was not dispatched in this session because the user did not explicitly authorize subagents. Before large-scale execution, run an independent review against this plan and the PRD if subagent delegation is authorized.

--- a/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
@@ -175,7 +175,7 @@
 - Test: `apps/packages/ui/src/services/__tests__/watchlists-overview.test.ts`
 - Test: new `apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts`
 
-- [ ] **Step 1: Write failing type/service tests**
+- [x] **Step 1: Write failing type/service tests**
 
 Add service tests proving `getWatchlistRunAudio(123)` calls `/api/v1/watchlists/runs/123/audio`, and compile-time fixtures proving `WatchlistOutputCreate` accepts backend-supported audio fields.
 
@@ -199,7 +199,7 @@ const output: WatchlistOutputCreate = {
 }
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run:
 
@@ -210,7 +210,7 @@ bunx vitest run src/services/__tests__/watchlists-audio.test.ts src/components/O
 
 Expected: FAIL because the service helper and several output audio fields are missing or incomplete.
 
-- [ ] **Step 3: Add types and service helper**
+- [x] **Step 3: Add types and service helper**
 
 Add these types to `watchlists.ts`:
 
@@ -260,13 +260,13 @@ export const getWatchlistRunAudio = async (
 }
 ```
 
-- [ ] **Step 4: Run focused tests**
+- [x] **Step 4: Run focused tests**
 
 Run the command from Step 2 again.
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/packages/ui/src/types/watchlists.ts apps/packages/ui/src/services/watchlists.ts apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts
@@ -284,7 +284,7 @@ git commit -m "feat: align watchlists audio contracts"
 - Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts`
 - Test: `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx`
 
-- [ ] **Step 1: Write failing schedule tests**
+- [x] **Step 1: Write failing schedule tests**
 
 Add coverage for:
 
@@ -295,7 +295,7 @@ Add coverage for:
 - Weekly still works
 - Raw cron still available
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 ```bash
 cd apps/packages/ui
@@ -304,7 +304,7 @@ bunx vitest run src/components/Option/Watchlists/JobsTab/__tests__/schedule-util
 
 Expected: FAIL because presets are fixed to hourly/every6/daily/weekly.
 
-- [ ] **Step 3: Implement interval preset state**
+- [x] **Step 3: Implement interval preset state**
 
 Update `SchedulePresetKey` and state:
 
@@ -337,7 +337,7 @@ Keep custom cron as the escape hatch for schedules cron can express but the pres
 
 Update `parsePresetFromCron` so existing `*/6` schedules map into the interval model instead of appearing as raw cron after upgrade.
 
-- [ ] **Step 4: Update UI copy and controls**
+- [x] **Step 4: Update UI copy and controls**
 
 In `SchedulePicker.tsx`, use segmented/select controls for:
 
@@ -351,13 +351,13 @@ In `SchedulePicker.tsx`, use segmented/select controls for:
 
 Always show generated cron and a human-readable preview via `CronDisplay`.
 
-- [ ] **Step 5: Run focused tests**
+- [x] **Step 5: Run focused tests**
 
 Run the command from Step 2 again.
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-frequency.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx
@@ -376,7 +376,7 @@ git commit -m "feat: add variable watchlist cadence controls"
 - Test: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx`
 - Test: `apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx`
 
-- [ ] **Step 1: Write failing source settings tests**
+- [x] **Step 1: Write failing source settings tests**
 
 Cover:
 
@@ -386,7 +386,7 @@ Cover:
 - Empty advanced fields do not create noisy settings.
 - Forum source option is enabled only when watchlists settings report `forums_enabled`.
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 ```bash
 cd apps/packages/ui
@@ -395,7 +395,7 @@ bunx vitest run src/components/Option/Watchlists/SourcesTab/__tests__/source-set
 
 Expected: FAIL because settings are not exposed or submitted.
 
-- [ ] **Step 3: Implement pure merge helpers**
+- [x] **Step 3: Implement pure merge helpers**
 
 Add helpers:
 
@@ -411,7 +411,7 @@ export const mergeSourceSettings = (
 
 Use more specific functions for scrape rules, so fields can be deleted intentionally without wiping unrelated advanced settings.
 
-- [ ] **Step 4: Update `SourceFormModal`**
+- [x] **Step 4: Update `SourceFormModal`**
 
 Change `onSubmit` values to include `settings`.
 
@@ -432,7 +432,7 @@ await testWatchlistSourceDraft(
 )
 ```
 
-- [ ] **Step 5: Add validation display placeholders**
+- [x] **Step 5: Add validation display placeholders**
 
 Show a compact diagnostics block when preview response includes:
 
@@ -445,13 +445,13 @@ Show a compact diagnostics block when preview response includes:
 
 Do not invent those fields in the UI if the backend does not return them yet; render only when present.
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run the command from Step 2 again.
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx

--- a/Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
+++ b/Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
@@ -42,6 +42,17 @@ These are verified implementation facts that the PRD must build on.
 - Current source modal gap: `SourceFormModal` only captures name, URL, source type, and tags, and tests only URL/type. It does not expose `settings`, `scrape_rules`, dedupe identity, selector validation, top-link discovery, history, or per-source backoff/seen controls.
 - Current audio UI gap: `JobFormModal` exposes a simple audio toggle, voice, speed, duration, test sample, background URI, and raw voice-map JSON. It does not expose speaker count, speaker roles, script review, per-speaker generation, per-speaker audio artifacts, or final mix status.
 
+## 2.1 Design Review Corrections Added Before Implementation Planning
+
+The review found the PRD directionally correct, but several requirements needed tighter implementation boundaries before being converted into an engineering plan.
+
+- Configurable dedupe identity is a required product/API improvement, not a verified current capability. The current system has per-source seen state and a fixed key fallback order; user-editable identity rules need backend work.
+- Typed source settings must be additive. The UI must read and write known fields without deleting unknown `settings` keys already used by advanced users or future backend features.
+- Scheduled digest/newsletter delivery depends on monitor output preferences. A run only creates recurring reports when `job_output_prefs.auto_output.enabled` or an equivalent backend contract is set; one-off test runs can still use explicit output creation.
+- Email delivery state belongs to the output artifact. Setup can validate availability and recipients, but success/failure/skipped status must be attached to the generated output or delivery attempt.
+- Multi-speaker audio requires persisted intermediate artifacts. The UI cannot credibly show script review, per-speaker generation, retry, or final mixing unless the workflow persists script, per-speaker clips, final mix, and fallback reason.
+- The guided pipeline must be additive. It should launch from an empty-state or primary CTA and reuse existing tabs/components; it must not remove the current full-control watchlists workflow used by news, OSINT, and CTI users.
+
 ## 3. Personas
 
 ### First-Time News User
@@ -85,7 +96,7 @@ Sources own fetch/extraction/dedupe identity:
 - URL and source type.
 - RSS normalization and conditional fetch metadata.
 - Website extraction rules: selectors, schema DSL, pagination, alternates, discovery settings.
-- Dedupe identity configuration: default key order is existing behavior; advanced rules can choose GUID, canonical URL, selector-derived ID, title, or content hash fallback.
+- Dedupe identity configuration: default key order is existing behavior; advanced user-editable rules for GUID, canonical URL, selector-derived ID, title, or content hash fallback require backend/API support before the UI exposes them as more than preview text.
 - Per-source seen state, backoff, disabled/deferred status, test results, and selector validation.
 
 ### Per-Monitor Ownership
@@ -157,23 +168,23 @@ Monitors own workflow intent:
 
 - R1: Add typed frontend support for all backend watchlist output audio fields, including `generate_audio`, target minutes, voice/model/speed, language, provider/model, persona fields, background options, and `voice_map`.
 - R2: Add a typed frontend service for `GET /watchlists/runs/{run_id}/audio`.
-- R3: Add source settings types for common scrape rules and discovery/dedupe options while keeping raw advanced JSON escape hatches.
+- R3: Add source settings types for common scrape rules and discovery/dedupe options while keeping raw advanced JSON escape hatches and preserving unknown `settings` keys on edit.
 - R4: Make `SourceFormModal` submit source `settings` instead of dropping them.
 - R5: Make forum source UI capability-driven from `/watchlists/settings`; disabled only when `forums_enabled` is false.
 - R6: Add recognition-friendly variable cadence controls that generate cron and honor the existing backend minimum interval.
-- R7: Expose `auto_output.enabled` in job output settings so scheduled monitors can create digest reports automatically.
-- R8: Surface email/chatbook delivery availability and skipped/failed statuses in setup review and output preview.
+- R7: Expose `auto_output.enabled` in job output settings so scheduled monitors can create digest reports automatically; keep explicit output creation for test runs and manual previews.
+- R8: Surface email/chatbook delivery availability in setup review and attach skipped/failed/sent statuses to output artifacts after generation.
 - R9: Keep existing tabs, aliases, deep links, and "Show all views" behavior intact.
 
 ### P1: Guided Pipeline MVP Inside `/watchlists`
 
 - R10: Replace the current partial "Briefing pipeline builder" with a complete create pipeline flow covering sources, monitor, digest/newsletter, optional 1-4 speaker audio, and review.
-- R11: Source setup must show fetch/extraction test results, selector validation warnings, dedupe identity preview, and whether a source will use RSS, scrape rules, or top-link discovery.
+- R11: Source setup must show fetch/extraction test results, selector validation warnings, dedupe identity preview, and whether a source will use RSS, scrape rules, or top-link discovery. If selector validation is not externally reachable today, add a route or expand source test responses to return those diagnostics.
 - R12: Monitor setup must show filter impact preview, include-only behavior, cadence summary, next run time, and delivery/audio expectations.
 - R13: Digest setup must preview rendered Markdown/HTML where run context exists, and show a credible sample otherwise.
 - R14: Email setup must validate recipients before save and explain fallback-to-user-email behavior only when relevant.
 - R15: Audio setup must support 1-4 speakers through structured controls, not raw JSON only.
-- R16: Audio MVP must produce visible script, per-speaker script/audio status, final mixed output status, and playable final audio inside `/watchlists`.
+- R16: Audio MVP must produce visible script, per-speaker script/audio status, final mixed output status, and playable final audio inside `/watchlists`; this requires workflow/output artifact persistence, not just polling final audio status.
 - R17: On run completion, Reports must show digest output, delivery status, audio task status, final audio player, and retry entry points.
 - R18: Activity must show when a run has an output, pending audio task, skipped audio, failed audio, or final audio artifact.
 
@@ -204,39 +215,57 @@ Goal: Remove the current frontend/backend mismatch without changing the full use
 
 Deliverables:
 
-- TypeScript contract updates for output audio fields and source settings.
+- TypeScript contract updates for output audio fields and source settings, including a safe merge path that preserves unknown advanced `settings` keys.
 - `getWatchlistRunAudio(runId)` service helper.
 - Source form pass-through for `settings`.
+- Selector/source-test response contract that returns validation diagnostics, or a new validation endpoint if the existing test route cannot return them cleanly.
 - Forum UI reads `/watchlists/settings`.
 - Schedule picker supports every N minutes/hours/days/weeks and custom cron.
 - Job output prefs UI exposes `auto_output.enabled`.
 - Reports and Activity can show pending/final audio status from existing APIs.
+- Structured audio cast payload shape for 1-4 speakers, with raw `voice_map` retained as an advanced escape hatch.
 
 Success criteria:
 
 - Existing watchlists tests still pass.
 - Users can configure every 5 hours without writing cron.
 - Frontend can create an output with `generate_audio: true` using typed fields.
+- Editing typed source settings does not delete unknown settings keys.
 - A run with `audio_briefing_task_id` displays pending/final audio state.
 
 ### Phase 1: End-To-End Guided MVP
 
 Goal: A first-time user can complete the core workflow inside `/watchlists`.
 
-Deliverables:
+Phase 1 should be built in dependency order. Do not start by building the full wizard shell if the output/audio contracts cannot yet support the promises shown in the UI.
 
-- "Create pipeline" wizard with Sources, Monitor, Digest, Audio, Review.
-- Source preview panel with extraction warnings, dedupe key preview, and fallback explanation.
-- Monitor preview panel with filter and include-only impact.
-- Digest/newsletter setup with auto-output and email delivery.
+#### Phase 1A: Guided Source And Monitor Setup
+
+- Additive "Create pipeline" entry point from empty state and current overview.
+- Source preview panel with extraction warnings, dedupe key preview, source settings preservation, and fallback explanation.
+- Monitor preview panel with filter and include-only impact, cadence summary, next run time, and explicit create/run/schedule options.
+
+#### Phase 1B: Digest And Newsletter Output
+
+- Digest/newsletter setup with template selection, `auto_output.enabled` for scheduled monitors, and explicit output creation for one-off test runs.
+- Email setup with recipient validation, availability status, and clear post-run delivery status.
+- Reports view showing digest content, source/filter/output provenance, and delivery status.
+
+#### Phase 1C: Optional Audio Briefing
+
 - Optional 1-4 speaker audio setup with structured speaker controls.
 - Script review and per-speaker generation state inside `/watchlists`.
-- Reports view showing digest, delivery, script, per-speaker artifacts, final audio.
+- Workflow/output metadata that persists script, per-speaker artifacts, final audio, and fallback reason.
+- Reports view showing script, per-speaker artifacts, final audio player, and audio retry entry points.
+
+Shared recovery states:
+
 - Recovery states for source test failure, empty preview, invalid schedule, invalid email, output render failure, skipped email, pending audio, failed audio, and fallback single-voice audio.
 
 Success criteria:
 
-- First-time user can create a pipeline, run it, review a digest, and play optional audio without leaving `/watchlists`.
+- First-time user can create a source-backed monitor, run it, and review a digest without leaving `/watchlists`.
+- If audio is enabled, the user can review the script, inspect per-speaker generation state, and play the final audio without leaving `/watchlists`.
 - The UI tells the user what will happen next before save.
 - Failures identify source, monitor, delivery, output, or audio stage.
 
@@ -286,10 +315,12 @@ Success criteria:
 | P0 | Both | Core audio output fields exist in backend but not in frontend `WatchlistOutputCreate` type. | Backend schema has `generate_audio` and audio fields; frontend output create type does not. | R1 |
 | P0 | Both | Run audio artifact endpoint exists but shared UI service does not expose it. | Backend `GET /runs/{run_id}/audio`; frontend search only finds `/api/v1/audio/speech`. | R2, R17, R18 |
 | P0 | First-time | Source settings exist but source modal drops them. | Backend source create/update persists `settings_json`; `SourceFormModal` onSubmit only includes name/url/type/tags. | R3, R4, R11 |
+| P0 | Power user | Typed source settings could accidentally erase advanced raw settings if implemented as replacement JSON. | Source `settings_json` is arbitrary today; advanced users may already rely on keys the first typed UI does not understand. | R3, R4, R25 |
 | P0 | First-time | Arbitrary cadence is possible but hidden behind cron. | Backend cron/min interval support; frontend presets only hourly/every6/daily/weekly. | R6 |
 | P0 | Both | Scheduled digest auto-output exists but is not first-class in current setup. | Pipeline reads `job_output_prefs.auto_output.enabled`; current builder mostly creates output after run or sets template defaults. | R7, R13 |
 | P0 | Both | Email delivery exists but availability/skipped states are not setup-visible enough. | `NotificationsService` may return `skipped: notifications_unavailable`; output preview shows statuses only after output. | R8, R14, R17 |
 | P1 | First-time | Website scraping setup lacks extraction-rule guidance and validation. | `validate_selector_rules` exists; Source UI does not expose it. | R11 |
+| P1 | Both | User-editable dedupe identity is desired but not verified as configurable in the current pipeline. | Current code has per-source seen state and fixed fallback key derivation; the UI cannot honestly offer custom identity rules until API support exists. | R11, R28 |
 | P1 | Both | Audio UI is too low-level and does not support user mental model of 1-4 speakers. | Current UI has voice/speed/duration plus raw voice-map JSON; backend workflow composes multi-voice script. | R15, R16 |
 | P1 | Operator | Audio workflow status is disconnected from watchlists run recovery. | Run stats store `audio_briefing_task_id`; endpoint scans Workflow artifacts. UI does not expose full lifecycle. | R17, R18, R30 |
 | P1 | Power user | Source dedupe seen state exists but is not usable as setup/recovery control. | Per-source seen APIs exist; source UI does not expose dedupe identity/reset as part of setup. | R11, R28 |
@@ -317,13 +348,16 @@ Success criteria:
 - Update `apps/packages/ui/src/types/watchlists.ts`.
 - Update `apps/packages/ui/src/services/watchlists.ts`.
 - Extend `SourceFormModal`, `SourcesTab`, `JobFormModal`, `SchedulePicker`, `OverviewTab`, `RunsTab`, `OutputsTab`, and `OutputPreviewDrawer`.
-- Add a source-rule editor with simple fields first and raw JSON fallback.
+- Add a source-rule editor with simple fields first, raw JSON fallback, and read-modify-write preservation of unknown settings keys.
 - Add a speaker/cast editor that writes structured output prefs and can derive `voice_map`.
+- Keep "Create pipeline" as an additive guided path; do not remove or simplify the current full-tab workflow to ship the wizard.
 
 ### Backend/API-Owned
 
 - Add explicit Pydantic schemas for common `source.settings` and scrape-rule validation responses while preserving arbitrary advanced keys.
 - Expose selector validation through a route if not already externally reachable.
+- Add or document API support for configurable source dedupe identity before exposing editable dedupe-key controls beyond preview/reset.
+- Add a structured `audio_cast` or equivalent speaker schema while preserving `voice_map` for advanced/manual use.
 - Add first-class audio status shape to run detail responses so the frontend does not need to stitch run stats, workflow scans, and output artifacts manually.
 - Add safe retry endpoints for delivery/audio-only retry if existing workflow/task APIs are too generic for `/watchlists`.
 - Add output metadata for script, per-speaker artifacts, final mix, and fallback reason.
@@ -357,9 +391,10 @@ Success criteria:
 ## 13. Testing Requirements
 
 - Unit tests for schedule preset generation, every-N cadence validation, source settings serialization, source rule validation UI helpers, and audio cast payload generation.
-- Frontend component tests for source modal settings, pipeline wizard steps, schedule picker, output delivery statuses, run audio status, and audio preview.
-- Backend tests for source settings validation, run audio status, output delivery metadata, `auto_output.enabled`, and audio workflow metadata.
-- E2E tests for empty-state first-time pipeline creation, digest generation, email configuration validation, optional 1-speaker audio, optional 3-speaker audio, and power-user full-layout clone/run/preview flow.
+- Frontend component tests for source modal settings, unknown settings preservation, pipeline wizard steps, schedule picker, output delivery statuses, run audio status, and audio preview.
+- Backend tests for source settings validation, dedupe identity configuration once added, run audio status, output delivery metadata, `auto_output.enabled`, and audio workflow metadata.
+- Workflow tests proving script, per-speaker audio, final mix, and fallback reason are persisted when audio is enabled.
+- E2E tests for empty-state first-time pipeline creation, digest generation, scheduled auto-output, email configuration validation, optional 1-speaker audio, optional 3-speaker audio, and power-user full-layout clone/run/preview flow.
 - Regression tests to ensure existing tabs, deep links, OPML import/export, templates, item review, and command palette behavior still work.
 
 ## 14. Real Risks And Resolved Non-Questions
@@ -375,27 +410,31 @@ Resolved by code inspection:
 
 Real risks:
 
-- Existing source settings are untyped and could become another raw JSON trap unless the PRD creates a typed simple path.
+- Existing source settings are untyped and could become another raw JSON trap unless the PRD creates a typed simple path without deleting unknown advanced keys.
+- Configurable dedupe identity is not proven as an existing backend setting; exposing it as editable UI before API support would be misleading.
 - The existing audio workflow may not currently persist all intermediate artifacts needed for script review and per-speaker recovery; that requires workflow/output metadata work.
-- Email availability may depend on AuthNZ email configuration; setup must expose skipped/unavailable honestly.
+- Email availability may depend on AuthNZ email configuration; setup must expose skipped/unavailable honestly, and recurring email requires generated outputs from auto-output or equivalent scheduler support.
 - Adding guided workflow must not hide existing OSINT/CTI workflows or slow expert paths.
 - The UI must not imply scheduled outputs will be created unless `auto_output.enabled` or an equivalent backend path is actually set.
 
 ## 15. Implementation Priority
 
 1. Phase 0 contract alignment.
-2. Variable cadence UI and source settings pass-through.
-3. Auto-output and delivery state surfacing.
-4. Run audio service/status in Activity and Reports.
-5. Complete guided pipeline MVP.
-6. Structured 1-4 speaker audio controls and artifact display.
-7. Power-user reuse and batch operations.
-8. Operator diagnostics and retry controls.
-9. Feature-flagged forum source setup.
+2. Variable cadence UI and source settings pass-through with unknown-key preservation.
+3. Source validation diagnostics and honest dedupe identity preview.
+4. Auto-output and delivery state surfacing.
+5. Run audio service/status in Activity and Reports.
+6. Guided source/monitor/digest flow.
+7. Structured 1-4 speaker audio controls and persisted script/per-speaker/final artifacts.
+8. Power-user reuse and batch operations.
+9. Operator diagnostics and retry controls.
+10. Feature-flagged forum source setup.
 
 ## 16. Acceptance Criteria
 
 - A first-time user can create a source-backed monitor, choose a variable cadence, configure digest/newsletter output, enable email, enable optional 1-4 speaker audio, run once, preview the digest, and play the final audio inside `/watchlists`.
+- Scheduled digest/newsletter creation uses monitor output preferences and does not rely on a manual post-run output action.
+- Optional audio shows script, per-speaker generation state/artifacts, final mix, and fallback reason when applicable.
 - A power user can keep using the full tabbed interface, raw cron, templates, source imports, batch source operations, item review, and advanced controls.
 - An operator can identify source, filter, output, email, and audio failures from `/watchlists` and retry or recover the correct stage.
 - Existing watchlists APIs and UI flows are extended, not replaced.

--- a/Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
+++ b/Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
@@ -1,0 +1,402 @@
+# Watchlists Digest And Audio Briefing PRD
+
+Status: Draft for implementation planning
+Date: 2026-05-18
+Backlog: TASK-424
+Scope: `/watchlists` WebUI and browser-extension shared UI, plus directly connected watchlists APIs, scheduler/workflow jobs, output artifacts, notifications, and run observability.
+
+## 1. Product Summary
+
+`/watchlists` should become the primary place to create, run, monitor, and recover a news scraping to digest to optional audio briefing workflow. The goal is not to replace existing watchlists behavior. The goal is to add a workflow-first path that sits on top of the existing Feeds, Monitors, Activity, Articles, Reports, Templates, and Settings surfaces.
+
+The target workflow must support:
+
+1. Creating news scraping sources for RSS feeds and websites.
+2. Configuring source-level fetch, extraction, and dedupe identity rules.
+3. Configuring monitor-level cadence, scope, inclusion/exclusion filters, output format, and delivery.
+4. Producing a digest or newsletter as an in-app report and optional email/chatbook delivery.
+5. Optionally producing a 1-4 person audio briefing or podcast-style recording inside `/watchlists`.
+6. Reviewing script, per-speaker script/audio artifacts, and final combined audio output without requiring users to leave `/watchlists` for the MVP.
+7. Letting experienced users and operators reuse setups, batch-edit, inspect failures, retry work, and understand what happened.
+
+## 2. Code-Grounded Current State
+
+These are verified implementation facts that the PRD must build on.
+
+- Route and shared UI: `apps/tldw-frontend/pages/watchlists.tsx` dynamically loads `@/routes/option-watchlists`; `option-watchlists.tsx` renders `WatchlistsPlaygroundPage` and supports deep links for tabs, source/job/run/output IDs.
+- Current IA: `WatchlistsPlaygroundPage.tsx` uses a progressive 3-primary-tab layout: Sources/Items/Outputs, with Jobs, Runs, and Templates as secondary inline sections. A full 8-tab layout is available behind "Show all views".
+- Sources: backend source schemas already include `settings: dict[str, Any] | None`; create/update persists `settings_json`. Source types are `rss`, `site`, and feature-flagged `forum`.
+- Source test behavior: RSS sources call `fetch_rss_feed`; site/forum sources use `settings.scrape_rules` when present, otherwise fall back to top-link discovery (`top_n`, `discover_method`).
+- Scrape rules: fetchers already support selector fields such as `entry_selector`, `title_selector`, `summary_selector`, `content_selector`, `author_selector`, `date_selector`, `guid_xpath`, pagination selectors, alternates, and a schema DSL. `validate_selector_rules` already returns selector errors, no-match warnings, non-unique warnings, fragile selector warnings, and optional selector counts.
+- Dedupe: per-source seen state already exists in `source_seen_items`, keyed by `(source_id, item_key)`. RSS/site pipeline keys default to `guid`, normalized URL, title, or content hash fallback. APIs exist to inspect and clear per-source seen state.
+- Monitors/jobs: `scrape_jobs` already stores `scope_json`, `schedule_expr`, `schedule_timezone`, `output_prefs_json`, and `job_filters_json`.
+- Cadence: backend uses APScheduler cron parsing. Minimum interval defaults to 5 minutes through `WATCHLIST_MIN_SCHEDULE_INTERVAL_MINUTES`. Frontend validates the same rule but only exposes hourly, every 6 hours, daily, weekly, and raw cron.
+- Filters: monitor filters already support `keyword`, `author`, `date_range`, `regex`, and `all` with `include`, `exclude`, and `flag`; include-only gating exists through `require_include`.
+- Outputs: output creation supports templates, Markdown/HTML formats, retention, generated variants, delivery plans, email delivery, and Chatbook delivery.
+- Email: `NotificationsService` is used at output creation. If notifications are unavailable, email/chatbook delivery returns a skipped status rather than silently pretending delivery happened.
+- Auto-output: the pipeline can generate a run output automatically when `job_output_prefs.auto_output.enabled` is set.
+- Audio: backend schemas already include `generate_audio`, `target_audio_minutes`, audio model/voice/speed, language, LLM provider/model, persona pre-summarization fields, background audio settings, and `voice_map`.
+- Audio workflow: `audio_briefing_workflow.py` defines a Scheduler workflow with `compose_script`, `clean_script`, `multi_voice_tts`, and single-voice fallback. It is triggered after completed runs or explicit output creation when `generate_audio` is true.
+- Audio retrieval: `GET /api/v1/watchlists/runs/{run_id}/audio` returns task status and final audio artifact/download metadata. The frontend service layer does not currently expose this helper.
+- Frontend gap: `WatchlistOutputCreate` TypeScript type omits many backend audio fields (`generate_audio`, `target_audio_minutes`, `audio_voice`, `voice_map`, etc.), so some valid backend output payloads are not first-class in the shared UI contract.
+- Current source modal gap: `SourceFormModal` only captures name, URL, source type, and tags, and tests only URL/type. It does not expose `settings`, `scrape_rules`, dedupe identity, selector validation, top-link discovery, history, or per-source backoff/seen controls.
+- Current audio UI gap: `JobFormModal` exposes a simple audio toggle, voice, speed, duration, test sample, background URI, and raw voice-map JSON. It does not expose speaker count, speaker roles, script review, per-speaker generation, per-speaker audio artifacts, or final mix status.
+
+## 3. Personas
+
+### First-Time News User
+
+Knows the sites they want to track and wants a daily/weekly/every-N-hours digest without learning cron, JSON, template internals, or workflow terminology. They need confidence that the system found real items, will run when expected, and will produce a digest/newsletter and optional audio briefing.
+
+### Power User / News Junkie / OSINT / CTI Researcher
+
+Already understands sources, scraping, filtering, dedupe, saved views, outputs, and templates. They need speed, batch operations, explicit controls, reusable configurations, filtering precision, failure visibility, and no loss of the existing dense workflows.
+
+### Operator / Admin
+
+Owns reliability. They need to answer what ran, what failed, what is queued, whether a schedule is active, whether email/audio was skipped or failed, when to retry, and which source, selector, filter, provider, or delivery channel caused the problem.
+
+## 4. Goals And Non-Goals
+
+### Goals
+
+- Make the end-to-end digest/audio workflow completable inside `/watchlists`.
+- Preserve all existing tabs, deep links, batch behaviors, templates, OPML, item review, and OSINT/CTI-style workflows.
+- Replace recall-heavy setup with a guided workflow that still reveals advanced controls.
+- Surface the existing backend power instead of building parallel source, delivery, or audio systems.
+- Make variable cadence recognizable: minutes, every N hours, daily, weekdays, weekly, and custom cron.
+- Make source rules and monitor rules separable and understandable.
+- Make every generated digest/audio artifact traceable to source, monitor, run, filters, template, and delivery status.
+
+### Non-Goals
+
+- Do not redesign the whole WebUI.
+- Do not move watchlists into Chat, TTS, Workflow Studio, or another top-level route for the MVP.
+- Do not remove raw cron, raw voice map JSON, templates, OPML, or existing advanced tabs.
+- Do not make forums a default source type until the existing feature flag says they are enabled.
+- Do not create a separate audio product or podcast studio for MVP; use watchlists plus the existing audio/workflow systems.
+
+## 5. Ownership Model
+
+### Per-Source Ownership
+
+Sources own fetch/extraction/dedupe identity:
+
+- URL and source type.
+- RSS normalization and conditional fetch metadata.
+- Website extraction rules: selectors, schema DSL, pagination, alternates, discovery settings.
+- Dedupe identity configuration: default key order is existing behavior; advanced rules can choose GUID, canonical URL, selector-derived ID, title, or content hash fallback.
+- Per-source seen state, backoff, disabled/deferred status, test results, and selector validation.
+
+### Per-Monitor Ownership
+
+Monitors own workflow intent:
+
+- Source/group/tag scope.
+- Cadence and timezone.
+- Inclusion/exclusion/flag filters and include-only behavior.
+- Output expectations: digest/newsletter/template, auto-output, retention, delivery.
+- Optional audio briefing settings: speaker count, cast, target length, voice mapping, script review mode, background audio, final output.
+- Run-now behavior, retry policy, concurrency, and run/delivery recovery.
+
+## 6. Target Workflow
+
+### 6.1 First-Time Workflow
+
+1. User opens `/watchlists` and chooses "Create briefing pipeline".
+2. Step 1, Sources:
+   - Paste one or more RSS/site URLs.
+   - The UI detects RSS vs website where possible.
+   - For RSS, run a feed preview.
+   - For website, offer "simple discovery" first, then "custom extraction rules" if preview is weak.
+   - Show sample items, selector warnings, dedupe identity preview, and "what will count as already seen".
+3. Step 2, Monitor:
+   - Choose sources/groups/tags.
+   - Choose cadence through plain controls: manual, every N minutes, every N hours, daily, weekdays, weekly, or advanced cron.
+   - Add optional include/exclude/flag filters with live preview counts.
+4. Step 3, Digest:
+   - Choose digest/report type: Markdown briefing, HTML newsletter, structured review.
+   - Enable email delivery and enter recipients if desired.
+   - Preview expected digest output using sample or latest completed run.
+5. Step 4, Optional Audio:
+   - Choose "No audio", "1 speaker", "2 speakers", "3 speakers", or "4 speakers".
+   - Select speaker roles and voices.
+   - Generate or preview script inside `/watchlists`.
+   - Generate per-speaker script/audio artifacts.
+   - Combine voices into final audio.
+   - Show fallback behavior if multi-voice generation fails.
+6. Step 5, Review and Run:
+   - Show plain-language summary: sources, dedupe key, cadence, filters, output, delivery, audio, first run behavior.
+   - User can create only, create and test run, or create and schedule.
+7. After completion:
+   - If a run starts, land on Activity with live logs and next-step status.
+   - When output exists, deep-link to Reports with digest preview, delivery status, audio status/player, and retry controls.
+
+### 6.2 Power-User Workflow
+
+1. User opens `/watchlists` in full-view or command-palette mode.
+2. User imports or batch-selects sources.
+3. User applies source rule templates or edits source settings directly.
+4. User batch-tests sources and sees extraction/dedupe failures inline.
+5. User creates or clones a monitor from an existing template.
+6. User sets cadence, filters, output, delivery, and audio cast from saved presets.
+7. User runs a preview, inspects filter/dedupe tallies, and saves.
+8. User monitors run queues, retries failed stages, exports evidence, and reuses generated artifacts.
+
+### 6.3 Operator Workflow
+
+1. User opens `/watchlists` overview or Activity.
+2. User sees failed/deferred/disabled sources, failed runs, skipped deliveries, pending audio tasks, and stale schedules.
+3. User drills into run detail: source fetch, extraction, dedupe, filters, output render, delivery, audio workflow.
+4. User retries a failed stage where safe, clears dedupe/backoff when intentional, or disables a bad source.
+5. User can export run logs/tallies and inspect scheduler linkage when authorized.
+
+## 7. Requirements
+
+### P0: Contract And Surface Fixes
+
+- R1: Add typed frontend support for all backend watchlist output audio fields, including `generate_audio`, target minutes, voice/model/speed, language, provider/model, persona fields, background options, and `voice_map`.
+- R2: Add a typed frontend service for `GET /watchlists/runs/{run_id}/audio`.
+- R3: Add source settings types for common scrape rules and discovery/dedupe options while keeping raw advanced JSON escape hatches.
+- R4: Make `SourceFormModal` submit source `settings` instead of dropping them.
+- R5: Make forum source UI capability-driven from `/watchlists/settings`; disabled only when `forums_enabled` is false.
+- R6: Add recognition-friendly variable cadence controls that generate cron and honor the existing backend minimum interval.
+- R7: Expose `auto_output.enabled` in job output settings so scheduled monitors can create digest reports automatically.
+- R8: Surface email/chatbook delivery availability and skipped/failed statuses in setup review and output preview.
+- R9: Keep existing tabs, aliases, deep links, and "Show all views" behavior intact.
+
+### P1: Guided Pipeline MVP Inside `/watchlists`
+
+- R10: Replace the current partial "Briefing pipeline builder" with a complete create pipeline flow covering sources, monitor, digest/newsletter, optional 1-4 speaker audio, and review.
+- R11: Source setup must show fetch/extraction test results, selector validation warnings, dedupe identity preview, and whether a source will use RSS, scrape rules, or top-link discovery.
+- R12: Monitor setup must show filter impact preview, include-only behavior, cadence summary, next run time, and delivery/audio expectations.
+- R13: Digest setup must preview rendered Markdown/HTML where run context exists, and show a credible sample otherwise.
+- R14: Email setup must validate recipients before save and explain fallback-to-user-email behavior only when relevant.
+- R15: Audio setup must support 1-4 speakers through structured controls, not raw JSON only.
+- R16: Audio MVP must produce visible script, per-speaker script/audio status, final mixed output status, and playable final audio inside `/watchlists`.
+- R17: On run completion, Reports must show digest output, delivery status, audio task status, final audio player, and retry entry points.
+- R18: Activity must show when a run has an output, pending audio task, skipped audio, failed audio, or final audio artifact.
+
+### P2: Power-User And Reuse
+
+- R19: Add clone monitor, clone source rules, saved pipeline presets, saved audio cast presets, and reusable delivery presets.
+- R20: Add batch operations for monitors and outputs, not only sources/items.
+- R21: Add batch source rule testing and validation for selected feeds/sites.
+- R22: Add saved filter sets and template/output presets for repeated daily workflows.
+- R23: Add bulk retry for failed runs/deliveries/audio tasks with clear limits and progress.
+- R24: Add compact observability columns: next run, last run, new/duplicate/filtered counts, output status, delivery status, audio status.
+- R25: Preserve raw JSON/cron/power-user controls behind advanced disclosure.
+
+### P3: Operator/Admin Hardening
+
+- R26: Add operator-oriented failure dashboard sections inside `/watchlists`: source health, scheduler health, delivery health, audio workflow health.
+- R27: Expose scheduler/workflow IDs only for authorized users and label them as diagnostic details.
+- R28: Add safe source dedupe/backoff reset controls with confirmation and audit-friendly result summaries.
+- R29: Add downloadable run diagnostic bundle: run metadata, source statuses, filter tallies, output metadata, delivery statuses, audio task metadata, and logs.
+- R30: Add delivery retry and audio retry semantics that do not duplicate source ingestion unless the user explicitly reruns ingestion.
+- R31: Add capability-driven forum setup when the backend feature flag is enabled.
+
+## 8. Phased Delivery Plan
+
+### Phase 0: Contract Alignment And Code Truth
+
+Goal: Remove the current frontend/backend mismatch without changing the full user journey yet.
+
+Deliverables:
+
+- TypeScript contract updates for output audio fields and source settings.
+- `getWatchlistRunAudio(runId)` service helper.
+- Source form pass-through for `settings`.
+- Forum UI reads `/watchlists/settings`.
+- Schedule picker supports every N minutes/hours/days/weeks and custom cron.
+- Job output prefs UI exposes `auto_output.enabled`.
+- Reports and Activity can show pending/final audio status from existing APIs.
+
+Success criteria:
+
+- Existing watchlists tests still pass.
+- Users can configure every 5 hours without writing cron.
+- Frontend can create an output with `generate_audio: true` using typed fields.
+- A run with `audio_briefing_task_id` displays pending/final audio state.
+
+### Phase 1: End-To-End Guided MVP
+
+Goal: A first-time user can complete the core workflow inside `/watchlists`.
+
+Deliverables:
+
+- "Create pipeline" wizard with Sources, Monitor, Digest, Audio, Review.
+- Source preview panel with extraction warnings, dedupe key preview, and fallback explanation.
+- Monitor preview panel with filter and include-only impact.
+- Digest/newsletter setup with auto-output and email delivery.
+- Optional 1-4 speaker audio setup with structured speaker controls.
+- Script review and per-speaker generation state inside `/watchlists`.
+- Reports view showing digest, delivery, script, per-speaker artifacts, final audio.
+- Recovery states for source test failure, empty preview, invalid schedule, invalid email, output render failure, skipped email, pending audio, failed audio, and fallback single-voice audio.
+
+Success criteria:
+
+- First-time user can create a pipeline, run it, review a digest, and play optional audio without leaving `/watchlists`.
+- The UI tells the user what will happen next before save.
+- Failures identify source, monitor, delivery, output, or audio stage.
+
+### Phase 2: Power-User Throughput
+
+Goal: Make repeated daily use fast and controllable.
+
+Deliverables:
+
+- Clone monitor/source rule/audio cast/delivery preset.
+- Saved source rule templates and saved monitor templates.
+- Batch source validation.
+- Batch monitor activation, schedule change, delivery change, and retry.
+- Advanced table columns for new/duplicate/filtered/output/delivery/audio status.
+- Saved views for common OSINT/CTI workflows.
+- Keyboard/command palette actions for create, clone, run, preview, retry, export.
+
+Success criteria:
+
+- Power users can create a new related pipeline from an existing one in under two minutes.
+- Batch operations have progress and partial-failure recovery.
+- Existing dense review workflows remain available.
+
+### Phase 3: Operator And Admin Reliability
+
+Goal: Make production-like operation explainable and recoverable.
+
+Deliverables:
+
+- Operator dashboard inside `/watchlists`.
+- Diagnostic run bundle export.
+- Delivery and audio retry controls.
+- Source dedupe/backoff reset with confirmation and audit text.
+- Capability-driven forum source setup.
+- Scheduler/workflow diagnostic details for authorized users.
+
+Success criteria:
+
+- Operators can identify and recover common failures without shell access.
+- Retrying delivery/audio does not accidentally rerun scraping.
+- Forum setup appears only when backend capability is enabled.
+
+## 9. Issue-To-Requirement Mapping
+
+| Severity | User Type | Issue | Evidence | Requirement |
+| --- | --- | --- | --- | --- |
+| P0 | Both | Core audio output fields exist in backend but not in frontend `WatchlistOutputCreate` type. | Backend schema has `generate_audio` and audio fields; frontend output create type does not. | R1 |
+| P0 | Both | Run audio artifact endpoint exists but shared UI service does not expose it. | Backend `GET /runs/{run_id}/audio`; frontend search only finds `/api/v1/audio/speech`. | R2, R17, R18 |
+| P0 | First-time | Source settings exist but source modal drops them. | Backend source create/update persists `settings_json`; `SourceFormModal` onSubmit only includes name/url/type/tags. | R3, R4, R11 |
+| P0 | First-time | Arbitrary cadence is possible but hidden behind cron. | Backend cron/min interval support; frontend presets only hourly/every6/daily/weekly. | R6 |
+| P0 | Both | Scheduled digest auto-output exists but is not first-class in current setup. | Pipeline reads `job_output_prefs.auto_output.enabled`; current builder mostly creates output after run or sets template defaults. | R7, R13 |
+| P0 | Both | Email delivery exists but availability/skipped states are not setup-visible enough. | `NotificationsService` may return `skipped: notifications_unavailable`; output preview shows statuses only after output. | R8, R14, R17 |
+| P1 | First-time | Website scraping setup lacks extraction-rule guidance and validation. | `validate_selector_rules` exists; Source UI does not expose it. | R11 |
+| P1 | Both | Audio UI is too low-level and does not support user mental model of 1-4 speakers. | Current UI has voice/speed/duration plus raw voice-map JSON; backend workflow composes multi-voice script. | R15, R16 |
+| P1 | Operator | Audio workflow status is disconnected from watchlists run recovery. | Run stats store `audio_briefing_task_id`; endpoint scans Workflow artifacts. UI does not expose full lifecycle. | R17, R18, R30 |
+| P1 | Power user | Source dedupe seen state exists but is not usable as setup/recovery control. | Per-source seen APIs exist; source UI does not expose dedupe identity/reset as part of setup. | R11, R28 |
+| P2 | Power user | Existing batch operations are uneven. | Sources/items have batch controls; monitors/outputs have weaker batch/reuse. | R19-R24 |
+| P2 | Both | Progressive IA hides some direct controls for users who know the system. | Full layout exists behind "Show all views"; PRD must preserve and improve expert access. | R9, R25 |
+
+## 10. UX And Interaction Requirements
+
+- Empty state must offer two paths: "Create briefing pipeline" and "Open full controls".
+- Every setup step must show what data will be created or changed.
+- Preview states must distinguish: not tested, loading, found items, no items, partial warning, failed.
+- Schedule UI must always show cron output and next run time after selection.
+- Source testing must label which fetch mode was used: RSS, scrape rules, discovery fallback, or forum.
+- Filter preview must show ingestable, filtered, flagged, include-only gated, and sample matched items.
+- Output preview must distinguish sample preview from real run output.
+- Email delivery must show recipient count, validation state, and delivery availability.
+- Audio must use a cast metaphor: speaker role, voice, style/persona, script section, generated audio, final mix.
+- Advanced controls must remain available but not required for the first successful pipeline.
+- Accessibility: wizard steps, drawers, audio players, validation errors, and live run status must have keyboard and screen-reader support. Existing focus restoration patterns should be reused.
+
+## 11. API, Backend, And Scheduler Recommendations
+
+### Frontend-Owned
+
+- Update `apps/packages/ui/src/types/watchlists.ts`.
+- Update `apps/packages/ui/src/services/watchlists.ts`.
+- Extend `SourceFormModal`, `SourcesTab`, `JobFormModal`, `SchedulePicker`, `OverviewTab`, `RunsTab`, `OutputsTab`, and `OutputPreviewDrawer`.
+- Add a source-rule editor with simple fields first and raw JSON fallback.
+- Add a speaker/cast editor that writes structured output prefs and can derive `voice_map`.
+
+### Backend/API-Owned
+
+- Add explicit Pydantic schemas for common `source.settings` and scrape-rule validation responses while preserving arbitrary advanced keys.
+- Expose selector validation through a route if not already externally reachable.
+- Add first-class audio status shape to run detail responses so the frontend does not need to stitch run stats, workflow scans, and output artifacts manually.
+- Add safe retry endpoints for delivery/audio-only retry if existing workflow/task APIs are too generic for `/watchlists`.
+- Add output metadata for script, per-speaker artifacts, final mix, and fallback reason.
+
+### Scheduler/Workflow-Owned
+
+- Keep using the existing Watchlists/Scheduler/Workflow path for audio; do not create a separate podcast job system.
+- Extend `audio_briefing_workflow` inputs to accept structured speaker config, script review mode, and per-speaker artifact naming.
+- Persist script and per-speaker artifacts as workflow/watchlist output artifacts.
+- Ensure fallback single-voice audio is visible as fallback, not as full multi-speaker success.
+
+### Notifications-Owned
+
+- Surface whether email delivery is configured before users save a recurring newsletter.
+- Preserve skipped/partial/failed delivery status details in output metadata.
+- Add retry semantics for delivery without regenerating output content unless explicitly requested.
+
+## 12. Measurement
+
+- First-time source setup success rate.
+- Time from empty `/watchlists` to first successful run.
+- Time from first successful run to first digest output.
+- Time from first digest output to playable audio output when audio is enabled.
+- Percentage of users who can configure non-daily cadence without raw cron.
+- Source preview failure rate by source type.
+- Selector validation warning rate and fix-through rate.
+- Delivery success/skipped/failed rate.
+- Audio compose/TTS/fallback/failure rate.
+- Power-user batch operation success and partial failure recovery rate.
+
+## 13. Testing Requirements
+
+- Unit tests for schedule preset generation, every-N cadence validation, source settings serialization, source rule validation UI helpers, and audio cast payload generation.
+- Frontend component tests for source modal settings, pipeline wizard steps, schedule picker, output delivery statuses, run audio status, and audio preview.
+- Backend tests for source settings validation, run audio status, output delivery metadata, `auto_output.enabled`, and audio workflow metadata.
+- E2E tests for empty-state first-time pipeline creation, digest generation, email configuration validation, optional 1-speaker audio, optional 3-speaker audio, and power-user full-layout clone/run/preview flow.
+- Regression tests to ensure existing tabs, deep links, OPML import/export, templates, item review, and command palette behavior still work.
+
+## 14. Real Risks And Resolved Non-Questions
+
+Resolved by code inspection:
+
+- Cadence is not an open backend question. Cron plus minimum interval validation already exists.
+- Email delivery is not an open backend question. It exists through `NotificationsService`, with skipped status when unavailable.
+- Audio briefing is not an open backend question. There is an existing Scheduler workflow with compose, clean, multi-voice TTS, and fallback.
+- Source settings are not an open storage question. Sources already persist arbitrary settings JSON.
+- Source dedupe ownership is not an open DB question. Dedupe seen state is per source.
+- Filters are not an open rule-engine question. The existing monitor filter engine is the baseline.
+
+Real risks:
+
+- Existing source settings are untyped and could become another raw JSON trap unless the PRD creates a typed simple path.
+- The existing audio workflow may not currently persist all intermediate artifacts needed for script review and per-speaker recovery; that requires workflow/output metadata work.
+- Email availability may depend on AuthNZ email configuration; setup must expose skipped/unavailable honestly.
+- Adding guided workflow must not hide existing OSINT/CTI workflows or slow expert paths.
+- The UI must not imply scheduled outputs will be created unless `auto_output.enabled` or an equivalent backend path is actually set.
+
+## 15. Implementation Priority
+
+1. Phase 0 contract alignment.
+2. Variable cadence UI and source settings pass-through.
+3. Auto-output and delivery state surfacing.
+4. Run audio service/status in Activity and Reports.
+5. Complete guided pipeline MVP.
+6. Structured 1-4 speaker audio controls and artifact display.
+7. Power-user reuse and batch operations.
+8. Operator diagnostics and retry controls.
+9. Feature-flagged forum source setup.
+
+## 16. Acceptance Criteria
+
+- A first-time user can create a source-backed monitor, choose a variable cadence, configure digest/newsletter output, enable email, enable optional 1-4 speaker audio, run once, preview the digest, and play the final audio inside `/watchlists`.
+- A power user can keep using the full tabbed interface, raw cron, templates, source imports, batch source operations, item review, and advanced controls.
+- An operator can identify source, filter, output, email, and audio failures from `/watchlists` and retry or recover the correct stage.
+- Existing watchlists APIs and UI flows are extended, not replaced.
+- The implementation plan can split work by frontend contract, source setup, monitor/output setup, audio workflow/artifacts, delivery/notifications, and observability.

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx
@@ -7,6 +7,10 @@ import { trackWatchlistsPreventionTelemetry } from "@/utils/watchlists-preventio
 import {
   buildCronFromPreset,
   createDefaultPresetState,
+  INTERVAL_HOURS_MAX,
+  INTERVAL_HOURS_MIN,
+  INTERVAL_MINUTES_MAX,
+  INTERVAL_MINUTES_MIN,
   parsePresetFromCron,
   type PresetScheduleState,
   type ScheduleIntervalUnit,
@@ -198,8 +202,10 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
 
   const handleIntervalValueChange = (value: number | null) => {
     updatePresetState((previous) => {
-      const min = previous.intervalUnit === "minutes" ? 5 : 1
-      const max = previous.intervalUnit === "minutes" ? 59 : 23
+      const min =
+        previous.intervalUnit === "minutes" ? INTERVAL_MINUTES_MIN : INTERVAL_HOURS_MIN
+      const max =
+        previous.intervalUnit === "minutes" ? INTERVAL_MINUTES_MAX : INTERVAL_HOURS_MAX
       const parsed = typeof value === "number" && value >= min ? Math.floor(value) : min
       return {
         ...previous,
@@ -210,8 +216,8 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
 
   const handleIntervalUnitChange = (intervalUnit: ScheduleIntervalUnit) => {
     updatePresetState((previous) => {
-      const min = intervalUnit === "minutes" ? 5 : 1
-      const max = intervalUnit === "minutes" ? 59 : 23
+      const min = intervalUnit === "minutes" ? INTERVAL_MINUTES_MIN : INTERVAL_HOURS_MIN
+      const max = intervalUnit === "minutes" ? INTERVAL_MINUTES_MAX : INTERVAL_HOURS_MAX
       return {
         ...previous,
         intervalUnit,
@@ -329,8 +335,16 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
                 </div>
                 <InputNumber
                   aria-label={t("watchlists:schedule.intervalValueA11y", "Interval value")}
-                  min={presetState.intervalUnit === "minutes" ? 5 : 1}
-                  max={presetState.intervalUnit === "minutes" ? 59 : 23}
+                  min={
+                    presetState.intervalUnit === "minutes"
+                      ? INTERVAL_MINUTES_MIN
+                      : INTERVAL_HOURS_MIN
+                  }
+                  max={
+                    presetState.intervalUnit === "minutes"
+                      ? INTERVAL_MINUTES_MAX
+                      : INTERVAL_HOURS_MAX
+                  }
                   precision={0}
                   value={presetState.intervalValue}
                   onChange={handleIntervalValueChange}

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx
@@ -9,6 +9,7 @@ import {
   createDefaultPresetState,
   parsePresetFromCron,
   type PresetScheduleState,
+  type ScheduleIntervalUnit,
   type SchedulePresetKey,
   type WeekdayToken
 } from "./schedule-utils"
@@ -44,6 +45,11 @@ const WEEKDAY_OPTIONS: Array<{ value: WeekdayToken; label: string }> = [
   { value: "FRI", label: "Friday" },
   { value: "SAT", label: "Saturday" },
   { value: "SUN", label: "Sunday" }
+]
+
+const INTERVAL_UNIT_OPTIONS: Array<{ value: ScheduleIntervalUnit; label: string }> = [
+  { value: "hours", label: "Hours" },
+  { value: "minutes", label: "Minutes" }
 ]
 
 const CRON_FIELDS = 5
@@ -135,19 +141,11 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
     () =>
       [
         {
-          value: "hourly",
-          label: t("watchlists:schedule.preset.hourly.label", "Every hour"),
+          value: "interval",
+          label: t("watchlists:schedule.preset.interval.label", "Every N hours/minutes"),
           description: t(
-            "watchlists:schedule.preset.hourly.description",
-            "Runs once each hour at the selected minute."
-          )
-        },
-        {
-          value: "every6hours",
-          label: t("watchlists:schedule.preset.every6hours.label", "Every 6 hours"),
-          description: t(
-            "watchlists:schedule.preset.every6hours.description",
-            "Runs four times each day at the selected minute."
+            "watchlists:schedule.preset.interval.description",
+            "Runs repeatedly at the interval you choose."
           )
         },
         {
@@ -156,6 +154,14 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
           description: t(
             "watchlists:schedule.preset.daily.description",
             "Runs every day at the selected time."
+          )
+        },
+        {
+          value: "weekdays",
+          label: t("watchlists:schedule.preset.weekdays.label", "Weekdays"),
+          description: t(
+            "watchlists:schedule.preset.weekdays.description",
+            "Runs Monday through Friday at the selected time."
           )
         },
         {
@@ -188,6 +194,30 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
 
   const handlePresetChange = (preset: SchedulePresetKey) => {
     updatePresetState((previous) => ({ ...previous, preset }))
+  }
+
+  const handleIntervalValueChange = (value: number | null) => {
+    updatePresetState((previous) => {
+      const min = previous.intervalUnit === "minutes" ? 5 : 1
+      const max = previous.intervalUnit === "minutes" ? 59 : 23
+      const parsed = typeof value === "number" && value >= min ? Math.floor(value) : min
+      return {
+        ...previous,
+        intervalValue: Math.min(max, parsed)
+      }
+    })
+  }
+
+  const handleIntervalUnitChange = (intervalUnit: ScheduleIntervalUnit) => {
+    updatePresetState((previous) => {
+      const min = intervalUnit === "minutes" ? 5 : 1
+      const max = intervalUnit === "minutes" ? 59 : 23
+      return {
+        ...previous,
+        intervalUnit,
+        intervalValue: Math.min(max, Math.max(min, previous.intervalValue))
+      }
+    })
   }
 
   const handleMinuteChange = (value: number | null) => {
@@ -291,12 +321,48 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
         </div>
 
         <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
-          {(presetState.preset === "daily" || presetState.preset === "weekly") && (
+          {presetState.preset === "interval" && (
+            <>
+              <div>
+                <div className="mb-1 text-xs text-text-muted">
+                  {t("watchlists:schedule.intervalValue", "Every")}
+                </div>
+                <InputNumber
+                  aria-label={t("watchlists:schedule.intervalValueA11y", "Interval value")}
+                  min={presetState.intervalUnit === "minutes" ? 5 : 1}
+                  max={presetState.intervalUnit === "minutes" ? 59 : 23}
+                  precision={0}
+                  value={presetState.intervalValue}
+                  onChange={handleIntervalValueChange}
+                  className="w-full"
+                />
+              </div>
+              <div>
+                <div className="mb-1 text-xs text-text-muted">
+                  {t("watchlists:schedule.intervalUnit", "Unit")}
+                </div>
+                <Select
+                  aria-label={t("watchlists:schedule.intervalUnitA11y", "Interval unit")}
+                  value={presetState.intervalUnit}
+                  onChange={(value) => handleIntervalUnitChange(value as ScheduleIntervalUnit)}
+                  options={INTERVAL_UNIT_OPTIONS.map((item) => ({
+                    value: item.value,
+                    label: t(`watchlists:schedule.intervalUnitOption.${item.value}`, item.label)
+                  }))}
+                  className="w-full"
+                />
+              </div>
+            </>
+          )}
+          {(presetState.preset === "daily" ||
+            presetState.preset === "weekdays" ||
+            presetState.preset === "weekly") && (
             <div>
               <div className="mb-1 text-xs text-text-muted">
                 {t("watchlists:schedule.hour", "Hour")}
               </div>
               <InputNumber
+                aria-label={t("watchlists:schedule.hourA11y", "Hour")}
                 min={0}
                 max={23}
                 precision={0}
@@ -306,31 +372,36 @@ export const SchedulePicker: React.FC<SchedulePickerProps> = ({
               />
             </div>
           )}
-          <div>
-            <div className="mb-1 text-xs text-text-muted">
-              {t("watchlists:schedule.minute", "Minute")}
+          {(presetState.preset !== "interval" || presetState.intervalUnit === "hours") && (
+            <div>
+              <div className="mb-1 text-xs text-text-muted">
+                {t("watchlists:schedule.minute", "Minute")}
+              </div>
+              <InputNumber
+                aria-label={t("watchlists:schedule.minuteA11y", "Minute")}
+                min={0}
+                max={59}
+                precision={0}
+                value={presetState.minute}
+                onChange={handleMinuteChange}
+                className="w-full"
+              />
             </div>
-            <InputNumber
-              min={0}
-              max={59}
-              precision={0}
-              value={presetState.minute}
-              onChange={handleMinuteChange}
-              className="w-full"
-            />
-          </div>
+          )}
           {presetState.preset === "weekly" && (
             <div>
               <div className="mb-1 text-xs text-text-muted">
                 {t("watchlists:schedule.weekday", "Weekday")}
               </div>
               <Select
+                aria-label={t("watchlists:schedule.weekdayA11y", "Weekday")}
                 value={presetState.weekday}
                 onChange={(value) => handleWeekdayChange(value as WeekdayToken)}
                 options={WEEKDAY_OPTIONS.map((item) => ({
                   value: item.value,
                   label: t(`watchlists:schedule.weekdayOption.${item.value}`, item.label)
                 }))}
+                className="w-full"
               />
             </div>
           )}

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx
@@ -113,4 +113,18 @@ describe("SchedulePicker contextual help", () => {
     fireEvent.click(screen.getByRole("button", { name: "Apply" }))
     expect(onChange).toHaveBeenCalledWith("0 9 * * *")
   })
+
+  it("lets users configure every-N-hour cadence without custom cron", async () => {
+    const onChange = vi.fn()
+    render(<SchedulePicker value={null} onChange={onChange} />)
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+    fireEvent.click(await screen.findByText("Every N hours/minutes"))
+    expect(screen.getByLabelText("Interval unit")).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText("Interval value"), { target: { value: "5" } })
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("0 */5 * * *")
+    })
+  })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts
@@ -105,6 +105,8 @@ describe("schedule-utils", () => {
 
   it("returns null for unsupported cron patterns", () => {
     expect(parsePresetFromCron("0 8 1 * *")).toBeNull()
+    expect(parsePresetFromCron("*/1 * * * *")).toBeNull()
+    expect(parsePresetFromCron("*/4 * * * *")).toBeNull()
     expect(parsePresetFromCron("")).toBeNull()
   })
 

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts
@@ -7,34 +7,96 @@ import {
 
 describe("schedule-utils", () => {
   it("builds cron expressions from preset state", () => {
-    expect(buildCronFromPreset({ preset: "hourly", hour: 9, minute: 15, weekday: "MON" })).toBe(
-      "15 * * * *"
-    )
     expect(
-      buildCronFromPreset({ preset: "every6hours", hour: 9, minute: 0, weekday: "MON" })
-    ).toBe("0 */6 * * *")
-    expect(buildCronFromPreset({ preset: "daily", hour: 8, minute: 30, weekday: "MON" })).toBe(
-      "30 8 * * *"
-    )
-    expect(buildCronFromPreset({ preset: "weekly", hour: 7, minute: 45, weekday: "FRI" })).toBe(
-      "45 7 * * FRI"
-    )
+      buildCronFromPreset({
+        preset: "interval",
+        intervalValue: 15,
+        intervalUnit: "minutes",
+        hour: 9,
+        minute: 0,
+        weekday: "MON"
+      })
+    ).toBe("*/15 * * * *")
+    expect(
+      buildCronFromPreset({
+        preset: "interval",
+        intervalValue: 5,
+        intervalUnit: "hours",
+        hour: 9,
+        minute: 0,
+        weekday: "MON"
+      })
+    ).toBe("0 */5 * * *")
+    expect(
+      buildCronFromPreset({
+        preset: "daily",
+        intervalValue: 1,
+        intervalUnit: "hours",
+        hour: 8,
+        minute: 30,
+        weekday: "MON"
+      })
+    ).toBe("30 8 * * *")
+    expect(
+      buildCronFromPreset({
+        preset: "weekdays",
+        intervalValue: 1,
+        intervalUnit: "hours",
+        hour: 8,
+        minute: 0,
+        weekday: "MON"
+      })
+    ).toBe("0 8 * * MON-FRI")
+    expect(
+      buildCronFromPreset({
+        preset: "weekly",
+        intervalValue: 1,
+        intervalUnit: "hours",
+        hour: 7,
+        minute: 45,
+        weekday: "FRI"
+      })
+    ).toBe("45 7 * * FRI")
   })
 
   it("parses supported cron patterns into preset state", () => {
-    expect(parsePresetFromCron("0 * * * *")).toMatchObject({ preset: "hourly", minute: 0 })
+    expect(parsePresetFromCron("*/15 * * * *")).toMatchObject({
+      preset: "interval",
+      intervalUnit: "minutes",
+      intervalValue: 15
+    })
+    expect(parsePresetFromCron("0 * * * *")).toMatchObject({
+      preset: "interval",
+      intervalUnit: "hours",
+      intervalValue: 1,
+      minute: 0
+    })
     expect(parsePresetFromCron("15 */6 * * *")).toMatchObject({
-      preset: "every6hours",
+      preset: "interval",
+      intervalUnit: "hours",
+      intervalValue: 6,
       minute: 15
     })
     expect(parsePresetFromCron("30 9 * * *")).toEqual({
       preset: "daily",
+      intervalValue: 1,
+      intervalUnit: "hours",
       hour: 9,
       minute: 30,
       weekday: "MON"
     })
+    expect(parsePresetFromCron("0 8 * * MON-FRI")).toEqual({
+      preset: "weekdays",
+      intervalValue: 1,
+      intervalUnit: "hours",
+      hour: 8,
+      minute: 0,
+      weekday: "MON"
+    })
     expect(parsePresetFromCron("5 14 * * TUE")).toEqual({
       preset: "weekly",
+      intervalValue: 1,
+      intervalUnit: "hours",
       hour: 14,
       minute: 5,
       weekday: "TUE"
@@ -42,7 +104,6 @@ describe("schedule-utils", () => {
   })
 
   it("returns null for unsupported cron patterns", () => {
-    expect(parsePresetFromCron("*/5 * * * *")).toBeNull()
     expect(parsePresetFromCron("0 8 1 * *")).toBeNull()
     expect(parsePresetFromCron("")).toBeNull()
   })
@@ -50,10 +111,11 @@ describe("schedule-utils", () => {
   it("creates a stable default state", () => {
     expect(createDefaultPresetState()).toEqual({
       preset: "daily",
+      intervalValue: 1,
+      intervalUnit: "hours",
       hour: 9,
       minute: 0,
       weekday: "MON"
     })
   })
 })
-

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts
@@ -1,3 +1,5 @@
+import { MIN_SCHEDULE_INTERVAL_MINUTES } from "./schedule-frequency"
+
 export type SchedulePresetKey = "interval" | "daily" | "weekdays" | "weekly"
 
 export type ScheduleIntervalUnit = "minutes" | "hours"
@@ -12,6 +14,11 @@ export interface PresetScheduleState {
   minute: number
   weekday: WeekdayToken
 }
+
+export const INTERVAL_MINUTES_MIN = MIN_SCHEDULE_INTERVAL_MINUTES
+export const INTERVAL_MINUTES_MAX = 59
+export const INTERVAL_HOURS_MIN = 1
+export const INTERVAL_HOURS_MAX = 23
 
 const WEEKDAY_MAP: Record<string, WeekdayToken> = {
   "0": "SUN",
@@ -71,10 +78,18 @@ export const buildCronFromPreset = (state: PresetScheduleState): string => {
   switch (state.preset) {
     case "interval": {
       if (intervalUnit === "minutes") {
-        const intervalMinutes = clampInteger(state.intervalValue, 5, 59)
+        const intervalMinutes = clampInteger(
+          state.intervalValue,
+          INTERVAL_MINUTES_MIN,
+          INTERVAL_MINUTES_MAX
+        )
         return `*/${intervalMinutes} * * * *`
       }
-      const intervalHours = clampInteger(state.intervalValue, 1, 23)
+      const intervalHours = clampInteger(
+        state.intervalValue,
+        INTERVAL_HOURS_MIN,
+        INTERVAL_HOURS_MAX
+      )
       return `${minute} */${intervalHours} * * *`
     }
     case "weekdays":
@@ -97,7 +112,11 @@ export const parsePresetFromCron = (
   const [minuteToken, hourToken, dayOfMonthToken, monthToken, dayOfWeekToken] = parts
   if (dayOfMonthToken !== "*" || monthToken !== "*") return null
 
-  const minuteStep = parseStepToken(minuteToken, 1, 59)
+  const minuteStep = parseStepToken(
+    minuteToken,
+    INTERVAL_MINUTES_MIN,
+    INTERVAL_MINUTES_MAX
+  )
   if (minuteStep !== null && hourToken === "*" && dayOfWeekToken === "*") {
     return {
       ...DEFAULT_PRESET_STATE,

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts
@@ -1,9 +1,13 @@
-export type SchedulePresetKey = "hourly" | "every6hours" | "daily" | "weekly"
+export type SchedulePresetKey = "interval" | "daily" | "weekdays" | "weekly"
+
+export type ScheduleIntervalUnit = "minutes" | "hours"
 
 export type WeekdayToken = "SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT"
 
 export interface PresetScheduleState {
   preset: SchedulePresetKey
+  intervalValue: number
+  intervalUnit: ScheduleIntervalUnit
   hour: number
   minute: number
   weekday: WeekdayToken
@@ -29,6 +33,8 @@ const WEEKDAY_MAP: Record<string, WeekdayToken> = {
 
 const DEFAULT_PRESET_STATE: PresetScheduleState = {
   preset: "daily",
+  intervalValue: 1,
+  intervalUnit: "hours",
   hour: 9,
   minute: 0,
   weekday: "MON"
@@ -45,16 +51,34 @@ export const normalizeWeekdayToken = (value: unknown): WeekdayToken => {
   return WEEKDAY_MAP[value.toUpperCase()] || DEFAULT_PRESET_STATE.weekday
 }
 
+export const normalizeIntervalUnit = (value: unknown): ScheduleIntervalUnit => {
+  return value === "minutes" ? "minutes" : "hours"
+}
+
+const parseStepToken = (token: string, min: number, max: number): number | null => {
+  if (!token.startsWith("*/")) return null
+  const parsed = Number(token.slice(2))
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) return null
+  return parsed
+}
+
 export const buildCronFromPreset = (state: PresetScheduleState): string => {
   const minute = clampInteger(state.minute, 0, 59)
   const hour = clampInteger(state.hour, 0, 23)
   const weekday = normalizeWeekdayToken(state.weekday)
+  const intervalUnit = normalizeIntervalUnit(state.intervalUnit)
 
   switch (state.preset) {
-    case "hourly":
-      return `${minute} * * * *`
-    case "every6hours":
-      return `${minute} */6 * * *`
+    case "interval": {
+      if (intervalUnit === "minutes") {
+        const intervalMinutes = clampInteger(state.intervalValue, 5, 59)
+        return `*/${intervalMinutes} * * * *`
+      }
+      const intervalHours = clampInteger(state.intervalValue, 1, 23)
+      return `${minute} */${intervalHours} * * *`
+    }
+    case "weekdays":
+      return `${minute} ${hour} * * MON-FRI`
     case "weekly":
       return `${minute} ${hour} * * ${weekday}`
     case "daily":
@@ -73,24 +97,37 @@ export const parsePresetFromCron = (
   const [minuteToken, hourToken, dayOfMonthToken, monthToken, dayOfWeekToken] = parts
   if (dayOfMonthToken !== "*" || monthToken !== "*") return null
 
+  const minuteStep = parseStepToken(minuteToken, 1, 59)
+  if (minuteStep !== null && hourToken === "*" && dayOfWeekToken === "*") {
+    return {
+      ...DEFAULT_PRESET_STATE,
+      preset: "interval",
+      intervalValue: minuteStep,
+      intervalUnit: "minutes"
+    }
+  }
+
   const minute = Number(minuteToken)
   if (!Number.isInteger(minute) || minute < 0 || minute > 59) return null
 
   if (hourToken === "*" && dayOfWeekToken === "*") {
     return {
-      preset: "hourly",
-      hour: DEFAULT_PRESET_STATE.hour,
-      minute,
-      weekday: DEFAULT_PRESET_STATE.weekday
+      ...DEFAULT_PRESET_STATE,
+      preset: "interval",
+      intervalValue: 1,
+      intervalUnit: "hours",
+      minute
     }
   }
 
-  if (hourToken === "*/6" && dayOfWeekToken === "*") {
+  const hourStep = parseStepToken(hourToken, 1, 23)
+  if (hourStep !== null && dayOfWeekToken === "*") {
     return {
-      preset: "every6hours",
-      hour: DEFAULT_PRESET_STATE.hour,
-      minute,
-      weekday: DEFAULT_PRESET_STATE.weekday
+      ...DEFAULT_PRESET_STATE,
+      preset: "interval",
+      intervalValue: hourStep,
+      intervalUnit: "hours",
+      minute
     }
   }
 
@@ -99,16 +136,26 @@ export const parsePresetFromCron = (
 
   if (dayOfWeekToken === "*") {
     return {
+      ...DEFAULT_PRESET_STATE,
       preset: "daily",
       hour,
-      minute,
-      weekday: DEFAULT_PRESET_STATE.weekday
+      minute
+    }
+  }
+
+  if (dayOfWeekToken.toUpperCase() === "MON-FRI") {
+    return {
+      ...DEFAULT_PRESET_STATE,
+      preset: "weekdays",
+      hour,
+      minute
     }
   }
 
   const weekday = WEEKDAY_MAP[dayOfWeekToken.toUpperCase()]
   if (!weekday) return null
   return {
+    ...DEFAULT_PRESET_STATE,
     preset: "weekly",
     hour,
     minute,
@@ -119,4 +166,3 @@ export const parsePresetFromCron = (
 export const createDefaultPresetState = (): PresetScheduleState => ({
   ...DEFAULT_PRESET_STATE
 })
-

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
@@ -7,6 +7,12 @@ import type { WatchlistSource, SourceType } from "@/types/watchlists"
 import { buildWatchlistsModalChrome, useWatchlistsViewport } from "../shared"
 import { mapWatchlistsError } from "../shared/watchlists-error"
 import {
+  buildSourceSettingsPayload,
+  SOURCE_SETTINGS_FORM_FIELDS,
+  sourceSettingsAreEqual,
+  sourceSettingsToFormValues
+} from "./source-settings"
+import {
   getFocusableActiveElement,
   restoreFocusToElement
 } from "../shared/focus-management"
@@ -19,9 +25,11 @@ interface SourceFormModalProps {
     url: string
     source_type: SourceType
     tags: string[]
+    settings?: Record<string, unknown> | null
   }) => Promise<void>
   initialValues?: WatchlistSource
   existingTags: string[]
+  forumsEnabled?: boolean
 }
 
 const toText = (value: unknown, fallback = ""): string =>
@@ -87,7 +95,8 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
   onClose,
   onSubmit,
   initialValues,
-  existingTags
+  existingTags,
+  forumsEnabled = false
 }) => {
   const { t } = useTranslation(["watchlists", "common"])
   const [form] = Form.useForm()
@@ -127,13 +136,15 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
           name: initialValues.name,
           url: initialValues.url,
           source_type: initialValues.source_type,
-          tags: initialValues.tags
+          tags: initialValues.tags,
+          ...sourceSettingsToFormValues(initialValues.settings)
         })
       } else {
         form.resetFields()
         form.setFieldsValue({
           source_type: "rss",
-          tags: []
+          tags: [],
+          ...sourceSettingsToFormValues(null)
         })
       }
       setTestResult(null)
@@ -145,8 +156,19 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
   const handleSubmit = async () => {
     try {
       const values = await form.validateFields()
+      const settingsPayload = buildSourceSettingsPayload(initialValues?.settings, values)
+      const hasInitialSettings =
+        Boolean(initialValues?.settings) &&
+        Object.keys(initialValues?.settings || {}).length > 0
+      const payload = {
+        name: String(values.name || ""),
+        url: String(values.url || ""),
+        source_type: values.source_type as SourceType,
+        tags: Array.isArray(values.tags) ? values.tags : [],
+        ...(settingsPayload || hasInitialSettings ? { settings: settingsPayload || null } : {})
+      }
       setSubmitting(true)
-      await onSubmit(values)
+      await onSubmit(payload)
       form.resetFields()
     } catch (err) {
       // Validation error or submit error - handled by parent
@@ -166,14 +188,20 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
 
   const handleTestSource = async () => {
     try {
-      const values = await form.validateFields(["url", "source_type"])
+      const values = await form.validateFields([
+        "url",
+        "source_type",
+        ...SOURCE_SETTINGS_FORM_FIELDS
+      ])
       const draftUrl = String(values?.url ?? "")
       const draftType = String(values?.source_type ?? "")
+      const settingsPayload = buildSourceSettingsPayload(initialValues?.settings, values)
       const isSavedSourceUnchanged =
         !!testSourceId &&
         !!initialValues &&
         draftUrl === String(initialValues.url) &&
-        draftType === String(initialValues.source_type)
+        draftType === String(initialValues.source_type) &&
+        sourceSettingsAreEqual(initialValues.settings, settingsPayload)
 
       setTestingSource(true)
       setTestError(null)
@@ -184,7 +212,8 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
         : await testWatchlistSourceDraft(
             {
               url: draftUrl,
-              source_type: draftType as SourceType
+              source_type: draftType as SourceType,
+              settings: settingsPayload || null
             },
             { limit: 10 }
           )
@@ -372,10 +401,14 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
         <Form.Item
           name="source_type"
           label={t("watchlists:sources.form.type", "Type")}
-          extra={t(
-            "watchlists:sources.form.forumDisabledHelp",
-            "Forum monitoring is coming soon. Use RSS Feed or Website for now."
-          )}
+          extra={
+            forumsEnabled
+              ? undefined
+              : t(
+                  "watchlists:sources.form.forumDisabledHelp",
+                  "Forum monitoring is coming soon. Use RSS Feed or Website for now."
+                )
+          }
           rules={[
             {
               required: true,
@@ -394,13 +427,152 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
                 value: "site"
               },
               {
-                label: t("watchlists:sources.types.forumComingSoon", "Forum (coming soon)"),
+                label: forumsEnabled
+                  ? t("watchlists:sources.types.forum", "Forum")
+                  : t("watchlists:sources.types.forumComingSoon", "Forum (coming soon)"),
                 value: "forum",
-                disabled: true // Forum support coming later
+                disabled: !forumsEnabled
               }
             ]}
           />
         </Form.Item>
+
+        <details className="mb-4 rounded-md border border-border p-3">
+          <summary className="cursor-pointer text-sm font-medium">
+            {t("watchlists:sources.form.advancedRules", "Advanced fetch and extraction rules")}
+          </summary>
+          <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+            <Form.Item
+              name="source_top_n"
+              label={t("watchlists:sources.form.topN", "Top links limit")}
+              extra={t(
+                "watchlists:sources.form.topNHelp",
+                "For websites without scrape rules, choose how many discovered links to inspect."
+              )}
+            >
+              <Input
+                placeholder={t("watchlists:sources.form.topNPlaceholder", "e.g., 10")}
+              />
+            </Form.Item>
+            <Form.Item
+              name="discover_method"
+              label={t("watchlists:sources.form.discoverMethod", "Discovery method")}
+            >
+              <Select
+                options={[
+                  {
+                    label: t("watchlists:sources.form.discoverAuto", "Auto"),
+                    value: "auto"
+                  },
+                  {
+                    label: t("watchlists:sources.form.discoverFrontpage", "Front page links"),
+                    value: "frontpage"
+                  },
+                  {
+                    label: t("watchlists:sources.form.discoverSearch", "Search provider"),
+                    value: "search"
+                  }
+                ]}
+              />
+            </Form.Item>
+          </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <Form.Item
+              name="scrape_list_url"
+              label={t("watchlists:sources.form.scrapeListUrl", "List page URL")}
+            >
+              <Input
+                placeholder={t(
+                  "watchlists:sources.form.scrapeListUrlPlaceholder",
+                  "Defaults to source URL"
+                )}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_limit"
+              label={t("watchlists:sources.form.scrapeLimit", "Scrape item limit")}
+            >
+              <Input
+                placeholder={t("watchlists:sources.form.scrapeLimitPlaceholder", "e.g., 20")}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_item_selector"
+              label={t("watchlists:sources.form.itemSelector", "Item selector")}
+            >
+              <Input
+                placeholder={t(
+                  "watchlists:sources.form.itemSelectorPlaceholder",
+                  "css:article"
+                )}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_link_selector"
+              label={t("watchlists:sources.form.linkSelector", "Link XPath")}
+            >
+              <Input
+                placeholder={t(
+                  "watchlists:sources.form.linkSelectorPlaceholder",
+                  ".//a/@href"
+                )}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_title_selector"
+              label={t("watchlists:sources.form.titleSelector", "Title selector")}
+            >
+              <Input
+                placeholder={t("watchlists:sources.form.titleSelectorPlaceholder", "css:h2")}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_summary_selector"
+              label={t("watchlists:sources.form.summarySelector", "Summary selector")}
+            >
+              <Input
+                placeholder={t(
+                  "watchlists:sources.form.summarySelectorPlaceholder",
+                  "css:.summary"
+                )}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_content_selector"
+              label={t("watchlists:sources.form.contentSelector", "Content selector")}
+            >
+              <Input
+                placeholder={t(
+                  "watchlists:sources.form.contentSelectorPlaceholder",
+                  "css:.article-body"
+                )}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_date_selector"
+              label={t("watchlists:sources.form.dateSelector", "Published date selector")}
+            >
+              <Input
+                placeholder={t("watchlists:sources.form.dateSelectorPlaceholder", "css:time")}
+              />
+            </Form.Item>
+            <Form.Item
+              name="scrape_guid_selector"
+              label={t("watchlists:sources.form.guidSelector", "Dedupe identity XPath")}
+              extra={t(
+                "watchlists:sources.form.guidSelectorHelp",
+                "Optional stable per-item identity when URLs alone are not reliable."
+              )}
+            >
+              <Input
+                placeholder={t(
+                  "watchlists:sources.form.guidSelectorPlaceholder",
+                  ".//@data-id"
+                )}
+              />
+            </Form.Item>
+          </div>
+        </details>
 
         <Form.Item
           name="tags"

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
@@ -96,12 +96,20 @@ const toDiagnosticList = (value: unknown): string[] => {
 }
 
 const buildDiagnosticsLines = (
-  diagnostics: SourcePreviewDiagnostics | null | undefined
+  diagnostics: SourcePreviewDiagnostics | null | undefined,
+  t: (...args: any[]) => unknown
 ): string[] => {
   if (!diagnostics) return []
   const lines: string[] = []
   if (diagnostics.fetch_mode) {
-    lines.push(`Fetch mode: ${diagnostics.fetch_mode}`)
+    lines.push(
+      toText(
+        t("watchlists:sources.form.fetchModeLine", "Fetch mode: {{value}}", {
+          value: diagnostics.fetch_mode
+        }),
+        `Fetch mode: ${diagnostics.fetch_mode}`
+      )
+    )
   }
   lines.push(...toDiagnosticList(diagnostics.selector_errors))
   lines.push(...toDiagnosticList(diagnostics.selector_warnings))
@@ -109,7 +117,14 @@ const buildDiagnosticsLines = (
   lines.push(...toDiagnosticList(diagnostics.non_unique_warnings))
   lines.push(...toDiagnosticList(diagnostics.fragile_selector_warnings))
   if (diagnostics.dedupe_preview_key) {
-    lines.push(`Dedupe preview key: ${diagnostics.dedupe_preview_key}`)
+    lines.push(
+      toText(
+        t("watchlists:sources.form.dedupePreviewKeyLine", "Dedupe preview key: {{value}}", {
+          value: diagnostics.dedupe_preview_key
+        }),
+        `Dedupe preview key: ${diagnostics.dedupe_preview_key}`
+      )
+    )
   }
   return lines
 }
@@ -136,7 +151,7 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
   const isEditing = !!initialValues
   const testSourceId = typeof initialValues?.id === "number" ? initialValues.id : null
   const modalChrome = buildWatchlistsModalChrome(isConstrained, 500)
-  const diagnosticsLines = buildDiagnosticsLines(testResult?.diagnostics)
+  const diagnosticsLines = buildDiagnosticsLines(testResult?.diagnostics, t)
 
   useLayoutEffect(() => {
     if (open) {

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useRef } from "react"
 import { Alert, Button, Form, Input, Modal, Select, message } from "antd"
 import { useTranslation } from "react-i18next"
 import { testWatchlistSource, testWatchlistSourceDraft } from "@/services/watchlists"
-import type { JobPreviewResult } from "@/types/watchlists"
+import type { JobPreviewResult, SourcePreviewDiagnostics } from "@/types/watchlists"
 import type { WatchlistSource, SourceType } from "@/types/watchlists"
 import { buildWatchlistsModalChrome, useWatchlistsViewport } from "../shared"
 import { mapWatchlistsError } from "../shared/watchlists-error"
@@ -90,6 +90,30 @@ const resolveTestSourceErrorHint = (
   )
 }
 
+const toDiagnosticList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0)
+}
+
+const buildDiagnosticsLines = (
+  diagnostics: SourcePreviewDiagnostics | null | undefined
+): string[] => {
+  if (!diagnostics) return []
+  const lines: string[] = []
+  if (diagnostics.fetch_mode) {
+    lines.push(`Fetch mode: ${diagnostics.fetch_mode}`)
+  }
+  lines.push(...toDiagnosticList(diagnostics.selector_errors))
+  lines.push(...toDiagnosticList(diagnostics.selector_warnings))
+  lines.push(...toDiagnosticList(diagnostics.no_match_warnings))
+  lines.push(...toDiagnosticList(diagnostics.non_unique_warnings))
+  lines.push(...toDiagnosticList(diagnostics.fragile_selector_warnings))
+  if (diagnostics.dedupe_preview_key) {
+    lines.push(`Dedupe preview key: ${diagnostics.dedupe_preview_key}`)
+  }
+  return lines
+}
+
 export const SourceFormModal: React.FC<SourceFormModalProps> = ({
   open,
   onClose,
@@ -112,6 +136,7 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
   const isEditing = !!initialValues
   const testSourceId = typeof initialValues?.id === "number" ? initialValues.id : null
   const modalChrome = buildWatchlistsModalChrome(isConstrained, 500)
+  const diagnosticsLines = buildDiagnosticsLines(testResult?.diagnostics)
 
   useLayoutEffect(() => {
     if (open) {
@@ -376,6 +401,23 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
                   filtered: Number(testResult.filtered || 0),
                   plural: Number(testResult.total || 0) === 1 ? "" : "s"
                 }
+              )}
+            />
+          )}
+          {diagnosticsLines.length > 0 && (
+            <Alert
+              type="info"
+              showIcon
+              message={t(
+                "watchlists:sources.form.validationDiagnostics",
+                "Validation diagnostics"
+              )}
+              description={(
+                <div className="space-y-1">
+                  {diagnosticsLines.map((line) => (
+                    <div key={line}>{line}</div>
+                  ))}
+                </div>
               )}
             />
           )}

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
@@ -147,6 +147,7 @@ export const SourcesTab: React.FC = () => {
   const sourcesPageSize = useWatchlistsStore((s) => s.sourcesPageSize)
   const tags = useWatchlistsStore((s) => s.tags)
   const groups = useWatchlistsStore((s) => s.groups)
+  const settings = useWatchlistsStore((s) => s.settings)
   const groupsLoading = useWatchlistsStore((s) => s.groupsLoading)
   const selectedGroupId = useWatchlistsStore((s) => s.selectedGroupId)
   const selectedTagName = useWatchlistsStore((s) => s.selectedTagName)
@@ -1109,7 +1110,13 @@ export const SourcesTab: React.FC = () => {
 
   // Handle form submit
   const handleFormSubmit = async (
-    values: { name: string; url: string; source_type: SourceType; tags: string[] }
+    values: {
+      name: string
+      url: string
+      source_type: SourceType
+      tags: string[]
+      settings?: Record<string, unknown> | null
+    }
   ) => {
     try {
       if (sourceFormEditId) {
@@ -1831,6 +1838,7 @@ export const SourcesTab: React.FC = () => {
         onSubmit={handleFormSubmit}
         initialValues={editingSource}
         existingTags={(Array.isArray(tags) ? tags : []).map((t) => t.name)}
+        forumsEnabled={Boolean(settings?.forums_enabled)}
       />
 
       <SourcesBulkImport

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx
@@ -75,4 +75,22 @@ describe("SourceFormModal forum type guidance", () => {
     ).toBeInTheDocument()
     expect(screen.getByText("Forum (coming soon)")).toBeInTheDocument()
   })
+
+  it("enables forum source option when the backend capability is enabled", () => {
+    render(
+      <SourceFormModal
+        open
+        forumsEnabled
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        existingTags={[]}
+      />
+    )
+
+    expect(
+      screen.queryByText("Forum monitoring is coming soon. Use RSS Feed or Website for now.")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Forum (coming soon)")).not.toBeInTheDocument()
+    expect(screen.getByText("Forum")).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
@@ -269,6 +269,48 @@ describe("SourceFormModal test-source preflight", () => {
     })
   })
 
+  it("renders optional source validation diagnostics from preview", async () => {
+    formApi.validateFields.mockResolvedValue({
+      url: "https://example.com/news",
+      source_type: "site",
+      scrape_item_selector: "css:article",
+      scrape_link_selector: ".//a/@href",
+      scrape_title_selector: "css:h2",
+      scrape_limit: 10,
+      source_top_n: null,
+      discover_method: "auto"
+    })
+    mocks.testWatchlistSourceDraft.mockResolvedValue({
+      items: [],
+      total: 1,
+      ingestable: 1,
+      filtered: 0,
+      diagnostics: {
+        fetch_mode: "scrape_rules",
+        selector_warnings: ["title selector matched 0 nodes"],
+        dedupe_preview_key: "guid_xpath"
+      }
+    })
+
+    render(
+      <SourceFormModal
+        open
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        existingTags={[]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Test Feed" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Validation diagnostics")).toBeInTheDocument()
+      expect(screen.getByText("Fetch mode: scrape_rules")).toBeInTheDocument()
+      expect(screen.getByText("title selector matched 0 nodes")).toBeInTheDocument()
+      expect(screen.getByText("Dedupe preview key: guid_xpath")).toBeInTheDocument()
+    })
+  })
+
   it("shows inline remediation guidance when draft preflight fails", async () => {
     mocks.testWatchlistSourceDraft.mockRejectedValue(
       new Error("invalid_youtube_rss_url: channel feed required")

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
@@ -131,7 +131,14 @@ describe("SourceFormModal test-source preflight", () => {
     setViewport(1024)
     formApi.validateFields.mockResolvedValue({
       url: "https://example.com/feed.xml",
-      source_type: "rss"
+      source_type: "rss",
+      scrape_item_selector: "",
+      scrape_link_selector: "",
+      scrape_title_selector: "",
+      scrape_summary_selector: "",
+      scrape_limit: null,
+      source_top_n: null,
+      discover_method: "auto"
     })
   })
 
@@ -196,7 +203,8 @@ describe("SourceFormModal test-source preflight", () => {
       expect(mocks.testWatchlistSourceDraft).toHaveBeenCalledWith(
         {
           url: "https://example.com/feed.xml",
-          source_type: "rss"
+          source_type: "rss",
+          settings: null
         },
         { limit: 10 }
       )
@@ -209,6 +217,56 @@ describe("SourceFormModal test-source preflight", () => {
     expect(
       screen.getByText("Run Test Feed to validate URL/type connectivity before saving.")
     ).toBeInTheDocument()
+  })
+
+  it("passes draft source settings to preflight", async () => {
+    formApi.validateFields.mockResolvedValue({
+      url: "https://example.com/news",
+      source_type: "site",
+      scrape_item_selector: "css:article",
+      scrape_link_selector: ".//a/@href",
+      scrape_title_selector: "css:h2",
+      scrape_summary_selector: "css:.summary",
+      scrape_limit: 10,
+      source_top_n: null,
+      discover_method: "auto"
+    })
+    mocks.testWatchlistSourceDraft.mockResolvedValue({
+      items: [],
+      total: 1,
+      ingestable: 1,
+      filtered: 0
+    })
+
+    render(
+      <SourceFormModal
+        open
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        existingTags={[]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Test Feed" }))
+
+    await waitFor(() => {
+      expect(mocks.testWatchlistSourceDraft).toHaveBeenCalledWith(
+        {
+          url: "https://example.com/news",
+          source_type: "site",
+          settings: {
+            scrape_rules: {
+              item_selector: "css:article",
+              link_xpath: ".//a/@href",
+              title_selector: "css:h2",
+              summary_selector: "css:.summary",
+              limit: 10
+            }
+          }
+        },
+        { limit: 10 }
+      )
+    })
   })
 
   it("shows inline remediation guidance when draft preflight fails", async () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts
@@ -10,7 +10,11 @@ describe("source-settings", () => {
       {
         retention: { days: 30 },
         custom_identity: "source-slug",
-        scrape_rules: { title_selector: "css:.old-title" }
+        scrape_rules: {
+          title_selector: "css:.old-title",
+          pagination: { next_link_xpath: ".//a[@rel='next']/@href" },
+          custom_rule: "keep-me"
+        }
       },
       {
         scrape_list_url: "https://example.com/news",
@@ -33,10 +37,32 @@ describe("source-settings", () => {
         link_xpath: ".//a/@href",
         title_selector: "css:h2",
         summary_selector: "css:.deck",
-        limit: 20
+        limit: 20,
+        pagination: { next_link_xpath: ".//a[@rel='next']/@href" },
+        custom_rule: "keep-me"
       },
       top_n: 10,
       discover_method: "frontpage"
+    })
+  })
+
+  it("preserves unknown nested scrape rules when clearing UI-owned rule fields", () => {
+    expect(
+      buildSourceSettingsPayload(
+        {
+          scrape_rules: {
+            item_selector: "css:article",
+            pagination: { next_link_xpath: ".//a[@rel='next']/@href" }
+          }
+        },
+        {
+          scrape_item_selector: ""
+        }
+      )
+    ).toEqual({
+      scrape_rules: {
+        pagination: { next_link_xpath: ".//a[@rel='next']/@href" }
+      }
     })
   })
 

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildSourceSettingsPayload,
+  sourceSettingsToFormValues
+} from "../source-settings"
+
+describe("source-settings", () => {
+  it("preserves unknown keys while serializing website scrape rules", () => {
+    const payload = buildSourceSettingsPayload(
+      {
+        retention: { days: 30 },
+        custom_identity: "source-slug",
+        scrape_rules: { title_selector: "css:.old-title" }
+      },
+      {
+        scrape_list_url: "https://example.com/news",
+        scrape_item_selector: "css:article",
+        scrape_link_selector: ".//a/@href",
+        scrape_title_selector: "css:h2",
+        scrape_summary_selector: "css:.deck",
+        scrape_limit: 20,
+        source_top_n: 10,
+        discover_method: "frontpage"
+      }
+    )
+
+    expect(payload).toEqual({
+      retention: { days: 30 },
+      custom_identity: "source-slug",
+      scrape_rules: {
+        list_url: "https://example.com/news",
+        item_selector: "css:article",
+        link_xpath: ".//a/@href",
+        title_selector: "css:h2",
+        summary_selector: "css:.deck",
+        limit: 20
+      },
+      top_n: 10,
+      discover_method: "frontpage"
+    })
+  })
+
+  it("does not create noisy settings when advanced fields are empty", () => {
+    expect(
+      buildSourceSettingsPayload(null, {
+        scrape_list_url: " ",
+        scrape_item_selector: "",
+        scrape_link_selector: "",
+        discover_method: "auto",
+        source_top_n: null
+      })
+    ).toBeUndefined()
+  })
+
+  it("clears empty advanced rule fields without deleting unrelated settings", () => {
+    expect(
+      buildSourceSettingsPayload(
+        {
+          retention: { days: 7 },
+          scrape_rules: { item_selector: "css:article" },
+          top_n: 5,
+          discover_method: "frontpage"
+        },
+        {
+          scrape_item_selector: "",
+          discover_method: "auto",
+          source_top_n: null
+        }
+      )
+    ).toEqual({
+      retention: { days: 7 }
+    })
+  })
+
+  it("maps existing settings back into editable form values", () => {
+    expect(
+      sourceSettingsToFormValues({
+        scrape_rules: {
+          list_url: "https://example.com/news",
+          item_selector: "css:article",
+          link_xpath: ".//a/@href",
+          title_selector: "css:h2",
+          limit: 15
+        },
+        top_n: 15,
+        discover_method: "frontpage"
+      })
+    ).toEqual({
+      scrape_list_url: "https://example.com/news",
+      scrape_item_selector: "css:article",
+      scrape_link_selector: ".//a/@href",
+      scrape_title_selector: "css:h2",
+      scrape_summary_selector: "",
+      scrape_content_selector: "",
+      scrape_date_selector: "",
+      scrape_guid_selector: "",
+      scrape_limit: 15,
+      source_top_n: 15,
+      discover_method: "frontpage",
+      skip_article_fetch: false
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts
@@ -1,0 +1,172 @@
+export interface SourceSettingsFormValues {
+  scrape_list_url?: unknown
+  scrape_item_selector?: unknown
+  scrape_link_selector?: unknown
+  scrape_title_selector?: unknown
+  scrape_summary_selector?: unknown
+  scrape_content_selector?: unknown
+  scrape_date_selector?: unknown
+  scrape_guid_selector?: unknown
+  scrape_limit?: unknown
+  source_top_n?: unknown
+  discover_method?: unknown
+  skip_article_fetch?: unknown
+}
+
+export interface SourceSettingsFormState {
+  scrape_list_url: string
+  scrape_item_selector: string
+  scrape_link_selector: string
+  scrape_title_selector: string
+  scrape_summary_selector: string
+  scrape_content_selector: string
+  scrape_date_selector: string
+  scrape_guid_selector: string
+  scrape_limit: number | null
+  source_top_n: number | null
+  discover_method: string
+  skip_article_fetch: boolean
+}
+
+export const SOURCE_SETTINGS_FORM_FIELDS = [
+  "scrape_list_url",
+  "scrape_item_selector",
+  "scrape_link_selector",
+  "scrape_title_selector",
+  "scrape_summary_selector",
+  "scrape_content_selector",
+  "scrape_date_selector",
+  "scrape_guid_selector",
+  "scrape_limit",
+  "source_top_n",
+  "discover_method",
+  "skip_article_fetch"
+] as const
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const cleanString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+const cleanPositiveInteger = (value: unknown): number | undefined => {
+  if (value === null || value === undefined || value === "") return undefined
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return undefined
+  const normalized = Math.floor(parsed)
+  return normalized > 0 ? normalized : undefined
+}
+
+const addStringRule = (
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown
+): void => {
+  const cleaned = cleanString(value)
+  if (cleaned) target[key] = cleaned
+}
+
+export const buildScrapeRulesFromForm = (
+  values: SourceSettingsFormValues
+): Record<string, unknown> | undefined => {
+  const scrapeRules: Record<string, unknown> = {}
+
+  addStringRule(scrapeRules, "list_url", values.scrape_list_url)
+  addStringRule(scrapeRules, "item_selector", values.scrape_item_selector)
+  addStringRule(scrapeRules, "link_xpath", values.scrape_link_selector)
+  addStringRule(scrapeRules, "title_selector", values.scrape_title_selector)
+  addStringRule(scrapeRules, "summary_selector", values.scrape_summary_selector)
+  addStringRule(scrapeRules, "content_selector", values.scrape_content_selector)
+  addStringRule(scrapeRules, "date_selector", values.scrape_date_selector)
+  addStringRule(scrapeRules, "guid_xpath", values.scrape_guid_selector)
+
+  const limit = cleanPositiveInteger(values.scrape_limit)
+  if (limit) scrapeRules.limit = limit
+  if (values.skip_article_fetch === true) scrapeRules.skip_article_fetch = true
+
+  return Object.keys(scrapeRules).length > 0 ? scrapeRules : undefined
+}
+
+export const buildSourceSettingsPayload = (
+  existing: Record<string, unknown> | null | undefined,
+  values: SourceSettingsFormValues
+): Record<string, unknown> | undefined => {
+  const next: Record<string, unknown> = isRecord(existing) ? { ...existing } : {}
+  const scrapeRules = buildScrapeRulesFromForm(values)
+
+  if (scrapeRules) {
+    next.scrape_rules = scrapeRules
+  } else {
+    delete next.scrape_rules
+  }
+
+  const topN = cleanPositiveInteger(values.source_top_n)
+  if (topN) {
+    next.top_n = topN
+  } else {
+    delete next.top_n
+  }
+
+  const discoverMethod = cleanString(values.discover_method)
+  if (discoverMethod && discoverMethod !== "auto") {
+    next.discover_method = discoverMethod
+  } else {
+    delete next.discover_method
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined
+}
+
+export const sourceSettingsToFormValues = (
+  settings: Record<string, unknown> | null | undefined
+): SourceSettingsFormState => {
+  const safeSettings = isRecord(settings) ? settings : {}
+  const scrapeRules = isRecord(safeSettings.scrape_rules) ? safeSettings.scrape_rules : {}
+
+  return {
+    scrape_list_url: cleanString(scrapeRules.list_url) || "",
+    scrape_item_selector: cleanString(scrapeRules.item_selector) || "",
+    scrape_link_selector:
+      cleanString(scrapeRules.link_xpath) || cleanString(scrapeRules.url_xpath) || "",
+    scrape_title_selector:
+      cleanString(scrapeRules.title_selector) || cleanString(scrapeRules.title_xpath) || "",
+    scrape_summary_selector:
+      cleanString(scrapeRules.summary_selector) || cleanString(scrapeRules.summary_xpath) || "",
+    scrape_content_selector:
+      cleanString(scrapeRules.content_selector) || cleanString(scrapeRules.content_xpath) || "",
+    scrape_date_selector:
+      cleanString(scrapeRules.date_selector) || cleanString(scrapeRules.date_xpath) || "",
+    scrape_guid_selector:
+      cleanString(scrapeRules.guid_xpath) || cleanString(scrapeRules.id_xpath) || "",
+    scrape_limit: cleanPositiveInteger(scrapeRules.limit) || null,
+    source_top_n: cleanPositiveInteger(safeSettings.top_n) || null,
+    discover_method: cleanString(safeSettings.discover_method) || "auto",
+    skip_article_fetch: scrapeRules.skip_article_fetch === true
+  }
+}
+
+export const sourceSettingsAreEqual = (
+  left: Record<string, unknown> | null | undefined,
+  right: Record<string, unknown> | null | undefined
+): boolean => {
+  const normalizedLeft = isRecord(left) && Object.keys(left).length > 0 ? left : null
+  const normalizedRight = isRecord(right) && Object.keys(right).length > 0 ? right : null
+  return (
+    JSON.stringify(sortJsonKeys(normalizedLeft)) ===
+    JSON.stringify(sortJsonKeys(normalizedRight))
+  )
+}
+
+const sortJsonKeys = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortJsonKeys)
+  if (!isRecord(value)) return value
+  return Object.keys(value)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = sortJsonKeys(value[key])
+      return acc
+    }, {})
+}

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts
@@ -43,6 +43,25 @@ export const SOURCE_SETTINGS_FORM_FIELDS = [
   "skip_article_fetch"
 ] as const
 
+const UI_OWNED_SCRAPE_RULE_KEYS = [
+  "list_url",
+  "item_selector",
+  "link_xpath",
+  "url_xpath",
+  "title_selector",
+  "title_xpath",
+  "summary_selector",
+  "summary_xpath",
+  "content_selector",
+  "content_xpath",
+  "date_selector",
+  "date_xpath",
+  "guid_xpath",
+  "id_xpath",
+  "limit",
+  "skip_article_fetch"
+] as const
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value)
 
@@ -96,9 +115,18 @@ export const buildSourceSettingsPayload = (
 ): Record<string, unknown> | undefined => {
   const next: Record<string, unknown> = isRecord(existing) ? { ...existing } : {}
   const scrapeRules = buildScrapeRulesFromForm(values)
+  const retainedScrapeRules = isRecord(next.scrape_rules) ? { ...next.scrape_rules } : {}
 
-  if (scrapeRules) {
-    next.scrape_rules = scrapeRules
+  for (const key of UI_OWNED_SCRAPE_RULE_KEYS) {
+    delete retainedScrapeRules[key]
+  }
+
+  const mergedScrapeRules = scrapeRules
+    ? { ...retainedScrapeRules, ...scrapeRules }
+    : retainedScrapeRules
+
+  if (Object.keys(mergedScrapeRules).length > 0) {
+    next.scrape_rules = mergedScrapeRules
   } else {
     delete next.scrape_rules
   }

--- a/apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts
+++ b/apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { WatchlistOutputCreate } from "@/types/watchlists"
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn(),
+  bgUpload: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: (...args: unknown[]) => mocks.bgRequest(...args),
+  bgUpload: (...args: unknown[]) => mocks.bgUpload(...args)
+}))
+
+import { getWatchlistRunAudio } from "@/services/watchlists"
+
+describe("watchlists audio services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("fetches run audio briefing status from the watchlists run endpoint", async () => {
+    mocks.bgRequest.mockResolvedValueOnce({
+      run_id: 123,
+      task_id: "task-abc",
+      status: "completed",
+      audio_uri: "file:///tmp/briefing.mp3",
+      download_url: "/api/v1/workflows/artifacts/art-1/download",
+      artifact_id: "art-1",
+      size_bytes: 1024,
+      mime_type: "audio/mpeg"
+    })
+
+    const result = await getWatchlistRunAudio(123)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/watchlists/runs/123/audio",
+        method: "GET"
+      })
+    )
+    expect(result).toEqual({
+      run_id: 123,
+      task_id: "task-abc",
+      status: "completed",
+      audio_uri: "file:///tmp/briefing.mp3",
+      download_url: "/api/v1/workflows/artifacts/art-1/download",
+      artifact_id: "art-1",
+      size_bytes: 1024,
+      mime_type: "audio/mpeg"
+    })
+  })
+
+  it("accepts backend-supported audio fields on output creation payloads", () => {
+    const output = {
+      run_id: 10,
+      generate_audio: true,
+      target_audio_minutes: 12,
+      audio_model: "kokoro",
+      audio_voice: "af_heart",
+      audio_speed: 1.05,
+      background_audio_uri: "file:///tmp/bed.mp3",
+      background_volume: 0.15,
+      background_delay_ms: 250,
+      background_fade_seconds: 2,
+      audio_language: "en",
+      llm_provider: "openai",
+      llm_model: "gpt-4.1-mini",
+      persona_summarize: true,
+      persona_id: "daily-anchor",
+      persona_provider: "openai",
+      persona_model: "gpt-4.1-mini",
+      voice_map: { HOST: "af_bella", ANALYST: "am_adam" },
+      audio_cast: {
+        speaker_count: 2,
+        speakers: [
+          { id: "host", label: "Host", role: "anchor", voice: "af_bella" },
+          { id: "analyst", label: "Analyst", role: "analysis", voice: "am_adam" }
+        ]
+      }
+    } satisfies WatchlistOutputCreate
+
+    expect(output.generate_audio).toBe(true)
+    expect(output.voice_map?.HOST).toBe("af_bella")
+    expect(output.audio_cast?.speaker_count).toBe(2)
+  })
+})

--- a/apps/packages/ui/src/services/watchlists.ts
+++ b/apps/packages/ui/src/services/watchlists.ts
@@ -53,6 +53,7 @@ import type {
   WatchlistOutputEvidenceResponse,
   WatchlistReportReadiness,
   WatchlistRun,
+  WatchlistRunAudioStatus,
   WatchlistSettings,
   WatchlistSource,
   WatchlistSourceCreate,
@@ -668,6 +669,15 @@ export const getWatchlistRun = async (runId: number): Promise<WatchlistRun> => {
 export const getRunDetails = async (runId: number): Promise<RunDetailResponse> => {
   return bgRequest<RunDetailResponse>({
     path: `/api/v1/watchlists/runs/${runId}/details?include_tallies=true` as any,
+    method: "GET"
+  })
+}
+
+export const getWatchlistRunAudio = async (
+  runId: number
+): Promise<WatchlistRunAudioStatus> => {
+  return bgRequest<WatchlistRunAudioStatus>({
+    path: `/api/v1/watchlists/runs/${runId}/audio` as any,
     method: "GET"
   })
 }

--- a/apps/packages/ui/src/types/watchlists.ts
+++ b/apps/packages/ui/src/types/watchlists.ts
@@ -141,12 +141,31 @@ export interface JobScope {
 }
 
 export interface JobOutputPrefs {
+  auto_output?: {
+    enabled?: boolean
+    type?: string
+    format?: "md" | "html"
+    template_name?: string
+    template_version?: number
+  }
   generate_audio?: boolean
   target_audio_minutes?: number
+  audio_model?: string
   audio_voice?: string
   audio_speed?: number
   background_audio_uri?: string
+  background_volume?: number
+  background_delay_ms?: number
+  background_fade_seconds?: number
+  audio_language?: string
+  llm_provider?: string
+  llm_model?: string
+  persona_summarize?: boolean
+  persona_id?: string
+  persona_provider?: string
+  persona_model?: string
   voice_map?: Record<string, string>
+  audio_cast?: WatchlistAudioCast
   retention?: {
     default_seconds?: number
     temporary_seconds?: number
@@ -283,6 +302,35 @@ export interface RunDetailResponse {
   log_path?: string | null
   truncated?: boolean
   filtered_sample?: Array<Record<string, unknown>> | null
+}
+
+export interface WatchlistAudioCastSpeaker {
+  id: string
+  label: string
+  role?: string
+  voice: string
+  persona?: string
+}
+
+export interface WatchlistAudioCast {
+  speaker_count: 1 | 2 | 3 | 4
+  speakers: WatchlistAudioCastSpeaker[]
+}
+
+export interface WatchlistRunAudioStatus {
+  run_id: number
+  task_id?: string | null
+  status: "pending" | "running" | "completed" | "failed" | "unknown" | string
+  audio_uri?: string | null
+  download_url?: string | null
+  artifact_id?: string | number | null
+  size_bytes?: number | null
+  mime_type?: string | null
+  script_artifact?: Record<string, unknown> | null
+  speaker_artifacts?: Array<Record<string, unknown>>
+  final_artifact?: Record<string, unknown> | null
+  fallback_reason?: string | null
+  error?: string | null
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -670,6 +718,24 @@ export interface WatchlistOutputCreate {
   allow_weak_evidence?: boolean
   template_name?: string
   template_version?: number
+  generate_audio?: boolean
+  target_audio_minutes?: number
+  audio_model?: string
+  audio_voice?: string
+  audio_speed?: number
+  background_audio_uri?: string
+  background_volume?: number
+  background_delay_ms?: number
+  background_fade_seconds?: number
+  audio_language?: string
+  llm_provider?: string
+  llm_model?: string
+  persona_summarize?: boolean
+  persona_id?: string
+  persona_provider?: string
+  persona_model?: string
+  voice_map?: Record<string, string>
+  audio_cast?: WatchlistAudioCast
   retention_seconds?: number
   temporary?: boolean
   deliveries?: {

--- a/apps/packages/ui/src/types/watchlists.ts
+++ b/apps/packages/ui/src/types/watchlists.ts
@@ -70,7 +70,7 @@ export interface WatchlistSourceCreate {
   source_type: SourceType
   active?: boolean
   tags?: string[]
-  settings?: Record<string, unknown>
+  settings?: Record<string, unknown> | null
   group_ids?: number[]
   watchlist_id?: number
 }
@@ -81,7 +81,7 @@ export interface WatchlistSourceUpdate {
   source_type?: SourceType
   active?: boolean
   tags?: string[]
-  settings?: Record<string, unknown>
+  settings?: Record<string, unknown> | null
   group_ids?: number[]
 }
 

--- a/apps/packages/ui/src/types/watchlists.ts
+++ b/apps/packages/ui/src/types/watchlists.ts
@@ -993,6 +993,17 @@ export interface JobPreviewResult {
   total: number
   ingestable: number
   filtered: number
+  diagnostics?: SourcePreviewDiagnostics | null
+}
+
+export interface SourcePreviewDiagnostics {
+  fetch_mode?: string | null
+  selector_errors?: string[]
+  selector_warnings?: string[]
+  no_match_warnings?: string[]
+  non_unique_warnings?: string[]
+  fragile_selector_warnings?: string[]
+  dedupe_preview_key?: string | null
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
+++ b/backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
@@ -40,13 +40,13 @@ Created a code-grounded phased PRD/spec for /watchlists that reuses existing sou
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Design review follow-up: tightened the PRD so implementation cannot overpromise current code. Added explicit constraints for unknown source settings preservation, configurable dedupe identity as backend/API work, scheduled digest auto-output dependency, delivery status ownership on output artifacts, and persisted script/per-speaker/final audio artifacts.
+Design review follow-up: tightened the PRD so implementation cannot overpromise current code. Added explicit constraints for unknown source settings preservation, configurable dedupe identity as backend/API work, scheduled digest auto-output dependency, delivery status ownership on output artifacts, and persisting script/per-speaker/final audio artifacts.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a design-review hardening pass to the Watchlists PRD before implementation planning. The PRD now explicitly separates verified current behavior from proposed backend/API work for configurable dedupe identity, preserves unknown source settings keys, distinguishes scheduled auto-output from manual test-run output creation, assigns delivery status to output artifacts, and requires persisted script/per-speaker/final audio artifacts for the optional briefing workflow. Verification: git diff --check passed for touched spec/task files; Bandit skipped because this is documentation/task metadata only.
+Added a design-review hardening pass to the Watchlists PRD before implementation planning. The PRD now explicitly separates verified current behavior from proposed backend/API work for configurable dedupe identity, preserves unknown source settings keys, distinguishes scheduled auto-output from manual test-run output creation, assigns delivery status to output artifacts, and requires persisting script/per-speaker/final audio artifacts for the optional briefing workflow. Verification: git diff --check passed for touched spec/task files; Bandit skipped because this is documentation/task metadata only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
+++ b/backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
@@ -1,0 +1,56 @@
+---
+id: TASK-424
+title: Create phased PRD for Watchlists digest and audio briefing workflow
+status: Done
+labels:
+- watchlists
+- prd
+- ux
+- design
+references:
+- apps/tldw-frontend/pages/watchlists.tsx
+- apps/packages/ui/src/components/Option/Watchlists
+- tldw_Server_API/app/api/v1/endpoints/watchlists.py
+- tldw_Server_API/app/core/Watchlists
+modified_files:
+- Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
+- backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write a code-grounded phased PRD/spec for improving /watchlists to support source scraping setup, monitor cadence/rules/filters/dedupe ownership, digest/newsletter output, optional 1-4 speaker audio briefing generation, and operator/power-user observability without removing existing OSINT/news workflows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Created a code-grounded phased PRD/spec for /watchlists that reuses existing source settings, monitor filters, Scheduler/audio workflow, output artifacts, delivery metadata, and run observability. The PRD is phased across contract alignment, guided MVP, power-user throughput, and operator/admin reliability.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md. The PRD addresses source scraping setup, per-source extraction/dedupe ownership, per-monitor cadence/filter/output/delivery ownership, variable cadence, digest/newsletter output, optional 1-4 speaker audio briefing generation inside /watchlists, and preservation of existing OSINT/news workflows. Verification: git diff --check passed for touched spec/task files; Bandit skipped because this is documentation/task metadata only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
+++ b/backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
@@ -25,6 +25,10 @@ Write a code-grounded phased PRD/spec for improving /watchlists to support sourc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] PRD is grounded in verified `/watchlists` route, UI, API, scheduler, output, notification, and audio workflow behavior.
+- [x] PRD separates existing capabilities from proposed backend/API/frontend improvements.
+- [x] PRD includes phased ownership for source setup, monitor setup, digest/newsletter output, optional 1-4 speaker audio, power-user reuse, and operator observability.
+- [x] Design review issues are incorporated before implementation planning, including dedupe configuration limits, source settings preservation, scheduled auto-output, email delivery status, and audio artifact persistence.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,21 +40,21 @@ Created a code-grounded phased PRD/spec for /watchlists that reuses existing sou
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Design review follow-up: tightened the PRD so implementation cannot overpromise current code. Added explicit constraints for unknown source settings preservation, configurable dedupe identity as backend/API work, scheduled digest auto-output dependency, delivery status ownership on output artifacts, and persisted script/per-speaker/final audio artifacts.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md. The PRD addresses source scraping setup, per-source extraction/dedupe ownership, per-monitor cadence/filter/output/delivery ownership, variable cadence, digest/newsletter output, optional 1-4 speaker audio briefing generation inside /watchlists, and preservation of existing OSINT/news workflows. Verification: git diff --check passed for touched spec/task files; Bandit skipped because this is documentation/task metadata only.
+Added a design-review hardening pass to the Watchlists PRD before implementation planning. The PRD now explicitly separates verified current behavior from proposed backend/API work for configurable dedupe identity, preserves unknown source settings keys, distinguishes scheduled auto-output from manual test-run output creation, assigns delivery status to output artifacts, and requires persisted script/per-speaker/final audio artifacts for the optional briefing workflow. Verification: git diff --check passed for touched spec/task files; Bandit skipped because this is documentation/task metadata only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-425 - Create-implementation-plan-for-Watchlists-digest-and-audio-briefing-workflow.md
+++ b/backlog/tasks/task-425 - Create-implementation-plan-for-Watchlists-digest-and-audio-briefing-workflow.md
@@ -1,0 +1,55 @@
+---
+id: TASK-425
+title: Create implementation plan for Watchlists digest and audio briefing workflow
+status: Done
+labels:
+- watchlists
+- plan
+- implementation
+- ux
+references:
+- Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
+- Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+- apps/packages/ui/src/components/Option/Watchlists
+- tldw_Server_API/app/api/v1/endpoints/watchlists.py
+- tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py
+modified_files:
+- Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+- backlog/tasks/task-425 - Create-implementation-plan-for-Watchlists-digest-and-audio-briefing-workflow.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a staged implementation plan from the hardened Watchlists digest/audio PRD, with exact files, tests, ownership boundaries, dependencies, verification commands, and phase/task sequencing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Plan includes exact frontend/backend files and tests for contract alignment, source setup, cadence/output, audio artifacts, guided MVP, power-user reuse, operator recovery, and verification.
+- [x] Plan is phased into reviewable PR slices and stage gates.
+- [x] Plan preserves existing `/watchlists` full-control workflows and marks non-MVP/deferred scope.
+- [x] Plan includes TDD-style failing-test, implementation, verification, and commit steps.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created the implementation plan at Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md. Self-review patched two gaps before finalizing: forum capability gating is now included in the source setup task, and the variable cadence task now requires existing every-6-hour cron to parse into the new interval model.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created a phased implementation plan for the hardened Watchlists digest/audio PRD. The plan maps concrete files, tests, stage gates, recommended PR slices, and TDD-style implementation steps across frontend contracts, source settings, cadence, auto-output/delivery, audio artifacts, guided pipeline MVP, power-user batch/reuse controls, operator diagnostics, and verification. Verification: git diff --check passed for the plan and task files; Bandit skipped because this change is documentation/task metadata only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-426 - Implement-Watchlists-digest-audio-PR1-contract-cadence-and-source-settings-slice.md
+++ b/backlog/tasks/task-426 - Implement-Watchlists-digest-audio-PR1-contract-cadence-and-source-settings-slice.md
@@ -1,0 +1,44 @@
+---
+id: TASK-426
+title: Implement Watchlists digest audio PR1 contract cadence and source settings
+  slice
+status: In Progress
+labels:
+- watchlists
+- frontend
+- implementation
+- audio
+- cadence
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first PR slice from the Watchlists digest/audio implementation plan: frontend watchlists audio contract alignment, variable cadence controls, source settings preservation, and forum capability gating without changing backend audio artifact persistence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-426 - Implement-Watchlists-digest-audio-PR1-contract-cadence-and-source-settings-slice.md
+++ b/backlog/tasks/task-426 - Implement-Watchlists-digest-audio-PR1-contract-cadence-and-source-settings-slice.md
@@ -6,7 +6,7 @@ title: >-
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 07:08'
+updated_date: '2026-05-18 07:14'
 labels:
   - watchlists
   - frontend
@@ -14,6 +14,8 @@ labels:
   - audio
   - cadence
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1838'
 ---
 
 ## Description
@@ -50,6 +52,8 @@ Bandit: skipped; touched runtime code is TypeScript frontend only.
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented PR1 frontend slice for watchlists digest/audio workflow: audio contract alignment, variable cadence controls, source settings preservation with scrape_rules, draft preflight settings, and forum capability gating. Verification recorded in final response.
+
+Draft PR: https://github.com/rmusser01/tldw_server/pull/1838
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-426 - Implement-Watchlists-digest-audio-PR1-contract-cadence-and-source-settings-slice.md
+++ b/backlog/tasks/task-426 - Implement-Watchlists-digest-audio-PR1-contract-cadence-and-source-settings-slice.md
@@ -1,14 +1,19 @@
 ---
 id: TASK-426
-title: Implement Watchlists digest audio PR1 contract cadence and source settings
+title: >-
+  Implement Watchlists digest audio PR1 contract cadence and source settings
   slice
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-18 07:08'
 labels:
-- watchlists
-- frontend
-- implementation
-- audio
-- cadence
+  - watchlists
+  - frontend
+  - implementation
+  - audio
+  - cadence
+dependencies: []
 ---
 
 ## Description
@@ -19,26 +24,40 @@ Implement the first PR slice from the Watchlists digest/audio implementation pla
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Watchlists frontend types and services represent backend-supported audio output fields and expose getWatchlistRunAudio(runId).
+- [x] #2 Schedule picker supports variable every-N hours/minutes, weekdays, daily, weekly, and raw cron fallback without dropping existing cron parsing.
+- [x] #3 Source form preserves unknown source settings, serializes website scrape_rules, passes draft settings to preflight, and gates forum source option from watchlists settings capability.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
+Commits:
+- ab2f60201 feat: align watchlists audio contracts
+- 5b249de37 feat: support variable watchlist cadence presets
+- 4782a68d4 feat: preserve watchlist source settings
+- 29a5d8d64 feat: show watchlist source diagnostics
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Verification:
+- bun run test -- src/services/__tests__/watchlists-audio.test.ts src/components/Option/Watchlists/__tests__/watchlists-static-guard.typecheck.test.ts src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx --maxWorkers=1 --no-file-parallelism
+- bun run test -- src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.bulk-move.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.advanced-details.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.load-error-retry.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.delete-confirm.test.tsx --maxWorkers=1 --no-file-parallelism
+- git diff --check
+
+Bandit: skipped; touched runtime code is TypeScript frontend only.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented PR1 frontend slice for watchlists digest/audio workflow: audio contract alignment, variable cadence controls, source settings preservation with scrape_rules, draft preflight settings, and forum capability gating. Verification recorded in final response.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-427 - Address-PR-1838-review-comments.md
+++ b/backlog/tasks/task-427 - Address-PR-1838-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-427
+title: Address PR 1838 review comments
+status: Done
+references:
+- https://github.com/rmusser01/tldw_server/pull/1838
+- https://github.com/rmusser01/tldw_server/pull/1838#discussion_r3257061627
+- https://github.com/rmusser01/tldw_server/pull/1838#discussion_r3257061636
+- https://github.com/rmusser01/tldw_server/pull/1838#discussion_r3257064174
+- https://github.com/rmusser01/tldw_server/pull/1838#discussion_r3257064185
+- https://github.com/rmusser01/tldw_server/pull/1838#discussion_r3257064189
+- https://github.com/rmusser01/tldw_server/pull/1838#discussion_r3257064194
+- https://github.com/rmusser01/tldw_server/pull/1838#discussion_r3257064204
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/source-settings.ts
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/schedule-utils.ts
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/SchedulePicker.tsx
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+- backlog/tasks/task-424 - Create-phased-PRD-for-Watchlists-digest-and-audio-briefing-workflow.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve actionable Qodo and CodeRabbit review feedback on PR #1838 for the Watchlists digest/audio PR1 branch. Scope is limited to nested scrape_rules preservation, interval scheduling consistency/constants, localized diagnostics labels, and minor task grammar cleanup. Do not broaden the PR beyond current Watchlists review findings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Preserve unknown nested `settings.scrape_rules` keys while allowing UI-owned scrape rule fields to be updated or cleared.
+- [x] Keep variable cadence preset parsing consistent with the 5-minute minimum and shared interval bounds.
+- [x] Localize source diagnostics labels and address the minor task grammar comment.
+- [x] Resolve stale/non-actionable and remediated PR review threads after verification and push.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Fixed Qodo/CodeRabbit findings on PR #1838. `buildSourceSettingsPayload` now removes only UI-owned scrape rule keys before merging current form values back into existing nested rules, so backend/advanced keys like pagination survive edits. Schedule interval bounds are exported from `schedule-utils` and reused by the picker and cron builder/parser; sub-5-minute step crons now fall back to advanced cron instead of being silently clamped by presets. Source diagnostics labels now go through the existing `t` helper. The stale Gemini thread targeted a pre-rebase file that is no longer in the PR diff and was resolved without code churn.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1838 review feedback with focused frontend/test/task updates. Verification: focused Watchlists review-fix Vitest slice passed, 7 files and 28 tests; existing SourcesTab regression slice passed, 4 files and 14 tests; `git diff --check` passed. Bandit skipped because no Python files were touched in this review-fix pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Align Watchlists frontend audio/output contracts with backend-supported fields and add the run-audio status service helper.
- Add variable cadence presets for every-N minutes/hours, weekdays, daily, weekly, while preserving raw cron fallback.
- Preserve per-source settings, serialize website scrape_rules, include settings in draft source preflight, gate forum source creation from backend capability, and render optional source diagnostics.

## Change summary
TODO: Human requester must replace this with a human-written change summary explaining what changed and why these implementation choices were made before this PR is merge-ready.

## Test plan
- [x] bun run test -- src/services/__tests__/watchlists-audio.test.ts src/components/Option/Watchlists/__tests__/watchlists-static-guard.typecheck.test.ts src/components/Option/Watchlists/JobsTab/__tests__/schedule-utils.test.ts src/components/Option/Watchlists/JobsTab/__tests__/SchedulePicker.help.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx --maxWorkers=1 --no-file-parallelism
- [x] bun run test -- src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.bulk-move.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.advanced-details.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.load-error-retry.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.delete-confirm.test.tsx --maxWorkers=1 --no-file-parallelism
- [x] git diff --check
- [x] Bandit skipped: touched runtime code is TypeScript frontend only.

## Tracking
- Backlog: TASK-426
- Plan: Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Watchlists audio/output contracts with the backend and adds interval scheduling and source settings so digest/audio runs can be scheduled, created, and tracked end to end. Addresses TASK-426.

- **New Features**
  - Added `getWatchlistRunAudio(runId)` and expanded output prefs: `auto_output` (format/template), audio model/voice/speed, and background track volume/fade/delay.
  - Schedule Picker supports “Every N minutes/hours,” weekdays, daily, and weekly; builds cron and enforces a backend-defined minimum interval.
  - Preserves per-source settings; serializes website `scrape_rules`; passes settings (or `null`) in draft-source preflight; keeps unknown keys intact.
  - Shows optional source diagnostics in test preview; gates Forum source by backend capability and enables it when available.

<sup>Written for commit 22275db0cedbfcb2200388238bbe9a03f808745c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1838?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

