### PR TITLE
Lock llama.cpp runtime API compatibility

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
@@ -238,7 +238,7 @@ git commit -m "fix: harden llama.cpp profile launch validation"
 - Test: `tldw_Server_API/tests/LLM_Local/test_llamacpp_lifecycle_api_contract.py`
 - Test: `tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py`
 
-- [ ] **Step 1: Write failing compatibility tests**
+- [x] **Step 1: Write failing compatibility tests**
 
 Add TestClient coverage for:
 - `POST /api/v1/llamacpp/start_server` updates/starts only the default profile;
@@ -248,7 +248,7 @@ Add TestClient coverage for:
 - `GET /api/v1/llamacpp/logs/tail` maps default-profile stopped/not-running state to HTTP 409;
 - all new profile/runtime routes require admin permissions.
 
-- [ ] **Step 2: Run API tests to verify failure**
+- [x] **Step 2: Run API tests to verify failure**
 
 ```bash
 python -m pytest \
@@ -259,7 +259,9 @@ python -m pytest \
 
 Expected: FAIL only for newly added coverage.
 
-- [ ] **Step 3: Patch endpoint/schema gaps**
+Result: FAIL as expected for `test_v1_log_tail_returns_conflict_when_default_runtime_is_stopped`; existing compatibility/auth coverage stayed green.
+
+- [x] **Step 3: Patch endpoint/schema gaps**
 
 Keep response mappings narrow:
 - 400 for validation/path/config mistakes;
@@ -267,7 +269,7 @@ Keep response mappings narrow:
 - 409 for stopped/not-running state conflicts;
 - 500 only for unexpected provider write failures or internal errors.
 
-- [ ] **Step 4: Run API tests**
+- [x] **Step 4: Run API tests**
 
 ```bash
 python -m pytest \
