### PR TITLE
Add VZ prepared-host evidence tracker

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -632,6 +632,8 @@ they execute on the self-hosted runner.
 The acceptance policy for when this workflow should run, what counts as an
 expected skip, and what counts as a blocking `vz_linux` regression lives in
 `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`.
+Prepared-host run evidence and residual gaps should be recorded in
+`Docs/Sandbox/vz-linux-prepared-host-evidence.md`.
 
 The workflow calls the same operator smoke script documented above:
 

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -3,6 +3,7 @@
 **Status:** Active policy for real `vz_linux` Apple silicon CI.
 **Date:** 2026-05-03.
 **Workflow:** `.github/workflows/vz-linux-host-gated.yml`.
+**Evidence tracker:** `Docs/Sandbox/vz-linux-prepared-host-evidence.md`.
 
 ## Purpose
 
@@ -12,6 +13,9 @@ canonical Linux bundle on the runner. That cannot be part of normal hosted CI.
 
 This policy defines when the host-gated workflow should run, what it proves,
 which skips are expected, and what counts as a blocking regression.
+Prepared-host results should be recorded in
+`Docs/Sandbox/vz-linux-prepared-host-evidence.md` so manual and nightly runs
+remain reviewable without making real VM execution part of normal PR CI.
 
 ## Entry Points
 
@@ -208,9 +212,16 @@ secondary failures.
 Uploaded logs are for operator debugging. They must not be treated as public API
 output and should not contain secrets or raw user data.
 
+Record the workflow run URL, artifact names, relevant byte sizes or checksums,
+and redacted log pointers in
+`Docs/Sandbox/vz-linux-prepared-host-evidence.md`. Do not paste secrets, raw user
+data, or full runner logs into the tracker.
+
 ## Maintenance Rules
 
 - Keep this policy aligned with `.github/workflows/vz-linux-host-gated.yml`.
