### PR TITLE
Migrate Prompt Studio alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2189,105 +2189,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-error-line-10-1at0kqu",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-error-line-11-g545ab",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-error-line-71-15cr4gy",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-info-line-654-1v3wnib",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-info-line-968-k7o9kd",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-warning-add-y-1pwgyhe",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-warning-can-t-kafs0z",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-warning-finis-fq7ljf",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx:Alert#antd-alert-promptstudioplaygroundpage-type-warning-line-qkbnrd",
-    "path": "src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Settings/chatbooks.tsx:Alert",
     "path": "src/components/Option/Settings/chatbooks.tsx",
     "rule": "antd-product-state-import",
@@ -3014,13 +2915,24 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx:Alert",
+    "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx:Alert#antd-alert-sourceformmodal-type-error-line-440-1b05f6o",
     "path": "src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
     "state": "allowed_legacy_exception",
     "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx before the guard.",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx before the stable duplicate-id guard.",
+    "replacement": "tldw design-system state primitive",
+    "migrationQueue": "shared-product-state"
+  },
+  {
+    "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx:Alert#antd-alert-sourceformmodal-type-info-line-423-bgehad",
+    "path": "src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx",
+    "rule": "antd-product-state-import",
+    "subject": "Alert",
+    "state": "allowed_legacy_exception",
+    "owner": "design-system",
+    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx before the stable duplicate-id guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx
@@ -586,14 +586,19 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
     return (
       <DesignSystemAlert
         variant="warning"
-        title="Add your credentials to use Prompt Studio"
+        title={t(
+          "option:promptStudio.addCredentialsTitle",
+          "Add your credentials to use Prompt Studio"
+        )}
         action={{
-          label: "Open Settings",
+          label: t("option:promptStudio.openSettings", "Open Settings"),
           onClick: () => navigate("/settings/tldw"),
           variant: "primary"
         }}>
-        Prompt Studio needs a reachable tldw server plus valid credentials before
-        projects, prompts, and evaluations can load.
+        {t(
+          "option:promptStudio.addCredentialsDesc",
+          "Prompt Studio needs a reachable tldw server plus valid credentials before projects, prompts, and evaluations can load."
+        )}
       </DesignSystemAlert>
     )
   }
@@ -602,15 +607,22 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
     return (
       <DesignSystemAlert
         variant="warning"
-        title="Finish setup to use Prompt Studio"
+        title={t(
+          "option:promptStudio.finishSetupTitle",
+          "Finish setup to use Prompt Studio"
+        )}
         action={{
-          label: hasCompletedFirstRun ? "Open Settings" : "Finish Setup",
+          label: hasCompletedFirstRun
+            ? t("option:promptStudio.openSettings", "Open Settings")
+            : t("option:promptStudio.finishSetupAction", "Finish Setup"),
           onClick: () =>
             navigate(hasCompletedFirstRun ? "/settings/tldw" : "/"),
           variant: "primary"
         }}>
-        Prompt Studio depends on a configured tldw server before projects,
-        prompts, and evaluations can load.
+        {t(
+          "option:promptStudio.finishSetupDesc",
+          "Prompt Studio depends on a configured tldw server before projects, prompts, and evaluations can load."
+        )}
       </DesignSystemAlert>
     )
   }
@@ -619,18 +631,26 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
     return (
       <DesignSystemAlert
         variant="warning"
-        title="Can't reach your tldw server right now"
+        title={t(
+          "option:promptStudio.unreachableTitle",
+          "Can't reach your tldw server right now"
+        )}
         action={{
-          label: "Health & diagnostics",
+          label: t(
+            "option:promptStudio.healthDiagnostics",
+            "Health & diagnostics"
+          ),
           onClick: () => navigate("/settings/health"),
           variant: "primary"
         }}
         secondaryAction={{
-          label: "Open Settings",
+          label: t("option:promptStudio.openSettings", "Open Settings"),
           onClick: () => navigate("/settings/tldw")
         }}>
-        Prompt Studio depends on a reachable tldw server. Review your server
-        status and URL before trying again.
+        {t(
+          "option:promptStudio.unreachableDesc",
+          "Prompt Studio depends on a reachable tldw server. Review your server status and URL before trying again."
+        )}
       </DesignSystemAlert>
     )
   }

