### PR TITLE
Remediate settings and model provider UX

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-webui-extension-ux-remediation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-webui-extension-ux-remediation-implementation-plan.md
@@ -219,7 +219,7 @@ Expected: each child task links to its before evidence before remediation.
 - Test: `apps/packages/ui/src/components/Common/__tests__/CommandPalette.shortcuts.test.tsx`
 - Test: `apps/tldw-frontend/e2e/smoke/route-contract-stage2.spec.ts`
 
-- [ ] **Step 1: Write the child implementation plan**
+- [x] **Step 1: Write the child implementation plan**
 
 Create `Docs/superpowers/plans/<date>-webui-route-contract-implementation-plan.md`.
 It must enumerate the metadata fields before code work starts:
@@ -446,17 +446,17 @@ Create `Docs/superpowers/plans/<date>-webui-settings-models-implementation-plan.
 The plan must separate routine preferences, provider setup, data management, and
 destructive actions.
 
-- [ ] **Step 2: Write failing label and configured-first tests**
+- [x] **Step 2: Write failing label and configured-first tests**
 
 Test that `providerKeys.navTitle` is never visible and that configured/usable
 providers appear before the full model catalog.
 
-- [ ] **Step 3: Implement settings grouping and model readiness summary**
+- [x] **Step 3: Implement settings grouping and model readiness summary**
 
 Keep full catalog available behind search/filter. Do not remove advanced model
 controls.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run:
 
@@ -472,6 +472,15 @@ bunx playwright test e2e/workflows/settings.spec.ts e2e/workflows/tier-1-critica
 
 Expected: settings routes are task-led, mobile-safe, and free of dotted i18n
 keys.
+
+**Status 2026-05-18:** Completed in child branch
+`codex/webui-settings-models` and tracked by `TASK-418.14`. The slice added
+task-led settings navigation groups, a visible Provider Keys route label,
+separate Data Management settings, configured-first model/provider orientation,
+and prompt route-intent browser guards. Verification recorded on the child task:
+focused Vitest settings/model tests passed, the settings Playwright workflow
+pair passed, and the WP4 responsive landmarks gate passed. The repo-wide
+TypeScript check still fails on existing baseline debt outside this slice.
 
 ## Task 6: Chat, Composer, And Global Chrome
 

--- a/apps/packages/ui/src/assets/locale/ar/settings.json
+++ b/apps/packages/ui/src/assets/locale/ar/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "الذكاء الاصطناعي والنماذج",
     "experience": "التجربة",
     "knowledgeWorkspace": "المعرفة ومساحة العمل",
-    "safetyAdmin": "السلامة والإدارة"
+    "safetyAdmin": "السلامة والإدارة",
+    "dataManagement": "إدارة البيانات"
   },
   "healthNav": "الحالة",
   "worldBooksNav": "كتب العوالم",
@@ -1667,5 +1668,8 @@
   "skillsNav": "المهارات",
   "providerKeys": {
     "navTitle": "مفاتيح المزوّدين"
+  },
+  "dataManagement": {
+    "navTitle": "إدارة البيانات"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ar/settings.json
+++ b/apps/packages/ui/src/assets/locale/ar/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "الخادم والمصادقة",
     "knowledgeTools": "أدوات المعرفة",
     "workspace": "مساحة العمل",
-    "about": "نبذة"
+    "about": "نبذة",
+    "connect": "الاتصال",
+    "aiModels": "الذكاء الاصطناعي والنماذج",
+    "experience": "التجربة",
+    "knowledgeWorkspace": "المعرفة ومساحة العمل",
+    "safetyAdmin": "السلامة والإدارة"
   },
   "healthNav": "الحالة",
   "worldBooksNav": "كتب العوالم",
@@ -1659,5 +1664,8 @@
     "subtitle": "اضبط القيم الافتراضية والإعدادات المسبقة وسلوك الإدخال السريع."
   },
   "acpPlaygroundNav": "ساحة ACP",
-  "skillsNav": "المهارات"
+  "skillsNav": "المهارات",
+  "providerKeys": {
+    "navTitle": "مفاتيح المزوّدين"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/da/settings.json
+++ b/apps/packages/ui/src/assets/locale/da/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "AI og modeller",
     "experience": "Oplevelse",
     "knowledgeWorkspace": "Viden og arbejdsområde",
-    "safetyAdmin": "Sikkerhed og administration"
+    "safetyAdmin": "Sikkerhed og administration",
+    "dataManagement": "Datahåndtering"
   },
   "healthNav": "Sundhed",
   "worldBooksNav": "Verdensbøger",
@@ -1667,5 +1668,8 @@
   "skillsNav": "Færdigheder",
   "providerKeys": {
     "navTitle": "Udbydernøgler"
+  },
+  "dataManagement": {
+    "navTitle": "Datahåndtering"
   }
 }

--- a/apps/packages/ui/src/assets/locale/da/settings.json
+++ b/apps/packages/ui/src/assets/locale/da/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Server og godkendelse",
     "knowledgeTools": "Videnværktøjer",
     "workspace": "Arbejdsområde",
-    "about": "Om"
+    "about": "Om",
+    "connect": "Forbindelse",
+    "aiModels": "AI og modeller",
+    "experience": "Oplevelse",
+    "knowledgeWorkspace": "Viden og arbejdsområde",
+    "safetyAdmin": "Sikkerhed og administration"
   },
   "healthNav": "Sundhed",
   "worldBooksNav": "Verdensbøger",
@@ -1659,5 +1664,8 @@
     "subtitle": "Konfigurer standarder, forudindstillinger og adfærd for hurtig import."
   },
   "acpPlaygroundNav": "ACP-legeplads",
-  "skillsNav": "Færdigheder"
+  "skillsNav": "Færdigheder",
+  "providerKeys": {
+    "navTitle": "Udbydernøgler"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/de/settings.json
+++ b/apps/packages/ui/src/assets/locale/de/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "KI & Modelle",
     "experience": "Erlebnis",
     "knowledgeWorkspace": "Wissen & Arbeitsbereich",
-    "safetyAdmin": "Sicherheit & Verwaltung"
+    "safetyAdmin": "Sicherheit & Verwaltung",
+    "dataManagement": "Datenverwaltung"
   },
   "healthNav": "Status",
   "worldBooksNav": "Weltbücher",
@@ -1677,5 +1678,8 @@
   "skillsNav": "Fähigkeiten",
   "providerKeys": {
     "navTitle": "Anbieter-Schlüssel"
+  },
+  "dataManagement": {
+    "navTitle": "Datenverwaltung"
   }
 }

--- a/apps/packages/ui/src/assets/locale/de/settings.json
+++ b/apps/packages/ui/src/assets/locale/de/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Server & Authentifizierung",
     "knowledgeTools": "Wissenswerkzeuge",
     "workspace": "Arbeitsbereich",
-    "about": "Info"
+    "about": "Info",
+    "connect": "Verbindung",
+    "aiModels": "KI & Modelle",
+    "experience": "Erlebnis",
+    "knowledgeWorkspace": "Wissen & Arbeitsbereich",
+    "safetyAdmin": "Sicherheit & Verwaltung"
   },
   "healthNav": "Status",
   "worldBooksNav": "Weltbücher",
@@ -1669,5 +1674,8 @@
     "subtitle": "Konfigurieren Sie Standardwerte, Presets und Verhalten für den Schnellimport."
   },
   "acpPlaygroundNav": "ACP-Spielplatz",
-  "skillsNav": "Fähigkeiten"
+  "skillsNav": "Fähigkeiten",
+  "providerKeys": {
+    "navTitle": "Anbieter-Schlüssel"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -5,7 +5,8 @@
     "experience": "Experience",
     "knowledgeWorkspace": "Knowledge & Workspace",
     "safetyAdmin": "Safety & Admin",
-    "about": "About"
+    "about": "About",
+    "dataManagement": "Data Management"
   },
   "healthNav": "Health & Diagnostics",
   "worldBooksNav": "World Books",
@@ -2404,5 +2405,10 @@
   },
   "serverOverview": {
     "docsUrl": "https://github.com/rmusser01/tldw_browser_assistant"
+  },
+  "dataManagement": {
+    "navTitle": "Data Management",
+    "title": "Data Management",
+    "description": "Export, import, sync, or reset local extension and WebUI data."
   }
 }

--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -1,8 +1,10 @@
 {
   "navigation": {
-    "serverAndAuth": "Server & Auth",
-    "knowledgeTools": "Knowledge Tools",
-    "workspace": "Workspace",
+    "connect": "Connect",
+    "aiModels": "AI & Models",
+    "experience": "Experience",
+    "knowledgeWorkspace": "Knowledge & Workspace",
+    "safetyAdmin": "Safety & Admin",
     "about": "About"
   },
   "healthNav": "Health & Diagnostics",
@@ -33,6 +35,9 @@
   "splashSettingsNav": "Splash screens",
   "familyGuardrailsWizardNav": "Family Guardrails Wizard",
   "guardianNav": "Guardian & Monitoring",
+  "providerKeys": {
+    "navTitle": "Provider Keys"
+  },
   "familyWizard": {
     "title": "Family Guardrails Wizard",
     "subtitle": "Template-first setup for guardians, dependents, and moderation acceptance tracking.",

--- a/apps/packages/ui/src/assets/locale/es/settings.json
+++ b/apps/packages/ui/src/assets/locale/es/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "IA y modelos",
     "experience": "Experiencia",
     "knowledgeWorkspace": "Conocimiento y área de trabajo",
-    "safetyAdmin": "Seguridad y administración"
+    "safetyAdmin": "Seguridad y administración",
+    "dataManagement": "Gestión de datos"
   },
   "healthNav": "Estado",
   "worldBooksNav": "Libros del mundo",
@@ -1668,5 +1669,8 @@
   "skillsNav": "Habilidades",
   "providerKeys": {
     "navTitle": "Claves de proveedores"
+  },
+  "dataManagement": {
+    "navTitle": "Gestión de datos"
   }
 }

--- a/apps/packages/ui/src/assets/locale/es/settings.json
+++ b/apps/packages/ui/src/assets/locale/es/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Servidor y Auth",
     "knowledgeTools": "Herramientas de conocimiento",
     "workspace": "Área de trabajo",
-    "about": "Acerca de"
+    "about": "Acerca de",
+    "connect": "Conectar",
+    "aiModels": "IA y modelos",
+    "experience": "Experiencia",
+    "knowledgeWorkspace": "Conocimiento y área de trabajo",
+    "safetyAdmin": "Seguridad y administración"
   },
   "healthNav": "Estado",
   "worldBooksNav": "Libros del mundo",
@@ -1660,5 +1665,8 @@
     "subtitle": "Configura los valores predeterminados, los ajustes preestablecidos y el comportamiento de Ingesta rápida."
   },
   "acpPlaygroundNav": "Laboratorio ACP",
-  "skillsNav": "Habilidades"
+  "skillsNav": "Habilidades",
+  "providerKeys": {
+    "navTitle": "Claves de proveedores"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/fa/settings.json
+++ b/apps/packages/ui/src/assets/locale/fa/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "سرور و احراز هویت",
     "knowledgeTools": "ابزارهای دانش",
     "workspace": "محیط کار",
-    "about": "درباره"
+    "about": "درباره",
+    "connect": "اتصال",
+    "aiModels": "هوش مصنوعی و مدل‌ها",
+    "experience": "تجربه",
+    "knowledgeWorkspace": "دانش و فضای کاری",
+    "safetyAdmin": "ایمنی و مدیریت"
   },
   "healthNav": "سلامت",
   "worldBooksNav": "کتاب‌های جهان",
@@ -1659,5 +1664,8 @@
     "subtitle": "پیش‌فرض‌ها، پیش‌تنظیم‌ها و رفتار ورود سریع را پیکربندی کنید."
   },
   "acpPlaygroundNav": "محیط آزمایشی ACP",
-  "skillsNav": "مهارت‌ها"
+  "skillsNav": "مهارت‌ها",
+  "providerKeys": {
+    "navTitle": "کلیدهای ارائه‌دهنده"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/fa/settings.json
+++ b/apps/packages/ui/src/assets/locale/fa/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "هوش مصنوعی و مدل‌ها",
     "experience": "تجربه",
     "knowledgeWorkspace": "دانش و فضای کاری",
-    "safetyAdmin": "ایمنی و مدیریت"
+    "safetyAdmin": "ایمنی و مدیریت",
+    "dataManagement": "مدیریت داده"
   },
   "healthNav": "سلامت",
   "worldBooksNav": "کتاب‌های جهان",
@@ -1667,5 +1668,8 @@
   "skillsNav": "مهارت‌ها",
   "providerKeys": {
     "navTitle": "کلیدهای ارائه‌دهنده"
+  },
+  "dataManagement": {
+    "navTitle": "مدیریت داده"
   }
 }

--- a/apps/packages/ui/src/assets/locale/fr/settings.json
+++ b/apps/packages/ui/src/assets/locale/fr/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "IA et modèles",
     "experience": "Expérience",
     "knowledgeWorkspace": "Connaissances et espace de travail",
-    "safetyAdmin": "Sécurité et administration"
+    "safetyAdmin": "Sécurité et administration",
+    "dataManagement": "Gestion des données"
   },
   "healthNav": "Santé",
   "worldBooksNav": "Livres du monde",
@@ -1668,5 +1669,8 @@
   "skillsNav": "Compétences",
   "providerKeys": {
     "navTitle": "Clés des fournisseurs"
+  },
+  "dataManagement": {
+    "navTitle": "Gestion des données"
   }
 }

--- a/apps/packages/ui/src/assets/locale/fr/settings.json
+++ b/apps/packages/ui/src/assets/locale/fr/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Serveur et Auth",
     "knowledgeTools": "Outils de connaissances",
     "workspace": "Espace de travail",
-    "about": "À propos"
+    "about": "À propos",
+    "connect": "Connexion",
+    "aiModels": "IA et modèles",
+    "experience": "Expérience",
+    "knowledgeWorkspace": "Connaissances et espace de travail",
+    "safetyAdmin": "Sécurité et administration"
   },
   "healthNav": "Santé",
   "worldBooksNav": "Livres du monde",
@@ -1660,5 +1665,8 @@
     "subtitle": "Configurez les valeurs par défaut, les préréglages et le comportement d'Ingestion rapide."
   },
   "acpPlaygroundNav": "Atelier ACP",
-  "skillsNav": "Compétences"
+  "skillsNav": "Compétences",
+  "providerKeys": {
+    "navTitle": "Clés des fournisseurs"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/it/settings.json
+++ b/apps/packages/ui/src/assets/locale/it/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "IA e modelli",
     "experience": "Esperienza",
     "knowledgeWorkspace": "Conoscenza e area di lavoro",
-    "safetyAdmin": "Sicurezza e amministrazione"
+    "safetyAdmin": "Sicurezza e amministrazione",
+    "dataManagement": "Gestione dati"
   },
   "healthNav": "Stato",
   "worldBooksNav": "Libri del mondo",
@@ -1678,5 +1679,8 @@
   "skillsNav": "Competenze",
   "providerKeys": {
     "navTitle": "Chiavi provider"
+  },
+  "dataManagement": {
+    "navTitle": "Gestione dati"
   }
 }

--- a/apps/packages/ui/src/assets/locale/it/settings.json
+++ b/apps/packages/ui/src/assets/locale/it/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Server e Auth",
     "knowledgeTools": "Strumenti di conoscenza",
     "workspace": "Area di lavoro",
-    "about": "Informazioni"
+    "about": "Informazioni",
+    "connect": "Connessione",
+    "aiModels": "IA e modelli",
+    "experience": "Esperienza",
+    "knowledgeWorkspace": "Conoscenza e area di lavoro",
+    "safetyAdmin": "Sicurezza e amministrazione"
   },
   "healthNav": "Stato",
   "worldBooksNav": "Libri del mondo",
@@ -1670,5 +1675,8 @@
     "subtitle": "Configura valori predefiniti, preset e comportamento di Importazione rapida."
   },
   "acpPlaygroundNav": "Area ACP",
-  "skillsNav": "Competenze"
+  "skillsNav": "Competenze",
+  "providerKeys": {
+    "navTitle": "Chiavi provider"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/ja-JP/settings.json
+++ b/apps/packages/ui/src/assets/locale/ja-JP/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "サーバーと認証",
     "knowledgeTools": "ナレッジツール",
     "workspace": "ワークスペース",
-    "about": "情報"
+    "about": "情報",
+    "connect": "接続",
+    "aiModels": "AI とモデル",
+    "experience": "体験",
+    "knowledgeWorkspace": "ナレッジとワークスペース",
+    "safetyAdmin": "安全性と管理"
   },
   "healthNav": "ヘルス",
   "worldBooksNav": "ワールドブック",
@@ -1662,5 +1667,8 @@
     "subtitle": "クイック取り込みの既定値、プリセット、動作を設定します。"
   },
   "acpPlaygroundNav": "ACPプレイグラウンド",
-  "skillsNav": "スキル"
+  "skillsNav": "スキル",
+  "providerKeys": {
+    "navTitle": "プロバイダーキー"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/ja-JP/settings.json
+++ b/apps/packages/ui/src/assets/locale/ja-JP/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "AI とモデル",
     "experience": "体験",
     "knowledgeWorkspace": "ナレッジとワークスペース",
-    "safetyAdmin": "安全性と管理"
+    "safetyAdmin": "安全性と管理",
+    "dataManagement": "データ管理"
   },
   "healthNav": "ヘルス",
   "worldBooksNav": "ワールドブック",
@@ -1670,5 +1671,8 @@
   "skillsNav": "スキル",
   "providerKeys": {
     "navTitle": "プロバイダーキー"
+  },
+  "dataManagement": {
+    "navTitle": "データ管理"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ko/settings.json
+++ b/apps/packages/ui/src/assets/locale/ko/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "AI 및 모델",
     "experience": "경험",
     "knowledgeWorkspace": "지식 및 작업 공간",
-    "safetyAdmin": "안전 및 관리"
+    "safetyAdmin": "안전 및 관리",
+    "dataManagement": "데이터 관리"
   },
   "healthNav": "상태",
   "worldBooksNav": "월드북",
@@ -1670,5 +1671,8 @@
   "skillsNav": "스킬",
   "providerKeys": {
     "navTitle": "제공자 키"
+  },
+  "dataManagement": {
+    "navTitle": "데이터 관리"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ko/settings.json
+++ b/apps/packages/ui/src/assets/locale/ko/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "서버 및 인증",
     "knowledgeTools": "지식 도구",
     "workspace": "작업 공간",
-    "about": "정보"
+    "about": "정보",
+    "connect": "연결",
+    "aiModels": "AI 및 모델",
+    "experience": "경험",
+    "knowledgeWorkspace": "지식 및 작업 공간",
+    "safetyAdmin": "안전 및 관리"
   },
   "healthNav": "상태",
   "worldBooksNav": "월드북",
@@ -1662,5 +1667,8 @@
     "subtitle": "빠른 가져오기의 기본값, 프리셋, 동작을 설정합니다."
   },
   "acpPlaygroundNav": "ACP 플레이그라운드",
-  "skillsNav": "스킬"
+  "skillsNav": "스킬",
+  "providerKeys": {
+    "navTitle": "제공자 키"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/ml/settings.json
+++ b/apps/packages/ui/src/assets/locale/ml/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "AI & മോഡലുകൾ",
     "experience": "അനുഭവം",
     "knowledgeWorkspace": "അറിവും വർക്ക്‌സ്പേസും",
-    "safetyAdmin": "സുരക്ഷയും അഡ്മിനും"
+    "safetyAdmin": "സുരക്ഷയും അഡ്മിനും",
+    "dataManagement": "ഡാറ്റ മാനേജ്മെന്റ്"
   },
   "healthNav": "ഹെൽത്ത്",
   "worldBooksNav": "വേൾഡ് ബുക്കുകൾ",
@@ -1670,5 +1671,8 @@
   "skillsNav": "നൈപുണ്യങ്ങൾ",
   "providerKeys": {
     "navTitle": "പ്രൊവൈഡർ കീകൾ"
+  },
+  "dataManagement": {
+    "navTitle": "ഡാറ്റ മാനേജ്മെന്റ്"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ml/settings.json
+++ b/apps/packages/ui/src/assets/locale/ml/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "സെർവർ & ഓത്",
     "knowledgeTools": "നോളജ് ടൂളുകൾ",
     "workspace": "വർക്ക്സ്പേസ്",
-    "about": "അറിയുക"
+    "about": "അറിയുക",
+    "connect": "കണക്ഷൻ",
+    "aiModels": "AI & മോഡലുകൾ",
+    "experience": "അനുഭവം",
+    "knowledgeWorkspace": "അറിവും വർക്ക്‌സ്പേസും",
+    "safetyAdmin": "സുരക്ഷയും അഡ്മിനും"
   },
   "healthNav": "ഹെൽത്ത്",
   "worldBooksNav": "വേൾഡ് ബുക്കുകൾ",
@@ -1662,5 +1667,8 @@
     "subtitle": "ദ്രുത ഇംപോർട്ടിന്റെ ഡീഫോൾട്ടുകൾ, പ്രീസെറ്റുകൾ, പെരുമാറ്റം കോൺഫിഗർ ചെയ്യുക."
   },
   "acpPlaygroundNav": "ACP പ്ലേഗ്രൗണ്ട്",
-  "skillsNav": "നൈപുണ്യങ്ങൾ"
+  "skillsNav": "നൈപുണ്യങ്ങൾ",
+  "providerKeys": {
+    "navTitle": "പ്രൊവൈഡർ കീകൾ"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/no/settings.json
+++ b/apps/packages/ui/src/assets/locale/no/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Server og Auth",
     "knowledgeTools": "Kunnskapsverktøy",
     "workspace": "Arbeidsområde",
-    "about": "Om"
+    "about": "Om",
+    "connect": "Tilkobling",
+    "aiModels": "KI og modeller",
+    "experience": "Opplevelse",
+    "knowledgeWorkspace": "Kunnskap og arbeidsområde",
+    "safetyAdmin": "Sikkerhet og administrasjon"
   },
   "healthNav": "Helse",
   "worldBooksNav": "Verdensbøker",
@@ -1660,5 +1665,8 @@
     "subtitle": "Konfigurer standardverdier, forhåndsinnstillinger og oppførsel for hurtig import."
   },
   "acpPlaygroundNav": "ACP-lekeplass",
-  "skillsNav": "Ferdigheter"
+  "skillsNav": "Ferdigheter",
+  "providerKeys": {
+    "navTitle": "Leverandørnøkler"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/no/settings.json
+++ b/apps/packages/ui/src/assets/locale/no/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "KI og modeller",
     "experience": "Opplevelse",
     "knowledgeWorkspace": "Kunnskap og arbeidsområde",
-    "safetyAdmin": "Sikkerhet og administrasjon"
+    "safetyAdmin": "Sikkerhet og administrasjon",
+    "dataManagement": "Dataadministrasjon"
   },
   "healthNav": "Helse",
   "worldBooksNav": "Verdensbøker",
@@ -1668,5 +1669,8 @@
   "skillsNav": "Ferdigheter",
   "providerKeys": {
     "navTitle": "Leverandørnøkler"
+  },
+  "dataManagement": {
+    "navTitle": "Dataadministrasjon"
   }
 }

--- a/apps/packages/ui/src/assets/locale/pt-BR/settings.json
+++ b/apps/packages/ui/src/assets/locale/pt-BR/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "IA e modelos",
     "experience": "Experiência",
     "knowledgeWorkspace": "Conhecimento e espaço de trabalho",
-    "safetyAdmin": "Segurança e administração"
+    "safetyAdmin": "Segurança e administração",
+    "dataManagement": "Gerenciamento de dados"
   },
   "healthNav": "Saúde",
   "worldBooksNav": "Livros do mundo",
@@ -1680,5 +1681,8 @@
   "skillsNav": "Habilidades",
   "providerKeys": {
     "navTitle": "Chaves de provedores"
+  },
+  "dataManagement": {
+    "navTitle": "Gerenciamento de dados"
   }
 }

--- a/apps/packages/ui/src/assets/locale/pt-BR/settings.json
+++ b/apps/packages/ui/src/assets/locale/pt-BR/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Servidor e Autenticação",
     "knowledgeTools": "Ferramentas de conhecimento",
     "workspace": "Área de trabalho",
-    "about": "Sobre"
+    "about": "Sobre",
+    "connect": "Conexão",
+    "aiModels": "IA e modelos",
+    "experience": "Experiência",
+    "knowledgeWorkspace": "Conhecimento e espaço de trabalho",
+    "safetyAdmin": "Segurança e administração"
   },
   "healthNav": "Saúde",
   "worldBooksNav": "Livros do mundo",
@@ -1672,5 +1677,8 @@
     "subtitle": "Configure padrões, predefinições e comportamento da Ingestão rápida."
   },
   "acpPlaygroundNav": "Laboratório ACP",
-  "skillsNav": "Habilidades"
+  "skillsNav": "Habilidades",
+  "providerKeys": {
+    "navTitle": "Chaves de provedores"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/ru/settings.json
+++ b/apps/packages/ui/src/assets/locale/ru/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Сервер и авторизация",
     "knowledgeTools": "Инструменты знаний",
     "workspace": "Рабочее пространство",
-    "about": "О нас"
+    "about": "О нас",
+    "connect": "Подключение",
+    "aiModels": "ИИ и модели",
+    "experience": "Опыт",
+    "knowledgeWorkspace": "Знания и рабочее пространство",
+    "safetyAdmin": "Безопасность и администрирование"
   },
   "healthNav": "Состояние",
   "worldBooksNav": "Книги мира",
@@ -1659,5 +1664,8 @@
     "subtitle": "Настройте значения по умолчанию, пресеты и поведение быстрого импорта."
   },
   "acpPlaygroundNav": "Песочница ACP",
-  "skillsNav": "Навыки"
+  "skillsNav": "Навыки",
+  "providerKeys": {
+    "navTitle": "Ключи провайдеров"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/ru/settings.json
+++ b/apps/packages/ui/src/assets/locale/ru/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "ИИ и модели",
     "experience": "Опыт",
     "knowledgeWorkspace": "Знания и рабочее пространство",
-    "safetyAdmin": "Безопасность и администрирование"
+    "safetyAdmin": "Безопасность и администрирование",
+    "dataManagement": "Управление данными"
   },
   "healthNav": "Состояние",
   "worldBooksNav": "Книги мира",
@@ -1667,5 +1668,8 @@
   "skillsNav": "Навыки",
   "providerKeys": {
     "navTitle": "Ключи провайдеров"
+  },
+  "dataManagement": {
+    "navTitle": "Управление данными"
   }
 }

--- a/apps/packages/ui/src/assets/locale/sv/settings.json
+++ b/apps/packages/ui/src/assets/locale/sv/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Server och autentisering",
     "knowledgeTools": "Kunskapsverktyg",
     "workspace": "Arbetsyta",
-    "about": "Om"
+    "about": "Om",
+    "connect": "Anslutning",
+    "aiModels": "AI och modeller",
+    "experience": "Upplevelse",
+    "knowledgeWorkspace": "Kunskap och arbetsyta",
+    "safetyAdmin": "Säkerhet och administration"
   },
   "healthNav": "Hälsa",
   "worldBooksNav": "Världböcker",
@@ -1659,5 +1664,8 @@
     "subtitle": "Konfigurera standardvärden, förinställningar och beteende för snabb import."
   },
   "acpPlaygroundNav": "ACP-lekplats",
-  "skillsNav": "Färdigheter"
+  "skillsNav": "Färdigheter",
+  "providerKeys": {
+    "navTitle": "Leverantörsnycklar"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/sv/settings.json
+++ b/apps/packages/ui/src/assets/locale/sv/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "AI och modeller",
     "experience": "Upplevelse",
     "knowledgeWorkspace": "Kunskap och arbetsyta",
-    "safetyAdmin": "Säkerhet och administration"
+    "safetyAdmin": "Säkerhet och administration",
+    "dataManagement": "Datahantering"
   },
   "healthNav": "Hälsa",
   "worldBooksNav": "Världböcker",
@@ -1667,5 +1668,8 @@
   "skillsNav": "Färdigheter",
   "providerKeys": {
     "navTitle": "Leverantörsnycklar"
+  },
+  "dataManagement": {
+    "navTitle": "Datahantering"
   }
 }

--- a/apps/packages/ui/src/assets/locale/uk/settings.json
+++ b/apps/packages/ui/src/assets/locale/uk/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "Сервер та автентифікація",
     "knowledgeTools": "Інструменти знань",
     "workspace": "Робочий простір",
-    "about": "Про нас"
+    "about": "Про нас",
+    "connect": "Підключення",
+    "aiModels": "ШІ та моделі",
+    "experience": "Досвід",
+    "knowledgeWorkspace": "Знання та робочий простір",
+    "safetyAdmin": "Безпека та адміністрування"
   },
   "healthNav": "Стан",
   "worldBooksNav": "Книги світу",
@@ -1659,5 +1664,8 @@
     "subtitle": "Налаштуйте значення за замовчуванням, пресети та поведінку швидкого додавання."
   },
   "acpPlaygroundNav": "Пісочниця ACP",
-  "skillsNav": "Навички"
+  "skillsNav": "Навички",
+  "providerKeys": {
+    "navTitle": "Ключі провайдерів"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/uk/settings.json
+++ b/apps/packages/ui/src/assets/locale/uk/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "ШІ та моделі",
     "experience": "Досвід",
     "knowledgeWorkspace": "Знання та робочий простір",
-    "safetyAdmin": "Безпека та адміністрування"
+    "safetyAdmin": "Безпека та адміністрування",
+    "dataManagement": "Керування даними"
   },
   "healthNav": "Стан",
   "worldBooksNav": "Книги світу",
@@ -1667,5 +1668,8 @@
   "skillsNav": "Навички",
   "providerKeys": {
     "navTitle": "Ключі провайдерів"
+  },
+  "dataManagement": {
+    "navTitle": "Керування даними"
   }
 }

--- a/apps/packages/ui/src/assets/locale/zh-TW/settings.json
+++ b/apps/packages/ui/src/assets/locale/zh-TW/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "AI 與模型",
     "experience": "體驗",
     "knowledgeWorkspace": "知識與工作區",
-    "safetyAdmin": "安全與管理"
+    "safetyAdmin": "安全與管理",
+    "dataManagement": "資料管理"
   },
   "healthNav": "健康",
   "worldBooksNav": "世界書",
@@ -1682,5 +1683,8 @@
   "skillsNav": "技能",
   "providerKeys": {
     "navTitle": "供應商金鑰"
+  },
+  "dataManagement": {
+    "navTitle": "資料管理"
   }
 }

--- a/apps/packages/ui/src/assets/locale/zh-TW/settings.json
+++ b/apps/packages/ui/src/assets/locale/zh-TW/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "伺服器與驗證",
     "knowledgeTools": "知識工具",
     "workspace": "工作區",
-    "about": "關於"
+    "about": "關於",
+    "connect": "連線",
+    "aiModels": "AI 與模型",
+    "experience": "體驗",
+    "knowledgeWorkspace": "知識與工作區",
+    "safetyAdmin": "安全與管理"
   },
   "healthNav": "健康",
   "worldBooksNav": "世界書",
@@ -1674,5 +1679,8 @@
     "subtitle": "設定快速匯入的預設值、預設集與行為。"
   },
   "acpPlaygroundNav": "ACP 實驗場",
-  "skillsNav": "技能"
+  "skillsNav": "技能",
+  "providerKeys": {
+    "navTitle": "供應商金鑰"
+  }
 }

--- a/apps/packages/ui/src/assets/locale/zh/settings.json
+++ b/apps/packages/ui/src/assets/locale/zh/settings.json
@@ -8,7 +8,8 @@
     "aiModels": "AI 与模型",
     "experience": "体验",
     "knowledgeWorkspace": "知识与工作区",
-    "safetyAdmin": "安全与管理"
+    "safetyAdmin": "安全与管理",
+    "dataManagement": "数据管理"
   },
   "healthNav": "健康",
   "worldBooksNav": "世界书籍",
@@ -1671,5 +1672,8 @@
   "skillsNav": "技能",
   "providerKeys": {
     "navTitle": "提供商密钥"
+  },
+  "dataManagement": {
+    "navTitle": "数据管理"
   }
 }

--- a/apps/packages/ui/src/assets/locale/zh/settings.json
+++ b/apps/packages/ui/src/assets/locale/zh/settings.json
@@ -3,7 +3,12 @@
     "serverAndAuth": "服务器与认证",
     "knowledgeTools": "知识工具",
     "workspace": "工作区",
-    "about": "关于"
+    "about": "关于",
+    "connect": "连接",
+    "aiModels": "AI 与模型",
+    "experience": "体验",
+    "knowledgeWorkspace": "知识与工作区",
+    "safetyAdmin": "安全与管理"
   },
   "healthNav": "健康",
   "worldBooksNav": "世界书籍",
@@ -1663,5 +1668,8 @@
     "subtitle": "配置快速导入的默认值、预设和行为。"
   },
   "acpPlaygroundNav": "ACP 实验场",
-  "skillsNav": "技能"
+  "skillsNav": "技能",
+  "providerKeys": {
+    "navTitle": "提供商密钥"
+  }
 }

--- a/apps/packages/ui/src/components/Layouts/__tests__/settings-layout-labels.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/settings-layout-labels.test.tsx
@@ -1,0 +1,83 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+
+import enOption from "@/assets/locale/en/option.json"
+import enSettings from "@/assets/locale/en/settings.json"
+import { SettingsLayout } from "../SettingsOptionLayout"
+
+const localeNamespaces: Record<string, unknown> = {
+  common: { close: "Close" },
+  option: enOption,
+  settings: enSettings
+}
+
+const resolveLocaleToken = (token: string): string | undefined => {
+  const [namespace, keyPath] = token.split(":")
+  if (!namespace || !keyPath) return undefined
+
+  const value = keyPath.split(".").reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== "object") return undefined
+    return (current as Record<string, unknown>)[segment]
+  }, localeNamespaces[namespace])
+
+  return typeof value === "string" ? value : undefined
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (token: string, fallback?: string) =>
+      resolveLocaleToken(token) ?? fallback ?? token
+  })
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: null,
+    loading: false
+  })
+}))
+
+vi.mock("@/utils/sidepanel", () => ({
+  isSidepanelSupported: () => false,
+  openSidepanel: vi.fn()
+}))
+
+vi.mock("@/services/settings/registry", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/services/settings/registry")>()
+  return {
+    ...actual,
+    setSetting: vi.fn()
+  }
+})
+
+vi.mock("@/utils/settings-return", () => ({
+  getSettingsReturnTo: () => null
+}))
+
+const renderSettingsLayout = () =>
+  render(
+    <MemoryRouter initialEntries={["/settings/provider-keys"]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <SettingsLayout>
+              <div>content</div>
+            </SettingsLayout>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe("settings navigation labels", () => {
+  it("renders provider keys as user-facing navigation text", () => {
+    renderSettingsLayout()
+
+    expect(screen.queryAllByText("settings:providerKeys.navTitle")).toHaveLength(0)
+    expect(screen.getByRole("link", { name: /provider keys/i })).toBeVisible()
+  })
+})

--- a/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
@@ -124,8 +124,10 @@ describe("settings nav guardian gating", () => {
       "navigation.experience",
       "navigation.knowledgeWorkspace",
       "navigation.safetyAdmin",
+      "navigation.dataManagement",
       "navigation.about",
-      "providerKeys.navTitle"
+      "providerKeys.navTitle",
+      "dataManagement.navTitle"
     ]
 
     for (const locale of fs.readdirSync(localeRoot)) {
@@ -159,6 +161,7 @@ describe("settings nav guardian gating", () => {
       "experience",
       "knowledgeWorkspace",
       "safetyAdmin",
+      "dataManagement",
       "about"
     ])
     expect(pathsByGroup.connect).toEqual(
@@ -172,6 +175,7 @@ describe("settings nav guardian gating", () => {
     expect(pathsByGroup.experience).toEqual(
       expect.arrayContaining(["/settings", "/settings/chat"])
     )
+    expect(pathsByGroup.dataManagement).toEqual(["/settings/data"])
   })
 
   it("keeps only settings-prefixed routes in settings navigation", () => {

--- a/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
@@ -1,9 +1,13 @@
+import fs from "node:fs"
+import path from "node:path"
 import { describe, expect, it, vi } from "vitest"
 
 import {
   getSettingsNavGroups,
   isSettingsAnnouncementBadgeActive
 } from "../settings-nav"
+import enOption from "@/assets/locale/en/option.json"
+import enSettings from "@/assets/locale/en/settings.json"
 import type { ServerCapabilities } from "@/services/tldw/server-capabilities"
 import {
   FAMILY_WIZARD_SETTINGS_PATH,
@@ -82,7 +86,94 @@ const makeCapabilities = (
 const flattenPaths = (caps?: ServerCapabilities | null): string[] =>
   getSettingsNavGroups(caps).flatMap((group) => group.items.map((item) => item.to))
 
+const localeNamespaces: Record<string, unknown> = {
+  option: enOption,
+  settings: enSettings
+}
+
+const getPathValue = (source: unknown, keyPath: string): unknown =>
+  keyPath.split(".").reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== "object") return undefined
+    return (current as Record<string, unknown>)[segment]
+  }, source)
+
+const resolveLocaleToken = (token: string): unknown => {
+  const [namespace, keyPath] = token.split(":")
+  if (!namespace || !keyPath) return undefined
+
+  return getPathValue(localeNamespaces[namespace], keyPath)
+}
+
 describe("settings nav guardian gating", () => {
+  it("uses label tokens that resolve to user-facing English locale copy", () => {
+    const missingTokens = getSettingsNavGroups(undefined)
+      .flatMap((group) => group.items.map((item) => item.labelToken))
+      .filter((token) => {
+        const value = resolveLocaleToken(token)
+        return typeof value !== "string" || value.trim().length === 0
+      })
+
+    expect(missingTokens).toEqual([])
+  })
+
+  it("keeps settings navigation locale keys present across locale directories", () => {
+    const localeRoot = path.resolve(process.cwd(), "src/assets/locale")
+    const requiredSettingsKeys = [
+      "navigation.connect",
+      "navigation.aiModels",
+      "navigation.experience",
+      "navigation.knowledgeWorkspace",
+      "navigation.safetyAdmin",
+      "navigation.about",
+      "providerKeys.navTitle"
+    ]
+
+    for (const locale of fs.readdirSync(localeRoot)) {
+      const settingsPath = path.join(localeRoot, locale, "settings.json")
+      expect(
+        fs.existsSync(settingsPath),
+        `Missing settings locale file: ${settingsPath}`
+      ).toBe(true)
+
+      const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as unknown
+      for (const keyPath of requiredSettingsKeys) {
+        const value = getPathValue(parsed, keyPath)
+        expect(
+          typeof value,
+          `Missing or non-string locale key: ${locale}.${keyPath}`
+        ).toBe("string")
+        expect(String(value).trim().length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it("groups settings routes by user task", () => {
+    const groups = getSettingsNavGroups(undefined)
+    const pathsByGroup = Object.fromEntries(
+      groups.map((group) => [group.key, group.items.map((item) => item.to)])
+    )
+
+    expect(groups.map((group) => group.key)).toEqual([
+      "connect",
+      "aiModels",
+      "experience",
+      "knowledgeWorkspace",
+      "safetyAdmin",
+      "about"
+    ])
+    expect(pathsByGroup.connect).toEqual(
+      expect.arrayContaining([
+        "/settings/tldw",
+        "/settings/provider-keys",
+        "/settings/health"
+      ])
+    )
+    expect(pathsByGroup.aiModels).toContain("/settings/model")
+    expect(pathsByGroup.experience).toEqual(
+      expect.arrayContaining(["/settings", "/settings/chat"])
+    )
+  })
+
   it("keeps only settings-prefixed routes in settings navigation", () => {
     const paths = flattenPaths(undefined)
     expect(paths).toContain("/settings/chat")

--- a/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
@@ -130,7 +130,12 @@ describe("settings nav guardian gating", () => {
       "dataManagement.navTitle"
     ]
 
-    for (const locale of fs.readdirSync(localeRoot)) {
+    const locales = fs
+      .readdirSync(localeRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+
+    for (const locale of locales) {
       const settingsPath = path.join(localeRoot, locale, "settings.json")
       expect(
         fs.existsSync(settingsPath),

--- a/apps/packages/ui/src/components/Layouts/settings-nav-config.ts
+++ b/apps/packages/ui/src/components/Layouts/settings-nav-config.ts
@@ -8,6 +8,7 @@ import {
   BrainCircuitIcon,
   ClipboardList,
   CombineIcon,
+  DatabaseIcon,
   Eye,
   FlaskConical,
   ImageIcon,
@@ -34,6 +35,7 @@ export type NavGroupKey =
   | "experience"
   | "knowledgeWorkspace"
   | "safetyAdmin"
+  | "dataManagement"
   | "about"
 
 export type SettingsNavRouteMeta = {
@@ -66,6 +68,13 @@ export const SETTINGS_ROUTE_NAV_ITEMS: SettingsNavRouteMeta[] = [
     labelToken: "settings:providerKeys.navTitle",
     icon: ServerIcon,
     order: 2
+  },
+  {
+    path: "/settings/data",
+    group: "dataManagement",
+    labelToken: "settings:dataManagement.navTitle",
+    icon: DatabaseIcon,
+    order: 1
   },
   {
     path: "/settings/model",

--- a/apps/packages/ui/src/components/Layouts/settings-nav-config.ts
+++ b/apps/packages/ui/src/components/Layouts/settings-nav-config.ts
@@ -28,7 +28,13 @@ import {
   MODERATION_RULES_PATH
 } from "@/routes/route-paths"
 
-export type NavGroupKey = "server" | "knowledge" | "workspace" | "about"
+export type NavGroupKey =
+  | "connect"
+  | "aiModels"
+  | "experience"
+  | "knowledgeWorkspace"
+  | "safetyAdmin"
+  | "about"
 
 export type SettingsNavRouteMeta = {
   path: string
@@ -42,159 +48,159 @@ export type SettingsNavRouteMeta = {
 export const SETTINGS_ROUTE_NAV_ITEMS: SettingsNavRouteMeta[] = [
   {
     path: "/settings",
-    group: "server",
+    group: "experience",
     labelToken: "settings:generalSettings.title",
     icon: OrbitIcon,
-    order: 2
+    order: 1
   },
   {
     path: "/settings/tldw",
-    group: "server",
+    group: "connect",
     labelToken: "settings:tldw.serverNav",
     icon: ServerIcon,
     order: 1
   },
   {
     path: "/settings/provider-keys",
-    group: "server",
+    group: "connect",
     labelToken: "settings:providerKeys.navTitle",
     icon: ServerIcon,
     order: 2
   },
   {
     path: "/settings/model",
-    group: "server",
+    group: "aiModels",
     labelToken: "settings:manageModels.title",
     icon: BrainCircuitIcon,
-    order: 6
+    order: 1
   },
   {
     path: "/settings/mcp-hub",
-    group: "server",
+    group: "aiModels",
     labelToken: "settings:mcpHubNav",
     icon: ServerIcon,
-    order: 7
+    order: 5
   },
   {
     path: "/settings/prompt",
-    group: "workspace",
+    group: "knowledgeWorkspace",
     labelToken: "settings:managePrompts.title",
     icon: BookIcon,
-    order: 6
+    order: 2
   },
   {
     path: "/settings/evaluations",
-    group: "server",
+    group: "safetyAdmin",
     labelToken: "settings:evaluationsSettings.title",
     icon: FlaskConical,
-    order: 9,
+    order: 3,
     beta: true
   },
   {
     path: "/settings/chat",
-    group: "server",
+    group: "experience",
     labelToken: "settings:chatSettingsNav",
     icon: MessageSquare,
-    order: 3
+    order: 2
   },
   {
     path: "/settings/ui",
-    group: "server",
+    group: "experience",
     labelToken: "settings:uiCustomizationNav",
     icon: SlidersHorizontal,
     order: 3.5
   },
   {
     path: "/settings/splash",
-    group: "server",
+    group: "experience",
     labelToken: "settings:splashSettingsNav",
     icon: Sparkles,
     order: 3.6
   },
   {
     path: "/settings/quick-ingest",
-    group: "server",
+    group: "experience",
     labelToken: "settings:quickIngestSettingsNav",
     icon: ClipboardList,
     order: 4
   },
   {
     path: "/settings/speech",
-    group: "server",
+    group: "aiModels",
     labelToken: "settings:speechSettingsNav",
     icon: MicIcon,
-    order: 5
+    order: 3
   },
   {
     path: "/settings/image-generation",
-    group: "server",
+    group: "aiModels",
     labelToken: "settings:imageGenerationSettingsNav",
     icon: ImageIcon,
-    order: 7
+    order: 4
   },
   {
     path: "/settings/share",
-    group: "workspace",
+    group: "knowledgeWorkspace",
     labelToken: "settings:manageShare.title",
     icon: ShareIcon,
     order: 7
   },
   {
     path: "/settings/health",
-    group: "server",
+    group: "connect",
     labelToken: "settings:healthNav",
     icon: ActivityIcon,
-    order: 11
+    order: 3
   },
   {
     path: "/settings/prompt-studio",
-    group: "server",
+    group: "knowledgeWorkspace",
     labelToken: "settings:promptStudio.nav",
     icon: Microscope,
-    order: 10,
+    order: 3,
     beta: true
   },
   {
     path: "/settings/knowledge",
-    group: "knowledge",
+    group: "knowledgeWorkspace",
     labelToken: "settings:manageKnowledge.title",
     icon: BookText,
     order: 1
   },
   {
     path: "/settings/chatbooks",
-    group: "knowledge",
+    group: "knowledgeWorkspace",
     labelToken: "settings:chatbooksNav",
     icon: BookText,
     order: 4
   },
   {
     path: "/settings/characters",
-    group: "knowledge",
+    group: "knowledgeWorkspace",
     labelToken: "settings:charactersNav",
     icon: BookIcon,
     order: 5
   },
   {
     path: "/settings/world-books",
-    group: "knowledge",
+    group: "knowledgeWorkspace",
     labelToken: "settings:worldBooksNav",
     icon: BookOpen,
-    order: 2
+    order: 5.1
   },
   {
     path: "/settings/chat-dictionaries",
-    group: "knowledge",
+    group: "knowledgeWorkspace",
     labelToken: "settings:chatDictionariesNav",
     icon: BookMarked,
-    order: 3
+    order: 5.2
   },
   {
     path: "/settings/rag",
-    group: "server",
+    group: "aiModels",
     labelToken: "settings:rag.title",
     icon: CombineIcon,
-    order: 4
+    order: 2
   },
   {
     path: "/settings/about",
@@ -205,30 +211,30 @@ export const SETTINGS_ROUTE_NAV_ITEMS: SettingsNavRouteMeta[] = [
   },
   {
     path: MODERATION_REVIEW_PATH,
-    group: "server",
+    group: "safetyAdmin",
     labelToken: "option:moderationReview.nav",
     icon: ClipboardList,
-    order: 10
+    order: 4
   },
   {
     path: MODERATION_RULES_PATH,
-    group: "server",
+    group: "safetyAdmin",
     labelToken: "option:moderationRules.nav",
     icon: ShieldCheck,
-    order: 10.1
+    order: 5
   },
   {
     path: "/settings/family-guardrails",
-    group: "server",
+    group: "safetyAdmin",
     labelToken: "settings:familyGuardrailsWizardNav",
     icon: Users,
-    order: 8
+    order: 2
   },
   {
     path: "/settings/guardian",
-    group: "server",
+    group: "safetyAdmin",
     labelToken: "settings:guardianNav",
     icon: Eye,
-    order: 9
+    order: 1
   }
 ]

--- a/apps/packages/ui/src/components/Layouts/settings-nav.ts
+++ b/apps/packages/ui/src/components/Layouts/settings-nav.ts
@@ -28,6 +28,7 @@ const NAV_GROUPS: Array<{ key: NavGroupKey; titleToken: string }> = [
     titleToken: "settings:navigation.knowledgeWorkspace"
   },
   { key: "safetyAdmin", titleToken: "settings:navigation.safetyAdmin" },
+  { key: "dataManagement", titleToken: "settings:navigation.dataManagement" },
   { key: "about", titleToken: "settings:navigation.about" }
 ]
 

--- a/apps/packages/ui/src/components/Layouts/settings-nav.ts
+++ b/apps/packages/ui/src/components/Layouts/settings-nav.ts
@@ -20,9 +20,14 @@ export type SettingsNavGroup = {
 }
 
 const NAV_GROUPS: Array<{ key: NavGroupKey; titleToken: string }> = [
-  { key: "server", titleToken: "settings:navigation.serverAndAuth" },
-  { key: "knowledge", titleToken: "settings:navigation.knowledgeTools" },
-  { key: "workspace", titleToken: "settings:navigation.workspace" },
+  { key: "connect", titleToken: "settings:navigation.connect" },
+  { key: "aiModels", titleToken: "settings:navigation.aiModels" },
+  { key: "experience", titleToken: "settings:navigation.experience" },
+  {
+    key: "knowledgeWorkspace",
+    titleToken: "settings:navigation.knowledgeWorkspace"
+  },
+  { key: "safetyAdmin", titleToken: "settings:navigation.safetyAdmin" },
   { key: "about", titleToken: "settings:navigation.about" }
 ]
 

--- a/apps/packages/ui/src/components/Option/Models/__tests__/ModelsBody.test.tsx
+++ b/apps/packages/ui/src/components/Option/Models/__tests__/ModelsBody.test.tsx
@@ -1,0 +1,151 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ModelsBody } from "../index"
+
+const mocks = vi.hoisted(() => ({
+  fetchChatModels: vi.fn(),
+  getOpenAIOAuthStatus: vi.fn(),
+  listUserProviderKeys: vi.fn(),
+  selectedModelSetter: vi.fn(),
+  defaultProviderSetter: vi.fn(),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [key: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      let value = fallbackOrOptions?.defaultValue ?? key
+      for (const [name, replacement] of Object.entries(fallbackOrOptions ?? {})) {
+        if (name === "defaultValue") continue
+        value = value.replace(`{{${name}}}`, String(replacement))
+      }
+      return value
+    }
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (key: string) => {
+    if (key === "selectedModel") return ["local-a", mocks.selectedModelSetter]
+    if (key === "defaultApiProvider") return ["ollama", mocks.defaultProviderSetter]
+    return [null, vi.fn()]
+  }
+}))
+
+vi.mock("@/hooks/useAntdNotification", () => ({
+  useAntdNotification: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn()
+  })
+}))
+
+vi.mock("@/services/tldw-server", () => ({
+  fetchChatModels: (...args: unknown[]) => mocks.fetchChatModels(...args)
+}))
+
+vi.mock("@/services/tldw", () => ({
+  tldwClient: {
+    getOpenAIOAuthStatus: (...args: unknown[]) =>
+      mocks.getOpenAIOAuthStatus(...args),
+    listUserProviderKeys: (...args: unknown[]) =>
+      mocks.listUserProviderKeys(...args),
+    startOpenAIOAuthAuthorize: vi.fn(),
+    refreshOpenAIOAuth: vi.fn(),
+    disconnectOpenAIOAuth: vi.fn(),
+    switchOpenAICredentialSource: vi.fn(),
+  },
+  tldwModels: {
+    warmCache: vi.fn()
+  }
+}))
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    runtime: {
+      sendMessage: vi.fn()
+    }
+  }
+}))
+
+vi.mock("../AvailableModelsList", () => ({
+  AvailableModelsList: () => <section>Available models</section>
+}))
+
+const renderModelsBody = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ModelsBody />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe("ModelsBody", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.fetchChatModels.mockResolvedValue([
+      {
+        model: "local-a",
+        nickname: "Local A",
+        provider: "ollama"
+      },
+      {
+        model: "remote-b",
+        provider: "openai"
+      }
+    ])
+    mocks.getOpenAIOAuthStatus.mockResolvedValue({
+      connected: false,
+      auth_source: "none"
+    })
+    mocks.listUserProviderKeys.mockResolvedValue({
+      items: [
+        {
+          provider: "ollama",
+          has_key: true,
+          source: "user",
+          key_hint: "oll-...",
+          auth_source: null,
+          last_used_at: null
+        }
+      ]
+    })
+  })
+
+  it("puts defaults and provider readiness before the full catalog", async () => {
+    renderModelsBody()
+
+    const defaults = await screen.findByText("Set your defaults")
+    const readiness = await screen.findByText("Provider readiness")
+    const catalog = await screen.findByText("Available models")
+
+    expect(
+      defaults.compareDocumentPosition(readiness) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(
+      readiness.compareDocumentPosition(catalog) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(screen.getByText("1 configured")).toBeInTheDocument()
+    expect(screen.getAllByText("2 usable").length).toBeGreaterThan(0)
+    expect(screen.getByText("Default provider")).toBeInTheDocument()
+    expect(screen.getAllByText("Ollama").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Default model").length).toBeGreaterThan(0)
+    expect(screen.getByText("local-a")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Models/__tests__/ModelsBody.test.tsx
+++ b/apps/packages/ui/src/components/Option/Models/__tests__/ModelsBody.test.tsx
@@ -107,7 +107,9 @@ describe("ModelsBody", () => {
       },
       {
         model: "remote-b",
-        provider: "openai"
+        provider: "openai",
+        catalog_only: true,
+        provider_is_configured: false
       }
     ])
     mocks.getOpenAIOAuthStatus.mockResolvedValue({
@@ -142,10 +144,42 @@ describe("ModelsBody", () => {
       readiness.compareDocumentPosition(catalog) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
     expect(screen.getByText("1 configured")).toBeInTheDocument()
-    expect(screen.getAllByText("2 usable").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("1 usable").length).toBeGreaterThan(0)
     expect(screen.getByText("Default provider")).toBeInTheDocument()
     expect(screen.getAllByText("Ollama").length).toBeGreaterThan(0)
     expect(screen.getAllByText("Default model").length).toBeGreaterThan(0)
     expect(screen.getByText("local-a")).toBeInTheDocument()
+  })
+
+  it("uses server model configuration fields when provider-key details are empty", async () => {
+    mocks.fetchChatModels.mockResolvedValue([
+      {
+        model: "configured-server-model",
+        provider: "anthropic",
+        is_configured: true,
+        provider_is_configured: true
+      },
+      {
+        model: "catalog-reference-model",
+        provider: "openrouter",
+        catalog_only: true,
+        is_configured: true,
+        provider_is_configured: true
+      }
+    ])
+    mocks.listUserProviderKeys.mockResolvedValue({ items: [] })
+
+    renderModelsBody()
+
+    expect(await screen.findByText("2 configured")).toBeInTheDocument()
+    expect(screen.getAllByText("1 usable").length).toBeGreaterThan(0)
+  })
+
+  it("does not show configured key counts when provider-key lookup fails", async () => {
+    mocks.listUserProviderKeys.mockRejectedValue({ status: 500 })
+
+    renderModelsBody()
+
+    expect(await screen.findByText("Unable to load account keys")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts
+++ b/apps/packages/ui/src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { formatModelsLastRefreshedTime } from "../modelsDisplayUtils"
+import {
+  buildConfiguredFirstModelOptions,
+  buildConfiguredFirstModelSections,
+  formatModelsLastRefreshedTime,
+  sortModelsConfiguredFirst,
+  summarizeProviderReadiness,
+} from "../modelsDisplayUtils"
 
 describe("models display utilities", () => {
   it.each([
@@ -7,5 +13,72 @@ describe("models display utilities", () => {
     [new Date(2026, 1, 18, 0, 7).getTime(), "00:07"],
   ])("formats %s as a dayjs-compatible HH:mm time", (value, expected) => {
     expect(formatModelsLastRefreshedTime(value)).toBe(expected)
+  })
+
+  it("orders the selected default model before other configured and catalog models", () => {
+    const sorted = sortModelsConfiguredFirst([
+      { id: "unavailable-a", provider: "alpha", configured: false, usable: false },
+      { id: "usable-b", provider: "beta", configured: false, usable: true },
+      { id: "configured-c", provider: "gamma", configured: true, usable: false },
+      { id: "selected-d", provider: "delta", configured: true, usable: true, selected: true },
+      { id: "configured-usable-e", provider: "epsilon", configured: true, usable: true },
+    ])
+
+    expect(sorted.map((model) => model.id)).toEqual([
+      "selected-d",
+      "configured-usable-e",
+      "configured-c",
+      "usable-b",
+      "unavailable-a",
+    ])
+  })
+
+  it("keeps the auto option before concrete configured-first model choices", () => {
+    const options = buildConfiguredFirstModelOptions(
+      [
+        { id: "llama3", provider: "ollama", configured: true, usable: true },
+        { id: "gpt-4o", provider: "openai", configured: false, usable: false },
+      ],
+      { autoLabel: "Auto (route on server)" }
+    )
+
+    expect(options.map((option) => option.value)).toEqual([
+      "auto",
+      "llama3",
+      "gpt-4o",
+    ])
+  })
+
+  it("keeps the full catalog available after the configured-first section", () => {
+    const sections = buildConfiguredFirstModelSections([
+      { id: "local-a", provider: "ollama", configured: true, usable: true },
+      { id: "remote-b", provider: "openai", configured: false, usable: false },
+      { id: "remote-c", provider: "anthropic", configured: false, usable: false },
+    ])
+
+    expect(sections.configuredFirst.map((model) => model.id)).toEqual(["local-a"])
+    expect(sections.fullCatalog.map((model) => model.id)).toEqual([
+      "local-a",
+      "remote-c",
+      "remote-b",
+    ])
+  })
+
+  it("summarizes provider readiness without treating unknown providers as configured", () => {
+    const summary = summarizeProviderReadiness([
+      { id: "local-a", provider: "ollama", configured: true, usable: true },
+      { id: "local-b", provider: "ollama", configured: true, usable: true },
+      { id: "remote-a", provider: "openai", configured: false, usable: false },
+      { id: "remote-b", provider: "anthropic", usable: true },
+    ])
+
+    expect(summary).toEqual({
+      totalProviders: 3,
+      configuredProviders: 1,
+      usableProviders: 2,
+      unavailableProviders: 1,
+      selectedModelIds: [],
+      hasConfiguredUsableProvider: true,
+    })
   })
 })

--- a/apps/packages/ui/src/components/Option/Models/index.tsx
+++ b/apps/packages/ui/src/components/Option/Models/index.tsx
@@ -2,9 +2,15 @@ import { Select, Spin } from "antd"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { Link } from "react-router-dom"
 import { browser } from "wxt/browser"
 import { AvailableModelsList } from "./AvailableModelsList"
-import { formatModelsLastRefreshedTime } from "./modelsDisplayUtils"
+import {
+  buildConfiguredFirstModelOptions,
+  formatModelsLastRefreshedTime,
+  summarizeProviderReadiness,
+  type ModelDisplayEntry
+} from "./modelsDisplayUtils"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
 import { tldwClient, tldwModels } from "@/services/tldw"
 import { useStorage } from "@plasmohq/storage/hook"
@@ -80,9 +86,24 @@ export const ModelsBody = () => {
     retry: false
   })
 
+  const {
+    data: providerKeysStatus,
+    isLoading: providerKeysLoading,
+    error: providerKeysError
+  } = useQuery({
+    queryKey: ["tldw-provider-keys-summary"],
+    queryFn: async () => tldwClient.listUserProviderKeys(),
+    staleTime: 30 * 1000,
+    retry: false
+  })
+
   const openaiOauthStatusCode = useMemo(
     () => getStatusCode(openaiOauthStatusError),
     [openaiOauthStatusError]
+  )
+  const providerKeysStatusCode = useMemo(
+    () => getStatusCode(providerKeysError),
+    [providerKeysError]
   )
 
   const openaiOauthUnavailable = useMemo(
@@ -96,6 +117,29 @@ export const ModelsBody = () => {
   const openaiAuthSource = openaiOauthStatus?.auth_source ?? "none"
   const openaiOauthConnected = Boolean(openaiOauthStatus?.connected)
   const openaiOauthActive = openaiAuthSource === "oauth"
+  const providerKeysUnavailable =
+    providerKeysStatusCode === 403 ||
+    providerKeysStatusCode === 404 ||
+    providerKeysStatusCode === 501
+
+  const configuredProviderKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const item of providerKeysStatus?.items ?? []) {
+      if (!item.has_key) continue
+      const normalized = normalizeProviderKey(item.provider)
+      if (normalized && normalized !== "unknown") {
+        keys.add(normalized)
+      }
+    }
+    if (
+      openaiOauthConnected ||
+      openaiAuthSource === "oauth" ||
+      openaiAuthSource === "api_key"
+    ) {
+      keys.add("openai")
+    }
+    return keys
+  }, [openaiAuthSource, openaiOauthConnected, providerKeysStatus])
 
   const openaiOauthChip = useMemo(() => {
     if (openaiOauthActive && openaiOauthConnected) {
@@ -149,35 +193,62 @@ export const ModelsBody = () => {
       .sort((a, b) => a.label.localeCompare(b.label))
   }, [availableModels])
 
+  const toModelDisplayEntry = useCallback(
+    (model: (typeof availableModels)[number]): ModelDisplayEntry | null => {
+      const rawProvider = model.details?.provider ?? model.provider
+      if (!rawProvider) return null
+      const normalizedProvider = normalizeProviderKey(rawProvider)
+      if (!normalizedProvider || normalizedProvider === "unknown") return null
+      return {
+        id: model.model,
+        provider: getProviderDisplayName(rawProvider),
+        nickname: model.nickname,
+        configured: configuredProviderKeys.has(normalizedProvider),
+        usable: true,
+        selected: selectedModel === model.model
+      }
+    },
+    [configuredProviderKeys, selectedModel]
+  )
+
+  const modelDisplayEntries = useMemo(
+    () =>
+      availableModels
+        .map(toModelDisplayEntry)
+        .filter((model): model is ModelDisplayEntry => model !== null),
+    [availableModels, toModelDisplayEntry]
+  )
+
+  const providerReadiness = useMemo(
+    () => summarizeProviderReadiness(modelDisplayEntries),
+    [modelDisplayEntries]
+  )
+
+  const defaultProviderLabel = normalizedDefaultProvider
+    ? getProviderDisplayName(normalizedDefaultProvider)
+    : t("settings:onboarding.defaults.providerAuto", "Auto (from model)")
+  const defaultModelLabel =
+    selectedModel && !isAutoModelId(selectedModel)
+      ? selectedModel
+      : t("settings:onboarding.defaults.modelAuto", "Auto (route on server)")
+
   const modelOptions = useMemo(() => {
-    return [
-      {
-        value: "auto",
-        label: t(
-          "settings:onboarding.defaults.modelAuto",
-          "Auto (route on server)"
-        )
-      },
-      ...availableModels
+    const modelEntries = availableModels
       .filter((model) => {
         if (!normalizedDefaultProvider) return true
         const rawProvider = model.details?.provider ?? model.provider
         if (!rawProvider) return false
         return normalizeProviderKey(rawProvider) === normalizedDefaultProvider
       })
-      .map((model) => {
-        const rawProvider = model.details?.provider ?? model.provider
-        const providerLabel = rawProvider
-          ? getProviderDisplayName(rawProvider)
-          : t("settings:onboarding.defaults.providerUnknown", "Provider")
-        const modelLabel = model.nickname || model.model
-        return {
-          value: model.model,
-          label: `${providerLabel} - ${modelLabel}`
-        }
-      })
-    ]
-  }, [availableModels, normalizedDefaultProvider, t])
+      .map(toModelDisplayEntry)
+      .filter((model): model is ModelDisplayEntry => model !== null)
+    return buildConfiguredFirstModelOptions(modelEntries, {
+      autoLabel: t(
+        "settings:onboarding.defaults.modelAuto",
+        "Auto (route on server)"
+      )
+    })
+  }, [availableModels, normalizedDefaultProvider, t, toModelDisplayEntry])
 
   const handleProviderChange = useCallback(
     (value: string) => {
@@ -521,6 +592,94 @@ export const ModelsBody = () => {
                     )}
                   </p>
                 </div>
+              </div>
+            )}
+          </div>
+          <div className="mt-4 rounded-2xl border border-border/70 bg-surface p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold text-text">
+                  {t("settings:models.readiness.title", "Provider readiness")}
+                </div>
+                <p className="mt-1 text-xs text-text-subtle">
+                  {t(
+                    "settings:models.readiness.subtitle",
+                    "Review usable providers and saved defaults before browsing the full catalog."
+                  )}
+                </p>
+              </div>
+              <span className="inline-flex items-center rounded-full border border-border/80 bg-surface2 px-2.5 py-1 text-[11px] font-medium text-text-subtle">
+                {modelsLoading
+                  ? t("common:loading.title", "Loading...")
+                  : t("settings:models.readiness.usableSummary", {
+                      defaultValue: "{{count}} usable",
+                      count: providerReadiness.usableProviders
+                    })}
+              </span>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-md border border-border/70 bg-surface2 p-3">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-text-subtle">
+                  {t(
+                    "settings:models.readiness.defaultProvider",
+                    "Default provider"
+                  )}
+                </div>
+                <div className="mt-1 text-sm font-medium text-text">
+                  {defaultProviderLabel}
+                </div>
+              </div>
+              <div className="rounded-md border border-border/70 bg-surface2 p-3">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-text-subtle">
+                  {t("settings:models.readiness.defaultModel", "Default model")}
+                </div>
+                <div className="mt-1 text-sm font-medium text-text">
+                  {defaultModelLabel}
+                </div>
+              </div>
+              <div className="rounded-md border border-border/70 bg-surface2 p-3">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-text-subtle">
+                  {t(
+                    "settings:models.readiness.configuredProviders",
+                    "Configured providers"
+                  )}
+                </div>
+                <div className="mt-1 text-sm font-medium text-text">
+                  {providerKeysLoading
+                    ? t("common:loading.title", "Loading...")
+                    : providerKeysUnavailable
+                      ? t(
+                          "settings:models.readiness.keysUnavailable",
+                          "Account keys unavailable"
+                        )
+                      : t("settings:models.readiness.configuredCount", {
+                          defaultValue: "{{count}} configured",
+                          count: providerReadiness.configuredProviders
+                        })}
+                </div>
+              </div>
+              <div className="rounded-md border border-border/70 bg-surface2 p-3">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-text-subtle">
+                  {t("settings:models.readiness.usableProviders", "Usable providers")}
+                </div>
+                <div className="mt-1 text-sm font-medium text-text">
+                  {t("settings:models.readiness.usableCount", {
+                    defaultValue: "{{count}} usable",
+                    count: providerReadiness.usableProviders
+                  })}
+                </div>
+              </div>
+            </div>
+            {availableModels.length === 0 && !modelsLoading && (
+              <div className="mt-4 flex flex-wrap gap-2 text-xs">
+                <Link className="text-primary hover:underline" to="/settings/tldw">
+                  {t("settings:models.readiness.configureServer", "Configure server")}
+                </Link>
+                <Link
+                  className="text-primary hover:underline"
+                  to="/settings/provider-keys">
+                  {t("settings:models.readiness.configureKeys", "Manage provider keys")}
+                </Link>
               </div>
             )}
           </div>

--- a/apps/packages/ui/src/components/Option/Models/index.tsx
+++ b/apps/packages/ui/src/components/Option/Models/index.tsx
@@ -20,6 +20,7 @@ import {
   normalizeProviderKey
 } from "@/utils/provider-registry"
 import { isAutoModelId } from "@/utils/resolve-api-provider"
+import { isConfiguredUsableModel } from "@/hooks/playground/modelSelectorUtils"
 
 interface RefreshResponse {
   ok: boolean
@@ -44,6 +45,49 @@ const getStatusCode = (error: unknown): number | null => {
     return null
   }
   return maybeStatus
+}
+
+const getRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null
+
+const getBooleanFromModelPaths = (
+  model: unknown,
+  keys: string[]
+): boolean | null => {
+  const root = getRecord(model)
+  if (!root) return null
+  const details = getRecord(root.details)
+  const metadata = getRecord(root.metadata)
+
+  for (const key of keys) {
+    const value = root[key] ?? details?.[key] ?? metadata?.[key]
+    if (typeof value === "boolean") return value
+  }
+
+  return null
+}
+
+const getModelConfiguredSignal = (model: unknown): boolean | null => {
+  const configuredKeys = [
+    "is_configured",
+    "isConfigured",
+    "configured",
+    "provider_is_configured",
+    "providerIsConfigured",
+    "provider_configured",
+    "providerConfigured"
+  ]
+  let sawConfigured = false
+
+  for (const key of configuredKeys) {
+    const value = getBooleanFromModelPaths(model, [key])
+    if (value === false) return false
+    if (value === true) sawConfigured = true
+  }
+
+  return sawConfigured ? true : null
 }
 
 export const ModelsBody = () => {
@@ -121,6 +165,8 @@ export const ModelsBody = () => {
     providerKeysStatusCode === 403 ||
     providerKeysStatusCode === 404 ||
     providerKeysStatusCode === 501
+  const providerKeysLoadFailed =
+    Boolean(providerKeysError) && !providerKeysUnavailable
 
   const configuredProviderKeys = useMemo(() => {
     const keys = new Set<string>()
@@ -199,12 +245,18 @@ export const ModelsBody = () => {
       if (!rawProvider) return null
       const normalizedProvider = normalizeProviderKey(rawProvider)
       if (!normalizedProvider || normalizedProvider === "unknown") return null
+      const configuredSignal = getModelConfiguredSignal(model)
+      const configured =
+        configuredSignal === false
+          ? false
+          : configuredProviderKeys.has(normalizedProvider) ||
+            configuredSignal === true
       return {
         id: model.model,
         provider: getProviderDisplayName(rawProvider),
         nickname: model.nickname,
-        configured: configuredProviderKeys.has(normalizedProvider),
-        usable: true,
+        configured,
+        usable: configured && isConfiguredUsableModel(model),
         selected: selectedModel === model.model
       }
     },
@@ -652,6 +704,11 @@ export const ModelsBody = () => {
                           "settings:models.readiness.keysUnavailable",
                           "Account keys unavailable"
                         )
+                      : providerKeysLoadFailed
+                        ? t(
+                            "settings:models.readiness.keysLoadFailed",
+                            "Unable to load account keys"
+                          )
                       : t("settings:models.readiness.configuredCount", {
                           defaultValue: "{{count}} configured",
                           count: providerReadiness.configuredProviders

--- a/apps/packages/ui/src/components/Option/Models/modelsDisplayUtils.ts
+++ b/apps/packages/ui/src/components/Option/Models/modelsDisplayUtils.ts
@@ -4,3 +4,131 @@ export const formatModelsLastRefreshedTime = (timestamp: number): string => {
   const minutes = date.getMinutes().toString().padStart(2, "0")
   return `${hours}:${minutes}`
 }
+
+export type ModelDisplayEntry = {
+  id: string
+  provider: string
+  nickname?: string | null
+  configured?: boolean
+  usable?: boolean
+  selected?: boolean
+}
+
+export type ModelDisplayOption = {
+  value: string
+  label: string
+  model?: ModelDisplayEntry
+}
+
+export type ConfiguredFirstModelSections = {
+  configuredFirst: ModelDisplayEntry[]
+  fullCatalog: ModelDisplayEntry[]
+}
+
+export type ProviderReadinessSummary = {
+  totalProviders: number
+  configuredProviders: number
+  usableProviders: number
+  unavailableProviders: number
+  selectedModelIds: string[]
+  hasConfiguredUsableProvider: boolean
+}
+
+const getReadinessRank = (model: ModelDisplayEntry): number => {
+  if (model.selected) return 0
+  if (model.configured === true && model.usable === true) return 1
+  if (model.configured === true) return 2
+  if (model.usable === true) return 3
+  return 4
+}
+
+const getModelLabel = (model: ModelDisplayEntry): string =>
+  (model.nickname || model.id).trim()
+
+export const compareConfiguredFirst = (
+  a: ModelDisplayEntry,
+  b: ModelDisplayEntry
+): number => {
+  const readiness = getReadinessRank(a) - getReadinessRank(b)
+  if (readiness !== 0) return readiness
+
+  const provider = a.provider.localeCompare(b.provider)
+  if (provider !== 0) return provider
+
+  return getModelLabel(a).localeCompare(getModelLabel(b))
+}
+
+export const sortModelsConfiguredFirst = (
+  models: ModelDisplayEntry[]
+): ModelDisplayEntry[] => models.slice().sort(compareConfiguredFirst)
+
+export const buildConfiguredFirstModelOptions = (
+  models: ModelDisplayEntry[],
+  options: { autoLabel: string }
+): ModelDisplayOption[] => [
+  { value: "auto", label: options.autoLabel },
+  ...sortModelsConfiguredFirst(models).map((model) => ({
+    value: model.id,
+    label: `${model.provider} - ${getModelLabel(model)}`,
+    model
+  }))
+]
+
+export const buildConfiguredFirstModelSections = (
+  models: ModelDisplayEntry[]
+): ConfiguredFirstModelSections => {
+  const fullCatalog = sortModelsConfiguredFirst(models)
+  return {
+    configuredFirst: fullCatalog.filter(
+      (model) =>
+        model.selected === true ||
+        model.configured === true ||
+        model.usable === true
+    ),
+    fullCatalog
+  }
+}
+
+export const summarizeProviderReadiness = (
+  models: ModelDisplayEntry[]
+): ProviderReadinessSummary => {
+  const providers = new Map<
+    string,
+    { configured: boolean; usable: boolean; selectedModelIds: string[] }
+  >()
+
+  for (const model of models) {
+    const provider = model.provider.trim()
+    if (!provider) continue
+    const current = providers.get(provider) ?? {
+      configured: false,
+      usable: false,
+      selectedModelIds: []
+    }
+    current.configured = current.configured || model.configured === true
+    current.usable = current.usable || model.usable === true
+    if (model.selected) current.selectedModelIds.push(model.id)
+    providers.set(provider, current)
+  }
+
+  const providerStates = Array.from(providers.values())
+  const configuredProviders = providerStates.filter(
+    (provider) => provider.configured
+  ).length
+  const usableProviders = providerStates.filter((provider) => provider.usable)
+    .length
+
+  return {
+    totalProviders: providers.size,
+    configuredProviders,
+    usableProviders,
+    unavailableProviders: providerStates.filter((provider) => !provider.usable)
+      .length,
+    selectedModelIds: providerStates.flatMap(
+      (provider) => provider.selectedModelIds
+    ),
+    hasConfiguredUsableProvider: providerStates.some(
+      (provider) => provider.configured && provider.usable
+    )
+  }
+}

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DataManagementSettings } from "../system-settings"
+
+const mutateMock = vi.fn()
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      return fallbackOrOptions?.defaultValue ?? key
+    }
+  })
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({
+    isPending: false,
+    mutate: mutateMock
+  }),
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/useMessageOption", () => ({
+  useMessageOption: () => ({
+    clearChat: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/useAntdNotification", () => ({
+  useAntdNotification: () => ({
+    destroy: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn()
+  })
+}))
+
+vi.mock("@/utils/is-private-mode", () => ({
+  isFireFox: false,
+  isFireFoxPrivateMode: false
+}))
+
+describe("DataManagementSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps import, export, and typed-reset actions on the data surface", () => {
+    render(<DataManagementSettings />)
+
+    expect(
+      screen.getByRole("heading", { name: /data management/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /export data/i })).toBeInTheDocument()
+    expect(screen.getByText(/import data/i)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /reset all/i })).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
@@ -1,9 +1,19 @@
-import { render, screen } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DataManagementSettings } from "../system-settings"
 
-const mutateMock = vi.fn()
+const mocks = vi.hoisted(() => ({
+  clearDB: vi.fn(),
+  clearChat: vi.fn(),
+  invalidateQueries: vi.fn(),
+  mutate: vi.fn(),
+  notificationDestroy: vi.fn(),
+  notificationError: vi.fn(),
+  notificationInfo: vi.fn(),
+  notificationSuccess: vi.fn(),
+  storageClear: vi.fn()
+}))
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -20,25 +30,33 @@ vi.mock("react-i18next", () => ({
 vi.mock("@tanstack/react-query", () => ({
   useMutation: () => ({
     isPending: false,
-    mutate: mutateMock
+    mutate: mocks.mutate
   }),
   useQueryClient: () => ({
-    invalidateQueries: vi.fn()
+    invalidateQueries: mocks.invalidateQueries
   })
 }))
 
 vi.mock("@/hooks/useMessageOption", () => ({
   useMessageOption: () => ({
-    clearChat: vi.fn()
+    clearChat: mocks.clearChat
   })
 }))
 
 vi.mock("@/hooks/useAntdNotification", () => ({
   useAntdNotification: () => ({
-    destroy: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    success: vi.fn()
+    destroy: mocks.notificationDestroy,
+    error: mocks.notificationError,
+    info: mocks.notificationInfo,
+    success: mocks.notificationSuccess
+  })
+}))
+
+vi.mock("@/db/dexie/chat", () => ({
+  PageAssistDatabase: vi.fn().mockImplementation(function () {
+    return {
+      clearDB: mocks.clearDB
+    }
   })
 }))
 
@@ -50,6 +68,20 @@ vi.mock("@/utils/is-private-mode", () => ({
 describe("DataManagementSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.clearDB.mockResolvedValue(undefined)
+    mocks.storageClear.mockResolvedValue(undefined)
+    vi.stubGlobal("browser", {
+      storage: {
+        local: { clear: mocks.storageClear },
+        session: { clear: mocks.storageClear },
+        sync: { clear: mocks.storageClear }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it("keeps import, export, and typed-reset actions on the data surface", () => {
@@ -61,5 +93,37 @@ describe("DataManagementSettings", () => {
     expect(screen.getByRole("button", { name: /export data/i })).toBeInTheDocument()
     expect(screen.getByText(/import data/i)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /reset all/i })).toBeInTheDocument()
+  })
+
+  it("clears the scheduled reset reload when the data surface unmounts", async () => {
+    vi.useFakeTimers()
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout")
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout")
+
+    const { unmount } = render(<DataManagementSettings />)
+
+    fireEvent.click(screen.getByRole("button", { name: /reset all/i }))
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "RESET" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }))
+
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mocks.clearDB).toHaveBeenCalledTimes(1)
+
+    const reloadTimerCallIndex = setTimeoutSpy.mock.calls.findIndex(
+      ([, delay]) => delay === 1500
+    )
+    expect(reloadTimerCallIndex).toBeGreaterThanOrEqual(0)
+    const reloadTimer =
+      setTimeoutSpy.mock.results[reloadTimerCallIndex]?.value
+
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(reloadTimer)
   })
 })

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
@@ -95,6 +95,16 @@ describe("DataManagementSettings", () => {
     expect(screen.getByRole("button", { name: /reset all/i })).toBeInTheDocument()
   })
 
+  it("opens the hidden import file input from a keyboard-focusable button", () => {
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click")
+
+    render(<DataManagementSettings />)
+
+    fireEvent.click(screen.getByRole("button", { name: /import data/i }))
+
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
   it("clears the scheduled reset reload when the data surface unmounts", async () => {
     vi.useFakeTimers()
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout")

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/GeneralSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/GeneralSettings.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { GeneralSettings } from "../general-settings"
+
+const setStorageMock = vi.fn()
+const setSettingMock = vi.fn()
+const restartOnboardingMock = vi.fn()
+const setUserPersonaMock = vi.fn()
+const resetTutorialProgressMock = vi.fn()
+const mutateMock = vi.fn()
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      return fallbackOrOptions?.defaultValue ?? key
+    }
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (key: string, defaultValue: unknown) => [
+    key === "settingsIntroDismissed" ? true : defaultValue,
+    setStorageMock
+  ]
+}))
+
+vi.mock("@/hooks/useAntdNotification", () => ({
+  useAntdNotification: () => ({
+    error: vi.fn(),
+    success: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/useI18n", () => ({
+  useI18n: () => ({
+    changeLocale: vi.fn(),
+    locale: "en",
+    supportLanguage: [{ label: "English", value: "en" }]
+  })
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => true
+}))
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionState: () => ({
+    serverUrl: "http://127.0.0.1:8000",
+    userPersona: null
+  }),
+  useConnectionActions: () => ({
+    restartOnboarding: restartOnboardingMock,
+    setUserPersona: setUserPersonaMock
+  })
+}))
+
+vi.mock("@/store/tutorials", () => ({
+  useTutorialCompletion: () => ({
+    completedTutorials: [],
+    resetProgress: resetTutorialProgressMock
+  })
+}))
+
+vi.mock("@/utils/browser-runtime", () => ({
+  isExtensionRuntime: () => false
+}))
+
+vi.mock("@/hooks/useSetting", () => ({
+  useSetting: () => [[], setSettingMock]
+}))
+
+vi.mock("@/context/FontSizeProvider", () => ({
+  useFontSize: () => ({
+    decrease: vi.fn(),
+    increase: vi.fn(),
+    scale: 1
+  })
+}))
+
+vi.mock("@/hooks/useMessageOption", () => ({
+  useMessageOption: () => ({
+    clearChat: vi.fn()
+  })
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({
+    isPending: false,
+    mutate: mutateMock
+  }),
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn()
+  })
+}))
+
+vi.mock("@/utils/is-private-mode", () => ({
+  isFireFox: false,
+  isFireFoxPrivateMode: false
+}))
+
+vi.mock("@/components/Common/Settings/ThemePicker", () => ({
+  ThemePicker: () => <div>Theme picker</div>
+}))
+
+vi.mock("../search-mode", () => ({
+  SearchModeSettings: () => <div>Search preferences</div>
+}))
+
+describe("GeneralSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps routine preferences separate from destructive data actions", () => {
+    render(
+      <MemoryRouter>
+        <GeneralSettings />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText("Connection")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /reset all/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Settings/data-management.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/data-management.tsx
@@ -1,0 +1,1 @@
+export { DataManagementSettings as default, DataManagementSettings } from "./system-settings"

--- a/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
@@ -68,7 +68,11 @@ export const DataManagementSettings = () => {
         message: t("settings:systemNotifications.resetSuccess", "All data has been reset")
       })
       setResetInput("")
-      setTimeout(() => {
+      if (reloadTimeoutRef.current) {
+        clearTimeout(reloadTimeoutRef.current)
+      }
+      reloadTimeoutRef.current = setTimeout(() => {
+        reloadTimeoutRef.current = null
         window.location.reload()
       }, 1500)
     } catch (e) {

--- a/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
@@ -37,6 +37,7 @@ export const DataManagementSettings = () => {
   const [resetModalOpen, setResetModalOpen] = useState(false)
   const [resetInput, setResetInput] = useState("")
   const [resetting, setResetting] = useState(false)
+  const importInputRef = React.useRef<HTMLInputElement | null>(null)
   const reloadTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   React.useEffect(() => {
@@ -172,7 +173,6 @@ export const DataManagementSettings = () => {
       })
     },
     onError: (error) => {
-      console.log(error)
       notification.error({
         message: t(
           "settings:systemNotifications.syncError",
@@ -250,9 +250,12 @@ export const DataManagementSettings = () => {
         <span className="text-text">
           {t("generalSettings.systemData.import.label", { defaultValue: t("generalSettings.system.import.label", { defaultValue: "Import Chat History, Knowledge Base, and Prompts" }) as string })}
         </span>
-        <label
-          htmlFor="import"
-          className="flex w-full cursor-pointer items-center justify-center rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong sm:w-auto">
+        <button
+          type="button"
+          disabled={importDataMutation.isPending}
+          aria-disabled={importDataMutation.isPending}
+          onClick={() => importInputRef.current?.click()}
+          className="flex w-full cursor-pointer items-center justify-center rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto">
           {importDataMutation.isPending ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -260,8 +263,9 @@ export const DataManagementSettings = () => {
           ) : (
             t("generalSettings.systemData.import.button", { defaultValue: t("generalSettings.system.import.button", { defaultValue: "Import Data" }) as string })
           )}
-        </label>
+        </button>
         <input
+          ref={importInputRef}
           type="file"
           accept=".json"
           id="import"

--- a/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
@@ -29,17 +29,23 @@ import {
   CONTEXT_MENU_CLICK_SETTING
 } from "@/services/action"
 
-export const SystemSettings = () => {
-  const { t } = useTranslation(["settings", "knowledge", "common"])
+export const DataManagementSettings = () => {
+  const { t } = useTranslation(["settings", "common"])
   const queryClient = useQueryClient()
   const { clearChat } = useMessageOption()
-  const { increase, decrease, scale } = useFontSize()
   const notification = useAntdNotification()
-
-  // Two-step reset confirmation state
   const [resetModalOpen, setResetModalOpen] = useState(false)
   const [resetInput, setResetInput] = useState("")
   const [resetting, setResetting] = useState(false)
+  const reloadTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (reloadTimeoutRef.current) {
+        clearTimeout(reloadTimeoutRef.current)
+      }
+    }
+  }, [])
 
   const handleResetAll = async () => {
     setResetting(true)
@@ -61,9 +67,7 @@ export const SystemSettings = () => {
       notification.success({
         message: t("settings:systemNotifications.resetSuccess", "All data has been reset")
       })
-      // Clear input after successful reset
       setResetInput("")
-      // Reload to ensure clean state after full reset
       setTimeout(() => {
         window.location.reload()
       }, 1500)
@@ -77,63 +81,6 @@ export const SystemSettings = () => {
     }
   }
 
-  const quotaFriendlyMessage = t(
-    "settings:storage.quotaFriendlyMessage",
-    "Too many settings writes in a short period; please wait a few seconds and try again."
-  )
-
-  const showStorageError = (error: unknown) => {
-    const msg =
-      error instanceof Error ? error.message : typeof error === "string" ? error : ""
-    const quotaHit =
-      msg?.includes("MAX_WRITE_OPERATIONS_PER_MINUTE") ||
-      msg?.includes("QUOTA_BYTES_PER_ITEM") ||
-      msg?.includes("QUOTA_BYTES")
-
-    notification.error({
-      message: quotaHit
-        ? t("settings:storage.quotaTitle", "Storage limit reached")
-        : t("settings:storage.writeError", "Could not save settings"),
-      description: quotaHit
-        ? quotaFriendlyMessage
-        : t(
-            "settings:storage.writeErrorDescription",
-            "We couldn't save your settings. Please try again shortly."
-          )
-    })
-  }
-
-
-  const [webuiBtnSidePanel, setWebuiBtnSidePanel] = useStorage(
-    "webuiBtnSidePanel",
-    false
-  )
-
-  // Default UI mode: fullscreen (webui) or sidebar (sidePanel)
-  const [uiMode, setUiMode] = useSetting(UI_MODE_SETTING)
-
-  const [actionIconClick, setActionIconClick] = useSetting(
-    ACTION_ICON_CLICK_SETTING
-  )
-
-  const [contextMenuClick, setContextMenuClick] = useSetting(
-    CONTEXT_MENU_CLICK_SETTING
-  )
-  const [chatBackgroundImage, setChatBackgroundImage] = useSetting(
-    CHAT_BACKGROUND_IMAGE_SETTING
-  )
-
-  // Track reload timeout for cancellation
-  const reloadTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  React.useEffect(() => {
-    return () => {
-      if (reloadTimeoutRef.current) {
-        clearTimeout(reloadTimeoutRef.current)
-      }
-    }
-  }, [])
-
   const importDataMutation = useMutation({
     mutationFn: async (file: File) => {
       await importPageAssistData(file)
@@ -143,12 +90,10 @@ export const SystemSettings = () => {
         queryKey: ["fetchChatHistory"]
       })
 
-      // Clear any existing reload timeout
       if (reloadTimeoutRef.current) {
         clearTimeout(reloadTimeoutRef.current)
       }
 
-      // Show notification with cancel option
       const key = `import-reload-${Date.now()}`
       notification.success({
         key,
@@ -211,6 +156,237 @@ export const SystemSettings = () => {
       })
     }
   })
+
+  const syncFirefoxData = useMutation({
+    mutationFn: firefoxSyncDataForPrivateMode,
+    onSuccess: () => {
+      notification.success({
+        message: t(
+          "settings:systemNotifications.syncSuccess",
+          "Firefox data synced successfully, You don't need to do this again"
+        )
+      })
+    },
+    onError: (error) => {
+      console.log(error)
+      notification.error({
+        message: t(
+          "settings:systemNotifications.syncError",
+          "Firefox data sync failed"
+        )
+      })
+    }
+  })
+
+  return (
+    <div>
+      <div className="mb-5">
+        <h2 className="text-base font-semibold leading-7 text-text">
+          {t("settings:dataManagement.title", "Data Management")}
+        </h2>
+        <p className="mt-1 text-xs text-text-muted">
+          {t(
+            "settings:dataManagement.description",
+            "Export, import, sync, or reset local extension and WebUI data."
+          )}
+        </p>
+        <div className="border-b border-border mt-3"></div>
+      </div>
+
+      {isFireFox && !isFireFoxPrivateMode && (
+        <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
+          <span className="text-text">
+            <BetaTag />
+            {t("generalSettings.systemData.firefoxPrivateModeSync.label", {
+              defaultValue:
+                "Sync Custom Models, Prompts for Firefox Private Windows (Incognito Mode)"
+            })}
+          </span>
+          <button
+            onClick={() => {
+              Modal.confirm({
+                title: t("generalSettings.systemData.firefoxPrivateModeSync.confirmTitle", {
+                  defaultValue: "Sync Firefox Data?"
+                }),
+                content: t("generalSettings.systemData.firefoxPrivateModeSync.confirmContent", {
+                  defaultValue: "This will sync your custom models and prompts to Firefox private mode storage. Continue?"
+                }),
+                okText: t("common:continue", "Continue"),
+                cancelText: t("common:cancel", "Cancel"),
+                onOk: () => {
+                  syncFirefoxData.mutate()
+                }
+              })
+            }}
+            disabled={syncFirefoxData.isPending}
+            className="cursor-pointer rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong w-full sm:w-auto">
+            {syncFirefoxData.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              t("generalSettings.systemData.firefoxPrivateModeSync.button", {
+                defaultValue: "Sync Data"
+              })
+            )}
+          </button>
+        </div>
+      )}
+
+      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
+        <span className="text-text">
+          {t("generalSettings.systemData.export.label", { defaultValue: t("generalSettings.system.export.label", { defaultValue: "Export Chat History, Knowledge Base, and Prompts" }) as string })}
+        </span>
+        <button
+          onClick={exportPageAssistData}
+          className="cursor-pointer rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong w-full sm:w-auto">
+          {t("generalSettings.systemData.export.button", { defaultValue: t("generalSettings.system.export.button", { defaultValue: "Export Data" }) as string })}
+        </button>
+      </div>
+
+      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
+        <span className="text-text">
+          {t("generalSettings.systemData.import.label", { defaultValue: t("generalSettings.system.import.label", { defaultValue: "Import Chat History, Knowledge Base, and Prompts" }) as string })}
+        </span>
+        <label
+          htmlFor="import"
+          className="flex w-full cursor-pointer items-center justify-center rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong sm:w-auto">
+          {importDataMutation.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            </>
+          ) : (
+            t("generalSettings.systemData.import.button", { defaultValue: t("generalSettings.system.import.button", { defaultValue: "Import Data" }) as string })
+          )}
+        </label>
+        <input
+          type="file"
+          accept=".json"
+          id="import"
+          className="hidden"
+          disabled={importDataMutation.isPending}
+          onChange={(e) => {
+            if (e.target.files && e.target.files[0]) {
+              importDataMutation.mutate(e.target.files[0])
+            }
+          }}
+        />
+      </div>
+
+      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
+        <span className="text-text">
+          {t("generalSettings.systemData.deleteChatHistory.label", { defaultValue: t("generalSettings.system.deleteChatHistory.label", { defaultValue: "System Reset" }) as string })}
+        </span>
+
+        <button
+          onClick={() => setResetModalOpen(true)}
+          className="w-full rounded-md bg-danger px-4 py-2 text-white transition-colors hover:bg-danger sm:w-auto">
+          {t("generalSettings.systemData.deleteChatHistory.button", { defaultValue: t("generalSettings.system.deleteChatHistory.button", { defaultValue: "Reset All" }) as string })}
+        </button>
+      </div>
+
+      <Modal
+        open={resetModalOpen}
+        title={t("generalSettings.systemData.deleteChatHistory.modalTitle", { defaultValue: "System Reset" })}
+        onCancel={() => {
+          setResetModalOpen(false)
+          setResetInput("")
+        }}
+        okText={t("common:reset", { defaultValue: "Reset" })}
+        cancelText={t("common:cancel", { defaultValue: "Cancel" })}
+        okButtonProps={{
+          danger: true,
+          disabled: resetInput.trim().toUpperCase() !== "RESET",
+          loading: resetting
+        }}
+        onOk={handleResetAll}
+        centered
+      >
+        <div className="space-y-4">
+          <p className="text-text-muted">
+            {t("generalSettings.systemData.deleteChatHistory.modalWarning", {
+              defaultValue: "This will permanently delete ALL data including:"
+            })}
+          </p>
+          <ul className="list-disc pl-5 text-text-muted text-sm space-y-1">
+            <li>{t("generalSettings.systemData.deleteChatHistory.dataChat", { defaultValue: "Chat history and conversations" })}</li>
+            <li>{t("generalSettings.systemData.deleteChatHistory.dataKnowledge", { defaultValue: "Knowledge base and documents" })}</li>
+            <li>{t("generalSettings.systemData.deleteChatHistory.dataPrompts", { defaultValue: "Custom prompts and models" })}</li>
+            <li>{t("generalSettings.systemData.deleteChatHistory.dataSettings", { defaultValue: "All settings and preferences" })}</li>
+          </ul>
+          <div className="pt-2">
+            <p className="mb-2 text-sm font-medium text-text">
+              {t("generalSettings.systemData.deleteChatHistory.typeToConfirm", {
+                defaultValue: "Type RESET to confirm:"
+              })}
+            </p>
+            <Input
+              value={resetInput}
+              onChange={(e) => setResetInput(e.target.value)}
+              placeholder={t("generalSettings.systemData.deleteChatHistory.placeholder", "RESET")}
+              className="font-mono"
+              autoFocus
+              aria-describedby="reset-hint"
+            />
+            <p id="reset-hint" className="text-xs text-text-subtle mt-1">
+              {t("generalSettings.systemData.deleteChatHistory.caseInsensitiveHint", "Case-insensitive: 'reset', 'RESET', or 'Reset' all work")}
+            </p>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  )
+}
+
+export const SystemSettings = () => {
+  const { t } = useTranslation(["settings", "knowledge", "common"])
+  const { increase, decrease, scale } = useFontSize()
+  const notification = useAntdNotification()
+
+  const quotaFriendlyMessage = t(
+    "settings:storage.quotaFriendlyMessage",
+    "Too many settings writes in a short period; please wait a few seconds and try again."
+  )
+
+  const showStorageError = (error: unknown) => {
+    const msg =
+      error instanceof Error ? error.message : typeof error === "string" ? error : ""
+    const quotaHit =
+      msg?.includes("MAX_WRITE_OPERATIONS_PER_MINUTE") ||
+      msg?.includes("QUOTA_BYTES_PER_ITEM") ||
+      msg?.includes("QUOTA_BYTES")
+
+    notification.error({
+      message: quotaHit
+        ? t("settings:storage.quotaTitle", "Storage limit reached")
+        : t("settings:storage.writeError", "Could not save settings"),
+      description: quotaHit
+        ? quotaFriendlyMessage
+        : t(
+            "settings:storage.writeErrorDescription",
+            "We couldn't save your settings. Please try again shortly."
+          )
+    })
+  }
+
+
+  const [webuiBtnSidePanel, setWebuiBtnSidePanel] = useStorage(
+    "webuiBtnSidePanel",
+    false
+  )
+
+  // Default UI mode: fullscreen (webui) or sidebar (sidePanel)
+  const [uiMode, setUiMode] = useSetting(UI_MODE_SETTING)
+
+  const [actionIconClick, setActionIconClick] = useSetting(
+    ACTION_ICON_CLICK_SETTING
+  )
+
+  const [contextMenuClick, setContextMenuClick] = useSetting(
+    CONTEXT_MENU_CLICK_SETTING
+  )
+  const [chatBackgroundImage, setChatBackgroundImage] = useSetting(
+    CHAT_BACKGROUND_IMAGE_SETTING
+  )
+
   const [codeTheme, setCodeTheme] = useStorage("codeTheme", "auto")
   const sampleCode = `function hello(name: string) {
   console.log('Hello, ' + name)
@@ -248,27 +424,6 @@ export const SystemSettings = () => {
         return themes.dracula
     }
   }
