### PR TITLE
Close out llama.cpp acquisition workflows

### DIFF
--- a/Docs/API-related/llamacpp_integration_modes.md
+++ b/Docs/API-related/llamacpp_integration_modes.md
@@ -20,7 +20,11 @@ This project supports two distinct `llama.cpp` integration planes. They are both
 | `GET /api/v1/llamacpp/config` and `PUT /api/v1/llamacpp/config` | managed plane | Reads and updates saved llama.cpp admin configuration |
 | `POST /api/v1/llamacpp/validate` | managed plane | Validates a local `llama-server` binary path |
 | `GET /api/v1/llamacpp/inventory` | managed plane | Lists bounded GGUF inventory with stable model IDs and metadata hints |
-| `POST /api/v1/llamacpp/models/register-path` | managed plane | Registers an allowed local GGUF path for inventory |
+| `POST /api/v1/llamacpp/models/register-path` | managed plane | Legacy inventory-only path registration for local GGUF models |
+| `GET /api/v1/llamacpp/assets` | managed plane | Lists GGUF, mmproj, and imported-folder assets for the Assets panel |
+| `POST /api/v1/llamacpp/assets/register-path` | managed plane | Registers an allowed local GGUF or mmproj path for the Assets panel |
+| `POST /api/v1/llamacpp/assets/import-folder/preview` and `POST /api/v1/llamacpp/assets/import-folder` | managed plane | Previews, then explicitly persists, an allowed local asset folder import |
+| `GET/POST/DELETE /api/v1/llamacpp/assets/downloads*` | managed plane | Lists, queues, reads, or cancels Jobs-backed remote GGUF acquisition jobs |
 | `GET /api/v1/llamacpp/models` | managed plane | Legacy model-file listing from managed-plane runtime |
 | `GET /api/v1/llamacpp/hardware` | managed plane | Returns best-effort local RAM/GPU snapshot and warnings |
 | `GET /api/v1/llamacpp/logs/tail` | managed plane | Tails the configured managed llama.cpp log with bounded line count |

--- a/Docs/API-related/llamacpp_integration_modes.md
+++ b/Docs/API-related/llamacpp_integration_modes.md
@@ -45,6 +45,26 @@ The `/admin/llamacpp` WebUI is an admin/operator surface for the managed plane. 
 
 After a managed server is running, the page shows **Use this in Chat**. This is intentionally explicit: it calls `POST /api/v1/llamacpp/use-in-chat` and updates the provider-plane `llama_api` endpoint only after the admin chooses it. Starting a managed server alone does not mutate chat provider settings.
 
+## Model Acquisition And Import
+
+The `/admin/llamacpp` **Assets** panel helps operators make local GGUF and mmproj files visible to the managed plane without changing runtime or provider-plane state by surprise.
+
+Local acquisition has two paths:
+
+1. **Register local asset path**: `POST /api/v1/llamacpp/assets/register-path` records one allowed local GGUF or mmproj file path. Use this when the asset already exists and only that file should be added to inventory.
+2. **Import local asset folder**: `POST /api/v1/llamacpp/assets/import-folder/preview` scans a folder first and returns counts, warnings, candidate assets, and `will_persist=false`. The preview does not mutate config. `POST /api/v1/llamacpp/assets/import-folder` is the explicit confirmation step that persists the folder in the managed asset inventory.
+
+Remote acquisition is Jobs-backed. `POST /api/v1/llamacpp/assets/downloads` validates a remote GGUF download request and creates an acquisition job. The worker downloads to a partial file, enforces size/checksum validation when requested, promotes the file atomically, then registers the completed asset. A queued or running download does not appear in normal asset inventory until the worker finishes validation and registration; the WebUI refreshes assets after it observes a newly completed download job.
+
+Acquisition is intentionally not a launch workflow. Registering, importing, or downloading an asset never creates a profile, starts a runtime, or wires the asset into Chat. Operators must still create or update a profile, start the desired runtime, and explicitly use **Use this in Chat** when they want provider-plane routing to change.
+
+Remote download policy is conservative by default:
+
+- download URLs must use `http` or `https`, must not embed credentials, and must not include known secret query keys;
+- local/private-network hosts are rejected unless the operator explicitly enables private downloads for the deployment;
+- destination paths must resolve under configured llama.cpp roots such as `models_dir` or `allowed_paths`;
+- destination filenames must be simple `.gguf` filenames.
+
 ## Common Misconfigurations
 
 | Symptom | Plane | Likely Cause | Correct Fix |

