### PR TITLE
Add watchlist source diagnostics and scheduled auto-output contract

### DIFF
--- a/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
@@ -468,7 +468,7 @@ git commit -m "feat: preserve watchlist source settings"
 - Test: `tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py`
 - Test: `tldw_Server_API/tests/Watchlists/test_preview_endpoint.py`
 
-- [ ] **Step 1: Write failing backend tests**
+- [x] **Step 1: Write failing backend tests**
 
 Add tests proving draft/saved source test returns diagnostics for site sources with scrape rules:
 
@@ -477,7 +477,7 @@ assert response.json()["diagnostics"]["fetch_mode"] == "scrape_rules"
 assert "selector_warnings" in response.json()["diagnostics"]
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 ```bash
 source .venv/bin/activate
@@ -486,7 +486,7 @@ python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py 
 
 Expected: FAIL because preview result currently exposes only item counts/items to the frontend contract.
 
-- [ ] **Step 3: Add response schema**
+- [x] **Step 3: Add response schema**
 
 Extend preview response schema with optional diagnostics:
 
@@ -500,17 +500,17 @@ class SourcePreviewDiagnostics(BaseModel):
 
 Keep fields optional to avoid breaking existing callers.
 
-- [ ] **Step 4: Populate diagnostics**
+- [x] **Step 4: Populate diagnostics**
 
 Reuse existing `validate_selector_rules` output for site/forum scrape rules. For RSS and discovery fallback, report `fetch_mode` only if no selector diagnostics exist.
 
-- [ ] **Step 5: Run backend tests**
+- [x] **Step 5: Run backend tests**
 
 Run the command from Step 2 again.
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
@@ -532,7 +532,7 @@ git commit -m "feat: expose watchlist source validation diagnostics"
 - Backend test: `tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py`
 - Backend test: `tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py`
 
-- [ ] **Step 1: Write failing frontend tests**
+- [x] **Step 1: Write failing frontend tests**
 
 Cover:
 
@@ -540,14 +540,14 @@ Cover:
 - Manual/test output creation remains explicit.
 - Delivery status helper distinguishes `sent`, `skipped`, `failed`, and `pending`.
 
-- [ ] **Step 2: Run frontend tests to verify failure**
+- [x] **Step 2: Run frontend tests to verify failure**
 
 ```bash
 cd apps/packages/ui
 bunx vitest run src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts --maxWorkers=1 --no-file-parallelism
 ```
 
-- [ ] **Step 3: Add `auto_output` type and UI**
+- [x] **Step 3: Add `auto_output` type and UI**
 
 Add to `JobOutputPrefs`:
 
@@ -563,11 +563,11 @@ auto_output?: {
 
 In `JobFormModal`, make scheduled output explicit: when delivery or audio is enabled for recurring monitors, require or default `auto_output.enabled` and show review copy that output artifacts will be generated each run.
 
-- [ ] **Step 4: Update pipeline payload helpers**
+- [x] **Step 4: Update pipeline payload helpers**
 
 In `pipeline-contract.ts`, set `auto_output.enabled` when the user chooses scheduled digest/newsletter output. Do not set it for manual/test-only flows.
 
-- [ ] **Step 5: Confirm backend roundtrip**
+- [x] **Step 5: Confirm backend roundtrip**
 
 Run:
 
@@ -578,13 +578,13 @@ python -m pytest tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtri
 
 Expected: PASS or only frontend-driven behavior needs update. If backend drops the field, fix schema/persistence before proceeding.
 
-- [ ] **Step 6: Run focused frontend tests**
+- [x] **Step 6: Run focused frontend tests**
 
 Run the command from Step 2 again.
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add apps/packages/ui/src/types/watchlists.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
@@ -563,6 +563,45 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
       }
     }
 
+    const hasRecurringSchedule = Boolean(schedule && schedule.trim().length > 0)
+    const existingAutoOutput = isRecord(basePrefs.auto_output)
+      ? { ...basePrefs.auto_output }
+      : {}
+    const shouldAutoOutput = (
+      hasRecurringSchedule &&
+      (
+        deliveryEmailEnabled ||
+        deliveryChatbookEnabled ||
+        audioBriefingEnabled ||
+        existingAutoOutput.enabled === true
+      )
+    )
+    if (shouldAutoOutput) {
+      existingAutoOutput.enabled = true
+      existingAutoOutput.type =
+        typeof existingAutoOutput.type === "string" && existingAutoOutput.type.trim().length > 0
+          ? existingAutoOutput.type.trim()
+          : "briefing_markdown"
+      if (isOutputFormat(outputTemplateFormat)) {
+        existingAutoOutput.format = outputTemplateFormat
+      } else {
+        delete existingAutoOutput.format
+      }
+      if (normalizedTemplateName) {
+        existingAutoOutput.template_name = normalizedTemplateName
+      } else {
+        delete existingAutoOutput.template_name
+      }
+      if (typeof outputTemplateVersion === "number" && outputTemplateVersion > 0) {
+        existingAutoOutput.template_version = Math.floor(outputTemplateVersion)
+      } else {
+        delete existingAutoOutput.template_version
+      }
+      basePrefs.auto_output = existingAutoOutput
+    } else {
+      delete basePrefs.auto_output
+    }
+
     if (Object.keys(basePrefs).length > 0) {
       return basePrefs as JobOutputPrefs
     }

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
@@ -404,6 +404,43 @@ describe("JobFormModal live summary", () => {
     )
   }, 15_000)
 
+  it("enables scheduled auto-output when recurring delivery or audio is configured", async () => {
+    render(<JobFormModal open onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(servicesMock.fetchWatchlistSources).toHaveBeenCalled()
+      expect(servicesMock.fetchWatchlistGroups).toHaveBeenCalled()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("e.g., Daily Tech News"), {
+      target: { value: "Scheduled Audio Brief" }
+    })
+    fireEvent.click(screen.getByTestId("scope-setter"))
+    fireEvent.click(screen.getByTestId("job-form-mode-advanced"))
+    const collapseHeaders = Array.from(document.querySelectorAll(".ant-collapse-header"))
+    fireEvent.click(collapseHeaders[1] as Element)
+    fireEvent.click(screen.getByTestId("schedule-setter"))
+    fireEvent.click(screen.getByText("Output & Delivery"))
+    fireEvent.click(screen.getByTestId("job-form-audio-enabled-switch"))
+    fireEvent.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(servicesMock.createWatchlistJob).toHaveBeenCalledTimes(1)
+    })
+
+    expect(servicesMock.createWatchlistJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output_prefs: expect.objectContaining({
+          auto_output: expect.objectContaining({
+            enabled: true,
+            type: "briefing_markdown"
+          }),
+          generate_audio: true
+        })
+      })
+    )
+  }, 15_000)
+
   it("shows practical audio setup guidance in monitor form", async () => {
     render(<JobFormModal open onClose={vi.fn()} onSuccess={vi.fn()} />)
 

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
@@ -124,12 +124,14 @@ describe("outputMetadata helpers", () => {
     expect(getDeliveryStatusColor("partial")).toBe("gold")
     expect(getDeliveryStatusColor("pending")).toBe("blue")
     expect(getDeliveryStatusColor("failed")).toBe("red")
+    expect(getDeliveryStatusColor("skipped")).toBe("default")
     expect(getDeliveryStatusColor("mystery")).toBe("default")
   })
 
   it("normalizes delivery status labels", () => {
     expect(getDeliveryStatusLabel("sent")).toBe("Sent")
     expect(getDeliveryStatusLabel("in_progress")).toBe("In progress")
+    expect(getDeliveryStatusLabel("skipped")).toBe("Skipped")
     expect(getDeliveryStatusLabel("failed")).toBe("Failed")
     expect(getDeliveryStatusLabel("mystery")).toBe("mystery")
   })

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
@@ -348,6 +348,7 @@ export const getDeliveryStatusLabel = (status: string): string => {
   if (normalized === "queued") return "Queued"
   if (normalized === "pending") return "Pending"
   if (normalized === "in_progress") return "In progress"
+  if (normalized === "skipped") return "Skipped"
   if (normalized === "failed") return "Failed"
   if (normalized === "error") return "Error"
   return status

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
@@ -67,6 +67,13 @@ describe("watchlists pipeline contract", () => {
         schedule_expr: "0 8 * * *",
         timezone: "UTC",
         output_prefs: expect.objectContaining({
+          auto_output: {
+            enabled: true,
+            type: "briefing_markdown",
+            format: "md",
+            template_name: "briefing_md",
+            template_version: 2
+          },
           template_name: "briefing_md",
           generate_audio: true,
           audio_voice: "alloy",
@@ -100,6 +107,18 @@ describe("watchlists pipeline contract", () => {
     })
 
     timezoneSpy.mockRestore()
+  })
+
+  it("does not auto-generate scheduled output for manual-only monitor drafts", () => {
+    expect(
+      toPipelineJobCreatePayload({
+        ...baseDraft,
+        schedulePreset: "none",
+        includeAudio: false,
+        emailRecipients: [],
+        createChatbook: false
+      }).output_prefs
+    ).not.toHaveProperty("auto_output")
   })
 
   it("propagates html template format into job and output payloads", () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
@@ -78,9 +78,10 @@ export const toPipelineJobCreatePayload = (
   const schedule = resolveQuickSetupSchedule(draft.schedulePreset)
   const recipients = normalizeRecipients(draft.emailRecipients)
   const normalizedTemplateName = String(draft.templateName || "").trim()
+  const templateVersionNum = Number(draft.templateVersion)
   const normalizedTemplateVersion =
-    Number.isFinite(Number(draft.templateVersion)) && Number(draft.templateVersion) > 0
-      ? Number(draft.templateVersion)
+    Number.isFinite(templateVersionNum) && templateVersionNum > 0
+      ? templateVersionNum
       : undefined
   const templateFormat =
     draft.templateFormat === "html" || draft.templateFormat === "md"

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
@@ -77,10 +77,16 @@ export const toPipelineJobCreatePayload = (
 ): WatchlistJobCreate => {
   const schedule = resolveQuickSetupSchedule(draft.schedulePreset)
   const recipients = normalizeRecipients(draft.emailRecipients)
+  const normalizedTemplateName = String(draft.templateName || "").trim()
+  const normalizedTemplateVersion =
+    Number.isFinite(Number(draft.templateVersion)) && Number(draft.templateVersion) > 0
+      ? Number(draft.templateVersion)
+      : undefined
   const templateFormat =
     draft.templateFormat === "html" || draft.templateFormat === "md"
       ? draft.templateFormat
       : undefined
+  const shouldAutoOutput = draft.schedulePreset !== "none"
 
   return {
     name: String(draft.monitorName || "").trim(),
@@ -88,14 +94,22 @@ export const toPipelineJobCreatePayload = (
     active: true,
     ...schedule,
     output_prefs: {
-      template_name: String(draft.templateName || "").trim(),
+      ...(shouldAutoOutput
+        ? {
+            auto_output: {
+              enabled: true,
+              type: "briefing_markdown",
+              ...(templateFormat ? { format: templateFormat } : {}),
+              ...(normalizedTemplateName ? { template_name: normalizedTemplateName } : {}),
+              ...(normalizedTemplateVersion ? { template_version: normalizedTemplateVersion } : {})
+            }
+          }
+        : {}),
+      template_name: normalizedTemplateName,
       template: {
-        default_name: String(draft.templateName || "").trim(),
+        default_name: normalizedTemplateName,
         ...(templateFormat ? { default_format: templateFormat } : {}),
-        default_version:
-          Number.isFinite(Number(draft.templateVersion)) && Number(draft.templateVersion) > 0
-            ? Number(draft.templateVersion)
-            : undefined
+        default_version: normalizedTemplateVersion
       },
       generate_audio: draft.includeAudio,
       audio_voice: draft.includeAudio

--- a/backlog/tasks/task-428 - Implement-Watchlists-digest-audio-PR2-diagnostics-and-auto-output-slice.md
+++ b/backlog/tasks/task-428 - Implement-Watchlists-digest-audio-PR2-diagnostics-and-auto-output-slice.md
@@ -1,0 +1,75 @@
+---
+id: TASK-428
+title: Implement Watchlists digest audio PR2 diagnostics and auto-output slice
+status: Done
+references:
+- Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+- Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
+- https://github.com/rmusser01/tldw_server/pull/1838
+modified_files:
+- Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+- tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+- tldw_Server_API/app/api/v1/endpoints/watchlists.py
+- tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement PR2 from the Watchlists digest/audio implementation plan. Scope: source validation diagnostics API for draft/saved source testing plus scheduled output/delivery contract visibility in /watchlists. Preserve existing news/OSINT/CTI workflows and do not start guided pipeline or audio artifact persistence work in this slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Draft and saved source tests return source preview diagnostics for scrape-rule site/forum sources.
+- [x] Scheduled watchlist monitor payloads can declare `output_prefs.auto_output.enabled` for recurring output/delivery/audio runs.
+- [x] Manual/test-only output creation remains explicit and does not set scheduled `auto_output`.
+- [x] Delivery status metadata labels include skipped delivery outcomes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Reused `validate_selector_rules` for source preview diagnostics rather than adding a second selector validation path.
+- Kept diagnostics optional on `PreviewResponse` so existing job preview callers are not forced to handle source-only metadata.
+- Preserved existing monitor form behavior by only enabling `auto_output` when a recurring schedule combines with delivery/audio output or an existing enabled auto-output preference.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented PR2 source diagnostics and scheduled auto-output contract.
+
+- Added source preview diagnostics to draft/saved source tests, including fetch mode, selector validation errors/warnings, and dedupe preview key for scrape rules.
+- Added scheduled auto-output payload creation for guided pipeline drafts and recurring monitor forms when delivery/audio output is configured.
+- Added skipped delivery label normalization for output metadata.
+
+Verification:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q -> 9 passed.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py -q -> 47 passed.
+- bun run test -- src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts --maxWorkers=1 --no-file-parallelism -> 42 passed.
+- git diff --check -> passed.
+- Bandit on touched backend files -> 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-428 - Implement-Watchlists-digest-audio-PR2-diagnostics-and-auto-output-slice.md
+++ b/backlog/tasks/task-428 - Implement-Watchlists-digest-audio-PR2-diagnostics-and-auto-output-slice.md
@@ -60,9 +60,10 @@ Initial implementation:
 Review-fix pass:
 - Addressed Gemini review comments by making selector validation errors/warnings tolerant of missing/None lists.
 - Normalized frontend template version once before reuse in pipeline payload construction.
+- Addressed CodeRabbit/Qodo comments by including selector identity variants in dedupe key inference, preserving warning detail text, and documenting diagnostics helpers.
 
 Verification after review fixes:
-- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q -> 9 passed.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q -> 10 passed.
 - /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py -q -> 47 passed.
 - bun run test -- src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts --maxWorkers=1 --no-file-parallelism -> 42 passed.
 - git diff --check -> passed.

--- a/backlog/tasks/task-428 - Implement-Watchlists-digest-audio-PR2-diagnostics-and-auto-output-slice.md
+++ b/backlog/tasks/task-428 - Implement-Watchlists-digest-audio-PR2-diagnostics-and-auto-output-slice.md
@@ -50,13 +50,18 @@ Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementatio
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented PR2 source diagnostics and scheduled auto-output contract.
+PR2 implementation plus review-fix pass.
 
+Initial implementation:
 - Added source preview diagnostics to draft/saved source tests, including fetch mode, selector validation errors/warnings, and dedupe preview key for scrape rules.
 - Added scheduled auto-output payload creation for guided pipeline drafts and recurring monitor forms when delivery/audio output is configured.
 - Added skipped delivery label normalization for output metadata.
 
-Verification:
+Review-fix pass:
+- Addressed Gemini review comments by making selector validation errors/warnings tolerant of missing/None lists.
+- Normalized frontend template version once before reuse in pipeline payload construction.
+
+Verification after review fixes:
 - /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q -> 9 passed.
 - /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py -q -> 47 passed.
 - bun run test -- src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts --maxWorkers=1 --no-file-parallelism -> 42 passed.

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -75,7 +75,11 @@ from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime as _is_e
 from tldw_Server_API.app.core.testing import is_test_mode as _is_test_mode
 from tldw_Server_API.app.core.testing import is_truthy as _is_truthy
 from tldw_Server_API.app.core.Watchlists import template_store
-from tldw_Server_API.app.core.Watchlists.fetchers import fetch_rss_feed, fetch_site_items_with_rules
+from tldw_Server_API.app.core.Watchlists.fetchers import (
+    fetch_rss_feed,
+    fetch_site_items_with_rules,
+    validate_selector_rules,
+)
 from tldw_Server_API.app.core.Watchlists.filters import evaluate_filters as _evaluate_filters
 from tldw_Server_API.app.core.Watchlists.filters import normalize_filters as _normalize_job_filters
 from tldw_Server_API.app.core.Watchlists.opml import generate_opml, parse_opml
@@ -166,6 +170,7 @@ from tldw_Server_API.app.api.v1.schemas.watchlists_schemas import (  # noqa: E40
     SourceCheckNowItem,
     SourceCreateRequest,
     SourceDeleteResponse,
+    SourcePreviewDiagnostics,
     SourcesCheckNowRequest,
     SourcesCheckNowResponse,
     SourcesBulkCreateItem,
@@ -2289,6 +2294,82 @@ def _normalize_source_test_url(source_url: str, source_type: str) -> str:
     return target_url
 
 
+def _format_selector_diagnostic(issue: Any) -> str:
+    if not isinstance(issue, dict):
+        return str(issue)
+    key = str(issue.get("key") or "selector").strip() or "selector"
+    label = str(issue.get("error") or issue.get("warning") or issue.get("detail") or "issue")
+    selector = str(issue.get("selector") or "").strip()
+    count = issue.get("count")
+    summary = f"{key}: {label}"
+    if selector:
+        summary = f"{summary} ({selector})"
+    if isinstance(count, int):
+        summary = f"{summary}; count={count}"
+    return summary
+
+
+def _first_present_rule_key(rules: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = rules.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str) and not value.strip():
+            continue
+        return key
+    return None
+
+
+def _infer_source_dedupe_preview_key(rules: dict[str, Any]) -> str:
+    identity_key = _first_present_rule_key(
+        rules,
+        ("guid_xpath", "id_xpath", "link_xpath", "url_xpath"),
+    )
+    if identity_key:
+        return identity_key
+    alternates = rules.get("alternates")
+    if isinstance(alternates, list):
+        for alt in alternates:
+            if not isinstance(alt, dict):
+                continue
+            identity_key = _first_present_rule_key(
+                alt,
+                ("guid_xpath", "id_xpath", "link_xpath", "url_xpath"),
+            )
+            if identity_key:
+                return f"alternates.{identity_key}"
+    return "url"
+
+
+def _build_source_preview_diagnostics(
+    *,
+    fetch_mode: str,
+    scrape_rules: dict[str, Any] | None = None,
+) -> SourcePreviewDiagnostics:
+    diagnostics = SourcePreviewDiagnostics(fetch_mode=fetch_mode)
+    if not scrape_rules:
+        return diagnostics
+
+    validation = validate_selector_rules(scrape_rules)
+    diagnostics.selector_errors = [
+        _format_selector_diagnostic(issue)
+        for issue in validation.get("errors", [])
+    ]
+    for issue in validation.get("warnings", []):
+        warning = issue.get("warning") if isinstance(issue, dict) else None
+        formatted = _format_selector_diagnostic(issue)
+        if warning == "no_matches":
+            diagnostics.no_match_warnings.append(formatted)
+        elif warning == "non_unique_selector":
+            diagnostics.non_unique_warnings.append(formatted)
+        elif warning == "fragile_selector":
+            diagnostics.fragile_selector_warnings.append(formatted)
+        else:
+            diagnostics.selector_warnings.append(formatted)
+    diagnostics.dedupe_preview_key = _infer_source_dedupe_preview_key(scrape_rules)
+    return diagnostics
+
+
 async def _build_source_preview_response(
     *,
     source_id: int,
@@ -2305,8 +2386,10 @@ async def _build_source_preview_response(
 
     items: list[dict[str, Any]] = []
     test_mode = _is_test_mode()
+    diagnostics: SourcePreviewDiagnostics | None = None
 
     if source_type.lower() == "rss":
+        diagnostics = _build_source_preview_diagnostics(fetch_mode="rss")
         try:
             res = await fetch_rss_feed(
                 normalized_url,
@@ -2325,6 +2408,10 @@ async def _build_source_preview_response(
             else None
         )
         if scrape_rules:
+            diagnostics = _build_source_preview_diagnostics(
+                fetch_mode="scrape_rules",
+                scrape_rules=scrape_rules,
+            )
             try:
                 items = await fetch_site_items_with_rules(
                     base_url=str(scrape_rules.get("list_url") or normalized_url),
@@ -2335,6 +2422,7 @@ async def _build_source_preview_response(
                 logger.debug(f"watchlists.test_source: scrape rules fetch failed: {exc}")
                 items = []
         elif test_mode:
+            diagnostics = _build_source_preview_diagnostics(fetch_mode="test_mode")
             items = [
                 {
                     "title": "Test scraped item 1",
@@ -2343,6 +2431,7 @@ async def _build_source_preview_response(
                 }
             ]
         else:
+            diagnostics = _build_source_preview_diagnostics(fetch_mode="discovery")
             try:
                 from tldw_Server_API.app.core.Watchlists.fetchers import fetch_site_top_links
 
@@ -2389,6 +2478,7 @@ async def _build_source_preview_response(
         ),
         ingestable=total,
         filtered=0,
+        diagnostics=diagnostics,
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -2353,9 +2353,9 @@ def _build_source_preview_diagnostics(
     validation = validate_selector_rules(scrape_rules)
     diagnostics.selector_errors = [
         _format_selector_diagnostic(issue)
-        for issue in validation.get("errors", [])
+        for issue in (validation.get("errors") or [])
     ]
-    for issue in validation.get("warnings", []):
+    for issue in (validation.get("warnings") or []):
         warning = issue.get("warning") if isinstance(issue, dict) else None
         formatted = _format_selector_diagnostic(issue)
         if warning == "no_matches":

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -2295,10 +2295,14 @@ def _normalize_source_test_url(source_url: str, source_type: str) -> str:
 
 
 def _format_selector_diagnostic(issue: Any) -> str:
+    """Format selector validation output into one concise preview diagnostic."""
     if not isinstance(issue, dict):
         return str(issue)
     key = str(issue.get("key") or "selector").strip() or "selector"
     label = str(issue.get("error") or issue.get("warning") or issue.get("detail") or "issue")
+    detail = str(issue.get("detail") or "").strip()
+    if detail and detail != label:
+        label = f"{label}: {detail}"
     selector = str(issue.get("selector") or "").strip()
     count = issue.get("count")
     summary = f"{key}: {label}"
@@ -2310,6 +2314,7 @@ def _format_selector_diagnostic(issue: Any) -> str:
 
 
 def _first_present_rule_key(rules: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    """Return the first configured scrape-rule key from a preferred key list."""
     for key in keys:
         value = rules.get(key)
         if value is None:
@@ -2320,10 +2325,23 @@ def _first_present_rule_key(rules: dict[str, Any], keys: tuple[str, ...]) -> str
     return None
 
 
+_SOURCE_DEDUPE_IDENTITY_KEYS = (
+    "guid_xpath",
+    "guid_selector",
+    "id_xpath",
+    "id_selector",
+    "link_xpath",
+    "link_selector",
+    "url_xpath",
+    "url_selector",
+)
+
+
 def _infer_source_dedupe_preview_key(rules: dict[str, Any]) -> str:
+    """Infer which scrape-rule field will likely provide item identity."""
     identity_key = _first_present_rule_key(
         rules,
-        ("guid_xpath", "id_xpath", "link_xpath", "url_xpath"),
+        _SOURCE_DEDUPE_IDENTITY_KEYS,
     )
     if identity_key:
         return identity_key
@@ -2334,7 +2352,7 @@ def _infer_source_dedupe_preview_key(rules: dict[str, Any]) -> str:
                 continue
             identity_key = _first_present_rule_key(
                 alt,
-                ("guid_xpath", "id_xpath", "link_xpath", "url_xpath"),
+                _SOURCE_DEDUPE_IDENTITY_KEYS,
             )
             if identity_key:
                 return f"alternates.{identity_key}"
@@ -2346,6 +2364,7 @@ def _build_source_preview_diagnostics(
     fetch_mode: str,
     scrape_rules: dict[str, Any] | None = None,
 ) -> SourcePreviewDiagnostics:
+    """Build optional source-test diagnostics without changing preview item behavior."""
     diagnostics = SourcePreviewDiagnostics(fetch_mode=fetch_mode)
     if not scrape_rules:
         return diagnostics

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -616,12 +616,23 @@ class PreviewItem(BaseModel):
     flagged: bool = False
 
 
+class SourcePreviewDiagnostics(BaseModel):
+    fetch_mode: str | None = None
+    selector_errors: list[str] = Field(default_factory=list)
+    selector_warnings: list[str] = Field(default_factory=list)
+    no_match_warnings: list[str] = Field(default_factory=list)
+    non_unique_warnings: list[str] = Field(default_factory=list)
+    fragile_selector_warnings: list[str] = Field(default_factory=list)
+    dedupe_preview_key: str | None = None
+
+
 class PreviewResponse(BaseModel):
     items: list[PreviewItem]
     total: int
     pagination: OffsetPaginationMeta
     ingestable: int
     filtered: int
+    diagnostics: SourcePreviewDiagnostics | None = None
 
 
 class RunDetail(BaseModel):

--- a/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+++ b/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
@@ -168,3 +168,29 @@ def test_draft_source_test_returns_scrape_rule_diagnostics(client_with_user: Tes
     assert diagnostics.get("dedupe_preview_key") == "guid_xpath"
     assert any("link_xpath" in item for item in diagnostics.get("selector_errors", []))
     assert "selector_warnings" in diagnostics
+
+
+def test_source_diagnostics_preserve_warning_detail_and_selector_identity():
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import (
+        _format_selector_diagnostic,
+        _infer_source_dedupe_preview_key,
+    )
+
+    formatted = _format_selector_diagnostic(
+        {
+            "key": "title_selector",
+            "selector": "css:.xYz123abc",
+            "warning": "fragile_selector",
+            "detail": "fragile class 'xYz123abc'",
+        }
+    )
+
+    assert "fragile_selector" in formatted
+    assert "fragile class 'xYz123abc'" in formatted
+    assert _infer_source_dedupe_preview_key({"guid_selector": "css:.entry-id"}) == "guid_selector"
+    assert (
+        _infer_source_dedupe_preview_key(
+            {"alternates": [{"url_selector": "css:a::attr(href)"}]}
+        )
+        == "alternates.url_selector"
+    )

--- a/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+++ b/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
@@ -138,3 +138,33 @@ def test_preview_site_without_include_only_gating(client_with_user: TestClient):
     # No enforced include-only; ensure some items can be 'ingest' even without include match
     assert any(it.get("decision") == "ingest" for it in data.get("items", []))
     # Some may be marked matched_action=None or include/flag depending on synthetic items
+
+
+def test_draft_source_test_returns_scrape_rule_diagnostics(client_with_user: TestClient):
+    c = client_with_user
+
+    r = c.post(
+        "/api/v1/watchlists/sources/test",
+        json={
+            "name": "Draft Site",
+            "url": "https://example.com/news",
+            "source_type": "site",
+            "settings": {
+                "scrape_rules": {
+                    "list_url": "https://example.com/news",
+                    "item_selector": "css:article",
+                    "link_xpath": "//*",
+                    "title_selector": "css:h2",
+                    "guid_xpath": ".//a/@href",
+                    "skip_article_fetch": True,
+                }
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    diagnostics = r.json().get("diagnostics") or {}
+    assert diagnostics.get("fetch_mode") == "scrape_rules"
+    assert diagnostics.get("dedupe_preview_key") == "guid_xpath"
+    assert any("link_xpath" in item for item in diagnostics.get("selector_errors", []))
+    assert "selector_warnings" in diagnostics


### PR DESCRIPTION
## Summary
- Exposes optional source preview diagnostics for draft/saved source tests, including fetch mode, selector validation issues, and dedupe key inference.
- Marks scheduled digest/newsletter output explicitly with `output_prefs.auto_output` for guided pipeline drafts and recurring monitor forms when delivery/audio is configured.
- Normalizes skipped delivery status labeling and records TASK-428 / PR2 plan progress.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q` -> 9 passed.
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py -q` -> 47 passed.
- [x] `bun run test -- src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts --maxWorkers=1 --no-file-parallelism` -> 42 passed.
- [x] `git diff --check` -> passed.
- [x] Bandit on touched backend files -> 0 findings.

## Change summary
Human-owned change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds source preview diagnostics to watchlist source tests and a scheduled auto-output contract for recurring monitors. Implements TASK-428 (PR2) with hardened diagnostics: clearer categories, safer parsing, and better dedupe inference.

- **New Features**
  - Preview API returns optional `diagnostics` with fetch mode, selector errors, categorized warnings (no_match, non_unique, fragile, generic), and a dedupe key; supports scrape-rule, RSS, discovery, and test modes, with alternates-aware dedupe inference.
  - `pipeline-contract` sets `output_prefs.auto_output` for all scheduled monitors; the Jobs form sets it only when delivery or audio is enabled; manual/test-only flows do not set it. Defaults `type: "briefing_markdown"` and propagates format/name/version when provided.
  - Delivery status labels include “Skipped,” with color mapping.

- **Bug Fixes**
  - Selector diagnostics tolerate missing/None lists, preserve warning detail text, and use clearer formatting.
  - Template version is normalized once in pipeline payload construction.

<sup>Written for commit 88299c54773ba116be017de7cc50fddac51f76d5. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1842?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