-
-  const syncFirefoxData = useMutation({
-    mutationFn: firefoxSyncDataForPrivateMode,
-    onSuccess: () => {
-      notification.success({
-        message: t(
-          "settings:systemNotifications.syncSuccess",
-          "Firefox data synced successfully, You don't need to do this again"
-        )
-      })
-    },
-    onError: (error) => {
-      console.log(error)
-      notification.error({
-        message: t(
-          "settings:systemNotifications.syncError",
-          "Firefox data sync failed"
-        )
-      })
-    }
-  })
 
   const handleImageUpload = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -478,43 +633,6 @@ export const SystemSettings = () => {
           }}
         />
       </div>
-      {isFireFox && !isFireFoxPrivateMode && (
-        <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
-          <span className="text-text">
-            <BetaTag />
-            {t("generalSettings.systemData.firefoxPrivateModeSync.label", {
-              defaultValue:
-                "Sync Custom Models, Prompts for Firefox Private Windows (Incognito Mode)"
-            })}
-          </span>
-          <button
-            onClick={() => {
-              Modal.confirm({
-                title: t("generalSettings.systemData.firefoxPrivateModeSync.confirmTitle", {
-                  defaultValue: "Sync Firefox Data?"
-                }),
-                content: t("generalSettings.systemData.firefoxPrivateModeSync.confirmContent", {
-                  defaultValue: "This will sync your custom models and prompts to Firefox private mode storage. Continue?"
-                }),
-                okText: t("common:continue", "Continue"),
-                cancelText: t("common:cancel", "Cancel"),
-                onOk: () => {
-                  syncFirefoxData.mutate()
-                }
-              })
-            }}
-            disabled={syncFirefoxData.isPending}
-            className="cursor-pointer rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong w-full sm:w-auto">
-            {syncFirefoxData.isPending ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              t("generalSettings.systemData.firefoxPrivateModeSync.button", {
-                defaultValue: "Sync Data"
-              })
-            )}
-          </button>
-        </div>
-      )}
       <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
         <span className="text-text">
           {t("generalSettings.systemBasics.webuiBtnSidePanel.label", { defaultValue: t("generalSettings.system.webuiBtnSidePanel.label", { defaultValue: "Show Web UI button in Sidebar" }) as string })}