--- a/Docs/Published/API-related/llamacpp_integration_modes.md
+++ b/Docs/Published/API-related/llamacpp_integration_modes.md
@@ -20,7 +20,11 @@ This project supports two distinct `llama.cpp` integration planes. They are both
 | `GET /api/v1/llamacpp/config` and `PUT /api/v1/llamacpp/config` | managed plane | Reads and updates saved llama.cpp admin configuration |
 | `POST /api/v1/llamacpp/validate` | managed plane | Validates a local `llama-server` binary path |
 | `GET /api/v1/llamacpp/inventory` | managed plane | Lists bounded GGUF inventory with stable model IDs and metadata hints |
-| `POST /api/v1/llamacpp/models/register-path` | managed plane | Registers an allowed local GGUF path for inventory |
+| `POST /api/v1/llamacpp/models/register-path` | managed plane | Legacy inventory-only path registration for local GGUF models |
+| `GET /api/v1/llamacpp/assets` | managed plane | Lists GGUF, mmproj, and imported-folder assets for the Assets panel |
+| `POST /api/v1/llamacpp/assets/register-path` | managed plane | Registers an allowed local GGUF or mmproj path for the Assets panel |
+| `POST /api/v1/llamacpp/assets/import-folder/preview` and `POST /api/v1/llamacpp/assets/import-folder` | managed plane | Previews, then explicitly persists, an allowed local asset folder import |
+| `GET/POST/DELETE /api/v1/llamacpp/assets/downloads*` | managed plane | Lists, queues, reads, or cancels Jobs-backed remote GGUF acquisition jobs |
 | `GET /api/v1/llamacpp/models` | managed plane | Legacy model-file listing from managed-plane runtime |
 | `GET /api/v1/llamacpp/hardware` | managed plane | Returns best-effort local RAM/GPU snapshot and warnings |
 | `GET /api/v1/llamacpp/logs/tail` | managed plane | Tails the configured managed llama.cpp log with bounded line count |

--- a/Docs/Published/API-related/llamacpp_integration_modes.md
+++ b/Docs/Published/API-related/llamacpp_integration_modes.md
@@ -45,6 +45,26 @@ The `/admin/llamacpp` WebUI is an admin/operator surface for the managed plane. 
 
 After a managed server is running, the page shows **Use this in Chat**. This is intentionally explicit: it calls `POST /api/v1/llamacpp/use-in-chat` and updates the provider-plane `llama_api` endpoint only after the admin chooses it. Starting a managed server alone does not mutate chat provider settings.
 
+## Model Acquisition And Import
+
+The `/admin/llamacpp` **Assets** panel helps operators make local GGUF and mmproj files visible to the managed plane without changing runtime or provider-plane state by surprise.
+
+Local acquisition has two paths:
+
+1. **Register local asset path**: `POST /api/v1/llamacpp/assets/register-path` records one allowed local GGUF or mmproj file path. Use this when the asset already exists and only that file should be added to inventory.
+2. **Import local asset folder**: `POST /api/v1/llamacpp/assets/import-folder/preview` scans a folder first and returns counts, warnings, candidate assets, and `will_persist=false`. The preview does not mutate config. `POST /api/v1/llamacpp/assets/import-folder` is the explicit confirmation step that persists the folder in the managed asset inventory.
+
+Remote acquisition is Jobs-backed. `POST /api/v1/llamacpp/assets/downloads` validates a remote GGUF download request and creates an acquisition job. The worker downloads to a partial file, enforces size/checksum validation when requested, promotes the file atomically, then registers the completed asset. A queued or running download does not appear in normal asset inventory until the worker finishes validation and registration; the WebUI refreshes assets after it observes a newly completed download job.
+
+Acquisition is intentionally not a launch workflow. Registering, importing, or downloading an asset never creates a profile, starts a runtime, or wires the asset into Chat. Operators must still create or update a profile, start the desired runtime, and explicitly use **Use this in Chat** when they want provider-plane routing to change.
+
+Remote download policy is conservative by default:
+
+- download URLs must use `http` or `https`, must not embed credentials, and must not include known secret query keys;
+- local/private-network hosts are rejected unless the operator explicitly enables private downloads for the deployment;
+- destination paths must resolve under configured llama.cpp roots such as `models_dir` or `allowed_paths`;
+- destination filenames must be simple `.gguf` filenames.
+
 ## Common Misconfigurations
 
 | Symptom | Plane | Likely Cause | Correct Fix |