+- Keep prepared-host acceptance evidence in
+  `Docs/Sandbox/vz-linux-prepared-host-evidence.md`.
 - Update `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
   when changing workflow triggers, labels, action pins, permissions, artifact
   paths, failure-drill opt-in behavior, or nightly opt-in behavior.

--- a/Docs/Sandbox/vz-linux-prepared-host-evidence.md
+++ b/Docs/Sandbox/vz-linux-prepared-host-evidence.md
@@ -1,0 +1,161 @@
+# VZ Linux Prepared-Host Evidence Tracker
+
+**Status:** Active tracker for prepared Apple silicon `vz_linux` acceptance evidence.
+**Scope:** Real `vz_linux` execution evidence from manual operator runs or the host-gated workflow on trusted refs.
+**Policy:** `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`.
+**Operator entrypoint:** `tools/macos-vz-helper/scripts/vz-helperctl.py smoke` or `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`.
+
+## Purpose
+
+This tracker makes prepared-host acceptance evidence reviewable without making
+real VM execution part of normal CI. It records what a prepared Apple silicon
+host proved, which expected skips were accepted, which artifacts were preserved,
+and what residual gaps remain.
+
+Normal PR checks should continue to use portable unit tests, workflow contract
+tests, fake/scaffolded paths, and docs checks. Real `vz_linux` execution remains
+manual or host-gated only:
+
+- local operator run on a prepared Apple silicon macOS host
+- `workflow_dispatch` on `main` or `dev`
+- opted-in scheduled host-gated workflow when
+  `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1`
+
+Do not add pull request triggers, push triggers, scheduled destructive drills,
+host reboot automation, launchd automation, or network expansion from this
+tracker.
+
+## Evidence Packet
+
+Each prepared-host evidence packet should include these fields.
+
+| Field | Required content |
+| --- | --- |
+| Evidence date | ISO date and local timezone. |
+| Evidence source | `local-operator`, `workflow_dispatch`, or `nightly-host-gated`. |
+| Git state | repository, branch, commit SHA, PR number if applicable, and dirty/clean status. |
+| Host identity | Apple silicon model or runner label summary, macOS version, architecture, runner name if CI, and whether the host is dedicated or shared. |
+| Host prep | Xcode command line tools availability, SwiftPM availability, `xcrun codesign` availability, Virtualization.framework availability, and runner labels for CI. |
+| Bundle/template | bundle path or registered template id, manifest path if registered, artifact hashes when available, build provenance, and whether validation used canonical bundle or compatibility mode. |
+| Helper build/signing | helper binary path, helper version, protocol version, signing mode, entitlements path, entitlement validation result, and skip-sign rationale when signing was skipped. |
+| Runtime paths | private runtime directory, socket path, serial-log directory, log directory, and evidence that runtime/log directories were owner-only. |
+| Commands | exact smoke, helperctl, pytest, workflow, restart-drill, and optional launchd-drill commands that were run. |
+| Results | pass/fail/skip for daemon smoke, ephemeral command execution, same-session VM reuse, recovery diagnostics, dry-run reconciliation repair, helper shutdown, and artifact upload. |
+| Failure drills | pass/fail/skip for drill-owned stale VM replacement and helper restart drill; include skip reason when `include_failure_drills` was not requested. |
+| Launchd drill | pass/fail/skip for `launchd-drill`; include skip reason unless a maintainer explicitly requested LaunchAgent validation. |
+| Artifacts | workflow run URL or local artifact root, helper stdout/stderr files, serial logs, pytest logs, workflow logs, and checksums or sizes for retained artifacts. |
+| Expected skips | explicit non-blocking skips from the acceptance policy, including missing nightly opt-in, no launchd request, no failure-drill request, or local unprepared-host checks. |
+| Blocking regressions | any failed guarantee from the acceptance policy and the first failing command/log pointer. |
+| Residual gaps | known uncovered cases such as host reboot, stuck boot/readiness, guest-agent mismatch, stale socket handling, or launchd validation when skipped. |
+| Follow-up owner | issue, task, or PR that will address each residual gap. |
+
+Do not paste secrets, API keys, raw user data, or full runner logs into the
+tracker. Prefer artifact links, file names, byte sizes, checksums, and short
+redacted excerpts.
+
+## Acceptance Checklist
+
+Use this checklist for a complete prepared-host acceptance entry.
+
+| Check | Evidence requirement | Required for default smoke |
+| --- | --- | --- |
+| Prepared Apple silicon host validation | Host facts and helper/template preflight passed or skipped with an operator-setup reason. | Yes |
+| Helper build/sign/start | Helper built or existing binary validated, signing/entitlements state recorded, daemon smoke passed, and socket/log paths were private. | Yes |
+| Real `vz_linux` ephemeral execution | A command executed inside a real VM and returned expected stdout/stderr/exit status. | Yes |
+| Same-session VM reuse | A second command in the same sandbox session reused the same healthy VM or recorded a blocking failure. | Yes |
+| Recovery diagnostics | macOS diagnostics and dry-run reconciliation repair planning ran without mutating session-control rows or terminating VMs. | Yes |
+| Helper shutdown/cleanup | The helper stopped on exit and did not leave the accepted socket path behind. | Yes |
+| Artifact upload or retention | Helper logs, serial logs, and pytest/workflow logs were retained or an early setup skip explains why none exist. | Yes |
+| Failure drills | Drill-owned stale VM replacement and helper restart drill results recorded. | Manual opt-in only |
+| Launchd drill | LaunchAgent bootstrap/kickstart/status/bootout drill results recorded. | Manual opt-in only |
+| Host reboot drill | Post-reboot helper/session recovery evidence recorded. | Manual operator procedure only |
+
+## Expected Skip Taxonomy
+
+These states are expected skips or setup gaps, not runtime regressions by
+themselves:
+
+- ordinary PR checks do not include the host-gated workflow
+- scheduled workflow skipped because
+  `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY` is unset or not `1`
+- workflow skipped on a ref other than `main` or `dev`
+- hosted CI lacks Apple silicon `Virtualization.framework`
+- local machine lacks a prepared bundle, helper, Xcode tools, or entitlements
+- failure drills skipped because `include_failure_drills=true` was not requested
+- managed helper `restart-drill` skipped because the helper was not started by
+  `vz-helperctl.py start`
+- `launchd-drill` skipped because no maintainer requested LaunchAgent validation
+- host reboot validation skipped because it remains a manual operator procedure
+
+If a prepared host passes preflight and then fails helper startup, real
+ephemeral execution, same-session VM reuse, recovery diagnostics, cleanup, or
+artifact retention, record it as a potential blocking regression and link the
+triage issue.
+
+## Latest Evidence
+
+No prepared-host evidence packet is currently recorded in this tracker. The
+next maintainer run should add a dated entry under this section or link a
+GitHub Actions run with the packet fields above.
+
+### Template
+
+```markdown
+### YYYY-MM-DD: <source> on <branch>@<sha>
+
+- Evidence source:
+- Operator or workflow run:
+- Host identity:
+- Host prep:
+- Bundle/template:
+- Helper build/signing:
+- Runtime paths:
+- Commands:
+- Results:
+- Failure drills:
+- Launchd drill:
+- Artifacts:
+- Expected skips:
+- Blocking regressions:
+- Residual gaps:
+- Follow-up owner:
+```
+
+## Current Residual Gaps
+
+| Gap | Current status | Next action |
+| --- | --- | --- |
+| Prepared-host default smoke evidence | Tracker exists, but no dated evidence packet has been recorded here yet. | Run local or host-gated smoke on a prepared Apple silicon host and add the evidence packet. |
+| Failure-drill evidence | Manual opt-in only. | Record results when a maintainer runs with `include_failure_drills=true`. |
+| Launchd-drill evidence | Manual opt-in only. | Record results only when a runner is intentionally configured for LaunchAgent validation. |
+| Host reboot recovery | Manual operator procedure only and out of scheduled CI. | Add a dedicated operator drill once a prepared host can tolerate disruptive reboot testing and preserve logs. |
+| Stuck boot/readiness and guest-agent mismatch | Not covered by the default smoke. | Add narrow manual drills or diagnostics checks before considering automated coverage. |
+| Stale socket handling | Covered by helper lifecycle docs and tests, but not yet recorded as prepared-host evidence in this tracker. | Include socket-path cleanup and status output in the next evidence packet. |
+
+## Recording Guidance
+
+For a local prepared-host run, prefer the managed helper wrapper:
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
+  --bundle /path/to/canonical/bundle \
+  --entitlements /path/to/helper.entitlements
+```
+
+For a lower-level run, use a private runtime directory and cleanup trap:
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-helper-e2e.XXXXXX")"
+chmod 700 "$runtime_dir"
+trap 'rm -rf "$runtime_dir"' EXIT
+
+tools/vz-linux-image/scripts/run-host-e2e-smoke.sh \
+  --bundle /path/to/canonical/bundle \
+  --socket "$runtime_dir/helper.sock" \
+  --serial-log-dir "$runtime_dir/serial" \
+  --entitlements /path/to/helper.entitlements
+```
+
+For host-gated CI, record the workflow run URL, runner labels, branch/ref, input
+values, artifact names, and any expected skips. The workflow must remain
+manual/nightly only and must not be promoted into normal PR-triggered CI.

--- a/Docs/superpowers/plans/2026-05-16-vz-prepared-host-evidence-tracker-plan.md
+++ b/Docs/superpowers/plans/2026-05-16-vz-prepared-host-evidence-tracker-plan.md
@@ -1,0 +1,27 @@
+# VZ Prepared-Host Evidence Tracker Plan
+
+## Stage 1: Evidence Contract
+**Goal**: Add a durable operator-facing tracker that defines the prepared-host evidence packet for real `vz_linux` runs.
+**Success Criteria**: The tracker names required host, git, helper, bundle, command, result, artifact, expected-skip, and residual-gap fields without claiming evidence that has not been recorded.
+**Tests**: Focused infrastructure doc tests assert the tracker exists and contains the required acceptance language.
+**Status**: Complete
+
+## Stage 2: Cross-References And Boundaries
+**Goal**: Link the tracker from the host-gated CI policy, macOS operator notes, and sandbox roadmap.
+**Success Criteria**: Contributors can find the tracker from the existing workflow policy and roadmap; the docs keep real VM execution manual or host-gated and keep destructive drills opt-in.
+**Tests**: Doc tests assert the policy links the tracker and preserves manual/nightly boundaries.
+**Status**: Complete
+
+## Stage 3: Verification And Task Closeout
+**Goal**: Validate docs/tests and close the Backlog task with the verification record.
+**Success Criteria**: Focused pytest and diff hygiene pass; Bandit is explicitly skipped as docs/test-only if no production Python changes are made.
+**Tests**: `python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q`, `git diff --check`.
+**Status**: Complete
+
+## Design Review Notes
+
+- Avoid turning evidence tracking into automatic PR execution. Real VZ runs stay limited to manual dispatch, opted-in nightly host-gated runs on trusted refs, and local prepared-host operator commands.
+- Avoid stale evidence looking current. Every evidence packet must include date, git SHA, runner identity, bundle/helper versions, workflow or command source, and a residual-gaps section.
+- Avoid leaking host/user data. Evidence should preserve artifact names, sizes, paths relative to the runner temp directory, and redacted log excerpts or checksums instead of raw secrets or user workspace contents.
+- Keep failure drills and `launchd-drill` separate from default smoke. They remain manually requested evidence fields with expected-skip reasons when not requested.
+- Keep this slice docs/test-only. Runtime behavior, repair semantics, and workflow triggers should not change in this PR.

--- a/Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
@@ -12,6 +12,7 @@ admin surfaces, CI, security, and all current runtime families.
 - `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
 - `Docs/Sandbox/sandbox-security-policy-matrix.md`
 - `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- `Docs/Sandbox/vz-linux-prepared-host-evidence.md`
 - `Docs/Design/2026-05-02-apple-containerization-evaluation.md`
 - `tldw_Server_API/app/core/Sandbox/README.md`
 
@@ -343,8 +344,9 @@ this table as the current status map before selecting new sandbox work.
    Capture manual/nightly `vz_linux` host-gated run evidence from a prepared
    Apple silicon host, including command execution, same-session reuse, helper
    restart drill, launchd-drill where explicitly requested, artifact upload, and
-   expected skips. This is the best next slice because it tests the stability
-   path the preceding PRs built.
+   expected skips. Record results in
+   `Docs/Sandbox/vz-linux-prepared-host-evidence.md`. This is the best next
+   slice because it tests the stability path the preceding PRs built.
 
 2. **Remaining `vz_linux` lifecycle drill gaps**
 

--- a/backlog/tasks/task-406 - Add-prepared-host-VZ-acceptance-evidence-tracker.md
+++ b/backlog/tasks/task-406 - Add-prepared-host-VZ-acceptance-evidence-tracker.md
@@ -4,7 +4,7 @@ title: Add prepared-host VZ acceptance evidence tracker
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-16 15:00'
+updated_date: '2026-05-18 12:42'
 labels:
   - sandbox
   - vz_linux
@@ -42,6 +42,8 @@ Implementation notes:
 - Linked the tracker from the host-gated acceptance policy, macOS operator notes, and sandbox roadmap.
 - Added focused infrastructure tests that guard the tracker fields and host-gated/manual execution boundary.
 - Kept the slice docs/test-only; no workflow triggers or runtime behavior changed.
+- PR review follow-up: replaced raw evidence-tracker substring checks with normalized doc-text helpers, section anchors, and targeted failure messages.
+- Verified CodeRabbit's return-type comment against current code; the cited test function already declares `-> None`.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -53,8 +55,12 @@ Verification:
 - /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
 - git diff --check
 
-Bandit skipped: docs/test-only change; no production Python/runtime code changed.
+Bandit initially skipped for the docs-only slice; PR review follow-up ran Bandit on the touched Python test file.
 Known skip: no new real VZ VM smoke was run in this slice; the tracker explicitly records that no dated prepared-host evidence packet has been added yet.
+
+PR review follow-up:
+- Addressed Qodo feedback by making evidence-tracker doc-contract tests less brittle to markdown wrapping/reflow.
+- CodeRabbit return-type feedback was already satisfied in current code.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-406 - Add-prepared-host-VZ-acceptance-evidence-tracker.md
+++ b/backlog/tasks/task-406 - Add-prepared-host-VZ-acceptance-evidence-tracker.md
@@ -1,0 +1,68 @@
+---
+id: TASK-406
+title: Add prepared-host VZ acceptance evidence tracker
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-16 15:00'
+labels:
+  - sandbox
+  - vz_linux
+  - host-gated
+  - docs
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - Docs/Sandbox/vz-linux-prepared-host-evidence.md
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the next sandbox roadmap slice for prepared-host VZ Linux acceptance evidence and gap tracking. The slice should make real-host acceptance runs reproducible and reviewable by documenting the evidence packet, expected skip taxonomy, residual manual boundaries, and next gaps without changing runtime behavior or enabling PR-triggered real VM execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Prepared-host acceptance evidence packet is documented with exact fields for host, bundle/helper versions, commands, results, artifacts, expected skips, and residual gaps.
+- [x] #2 The tracker keeps real VZ execution host-gated/manual and does not enable PR-triggered or scheduled destructive behavior.
+- [x] #3 Operator docs or roadmap docs link to the evidence tracker so contributors know where to record manual/nightly prepared-host results.
+- [x] #4 Verification covers docs references, host-gated workflow policy tests, diff hygiene, and a Bandit skip rationale for docs-only changes unless production code changes are added.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation notes:
+- Added Docs/Sandbox/vz-linux-prepared-host-evidence.md as the prepared-host evidence packet tracker and gap log.
+- Linked the tracker from the host-gated acceptance policy, macOS operator notes, and sandbox roadmap.
+- Added focused infrastructure tests that guard the tracker fields and host-gated/manual execution boundary.
+- Kept the slice docs/test-only; no workflow triggers or runtime behavior changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a prepared-host VZ Linux evidence tracker with exact packet fields, expected skip taxonomy, acceptance checklist, residual gaps, and recording guidance. Cross-linked it from the acceptance policy, operator notes, and roadmap, and added focused tests for the evidence contract and manual/host-gated boundary.
+
+Verification:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+- git diff --check
+
+Bandit skipped: docs/test-only change; no production Python/runtime code changed.
+Known skip: no new real VZ VM smoke was run in this slice; the tracker explicitly records that no dated prepared-host evidence packet has been added yet.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 
@@ -27,6 +28,17 @@ def _workflow_triggers(workflow: dict[str, Any]) -> dict[str, Any]:
     triggers = workflow.get("on", workflow.get(True))
     assert isinstance(triggers, dict)  # nosec B101
     return triggers
+
+
+def _normalized_text(path: Path) -> str:
+    """Return doc text normalized so wrapping-only edits do not break contracts."""
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+def _require(condition: bool, message: str) -> None:
+    """Fail with a targeted message for easier doc-contract triage."""
+    if not condition:
+        pytest.fail(message)
 
 
 def test_vz_linux_host_gated_workflow_is_manual_and_nightly() -> None:
@@ -181,29 +193,48 @@ def test_vz_linux_host_gated_acceptance_policy_doc_exists_and_references_workflo
 
 def test_vz_linux_prepared_host_evidence_tracker_defines_packet() -> None:
     """Prepared-host evidence should be durable, reviewable, and non-secret."""
-    tracker = EVIDENCE_TRACKER_PATH.read_text(encoding="utf-8")
-    tracker_lower = tracker.lower()
+    tracker = _normalized_text(EVIDENCE_TRACKER_PATH)
 
-    assert "prepared apple silicon" in tracker_lower  # nosec B101
-    assert "evidence packet" in tracker_lower  # nosec B101
-    assert "real `vz_linux` ephemeral execution" in tracker_lower  # nosec B101
-    assert "same-session vm reuse" in tracker_lower  # nosec B101
-    assert "helper build/signing" in tracker_lower  # nosec B101
-    assert "artifact" in tracker_lower  # nosec B101
-    assert "expected skips" in tracker_lower  # nosec B101
-    assert "residual gaps" in tracker_lower  # nosec B101
-    assert "do not paste secrets" in tracker_lower  # nosec B101
+    for section in (
+        "## Evidence Packet",
+        "## Acceptance Checklist",
+        "## Expected Skip Taxonomy",
+        "## Current Residual Gaps",
+        "## Recording Guidance",
+    ):
+        _require(section in tracker, f"Evidence tracker should include section {section}")
+
+    for required_term in (
+        "Prepared Apple silicon",
+        "Git state",
+        "Helper build/signing",
+        "Real `vz_linux` ephemeral execution",
+        "Same-session VM reuse",
+        "Artifacts",
+        "Expected skips",
+        "Residual gaps",
+        "Do not paste secrets",
+    ):
+        _require(
+            required_term in tracker,
+            f"Evidence tracker should include packet term {required_term}",
+        )
 
 
 def test_vz_linux_prepared_host_evidence_tracker_keeps_real_vm_runs_gated() -> None:
     """The tracker must not promote real VM execution into normal PR CI."""
-    tracker = EVIDENCE_TRACKER_PATH.read_text(encoding="utf-8")
-    tracker_lower = tracker.lower()
+    tracker = _normalized_text(EVIDENCE_TRACKER_PATH)
 
-    assert "manual or host-gated only" in tracker_lower  # nosec B101
-    assert "do not add pull request triggers" in tracker_lower  # nosec B101
-    assert "push triggers" in tracker_lower  # nosec B101
-    assert "scheduled destructive drills" in tracker_lower  # nosec B101
-    assert "manual opt-in only" in tracker_lower  # nosec B101
-    assert "launchd-drill" in tracker_lower  # nosec B101
-    assert "host reboot" in tracker_lower  # nosec B101
+    for boundary in (
+        "manual or host-gated only",
+        "pull request triggers",
+        "push triggers",
+        "scheduled destructive drills",
+        "manual opt-in only",
+        "launchd-drill",
+        "host reboot",
+    ):
+        _require(
+            boundary in tracker.lower(),
+            f"Evidence tracker should preserve gated-run boundary: {boundary}",
+        )

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -11,6 +11,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "vz-linux-host-gated.yml"
 POLICY_PATH = REPO_ROOT / "Docs" / "Sandbox" / "vz-linux-host-gated-ci-acceptance-policy.md"
+EVIDENCE_TRACKER_PATH = REPO_ROOT / "Docs" / "Sandbox" / "vz-linux-prepared-host-evidence.md"
 SMOKE_SCRIPT_PATH = REPO_ROOT / "tools" / "vz-linux-image" / "scripts" / "run-host-e2e-smoke.sh"
 
 
@@ -175,3 +176,34 @@ def test_vz_linux_host_gated_acceptance_policy_doc_exists_and_references_workflo
     assert ".github/workflows/vz-linux-host-gated.yml" in policy  # nosec B101
     assert "TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY" in policy  # nosec B101
     assert "blocking regression" in policy.lower()  # nosec B101
+    assert "Docs/Sandbox/vz-linux-prepared-host-evidence.md" in policy  # nosec B101
+
+
+def test_vz_linux_prepared_host_evidence_tracker_defines_packet() -> None:
+    """Prepared-host evidence should be durable, reviewable, and non-secret."""
+    tracker = EVIDENCE_TRACKER_PATH.read_text(encoding="utf-8")
+    tracker_lower = tracker.lower()
+
+    assert "prepared apple silicon" in tracker_lower  # nosec B101
+    assert "evidence packet" in tracker_lower  # nosec B101
+    assert "real `vz_linux` ephemeral execution" in tracker_lower  # nosec B101
+    assert "same-session vm reuse" in tracker_lower  # nosec B101
+    assert "helper build/signing" in tracker_lower  # nosec B101
+    assert "artifact" in tracker_lower  # nosec B101
+    assert "expected skips" in tracker_lower  # nosec B101
+    assert "residual gaps" in tracker_lower  # nosec B101
+    assert "do not paste secrets" in tracker_lower  # nosec B101
+
+
+def test_vz_linux_prepared_host_evidence_tracker_keeps_real_vm_runs_gated() -> None:
+    """The tracker must not promote real VM execution into normal PR CI."""
+    tracker = EVIDENCE_TRACKER_PATH.read_text(encoding="utf-8")
+    tracker_lower = tracker.lower()
+
+    assert "manual or host-gated only" in tracker_lower  # nosec B101
+    assert "do not add pull request triggers" in tracker_lower  # nosec B101
+    assert "push triggers" in tracker_lower  # nosec B101
+    assert "scheduled destructive drills" in tracker_lower  # nosec B101
+    assert "manual opt-in only" in tracker_lower  # nosec B101
+    assert "launchd-drill" in tracker_lower  # nosec B101
+    assert "host reboot" in tracker_lower  # nosec B101


### PR DESCRIPTION
## Summary
- Add a prepared-host `vz_linux` evidence tracker with packet fields, expected skips, acceptance checklist, residual gaps, and recording guidance.
- Link the tracker from the host-gated CI policy, macOS operator notes, and sandbox roadmap.
- Add focused infrastructure tests that guard the evidence contract and manual/host-gated execution boundary.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q`
- `git diff --check origin/dev..HEAD`

## Bandit
Skipped: docs/test-only change; no production Python/runtime code changed.

## Change summary
Human-authored change summary pending.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a prepared-host evidence tracker for Apple silicon `vz_linux` runs that defines the evidence packet, acceptance checklist, expected skips, residual gaps, and recording guidance. Cross-links it from the host-gated CI policy, macOS operator notes, and the sandbox roadmap, and adds hardened infra tests that enforce the evidence contract and keep real VM execution manual/host-gated; no runtime or workflow-trigger changes.

<sup>Written for commit 8296d0361529f9aad94742b135bf1b74f5832804. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1847?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