@@ -559,108 +677,6 @@ export const SystemSettings = () => {
           />
         </div>
       </div>
-
-      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
-        <span className="text-text">
-          {t("generalSettings.systemData.export.label", { defaultValue: t("generalSettings.system.export.label", { defaultValue: "Export Chat History, Knowledge Base, and Prompts" }) as string })}
-        </span>
-        <button
-          onClick={exportPageAssistData}
-          className="cursor-pointer rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong w-full sm:w-auto">
-          {t("generalSettings.systemData.export.button", { defaultValue: t("generalSettings.system.export.button", { defaultValue: "Export Data" }) as string })}
-        </button>
-      </div>
-      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
-        <span className="text-text">
-          {t("generalSettings.systemData.import.label", { defaultValue: t("generalSettings.system.import.label", { defaultValue: "Import Chat History, Knowledge Base, and Prompts" }) as string })}
-        </span>
-        <label
-          htmlFor="import"
-          className="flex w-full cursor-pointer items-center justify-center rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong sm:w-auto">
-          {importDataMutation.isPending ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            </>
-          ) : (
-            t("generalSettings.systemData.import.button", { defaultValue: t("generalSettings.system.import.button", { defaultValue: "Import Data" }) as string })
-          )}
-        </label>
-        <input
-          type="file"
-          accept=".json"
-          id="import"
-          className="hidden"
-          disabled={importDataMutation.isPending}
-          onChange={(e) => {
-            if (e.target.files && e.target.files[0]) {
-              importDataMutation.mutate(e.target.files[0])
-            }
-          }}
-        />
-      </div>
-
-      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
-        <span className="text-text">
-          {t("generalSettings.systemData.deleteChatHistory.label", { defaultValue: t("generalSettings.system.deleteChatHistory.label", { defaultValue: "System Reset" }) as string })}
-        </span>
-
-        <button
-          onClick={() => setResetModalOpen(true)}
-          className="w-full rounded-md bg-danger px-4 py-2 text-white transition-colors hover:bg-danger sm:w-auto">
-          {t("generalSettings.systemData.deleteChatHistory.button", { defaultValue: t("generalSettings.system.deleteChatHistory.button", { defaultValue: "Reset All" }) as string })}
-        </button>
-      </div>
-
-      {/* Two-step reset confirmation modal */}
-      <Modal
-        open={resetModalOpen}
-        title={t("generalSettings.systemData.deleteChatHistory.modalTitle", { defaultValue: "System Reset" })}
-        onCancel={() => {
-          setResetModalOpen(false)
-          setResetInput("")
-        }}
-        okText={t("common:reset", { defaultValue: "Reset" })}
-        cancelText={t("common:cancel", { defaultValue: "Cancel" })}
-        okButtonProps={{
-          danger: true,
-          disabled: resetInput.trim().toUpperCase() !== "RESET",
-          loading: resetting
-        }}
-        onOk={handleResetAll}
-        centered
-      >
-        <div className="space-y-4">
-          <p className="text-text-muted">
-            {t("generalSettings.systemData.deleteChatHistory.modalWarning", {
-              defaultValue: "This will permanently delete ALL data including:"
-            })}
-          </p>
-          <ul className="list-disc pl-5 text-text-muted text-sm space-y-1">
-            <li>{t("generalSettings.systemData.deleteChatHistory.dataChat", { defaultValue: "Chat history and conversations" })}</li>
-            <li>{t("generalSettings.systemData.deleteChatHistory.dataKnowledge", { defaultValue: "Knowledge base and documents" })}</li>
-            <li>{t("generalSettings.systemData.deleteChatHistory.dataPrompts", { defaultValue: "Custom prompts and models" })}</li>
-            <li>{t("generalSettings.systemData.deleteChatHistory.dataSettings", { defaultValue: "All settings and preferences" })}</li>
-          </ul>
-          <div className="pt-2">
-            <p className="mb-2 text-sm font-medium text-text">
-              {t("generalSettings.systemData.deleteChatHistory.typeToConfirm", {
-                defaultValue: "Type RESET to confirm:"
-              })}
-            </p>
-            <Input
-              value={resetInput}
-              onChange={(e) => setResetInput(e.target.value)}
-              placeholder={t("generalSettings.systemData.deleteChatHistory.placeholder", "RESET")}
-              className="font-mono"
-              autoFocus
-              aria-describedby="reset-hint"
-            />
-            <p id="reset-hint" className="text-xs text-text-subtle mt-1">
-              {t("generalSettings.systemData.deleteChatHistory.caseInsensitiveHint", "Case-insensitive: 'reset', 'RESET', or 'Reset' all work")}
-            </p>
-          </div>
-        </div>
-      </Modal>
     </div>
   )
 }