--- a/Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
@@ -619,9 +619,10 @@ git commit -m "feat: add llama.cpp acquisition workflow UI"
 - Modify: `Docs/API-related/llamacpp_integration_modes.md`
 - Modify: `Docs/Published/API-related/llamacpp_integration_modes.md`
 - Modify: `apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts`
-- Modify: `backlog/tasks/task-416 - Plan-llama.cpp-model-acquisition-and-import-workflows.md`
+- Modify: `Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md`
+- Modify: `backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md`
 
-- [ ] **Step 1: Update docs**
+- [x] **Step 1: Update docs**
 
 Document:
 
@@ -632,7 +633,7 @@ Document:
 - acquisition never creates/starts/wires profiles automatically;
 - private network URL policy and destination allowlist policy.
 
-- [ ] **Step 2: Add or extend admin E2E smoke**
+- [x] **Step 2: Add or extend admin E2E smoke**
 
 Mock backend responses for:
 
@@ -643,7 +644,7 @@ Mock backend responses for:
 
 Do not require real remote downloads in E2E.
 
-- [ ] **Step 3: Run focused backend tests**
+- [x] **Step 3: Run focused backend tests**
 
 Run:
 
@@ -659,7 +660,9 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 4: Run focused frontend tests**
+Result: PASS, 102 passed and 5 warnings.
+
+- [x] **Step 4: Run focused frontend tests**
 
 Run from `apps/packages/ui`:
 
@@ -672,7 +675,9 @@ Run from `apps/packages/ui`:
 
 Expected: PASS.
 
-- [ ] **Step 5: Run Playwright smoke if dev-server prerequisites are available**
+Result: PASS, 33 passed across 3 files.
+
+- [x] **Step 5: Run Playwright smoke if dev-server prerequisites are available**
 
 Run:
 
@@ -682,7 +687,9 @@ bunx playwright test apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacp
 
 If the suite requires a running backend/frontend server, start the established dev server workflow or record the blocker clearly.
 
-- [ ] **Step 6: Run Bandit on touched Python paths**
+Result: PASS after rerunning with elevated localhost dev-server permissions, 6 passed.
+
+- [x] **Step 6: Run Bandit on touched Python paths**
 
 Run:
 
@@ -698,7 +705,9 @@ python -m bandit \
 
 Expected: no high/medium findings in touched code. If Bandit flags network/download behavior, fix the policy or document a narrow justified suppression only after reviewing the finding.
 
-- [ ] **Step 7: Run diff checks**
+Result: SKIPPED. This closeout changed docs and TypeScript E2E only; no Python files were touched.
+
+- [x] **Step 7: Run diff checks**
 
 Run:
 
@@ -709,16 +718,19 @@ git status --short --branch
 
 Expected: no whitespace errors and only intentional files.
 
-- [ ] **Step 8: Update Backlog and commit docs closeout**
+Result: PASS. `git diff --check` passed, and `git status --short --branch` showed only intentional docs, E2E, plan, and Backlog task changes.
 