@@ -278,7 +280,9 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit Task 3**
+Result: PASS, 79 passed, 5 warnings.
+
+- [x] **Step 5: Commit Task 3**
 
 ```bash
 git add \

--- a/backlog/completed/task-418.14 - Lock-llama.cpp-runtime-API-compatibility.md
+++ b/backlog/completed/task-418.14 - Lock-llama.cpp-runtime-API-compatibility.md
@@ -1,0 +1,61 @@
+---
+id: TASK-418.14
+title: Lock llama.cpp runtime API compatibility
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-18 19:43
+labels:
+- llamacpp
+- backend
+- api
+dependencies: []
+documentation:
+- Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+parent_task_id: TASK-418
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 3 from the llama.cpp managed runtime closeout plan: prove the legacy one-server API targets only the reserved default profile while profile and instance APIs expose all managed runtimes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 POST /api/v1/llamacpp/start_server updates/starts only the reserved default profile.
+- [x] #2 POST /api/v1/llamacpp/start-by-model updates/starts only the reserved default profile.
+- [x] #3 GET /api/v1/llamacpp/status keeps the legacy response shape and does not enumerate every profile.
+- [x] #4 GET /api/v1/llamacpp/instances returns both default and non-default managed profiles.
+- [x] #5 GET /api/v1/llamacpp/logs/tail maps default-profile stopped/not-running state to HTTP 409.
+- [x] #6 New profile/runtime routes require admin permissions.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Task 3 from Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red check: focused API/auth tests failed only for test_v1_log_tail_returns_conflict_when_default_runtime_is_stopped before the endpoint patch. Green check: focused Task 3 suite passed with 79 passed, 5 warnings after patching the legacy default log-tail path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Locked the Task 3 llama.cpp runtime API compatibility contract. Legacy V1 start-by-model/start-server continue to target only the reserved default profile, legacy status keeps its one-server response shape, instances expose default plus non-default runtimes, legacy default log tail now returns HTTP 409 when the default runtime is not running, and profile/runtime routes are covered by 401/403 admin-gate tests. Verification: focused Task 3 pytest suite passed with 79 passed and 5 warnings; git diff --check passed; Bandit on the touched runtime endpoint reported zero findings. Bandit over touched tests reported existing pytest/assert and fixture-literal findings, with no runtime-code findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/completed/task-431 - Address-PR-1848-llama.cpp-log-tail-review-comments.md
+++ b/backlog/completed/task-431 - Address-PR-1848-llama.cpp-log-tail-review-comments.md
@@ -1,0 +1,54 @@
+---
+id: TASK-431
+title: Address PR 1848 llama.cpp log-tail review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-18 20:02
+labels:
+- llamacpp
+- backend
+- review-fix
+dependencies: []
+documentation:
+- https://github.com/rmusser01/tldw_server/pull/1848
+- Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address still-valid PR #1848 review findings for the legacy llama.cpp default log-tail endpoint. Verify and fix only actionable comments. Related managed-runtime parent: TASK-418.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Default log-tail running-state check is not performed as blocking filesystem-prone endpoint code.
+- [x] #2 Default log-tail check and tail operation are atomic with respect to the supervisor profile lock.
+- [x] #3 Legacy default stopped/not-running log-tail behavior still maps to HTTP 409.
+- [x] #4 Focused runtime API tests pass.
+- [x] #5 Bandit is run for touched runtime code.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified Qodo findings as still valid: the endpoint-level get_runtime() could hit the JSON profile store synchronously, and the split state-check/tail sequence was non-atomic. Added LlamaCppSupervisor.tail_logs_if_running() to hold the profile lock, avoid store reads, enforce RUNNING semantics, and run runner log file reads off the event loop.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed both PR #1848 Qodo findings by moving default log-tail running-state enforcement into LlamaCppSupervisor.tail_logs_if_running(). The helper checks runner state and tails logs under the same profile lock, raises a 409-mapped domain conflict when the runtime is not running, avoids profile-store reads from the async endpoint, and offloads the runner log file read with asyncio.to_thread. Added focused supervisor tests for no store lookup, stopped-runner conflict, and stop/tail serialization. Verification: red helper tests failed before implementation; focused helper tests passed; broader focused API/supervisor/auth suite passed with 112 passed and 5 warnings; git diff --check passed; Bandit on touched runtime code reported zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -1019,9 +1019,14 @@ async def tail_llamacpp_logs_endpoint(
     supervisor = getattr(llm_manager, "llamacpp_supervisor", None)
     if supervisor is not None:
         try:
+            runtime = supervisor.get_runtime(DEFAULT_PROFILE_ID)
+            if runtime.state != LlamaCppRuntimeState.RUNNING:
+                raise HTTPException(status_code=409, detail="Managed llama.cpp server is not running.")
             return await run_in_threadpool(supervisor.tail_logs, DEFAULT_PROFILE_ID, lines)
         except LlamaCppProfileNotFoundError as e:
             raise HTTPException(status_code=409, detail="Managed llama.cpp server is not running.") from e
+        except HTTPException:
+            raise
         except Exception as e:
             raise _supervisor_error_to_http(e, llm_manager, "Unexpected error tailing Llama.cpp default logs") from e
 

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -1019,14 +1019,9 @@ async def tail_llamacpp_logs_endpoint(
     supervisor = getattr(llm_manager, "llamacpp_supervisor", None)
     if supervisor is not None:
         try:
-            runtime = supervisor.get_runtime(DEFAULT_PROFILE_ID)
-            if runtime.state != LlamaCppRuntimeState.RUNNING:
-                raise HTTPException(status_code=409, detail="Managed llama.cpp server is not running.")
-            return await run_in_threadpool(supervisor.tail_logs, DEFAULT_PROFILE_ID, lines)
+            return await supervisor.tail_logs_if_running(DEFAULT_PROFILE_ID, lines)
         except LlamaCppProfileNotFoundError as e:
             raise HTTPException(status_code=409, detail="Managed llama.cpp server is not running.") from e
-        except HTTPException:
-            raise
         except Exception as e:
             raise _supervisor_error_to_http(e, llm_manager, "Unexpected error tailing Llama.cpp default logs") from e
 

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py
@@ -305,6 +305,22 @@ class LlamaCppSupervisor:
             return {"lines": [], "truncated": False, "warnings": ["No active managed llama.cpp log file is available."]}
         return runner.tail_logs(lines)
 
+    async def tail_logs_if_running(self, profile_id: str, lines: int) -> dict[str, object]:
+        """Tail logs only when the supervised runtime is still running.
+
+        The check and tail are protected by the same profile lock used by
+        lifecycle mutations so a stop cannot race between the state check and
+        the log read. The file read itself runs off the event loop.
+        """
+        async with self._lock_for(profile_id):
+            runner = self._runners.get(profile_id)
+            if runner is None:
+                raise LlamaCppProfileConflictError("Managed llama.cpp server is not running.")
+            runtime = runner.status()
+            if runtime.state != LlamaCppRuntimeState.RUNNING:
+                raise LlamaCppProfileConflictError("Managed llama.cpp server is not running.")
+            return await asyncio.to_thread(runner.tail_logs, lines)
+
     async def shutdown(self) -> None:
         failures: list[tuple[str, BaseException]] = []
         for profile_id in list(self._runners):

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py
@@ -220,6 +220,19 @@ def _patch_provider_config_writes(monkeypatch) -> None:  # noqa: ANN001
         ("get", "/api/v1/llamacpp/metrics", None),
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
+        ("get", "/api/v1/llamacpp/profiles", None),
+        ("post", "/api/v1/llamacpp/profiles", {"name": "Default", "model_path": "/models/model.gguf"}),
+        ("get", "/api/v1/llamacpp/profiles/default", None),
+        ("put", "/api/v1/llamacpp/profiles/default", {"name": "Updated"}),
+        ("delete", "/api/v1/llamacpp/profiles/default", None),
+        ("post", "/api/v1/llamacpp/profiles/default/start", None),
+        ("post", "/api/v1/llamacpp/profiles/default/stop", None),
+        ("post", "/api/v1/llamacpp/profiles/default/pause", None),
+        ("post", "/api/v1/llamacpp/profiles/default/resume", None),
+        ("post", "/api/v1/llamacpp/profiles/default/use-in-chat", None),
+        ("get", "/api/v1/llamacpp/instances", None),
+        ("get", "/api/v1/llamacpp/instances/default", None),
+        ("get", "/api/v1/llamacpp/instances/default/logs/tail", None),
         ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
         ("post", "/api/v1/llamacpp/assets/downloads", {"url": "https://example.com/model.gguf"}),
         ("get", "/api/v1/llamacpp/assets/downloads", None),
@@ -239,6 +252,8 @@ def test_llamacpp_lifecycle_401_when_principal_unavailable(
     with TestClient(app) as client:
         if method == "post":
             resp = client.post(path, json=payload or {})
+        elif method == "put":
+            resp = client.put(path, json=payload or {})
         elif method == "delete":
             resp = client.delete(path)
         else:
@@ -260,6 +275,19 @@ def test_llamacpp_lifecycle_401_when_principal_unavailable(
         ("get", "/api/v1/llamacpp/metrics", None),
         ("get", "/api/v1/llamacpp/logs/tail", None),
         ("get", "/api/v1/llamacpp/hardware", None),
+        ("get", "/api/v1/llamacpp/profiles", None),
+        ("post", "/api/v1/llamacpp/profiles", {"name": "Default", "model_path": "/models/model.gguf"}),
+        ("get", "/api/v1/llamacpp/profiles/default", None),
+        ("put", "/api/v1/llamacpp/profiles/default", {"name": "Updated"}),
+        ("delete", "/api/v1/llamacpp/profiles/default", None),
+        ("post", "/api/v1/llamacpp/profiles/default/start", None),
+        ("post", "/api/v1/llamacpp/profiles/default/stop", None),
+        ("post", "/api/v1/llamacpp/profiles/default/pause", None),
+        ("post", "/api/v1/llamacpp/profiles/default/resume", None),
+        ("post", "/api/v1/llamacpp/profiles/default/use-in-chat", None),
+        ("get", "/api/v1/llamacpp/instances", None),
+        ("get", "/api/v1/llamacpp/instances/default", None),
+        ("get", "/api/v1/llamacpp/instances/default/logs/tail", None),
         ("post", "/api/v1/llamacpp/assets/import-folder/preview", {"path": "/models"}),
         ("post", "/api/v1/llamacpp/assets/downloads", {"url": "https://example.com/model.gguf"}),
         ("get", "/api/v1/llamacpp/assets/downloads", None),
@@ -284,6 +312,8 @@ def test_llamacpp_lifecycle_403_when_missing_admin_role(
     with TestClient(app) as client:
         if method == "post":
             resp = client.post(path, json=payload or {})
+        elif method == "put":
+            resp = client.put(path, json=payload or {})
         elif method == "delete":
             resp = client.delete(path)
         else:

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py
@@ -336,6 +336,7 @@ def test_v1_start_by_model_targets_default_profile_only():
             json={"model_id": "gguf:abc", "server_args": {"port": 8181}},
         )
         status = client.get("/api/v1/llamacpp/status")
+        instances = client.get("/api/v1/llamacpp/instances")
         logs = client.get("/api/v1/llamacpp/logs/tail?lines=3")
         stopped = client.post("/api/v1/llamacpp/stop_server", json={})
 
@@ -345,6 +346,13 @@ def test_v1_start_by_model_targets_default_profile_only():
     assert supervisor.started_profile_ids == [DEFAULT_PROFILE_ID]
     assert status.json()["backend"] == "llamacpp"
     assert status.json()["status"] == "running"
+    assert "runtimes" not in status.json()
+    assert "profiles" not in status.json()
+    assert {runtime["profile_id"] for runtime in instances.json()["runtimes"]} == {
+        DEFAULT_PROFILE_ID,
+        "one",
+        "two",
+    }
     assert logs.json()["lines"] == ["first", "second"]
     assert supervisor.tail_requests == [(DEFAULT_PROFILE_ID, 3)]
     assert stopped.json()["status"] == "stopped"
@@ -471,6 +479,30 @@ def test_v1_start_server_uses_supervisor_default_when_legacy_handler_exists():
     assert status.json()["model"] == "/models/tiny.gguf"
     assert stopped.json()["status"] == "stopped"
     assert handler.stop_calls == 0
+
+
+@pytest.mark.unit
+def test_v1_log_tail_returns_conflict_when_default_runtime_is_stopped():
+    supervisor = _SupervisorStub()
+    supervisor.profiles[DEFAULT_PROFILE_ID] = LlamaCppProfile(
+        profile_id=DEFAULT_PROFILE_ID,
+        name="Default",
+        model_path="/models/default.gguf",
+        host="127.0.0.1",
+        port=8181,
+    )
+    supervisor.runtimes[DEFAULT_PROFILE_ID] = LlamaCppRuntime(
+        profile_id=DEFAULT_PROFILE_ID,
+        state=LlamaCppRuntimeState.STOPPED,
+    )
+    app = _make_app_with_manager(_ManagerStub(supervisor))
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/llamacpp/logs/tail?lines=3")
+
+    assert response.status_code == 409
+    assert "not running" in response.json()["detail"].lower()
+    assert supervisor.tail_requests == []
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py
@@ -16,6 +16,7 @@ from tldw_Server_API.app.core.Local_LLM.llamacpp_profile_store import DEFAULT_PR
 from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
     LlamaCppPortPolicy,
     LlamaCppProfile,
+    LlamaCppProfileConflictError,
     LlamaCppProfileNotFoundError,
     LlamaCppRuntime,
     LlamaCppRuntimeState,
@@ -150,6 +151,12 @@ class _SupervisorStub:
     def tail_logs(self, profile_id: str, lines: int) -> dict[str, object]:
         self.tail_requests.append((profile_id, lines))
         return {"lines": ["first", "second"], "truncated": False, "warnings": []}
+
+    async def tail_logs_if_running(self, profile_id: str, lines: int) -> dict[str, object]:
+        runtime = self.get_runtime(profile_id)
+        if runtime.state != LlamaCppRuntimeState.RUNNING:
+            raise LlamaCppProfileConflictError("Managed llama.cpp server is not running.")
+        return self.tail_logs(profile_id, lines)
 
     async def start_default_by_model(self, model_id: str, server_args: dict[str, object]) -> LlamaCppRuntime:
         _ = server_args

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import threading
 from configparser import ConfigParser
 from pathlib import Path
 from typing import Any
@@ -112,6 +113,7 @@ class FakeRunner:
         self.starts: list[LlamaCppProfile] = []
         self.cleaned = False
         self.stop_calls = 0
+        self.tail_requests: list[int] = []
 
     async def start(self, model_path: Path, profile: LlamaCppProfile) -> LlamaCppRuntime:
         self.calls[self.profile_id] = self.calls.get(self.profile_id, 0) + 1
@@ -144,6 +146,10 @@ class FakeRunner:
     def status(self) -> LlamaCppRuntime:
         return self.runtime
 
+    def tail_logs(self, lines: int) -> dict[str, object]:
+        self.tail_requests.append(lines)
+        return {"lines": [f"{self.profile_id}:{lines}"], "truncated": False, "warnings": []}
+
     def cleanup_sync(self) -> None:
         self.cleaned = True
         self.runtime = self.runtime.model_copy(update={"state": LlamaCppRuntimeState.STOPPED, "pid": None})
@@ -172,6 +178,36 @@ class StopFailingRunnerFactory(FakeRunnerFactory):
             runner = StopFailingRunner(profile_id, self.calls)
         else:
             runner = FakeRunner(profile_id, self.calls)
+        self.runners[profile_id] = runner
+        return runner
+
+
+class BlockingTailRunner(FakeRunner):
+    def __init__(
+        self,
+        profile_id: str,
+        calls: dict[str, int],
+        tail_started: threading.Event,
+        release_tail: threading.Event,
+    ):
+        super().__init__(profile_id, calls)
+        self.tail_started = tail_started
+        self.release_tail = release_tail
+
+    def tail_logs(self, lines: int) -> dict[str, object]:
+        self.tail_started.set()
+        assert self.release_tail.wait(timeout=2), "tail release timed out"
+        return super().tail_logs(lines)
+
+
+class BlockingTailRunnerFactory(FakeRunnerFactory):
+    def __init__(self):
+        super().__init__()
+        self.tail_started = threading.Event()
+        self.release_tail = threading.Event()
+
+    def __call__(self, config: LlamaCppConfig, profile_id: str) -> BlockingTailRunner:
+        runner = BlockingTailRunner(profile_id, self.calls, self.tail_started, self.release_tail)
         self.runners[profile_id] = runner
         return runner
 
@@ -885,6 +921,70 @@ async def test_supervisor_default_start_swaps_running_model(monkeypatch: pytest.
     assert second_runtime.model_id == "gguf:second"
     assert second_runtime.port == 8182
     assert factory.calls == {"default": 2}
+
+
+@pytest.mark.asyncio
+async def test_supervisor_tail_logs_if_running_uses_runner_without_store_lookup(tmp_path: Path, monkeypatch):
+    supervisor, config, factory = make_supervisor(tmp_path)
+    model_path = make_model(config)
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(profile_id="one", name="One", model_path=str(model_path), port=8181)
+    )
+    await supervisor.start_profile("one")
+
+    def fail_store_get(_profile_id: str) -> None:
+        raise AssertionError("tail_logs_if_running should not read the profile store")
+
+    monkeypatch.setattr(supervisor.store, "get", fail_store_get)
+
+    result = await supervisor.tail_logs_if_running("one", 7)
+
+    assert result == {"lines": ["one:7"], "truncated": False, "warnings": []}
+    assert factory.runners["one"].tail_requests == [7]
+
+
+@pytest.mark.asyncio
+async def test_supervisor_tail_logs_if_running_rejects_stopped_runner(tmp_path: Path):
+    supervisor, config, factory = make_supervisor(tmp_path)
+    model_path = make_model(config)
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(profile_id="one", name="One", model_path=str(model_path), port=8181)
+    )
+    await supervisor.start_profile("one")
+    await supervisor.stop_profile("one")
+
+    with pytest.raises(LlamaCppProfileConflictError, match="not running"):
+        await supervisor.tail_logs_if_running("one", 7)
+
+    assert factory.runners["one"].tail_requests == []
+
+
+@pytest.mark.asyncio
+async def test_supervisor_tail_logs_if_running_serializes_stop_until_tail_finishes(tmp_path: Path):
+    config = make_config(tmp_path)
+    store = JsonLlamaCppProfileStore(tmp_path / "profiles.json")
+    factory = BlockingTailRunnerFactory()
+    supervisor = LlamaCppSupervisor(config=config, store=store, runner_factory=factory)
+    model_path = make_model(config)
+    await supervisor.create_profile(
+        LlamaCppProfileCreateRequest(profile_id="one", name="One", model_path=str(model_path), port=8181)
+    )
+    await supervisor.start_profile("one")
+
+    tail_task = asyncio.create_task(supervisor.tail_logs_if_running("one", 7))
+    assert await asyncio.to_thread(factory.tail_started.wait, 2)
+    stop_task = asyncio.create_task(supervisor.stop_profile("one"))
+    await asyncio.sleep(0)
+
+    assert factory.runners["one"].stop_calls == 0
+
+    factory.release_tail.set()
+    tail_result = await tail_task
+    stop_result = await stop_task
+
+    assert tail_result == {"lines": ["one:7"], "truncated": False, "warnings": []}
+    assert stop_result.state == LlamaCppRuntimeState.STOPPED
+    assert factory.runners["one"].stop_calls == 1
 
 
 def test_manager_attaches_supervisor_and_uses_it_for_cleanup(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- Lock the llama.cpp Task 3 API compatibility contract around legacy default-profile behavior and multi-profile runtime listing.
- Return HTTP 409 from legacy default log tail when the reserved default runtime is stopped or otherwise not running.
- Extend focused tests for legacy status shape, default plus non-default instance visibility, and admin gates on profile/runtime routes.

## Test Plan
- [x] `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_lifecycle_api_contract.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -v`
- [x] `git diff --check`
- [x] `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/llamacpp.py -f json -o /tmp/bandit_llamacpp_runtime_compat_endpoint.json`

## Change summary
Human-authored Change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the llama.cpp runtime API to preserve legacy default-profile behavior and clarify multi-profile listing. V1 start endpoints act only on the reserved default profile, status keeps the one-server shape, `GET /api/v1/llamacpp/instances` lists all runtimes, profile/instance routes are admin-gated, and the default log tail is now atomic under the supervisor lock and returns HTTP 409 when the default runtime is not running.

<sup>Written for commit 648bcdd58a02751c5167691f72b6a98ef23b7bce. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1848?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