--- a/apps/packages/ui/src/public/_locales/ar/settings.json
+++ b/apps/packages/ui/src/public/_locales/ar/settings.json
@@ -3367,5 +3367,11 @@
   },
   "providerKeys_navTitle": {
     "message": "مفاتيح المزوّدين"
+  },
+  "navigation_dataManagement": {
+    "message": "إدارة البيانات"
+  },
+  "dataManagement_navTitle": {
+    "message": "إدارة البيانات"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ar/settings.json
+++ b/apps/packages/ui/src/public/_locales/ar/settings.json
@@ -3349,5 +3349,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "لون خلفية الاقتباس"
+  },
+  "navigation_connect": {
+    "message": "الاتصال"
+  },
+  "navigation_aiModels": {
+    "message": "الذكاء الاصطناعي والنماذج"
+  },
+  "navigation_experience": {
+    "message": "التجربة"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "المعرفة ومساحة العمل"
+  },
+  "navigation_safetyAdmin": {
+    "message": "السلامة والإدارة"
+  },
+  "providerKeys_navTitle": {
+    "message": "مفاتيح المزوّدين"
   }
 }

--- a/apps/packages/ui/src/public/_locales/da/settings.json
+++ b/apps/packages/ui/src/public/_locales/da/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Udbydernøgler"
+  },
+  "navigation_dataManagement": {
+    "message": "Datahåndtering"
+  },
+  "dataManagement_navTitle": {
+    "message": "Datahåndtering"
   }
 }