-Update `TASK-416` with exact verification results, known skips, and final summary.
+- [x] **Step 8: Update Backlog and commit docs closeout**
+
+Update `TASK-416.5` with exact verification results, known skips, and final summary.
 
 ```bash
 git add \
   Docs/API-related/llamacpp_integration_modes.md \
   Docs/Published/API-related/llamacpp_integration_modes.md \
   apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts \
-  "backlog/tasks/task-416 - Plan-llama.cpp-model-acquisition-and-import-workflows.md"
+  Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md \
+  "backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md"
 git commit -m "docs: document llama.cpp acquisition workflows"
 ```
 

--- a/apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts
@@ -7,6 +7,7 @@
  * - Guided readiness, inventory, and launch panels
  * - Start Server calls start-by-model with stable model_id
  * - Use this in Chat is explicit and calls provider wiring API
+ * - Acquisition import/download flows stay mocked and do not require remote downloads
  *
  * Run: npx playwright test e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts
  */
@@ -61,6 +62,7 @@ const mockConfig = {
     port_probe_max: 10,
     allowed_paths: ["/srv/models"],
     registered_model_paths: [],
+    imported_asset_folders: [],
     log_output_file: null,
   },
   active_config: {
@@ -113,9 +115,138 @@ const mockHardware = {
   warnings: ["GPU probe unavailable."],
 }
 
+const mockGgufAsset = {
+  asset_id: "gguf:toy-model-id",
+  kind: "gguf",
+  identity_basis: "resolved_path",
+  path: "/srv/models/gguf/toy-7b-q4_k_m.gguf",
+  resolved_path: "/srv/models/gguf/toy-7b-q4_k_m.gguf",
+  display_name: "Toy 7B Q4_K_M",
+  source: "models_dir",
+  size_bytes: 4_200_000_000,
+  modified_at: "2026-05-15T10:00:00Z",
+  metadata: {
+    quantization: "Q4_K_M",
+    parameter_hint: "7B",
+    context_hint: 4096,
+    family_hint: "toy",
+  },
+  capabilities: ["chat"],
+  mmproj_asset_ids: ["mmproj:toy-vision"],
+  base_model_asset_ids: [],
+  warnings: [],
+}
+
+const mockMmprojAsset = {
+  asset_id: "mmproj:toy-vision",
+  kind: "mmproj",
+  identity_basis: "resolved_path",
+  path: "/srv/models/gguf/toy-mmproj.gguf",
+  resolved_path: "/srv/models/gguf/toy-mmproj.gguf",
+  display_name: "Toy Vision Projector",
+  source: "models_dir",
+  size_bytes: 320_000_000,
+  modified_at: "2026-05-15T10:05:00Z",
+  metadata: {
+    family_hint: "toy",
+  },
+  capabilities: ["vision"],
+  mmproj_asset_ids: [],
+  base_model_asset_ids: ["gguf:toy-model-id"],
+  warnings: [],
+}
+
+const mockImportedFolderAsset = {
+  asset_id: "folder:imported",
+  kind: "folder",
+  identity_basis: "resolved_path",
+  path: "/srv/models/imported",
+  resolved_path: "/srv/models/imported",
+  display_name: "imported",
+  source: "imported_folder",
+  size_bytes: null,
+  modified_at: "2026-05-15T11:00:00Z",
+  metadata: {},
+  capabilities: [],
+  mmproj_asset_ids: [],
+  base_model_asset_ids: [],
+  warnings: [],
+}
+
+const mockImportedGgufAsset = {
+  asset_id: "gguf:imported-toy",
+  kind: "gguf",
+  identity_basis: "resolved_path",
+  path: "/srv/models/imported/imported-toy.gguf",
+  resolved_path: "/srv/models/imported/imported-toy.gguf",
+  display_name: "Imported Toy",
+  source: "imported_folder",
+  size_bytes: 2_100_000_000,
+  modified_at: "2026-05-15T11:01:00Z",
+  metadata: {
+    quantization: "Q4_K_M",
+    parameter_hint: "3B",
+  },
+  capabilities: ["chat"],
+  mmproj_asset_ids: [],
+  base_model_asset_ids: [],
+  warnings: [],
+}
+
+const mockDownloadedAsset = {
+  asset_id: "gguf:downloaded-toy",
+  kind: "gguf",
+  identity_basis: "resolved_path",
+  path: "/srv/models/downloaded-toy.gguf",
+  resolved_path: "/srv/models/downloaded-toy.gguf",
+  display_name: "Downloaded Toy",
+  source: "models_dir",
+  size_bytes: 2_200_000_000,
+  modified_at: "2026-05-15T12:00:00Z",
+  metadata: {
+    quantization: "Q4_K_M",
+    parameter_hint: "3B",
+  },
+  capabilities: ["chat"],
+  mmproj_asset_ids: [],
+  base_model_asset_ids: [],
+  warnings: [],
+}
+
+const mockQueuedDownloadJob = {
+  job_id: "42",
+  status: "queued",
+  operation: "download",
+  queue: "acquisition",
+  source_label: "Toy download",
+  destination_path: "/srv/models/downloaded-toy.gguf",
+  asset_id: null,
+  progress: {},
+  warnings: [],
+  error_message: null,
+}
+
+const mockCompletedDownloadJob = {
+  ...mockQueuedDownloadJob,
+  status: "completed",
+  asset_id: "gguf:downloaded-toy",
+  progress: {
+    progress_percent: 100,
+  },
+}
+
 async function mockLlamacppAdminFlow(page: Page) {
   let currentStatus = stoppedStatus
+  let currentAssets = {
+    assets: [mockGgufAsset, mockMmprojAsset],
+    warnings: [],
+    scan_limited: false,
+  }
+  let downloadJobs: unknown[] = []
+  let assetsRequestCount = 0
   let startRequestBody: unknown = null
+  let importRequestBody: unknown = null
+  let downloadRequestBody: unknown = null
   let useInChatCalled = false
 
   await page.route("**/api/v1/llamacpp/config", async (route) => {
@@ -132,6 +263,61 @@ async function mockLlamacppAdminFlow(page: Page) {
 
   await page.route("**/api/v1/llamacpp/hardware", async (route) => {
     await fulfillJson(route, mockHardware)
+  })
+
+  await page.route("**/api/v1/llamacpp/assets", async (route) => {
+    assetsRequestCount += 1
+    await fulfillJson(route, currentAssets)
+  })
+
+  await page.route("**/api/v1/llamacpp/assets/import-folder/preview", async (route) => {
+    await fulfillJson(route, {
+      folder: mockImportedFolderAsset,
+      assets: [mockImportedGgufAsset, mockMmprojAsset],
+      asset_counts: {
+        gguf: 1,
+        mmproj: 1,
+      },
+      warnings: ["Preview skipped unreadable sidecar file."],
+      scan_limited: false,
+      will_persist: false,
+    })
+  })
+
+  await page.route("**/api/v1/llamacpp/assets/import-folder", async (route) => {
+    importRequestBody = route.request().postDataJSON()
+    currentAssets = {
+      assets: [mockGgufAsset, mockMmprojAsset, mockImportedFolderAsset, mockImportedGgufAsset],
+      warnings: [],
+      scan_limited: false,
+    }
+    await fulfillJson(route, mockImportedFolderAsset)
+  })
+
+  await page.route("**/api/v1/llamacpp/assets/downloads", async (route) => {
+    if (route.request().method() === "POST") {
+      downloadRequestBody = route.request().postDataJSON()
+      downloadJobs = [mockQueuedDownloadJob]
+      await fulfillJson(route, mockQueuedDownloadJob)
+      return
+    }
+
+    await fulfillJson(route, {
+      jobs: downloadJobs,
+    })
+  })
+
+  await page.route("**/api/v1/llamacpp/profiles", async (route) => {
+    await fulfillJson(route, {
+      profiles: [],
+    })
+  })
+
+  await page.route("**/api/v1/llamacpp/instances", async (route) => {
+    await fulfillJson(route, {
+      runtimes: [],
+      warnings: [],
+    })
   })
 
   await page.route("**/api/v1/llamacpp/start-by-model", async (route) => {
@@ -157,6 +343,23 @@ async function mockLlamacppAdminFlow(page: Page) {
 
   return {
     getStartRequestBody: () => startRequestBody,
+    getImportRequestBody: () => importRequestBody,
+    getDownloadRequestBody: () => downloadRequestBody,
+    getAssetsRequestCount: () => assetsRequestCount,
+    markDownloadCompleted: () => {
+      downloadJobs = [mockCompletedDownloadJob]
+      currentAssets = {
+        assets: [
+          mockGgufAsset,
+          mockMmprojAsset,
+          mockImportedFolderAsset,
+          mockImportedGgufAsset,
+          mockDownloadedAsset,
+        ],
+        warnings: [],
+        scan_limited: false,
+      }
+    },
     wasUseInChatCalled: () => useInChatCalled,
   }
 }
@@ -280,6 +483,68 @@ test.describe("Admin Llama.cpp", () => {
       await admin.llamacppUseInChatButton.click()
       await expect(authedPage.getByText("Chat provider updated.")).toBeVisible()
       expect(api.wasUseInChatCalled()).toBe(true)
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+
+    test("should import folders and refresh completed downloads without live downloads", async ({
+      authedPage,
+      diagnostics,
+    }) => {
+      const api = await mockLlamacppAdminFlow(authedPage)
+
+      admin = new AdminPage(authedPage)
+      await admin.gotoSection("llamacpp")
+      await admin.assertSectionReady("llamacpp")
+
+      await expect(authedPage.getByText("Assets")).toBeVisible()
+      await expect(authedPage.getByText("Toy 7B Q4_K_M").first()).toBeVisible()
+
+      await authedPage
+        .getByLabel("Import local asset folder")
+        .fill("/srv/models/imported")
+      await authedPage.getByRole("button", { name: "Preview folder" }).click()
+
+      await expect(authedPage.getByText("Import preview")).toBeVisible()
+      await expect(authedPage.getByText("GGUF: 1")).toBeVisible()
+      await expect(authedPage.getByText("mmproj: 1")).toBeVisible()
+      expect(api.getImportRequestBody()).toBeNull()
+
+      await authedPage.getByRole("button", { name: "Confirm import" }).click()
+      await expect(authedPage.getByText("Imported Toy")).toBeVisible()
+      expect(api.getImportRequestBody()).toEqual({
+        path: "/srv/models/imported",
+      })
+
+      await authedPage
+        .getByLabel("Download source URL")
+        .fill("https://example.com/downloaded-toy.gguf")
+      await authedPage
+        .getByLabel("Download destination directory")
+        .fill("/srv/models")
+      await authedPage
+        .getByLabel("Download filename")
+        .fill("downloaded-toy.gguf")
+      await authedPage.getByRole("button", { name: "Queue download" }).click()
+
+      await expect(authedPage.getByText("Toy download")).toBeVisible()
+      await expect(authedPage.getByText("queued")).toBeVisible()
+      expect(api.getDownloadRequestBody()).toEqual({
+        url: "https://example.com/downloaded-toy.gguf",
+        destination_dir: "/srv/models",
+        filename: "downloaded-toy.gguf",
+      })
+
+      const assetsRequestsBeforeCompletion = api.getAssetsRequestCount()
+      api.markDownloadCompleted()
+      await authedPage.getByRole("button", { name: /Refresh downloads/i }).click()
+
+      await expect(authedPage.getByText("completed")).toBeVisible()
+      await expect(authedPage.getByText("Downloaded Toy")).toBeVisible()
+      expect(api.getAssetsRequestCount()).toBeGreaterThan(
+        assetsRequestsBeforeCompletion
+      )
+      expect(api.wasUseInChatCalled()).toBe(false)
 
       await assertNoCriticalErrors(diagnostics)
     })

--- a/backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md
+++ b/backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md
@@ -1,0 +1,69 @@
+---
+id: TASK-416.5
+title: Finalize llama.cpp acquisition docs and E2E smoke
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-18 14:42'
+labels:
+  - llamacpp
+  - webui
+  - docs
+  - e2e
+  - local-llm
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+parent_task_id: TASK-416
+priority: medium
+modified_files:
+  - Docs/API-related/llamacpp_integration_modes.md
+  - Docs/Published/API-related/llamacpp_integration_modes.md
+  - Docs/superpowers/plans/2026-05-16-llamacpp-model-acquisition-import-workflows-plan.md
+  - apps/tldw-frontend/e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts
+  - backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Docs explain local register path vs import folder behavior and the non-mutating import preview.
+- [x] #2 Docs explain Jobs-backed remote downloads, validation-to-inventory flow, and the explicit no auto-profile/start/wiring boundary.
+- [x] #3 Admin E2E smoke covers import preview, confirmed folder import, queued download, completed download, and asset refresh without real remote downloads.
+- [x] #4 Focused backend/frontend tests and diff checks are run or any skips are documented with reasons.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Task 5 from the llama.cpp model acquisition/import workflow plan: document the acquisition/import lifecycle, add or extend admin E2E smoke coverage using mocked APIs, run focused backend/frontend verification where available, run Bandit for touched Python scope if Python files are touched, and close out the plan/task notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Task 5 closeout from the llama.cpp acquisition/import workflow plan. Updated public and published integration-mode docs with local register vs folder import behavior, non-mutating previews, Jobs-backed remote downloads, validation-to-inventory flow, no automatic profile/start/chat wiring, private-network URL policy, and destination allowlist rules. Extended the tier-4 admin Playwright smoke with mocked import preview, confirmed folder import, queued download, completed download, and asset refresh coverage.
+
+Verification: backend focused pytest passed (102 passed, 5 warnings); frontend focused Vitest passed (33 passed across 3 files); Playwright admin llama.cpp smoke passed after elevated localhost dev-server run (6 passed); git diff --check passed. Bandit skipped because this closeout changed docs and TypeScript E2E only, with no touched Python scope.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Finalized llama.cpp acquisition/import closeout documentation and mocked admin E2E smoke coverage. The docs now explain the explicit acquisition boundaries and safety policies, while the Playwright smoke proves import and download flows stay mocked, Jobs-backed, and separate from profile creation/runtime launch/chat wiring.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md
+++ b/backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md
@@ -49,7 +49,7 @@ Execute Task 5 from the llama.cpp model acquisition/import workflow plan: docume
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implemented Task 5 closeout from the llama.cpp acquisition/import workflow plan. Updated public and published integration-mode docs with local register vs folder import behavior, non-mutating previews, Jobs-backed remote downloads, validation-to-inventory flow, no automatic profile/start/chat wiring, private-network URL policy, and destination allowlist rules. Extended the tier-4 admin Playwright smoke with mocked import preview, confirmed folder import, queued download, completed download, and asset refresh coverage.
 
-Verification: backend focused pytest passed (102 passed, 5 warnings); frontend focused Vitest passed (33 passed across 3 files); Playwright admin llama.cpp smoke passed after elevated localhost dev-server run (6 passed); git diff --check passed. Bandit skipped because this closeout changed docs and TypeScript E2E only, with no touched Python scope.
+Verification: backend-focused pytest passed (102 passed, 5 warnings); frontend-focused Vitest passed (33 passed across 3 files); Playwright admin llama.cpp smoke passed after elevated localhost dev-server run (6 passed); git diff --check passed. Bandit skipped because this closeout changed docs and TypeScript E2E only, with no touched Python scope.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-416.5.1 - Address-PR-1843-llama.cpp-acquisition-closeout-review-comments.md
+++ b/backlog/tasks/task-416.5.1 - Address-PR-1843-llama.cpp-acquisition-closeout-review-comments.md
@@ -1,0 +1,67 @@
+---
+id: TASK-416.5.1
+title: Address PR 1843 llama.cpp acquisition closeout review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-18 19:34'
+labels:
+  - llamacpp
+  - docs
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1843'
+documentation:
+  - Docs/API-related/llamacpp_integration_modes.md
+  - Docs/Published/API-related/llamacpp_integration_modes.md
+parent_task_id: TASK-416.5
+priority: medium
+modified_files:
+  - Docs/API-related/llamacpp_integration_modes.md
+  - Docs/Published/API-related/llamacpp_integration_modes.md
+  - backlog/tasks/task-416.5 - Finalize-llama.cpp-acquisition-docs-and-E2E-smoke.md
+  - backlog/tasks/task-416.5.1 - Address-PR-1843-llama.cpp-acquisition-closeout-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Docs endpoint mapping distinguishes legacy model-only register-path from assets register-path and lists assets endpoints in source and published docs.
+- [x] #2 Backlog verification wording uses the requested hyphenated compound modifiers.
+- [x] #3 Focused documentation/diff verification is run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Verify each PR review finding against current code, fix only still-valid issues, update the review-fix task with verification, and push a minimal follow-up commit to PR 1843.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verified Qodo finding against docs and backend endpoints: `/api/v1/llamacpp/models/register-path` and `/api/v1/llamacpp/assets/register-path` both exist, but the table only listed the legacy model-only route. Updated source and published docs to label `models/register-path` as legacy inventory-only and to list `GET /assets`, `POST /assets/register-path`, import-folder preview/confirm, and downloads endpoints. Applied the CodeRabbit wording nit in TASK-416.5 by changing backend/frontend focused to backend-focused/frontend-focused.
+
+Verification: `git diff --check` passed; `cmp -s Docs/API-related/llamacpp_integration_modes.md Docs/Published/API-related/llamacpp_integration_modes.md` passed; `rg` confirmed both docs include legacy model-only and assets endpoint rows; `rg` confirmed the requested hyphenated wording. Bandit skipped because the review fix touched docs/Backlog only and no Python code.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR 1843 review feedback with a minimal docs/backlog-only patch: clarified the llama.cpp endpoint table in both docs copies and fixed the Backlog verification wording.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Documented llama.cpp local register, folder import preview, Jobs-backed remote downloads, validation-to-inventory flow, and explicit no auto-profile/start/chat wiring boundaries.
- Extended the tier-4 admin llama.cpp Playwright smoke with mocked import preview, confirmed import, queued download, completed download, and asset refresh coverage.
- Closed TASK-416.5 and marked the acquisition workflow plan Task 5 verification results.

## Test Plan
- [x] `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_asset_inventory_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_inventory_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_jobs_worker.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -v` (102 passed, 5 warnings)
- [x] `./node_modules/.bin/vitest run src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx src/services/__tests__/tldw-api-client.models-normalization.test.ts` (33 passed)
- [x] `bunx playwright test e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts --reporter=line` (6 passed; required elevated localhost dev-server permissions after sandbox bind failure)
- [x] `git diff --check`
- [x] Bandit not applicable: docs and TypeScript E2E only, no touched Python scope.

## Change summary
Human-owned Change summary required before merge:

> TODO: Human maintainer fills in what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalized llama.cpp model acquisition/import workflows with clear docs and expanded admin E2E smoke. Clarifies explicit, safe flows (no auto profile/start/chat wiring) and addresses review feedback by marking legacy `.../models/register-path` and listing assets endpoints; closes TASK-416.5.

- **Docs & E2E**
  - Added “Model Acquisition And Import” to `Docs/API-related/llamacpp_integration_modes.md` and Published docs.
  - Documented `GET /api/v1/llamacpp/assets`, `POST /api/v1/llamacpp/assets/register-path`, `POST .../assets/import-folder/preview`, `POST .../assets/import-folder`, and `GET/POST/DELETE .../assets/downloads*`; labeled `POST .../models/register-path` as legacy inventory-only.
  - Recorded conservative download policy: `http/https` only, no embedded secrets, private hosts blocked by default, destinations under `models_dir`/`allowed_paths`, simple `.gguf` filenames.
  - Extended `admin-llamacpp.spec.ts` to mock import preview → confirm import, queue download → complete job → refresh assets; verifies “Use this in Chat” is never auto-called.

- **Verification**
  - Backend pytest: 102 passed; Frontend Vitest: 33 passed; Playwright: 6 passed.
  - `git diff --check` clean; Bandit not applicable (docs + TS E2E only).

<sup>Written for commit f9213d6f6c0dd3fecd6074ba9dc8796ae3b57752. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1843?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