--- a/apps/packages/ui/src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import {
-  Alert,
   Badge,
   Button,
   Card,
@@ -24,6 +23,7 @@ import { BugOutlined, HistoryOutlined, PlayCircleOutlined, SyncOutlined } from "
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives/Alert"
 import { useConnectionUxState } from "@/hooks/useConnectionState"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import {
@@ -584,62 +584,61 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
 
   if (uxState === "error_auth" || uxState === "configuring_auth") {
     return (
-      <Alert
-        type="warning"
+      <DesignSystemAlert
+        variant="warning"
         title="Add your credentials to use Prompt Studio"
-        description="Prompt Studio needs a reachable tldw server plus valid credentials before projects, prompts, and evaluations can load."
-        action={
-          <Button type="primary" onClick={() => navigate("/settings/tldw")}>
-            Open Settings
-          </Button>
-        }
-      />
+        action={{
+          label: "Open Settings",
+          onClick: () => navigate("/settings/tldw"),
+          variant: "primary"
+        }}>
+        Prompt Studio needs a reachable tldw server plus valid credentials before
+        projects, prompts, and evaluations can load.
+      </DesignSystemAlert>
     )
   }
 
   if (uxState === "unconfigured" || uxState === "configuring_url") {
     return (
-      <Alert
-        type="warning"
+      <DesignSystemAlert
+        variant="warning"
         title="Finish setup to use Prompt Studio"
-        description="Prompt Studio depends on a configured tldw server before projects, prompts, and evaluations can load."
-        action={
-          <Button
-            type="primary"
-            onClick={() =>
-              navigate(hasCompletedFirstRun ? "/settings/tldw" : "/")
-            }>
-            {hasCompletedFirstRun ? "Open Settings" : "Finish Setup"}
-          </Button>
-        }
-      />
+        action={{
+          label: hasCompletedFirstRun ? "Open Settings" : "Finish Setup",
+          onClick: () =>
+            navigate(hasCompletedFirstRun ? "/settings/tldw" : "/"),
+          variant: "primary"
+        }}>
+        Prompt Studio depends on a configured tldw server before projects,
+        prompts, and evaluations can load.
+      </DesignSystemAlert>
     )
   }
 
   if (uxState === "error_unreachable") {
     return (
-      <Alert
-        type="warning"
+      <DesignSystemAlert
+        variant="warning"
         title="Can't reach your tldw server right now"
-        description="Prompt Studio depends on a reachable tldw server. Review your server status and URL before trying again."
-        action={
-          <Space>
-            <Button type="primary" onClick={() => navigate("/settings/health")}>
-              Health & diagnostics
-            </Button>
-            <Button onClick={() => navigate("/settings/tldw")}>
-              Open Settings
-            </Button>
-          </Space>
-        }
-      />
+        action={{
+          label: "Health & diagnostics",
+          onClick: () => navigate("/settings/health"),
+          variant: "primary"
+        }}
+        secondaryAction={{
+          label: "Open Settings",
+          onClick: () => navigate("/settings/tldw")
+        }}>
+        Prompt Studio depends on a reachable tldw server. Review your server
+        status and URL before trying again.
+      </DesignSystemAlert>
     )
   }
 
   if (!online && uxState !== "testing") {
     return (
-      <Alert
-        type="warning"
+      <DesignSystemAlert
+        variant="warning"
         title={t("option:promptStudio.offline", "Connect to your server to use Prompt Studio")}
       />
     )
@@ -651,14 +650,14 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
 
   if (capabilityQuery.data === false) {
     return (
-      <Alert
-        type="info"
-        title={t("option:promptStudio.unavailable", "Prompt Studio is not enabled on this server.")}
-        description={t(
+      <DesignSystemAlert
+        variant="info"
+        title={t("option:promptStudio.unavailable", "Prompt Studio is not enabled on this server.")}>
+        {t(
           "option:promptStudio.unavailableBody",
           "When available, you will see projects, prompt history, execute flows, and evaluations here."
         )}
-      />
+      </DesignSystemAlert>
     )
   }
 
@@ -711,8 +710,8 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
             </Space>
           }>
           {projectsQuery.isError && (
-            <Alert
-              type="error"
+            <DesignSystemAlert
+              variant="error"
               title={t("option:promptStudio.projectsError", "Could not load projects")}
             />
           )}
@@ -965,17 +964,17 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
                         </Text>
                       }>
                       {lastDebugTestCase && (
-                        <Alert
-                          type="info"
+                        <DesignSystemAlert
+                          variant="info"
                           className="mb-3"
                           title={t("option:promptStudio.debugging", "Debugging {{name}}", {
                             name: lastDebugTestCase.name || lastDebugTestCase.id
-                          })}
-                          description={t(
+                          })}>
+                          {t(
                             "option:promptStudio.debuggingDesc",
                             "Inputs pre-filled from this test case. Adjust and run to iterate quickly."
                           )}
-                        />
+                        </DesignSystemAlert>
                       )}
                       <Form
                         layout="vertical"
@@ -1011,7 +1010,11 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
                         </Space>
                       </Form>
                       {executionError && (
-                        <Alert className="mt-3" type="error" title={executionError} />
+                        <DesignSystemAlert
+                          className="mt-3"
+                          variant="error"
+                          title={executionError}
+                        />
                       )}
                       {executionResult && (
                         <Card className="mt-3" size="small" title={t("common:result", "Result")}>
@@ -1171,7 +1174,12 @@ export const PromptStudioPlaygroundPage: React.FC = () => {
                                   )
                                 }
                                 if (run.status === "error") {
-                                  return <Alert type="error" title={run.error} />
+                                  return (
+                                    <DesignSystemAlert
+                                      variant="error"
+                                      title={run.error}
+                                    />
+                                  )
                                 }
                                 return (
                                   <div>

--- a/apps/packages/ui/src/components/Option/PromptStudio/__tests__/PromptStudioPlaygroundPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/PromptStudio/__tests__/PromptStudioPlaygroundPage.connection.test.tsx
@@ -172,6 +172,11 @@ const renderPage = () => {
   )
 }
 
+const expectDesignSystemAlertForText = (text: string) => {
+  const alertText = screen.getByText(text)
+  expect(alertText.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+}
+
 describe("PromptStudioPlaygroundPage connection states", () => {
   beforeEach(() => {
     mocks.online = true
@@ -196,6 +201,7 @@ describe("PromptStudioPlaygroundPage connection states", () => {
     expect(
       screen.getByText("Add your credentials to use Prompt Studio")
     ).toBeInTheDocument()
+    expectDesignSystemAlertForText("Add your credentials to use Prompt Studio")
     expect(
       screen.queryByText("Connect to your server to use Prompt Studio")
     ).not.toBeInTheDocument()
@@ -214,6 +220,7 @@ describe("PromptStudioPlaygroundPage connection states", () => {
     expect(
       screen.getByText("Finish setup to use Prompt Studio")
     ).toBeInTheDocument()
+    expectDesignSystemAlertForText("Finish setup to use Prompt Studio")
 
     fireEvent.click(screen.getByRole("button", { name: "Finish Setup" }))
     expect(mocks.navigate).toHaveBeenCalledWith("/")
@@ -228,6 +235,7 @@ describe("PromptStudioPlaygroundPage connection states", () => {
     expect(
       screen.getByText("Can't reach your tldw server right now")
     ).toBeInTheDocument()
+    expectDesignSystemAlertForText("Can't reach your tldw server right now")
 
     fireEvent.click(screen.getByRole("button", { name: "Health & diagnostics" }))
     expect(mocks.navigate).toHaveBeenCalledWith("/settings/health")

--- a/apps/packages/ui/src/components/Option/PromptStudio/__tests__/PromptStudioPlaygroundPage.connection.test.tsx
+++ b/apps/packages/ui/src/components/Option/PromptStudio/__tests__/PromptStudioPlaygroundPage.connection.test.tsx
@@ -25,9 +25,13 @@ const serviceMocks = vi.hoisted(() => ({
   getPromptStudioDefaults: vi.fn()
 }))
 
+const i18nMocks = vi.hoisted(() => ({
+  t: vi.fn((_key: string, fallback?: string) => fallback ?? _key)
+}))
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key
+    t: i18nMocks.t
   })
 }))
 
@@ -177,6 +181,10 @@ const expectDesignSystemAlertForText = (text: string) => {
   expect(alertText.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
 }
 
+const expectTranslation = (key: string, fallback: string) => {
+  expect(i18nMocks.t).toHaveBeenCalledWith(key, fallback)
+}
+
 describe("PromptStudioPlaygroundPage connection states", () => {
   beforeEach(() => {
     mocks.online = true
@@ -185,6 +193,7 @@ describe("PromptStudioPlaygroundPage connection states", () => {
     mocks.navigate.mockReset()
     serviceMocks.hasPromptStudio.mockReset()
     serviceMocks.getPromptStudioDefaults.mockReset()
+    i18nMocks.t.mockClear()
     serviceMocks.hasPromptStudio.mockResolvedValue(true)
     serviceMocks.getPromptStudioDefaults.mockResolvedValue({
       pageSize: 10,
@@ -202,6 +211,11 @@ describe("PromptStudioPlaygroundPage connection states", () => {
       screen.getByText("Add your credentials to use Prompt Studio")
     ).toBeInTheDocument()
     expectDesignSystemAlertForText("Add your credentials to use Prompt Studio")
+    expectTranslation("option:promptStudio.openSettings", "Open Settings")
+    expectTranslation(
+      "option:promptStudio.addCredentialsDesc",
+      "Prompt Studio needs a reachable tldw server plus valid credentials before projects, prompts, and evaluations can load."
+    )
     expect(
       screen.queryByText("Connect to your server to use Prompt Studio")
     ).not.toBeInTheDocument()
@@ -221,6 +235,11 @@ describe("PromptStudioPlaygroundPage connection states", () => {
       screen.getByText("Finish setup to use Prompt Studio")
     ).toBeInTheDocument()
     expectDesignSystemAlertForText("Finish setup to use Prompt Studio")
+    expectTranslation("option:promptStudio.finishSetupAction", "Finish Setup")
+    expectTranslation(
+      "option:promptStudio.finishSetupDesc",
+      "Prompt Studio depends on a configured tldw server before projects, prompts, and evaluations can load."
+    )
 
     fireEvent.click(screen.getByRole("button", { name: "Finish Setup" }))
     expect(mocks.navigate).toHaveBeenCalledWith("/")
@@ -236,6 +255,15 @@ describe("PromptStudioPlaygroundPage connection states", () => {
       screen.getByText("Can't reach your tldw server right now")
     ).toBeInTheDocument()
     expectDesignSystemAlertForText("Can't reach your tldw server right now")
+    expectTranslation(
+      "option:promptStudio.healthDiagnostics",
+      "Health & diagnostics"
+    )
+    expectTranslation("option:promptStudio.openSettings", "Open Settings")
+    expectTranslation(
+      "option:promptStudio.unreachableDesc",
+      "Prompt Studio depends on a reachable tldw server. Review your server status and URL before trying again."
+    )
 
     fireEvent.click(screen.getByRole("button", { name: "Health & diagnostics" }))
     expect(mocks.navigate).toHaveBeenCalledWith("/settings/health")

--- a/backlog/tasks/task-45.44.8.1 - Migrate-PromptStudioPlaygroundPage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.8.1 - Migrate-PromptStudioPlaygroundPage-alerts-to-design-system-Alert.md
@@ -40,13 +40,14 @@ Migrate PromptStudioPlaygroundPage product-state alerts from AntD Alert to the s
 - Migrated PromptStudioPlaygroundPage product-state Alert usages to the shared design-system Alert primitive while preserving existing AntD layout controls.
 - Added PromptStudioPlaygroundPage.connection.test.tsx assertions that connection guidance titles are rendered inside `data-ds-component="Alert"`.
 - Removed nine PromptStudioPlaygroundPage entries from `design-system-product-state-baseline.json` and normalized the inherited stale SourceFormModal baseline entry into the two current duplicate-stable entries required by the guard.
+- Addressed PR #1849 Gemini review comments by routing the migrated connection-state Alert titles, action labels, and descriptions through `t()`, with focused assertions for the reviewed labels/descriptions.
 - Bandit was not run because this slice touches only TypeScript/TSX and JSON baseline files.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-PromptStudioPlaygroundPage now uses the canonical design-system Alert primitive for product-state alert messaging. The product-state baseline has zero entries for that page; the repo baseline is 360 after removing nine PromptStudio entries and normalizing one unrelated stale SourceFormModal baseline entry into two current entries. Verification: focused Prompt Studio Vitest passed, product-state guard Vitest passed, verify:design-system-state passed, git diff --check passed. Full TypeScript still fails on inherited repo-wide debt; /tmp/promptstudio-alerts-tsc.log has 240 lines and no diagnostics for PromptStudioPlaygroundPage, its test, SourceFormModal, or the baseline file.
+PromptStudioPlaygroundPage now uses the canonical design-system Alert primitive for product-state alert messaging. The product-state baseline has zero entries for that page; the repo baseline is 360 after removing nine PromptStudio entries and normalizing one unrelated stale SourceFormModal baseline entry into two current entries. PR #1849 review follow-up internationalized the migrated connection-state Alert titles, labels, and descriptions via `t()`. Verification: focused Prompt Studio Vitest passed after a red i18n assertion, product-state guard Vitest passed, verify:design-system-state passed, git diff --check passed. Full TypeScript still fails on inherited repo-wide debt; /tmp/promptstudio-alerts-review-tsc.log has 240 lines and no diagnostics for PromptStudioPlaygroundPage, its test, SourceFormModal, or the baseline file.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.8.1 - Migrate-PromptStudioPlaygroundPage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.8.1 - Migrate-PromptStudioPlaygroundPage-alerts-to-design-system-Alert.md
@@ -1,0 +1,60 @@
+---
+id: TASK-45.44.8.1
+title: Migrate PromptStudioPlaygroundPage alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.8
+references:
+- https://github.com/rmusser01/tldw_server/issues/1665
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- apps/packages/ui/src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+modified_files:
+- apps/packages/ui/src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx
+- apps/packages/ui/src/components/Option/PromptStudio/__tests__
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate PromptStudioPlaygroundPage product-state alerts from AntD Alert to the shared design-system Alert primitive, then remove the matching product-state guard baseline entries for this file.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PromptStudioPlaygroundPage no longer imports or renders AntD Alert for product-state messaging.
+- [x] #2 A focused Prompt Studio test asserts migrated alert copy renders through the design-system Alert primitive.
+- [x] #3 The product-state guard baseline no longer contains entries for src/components/Option/PromptStudio/PromptStudioPlaygroundPage.tsx.
+- [x] #4 Focused UI tests and design-system guard verification pass, with non-code security skip documented.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Migrated PromptStudioPlaygroundPage product-state Alert usages to the shared design-system Alert primitive while preserving existing AntD layout controls.
+- Added PromptStudioPlaygroundPage.connection.test.tsx assertions that connection guidance titles are rendered inside `data-ds-component="Alert"`.
+- Removed nine PromptStudioPlaygroundPage entries from `design-system-product-state-baseline.json` and normalized the inherited stale SourceFormModal baseline entry into the two current duplicate-stable entries required by the guard.
+- Bandit was not run because this slice touches only TypeScript/TSX and JSON baseline files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PromptStudioPlaygroundPage now uses the canonical design-system Alert primitive for product-state alert messaging. The product-state baseline has zero entries for that page; the repo baseline is 360 after removing nine PromptStudio entries and normalizing one unrelated stale SourceFormModal baseline entry into two current entries. Verification: focused Prompt Studio Vitest passed, product-state guard Vitest passed, verify:design-system-state passed, git diff --check passed. Full TypeScript still fails on inherited repo-wide debt; /tmp/promptstudio-alerts-tsc.log has 240 lines and no diagnostics for PromptStudioPlaygroundPage, its test, SourceFormModal, or the baseline file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Migrates `PromptStudioPlaygroundPage` product-state alerts from AntD `Alert` to the shared design-system `Alert` primitive.
- Adds focused connection-state test assertions that Prompt Studio guidance renders through `data-ds-component="Alert"` and routes reviewed alert copy through `t()`.
- Removes the nine Prompt Studio product-state baseline entries and normalizes one inherited stale `SourceFormModal` baseline entry into its two current duplicate-stable entries.

## Verification

- `bunx vitest run src/components/Option/PromptStudio/__tests__/PromptStudioPlaygroundPage.connection.test.tsx --maxWorkers=1 --no-file-parallelism`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism`
- `bun run verify:design-system-state`
- `git diff --check`
- `bunx tsc --noEmit --pretty false` still fails on inherited repo-wide TypeScript debt; `/tmp/promptstudio-alerts-review-tsc.log` has no diagnostics for this slice's touched files.
- Bandit skipped: this slice touches only TypeScript/TSX and JSON baseline files.

## Risk & Rollback

- Risk: Low. This is a UI primitive migration plus i18n wrapping for existing Prompt Studio alert copy. It does not change backend behavior, routes, persisted data, or service contracts.
- Rollback: Revert the PR commits to restore the prior AntD Alert rendering and baseline entries. If only the review follow-up needs rollback, revert `ba7cbf1fd` to keep the design-system migration while undoing the i18n test/copy wrapper change.

## Change summary

Maintainer-written change summary required before merge. Please describe what changed and why these design-system migration choices were made.