--- a/apps/packages/ui/src/public/_locales/da/settings.json
+++ b/apps/packages/ui/src/public/_locales/da/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Citatbaggrundsfarve"
+  },
+  "navigation_connect": {
+    "message": "Forbindelse"
+  },
+  "navigation_aiModels": {
+    "message": "AI og modeller"
+  },
+  "navigation_experience": {
+    "message": "Oplevelse"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Viden og arbejdsområde"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Sikkerhed og administration"
+  },
+  "providerKeys_navTitle": {
+    "message": "Udbydernøgler"
   }
 }

--- a/apps/packages/ui/src/public/_locales/de/settings.json
+++ b/apps/packages/ui/src/public/_locales/de/settings.json
@@ -3385,5 +3385,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Anbieter-Schlüssel"
+  },
+  "navigation_dataManagement": {
+    "message": "Datenverwaltung"
+  },
+  "dataManagement_navTitle": {
+    "message": "Datenverwaltung"
   }
 }

--- a/apps/packages/ui/src/public/_locales/de/settings.json
+++ b/apps/packages/ui/src/public/_locales/de/settings.json
@@ -3367,5 +3367,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Hintergrundfarbe für Zitate"
+  },
+  "navigation_connect": {
+    "message": "Verbindung"
+  },
+  "navigation_aiModels": {
+    "message": "KI & Modelle"
+  },
+  "navigation_experience": {
+    "message": "Erlebnis"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Wissen & Arbeitsbereich"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Sicherheit & Verwaltung"
+  },
+  "providerKeys_navTitle": {
+    "message": "Anbieter-Schlüssel"
   }
 }

--- a/apps/packages/ui/src/public/_locales/en/settings.json
+++ b/apps/packages/ui/src/public/_locales/en/settings.json
@@ -5842,5 +5842,17 @@
   },
   "generalSettings_stt_noModelsAlert": {
     "message": "No STT models available on your server. Configure a transcription engine to enable speech-to-text."
+  },
+  "navigation_dataManagement": {
+    "message": "Data Management"
+  },
+  "dataManagement_navTitle": {
+    "message": "Data Management"
+  },
+  "dataManagement_title": {
+    "message": "Data Management"
+  },
+  "dataManagement_description": {
+    "message": "Export, import, sync, or reset local extension and WebUI data."
   }
 }

--- a/apps/packages/ui/src/public/_locales/en/settings.json
+++ b/apps/packages/ui/src/public/_locales/en/settings.json
@@ -5761,5 +5761,86 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Quote background color"
+  },
+  "navigation_connect": {
+    "message": "Connect"
+  },
+  "navigation_aiModels": {
+    "message": "AI & Models"
+  },
+  "navigation_experience": {
+    "message": "Experience"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Knowledge & Workspace"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Safety & Admin"
+  },
+  "audioSourcePicker_defaultMic": {
+    "message": "Default microphone"
+  },
+  "audioSourcePicker_selectLabel": {
+    "message": "Audio input source"
+  },
+  "audioSourcePicker_sourceFallbackActive": {
+    "message": "Source fallback active"
+  },
+  "audioSourcePicker_unavailable": {
+    "message": "Unavailable"
+  },
+  "familyGuardrailsWizardNav": {
+    "message": "Family Guardrails Wizard"
+  },
+  "providerKeys_navTitle": {
+    "message": "Provider Keys"
+  },
+  "familyWizard_title": {
+    "message": "Family Guardrails Wizard"
+  },
+  "familyWizard_subtitle": {
+    "message": "Template-first setup for guardians, dependents, and moderation acceptance tracking."
+  },
+  "familyWizard_steps_householdBasics": {
+    "message": "Household Basics"
+  },
+  "familyWizard_steps_addGuardians": {
+    "message": "Add Guardians"
+  },
+  "familyWizard_steps_addDependents": {
+    "message": "Add Dependents (Accounts)"
+  },
+  "familyWizard_steps_relationshipMapping": {
+    "message": "Relationship Mapping"
+  },
+  "familyWizard_steps_templates": {
+    "message": "Templates + Customization"
+  },
+  "familyWizard_steps_alertPreferences": {
+    "message": "Alert Preferences"
+  },
+  "familyWizard_steps_acceptanceTracker": {
+    "message": "Invite + Acceptance Tracker"
+  },
+  "familyWizard_steps_reviewActivate": {
+    "message": "Review + Activate"
+  },
+  "generalSettings_stt_sourcePreferences_title": {
+    "message": "Audio input source preferences"
+  },
+  "generalSettings_stt_sourcePreferences_description": {
+    "message": "Choose which microphone each speech surface should prefer by default."
+  },
+  "generalSettings_stt_sourcePreferences_dictation": {
+    "message": "Dictation"
+  },
+  "generalSettings_stt_sourcePreferences_liveVoice": {
+    "message": "Live voice"
+  },
+  "generalSettings_stt_sourcePreferences_speechPlayground": {
+    "message": "Speech Playground"
+  },
+  "generalSettings_stt_noModelsAlert": {
+    "message": "No STT models available on your server. Configure a transcription engine to enable speech-to-text."
   }
 }

--- a/apps/packages/ui/src/public/_locales/es/settings.json
+++ b/apps/packages/ui/src/public/_locales/es/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Color de fondo de cita"
+  },
+  "navigation_connect": {
+    "message": "Conectar"
+  },
+  "navigation_aiModels": {
+    "message": "IA y modelos"
+  },
+  "navigation_experience": {
+    "message": "Experiencia"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Conocimiento y área de trabajo"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Seguridad y administración"
+  },
+  "providerKeys_navTitle": {
+    "message": "Claves de proveedores"
   }
 }

--- a/apps/packages/ui/src/public/_locales/es/settings.json
+++ b/apps/packages/ui/src/public/_locales/es/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Claves de proveedores"
+  },
+  "navigation_dataManagement": {
+    "message": "Gestión de datos"
+  },
+  "dataManagement_navTitle": {
+    "message": "Gestión de datos"
   }
 }

--- a/apps/packages/ui/src/public/_locales/fa/settings.json
+++ b/apps/packages/ui/src/public/_locales/fa/settings.json
@@ -3367,5 +3367,11 @@
   },
   "providerKeys_navTitle": {
     "message": "کلیدهای ارائه‌دهنده"
+  },
+  "navigation_dataManagement": {
+    "message": "مدیریت داده"
+  },
+  "dataManagement_navTitle": {
+    "message": "مدیریت داده"
   }
 }

--- a/apps/packages/ui/src/public/_locales/fa/settings.json
+++ b/apps/packages/ui/src/public/_locales/fa/settings.json
@@ -3349,5 +3349,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "رنگ پس‌زمینه نقل‌قول"
+  },
+  "navigation_connect": {
+    "message": "اتصال"
+  },
+  "navigation_aiModels": {
+    "message": "هوش مصنوعی و مدل‌ها"
+  },
+  "navigation_experience": {
+    "message": "تجربه"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "دانش و فضای کاری"
+  },
+  "navigation_safetyAdmin": {
+    "message": "ایمنی و مدیریت"
+  },
+  "providerKeys_navTitle": {
+    "message": "کلیدهای ارائه‌دهنده"
   }
 }

--- a/apps/packages/ui/src/public/_locales/fr/settings.json
+++ b/apps/packages/ui/src/public/_locales/fr/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Clés des fournisseurs"
+  },
+  "navigation_dataManagement": {
+    "message": "Gestion des données"
+  },
+  "dataManagement_navTitle": {
+    "message": "Gestion des données"
   }
 }

--- a/apps/packages/ui/src/public/_locales/fr/settings.json
+++ b/apps/packages/ui/src/public/_locales/fr/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Couleur d’arrière-plan de citation"
+  },
+  "navigation_connect": {
+    "message": "Connexion"
+  },
+  "navigation_aiModels": {
+    "message": "IA et modèles"
+  },
+  "navigation_experience": {
+    "message": "Expérience"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Connaissances et espace de travail"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Sécurité et administration"
+  },
+  "providerKeys_navTitle": {
+    "message": "Clés des fournisseurs"
   }
 }

--- a/apps/packages/ui/src/public/_locales/it/settings.json
+++ b/apps/packages/ui/src/public/_locales/it/settings.json
@@ -3370,5 +3370,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Colore sfondo citazione"
+  },
+  "navigation_connect": {
+    "message": "Connessione"
+  },
+  "navigation_aiModels": {
+    "message": "IA e modelli"
+  },
+  "navigation_experience": {
+    "message": "Esperienza"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Conoscenza e area di lavoro"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Sicurezza e amministrazione"
+  },
+  "providerKeys_navTitle": {
+    "message": "Chiavi provider"
   }
 }

--- a/apps/packages/ui/src/public/_locales/it/settings.json
+++ b/apps/packages/ui/src/public/_locales/it/settings.json
@@ -3388,5 +3388,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Chiavi provider"
+  },
+  "navigation_dataManagement": {
+    "message": "Gestione dati"
+  },
+  "dataManagement_navTitle": {
+    "message": "Gestione dati"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja-JP/settings.json
+++ b/apps/packages/ui/src/public/_locales/ja-JP/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "プロバイダーキー"
+  },
+  "navigation_dataManagement": {
+    "message": "データ管理"
+  },
+  "dataManagement_navTitle": {
+    "message": "データ管理"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja-JP/settings.json
+++ b/apps/packages/ui/src/public/_locales/ja-JP/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "引用背景の色"
+  },
+  "navigation_connect": {
+    "message": "接続"
+  },
+  "navigation_aiModels": {
+    "message": "AI とモデル"
+  },
+  "navigation_experience": {
+    "message": "体験"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "ナレッジとワークスペース"
+  },
+  "navigation_safetyAdmin": {
+    "message": "安全性と管理"
+  },
+  "providerKeys_navTitle": {
+    "message": "プロバイダーキー"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja/settings.json
+++ b/apps/packages/ui/src/public/_locales/ja/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "プロバイダーキー"
+  },
+  "navigation_dataManagement": {
+    "message": "データ管理"
+  },
+  "dataManagement_navTitle": {
+    "message": "データ管理"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja/settings.json
+++ b/apps/packages/ui/src/public/_locales/ja/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "引用背景の色"
+  },
+  "navigation_connect": {
+    "message": "接続"
+  },
+  "navigation_aiModels": {
+    "message": "AI とモデル"
+  },
+  "navigation_experience": {
+    "message": "体験"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "ナレッジとワークスペース"
+  },
+  "navigation_safetyAdmin": {
+    "message": "安全性と管理"
+  },
+  "providerKeys_navTitle": {
+    "message": "プロバイダーキー"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ko/settings.json
+++ b/apps/packages/ui/src/public/_locales/ko/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "인용문 배경 색상"
+  },
+  "navigation_connect": {
+    "message": "연결"
+  },
+  "navigation_aiModels": {
+    "message": "AI 및 모델"
+  },
+  "navigation_experience": {
+    "message": "경험"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "지식 및 작업 공간"
+  },
+  "navigation_safetyAdmin": {
+    "message": "안전 및 관리"
+  },
+  "providerKeys_navTitle": {
+    "message": "제공자 키"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ko/settings.json
+++ b/apps/packages/ui/src/public/_locales/ko/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "제공자 키"
+  },
+  "navigation_dataManagement": {
+    "message": "데이터 관리"
+  },
+  "dataManagement_navTitle": {
+    "message": "데이터 관리"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ml/settings.json
+++ b/apps/packages/ui/src/public/_locales/ml/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "ഉദ്ധരണി പശ്ചാത്തല നിറം"
+  },
+  "navigation_connect": {
+    "message": "കണക്ഷൻ"
+  },
+  "navigation_aiModels": {
+    "message": "AI & മോഡലുകൾ"
+  },
+  "navigation_experience": {
+    "message": "അനുഭവം"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "അറിവും വർക്ക്‌സ്പേസും"
+  },
+  "navigation_safetyAdmin": {
+    "message": "സുരക്ഷയും അഡ്മിനും"
+  },
+  "providerKeys_navTitle": {
+    "message": "പ്രൊവൈഡർ കീകൾ"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ml/settings.json
+++ b/apps/packages/ui/src/public/_locales/ml/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "പ്രൊവൈഡർ കീകൾ"
+  },
+  "navigation_dataManagement": {
+    "message": "ഡാറ്റ മാനേജ്മെന്റ്"
+  },
+  "dataManagement_navTitle": {
+    "message": "ഡാറ്റ മാനേജ്മെന്റ്"
   }
 }

--- a/apps/packages/ui/src/public/_locales/no/settings.json
+++ b/apps/packages/ui/src/public/_locales/no/settings.json
@@ -3370,5 +3370,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Leverandørnøkler"
+  },
+  "navigation_dataManagement": {
+    "message": "Dataadministrasjon"
+  },
+  "dataManagement_navTitle": {
+    "message": "Dataadministrasjon"
   }
 }

--- a/apps/packages/ui/src/public/_locales/no/settings.json
+++ b/apps/packages/ui/src/public/_locales/no/settings.json
@@ -3352,5 +3352,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Sitatbakgrunnsfarge"
+  },
+  "navigation_connect": {
+    "message": "Tilkobling"
+  },
+  "navigation_aiModels": {
+    "message": "KI og modeller"
+  },
+  "navigation_experience": {
+    "message": "Opplevelse"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Kunnskap og arbeidsområde"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Sikkerhet og administrasjon"
+  },
+  "providerKeys_navTitle": {
+    "message": "Leverandørnøkler"
   }
 }

--- a/apps/packages/ui/src/public/_locales/pt-BR/settings.json
+++ b/apps/packages/ui/src/public/_locales/pt-BR/settings.json
@@ -3394,5 +3394,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Chaves de provedores"
+  },
+  "navigation_dataManagement": {
+    "message": "Gerenciamento de dados"
+  },
+  "dataManagement_navTitle": {
+    "message": "Gerenciamento de dados"
   }
 }

--- a/apps/packages/ui/src/public/_locales/pt-BR/settings.json
+++ b/apps/packages/ui/src/public/_locales/pt-BR/settings.json
@@ -3376,5 +3376,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Cor de fundo da citação"
+  },
+  "navigation_connect": {
+    "message": "Conexão"
+  },
+  "navigation_aiModels": {
+    "message": "IA e modelos"
+  },
+  "navigation_experience": {
+    "message": "Experiência"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Conhecimento e espaço de trabalho"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Segurança e administração"
+  },
+  "providerKeys_navTitle": {
+    "message": "Chaves de provedores"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ru/settings.json
+++ b/apps/packages/ui/src/public/_locales/ru/settings.json
@@ -3367,5 +3367,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Ключи провайдеров"
+  },
+  "navigation_dataManagement": {
+    "message": "Управление данными"
+  },
+  "dataManagement_navTitle": {
+    "message": "Управление данными"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ru/settings.json
+++ b/apps/packages/ui/src/public/_locales/ru/settings.json
@@ -3349,5 +3349,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Цвет фона цитаты"
+  },
+  "navigation_connect": {
+    "message": "Подключение"
+  },
+  "navigation_aiModels": {
+    "message": "ИИ и модели"
+  },
+  "navigation_experience": {
+    "message": "Опыт"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Знания и рабочее пространство"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Безопасность и администрирование"
+  },
+  "providerKeys_navTitle": {
+    "message": "Ключи провайдеров"
   }
 }

--- a/apps/packages/ui/src/public/_locales/sv/settings.json
+++ b/apps/packages/ui/src/public/_locales/sv/settings.json
@@ -3349,5 +3349,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Bakgrundsfärg för citat"
+  },
+  "navigation_connect": {
+    "message": "Anslutning"
+  },
+  "navigation_aiModels": {
+    "message": "AI och modeller"
+  },
+  "navigation_experience": {
+    "message": "Upplevelse"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Kunskap och arbetsyta"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Säkerhet och administration"
+  },
+  "providerKeys_navTitle": {
+    "message": "Leverantörsnycklar"
   }
 }

--- a/apps/packages/ui/src/public/_locales/sv/settings.json
+++ b/apps/packages/ui/src/public/_locales/sv/settings.json
@@ -3367,5 +3367,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Leverantörsnycklar"
+  },
+  "navigation_dataManagement": {
+    "message": "Datahantering"
+  },
+  "dataManagement_navTitle": {
+    "message": "Datahantering"
   }
 }

--- a/apps/packages/ui/src/public/_locales/uk/settings.json
+++ b/apps/packages/ui/src/public/_locales/uk/settings.json
@@ -3349,5 +3349,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "Колір тла цитати"
+  },
+  "navigation_connect": {
+    "message": "Підключення"
+  },
+  "navigation_aiModels": {
+    "message": "ШІ та моделі"
+  },
+  "navigation_experience": {
+    "message": "Досвід"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "Знання та робочий простір"
+  },
+  "navigation_safetyAdmin": {
+    "message": "Безпека та адміністрування"
+  },
+  "providerKeys_navTitle": {
+    "message": "Ключі провайдерів"
   }
 }

--- a/apps/packages/ui/src/public/_locales/uk/settings.json
+++ b/apps/packages/ui/src/public/_locales/uk/settings.json
@@ -3367,5 +3367,11 @@
   },
   "providerKeys_navTitle": {
     "message": "Ключі провайдерів"
+  },
+  "navigation_dataManagement": {
+    "message": "Керування даними"
+  },
+  "dataManagement_navTitle": {
+    "message": "Керування даними"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh-TW/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh-TW/settings.json
@@ -3382,5 +3382,11 @@
   },
   "providerKeys_navTitle": {
     "message": "供應商金鑰"
+  },
+  "navigation_dataManagement": {
+    "message": "資料管理"
+  },
+  "dataManagement_navTitle": {
+    "message": "資料管理"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh-TW/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh-TW/settings.json
@@ -3364,5 +3364,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "引用背景顏色"
+  },
+  "navigation_connect": {
+    "message": "連線"
+  },
+  "navigation_aiModels": {
+    "message": "AI 與模型"
+  },
+  "navigation_experience": {
+    "message": "體驗"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "知識與工作區"
+  },
+  "navigation_safetyAdmin": {
+    "message": "安全與管理"
+  },
+  "providerKeys_navTitle": {
+    "message": "供應商金鑰"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh/settings.json
@@ -3355,5 +3355,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "引用背景颜色"
+  },
+  "navigation_connect": {
+    "message": "连接"
+  },
+  "navigation_aiModels": {
+    "message": "AI 与模型"
+  },
+  "navigation_experience": {
+    "message": "体验"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "知识与工作区"
+  },
+  "navigation_safetyAdmin": {
+    "message": "安全与管理"
+  },
+  "providerKeys_navTitle": {
+    "message": "提供商密钥"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh/settings.json
@@ -3373,5 +3373,11 @@
   },
   "providerKeys_navTitle": {
     "message": "提供商密钥"
+  },
+  "navigation_dataManagement": {
+    "message": "数据管理"
+  },
+  "dataManagement_navTitle": {
+    "message": "数据管理"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_CN/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh_CN/settings.json
@@ -3355,5 +3355,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "引用背景颜色"
+  },
+  "navigation_connect": {
+    "message": "连接"
+  },
+  "navigation_aiModels": {
+    "message": "AI 与模型"
+  },
+  "navigation_experience": {
+    "message": "体验"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "知识与工作区"
+  },
+  "navigation_safetyAdmin": {
+    "message": "安全与管理"
+  },
+  "providerKeys_navTitle": {
+    "message": "提供商密钥"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_CN/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh_CN/settings.json
@@ -3373,5 +3373,11 @@
   },
   "providerKeys_navTitle": {
     "message": "提供商密钥"
+  },
+  "navigation_dataManagement": {
+    "message": "数据管理"
+  },
+  "dataManagement_navTitle": {
+    "message": "数据管理"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_TW/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh_TW/settings.json
@@ -3382,5 +3382,11 @@
   },
   "providerKeys_navTitle": {
     "message": "供應商金鑰"
+  },
+  "navigation_dataManagement": {
+    "message": "資料管理"
+  },
+  "dataManagement_navTitle": {
+    "message": "資料管理"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_TW/settings.json
+++ b/apps/packages/ui/src/public/_locales/zh_TW/settings.json
@@ -3364,5 +3364,23 @@
   },
   "generalSettings_settings_chatRichTextStyles_quoteBackgroundColor": {
     "message": "引用背景顏色"
+  },
+  "navigation_connect": {
+    "message": "連線"
+  },
+  "navigation_aiModels": {
+    "message": "AI 與模型"
+  },
+  "navigation_experience": {
+    "message": "體驗"
+  },
+  "navigation_knowledgeWorkspace": {
+    "message": "知識與工作區"
+  },
+  "navigation_safetyAdmin": {
+    "message": "安全與管理"
+  },
+  "providerKeys_navTitle": {
+    "message": "供應商金鑰"
   }
 }

--- a/apps/packages/ui/src/routes/option-settings-route-registry.tsx
+++ b/apps/packages/ui/src/routes/option-settings-route-registry.tsx
@@ -63,6 +63,10 @@ const OptionProviderKeysSettings = createSettingsRoute(
   () => import("~/components/Option/Settings/ProviderKeysSettings"),
   "ProviderKeysSettings"
 )
+const OptionDataManagementSettings = createSettingsRoute(
+  () => import("~/components/Option/Settings/data-management"),
+  "DataManagementSettings"
+)
 const OptionChatSettings = createSettingsRoute(
   () => import("~/components/Option/Settings/ChatSettings"),
   "ChatSettings"
@@ -114,6 +118,11 @@ export const optionSettingsRoutes: RouteDefinition[] = [
     kind: "options",
     path: "/settings/provider-keys",
     element: <OptionProviderKeysSettings />,
+  },
+  {
+    kind: "options",
+    path: "/settings/data",
+    element: <OptionDataManagementSettings />,
   },
   {
     kind: "options",

--- a/apps/tldw-frontend/e2e/workflows/tier-1-critical/settings-core.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-1-critical/settings-core.spec.ts
@@ -136,7 +136,7 @@ test.describe("Settings", () => {
       })
       await settings.waitForReady()
 
-      await expect(authedPage).toHaveURL(/\/settings\/prompt/)
+      await expect(authedPage).toHaveURL(/\/settings\/prompt(?:\?.*)?$/)
       await expect(
         authedPage.getByRole("heading", { name: "Prompts workspace" })
       ).toBeVisible({ timeout: 20_000 })

--- a/apps/tldw-frontend/e2e/workflows/tier-1-critical/settings-core.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-1-critical/settings-core.spec.ts
@@ -94,6 +94,83 @@ test.describe("Settings", () => {
     })
   }
 
+  test.describe("Prompt route intent", () => {
+    test("legacy prompt studio route redirects to the prompts studio tab", async ({
+      authedPage,
+      diagnostics,
+    }) => {
+      await authedPage.goto("/prompt-studio", { waitUntil: "domcontentloaded" })
+
+      await expect(authedPage).toHaveURL(/\/prompts\?tab=studio/)
+      await expect(
+        authedPage.getByRole("heading", { name: /^prompts$/i }).first()
+      ).toBeVisible({ timeout: 20_000 })
+      await expect(
+        authedPage.getByText("Getting started with Prompt Studio")
+      ).toBeVisible({ timeout: 20_000 })
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+
+    test("prompt workspace link settings and prompt studio settings stay distinct", async ({
+      authedPage,
+      diagnostics,
+    }) => {
+      await authedPage.goto("/settings/prompt-studio", {
+        waitUntil: "domcontentloaded",
+      })
+      await settings.waitForReady()
+
+      await expect(authedPage).toHaveURL(/\/settings\/prompt-studio/)
+      await expect(
+        authedPage.getByText(
+          "Configure defaults and monitor Prompt Studio health."
+        )
+      ).toBeVisible({ timeout: 20_000 })
+      await expect(
+        authedPage.getByRole("button", { name: /test prompt studio/i })
+      ).toBeVisible({ timeout: 20_000 })
+
+      await authedPage.goto("/settings/prompt", {
+        waitUntil: "domcontentloaded",
+      })
+      await settings.waitForReady()
+
+      await expect(authedPage).toHaveURL(/\/settings\/prompt/)
+      await expect(
+        authedPage.getByRole("heading", { name: "Prompts workspace" })
+      ).toBeVisible({ timeout: 20_000 })
+      await expect(
+        authedPage.getByRole("button", { name: /open prompts workspace/i })
+      ).toBeVisible({ timeout: 20_000 })
+      await expect(
+        authedPage.getByRole("button", { name: /test prompt studio/i })
+      ).toHaveCount(0)
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+
+    test("settings navigation uses different labels for prompt workspace and prompt studio settings", async ({
+      diagnostics,
+    }) => {
+      await settings.goto()
+      await settings.waitForReady()
+
+      const promptSettingsLink = settings.page.getByTestId(
+        "settings-nav-link--settings-prompt"
+      )
+      const promptStudioSettingsLink = settings.page.getByTestId(
+        "settings-nav-link--settings-prompt-studio"
+      )
+
+      await expect(promptSettingsLink).toContainText(/manage prompts/i)
+      await expect(promptSettingsLink).not.toContainText(/prompt studio/i)
+      await expect(promptStudioSettingsLink).toContainText(/prompt studio/i)
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+  })
+
   // --- Save button fires an API call ---
   test("save settings fires API", async ({ authedPage, diagnostics }) => {
     await settings.goto()

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -4,7 +4,7 @@ title: Implement WebUI settings and model provider remediation
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 18:03'
+updated_date: '2026-05-18 19:13'
 labels:
   - ux
   - webui
@@ -66,6 +66,8 @@ Completed fourth remediation slice: added browser route-intent guards for Prompt
 Verification: bunx playwright test e2e/workflows/tier-1-critical/settings-core.spec.ts --grep "Prompt route intent" --reporter=line -> 3 passed. bunx playwright test e2e/workflows/settings.spec.ts e2e/workflows/tier-1-critical/settings-core.spec.ts --reporter=line -> 59 passed. git diff --check passed.
 
 Final verification 2026-05-18: focused UI Vitest suite passed 11 files / 41 tests; settings Playwright workflow pair passed 59 tests; WP4 responsive landmarks passed 12 tests including /settings and /settings/model; git diff --check passed. Documentation governance scans for the child plan and TASK-418.2 produced no placeholder/trailing-whitespace/non-ASCII findings and diff-check passed. Bandit was not run because this slice touched frontend TypeScript/TSX, Playwright tests, Markdown, locale JSON, and Backlog files only. Full apps/packages/ui TypeScript remains blocked by pre-existing repo-wide baseline debt outside this slice; first failures are in audio, chat composer, common prompt utils, quick-ingest, flashcards, playground, services, and route baseline tests before this branch’s settings/model files.
+
+Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1845
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -4,7 +4,7 @@ title: Implement WebUI settings and model provider remediation
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 19:40'
+updated_date: '2026-05-18 19:49'
 labels:
   - ux
   - webui
@@ -72,6 +72,10 @@ Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1845
 PR #1845 review follow-up 2026-05-18: Gemini flagged the reset reload timer in DataManagementSettings because handleResetAll uses a bare setTimeout while the component cleanup and import cancellation use reloadTimeoutRef. Reopening the task to route the reset reload timer through the existing ref and verify the focused settings tests.
 
 PR #1845 review follow-up verification 2026-05-18: added a regression test proving the reset reload timer is cleared on DataManagementSettings unmount, then stored the reset timer in reloadTimeoutRef and nulled it before window.location.reload. Targeted test passed before broad rerun: bunx vitest run src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx -> 1 file / 2 tests passed. Broader focused settings/model Vitest suite passed 11 files / 42 tests. git diff --check passed. bunx tsc --noEmit --pretty false remains blocked by existing repo-wide UI baseline errors outside this touched settings slice, with no touched settings file diagnostics in the observed output.
+
+PR #1845 second review sweep 2026-05-18: CodeRabbit/Qodo added actionable comments after commit c229a70aa. Current items to verify/fix: locale directory filtering in settings nav guardian, provider-key error handling in model readiness UI, keyboard-accessible import trigger, exact prompt settings URL assertion, duplicate FINAL_SUMMARY markers in TASK-418.14 and TASK-418.2, raw syncFirefoxData error logging, and model usability/configuration derived from server catalog fields.
+
+PR #1845 second review sweep verification 2026-05-18: fixed the new CodeRabbit/Qodo comments by filtering locale guard iteration to directories, showing provider-key load failures separately from configured counts, deriving model configured/usable state from provider keys plus server model flags, replacing the import label with a disabled-aware button that clicks the hidden file input, removing raw syncFirefoxData error logging, tightening the prompt settings URL assertion, and removing duplicate FINAL_SUMMARY markers from TASK-418.14 and TASK-418.2. Verification: affected Vitest tests passed 3 files / 21 tests; broader focused settings/model Vitest suite passed 11 files / 45 tests; git diff --check passed. Focused Playwright prompt-route command was rerun outside the sandbox after a port-bind EPERM, but skipped 3 tests because the E2E fixture marked the backend server unavailable. bunx tsc --noEmit --pretty false still fails on existing repo-wide UI baseline diagnostics outside this touched slice.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -80,10 +84,8 @@ PR #1845 review follow-up verification 2026-05-18: added a regression test provi
 Completed WP5 settings/model-provider UX remediation for WebUI/extension. Implemented task-led settings grouping, user-facing Provider Keys navigation, separate Data Management settings for import/export/reset, configured-first /settings/model defaults and provider readiness, model utility coverage, and browser route-intent guards for /prompts, /prompt-studio, /settings/prompt, and /settings/prompt-studio. Verification passed for focused Vitest settings/model coverage, settings Playwright workflows, WP4 responsive landmarks, and diff/governance checks. Full TypeScript remains blocked by existing unrelated baseline debt; Bandit is not applicable to this frontend/docs-only slice.
 
 PR review follow-up: addressed Gemini's reset reload timeout comment by routing the reset reload through reloadTimeoutRef so import cancellation and unmount cleanup can clear it. Added focused regression coverage and re-ran the focused settings/model suite.
-<!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Second PR review sweep: addressed all still-actionable CodeRabbit/Qodo comments available at the time of refresh, including import accessibility, model readiness correctness, provider-key error state, guard/test hardening, raw error logging, and Backlog marker cleanup.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -4,7 +4,7 @@ title: Implement WebUI settings and model provider remediation
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 15:11'
+updated_date: '2026-05-18 15:17'
 labels:
   - ux
   - webui
@@ -52,6 +52,10 @@ Started implementation in clean worktree codex/webui-settings-models from origin
 Completed first remediation slice: regrouped Settings navigation around user tasks (Connect, AI & Models, Experience, Knowledge & Workspace, Safety & Admin, About); fixed Provider Keys nav token; added locale guards for nav labels across source locales; regenerated public settings locale mirrors with the existing sync script.
 
 Verification: bunx vitest run src/components/Layouts/__tests__/settings-nav.guardian.test.ts src/components/Layouts/__tests__/settings-layout-labels.test.tsx src/components/Layouts/__tests__/settings-layout-filter.test.tsx src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx src/components/Layouts/__tests__/settings-layout-active-route.test.ts -> 5 files / 29 tests passed.
+
+Completed second remediation slice: split high-risk data management actions out of routine General Settings into /settings/data; preserved the existing import/export flow, Firefox private-mode sync, typed RESET confirmation, danger reset button, reload cancellation, and storage-clearing code path. Added settings nav Data Management group, source locale keys, and regenerated public settings locale mirrors.
+
+Verification: bunx vitest run src/components/Option/Settings/__tests__/GeneralSettings.test.tsx src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx src/components/Option/Settings/__tests__/system-settings.highlight-preview.test.ts src/components/Layouts/__tests__/settings-nav.guardian.test.ts src/components/Layouts/__tests__/settings-layout-filter.test.tsx src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx src/components/Layouts/__tests__/settings-layout-active-route.test.ts -> 7 files / 31 tests passed. git diff --check passed. bunx tsc --noEmit --pretty false remains blocked by existing unrelated TypeScript baseline failures before touched settings files, starting in audio/chat/flashcards test fixtures.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -4,7 +4,7 @@ title: Implement WebUI settings and model provider remediation
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 15:24'
+updated_date: '2026-05-18 17:07'
 labels:
   - ux
   - webui
@@ -36,7 +36,7 @@ Implement the WP5 settings and model/provider UX remediation slice for WebUI/ext
 - [ ] #2 /settings/provider-keys has a user-facing label and remains searchable/filterable from settings navigation.
 - [ ] #3 Routine settings are separated from data/import/export/reset actions while preserving existing reset safeguards.
 - [x] #4 /settings/model prioritizes default/configured/usable model setup before full catalog browsing while preserving advanced controls.
-- [ ] #5 Prompt Library, Prompt Studio, and Prompt Studio settings route intent remains distinct and covered by tests.
+- [x] #5 Prompt Library, Prompt Studio, and Prompt Studio settings route intent remains distinct and covered by tests.
 - [ ] #6 Focused Vitest settings/model tests, settings browser workflow checks, WP4 responsive landmarks, git diff --check, and applicable security checks are recorded.
 <!-- AC:END -->
 
@@ -60,6 +60,10 @@ Verification: bunx vitest run src/components/Option/Settings/__tests__/GeneralSe
 Completed third remediation slice: /settings/model now puts default provider/model selection first, adds a provider readiness summary before the full catalog, and orders model choices configured-first while preserving the full AvailableModelsList catalog and OpenAI OAuth controls. The readiness summary uses server-returned chat models plus provider-key/OAuth status without adding backend API requirements.
 
 Verification: bunx vitest run src/components/Option/Models/__tests__/ModelsBody.test.tsx src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts src/components/Option/Models/__tests__/AvailableModelsList.test.tsx -> 3 files / 9 tests passed. git diff --check passed.
+
+Completed fourth remediation slice: added browser route-intent guards for Prompt Library/Prompts workspace, legacy /prompt-studio redirect, /settings/prompt, and /settings/prompt-studio. No route/component code changes were needed; existing route ownership already matched the intended UX contract.
+
+Verification: bunx playwright test e2e/workflows/tier-1-critical/settings-core.spec.ts --grep "Prompt route intent" --reporter=line -> 3 passed. bunx playwright test e2e/workflows/settings.spec.ts e2e/workflows/tier-1-critical/settings-core.spec.ts --reporter=line -> 59 passed. git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-418.14
 title: Implement WebUI settings and model provider remediation
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 17:07'
+updated_date: '2026-05-18 18:03'
 labels:
   - ux
   - webui
@@ -32,12 +32,12 @@ Implement the WP5 settings and model/provider UX remediation slice for WebUI/ext
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Settings navigation has task-led groups and no visible dotted i18n keys.
-- [ ] #2 /settings/provider-keys has a user-facing label and remains searchable/filterable from settings navigation.
-- [ ] #3 Routine settings are separated from data/import/export/reset actions while preserving existing reset safeguards.
+- [x] #1 Settings navigation has task-led groups and no visible dotted i18n keys.
+- [x] #2 /settings/provider-keys has a user-facing label and remains searchable/filterable from settings navigation.
+- [x] #3 Routine settings are separated from data/import/export/reset actions while preserving existing reset safeguards.
 - [x] #4 /settings/model prioritizes default/configured/usable model setup before full catalog browsing while preserving advanced controls.
 - [x] #5 Prompt Library, Prompt Studio, and Prompt Studio settings route intent remains distinct and covered by tests.
-- [ ] #6 Focused Vitest settings/model tests, settings browser workflow checks, WP4 responsive landmarks, git diff --check, and applicable security checks are recorded.
+- [x] #6 Focused Vitest settings/model tests, settings browser workflow checks, WP4 responsive landmarks, git diff --check, and applicable security checks are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -64,12 +64,14 @@ Verification: bunx vitest run src/components/Option/Models/__tests__/ModelsBody.
 Completed fourth remediation slice: added browser route-intent guards for Prompt Library/Prompts workspace, legacy /prompt-studio redirect, /settings/prompt, and /settings/prompt-studio. No route/component code changes were needed; existing route ownership already matched the intended UX contract.
 
 Verification: bunx playwright test e2e/workflows/tier-1-critical/settings-core.spec.ts --grep "Prompt route intent" --reporter=line -> 3 passed. bunx playwright test e2e/workflows/settings.spec.ts e2e/workflows/tier-1-critical/settings-core.spec.ts --reporter=line -> 59 passed. git diff --check passed.
+
+Final verification 2026-05-18: focused UI Vitest suite passed 11 files / 41 tests; settings Playwright workflow pair passed 59 tests; WP4 responsive landmarks passed 12 tests including /settings and /settings/model; git diff --check passed. Documentation governance scans for the child plan and TASK-418.2 produced no placeholder/trailing-whitespace/non-ASCII findings and diff-check passed. Bandit was not run because this slice touched frontend TypeScript/TSX, Playwright tests, Markdown, locale JSON, and Backlog files only. Full apps/packages/ui TypeScript remains blocked by pre-existing repo-wide baseline debt outside this slice; first failures are in audio, chat composer, common prompt utils, quick-ingest, flashcards, playground, services, and route baseline tests before this branch’s settings/model files.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed WP5 settings/model-provider UX remediation for WebUI/extension. Implemented task-led settings grouping, user-facing Provider Keys navigation, separate Data Management settings for import/export/reset, configured-first /settings/model defaults and provider readiness, model utility coverage, and browser route-intent guards for /prompts, /prompt-studio, /settings/prompt, and /settings/prompt-studio. Verification passed for focused Vitest settings/model coverage, settings Playwright workflows, WP4 responsive landmarks, and diff/governance checks. Full TypeScript remains blocked by existing unrelated baseline debt; Bandit is not applicable to this frontend/docs-only slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
@@ -78,10 +80,10 @@ Verification: bunx playwright test e2e/workflows/tier-1-critical/settings-core.s
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -1,0 +1,75 @@
+---
+id: TASK-418.14
+title: Implement WebUI settings and model provider remediation
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-18 15:11'
+labels:
+  - ux
+  - webui
+  - extension
+  - implementation
+  - settings
+  - models
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-17-webui-settings-models-implementation-plan.md
+  - >-
+    Docs/superpowers/plans/2026-05-17-webui-extension-ux-remediation-implementation-plan.md
+  - >-
+    Docs/superpowers/specs/2026-05-17-webui-extension-ux-remediation-program-design.md
+parent_task_id: TASK-418
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the WP5 settings and model/provider UX remediation slice for WebUI/extension. Scope: task-led settings grouping, provider-keys label repair, configured-first model/provider orientation, separation of routine preferences from data/destructive actions, prompt/settings route relationship guards, and focused unit/browser verification. Preserve existing routes, advanced controls, and backend APIs unless existing frontend data cannot responsibly represent the required UX state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Settings navigation has task-led groups and no visible dotted i18n keys.
+- [ ] #2 /settings/provider-keys has a user-facing label and remains searchable/filterable from settings navigation.
+- [ ] #3 Routine settings are separated from data/import/export/reset actions while preserving existing reset safeguards.
+- [ ] #4 /settings/model prioritizes default/configured/usable model setup before full catalog browsing while preserving advanced controls.
+- [ ] #5 Prompt Library, Prompt Studio, and Prompt Studio settings route intent remains distinct and covered by tests.
+- [ ] #6 Focused Vitest settings/model tests, settings browser workflow checks, WP4 responsive landmarks, git diff --check, and applicable security checks are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Started implementation in clean worktree codex/webui-settings-models from origin/dev at e61681e99a04b655d14404d96f90f8f3b54b12aa after PR #1839 merged. Main checkout remains dirty and unrelated. Following Docs/superpowers/plans/2026-05-17-webui-settings-models-implementation-plan.md with TDD: add failing settings label/grouping tests before product code changes.
+
+Completed first remediation slice: regrouped Settings navigation around user tasks (Connect, AI & Models, Experience, Knowledge & Workspace, Safety & Admin, About); fixed Provider Keys nav token; added locale guards for nav labels across source locales; regenerated public settings locale mirrors with the existing sync script.
+
+Verification: bunx vitest run src/components/Layouts/__tests__/settings-nav.guardian.test.ts src/components/Layouts/__tests__/settings-layout-labels.test.tsx src/components/Layouts/__tests__/settings-layout-filter.test.tsx src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx src/components/Layouts/__tests__/settings-layout-active-route.test.ts -> 5 files / 29 tests passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -4,7 +4,7 @@ title: Implement WebUI settings and model provider remediation
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 15:17'
+updated_date: '2026-05-18 15:24'
 labels:
   - ux
   - webui
@@ -35,7 +35,7 @@ Implement the WP5 settings and model/provider UX remediation slice for WebUI/ext
 - [ ] #1 Settings navigation has task-led groups and no visible dotted i18n keys.
 - [ ] #2 /settings/provider-keys has a user-facing label and remains searchable/filterable from settings navigation.
 - [ ] #3 Routine settings are separated from data/import/export/reset actions while preserving existing reset safeguards.
-- [ ] #4 /settings/model prioritizes default/configured/usable model setup before full catalog browsing while preserving advanced controls.
+- [x] #4 /settings/model prioritizes default/configured/usable model setup before full catalog browsing while preserving advanced controls.
 - [ ] #5 Prompt Library, Prompt Studio, and Prompt Studio settings route intent remains distinct and covered by tests.
 - [ ] #6 Focused Vitest settings/model tests, settings browser workflow checks, WP4 responsive landmarks, git diff --check, and applicable security checks are recorded.
 <!-- AC:END -->
@@ -56,6 +56,10 @@ Verification: bunx vitest run src/components/Layouts/__tests__/settings-nav.guar
 Completed second remediation slice: split high-risk data management actions out of routine General Settings into /settings/data; preserved the existing import/export flow, Firefox private-mode sync, typed RESET confirmation, danger reset button, reload cancellation, and storage-clearing code path. Added settings nav Data Management group, source locale keys, and regenerated public settings locale mirrors.
 
 Verification: bunx vitest run src/components/Option/Settings/__tests__/GeneralSettings.test.tsx src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx src/components/Option/Settings/__tests__/system-settings.highlight-preview.test.ts src/components/Layouts/__tests__/settings-nav.guardian.test.ts src/components/Layouts/__tests__/settings-layout-filter.test.tsx src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx src/components/Layouts/__tests__/settings-layout-active-route.test.ts -> 7 files / 31 tests passed. git diff --check passed. bunx tsc --noEmit --pretty false remains blocked by existing unrelated TypeScript baseline failures before touched settings files, starting in audio/chat/flashcards test fixtures.
+
+Completed third remediation slice: /settings/model now puts default provider/model selection first, adds a provider readiness summary before the full catalog, and orders model choices configured-first while preserving the full AvailableModelsList catalog and OpenAI OAuth controls. The readiness summary uses server-returned chat models plus provider-key/OAuth status without adding backend API requirements.
+
+Verification: bunx vitest run src/components/Option/Models/__tests__/ModelsBody.test.tsx src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts src/components/Option/Models/__tests__/AvailableModelsList.test.tsx -> 3 files / 9 tests passed. git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
+++ b/backlog/tasks/task-418.14 - Implement-WebUI-settings-and-model-provider-remediation.md
@@ -4,7 +4,7 @@ title: Implement WebUI settings and model provider remediation
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-18 19:13'
+updated_date: '2026-05-18 19:40'
 labels:
   - ux
   - webui
@@ -68,12 +68,18 @@ Verification: bunx playwright test e2e/workflows/tier-1-critical/settings-core.s
 Final verification 2026-05-18: focused UI Vitest suite passed 11 files / 41 tests; settings Playwright workflow pair passed 59 tests; WP4 responsive landmarks passed 12 tests including /settings and /settings/model; git diff --check passed. Documentation governance scans for the child plan and TASK-418.2 produced no placeholder/trailing-whitespace/non-ASCII findings and diff-check passed. Bandit was not run because this slice touched frontend TypeScript/TSX, Playwright tests, Markdown, locale JSON, and Backlog files only. Full apps/packages/ui TypeScript remains blocked by pre-existing repo-wide baseline debt outside this slice; first failures are in audio, chat composer, common prompt utils, quick-ingest, flashcards, playground, services, and route baseline tests before this branch’s settings/model files.
 
 Draft PR opened: https://github.com/rmusser01/tldw_server/pull/1845
+
+PR #1845 review follow-up 2026-05-18: Gemini flagged the reset reload timer in DataManagementSettings because handleResetAll uses a bare setTimeout while the component cleanup and import cancellation use reloadTimeoutRef. Reopening the task to route the reset reload timer through the existing ref and verify the focused settings tests.
+
+PR #1845 review follow-up verification 2026-05-18: added a regression test proving the reset reload timer is cleared on DataManagementSettings unmount, then stored the reset timer in reloadTimeoutRef and nulled it before window.location.reload. Targeted test passed before broad rerun: bunx vitest run src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx -> 1 file / 2 tests passed. Broader focused settings/model Vitest suite passed 11 files / 42 tests. git diff --check passed. bunx tsc --noEmit --pretty false remains blocked by existing repo-wide UI baseline errors outside this touched settings slice, with no touched settings file diagnostics in the observed output.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Completed WP5 settings/model-provider UX remediation for WebUI/extension. Implemented task-led settings grouping, user-facing Provider Keys navigation, separate Data Management settings for import/export/reset, configured-first /settings/model defaults and provider readiness, model utility coverage, and browser route-intent guards for /prompts, /prompt-studio, /settings/prompt, and /settings/prompt-studio. Verification passed for focused Vitest settings/model coverage, settings Playwright workflows, WP4 responsive landmarks, and diff/governance checks. Full TypeScript remains blocked by existing unrelated baseline debt; Bandit is not applicable to this frontend/docs-only slice.
+
+PR review follow-up: addressed Gemini's reset reload timeout comment by routing the reset reload through reloadTimeoutRef so import cancellation and unmount cleanup can clear it. Added focused regression coverage and re-ran the focused settings/model suite.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-418.2 - Plan-WebUI-settings-and-model-provider-implementation.md
+++ b/backlog/tasks/task-418.2 - Plan-WebUI-settings-and-model-provider-implementation.md
@@ -4,7 +4,7 @@ title: Plan WebUI settings and model provider implementation
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-17 18:46'
+updated_date: '2026-05-18 18:03'
 labels:
   - ux
   - design
@@ -52,6 +52,8 @@ Documentation-only child implementation plan for the approved WebUI/extension UX
 - The plan preserves ProviderKeysSettings, ModelsBody, AvailableModelsList, ModelSettings, SettingsLayout, and the existing route registry patterns.
 - Verification run for this planning artifact: placeholder-language scan exited 1 with no output; ASCII/trailing-whitespace scan exited 1 with no output; git diff check exited 0; Node coverage check confirmed required route, finding, file, and test tokens are present.
 - Bandit was not run because this task changed only Markdown planning and Backlog task files.
+
+Implementation follow-through recorded 2026-05-18: child task TASK-418.14 completed the settings/model-provider implementation slice from this plan in branch codex/webui-settings-models. Scope included task-led settings grouping, Provider Keys label repair, Data Management separation, configured-first /settings/model orientation, prompt route-intent browser guards, focused Vitest settings/model tests, settings Playwright workflow tests, and WP4 responsive landmark verification. Full apps/packages/ui TypeScript remains blocked by pre-existing repo-wide baseline debt outside this slice.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-418.2 - Plan-WebUI-settings-and-model-provider-implementation.md
+++ b/backlog/tasks/task-418.2 - Plan-WebUI-settings-and-model-provider-implementation.md
@@ -62,8 +62,6 @@ Implementation follow-through recorded 2026-05-18: child task TASK-418.14 comple
 Completed the documentation-only child implementation plan for WP5 settings and model/provider remediation. The plan defines route scope, settings grouping, provider-key label repair, configured-first model UX, destructive-action separation, tests, and browser QA gates without changing product code.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed


### PR DESCRIPTION
## Change summary

Human maintainer to fill in before merge. This PR is AI-authored and is not merge-ready until a human-owned change summary explains what changed and why these implementation choices were made.

## Summary

- What changed:
  - Regroups Settings navigation around task-led categories and fixes the visible Provider Keys navigation label.
  - Moves import/export/sync/reset actions out of General Settings into a dedicated Data Management settings page while preserving the typed reset safeguard.
  - Adds configured-first model/provider orientation on `/settings/model`, provider readiness summary, and route-intent browser guards for `/prompts`, `/prompt-studio`, `/settings/prompt`, and `/settings/prompt-studio`.
- Why:
  - Addresses the WP5 settings/model-provider UX audit slice without changing backend APIs, route names, or advanced model/catalog controls.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:

- `cd apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/settings-layout-filter.test.tsx src/components/Layouts/__tests__/settings-layout-active-route.test.ts src/components/Layouts/__tests__/settings-nav.guardian.test.ts src/components/Layouts/__tests__/settings-layout-labels.test.tsx src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx src/components/Option/Settings/__tests__/GeneralSettings.test.tsx src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx src/components/Option/Settings/__tests__/system-settings.highlight-preview.test.ts src/components/Option/Models/__tests__/modelsDisplayUtils.test.ts src/components/Option/Models/__tests__/AvailableModelsList.test.tsx src/components/Option/Models/__tests__/ModelsBody.test.tsx` -> 11 files / 41 tests passed.
- `cd apps/tldw-frontend && bunx playwright test e2e/workflows/settings.spec.ts e2e/workflows/tier-1-critical/settings-core.spec.ts --reporter=line` -> 59 passed.
- `cd apps/tldw-frontend && bunx playwright test e2e/smoke/stage4-responsive-landmarks.spec.ts --reporter=line` -> 12 passed.
- `git diff --check` -> passed.
- `cd apps/packages/ui && bunx tsc --noEmit --pretty false` -> fails on existing repo-wide TypeScript baseline debt outside this slice. First failures are in audio, chat composer, common prompt utils, quick-ingest, flashcards, playground, services, and route baseline tests before this branch's settings/model files.
- Bandit not run: frontend TypeScript/TSX, Playwright, Markdown, locale JSON, and Backlog changes only.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [x] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

Notes:

- Stage 5 smoke/all-pages were not run for this WP5 slice; focused settings workflows and the WP4 responsive landmark gate were run instead.
- Vitest output includes an existing Ant Design `Alert.message` deprecation warning from `GeneralSettings.test.tsx`.
- Flashcards and Watchlists checklist rows are not applicable to this PR.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [ ] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [ ] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
- [ ] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
- [ ] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

## Risk & Rollback

- Risk level: Medium
- Rollback plan: Revert this PR. Changes are isolated to settings navigation/settings pages, model display ordering, route-intent tests, locale mirrors, and Backlog/plan records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized Settings and model provider UX into task-led groups, with configured-first models and a dedicated Data Management page to speed setup and housekeeping. Adds route guards, fixes Provider Keys labeling, expands i18n (including extension locales), and cleans up the reset reload timeout; no backend API changes.

- **New Features**
  - Task-led Settings groups: Connect, AI & Models, Experience, Knowledge & Workspace, Safety & Admin, Data Management, About.
  - New Data Management page at /settings/data for import/export/sync/reset, preserving the typed reset confirmation and clearing any reload timeout on unmount.
  - Models page prioritizes configured and usable providers/models, pins the selected default model, and shows provider readiness.
  - Route-intent guards: legacy /prompt-studio redirects to /prompts?tab=studio; prompt settings remain distinct from prompt studio.
  - Fixed Provider Keys navigation label and updated i18n across app and extension locales.

- **Migration**
  - No API changes. A new route /settings/data was added.
  - Existing links to /prompt-studio auto-redirect; no user action needed.

<sup>Written for commit 5500f1dfd5567c45202a3e10bd1de904a0387222. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1845?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

