### PR TITLE
Add watchlists briefing pipeline wizard

### DIFF
--- a/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
@@ -760,7 +760,7 @@ git commit -m "feat: persist watchlist audio briefing artifacts"
 - Test: `apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts`
 - Regression: `apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.experimental-ia.test.tsx`
 
-- [ ] **Step 1: Write failing wizard state tests**
+- [x] **Step 1: Write failing wizard state tests**
 
 Cover:
 
@@ -771,18 +771,18 @@ Cover:
 - Optional audio supports 0-4 speakers.
 - Review summary names source, cadence, filters, output, delivery, and audio.
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 ```bash
 cd apps/packages/ui
 bunx vitest run src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts --maxWorkers=1 --no-file-parallelism
 ```
 
-- [ ] **Step 3: Implement wizard state helpers**
+- [x] **Step 3: Implement wizard state helpers**
 
 Keep state pure. Use existing service calls from the component, not from helper files.
 
-- [ ] **Step 4: Implement additive `PipelineWizard`**
+- [x] **Step 4: Implement additive `PipelineWizard`**
 
 Wizard steps:
 
@@ -794,17 +794,17 @@ Wizard steps:
 
 The wizard should call existing `createWatchlistSource`, `createWatchlistJob`, `triggerWatchlistRun`, and `createWatchlistOutput` helpers. It must not bypass existing API contracts.
 
-- [ ] **Step 5: Wire into overview without removing full controls**
+- [x] **Step 5: Wire into overview without removing full controls**
 
 Add "Create briefing pipeline" as an entry point. Preserve current Sources/Items/Outputs primary tabs and "Show all views".
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run the command from Step 2 again.
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/quick-setup.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.experimental-ia.test.tsx

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
@@ -35,6 +35,7 @@ import {
   createWatchlistJob,
   createWatchlistSource,
   deleteWatchlistJob,
+  deleteWatchlistSource,
   fetchWatchlistRuns,
   fetchWatchlistSources,
   getWatchlistTemplate,
@@ -764,6 +765,7 @@ export const OverviewTab: React.FC = () => {
     wizardDraft: PipelineWizardDraft,
     options: { mode?: "create" | "test" } = {}
   ) => {
+    let createdSourceId: number | null = null
     let createdJobId: number | null = null
     let createdRunId: number | null = null
     const mode = options?.mode || "create"
@@ -786,6 +788,7 @@ export const OverviewTab: React.FC = () => {
           throw new Error("source_payload_missing")
         }
         const source = await createWatchlistSource(sourcePayload)
+        createdSourceId = source.id
         sourceIds = [source.id]
       }
 
@@ -866,16 +869,24 @@ export const OverviewTab: React.FC = () => {
         mode,
         runNow: shouldRunNowForTelemetry
       })
-      if (createdJobId != null && createdRunId == null) {
+      if (createdRunId != null) {
+        setActiveTab("runs")
+        openRunDetail(createdRunId)
+        message.error(
+          t(
+            "watchlists:overview.pipelineSetup.error",
+            "Pipeline setup failed. Open Activity or Reports to inspect recovery options."
+          )
+        )
+        return
+      }
+
+      let rollbackFailed = false
+      if (createdJobId != null) {
         try {
           await deleteWatchlistJob(createdJobId)
-          message.warning(
-            t(
-              "watchlists:overview.pipelineSetup.rollbackSuccess",
-              "Pipeline setup failed before run start. Monitor creation was rolled back."
-            )
-          )
         } catch (rollbackError) {
+          rollbackFailed = true
           console.error("Failed to rollback pipeline monitor creation:", rollbackError)
           void trackWatchlistsOnboardingTelemetry({
             type: "pipeline_setup_failed",
@@ -883,18 +894,40 @@ export const OverviewTab: React.FC = () => {
             mode,
             runNow: shouldRunNowForTelemetry
           })
+        }
+      }
+      if (createdSourceId != null) {
+        try {
+          await deleteWatchlistSource(createdSourceId)
+        } catch (rollbackError) {
+          rollbackFailed = true
+          console.error("Failed to rollback pipeline source creation:", rollbackError)
+          void trackWatchlistsOnboardingTelemetry({
+            type: "pipeline_setup_failed",
+            stage: "rollback",
+            mode,
+            runNow: shouldRunNowForTelemetry
+          })
+        }
+      }
+
+      if (createdJobId != null || createdSourceId != null) {
+        if (rollbackFailed) {
           message.error(
             t(
               "watchlists:overview.pipelineSetup.rollbackFailed",
               "Pipeline setup failed and rollback was incomplete. Review Monitors for cleanup."
             )
           )
+        } else {
+          message.warning(
+            t(
+              "watchlists:overview.pipelineSetup.rollbackSuccess",
+              "Pipeline setup failed before run start. Created resources were rolled back."
+            )
+          )
         }
       } else {
-        if (createdRunId != null) {
-          setActiveTab("runs")
-          openRunDetail(createdRunId)
-        }
         message.error(
           t(
             "watchlists:overview.pipelineSetup.error",
@@ -907,6 +940,7 @@ export const OverviewTab: React.FC = () => {
     }
   }, [
     closePipelineSetup,
+    deleteWatchlistSource,
     loadOverview,
     openOutputPreview,
     openRunDetail,

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Button,
   Card,
-  Checkbox,
   Empty,
   Form,
   Input,
@@ -19,7 +18,6 @@ import {
   Tag,
   Tooltip
 } from "antd"
-import type { StepsProps } from "antd"
 import {
   AlertTriangle,
   BellRing,
@@ -59,12 +57,15 @@ import {
 } from "./quick-setup"
 import type { JobPreviewResult } from "@/types/watchlists"
 import {
-  buildPipelineReviewSummary,
   toPipelineJobCreatePayload,
-  toPipelineOutputCreatePayload,
-  validateBriefingPipelineDraft,
-  type BriefingPipelineDraft
+  toPipelineOutputCreatePayload
 } from "./pipeline-contract"
+import { PipelineWizard } from "./PipelineWizard"
+import {
+  toBriefingPipelineDraft,
+  toPipelineWizardSourcePayload,
+  type PipelineWizardDraft
+} from "./pipeline-wizard-state"
 import {
   type WatchlistsOnboardingPath,
   readWatchlistsOnboardingPath,
@@ -88,61 +89,6 @@ const QUICK_SETUP_STEP_FIELDS: Array<Array<keyof QuickSetupValues>> = [
   ["monitorName", "schedulePreset", "setupGoal", "runNow", "includeAudioBriefing"],
   []
 ]
-const PIPELINE_SETUP_MAX_STEP = 2
-
-interface PipelineBuilderValues {
-  sourceIds: number[]
-  monitorName: string
-  schedulePreset: "none" | "hourly" | "daily" | "weekdays"
-  templateName: string
-  includeAudio: boolean
-  audioVoice: string
-  targetAudioMinutes: number
-  emailDeliveryEnabled: boolean
-  emailRecipients: string[]
-  chatbookDeliveryEnabled: boolean
-  chatbookTitle: string
-  runNow: boolean
-}
-
-const PIPELINE_DEFAULT_VALUES: PipelineBuilderValues = {
-  sourceIds: [],
-  monitorName: "",
-  schedulePreset: "daily",
-  templateName: "briefing_md",
-  includeAudio: true,
-  audioVoice: "alloy",
-  targetAudioMinutes: 8,
-  emailDeliveryEnabled: false,
-  emailRecipients: [],
-  chatbookDeliveryEnabled: false,
-  chatbookTitle: "",
-  runNow: true
-}
-
-const toPipelineDraft = (values: PipelineBuilderValues): BriefingPipelineDraft => ({
-  monitorName: values.monitorName,
-  sourceIds: values.sourceIds || [],
-  schedulePreset: values.schedulePreset,
-  templateName: values.templateName,
-  includeAudio: values.includeAudio,
-  audioVoice: values.includeAudio ? values.audioVoice : undefined,
-  targetAudioMinutes: values.includeAudio ? Number(values.targetAudioMinutes) : undefined,
-  emailRecipients: values.emailDeliveryEnabled
-    ? (values.emailRecipients || []).map((entry) => String(entry || "").trim()).filter((entry) => entry.length > 0)
-    : [],
-  createChatbook: Boolean(values.chatbookDeliveryEnabled),
-  chatbookTitle: values.chatbookDeliveryEnabled ? String(values.chatbookTitle || "").trim() : undefined
-})
-
-const PIPELINE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-
-const normalizePipelineRecipients = (value: unknown): string[] =>
-  Array.isArray(value)
-    ? value
-      .map((entry) => String(entry || "").trim().toLowerCase())
-      .filter((entry) => entry.length > 0)
-    : []
 
 export const OverviewTab: React.FC = () => {
   const { t } = useTranslation(["watchlists", "common"])
@@ -157,7 +103,6 @@ export const OverviewTab: React.FC = () => {
   const [quickSetupCandidatePreviewLoading, setQuickSetupCandidatePreviewLoading] = useState(false)
   const [quickSetupCandidatePreviewError, setQuickSetupCandidatePreviewError] = useState<string | null>(null)
   const [pipelineSetupOpen, setPipelineSetupOpen] = useState(false)
-  const [pipelineSetupStep, setPipelineSetupStep] = useState(0)
   const [pipelineSetupSubmitting, setPipelineSetupSubmitting] = useState(false)
   const [pipelineSourcesLoading, setPipelineSourcesLoading] = useState(false)
   const [pipelineSources, setPipelineSources] = useState<WatchlistSource[]>([])
@@ -176,7 +121,6 @@ export const OverviewTab: React.FC = () => {
   const pipelineSetupWasOpenRef = useRef(false)
   const quickSetupPreviewRequestRef = useRef(0)
   const [quickSetupForm] = Form.useForm<QuickSetupValues>()
-  const [pipelineSetupForm] = Form.useForm<PipelineBuilderValues>()
 
   const setActiveTab = useWatchlistsStore((s) => s.setActiveTab)
   const setOutputsRunFilter = useWatchlistsStore((s) => s.setOutputsRunFilter)
@@ -660,10 +604,6 @@ export const OverviewTab: React.FC = () => {
       })
       const items = Array.isArray(result.items) ? result.items : []
       setPipelineSources(items)
-      const selectedIds = pipelineSetupForm.getFieldValue("sourceIds") as number[] | undefined
-      if ((!selectedIds || selectedIds.length === 0) && items.length === 1) {
-        pipelineSetupForm.setFieldsValue({ sourceIds: [items[0].id] })
-      }
     } catch (err) {
       console.error("Failed to load watchlist sources for pipeline setup:", err)
       setPipelineSources([])
@@ -676,11 +616,9 @@ export const OverviewTab: React.FC = () => {
     } finally {
       setPipelineSourcesLoading(false)
     }
-  }, [pipelineSetupForm, selectedWatchlistId, t])
+  }, [selectedWatchlistId, t])
 
   const openPipelineSetup = useCallback(() => {
-    pipelineSetupForm.setFieldsValue(PIPELINE_DEFAULT_VALUES)
-    setPipelineSetupStep(0)
     setPipelinePreviewError(null)
     setPipelinePreviewRendered(null)
     setPipelinePreviewRunId(null)
@@ -688,60 +626,19 @@ export const OverviewTab: React.FC = () => {
     setPipelineSetupOpen(true)
     void trackWatchlistsOnboardingTelemetry({ type: "pipeline_setup_opened" })
     void loadPipelineSources()
-  }, [loadPipelineSources, pipelineSetupForm])
+  }, [loadPipelineSources])
 
   const closePipelineSetup = useCallback(() => {
     if (pipelineSetupSubmitting) return
     setPipelineSetupOpen(false)
-    setPipelineSetupStep(0)
     setPipelinePreviewLoading(false)
     setPipelinePreviewError(null)
     setPipelinePreviewRendered(null)
     setPipelinePreviewRunId(null)
     setPipelinePreviewWarnings([])
-    pipelineSetupForm.resetFields()
-  }, [pipelineSetupForm, pipelineSetupSubmitting])
+  }, [pipelineSetupSubmitting])
 
-  const handlePipelineSetupBack = useCallback(() => {
-    setPipelineSetupStep((prev) => Math.max(0, prev - 1))
-  }, [])
-
-  const handlePipelineSetupNext = useCallback(async () => {
-    try {
-      let completedStep: "scope" | "briefing" | null = null
-      if (pipelineSetupStep === 0) {
-        await pipelineSetupForm.validateFields(["sourceIds"])
-        completedStep = "scope"
-      } else if (pipelineSetupStep === 1) {
-        const includeAudio = Boolean(pipelineSetupForm.getFieldValue("includeAudio"))
-        const emailDeliveryEnabled = Boolean(pipelineSetupForm.getFieldValue("emailDeliveryEnabled"))
-        const fields: Array<keyof PipelineBuilderValues> = [
-          "monitorName",
-          "schedulePreset",
-          "templateName"
-        ]
-        if (includeAudio) {
-          fields.push("audioVoice", "targetAudioMinutes")
-        }
-        if (emailDeliveryEnabled) {
-          fields.push("emailRecipients")
-        }
-        await pipelineSetupForm.validateFields(fields)
-        completedStep = "briefing"
-      }
-      if (completedStep) {
-        void trackWatchlistsOnboardingTelemetry({
-          type: "pipeline_setup_step_completed",
-          step: completedStep
-        })
-      }
-      setPipelineSetupStep((prev) => Math.min(prev + 1, PIPELINE_SETUP_MAX_STEP))
-    } catch {
-      // Field-level validation state is already surfaced by antd form.
-    }
-  }, [pipelineSetupForm, pipelineSetupStep])
-
-  const generatePipelineTemplatePreview = useCallback(async () => {
+  const generatePipelineTemplatePreview = useCallback(async (wizardDraft: PipelineWizardDraft) => {
     setPipelinePreviewLoading(true)
     setPipelinePreviewError(null)
     setPipelinePreviewRendered(null)
@@ -749,11 +646,7 @@ export const OverviewTab: React.FC = () => {
     setPipelinePreviewWarnings([])
 
     try {
-      const values = {
-        ...PIPELINE_DEFAULT_VALUES,
-        ...pipelineSetupForm.getFieldsValue(true)
-      } as PipelineBuilderValues
-      const draft = toPipelineDraft(values)
+      const draft = toBriefingPipelineDraft(wizardDraft)
       const templateName = String(draft.templateName || "").trim()
       if (!templateName) {
         setPipelinePreviewError(
@@ -865,58 +758,35 @@ export const OverviewTab: React.FC = () => {
     } finally {
       setPipelinePreviewLoading(false)
     }
-  }, [pipelineSetupForm, selectedWatchlistId, t])
+  }, [selectedWatchlistId, t])
 
   const completePipelineSetup = useCallback(async (
-    options?: { mode?: "create" | "test"; forceRunNow?: boolean }
+    wizardDraft: PipelineWizardDraft,
+    options: { mode?: "create" | "test" } = {}
   ) => {
     let createdJobId: number | null = null
     let createdRunId: number | null = null
     const mode = options?.mode || "create"
     let shouldRunNowForTelemetry = false
-    let pipelineFailureStage: "validation" | "job_create" | "run_trigger" | "output_create" | "rollback" =
-      "job_create"
+    let pipelineFailureStage: "source_create" | "job_create" | "run_trigger" | "output_create" | "rollback" =
+      wizardDraft.sourceMode === "new" ? "source_create" : "job_create"
 
     try {
       setPipelineSetupSubmitting(true)
-      const values = {
-        ...PIPELINE_DEFAULT_VALUES,
-        ...pipelineSetupForm.getFieldsValue(true)
-      } as PipelineBuilderValues
-      const shouldRunNow = Boolean(values.runNow || options?.forceRunNow)
+      const shouldRunNow = Boolean(wizardDraft.runNow || mode === "test")
       shouldRunNowForTelemetry = shouldRunNow
 
-      const draft = toPipelineDraft(values)
-      const validation = validateBriefingPipelineDraft(draft)
-      if (!validation.valid) {
-        const errorFields = validation.errors.map((key) => ({
-          name: key as keyof PipelineBuilderValues,
-          errors: [
-            t(
-              "watchlists:overview.pipelineSetup.validation.required",
-              "Complete this field before continuing."
-            )
-          ]
-        }))
-        pipelineSetupForm.setFields(errorFields)
-        if (validation.errors.includes("sourceIds")) {
-          setPipelineSetupStep(0)
-        } else {
-          setPipelineSetupStep(1)
-        }
-        message.error(
-          t(
-            "watchlists:overview.pipelineSetup.validationError",
-            "Review the highlighted pipeline fields."
-          )
+      let sourceIds = wizardDraft.sourceIds
+      if (wizardDraft.sourceMode === "new") {
+        const sourcePayload = toPipelineWizardSourcePayload(
+          wizardDraft,
+          selectedWatchlistId ?? undefined
         )
-        void trackWatchlistsOnboardingTelemetry({
-          type: "pipeline_setup_failed",
-          stage: "validation",
-          mode,
-          runNow: shouldRunNow
-        })
-        return
+        if (!sourcePayload) {
+          throw new Error("source_payload_missing")
+        }
+        const source = await createWatchlistSource(sourcePayload)
+        sourceIds = [source.id]
       }
 
       void trackWatchlistsOnboardingTelemetry({
@@ -930,6 +800,7 @@ export const OverviewTab: React.FC = () => {
       })
 
       pipelineFailureStage = "job_create"
+      const draft = toBriefingPipelineDraft(wizardDraft, sourceIds)
       const job = await createWatchlistJob({
         ...toPipelineJobCreatePayload(draft),
         watchlist_id: selectedWatchlistId ?? undefined
@@ -1039,7 +910,6 @@ export const OverviewTab: React.FC = () => {
     loadOverview,
     openOutputPreview,
     openRunDetail,
-    pipelineSetupForm,
     selectedWatchlistId,
     setActiveTab,
     setOutputsRunFilter,
@@ -1172,44 +1042,6 @@ export const OverviewTab: React.FC = () => {
           "watchlists:overview.onboarding.quickSetup.destination.jobs",
           "After setup, you will land in Monitors to schedule and tune your workflow."
         )
-  const pipelineSetupValues = Form.useWatch([], pipelineSetupForm) as
-    | Partial<PipelineBuilderValues>
-    | undefined
-  const pipelineDraftPreview = toPipelineDraft({
-    ...PIPELINE_DEFAULT_VALUES,
-    ...(pipelineSetupValues || {})
-  } as PipelineBuilderValues)
-  const pipelineReviewSummary = buildPipelineReviewSummary(pipelineDraftPreview)
-  const pipelineEmailRecipients = normalizePipelineRecipients(pipelineSetupValues?.emailRecipients)
-  const pipelineHasValidEmailRecipients = !pipelineSetupValues?.emailDeliveryEnabled || (
-    pipelineEmailRecipients.length > 0 &&
-    pipelineEmailRecipients.every((entry) => PIPELINE_EMAIL_PATTERN.test(entry))
-  )
-  const pipelineScopeComplete = Array.isArray(pipelineDraftPreview.sourceIds) && pipelineDraftPreview.sourceIds.length > 0
-  const pipelineBriefingComplete = Boolean(
-    pipelineDraftPreview.monitorName.trim().length > 0 &&
-      pipelineDraftPreview.templateName.trim().length > 0 &&
-      (!pipelineDraftPreview.includeAudio ||
-        (Boolean(pipelineDraftPreview.audioVoice) &&
-          Number(pipelineDraftPreview.targetAudioMinutes || 0) > 0)) &&
-      pipelineHasValidEmailRecipients
-  )
-  const pipelineReviewComplete = pipelineScopeComplete && pipelineBriefingComplete
-  const pipelineStepItems = useMemo<NonNullable<StepsProps["items"]>>(() => ([
-    {
-      title: t("watchlists:overview.pipelineSetup.steps.scope", "Scope"),
-      status: pipelineScopeComplete ? "finish" : pipelineSetupStep === 0 ? "process" : "wait"
-    },
-    {
-      title: t("watchlists:overview.pipelineSetup.steps.briefing", "Briefing"),
-      status: pipelineBriefingComplete ? "finish" : pipelineSetupStep === 1 ? "process" : "wait"
-    },
-    {
-      title: t("watchlists:overview.pipelineSetup.steps.review", "Review"),
-      status: pipelineReviewComplete ? "finish" : pipelineSetupStep === 2 ? "process" : "wait"
-    }
-  ]), [pipelineBriefingComplete, pipelineReviewComplete, pipelineScopeComplete, pipelineSetupStep, t])
-  const pipelineSetupIsLastStep = pipelineSetupStep >= PIPELINE_SETUP_MAX_STEP
   const overviewBadges = getOverviewTabBadges(data?.health)
 
   if (!hasSelectedWatchlist) {
@@ -2213,455 +2045,24 @@ export const OverviewTab: React.FC = () => {
         </div>
       </Modal>
 
-      <Modal
+      <PipelineWizard
         open={pipelineSetupOpen}
-        title={t("watchlists:overview.pipelineSetup.title", "Briefing pipeline builder")}
+        sources={pipelineSources}
+        sourcesLoading={pipelineSourcesLoading}
+        submitting={pipelineSetupSubmitting}
+        previewLoading={pipelinePreviewLoading}
+        previewError={pipelinePreviewError}
+        previewRendered={pipelinePreviewRendered}
+        previewRunId={pipelinePreviewRunId}
+        previewWarnings={pipelinePreviewWarnings}
         onCancel={closePipelineSetup}
-        destroyOnHidden
-        maskClosable={!pipelineSetupSubmitting}
-        footer={[
-          <Button
-            key="cancel"
-            onClick={closePipelineSetup}
-            disabled={pipelineSetupSubmitting}
-          >
-            {t("common:cancel", "Cancel")}
-          </Button>,
-          <Button
-            key="back"
-            onClick={handlePipelineSetupBack}
-            disabled={pipelineSetupSubmitting || pipelineSetupStep === 0}
-          >
-            {t("common:back", "Back")}
-          </Button>,
-          pipelineSetupIsLastStep ? (
-            <Button
-              key="test-generation"
-              data-testid="watchlists-pipeline-test-generation"
-              onClick={() => {
-                void completePipelineSetup({ mode: "test", forceRunNow: true })
-              }}
-              loading={pipelineSetupSubmitting}
-            >
-              {t("watchlists:overview.pipelineSetup.actions.testGeneration", "Run test generation")}
-            </Button>
-          ) : null,
-          <Button
-            key="next"
-            type="primary"
-            loading={pipelineSetupSubmitting}
-            onClick={() => {
-              if (pipelineSetupIsLastStep) {
-                void completePipelineSetup({ mode: "create" })
-              } else {
-                void handlePipelineSetupNext()
-              }
-            }}
-          >
-            {pipelineSetupIsLastStep
-              ? t("watchlists:overview.pipelineSetup.actions.finish", "Create pipeline")
-              : t("common:next", "Next")}
-          </Button>
-        ]}
-      >
-        <div className="space-y-4">
-          <Steps
-            size="small"
-            current={pipelineSetupStep}
-            items={pipelineStepItems}
-          />
-
-          <Form
-            form={pipelineSetupForm}
-            layout="vertical"
-            initialValues={PIPELINE_DEFAULT_VALUES}
-          >
-            {pipelineSetupStep === 0 && (
-              <div className="space-y-2">
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.sources", "Feeds")}
-                  name="sourceIds"
-                  rules={[
-                    {
-                      validator: (_rule, value) => {
-                        if (Array.isArray(value) && value.length > 0) {
-                          return Promise.resolve()
-                        }
-                        return Promise.reject(
-                          new Error(
-                            t(
-                              "watchlists:overview.pipelineSetup.validation.sourcesRequired",
-                              "Select at least one feed"
-                            )
-                          )
-                        )
-                      }
-                    }
-                  ]}
-                >
-                  <Checkbox.Group className="grid gap-2">
-                    {pipelineSources.map((source) => (
-                      <Checkbox key={source.id} value={source.id}>
-                        {source.name || `Feed #${source.id}`}
-                      </Checkbox>
-                    ))}
-                  </Checkbox.Group>
-                </Form.Item>
-                {pipelineSourcesLoading && (
-                  <div className="text-xs text-text-muted">
-                    {t("watchlists:overview.pipelineSetup.sourcesLoading", "Loading feeds...")}
-                  </div>
-                )}
-              </div>
-            )}
-
-            {pipelineSetupStep === 1 && (
-              <div className="space-y-1">
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.monitorName", "Monitor name")}
-                  name="monitorName"
-                  rules={[
-                    {
-                      required: true,
-                      message: t(
-                        "watchlists:overview.pipelineSetup.validation.monitorNameRequired",
-                        "Enter a monitor name"
-                      )
-                    }
-                  ]}
-                >
-                  <Input autoFocus />
-                </Form.Item>
-
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.schedule", "Schedule")}
-                  name="schedulePreset"
-                >
-                  <Select
-                    options={[
-                      { value: "none", label: t("watchlists:overview.onboarding.quickSetup.schedule.none", "Manual only") },
-                      { value: "hourly", label: t("watchlists:overview.onboarding.quickSetup.schedule.hourly", "Hourly") },
-                      { value: "daily", label: t("watchlists:overview.onboarding.quickSetup.schedule.daily", "Daily at 08:00") },
-                      { value: "weekdays", label: t("watchlists:overview.onboarding.quickSetup.schedule.weekdays", "Weekdays at 08:00") }
-                    ]}
-                  />
-                </Form.Item>
-
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.template", "Template")}
-                  name="templateName"
-                  rules={[
-                    {
-                      required: true,
-                      message: t(
-                        "watchlists:overview.pipelineSetup.validation.templateRequired",
-                        "Enter a template name"
-                      )
-                    }
-                  ]}
-                >
-                  <Input />
-                </Form.Item>
-
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.includeAudio", "Include audio briefing")}
-                  name="includeAudio"
-                  valuePropName="checked"
-                >
-                  <Switch
-                    aria-label={t(
-                      "watchlists:overview.pipelineSetup.fields.includeAudio",
-                      "Include audio briefing"
-                    )}
-                  />
-                </Form.Item>
-
-                {pipelineSetupValues?.includeAudio && (
-                  <>
-                    <Form.Item
-                      label={t("watchlists:overview.pipelineSetup.fields.audioVoice", "Audio voice")}
-                      name="audioVoice"
-                      rules={[
-                        {
-                          required: true,
-                          message: t(
-                            "watchlists:overview.pipelineSetup.validation.audioVoiceRequired",
-                            "Select an audio voice"
-                          )
-                        }
-                      ]}
-                    >
-                      <Select
-                        options={[
-                          { value: "alloy", label: "Alloy" },
-                          { value: "nova", label: "Nova" },
-                          { value: "echo", label: "Echo" }
-                        ]}
-                      />
-                    </Form.Item>
-                    <Form.Item
-                      label={t("watchlists:overview.pipelineSetup.fields.audioMinutes", "Target audio minutes")}
-                      name="targetAudioMinutes"
-                      rules={[
-                        {
-                          required: true,
-                          type: "number",
-                          min: 1,
-                          message: t(
-                            "watchlists:overview.pipelineSetup.validation.audioMinutesRequired",
-                            "Enter target audio minutes"
-                          )
-                        }
-                      ]}
-                    >
-                      <Input type="number" min={1} />
-                    </Form.Item>
-                  </>
-                )}
-
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.emailDelivery", "Email delivery")}
-                  name="emailDeliveryEnabled"
-                  valuePropName="checked"
-                >
-                  <Switch
-                    aria-label={t("watchlists:overview.pipelineSetup.fields.emailDelivery", "Email delivery")}
-                  />
-                </Form.Item>
-
-                {pipelineSetupValues?.emailDeliveryEnabled && (
-                  <Form.Item
-                    label={t("watchlists:overview.pipelineSetup.fields.emailRecipients", "Email recipients")}
-                    name="emailRecipients"
-                    rules={[
-                      {
-                        validator: (_rule, value) => {
-                          const recipients = normalizePipelineRecipients(value)
-                          if (recipients.length === 0) {
-                            return Promise.reject(
-                              new Error(
-                                t(
-                                  "watchlists:overview.pipelineSetup.validation.emailRecipientsRequired",
-                                  "Enter at least one recipient email"
-                                )
-                              )
-                            )
-                          }
-                          const invalidRecipients = recipients.filter(
-                            (entry) => !PIPELINE_EMAIL_PATTERN.test(entry)
-                          )
-                          if (invalidRecipients.length > 0) {
-                            return Promise.reject(
-                              new Error(
-                                t(
-                                  "watchlists:overview.pipelineSetup.validation.emailRecipientsInvalid",
-                                  "Fix invalid email recipients before continuing."
-                                )
-                              )
-                            )
-                          }
-                          return Promise.resolve()
-                        }
-                      }
-                    ]}
-                  >
-                    <Select
-                      mode="tags"
-                      tokenSeparators={[","]}
-                      placeholder={t(
-                        "watchlists:overview.pipelineSetup.fields.emailRecipientsPlaceholder",
-                        "name@example.com"
-                      )}
-                    />
-                  </Form.Item>
-                )}
-
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.chatbookDelivery", "Chatbook delivery")}
-                  name="chatbookDeliveryEnabled"
-                  valuePropName="checked"
-                >
-                  <Switch
-                    aria-label={t(
-                      "watchlists:overview.pipelineSetup.fields.chatbookDelivery",
-                      "Chatbook delivery"
-                    )}
-                  />
-                </Form.Item>
-
-                {pipelineSetupValues?.chatbookDeliveryEnabled && (
-                  <Form.Item
-                    label={t("watchlists:overview.pipelineSetup.fields.chatbookTitle", "Chatbook title")}
-                    name="chatbookTitle"
-                  >
-                    <Input
-                      placeholder={t(
-                        "watchlists:overview.pipelineSetup.fields.chatbookTitlePlaceholder",
-                        "Morning Intel"
-                      )}
-                    />
-                  </Form.Item>
-                )}
-
-                <Form.Item
-                  label={t("watchlists:overview.pipelineSetup.fields.runNow", "Run immediately")}
-                  name="runNow"
-                  valuePropName="checked"
-                >
-                  <Switch
-                    aria-label={t("watchlists:overview.pipelineSetup.fields.runNow", "Run immediately")}
-                  />
-                </Form.Item>
-              </div>
-            )}
-
-            {pipelineSetupStep === 2 && (
-              <div className="space-y-3 text-sm">
-                <p className="text-text-muted">
-                  {t(
-                    "watchlists:overview.pipelineSetup.reviewDescription",
-                    "Confirm this pipeline before creating monitor, run, and output artifacts."
-                  )}
-                </p>
-                <div className="rounded-md border border-border bg-surface p-3">
-                  <p>
-                    <span className="font-medium">
-                      {t("watchlists:overview.pipelineSetup.review.monitor", "Monitor")}:
-                    </span>{" "}
-                    {pipelineSetupValues?.monitorName || "—"}
-                  </p>
-                  <p>
-                    <span className="font-medium">
-                      {t("watchlists:overview.pipelineSetup.review.feeds", "Feeds")}:
-                    </span>{" "}
-                    {Array.isArray(pipelineSetupValues?.sourceIds)
-                      ? pipelineSetupValues?.sourceIds.length
-                      : 0}
-                  </p>
-                  <p>
-                    <span className="font-medium">
-                      {t("watchlists:overview.pipelineSetup.review.schedule", "Schedule")}:
-                    </span>{" "}
-                    {pipelineReviewSummary.scheduleLabel}
-                  </p>
-                  <p>
-                    <span className="font-medium">
-                      {t("watchlists:overview.pipelineSetup.review.artifacts", "Artifacts")}:
-                    </span>{" "}
-                    {pipelineReviewSummary.artifacts.join(", ")}
-                  </p>
-                  <p>
-                    <span className="font-medium">
-                      {t("watchlists:overview.pipelineSetup.review.deliveries", "Deliveries")}:
-                    </span>{" "}
-                    {pipelineReviewSummary.deliveries.join(", ")}
-                  </p>
-                  {pipelineSetupValues?.emailDeliveryEnabled && (
-                    <p>
-                      <span className="font-medium">
-                        {t("watchlists:overview.pipelineSetup.review.emailRecipients", "Email recipients")}:
-                      </span>{" "}
-                      {pipelineEmailRecipients.length}
-                    </p>
-                  )}
-                  {pipelineSetupValues?.chatbookDeliveryEnabled && (
-                    <p>
-                      <span className="font-medium">
-                        {t("watchlists:overview.pipelineSetup.review.chatbookTitle", "Chatbook title")}:
-                      </span>{" "}
-                      {String(pipelineSetupValues?.chatbookTitle || "").trim() || "Watchlists Briefing"}
-                    </p>
-                  )}
-                  <p>
-                    <span className="font-medium">
-                      {t("watchlists:overview.pipelineSetup.review.runNow", "Run now")}:
-                    </span>{" "}
-                    {pipelineSetupValues?.runNow ? t("common:yes", "Yes") : t("common:no", "No")}
-                  </p>
-                </div>
-                <div className="rounded-md border border-border bg-surface p-3 text-xs text-text-muted space-y-1">
-                  <p data-testid="watchlists-pipeline-review-outcome-text">
-                    {t(
-                      "watchlists:overview.pipelineSetup.review.textOutcome",
-                      "Text outcome: {{template}} template will generate a written report artifact.",
-                      {
-                        template: String(pipelineSetupValues?.templateName || "briefing_md")
-                      }
-                    )}
-                  </p>
-                  <p data-testid="watchlists-pipeline-review-outcome-audio">
-                    {pipelineSetupValues?.includeAudio
-                      ? t(
-                          "watchlists:overview.pipelineSetup.review.audioOutcomeEnabled",
-                          "Audio outcome: voice {{voice}} targeting about {{minutes}} minutes.",
-                          {
-                            voice: String(pipelineSetupValues?.audioVoice || "alloy"),
-                            minutes: Number(pipelineSetupValues?.targetAudioMinutes || 8)
-                          }
-                        )
-                      : t(
-                          "watchlists:overview.pipelineSetup.review.audioOutcomeDisabled",
-                          "Audio outcome: disabled. Reports will be text-only."
-                        )}
-                  </p>
-                </div>
-                <div className="rounded-md border border-border bg-surface p-3 space-y-2">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="text-xs text-text-muted">
-                      {t(
-                        "watchlists:overview.pipelineSetup.preview.description",
-                        "Preview template output using the latest completed run context before creating the pipeline."
-                      )}
-                    </p>
-                    <Button
-                      size="small"
-                      onClick={() => {
-                        void generatePipelineTemplatePreview()
-                      }}
-                      loading={pipelinePreviewLoading}
-                      data-testid="watchlists-pipeline-preview-generate"
-                    >
-                      {t("watchlists:overview.pipelineSetup.preview.generate", "Generate preview")}
-                    </Button>
-                  </div>
-                  {pipelinePreviewError && (
-                    <Alert
-                      type="warning"
-                      showIcon
-                      data-testid="watchlists-pipeline-preview-error"
-                      title={pipelinePreviewError}
-                    />
-                  )}
-                  {pipelinePreviewRunId != null && !pipelinePreviewError && (
-                    <p className="text-xs text-text-muted">
-                      {t(
-                        "watchlists:overview.pipelineSetup.preview.context",
-                        "Preview context run: #{{runId}}",
-                        { runId: pipelinePreviewRunId }
-                      )}
-                    </p>
-                  )}
-                  {pipelinePreviewWarnings.length > 0 && (
-                    <ul className="list-disc pl-5 text-xs text-text-muted">
-                      {pipelinePreviewWarnings.map((warning, index) => (
-                        <li key={`${warning}-${index}`}>{warning}</li>
-                      ))}
-                    </ul>
-                  )}
-                  {pipelinePreviewRendered && (
-                    <pre
-                      className="max-h-48 overflow-auto rounded border border-border bg-background p-2 text-xs"
-                      data-testid="watchlists-pipeline-preview-rendered"
-                    >
-                      {pipelinePreviewRendered}
-                    </pre>
-                  )}
-                </div>
-              </div>
-            )}
-          </Form>
-        </div>
-      </Modal>
+        onSubmit={(draft, options) => {
+          void completePipelineSetup(draft, options)
+        }}
+        onPreview={(draft) => {
+          void generatePipelineTemplatePreview(draft)
+        }}
+      />
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
@@ -5,6 +5,7 @@ import {
   Checkbox,
   Form,
   Input,
+  InputNumber,
   Modal,
   Radio,
   Select,
@@ -15,6 +16,14 @@ import {
 import { useTranslation } from "react-i18next"
 import type { WatchlistSource } from "@/types/watchlists"
 import {
+  INTERVAL_HOURS_MAX,
+  INTERVAL_HOURS_MIN,
+  INTERVAL_MINUTES_MAX,
+  INTERVAL_MINUTES_MIN,
+  type ScheduleIntervalUnit,
+  type WeekdayToken
+} from "../JobsTab/schedule-utils"
+import {
   buildPipelineWizardReviewSummary,
   createDefaultPipelineWizardDraft,
   type PipelineWizardAudioSpeakerDraft,
@@ -23,7 +32,6 @@ import {
   type PipelineWizardSourceMode,
   validatePipelineWizardDraft
 } from "./pipeline-wizard-state"
-import type { ScheduleIntervalUnit, WeekdayToken } from "../JobsTab/schedule-utils"
 
 interface PipelineWizardProps {
   open: boolean
@@ -45,46 +53,18 @@ export type { PipelineWizardProps }
 const STEP_COUNT = 5
 const LAST_STEP = STEP_COUNT - 1
 
-const WEEKDAY_OPTIONS: Array<{ value: WeekdayToken; label: string }> = [
-  { value: "MON", label: "Monday" },
-  { value: "TUE", label: "Tuesday" },
-  { value: "WED", label: "Wednesday" },
-  { value: "THU", label: "Thursday" },
-  { value: "FRI", label: "Friday" },
-  { value: "SAT", label: "Saturday" },
-  { value: "SUN", label: "Sunday" }
-]
-
-const SCHEDULE_OPTIONS: Array<{ value: PipelineWizardScheduleMode; label: string }> = [
-  { value: "manual", label: "Manual only" },
-  { value: "interval", label: "Every N hours/minutes" },
-  { value: "daily", label: "Daily" },
-  { value: "weekly", label: "Weekly" }
-]
-
-const INTERVAL_UNIT_OPTIONS: Array<{ value: ScheduleIntervalUnit; label: string }> = [
-  { value: "hours", label: "Hours" },
-  { value: "minutes", label: "Minutes" }
-]
-
-const SPEAKER_COUNT_OPTIONS = [
-  { value: 1, label: "1 speaker" },
-  { value: 2, label: "2 speakers" },
-  { value: 3, label: "3 speakers" },
-  { value: 4, label: "4 speakers" }
-]
-
 const DEFAULT_SPEAKER_VOICES = ["alloy", "nova", "echo", "fable"]
 
 const createSpeakers = (
   count: number,
-  existing: PipelineWizardAudioSpeakerDraft[]
+  existing: PipelineWizardAudioSpeakerDraft[],
+  speakerLabel: (index: number) => string = (index) => `Speaker ${index}`
 ): PipelineWizardAudioSpeakerDraft[] =>
   Array.from({ length: Math.max(1, Math.min(4, count)) }, (_item, index) => {
     const current = existing[index]
     return {
       id: current?.id || `speaker_${index + 1}`,
-      label: current?.label || `Speaker ${index + 1}`,
+      label: current?.label || speakerLabel(index + 1),
       role: current?.role || (index === 0 ? "host" : "speaker"),
       voice: current?.voice || DEFAULT_SPEAKER_VOICES[index] || DEFAULT_SPEAKER_VOICES[0],
       persona: current?.persona
@@ -141,12 +121,19 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
     setStepErrors([])
   }
 
+  const getSpeakerLabel = (index: number) =>
+    t("watchlists:overview.pipelineSetup.speaker.defaultLabel", "Speaker {{index}}", { index })
+
   const updateSpeaker = (
     index: number,
     patch: Partial<PipelineWizardAudioSpeakerDraft>
   ) => {
     setDraft((previous) => {
-      const nextSpeakers = createSpeakers(previous.audioSpeakers.length || 1, previous.audioSpeakers)
+      const nextSpeakers = createSpeakers(
+        previous.audioSpeakers.length || 1,
+        previous.audioSpeakers,
+        getSpeakerLabel
+      )
       nextSpeakers[index] = {
         ...nextSpeakers[index],
         ...patch
@@ -159,9 +146,100 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
     setStepErrors([])
   }
 
+  const weekdayOptions = useMemo<Array<{ value: WeekdayToken; label: string }>>(
+    () => [
+      { value: "MON", label: t("watchlists:overview.pipelineSetup.weekdays.monday", "Monday") },
+      { value: "TUE", label: t("watchlists:overview.pipelineSetup.weekdays.tuesday", "Tuesday") },
+      { value: "WED", label: t("watchlists:overview.pipelineSetup.weekdays.wednesday", "Wednesday") },
+      { value: "THU", label: t("watchlists:overview.pipelineSetup.weekdays.thursday", "Thursday") },
+      { value: "FRI", label: t("watchlists:overview.pipelineSetup.weekdays.friday", "Friday") },
+      { value: "SAT", label: t("watchlists:overview.pipelineSetup.weekdays.saturday", "Saturday") },
+      { value: "SUN", label: t("watchlists:overview.pipelineSetup.weekdays.sunday", "Sunday") }
+    ],
+    [t]
+  )
+  const weekdayLabelByToken = useMemo(
+    () => Object.fromEntries(weekdayOptions.map((option) => [option.value, option.label])) as Record<WeekdayToken, string>,
+    [weekdayOptions]
+  )
+  const scheduleOptions = useMemo<Array<{ value: PipelineWizardScheduleMode; label: string }>>(
+    () => [
+      { value: "manual", label: t("watchlists:overview.pipelineSetup.schedule.manual", "Manual only") },
+      { value: "interval", label: t("watchlists:overview.pipelineSetup.schedule.interval", "Every N hours/minutes") },
+      { value: "daily", label: t("watchlists:overview.pipelineSetup.schedule.daily", "Daily") },
+      { value: "weekly", label: t("watchlists:overview.pipelineSetup.schedule.weekly", "Weekly") }
+    ],
+    [t]
+  )
+  const intervalUnitOptions = useMemo<Array<{ value: ScheduleIntervalUnit; label: string }>>(
+    () => [
+      { value: "hours", label: t("watchlists:overview.pipelineSetup.intervalUnits.hours", "Hours") },
+      { value: "minutes", label: t("watchlists:overview.pipelineSetup.intervalUnits.minutes", "Minutes") }
+    ],
+    [t]
+  )
+  const speakerCountOptions = useMemo(
+    () => [1, 2, 3, 4].map((count) => ({
+      value: count,
+      label: t(
+        "watchlists:overview.pipelineSetup.speaker.count",
+        `${count} speaker${count === 1 ? "" : "s"}`,
+        { count }
+      )
+    })),
+    [t]
+  )
+
+  const reviewSummaryCopy = useMemo(() => ({
+    newFeed: t("watchlists:overview.pipelineSetup.review.newFeed", "New feed"),
+    noFeedsSelected: t("watchlists:overview.pipelineSetup.review.noFeedsSelected", "No feeds selected"),
+    feedLabel: (id: number) => t("watchlists:overview.pipelineSetup.review.feedLabel", "Feed #{{id}}", { id }),
+    filters: t(
+      "watchlists:overview.pipelineSetup.review.filtersRefine",
+      "Monitor filters can be refined after creation"
+    ),
+    noTemplate: t("watchlists:overview.pipelineSetup.review.noTemplate", "No template"),
+    outputDigest: (templateName: string) =>
+      t("watchlists:overview.pipelineSetup.review.outputDigest", "{{templateName}} digest", { templateName }),
+    email: t("watchlists:overview.pipelineSetup.review.delivery.email", "Email"),
+    chatbook: t("watchlists:overview.pipelineSetup.review.delivery.chatbook", "Chatbook"),
+    inAppReports: t("watchlists:overview.pipelineSetup.review.delivery.inAppReports", "In-app reports"),
+    audioBriefing: (speakerCount: number) =>
+      t(
+        "watchlists:overview.pipelineSetup.review.audioBriefing",
+        `${speakerCount} speaker${speakerCount === 1 ? "" : "s"} audio briefing`,
+        { count: speakerCount }
+      ),
+    audioDisabled: t("watchlists:overview.pipelineSetup.review.audioDisabled", "Audio disabled"),
+    cadence: {
+      manual: t("watchlists:overview.pipelineSetup.schedule.manual", "Manual only"),
+      interval: (value: number, unit: ScheduleIntervalUnit) =>
+        unit === "minutes"
+          ? t(
+            "watchlists:overview.pipelineSetup.review.cadence.everyMinutes",
+            `Every ${value} minute${value === 1 ? "" : "s"}`,
+            { count: value }
+          )
+          : t(
+            "watchlists:overview.pipelineSetup.review.cadence.everyHours",
+            `Every ${value} hour${value === 1 ? "" : "s"}`,
+            { count: value }
+          ),
+      daily: (time: string) =>
+        t("watchlists:overview.pipelineSetup.review.cadence.daily", "Daily at {{time}}", { time }),
+      weekly: (weekday: string, time: string) =>
+        t(
+          "watchlists:overview.pipelineSetup.review.cadence.weekly",
+          "Weekly on {{weekday}} at {{time}}",
+          { weekday, time }
+        ),
+      weekdayLabels: weekdayLabelByToken
+    }
+  }), [t, weekdayLabelByToken])
+
   const summary = useMemo(
-    () => buildPipelineWizardReviewSummary(draft, sources),
-    [draft, sources]
+    () => buildPipelineWizardReviewSummary(draft, sources, reviewSummaryCopy),
+    [draft, reviewSummaryCopy, sources]
   )
 
   const stepItems = useMemo(
@@ -181,7 +259,9 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
       if (currentStep === 0) {
         return draft.sourceMode === "new" ? ["sourceName", "sourceUrl"] : ["sourceIds"]
       }
-      if (currentStep === 1) return ["monitorName", "scheduleIntervalValue"]
+      if (currentStep === 1) {
+        return ["monitorName", "scheduleIntervalValue", "scheduleHour", "scheduleMinute"]
+      }
       if (currentStep === 2) return ["templateName", "emailRecipients"]
       if (currentStep === 3) {
         return [
@@ -209,7 +289,12 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
       setStepErrors(validation.errors)
       const firstError = validation.errors[0]
       if (["sourceIds", "sourceName", "sourceUrl"].includes(firstError)) setCurrentStep(0)
-      else if (["monitorName", "scheduleIntervalValue"].includes(firstError)) setCurrentStep(1)
+      else if ([
+        "monitorName",
+        "scheduleIntervalValue",
+        "scheduleHour",
+        "scheduleMinute"
+      ].includes(firstError)) setCurrentStep(1)
       else if (["templateName", "emailRecipients"].includes(firstError)) setCurrentStep(2)
       else setCurrentStep(3)
       return
@@ -218,6 +303,10 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
   }
 
   const currentSpeakerCount = Math.max(1, Math.min(4, draft.audioSpeakers.length || 1))
+  const intervalMin =
+    draft.scheduleIntervalUnit === "minutes" ? INTERVAL_MINUTES_MIN : INTERVAL_HOURS_MIN
+  const intervalMax =
+    draft.scheduleIntervalUnit === "minutes" ? INTERVAL_MINUTES_MAX : INTERVAL_HOURS_MAX
 
   return (
     <Modal
@@ -360,7 +449,7 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
               <Select
                 aria-label={t("watchlists:overview.pipelineSetup.fields.schedule", "Schedule")}
                 value={draft.scheduleMode}
-                options={SCHEDULE_OPTIONS}
+                options={scheduleOptions}
                 onChange={(value) => updateDraft({ scheduleMode: value })}
               />
             </Form.Item>
@@ -370,19 +459,21 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                   label={t("watchlists:overview.pipelineSetup.fields.intervalEvery", "Every")}
                   validateStatus={stepErrors.includes("scheduleIntervalValue") ? "error" : undefined}
                 >
-                  <Input
+                  <InputNumber
                     aria-label={t("watchlists:overview.pipelineSetup.fields.intervalEvery", "Every")}
-                    type="number"
-                    min={1}
+                    className="w-full"
+                    min={intervalMin}
+                    max={intervalMax}
+                    precision={0}
                     value={draft.scheduleIntervalValue}
-                    onChange={(event) => updateDraft({ scheduleIntervalValue: Number(event.target.value) })}
+                    onChange={(value) => updateDraft({ scheduleIntervalValue: Number(value) })}
                   />
                 </Form.Item>
                 <Form.Item label={t("watchlists:overview.pipelineSetup.fields.intervalUnit", "Interval unit")}>
                   <Select
                     aria-label={t("watchlists:overview.pipelineSetup.fields.intervalUnit", "Interval unit")}
                     value={draft.scheduleIntervalUnit}
-                    options={INTERVAL_UNIT_OPTIONS}
+                    options={intervalUnitOptions}
                     onChange={(value) => updateDraft({ scheduleIntervalUnit: value })}
                   />
                 </Form.Item>
@@ -395,29 +486,37 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                     <Select
                       aria-label={t("watchlists:overview.pipelineSetup.fields.weekday", "Weekday")}
                       value={draft.scheduleWeekday}
-                      options={WEEKDAY_OPTIONS}
+                      options={weekdayOptions}
                       onChange={(value) => updateDraft({ scheduleWeekday: value })}
                     />
                   </Form.Item>
                 )}
-                <Form.Item label={t("watchlists:overview.pipelineSetup.fields.hour", "Hour")}>
-                  <Input
+                <Form.Item
+                  label={t("watchlists:overview.pipelineSetup.fields.hour", "Hour")}
+                  validateStatus={stepErrors.includes("scheduleHour") ? "error" : undefined}
+                >
+                  <InputNumber
                     aria-label={t("watchlists:overview.pipelineSetup.fields.hour", "Hour")}
-                    type="number"
+                    className="w-full"
                     min={0}
                     max={23}
+                    precision={0}
                     value={draft.scheduleHour}
-                    onChange={(event) => updateDraft({ scheduleHour: Number(event.target.value) })}
+                    onChange={(value) => updateDraft({ scheduleHour: Number(value) })}
                   />
                 </Form.Item>
-                <Form.Item label={t("watchlists:overview.pipelineSetup.fields.minute", "Minute")}>
-                  <Input
+                <Form.Item
+                  label={t("watchlists:overview.pipelineSetup.fields.minute", "Minute")}
+                  validateStatus={stepErrors.includes("scheduleMinute") ? "error" : undefined}
+                >
+                  <InputNumber
                     aria-label={t("watchlists:overview.pipelineSetup.fields.minute", "Minute")}
-                    type="number"
+                    className="w-full"
                     min={0}
                     max={59}
+                    precision={0}
                     value={draft.scheduleMinute}
-                    onChange={(event) => updateDraft({ scheduleMinute: Number(event.target.value) })}
+                    onChange={(value) => updateDraft({ scheduleMinute: Number(value) })}
                   />
                 </Form.Item>
               </div>
@@ -483,7 +582,9 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                 checked={draft.audioEnabled}
                 onChange={(checked) => updateDraft({
                   audioEnabled: checked,
-                  audioSpeakers: checked ? createSpeakers(currentSpeakerCount, draft.audioSpeakers) : []
+                  audioSpeakers: checked
+                    ? createSpeakers(currentSpeakerCount, draft.audioSpeakers, getSpeakerLabel)
+                    : []
                 })}
               />
             </Form.Item>
@@ -494,8 +595,10 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                     <Select
                       aria-label={t("watchlists:overview.pipelineSetup.fields.speakerCount", "Speaker count")}
                       value={currentSpeakerCount}
-                      options={SPEAKER_COUNT_OPTIONS}
-                      onChange={(value) => updateDraft({ audioSpeakers: createSpeakers(value, draft.audioSpeakers) })}
+                      options={speakerCountOptions}
+                      onChange={(value) => updateDraft({
+                        audioSpeakers: createSpeakers(value, draft.audioSpeakers, getSpeakerLabel)
+                      })}
                     />
                   </Form.Item>
                   <Form.Item
@@ -517,16 +620,36 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                       key={speaker.id || index}
                       className="grid gap-3 rounded-md border border-border bg-surface p-3 sm:grid-cols-2"
                     >
-                      <Form.Item label={`Speaker ${index + 1} label`}>
+                      <Form.Item
+                        label={t(
+                          "watchlists:overview.pipelineSetup.speaker.labelField",
+                          "Speaker {{index}} label",
+                          { index: index + 1 }
+                        )}
+                      >
                         <Input
-                          aria-label={`Speaker ${index + 1} label`}
+                          aria-label={t(
+                            "watchlists:overview.pipelineSetup.speaker.labelField",
+                            "Speaker {{index}} label",
+                            { index: index + 1 }
+                          )}
                           value={speaker.label}
                           onChange={(event) => updateSpeaker(index, { label: event.target.value })}
                         />
                       </Form.Item>
-                      <Form.Item label={`Speaker ${index + 1} voice`}>
+                      <Form.Item
+                        label={t(
+                          "watchlists:overview.pipelineSetup.speaker.voiceField",
+                          "Speaker {{index}} voice",
+                          { index: index + 1 }
+                        )}
+                      >
                         <Select
-                          aria-label={`Speaker ${index + 1} voice`}
+                          aria-label={t(
+                            "watchlists:overview.pipelineSetup.speaker.voiceField",
+                            "Speaker {{index}} voice",
+                            { index: index + 1 }
+                          )}
                           value={speaker.voice}
                           options={DEFAULT_SPEAKER_VOICES.map((voice) => ({
                             value: voice,
@@ -549,12 +672,42 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
               className="rounded-md border border-border bg-surface p-3"
               data-testid="watchlists-pipeline-review-summary"
             >
-              <p><span className="font-medium">Sources:</span> {summary.sources}</p>
-              <p><span className="font-medium">Cadence:</span> {summary.cadence}</p>
-              <p><span className="font-medium">Filters:</span> {summary.filters}</p>
-              <p><span className="font-medium">Output:</span> {summary.output}</p>
-              <p><span className="font-medium">Delivery:</span> {summary.delivery}</p>
-              <p><span className="font-medium">Audio:</span> {summary.audio}</p>
+              <p>
+                <span className="font-medium">
+                  {t("watchlists:overview.pipelineSetup.review.sources", "Sources")}:
+                </span>{" "}
+                {summary.sources}
+              </p>
+              <p>
+                <span className="font-medium">
+                  {t("watchlists:overview.pipelineSetup.review.cadence", "Cadence")}:
+                </span>{" "}
+                {summary.cadence}
+              </p>
+              <p>
+                <span className="font-medium">
+                  {t("watchlists:overview.pipelineSetup.review.filters", "Filters")}:
+                </span>{" "}
+                {summary.filters}
+              </p>
+              <p>
+                <span className="font-medium">
+                  {t("watchlists:overview.pipelineSetup.review.output", "Output")}:
+                </span>{" "}
+                {summary.output}
+              </p>
+              <p>
+                <span className="font-medium">
+                  {t("watchlists:overview.pipelineSetup.review.delivery", "Delivery")}:
+                </span>{" "}
+                {summary.delivery}
+              </p>
+              <p>
+                <span className="font-medium">
+                  {t("watchlists:overview.pipelineSetup.review.audio", "Audio")}:
+                </span>{" "}
+                {summary.audio}
+              </p>
             </div>
             <div className="rounded-md border border-border bg-surface p-3 space-y-2">
               <div className="flex flex-wrap items-center justify-between gap-2">

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
@@ -1,0 +1,614 @@
+import React, { useEffect, useMemo, useState } from "react"
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Form,
+  Input,
+  Modal,
+  Radio,
+  Select,
+  Space,
+  Steps,
+  Switch
+} from "antd"
+import { useTranslation } from "react-i18next"
+import type { WatchlistSource } from "@/types/watchlists"
+import {
+  buildPipelineWizardReviewSummary,
+  createDefaultPipelineWizardDraft,
+  type PipelineWizardAudioSpeakerDraft,
+  type PipelineWizardDraft,
+  type PipelineWizardScheduleMode,
+  type PipelineWizardSourceMode,
+  validatePipelineWizardDraft
+} from "./pipeline-wizard-state"
+import type { ScheduleIntervalUnit, WeekdayToken } from "../JobsTab/schedule-utils"
+
+interface PipelineWizardProps {
+  open: boolean
+  sources: WatchlistSource[]
+  sourcesLoading: boolean
+  submitting: boolean
+  previewLoading: boolean
+  previewError: string | null
+  previewRendered: string | null
+  previewRunId: number | null
+  previewWarnings: string[]
+  onCancel: () => void
+  onSubmit: (draft: PipelineWizardDraft, options: { mode: "create" | "test" }) => void
+  onPreview: (draft: PipelineWizardDraft) => void
+}
+
+export type { PipelineWizardProps }
+
+const STEP_COUNT = 5
+const LAST_STEP = STEP_COUNT - 1
+
+const WEEKDAY_OPTIONS: Array<{ value: WeekdayToken; label: string }> = [
+  { value: "MON", label: "Monday" },
+  { value: "TUE", label: "Tuesday" },
+  { value: "WED", label: "Wednesday" },
+  { value: "THU", label: "Thursday" },
+  { value: "FRI", label: "Friday" },
+  { value: "SAT", label: "Saturday" },
+  { value: "SUN", label: "Sunday" }
+]
+
+const SCHEDULE_OPTIONS: Array<{ value: PipelineWizardScheduleMode; label: string }> = [
+  { value: "manual", label: "Manual only" },
+  { value: "interval", label: "Every N hours/minutes" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" }
+]
+
+const INTERVAL_UNIT_OPTIONS: Array<{ value: ScheduleIntervalUnit; label: string }> = [
+  { value: "hours", label: "Hours" },
+  { value: "minutes", label: "Minutes" }
+]
+
+const SPEAKER_COUNT_OPTIONS = [
+  { value: 1, label: "1 speaker" },
+  { value: 2, label: "2 speakers" },
+  { value: 3, label: "3 speakers" },
+  { value: 4, label: "4 speakers" }
+]
+
+const DEFAULT_SPEAKER_VOICES = ["alloy", "nova", "echo", "fable"]
+
+const createSpeakers = (
+  count: number,
+  existing: PipelineWizardAudioSpeakerDraft[]
+): PipelineWizardAudioSpeakerDraft[] =>
+  Array.from({ length: Math.max(1, Math.min(4, count)) }, (_item, index) => {
+    const current = existing[index]
+    return {
+      id: current?.id || `speaker_${index + 1}`,
+      label: current?.label || `Speaker ${index + 1}`,
+      role: current?.role || (index === 0 ? "host" : "speaker"),
+      voice: current?.voice || DEFAULT_SPEAKER_VOICES[index] || DEFAULT_SPEAKER_VOICES[0],
+      persona: current?.persona
+    }
+  })
+
+export const PipelineWizard: React.FC<PipelineWizardProps> = ({
+  open,
+  sources,
+  sourcesLoading,
+  submitting,
+  previewLoading,
+  previewError,
+  previewRendered,
+  previewRunId,
+  previewWarnings,
+  onCancel,
+  onSubmit,
+  onPreview
+}) => {
+  const { t } = useTranslation(["watchlists", "common"])
+  const [currentStep, setCurrentStep] = useState(0)
+  const [draft, setDraft] = useState<PipelineWizardDraft>(() => ({
+    ...createDefaultPipelineWizardDraft(),
+    templateName: "briefing_md"
+  }))
+  const [stepErrors, setStepErrors] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!open) return
+    setCurrentStep(0)
+    setStepErrors([])
+    setDraft({
+      ...createDefaultPipelineWizardDraft(),
+      templateName: "briefing_md"
+    })
+  }, [open])
+
+  useEffect(() => {
+    if (!open || draft.sourceIds.length > 0 || draft.sourceMode !== "existing") return
+    if (sources.length === 1) {
+      setDraft((previous) => ({
+        ...previous,
+        sourceIds: [sources[0].id]
+      }))
+    }
+  }, [draft.sourceIds.length, draft.sourceMode, open, sources])
+
+  const updateDraft = (patch: Partial<PipelineWizardDraft>) => {
+    setDraft((previous) => ({
+      ...previous,
+      ...patch
+    }))
+    setStepErrors([])
+  }
+
+  const updateSpeaker = (
+    index: number,
+    patch: Partial<PipelineWizardAudioSpeakerDraft>
+  ) => {
+    setDraft((previous) => {
+      const nextSpeakers = createSpeakers(previous.audioSpeakers.length || 1, previous.audioSpeakers)
+      nextSpeakers[index] = {
+        ...nextSpeakers[index],
+        ...patch
+      }
+      return {
+        ...previous,
+        audioSpeakers: nextSpeakers
+      }
+    })
+    setStepErrors([])
+  }
+
+  const summary = useMemo(
+    () => buildPipelineWizardReviewSummary(draft, sources),
+    [draft, sources]
+  )
+
+  const stepItems = useMemo(
+    () => [
+      { title: t("watchlists:overview.pipelineSetup.steps.source", "Source") },
+      { title: t("watchlists:overview.pipelineSetup.steps.monitor", "Monitor") },
+      { title: t("watchlists:overview.pipelineSetup.steps.digest", "Digest") },
+      { title: t("watchlists:overview.pipelineSetup.steps.audio", "Audio") },
+      { title: t("watchlists:overview.pipelineSetup.steps.review", "Review") }
+    ],
+    [t]
+  )
+
+  const validateCurrentStep = (): boolean => {
+    const validation = validatePipelineWizardDraft(draft)
+    const currentStepFields: string[] = (() => {
+      if (currentStep === 0) {
+        return draft.sourceMode === "new" ? ["sourceName", "sourceUrl"] : ["sourceIds"]
+      }
+      if (currentStep === 1) return ["monitorName", "scheduleIntervalValue"]
+      if (currentStep === 2) return ["templateName", "emailRecipients"]
+      if (currentStep === 3) {
+        return [
+          "audioSpeakers",
+          "audioSpeakerIds",
+          "audioSpeakerVoices",
+          "targetAudioMinutes"
+        ]
+      }
+      return validation.errors
+    })()
+    const errors = validation.errors.filter((error) => currentStepFields.includes(error))
+    setStepErrors(errors)
+    return errors.length === 0
+  }
+
+  const handleNext = () => {
+    if (!validateCurrentStep()) return
+    setCurrentStep((previous) => Math.min(LAST_STEP, previous + 1))
+  }
+
+  const handleSubmit = (mode: "create" | "test") => {
+    const validation = validatePipelineWizardDraft(draft)
+    if (!validation.valid) {
+      setStepErrors(validation.errors)
+      const firstError = validation.errors[0]
+      if (["sourceIds", "sourceName", "sourceUrl"].includes(firstError)) setCurrentStep(0)
+      else if (["monitorName", "scheduleIntervalValue"].includes(firstError)) setCurrentStep(1)
+      else if (["templateName", "emailRecipients"].includes(firstError)) setCurrentStep(2)
+      else setCurrentStep(3)
+      return
+    }
+    onSubmit(draft, { mode })
+  }
+
+  const currentSpeakerCount = Math.max(1, Math.min(4, draft.audioSpeakers.length || 1))
+
+  return (
+    <Modal
+      open={open}
+      title={t("watchlists:overview.pipelineSetup.title", "Briefing pipeline builder")}
+      onCancel={onCancel}
+      destroyOnHidden
+      maskClosable={!submitting}
+      width={760}
+      footer={[
+        <Button key="cancel" onClick={onCancel} disabled={submitting}>
+          {t("common:cancel", "Cancel")}
+        </Button>,
+        <Button
+          key="back"
+          onClick={() => setCurrentStep((previous) => Math.max(0, previous - 1))}
+          disabled={submitting || currentStep === 0}
+        >
+          {t("common:back", "Back")}
+        </Button>,
+        currentStep === LAST_STEP ? (
+          <Button
+            key="test-generation"
+            data-testid="watchlists-pipeline-test-generation"
+            onClick={() => handleSubmit("test")}
+            loading={submitting}
+          >
+            {t("watchlists:overview.pipelineSetup.actions.testGeneration", "Run test generation")}
+          </Button>
+        ) : null,
+        <Button
+          key="next"
+          type="primary"
+          loading={submitting}
+          onClick={() => {
+            if (currentStep === LAST_STEP) {
+              handleSubmit("create")
+              return
+            }
+            handleNext()
+          }}
+        >
+          {currentStep === LAST_STEP
+            ? t("watchlists:overview.pipelineSetup.actions.finish", "Create pipeline")
+            : t("common:next", "Next")}
+        </Button>
+      ]}
+    >
+      <div className="space-y-4">
+        <Steps size="small" current={currentStep} items={stepItems} />
+        {stepErrors.length > 0 && (
+          <Alert
+            type="warning"
+            showIcon
+            title={t(
+              "watchlists:overview.pipelineSetup.validationError",
+              "Review the highlighted pipeline fields."
+            )}
+          />
+        )}
+
+        {currentStep === 0 && (
+          <div className="space-y-3">
+            <Radio.Group
+              value={draft.sourceMode}
+              onChange={(event) => updateDraft({ sourceMode: event.target.value as PipelineWizardSourceMode })}
+            >
+              <Space orientation="vertical">
+                <Radio value="existing">{t("watchlists:overview.pipelineSetup.source.existing", "Use existing feeds")}</Radio>
+                <Radio value="new">{t("watchlists:overview.pipelineSetup.source.new", "Create a new feed")}</Radio>
+              </Space>
+            </Radio.Group>
+
+            {draft.sourceMode === "existing" ? (
+              <Form layout="vertical">
+                <Form.Item
+                  label={t("watchlists:overview.pipelineSetup.fields.sources", "Feeds")}
+                  validateStatus={stepErrors.includes("sourceIds") ? "error" : undefined}
+                  help={stepErrors.includes("sourceIds") ? t("watchlists:overview.pipelineSetup.validation.sourcesRequired", "Select at least one feed") : undefined}
+                >
+                  <Checkbox.Group
+                    className="grid gap-2"
+                    value={draft.sourceIds}
+                    onChange={(values) => updateDraft({ sourceIds: values.map((value) => Number(value)) })}
+                  >
+                    {sources.map((source) => (
+                      <Checkbox key={source.id} value={source.id}>
+                        {source.name || `Feed #${source.id}`}
+                      </Checkbox>
+                    ))}
+                  </Checkbox.Group>
+                </Form.Item>
+                {sourcesLoading && (
+                  <p className="text-xs text-text-muted">
+                    {t("watchlists:overview.pipelineSetup.sourcesLoading", "Loading feeds...")}
+                  </p>
+                )}
+              </Form>
+            ) : (
+              <Form layout="vertical">
+                <Form.Item
+                  label={t("watchlists:overview.pipelineSetup.fields.sourceName", "Feed name")}
+                  validateStatus={stepErrors.includes("sourceName") ? "error" : undefined}
+                >
+                  <Input
+                    aria-label={t("watchlists:overview.pipelineSetup.fields.sourceName", "Feed name")}
+                    value={draft.sourceName}
+                    onChange={(event) => updateDraft({ sourceName: event.target.value })}
+                  />
+                </Form.Item>
+                <Form.Item
+                  label={t("watchlists:overview.pipelineSetup.fields.sourceUrl", "Feed URL")}
+                  validateStatus={stepErrors.includes("sourceUrl") ? "error" : undefined}
+                  help={stepErrors.includes("sourceUrl") ? t("watchlists:overview.pipelineSetup.validation.sourceUrlRequired", "Enter a valid http or https feed URL") : undefined}
+                >
+                  <Input
+                    aria-label={t("watchlists:overview.pipelineSetup.fields.sourceUrl", "Feed URL")}
+                    value={draft.sourceUrl}
+                    onChange={(event) => updateDraft({ sourceUrl: event.target.value })}
+                  />
+                </Form.Item>
+              </Form>
+            )}
+          </div>
+        )}
+
+        {currentStep === 1 && (
+          <Form layout="vertical">
+            <Form.Item
+              label={t("watchlists:overview.pipelineSetup.fields.monitorName", "Monitor name")}
+              validateStatus={stepErrors.includes("monitorName") ? "error" : undefined}
+            >
+              <Input
+                aria-label={t("watchlists:overview.pipelineSetup.fields.monitorName", "Monitor name")}
+                value={draft.monitorName}
+                onChange={(event) => updateDraft({ monitorName: event.target.value })}
+              />
+            </Form.Item>
+            <Form.Item label={t("watchlists:overview.pipelineSetup.fields.schedule", "Schedule")}>
+              <Select
+                aria-label={t("watchlists:overview.pipelineSetup.fields.schedule", "Schedule")}
+                value={draft.scheduleMode}
+                options={SCHEDULE_OPTIONS}
+                onChange={(value) => updateDraft({ scheduleMode: value })}
+              />
+            </Form.Item>
+            {draft.scheduleMode === "interval" && (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Form.Item
+                  label={t("watchlists:overview.pipelineSetup.fields.intervalEvery", "Every")}
+                  validateStatus={stepErrors.includes("scheduleIntervalValue") ? "error" : undefined}
+                >
+                  <Input
+                    aria-label={t("watchlists:overview.pipelineSetup.fields.intervalEvery", "Every")}
+                    type="number"
+                    min={1}
+                    value={draft.scheduleIntervalValue}
+                    onChange={(event) => updateDraft({ scheduleIntervalValue: Number(event.target.value) })}
+                  />
+                </Form.Item>
+                <Form.Item label={t("watchlists:overview.pipelineSetup.fields.intervalUnit", "Interval unit")}>
+                  <Select
+                    aria-label={t("watchlists:overview.pipelineSetup.fields.intervalUnit", "Interval unit")}
+                    value={draft.scheduleIntervalUnit}
+                    options={INTERVAL_UNIT_OPTIONS}
+                    onChange={(value) => updateDraft({ scheduleIntervalUnit: value })}
+                  />
+                </Form.Item>
+              </div>
+            )}
+            {(draft.scheduleMode === "daily" || draft.scheduleMode === "weekly") && (
+              <div className="grid gap-3 sm:grid-cols-3">
+                {draft.scheduleMode === "weekly" && (
+                  <Form.Item label={t("watchlists:overview.pipelineSetup.fields.weekday", "Weekday")}>
+                    <Select
+                      aria-label={t("watchlists:overview.pipelineSetup.fields.weekday", "Weekday")}
+                      value={draft.scheduleWeekday}
+                      options={WEEKDAY_OPTIONS}
+                      onChange={(value) => updateDraft({ scheduleWeekday: value })}
+                    />
+                  </Form.Item>
+                )}
+                <Form.Item label={t("watchlists:overview.pipelineSetup.fields.hour", "Hour")}>
+                  <Input
+                    aria-label={t("watchlists:overview.pipelineSetup.fields.hour", "Hour")}
+                    type="number"
+                    min={0}
+                    max={23}
+                    value={draft.scheduleHour}
+                    onChange={(event) => updateDraft({ scheduleHour: Number(event.target.value) })}
+                  />
+                </Form.Item>
+                <Form.Item label={t("watchlists:overview.pipelineSetup.fields.minute", "Minute")}>
+                  <Input
+                    aria-label={t("watchlists:overview.pipelineSetup.fields.minute", "Minute")}
+                    type="number"
+                    min={0}
+                    max={59}
+                    value={draft.scheduleMinute}
+                    onChange={(event) => updateDraft({ scheduleMinute: Number(event.target.value) })}
+                  />
+                </Form.Item>
+              </div>
+            )}
+            <Form.Item label={t("watchlists:overview.pipelineSetup.fields.runNow", "Run immediately")}>
+              <Switch
+                aria-label={t("watchlists:overview.pipelineSetup.fields.runNow", "Run immediately")}
+                checked={draft.runNow}
+                onChange={(checked) => updateDraft({ runNow: checked })}
+              />
+            </Form.Item>
+          </Form>
+        )}
+
+        {currentStep === 2 && (
+          <Form layout="vertical">
+            <Form.Item
+              label={t("watchlists:overview.pipelineSetup.fields.template", "Template")}
+              validateStatus={stepErrors.includes("templateName") ? "error" : undefined}
+            >
+              <Input
+                aria-label={t("watchlists:overview.pipelineSetup.fields.template", "Template")}
+                value={draft.templateName}
+                onChange={(event) => updateDraft({ templateName: event.target.value })}
+              />
+            </Form.Item>
+            <Form.Item label={t("watchlists:overview.pipelineSetup.fields.emailDelivery", "Email delivery")}>
+              <Switch
+                aria-label={t("watchlists:overview.pipelineSetup.fields.emailDelivery", "Email delivery")}
+                checked={draft.emailDeliveryEnabled}
+                onChange={(checked) => updateDraft({ emailDeliveryEnabled: checked })}
+              />
+            </Form.Item>
+            {draft.emailDeliveryEnabled && (
+              <Form.Item
+                label={t("watchlists:overview.pipelineSetup.fields.emailRecipients", "Email recipients")}
+                validateStatus={stepErrors.includes("emailRecipients") ? "error" : undefined}
+              >
+                <Select
+                  mode="tags"
+                  tokenSeparators={[","]}
+                  aria-label={t("watchlists:overview.pipelineSetup.fields.emailRecipients", "Email recipients")}
+                  value={draft.emailRecipients}
+                  onChange={(value) => updateDraft({ emailRecipients: value })}
+                />
+              </Form.Item>
+            )}
+            <Form.Item label={t("watchlists:overview.pipelineSetup.fields.chatbookDelivery", "Chatbook delivery")}>
+              <Switch
+                aria-label={t("watchlists:overview.pipelineSetup.fields.chatbookDelivery", "Chatbook delivery")}
+                checked={draft.chatbookDeliveryEnabled}
+                onChange={(checked) => updateDraft({ chatbookDeliveryEnabled: checked })}
+              />
+            </Form.Item>
+          </Form>
+        )}
+
+        {currentStep === 3 && (
+          <Form layout="vertical">
+            <Form.Item label={t("watchlists:overview.pipelineSetup.fields.includeAudio", "Audio briefing")}>
+              <Switch
+                aria-label={t("watchlists:overview.pipelineSetup.fields.includeAudio", "Audio briefing")}
+                checked={draft.audioEnabled}
+                onChange={(checked) => updateDraft({
+                  audioEnabled: checked,
+                  audioSpeakers: checked ? createSpeakers(currentSpeakerCount, draft.audioSpeakers) : []
+                })}
+              />
+            </Form.Item>
+            {draft.audioEnabled && (
+              <>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Form.Item label={t("watchlists:overview.pipelineSetup.fields.speakerCount", "Speaker count")}>
+                    <Select
+                      aria-label={t("watchlists:overview.pipelineSetup.fields.speakerCount", "Speaker count")}
+                      value={currentSpeakerCount}
+                      options={SPEAKER_COUNT_OPTIONS}
+                      onChange={(value) => updateDraft({ audioSpeakers: createSpeakers(value, draft.audioSpeakers) })}
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    label={t("watchlists:overview.pipelineSetup.fields.audioMinutes", "Target audio minutes")}
+                    validateStatus={stepErrors.includes("targetAudioMinutes") ? "error" : undefined}
+                  >
+                    <Input
+                      aria-label={t("watchlists:overview.pipelineSetup.fields.audioMinutes", "Target audio minutes")}
+                      type="number"
+                      min={1}
+                      value={draft.targetAudioMinutes}
+                      onChange={(event) => updateDraft({ targetAudioMinutes: Number(event.target.value) })}
+                    />
+                  </Form.Item>
+                </div>
+                <div className="space-y-3">
+                  {draft.audioSpeakers.map((speaker, index) => (
+                    <div
+                      key={speaker.id || index}
+                      className="grid gap-3 rounded-md border border-border bg-surface p-3 sm:grid-cols-2"
+                    >
+                      <Form.Item label={`Speaker ${index + 1} label`}>
+                        <Input
+                          aria-label={`Speaker ${index + 1} label`}
+                          value={speaker.label}
+                          onChange={(event) => updateSpeaker(index, { label: event.target.value })}
+                        />
+                      </Form.Item>
+                      <Form.Item label={`Speaker ${index + 1} voice`}>
+                        <Select
+                          aria-label={`Speaker ${index + 1} voice`}
+                          value={speaker.voice}
+                          options={DEFAULT_SPEAKER_VOICES.map((voice) => ({
+                            value: voice,
+                            label: voice
+                          }))}
+                          onChange={(value) => updateSpeaker(index, { voice: value })}
+                        />
+                      </Form.Item>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </Form>
+        )}
+
+        {currentStep === 4 && (
+          <div className="space-y-3 text-sm">
+            <div
+              className="rounded-md border border-border bg-surface p-3"
+              data-testid="watchlists-pipeline-review-summary"
+            >
+              <p><span className="font-medium">Sources:</span> {summary.sources}</p>
+              <p><span className="font-medium">Cadence:</span> {summary.cadence}</p>
+              <p><span className="font-medium">Filters:</span> {summary.filters}</p>
+              <p><span className="font-medium">Output:</span> {summary.output}</p>
+              <p><span className="font-medium">Delivery:</span> {summary.delivery}</p>
+              <p><span className="font-medium">Audio:</span> {summary.audio}</p>
+            </div>
+            <div className="rounded-md border border-border bg-surface p-3 space-y-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs text-text-muted">
+                  {t(
+                    "watchlists:overview.pipelineSetup.preview.description",
+                    "Preview template output using the latest completed run context before creating the pipeline."
+                  )}
+                </p>
+                <Button
+                  size="small"
+                  onClick={() => onPreview(draft)}
+                  loading={previewLoading}
+                  data-testid="watchlists-pipeline-preview-generate"
+                >
+                  {t("watchlists:overview.pipelineSetup.preview.generate", "Generate preview")}
+                </Button>
+              </div>
+              {previewError && (
+                <Alert
+                  type="warning"
+                  showIcon
+                  data-testid="watchlists-pipeline-preview-error"
+                  title={previewError}
+                />
+              )}
+              {previewRunId != null && !previewError && (
+                <p className="text-xs text-text-muted">
+                  {t(
+                    "watchlists:overview.pipelineSetup.preview.context",
+                    "Preview context run: #{{runId}}",
+                    { runId: previewRunId }
+                  )}
+                </p>
+              )}
+              {previewWarnings.length > 0 && (
+                <ul className="list-disc pl-5 text-xs text-text-muted">
+                  {previewWarnings.map((warning, index) => (
+                    <li key={`${warning}-${index}`}>{warning}</li>
+                  ))}
+                </ul>
+              )}
+              {previewRendered && (
+                <pre
+                  className="max-h-48 overflow-auto rounded border border-border bg-background p-2 text-xs"
+                  data-testid="watchlists-pipeline-preview-rendered"
+                >
+                  {previewRendered}
+                </pre>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
@@ -14,6 +14,7 @@ const mockState = vi.hoisted(() => ({
   fetchWatchlistRunsMock: vi.fn(),
   bulkCreateSourcesMock: vi.fn(),
   createWatchlistSourceMock: vi.fn(),
+  deleteWatchlistSourceMock: vi.fn(),
   createWatchlistJobMock: vi.fn(),
   deleteWatchlistJobMock: vi.fn(),
   triggerWatchlistRunMock: vi.fn(),
@@ -72,6 +73,7 @@ vi.mock("@/services/watchlists", () => ({
   fetchWatchlistRuns: (...args: unknown[]) => mockState.fetchWatchlistRunsMock(...args),
   bulkCreateSources: (...args: unknown[]) => mockState.bulkCreateSourcesMock(...args),
   createWatchlistSource: (...args: unknown[]) => mockState.createWatchlistSourceMock(...args),
+  deleteWatchlistSource: (...args: unknown[]) => mockState.deleteWatchlistSourceMock(...args),
   createWatchlistJob: (...args: unknown[]) => mockState.createWatchlistJobMock(...args),
   deleteWatchlistJob: (...args: unknown[]) => mockState.deleteWatchlistJobMock(...args),
   triggerWatchlistRun: (...args: unknown[]) => mockState.triggerWatchlistRunMock(...args),
@@ -783,6 +785,54 @@ describe("OverviewTab quick setup flow", () => {
       mode: "create",
       runNow: true
     })
+    consoleErrorSpy.mockRestore()
+  }, 20_000)
+
+  it("rolls back a wizard-created source when pipeline creation fails before run start", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    mockState.fetchOverviewMock.mockResolvedValue(
+      createOverviewPayload({
+        sources: { total: 2, healthy: 2 },
+        jobs: { total: 1, active: 1 }
+      })
+    )
+    mockState.createWatchlistSourceMock.mockResolvedValue({ id: 707 })
+    mockState.createWatchlistJobMock.mockRejectedValue(new Error("job failed"))
+    mockState.deleteWatchlistSourceMock.mockResolvedValue({ success: true, source_id: 707 })
+
+    render(<OverviewTab />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlists-overview-cta-pipeline-builder")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId("watchlists-overview-cta-pipeline-builder"))
+    await waitFor(() => {
+      expect(pipelineQueries().getByLabelText("Create a new feed")).toBeInTheDocument()
+    })
+    fireEvent.click(pipelineQueries().getByLabelText("Create a new feed"))
+    fireEvent.change(pipelineQueries().getByLabelText("Feed name"), {
+      target: { value: "Policy Feed" }
+    })
+    fireEvent.change(pipelineQueries().getByLabelText("Feed URL"), {
+      target: { value: "https://example.com/policy.xml" }
+    })
+    clickPipelineNext()
+    await waitFor(() => {
+      expect(pipelineQueries().getByLabelText("Monitor name")).toBeInTheDocument()
+    })
+    fireEvent.change(pipelineQueries().getByLabelText("Monitor name"), {
+      target: { value: "Policy Brief" }
+    })
+    await advancePipelineFromMonitorToReview()
+    fireEvent.click(pipelineQueries().getByRole("button", { name: "Create pipeline" }))
+
+    await waitFor(() => {
+      expect(mockState.deleteWatchlistSourceMock).toHaveBeenCalledWith(707)
+    })
+    expect(mockState.deleteWatchlistJobMock).not.toHaveBeenCalled()
+    expect(mockState.openOutputPreviewMock).not.toHaveBeenCalled()
+    expect(mockState.openRunDetailMock).not.toHaveBeenCalled()
     consoleErrorSpy.mockRestore()
   }, 20_000)
 

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
@@ -175,6 +175,21 @@ const clickPipelineNext = () => {
   fireEvent.click(pipelineQueries().getByRole("button", { name: "Next" }))
 }
 
+const advancePipelineFromMonitorToReview = async () => {
+  clickPipelineNext()
+  await waitFor(() => {
+    expect(pipelineQueries().getByLabelText("Template")).toBeInTheDocument()
+  })
+  clickPipelineNext()
+  await waitFor(() => {
+    expect(pipelineQueries().getByLabelText("Audio briefing")).toBeInTheDocument()
+  })
+  clickPipelineNext()
+  await waitFor(() => {
+    expect(screen.getByTestId("watchlists-pipeline-review-summary")).toBeInTheDocument()
+  })
+}
+
 const selectPipelineFeed = async (label: string) => {
   await waitFor(() => {
     const checkbox = pipelineQueries().getByRole("checkbox", { name: label }) as HTMLInputElement
@@ -679,7 +694,7 @@ describe("OverviewTab quick setup flow", () => {
     fireEvent.change(pipelineQueries().getByLabelText("Monitor name"), {
       target: { value: "Morning Brief" }
     })
-    clickPipelineNext()
+    await advancePipelineFromMonitorToReview()
     await waitFor(() => {
       expect(pipelineQueries().getByRole("button", { name: "Create pipeline" })).toBeInTheDocument()
     })
@@ -703,14 +718,6 @@ describe("OverviewTab quick setup flow", () => {
     expect(mockState.openOutputPreviewMock).toHaveBeenCalledWith(505)
     expect(mockState.trackWatchlistsOnboardingTelemetryMock).toHaveBeenCalledWith({
       type: "pipeline_setup_opened"
-    })
-    expect(mockState.trackWatchlistsOnboardingTelemetryMock).toHaveBeenCalledWith({
-      type: "pipeline_setup_step_completed",
-      step: "scope"
-    })
-    expect(mockState.trackWatchlistsOnboardingTelemetryMock).toHaveBeenCalledWith({
-      type: "pipeline_setup_step_completed",
-      step: "briefing"
     })
     expect(mockState.trackWatchlistsOnboardingTelemetryMock).toHaveBeenCalledWith({
       type: "pipeline_setup_step_completed",
@@ -759,7 +766,7 @@ describe("OverviewTab quick setup flow", () => {
     fireEvent.change(pipelineQueries().getByLabelText("Monitor name"), {
       target: { value: "Morning Brief" }
     })
-    clickPipelineNext()
+    await advancePipelineFromMonitorToReview()
     await waitFor(() => {
       expect(pipelineQueries().getByRole("button", { name: "Create pipeline" })).toBeInTheDocument()
     })
@@ -826,7 +833,7 @@ describe("OverviewTab quick setup flow", () => {
     fireEvent.change(pipelineQueries().getByLabelText("Monitor name"), {
       target: { value: "Morning Brief" }
     })
-    clickPipelineNext()
+    await advancePipelineFromMonitorToReview()
 
     await waitFor(() => {
       expect(screen.getByTestId("watchlists-pipeline-preview-generate")).toBeInTheDocument()
@@ -883,7 +890,7 @@ describe("OverviewTab quick setup flow", () => {
     fireEvent.change(pipelineQueries().getByLabelText("Monitor name"), {
       target: { value: "Morning Brief" }
     })
-    clickPipelineNext()
+    await advancePipelineFromMonitorToReview()
 
     await waitFor(() => {
       expect(screen.getByTestId("watchlists-pipeline-preview-generate")).toBeInTheDocument()
@@ -931,7 +938,7 @@ describe("OverviewTab quick setup flow", () => {
     fireEvent.change(pipelineQueries().getByLabelText("Monitor name"), {
       target: { value: "Morning Brief" }
     })
-    clickPipelineNext()
+    await advancePipelineFromMonitorToReview()
     await waitFor(() => {
       expect(screen.getByTestId("watchlists-pipeline-test-generation")).toBeInTheDocument()
     })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
@@ -5,7 +5,11 @@ import { PipelineWizard } from "../PipelineWizard"
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback || key
+    t: (key: string, fallback?: string, options?: Record<string, unknown>) =>
+      (fallback || key).replace(/\{\{(\w+)\}\}/g, (_match, token) => {
+        const value = options?.[token]
+        return value == null ? "" : String(value)
+      })
   })
 }))
 
@@ -180,5 +184,33 @@ describe("PipelineWizard", () => {
         { mode: "create" }
       )
     })
+  })
+
+  it("surfaces interval bounds that match the persisted cron bounds", async () => {
+    renderWizard()
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("AI Feed")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByLabelText("AI Feed"))
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Monitor name")).toBeInTheDocument()
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Monitor name"), {
+      target: { value: "Oversized Interval" }
+    })
+    fireEvent.mouseDown(getDialogQueries().getByLabelText("Schedule"))
+    fireEvent.click(await screen.findByText("Every N hours/minutes"))
+
+    expect(getDialogQueries().getByLabelText("Every")).toHaveAttribute("aria-valuemin", "1")
+    expect(getDialogQueries().getByLabelText("Every")).toHaveAttribute("aria-valuemax", "23")
+
+    fireEvent.mouseDown(getDialogQueries().getByLabelText("Interval unit"))
+    fireEvent.click(await screen.findByText("Minutes"))
+
+    expect(getDialogQueries().getByLabelText("Every")).toHaveAttribute("aria-valuemin", "5")
+    expect(getDialogQueries().getByLabelText("Every")).toHaveAttribute("aria-valuemax", "59")
   })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
@@ -1,0 +1,184 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { PipelineWizard } from "../PipelineWizard"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key
+  })
+}))
+
+const sources = [
+  {
+    id: 11,
+    name: "AI Feed",
+    url: "https://example.com/ai.xml",
+    source_type: "rss" as const,
+    active: true,
+    tags: [],
+    created_at: "2026-05-18T00:00:00Z"
+  },
+  {
+    id: 12,
+    name: "Security Feed",
+    url: "https://example.com/security.xml",
+    source_type: "rss" as const,
+    active: true,
+    tags: [],
+    created_at: "2026-05-18T00:00:00Z"
+  }
+]
+
+const renderWizard = (overrides: Partial<React.ComponentProps<typeof PipelineWizard>> = {}) => {
+  const onCancel = vi.fn()
+  const onSubmit = vi.fn()
+  const onPreview = vi.fn()
+  const result = render(
+    <PipelineWizard
+      open
+      sources={sources}
+      sourcesLoading={false}
+      submitting={false}
+      previewLoading={false}
+      previewError={null}
+      previewRendered={null}
+      previewRunId={null}
+      previewWarnings={[]}
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+      onPreview={onPreview}
+      {...overrides}
+    />
+  )
+  return { ...result, onCancel, onSubmit, onPreview }
+}
+
+const getDialog = () => screen.getByRole("dialog", { name: "Briefing pipeline builder" })
+const getDialogQueries = () => within(getDialog())
+
+describe("PipelineWizard", () => {
+  it("creates a pipeline from an existing source with digest and two-speaker audio", async () => {
+    const { onSubmit } = renderWizard()
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("AI Feed")).toBeInTheDocument()
+    })
+
+    fireEvent.click(getDialogQueries().getByLabelText("AI Feed"))
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Monitor name")).toBeInTheDocument()
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Monitor name"), {
+      target: { value: "Five Hour Brief" }
+    })
+    fireEvent.mouseDown(getDialogQueries().getByLabelText("Schedule"))
+    fireEvent.click(await screen.findByText("Every N hours/minutes"))
+    fireEvent.change(getDialogQueries().getByLabelText("Every"), {
+      target: { value: "5" }
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Template")).toBeInTheDocument()
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Template"), {
+      target: { value: "newsletter_markdown" }
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Audio briefing")).toBeInTheDocument()
+    })
+    fireEvent.mouseDown(getDialogQueries().getByLabelText("Speaker count"))
+    fireEvent.click(await screen.findByText("2 speakers"))
+    fireEvent.change(getDialogQueries().getByLabelText("Speaker 1 label"), {
+      target: { value: "Host" }
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Speaker 2 label"), {
+      target: { value: "Analyst" }
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlists-pipeline-review-summary")).toHaveTextContent("AI Feed")
+    })
+    expect(screen.getByTestId("watchlists-pipeline-review-summary")).toHaveTextContent("Every 5 hours")
+    expect(screen.getByTestId("watchlists-pipeline-review-summary")).toHaveTextContent("2 speakers audio briefing")
+
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Create pipeline" }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceMode: "existing",
+          sourceIds: [11],
+          monitorName: "Five Hour Brief",
+          scheduleMode: "interval",
+          scheduleIntervalValue: 5,
+          templateName: "newsletter_markdown",
+          audioEnabled: true,
+          audioSpeakers: expect.arrayContaining([
+            expect.objectContaining({ label: "Host" }),
+            expect.objectContaining({ label: "Analyst" })
+          ])
+        }),
+        { mode: "create" }
+      )
+    })
+  })
+
+  it("supports creating a new source before monitor setup", async () => {
+    const { onSubmit } = renderWizard()
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Create a new feed")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByLabelText("Create a new feed"))
+    fireEvent.change(getDialogQueries().getByLabelText("Feed name"), {
+      target: { value: "Policy Feed" }
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Feed URL"), {
+      target: { value: "https://example.com/policy.xml" }
+    })
+
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Monitor name")).toBeInTheDocument()
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Monitor name"), {
+      target: { value: "Policy Brief" }
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Template")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Audio briefing")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByLabelText("Audio briefing"))
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlists-pipeline-review-summary")).toHaveTextContent("Policy Feed")
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Create pipeline" }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceMode: "new",
+          sourceName: "Policy Feed",
+          sourceUrl: "https://example.com/policy.xml",
+          monitorName: "Policy Brief",
+          audioEnabled: false,
+          audioSpeakers: []
+        }),
+        { mode: "create" }
+      )
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
@@ -93,6 +93,9 @@ describe("watchlists pipeline contract", () => {
       format: "md",
       template_name: "briefing_md",
       template_version: 2,
+      generate_audio: true,
+      audio_voice: "alloy",
+      target_audio_minutes: 8,
       metadata: {
         audio: {
           enabled: true,

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
@@ -25,6 +25,9 @@ describe("watchlists pipeline wizard state", () => {
         sourceType: "rss",
         monitorName: "Morning Brief",
         templateName: "briefing_md",
+        scheduleMode: "interval",
+        scheduleIntervalUnit: "hours",
+        scheduleIntervalValue: 100,
         emailDeliveryEnabled: true,
         emailRecipients: ["bad-email"],
         audioEnabled: true,
@@ -40,6 +43,7 @@ describe("watchlists pipeline wizard state", () => {
     ).toEqual({
       valid: false,
       errors: expect.arrayContaining([
+        "scheduleIntervalValue",
         "emailRecipients",
         "audioSpeakers",
         "audioSpeakerIds",
@@ -59,6 +63,24 @@ describe("watchlists pipeline wizard state", () => {
         audioSpeakers: []
       })
     ).toEqual({ valid: true, errors: [] })
+
+    expect(
+      validatePipelineWizardDraft({
+        ...base,
+        sourceMode: "existing",
+        sourceIds: [10],
+        monitorName: "Morning Brief",
+        templateName: "briefing_md",
+        scheduleMode: "daily",
+        scheduleHour: 24,
+        scheduleMinute: 60,
+        audioEnabled: false,
+        audioSpeakers: []
+      })
+    ).toEqual({
+      valid: false,
+      errors: expect.arrayContaining(["scheduleHour", "scheduleMinute"])
+    })
   })
 
   it("builds source payloads and variable cadence contract drafts", () => {
@@ -123,6 +145,24 @@ describe("watchlists pipeline wizard state", () => {
     )
 
     timezoneSpy.mockRestore()
+  })
+
+  it("does not force an unknown template format into payload drafts", () => {
+    const draft = {
+      ...createDefaultPipelineWizardDraft(),
+      sourceMode: "existing" as const,
+      sourceIds: [10],
+      monitorName: "HTML Brief",
+      templateName: "html_newsletter",
+      audioEnabled: false,
+      audioSpeakers: []
+    }
+
+    expect(toBriefingPipelineDraft(draft)).toEqual(
+      expect.not.objectContaining({
+        templateFormat: expect.any(String)
+      })
+    )
   })
 
   it("summarizes source, cadence, filters, output, delivery, and audio expectations", () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  buildPipelineWizardReviewSummary,
+  createDefaultPipelineWizardDraft,
+  toBriefingPipelineDraft,
+  toPipelineWizardSourcePayload,
+  validatePipelineWizardDraft
+} from "../pipeline-wizard-state"
+
+describe("watchlists pipeline wizard state", () => {
+  it("validates source, monitor, digest, delivery, and optional audio requirements", () => {
+    const base = createDefaultPipelineWizardDraft()
+
+    expect(validatePipelineWizardDraft(base)).toEqual({
+      valid: false,
+      errors: expect.arrayContaining(["sourceIds", "monitorName", "templateName"])
+    })
+
+    expect(
+      validatePipelineWizardDraft({
+        ...base,
+        sourceMode: "new",
+        sourceName: "Security News",
+        sourceUrl: "https://example.com/rss.xml",
+        sourceType: "rss",
+        monitorName: "Morning Brief",
+        templateName: "briefing_md",
+        emailDeliveryEnabled: true,
+        emailRecipients: ["bad-email"],
+        audioEnabled: true,
+        audioSpeakers: [
+          { id: "host", label: "Host", role: "host", voice: "alloy" },
+          { id: "host", label: "Duplicate", role: "analyst", voice: "" },
+          { id: "guest", label: "Guest", role: "guest", voice: "nova" },
+          { id: "editor", label: "Editor", role: "editor", voice: "echo" },
+          { id: "extra", label: "Extra", role: "extra", voice: "fable" }
+        ],
+        targetAudioMinutes: 0
+      })
+    ).toEqual({
+      valid: false,
+      errors: expect.arrayContaining([
+        "emailRecipients",
+        "audioSpeakers",
+        "audioSpeakerIds",
+        "audioSpeakerVoices",
+        "targetAudioMinutes"
+      ])
+    })
+
+    expect(
+      validatePipelineWizardDraft({
+        ...base,
+        sourceMode: "existing",
+        sourceIds: [10],
+        monitorName: "Morning Brief",
+        templateName: "briefing_md",
+        audioEnabled: false,
+        audioSpeakers: []
+      })
+    ).toEqual({ valid: true, errors: [] })
+  })
+
+  it("builds source payloads and variable cadence contract drafts", () => {
+    const timezoneSpy = vi
+      .spyOn(Intl, "DateTimeFormat")
+      .mockImplementation(
+        () =>
+          ({
+            resolvedOptions: () => ({ timeZone: "UTC" })
+          }) as Intl.DateTimeFormat
+      )
+
+    const draft = {
+      ...createDefaultPipelineWizardDraft(),
+      sourceMode: "new" as const,
+      sourceName: "AI News",
+      sourceUrl: "https://example.com/feed.xml",
+      sourceType: "rss" as const,
+      monitorName: "Five Hour Brief",
+      scheduleMode: "interval" as const,
+      scheduleIntervalValue: 5,
+      scheduleIntervalUnit: "hours" as const,
+      scheduleMinute: 15,
+      templateName: "newsletter_markdown",
+      templateFormat: "md" as const,
+      audioEnabled: true,
+      audioSpeakers: [
+        { id: "host", label: "Host", role: "host", voice: "alloy" },
+        { id: "analyst", label: "Analyst", role: "analyst", voice: "nova" }
+      ],
+      targetAudioMinutes: 9
+    }
+
+    expect(toPipelineWizardSourcePayload(draft, 42)).toEqual({
+      name: "AI News",
+      url: "https://example.com/feed.xml",
+      source_type: "rss",
+      active: true,
+      watchlist_id: 42
+    })
+
+    expect(toBriefingPipelineDraft(draft, [88])).toEqual(
+      expect.objectContaining({
+        monitorName: "Five Hour Brief",
+        sourceIds: [88],
+        scheduleExpr: "15 */5 * * *",
+        timezone: "UTC",
+        templateName: "newsletter_markdown",
+        includeAudio: true,
+        audioCast: {
+          speaker_count: 2,
+          speakers: [
+            { id: "host", label: "Host", role: "host", voice: "alloy" },
+            { id: "analyst", label: "Analyst", role: "analyst", voice: "nova" }
+          ]
+        },
+        voiceMap: {
+          host: "alloy",
+          analyst: "nova"
+        }
+      })
+    )
+
+    timezoneSpy.mockRestore()
+  })
+
+  it("summarizes source, cadence, filters, output, delivery, and audio expectations", () => {
+    const summary = buildPipelineWizardReviewSummary(
+      {
+        ...createDefaultPipelineWizardDraft(),
+        sourceMode: "existing",
+        sourceIds: [7, 8],
+        monitorName: "Weekly Policy Brief",
+        scheduleMode: "weekly",
+        scheduleHour: 7,
+        scheduleMinute: 30,
+        scheduleWeekday: "MON",
+        templateName: "briefing_md",
+        emailDeliveryEnabled: true,
+        emailRecipients: ["team@example.com"],
+        audioEnabled: true,
+        audioSpeakers: [
+          { id: "host", label: "Host", role: "host", voice: "alloy" }
+        ]
+      },
+      [
+        { id: 7, name: "AI Feed" },
+        { id: 8, name: "Security Feed" }
+      ]
+    )
+
+    expect(summary).toEqual({
+      sources: "AI Feed, Security Feed",
+      cadence: "Weekly on Monday at 07:30",
+      filters: "Monitor filters can be refined after creation",
+      output: "briefing_md digest",
+      delivery: "Email",
+      audio: "1 speaker audio briefing"
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
@@ -1,4 +1,8 @@
-import type { WatchlistJobCreate, WatchlistOutputCreate } from "@/types/watchlists"
+import type {
+  WatchlistAudioCast,
+  WatchlistJobCreate,
+  WatchlistOutputCreate
+} from "@/types/watchlists"
 import {
   resolveQuickSetupSchedule,
   type QuickSetupSchedulePreset
@@ -8,11 +12,15 @@ export interface BriefingPipelineDraft {
   monitorName: string
   sourceIds: number[]
   schedulePreset: QuickSetupSchedulePreset
+  scheduleExpr?: string | null
+  timezone?: string
   templateName: string
   templateFormat?: "md" | "html"
   templateVersion?: number
   includeAudio: boolean
   audioVoice?: string
+  audioCast?: WatchlistAudioCast
+  voiceMap?: Record<string, string>
   targetAudioMinutes?: number
   emailRecipients?: string[]
   createChatbook?: boolean
@@ -75,7 +83,12 @@ export const validateBriefingPipelineDraft = (
 export const toPipelineJobCreatePayload = (
   draft: BriefingPipelineDraft
 ): WatchlistJobCreate => {
-  const schedule = resolveQuickSetupSchedule(draft.schedulePreset)
+  const schedule = draft.scheduleExpr
+    ? {
+        schedule_expr: draft.scheduleExpr,
+        timezone: draft.timezone
+      }
+    : resolveQuickSetupSchedule(draft.schedulePreset)
   const recipients = normalizeRecipients(draft.emailRecipients)
   const normalizedTemplateName = String(draft.templateName || "").trim()
   const templateVersionNum = Number(draft.templateVersion)
@@ -87,7 +100,8 @@ export const toPipelineJobCreatePayload = (
     draft.templateFormat === "html" || draft.templateFormat === "md"
       ? draft.templateFormat
       : undefined
-  const shouldAutoOutput = draft.schedulePreset !== "none"
+  const shouldAutoOutput = Boolean(schedule.schedule_expr)
+  const normalizedAudioVoice = String(draft.audioVoice || "").trim() || undefined
 
   return {
     name: String(draft.monitorName || "").trim(),
@@ -113,9 +127,9 @@ export const toPipelineJobCreatePayload = (
         default_version: normalizedTemplateVersion
       },
       generate_audio: draft.includeAudio,
-      audio_voice: draft.includeAudio
-        ? String(draft.audioVoice || "").trim() || undefined
-        : undefined,
+      audio_voice: draft.includeAudio ? normalizedAudioVoice : undefined,
+      audio_cast: draft.includeAudio ? draft.audioCast : undefined,
+      voice_map: draft.includeAudio ? draft.voiceMap : undefined,
       target_audio_minutes: draft.includeAudio
         ? Number(draft.targetAudioMinutes)
         : undefined,
@@ -161,11 +175,21 @@ export const toPipelineOutputCreatePayload = (
   }
 
   if (draft.includeAudio) {
+    const normalizedAudioVoice = String(draft.audioVoice || "").trim() || undefined
+    payload.generate_audio = true
+    if (normalizedAudioVoice) payload.audio_voice = normalizedAudioVoice
+    if (draft.audioCast) payload.audio_cast = draft.audioCast
+    if (draft.voiceMap) payload.voice_map = draft.voiceMap
+    const targetAudioMinutes = Number(draft.targetAudioMinutes)
+    if (Number.isFinite(targetAudioMinutes) && targetAudioMinutes > 0) {
+      payload.target_audio_minutes = targetAudioMinutes
+    }
     payload.metadata = {
       audio: {
         enabled: true,
-        voice: String(draft.audioVoice || "").trim() || null,
-        target_minutes: Number(draft.targetAudioMinutes)
+        voice: normalizedAudioVoice || null,
+        ...(draft.audioCast ? { speaker_count: draft.audioCast.speaker_count } : {}),
+        target_minutes: targetAudioMinutes
       }
     }
   }

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
@@ -1,0 +1,342 @@
+import type {
+  SourceType,
+  WatchlistAudioCast,
+  WatchlistAudioCastSpeaker,
+  WatchlistSourceCreate
+} from "@/types/watchlists"
+import {
+  buildCronFromPreset,
+  type ScheduleIntervalUnit,
+  type WeekdayToken
+} from "../JobsTab/schedule-utils"
+import { getLocalTimezone } from "./quick-setup"
+import type { BriefingPipelineDraft } from "./pipeline-contract"
+
+export type PipelineWizardSourceMode = "existing" | "new"
+export type PipelineWizardScheduleMode = "manual" | "interval" | "daily" | "weekly"
+
+export interface PipelineWizardAudioSpeakerDraft {
+  id: string
+  label: string
+  role?: string
+  voice: string
+  persona?: string
+}
+
+export interface PipelineWizardDraft {
+  sourceMode: PipelineWizardSourceMode
+  sourceIds: number[]
+  sourceName: string
+  sourceUrl: string
+  sourceType: SourceType
+  monitorName: string
+  scheduleMode: PipelineWizardScheduleMode
+  scheduleIntervalValue: number
+  scheduleIntervalUnit: ScheduleIntervalUnit
+  scheduleHour: number
+  scheduleMinute: number
+  scheduleWeekday: WeekdayToken
+  templateName: string
+  templateFormat: "md" | "html"
+  emailDeliveryEnabled: boolean
+  emailRecipients: string[]
+  chatbookDeliveryEnabled: boolean
+  chatbookTitle: string
+  audioEnabled: boolean
+  audioSpeakers: PipelineWizardAudioSpeakerDraft[]
+  targetAudioMinutes: number
+  runNow: boolean
+}
+
+export interface PipelineWizardValidationResult {
+  valid: boolean
+  errors: string[]
+}
+
+export interface PipelineWizardReviewSummary {
+  sources: string
+  cadence: string
+  filters: string
+  output: string
+  delivery: string
+  audio: string
+}
+
+interface SourceLabel {
+  id: number
+  name?: string | null
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export const createDefaultPipelineWizardDraft = (): PipelineWizardDraft => ({
+  sourceMode: "existing",
+  sourceIds: [],
+  sourceName: "",
+  sourceUrl: "",
+  sourceType: "rss",
+  monitorName: "",
+  scheduleMode: "daily",
+  scheduleIntervalValue: 5,
+  scheduleIntervalUnit: "hours",
+  scheduleHour: 8,
+  scheduleMinute: 0,
+  scheduleWeekday: "MON",
+  templateName: "",
+  templateFormat: "md",
+  emailDeliveryEnabled: false,
+  emailRecipients: [],
+  chatbookDeliveryEnabled: false,
+  chatbookTitle: "",
+  audioEnabled: true,
+  audioSpeakers: [
+    {
+      id: "speaker_1",
+      label: "Speaker 1",
+      role: "host",
+      voice: "alloy"
+    }
+  ],
+  targetAudioMinutes: 8,
+  runNow: true
+})
+
+const trim = (value: unknown): string => String(value || "").trim()
+
+const normalizeEmails = (value: string[] | undefined): string[] =>
+  Array.isArray(value)
+    ? value.map((entry) => trim(entry).toLowerCase()).filter(Boolean)
+    : []
+
+const isHttpUrl = (value: string): boolean => {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+export const normalizePipelineWizardSpeakers = (
+  speakers: PipelineWizardAudioSpeakerDraft[] | undefined
+): PipelineWizardAudioSpeakerDraft[] =>
+  (Array.isArray(speakers) ? speakers : [])
+    .map((speaker, index) => ({
+      id: trim(speaker.id) || `speaker_${index + 1}`,
+      label: trim(speaker.label) || `Speaker ${index + 1}`,
+      role: trim(speaker.role) || undefined,
+      voice: trim(speaker.voice),
+      persona: trim(speaker.persona) || undefined
+    }))
+    .filter((speaker) => speaker.id.length > 0 || speaker.label.length > 0 || speaker.voice.length > 0)
+
+export const validatePipelineWizardDraft = (
+  draft: PipelineWizardDraft
+): PipelineWizardValidationResult => {
+  const errors: string[] = []
+  const sourceMode = draft.sourceMode || "existing"
+  if (sourceMode === "existing") {
+    if (!Array.isArray(draft.sourceIds) || draft.sourceIds.length === 0) {
+      errors.push("sourceIds")
+    }
+  } else {
+    if (!trim(draft.sourceName)) errors.push("sourceName")
+    const sourceUrl = trim(draft.sourceUrl)
+    if (!sourceUrl) {
+      errors.push("sourceUrl")
+    } else if (!isHttpUrl(sourceUrl)) {
+      errors.push("sourceUrl")
+    }
+  }
+
+  if (!trim(draft.monitorName)) errors.push("monitorName")
+  if (!trim(draft.templateName)) errors.push("templateName")
+
+  if (draft.scheduleMode === "interval") {
+    const value = Number(draft.scheduleIntervalValue)
+    if (!Number.isFinite(value) || value <= 0) errors.push("scheduleIntervalValue")
+  }
+
+  if (draft.emailDeliveryEnabled) {
+    const recipients = normalizeEmails(draft.emailRecipients)
+    if (recipients.length === 0 || recipients.some((entry) => !EMAIL_PATTERN.test(entry))) {
+      errors.push("emailRecipients")
+    }
+  }
+
+  if (draft.audioEnabled) {
+    const speakers = normalizePipelineWizardSpeakers(draft.audioSpeakers)
+    if (speakers.length < 1 || speakers.length > 4) errors.push("audioSpeakers")
+    const ids = speakers.map((speaker) => speaker.id)
+    if (new Set(ids).size !== ids.length) errors.push("audioSpeakerIds")
+    if (speakers.some((speaker) => !trim(speaker.voice))) errors.push("audioSpeakerVoices")
+    const minutes = Number(draft.targetAudioMinutes)
+    if (!Number.isFinite(minutes) || minutes <= 0) errors.push("targetAudioMinutes")
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors
+  }
+}
+
+export const toPipelineWizardSourcePayload = (
+  draft: PipelineWizardDraft,
+  watchlistId?: number | null
+): WatchlistSourceCreate | null => {
+  if (draft.sourceMode !== "new") return null
+  const payload: WatchlistSourceCreate = {
+    name: trim(draft.sourceName),
+    url: trim(draft.sourceUrl),
+    source_type: draft.sourceType || "rss",
+    active: true
+  }
+  const normalizedWatchlistId = Number(watchlistId)
+  if (Number.isFinite(normalizedWatchlistId) && normalizedWatchlistId > 0) {
+    payload.watchlist_id = normalizedWatchlistId
+  }
+  return payload
+}
+
+export const buildPipelineWizardSchedule = (
+  draft: PipelineWizardDraft
+): { schedule_expr?: string; timezone?: string } => {
+  if (draft.scheduleMode === "manual") return {}
+  const preset =
+    draft.scheduleMode === "interval"
+      ? "interval"
+      : draft.scheduleMode === "weekly"
+        ? "weekly"
+        : "daily"
+  return {
+    schedule_expr: buildCronFromPreset({
+      preset,
+      intervalValue: draft.scheduleIntervalValue,
+      intervalUnit: draft.scheduleIntervalUnit,
+      hour: draft.scheduleHour,
+      minute: draft.scheduleMinute,
+      weekday: draft.scheduleWeekday
+    }),
+    timezone: getLocalTimezone()
+  }
+}
+
+export const toWatchlistAudioCast = (
+  draft: PipelineWizardDraft
+): WatchlistAudioCast | undefined => {
+  if (!draft.audioEnabled) return undefined
+  const speakers = normalizePipelineWizardSpeakers(draft.audioSpeakers)
+  if (speakers.length < 1 || speakers.length > 4) return undefined
+  return {
+    speaker_count: speakers.length as 1 | 2 | 3 | 4,
+    speakers: speakers.map((speaker): WatchlistAudioCastSpeaker => ({
+      id: speaker.id,
+      label: speaker.label,
+      role: speaker.role,
+      voice: speaker.voice,
+      persona: speaker.persona
+    }))
+  }
+}
+
+export const toAudioVoiceMap = (
+  draft: PipelineWizardDraft
+): Record<string, string> | undefined => {
+  if (!draft.audioEnabled) return undefined
+  const entries = normalizePipelineWizardSpeakers(draft.audioSpeakers)
+    .filter((speaker) => speaker.id && speaker.voice)
+    .map((speaker) => [speaker.id, speaker.voice] as const)
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+export const toBriefingPipelineDraft = (
+  draft: PipelineWizardDraft,
+  sourceIdsOverride?: number[]
+): BriefingPipelineDraft => {
+  const sourceIds =
+    sourceIdsOverride && sourceIdsOverride.length > 0
+      ? sourceIdsOverride
+      : draft.sourceIds
+  const schedule = buildPipelineWizardSchedule(draft)
+  const audioCast = toWatchlistAudioCast(draft)
+  const voiceMap = toAudioVoiceMap(draft)
+  const firstSpeakerVoice = audioCast?.speakers[0]?.voice
+
+  return {
+    monitorName: trim(draft.monitorName),
+    sourceIds,
+    schedulePreset: schedule.schedule_expr ? "daily" : "none",
+    scheduleExpr: schedule.schedule_expr,
+    timezone: schedule.timezone,
+    templateName: trim(draft.templateName),
+    templateFormat: draft.templateFormat,
+    includeAudio: Boolean(draft.audioEnabled),
+    audioVoice: firstSpeakerVoice,
+    audioCast,
+    voiceMap,
+    targetAudioMinutes: draft.audioEnabled ? Number(draft.targetAudioMinutes) : undefined,
+    emailRecipients: draft.emailDeliveryEnabled ? normalizeEmails(draft.emailRecipients) : [],
+    createChatbook: Boolean(draft.chatbookDeliveryEnabled),
+    chatbookTitle: draft.chatbookDeliveryEnabled ? trim(draft.chatbookTitle) : undefined
+  }
+}
+
+const formatTime = (hour: number, minute: number): string => {
+  const normalizedHour = Math.max(0, Math.min(23, Math.floor(Number(hour) || 0)))
+  const normalizedMinute = Math.max(0, Math.min(59, Math.floor(Number(minute) || 0)))
+  return `${String(normalizedHour).padStart(2, "0")}:${String(normalizedMinute).padStart(2, "0")}`
+}
+
+const WEEKDAY_LABELS: Record<WeekdayToken, string> = {
+  MON: "Monday",
+  TUE: "Tuesday",
+  WED: "Wednesday",
+  THU: "Thursday",
+  FRI: "Friday",
+  SAT: "Saturday",
+  SUN: "Sunday"
+}
+
+export const formatPipelineWizardCadence = (draft: PipelineWizardDraft): string => {
+  if (draft.scheduleMode === "manual") return "Manual only"
+  if (draft.scheduleMode === "interval") {
+    const value = Math.max(1, Math.floor(Number(draft.scheduleIntervalValue) || 1))
+    const unit = draft.scheduleIntervalUnit === "minutes" ? "minute" : "hour"
+    return `Every ${value} ${unit}${value === 1 ? "" : "s"}`
+  }
+  if (draft.scheduleMode === "weekly") {
+    return `Weekly on ${WEEKDAY_LABELS[draft.scheduleWeekday]} at ${formatTime(
+      draft.scheduleHour,
+      draft.scheduleMinute
+    )}`
+  }
+  return `Daily at ${formatTime(draft.scheduleHour, draft.scheduleMinute)}`
+}
+
+export const buildPipelineWizardReviewSummary = (
+  draft: PipelineWizardDraft,
+  existingSources: SourceLabel[] = []
+): PipelineWizardReviewSummary => {
+  const sourceLookup = new Map(existingSources.map((source) => [source.id, trim(source.name) || `Feed #${source.id}`]))
+  const selectedSources = draft.sourceMode === "new"
+    ? trim(draft.sourceName) || "New feed"
+    : (draft.sourceIds || [])
+      .map((id) => sourceLookup.get(id) || `Feed #${id}`)
+      .join(", ") || "No feeds selected"
+  const delivery = [
+    draft.emailDeliveryEnabled ? "Email" : null,
+    draft.chatbookDeliveryEnabled ? "Chatbook" : null
+  ].filter(Boolean).join(", ") || "In-app reports"
+  const speakers = draft.audioEnabled ? normalizePipelineWizardSpeakers(draft.audioSpeakers).length : 0
+
+  return {
+    sources: selectedSources,
+    cadence: formatPipelineWizardCadence(draft),
+    filters: "Monitor filters can be refined after creation",
+    output: `${trim(draft.templateName) || "No template"} digest`,
+    delivery,
+    audio: speakers > 0
+      ? `${speakers} speaker${speakers === 1 ? "" : "s"} audio briefing`
+      : "Audio disabled"
+  }
+}

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
@@ -6,6 +6,10 @@ import type {
 } from "@/types/watchlists"
 import {
   buildCronFromPreset,
+  INTERVAL_HOURS_MAX,
+  INTERVAL_HOURS_MIN,
+  INTERVAL_MINUTES_MAX,
+  INTERVAL_MINUTES_MIN,
   type ScheduleIntervalUnit,
   type WeekdayToken
 } from "../JobsTab/schedule-utils"
@@ -37,7 +41,7 @@ export interface PipelineWizardDraft {
   scheduleMinute: number
   scheduleWeekday: WeekdayToken
   templateName: string
-  templateFormat: "md" | "html"
+  templateFormat?: "md" | "html"
   emailDeliveryEnabled: boolean
   emailRecipients: string[]
   chatbookDeliveryEnabled: boolean
@@ -62,6 +66,29 @@ export interface PipelineWizardReviewSummary {
   audio: string
 }
 
+interface PipelineWizardCadenceCopy {
+  manual?: string
+  interval?: (value: number, unit: ScheduleIntervalUnit) => string
+  daily?: (time: string) => string
+  weekly?: (weekday: string, time: string) => string
+  weekdayLabels?: Partial<Record<WeekdayToken, string>>
+}
+
+export interface PipelineWizardReviewSummaryCopy {
+  newFeed?: string
+  noFeedsSelected?: string
+  feedLabel?: (id: number) => string
+  filters?: string
+  noTemplate?: string
+  outputDigest?: (templateName: string) => string
+  email?: string
+  chatbook?: string
+  inAppReports?: string
+  audioBriefing?: (speakerCount: number) => string
+  audioDisabled?: string
+  cadence?: PipelineWizardCadenceCopy
+}
+
 interface SourceLabel {
   id: number
   name?: string | null
@@ -83,7 +110,6 @@ export const createDefaultPipelineWizardDraft = (): PipelineWizardDraft => ({
   scheduleMinute: 0,
   scheduleWeekday: "MON",
   templateName: "",
-  templateFormat: "md",
   emailDeliveryEnabled: false,
   emailRecipients: [],
   chatbookDeliveryEnabled: false,
@@ -154,7 +180,24 @@ export const validatePipelineWizardDraft = (
 
   if (draft.scheduleMode === "interval") {
     const value = Number(draft.scheduleIntervalValue)
-    if (!Number.isFinite(value) || value <= 0) errors.push("scheduleIntervalValue")
+    const minValue =
+      draft.scheduleIntervalUnit === "minutes" ? INTERVAL_MINUTES_MIN : INTERVAL_HOURS_MIN
+    const maxValue =
+      draft.scheduleIntervalUnit === "minutes" ? INTERVAL_MINUTES_MAX : INTERVAL_HOURS_MAX
+    if (!Number.isInteger(value) || value < minValue || value > maxValue) {
+      errors.push("scheduleIntervalValue")
+    }
+    if (draft.scheduleIntervalUnit === "hours") {
+      const minute = Number(draft.scheduleMinute)
+      if (!Number.isInteger(minute) || minute < 0 || minute > 59) errors.push("scheduleMinute")
+    }
+  }
+
+  if (draft.scheduleMode === "daily" || draft.scheduleMode === "weekly") {
+    const hour = Number(draft.scheduleHour)
+    const minute = Number(draft.scheduleMinute)
+    if (!Number.isInteger(hour) || hour < 0 || hour > 23) errors.push("scheduleHour")
+    if (!Number.isInteger(minute) || minute < 0 || minute > 59) errors.push("scheduleMinute")
   }
 
   if (draft.emailDeliveryEnabled) {
@@ -269,7 +312,7 @@ export const toBriefingPipelineDraft = (
     scheduleExpr: schedule.schedule_expr,
     timezone: schedule.timezone,
     templateName: trim(draft.templateName),
-    templateFormat: draft.templateFormat,
+    ...(draft.templateFormat ? { templateFormat: draft.templateFormat } : {}),
     includeAudio: Boolean(draft.audioEnabled),
     audioVoice: firstSpeakerVoice,
     audioCast,
@@ -297,46 +340,60 @@ const WEEKDAY_LABELS: Record<WeekdayToken, string> = {
   SUN: "Sunday"
 }
 
-export const formatPipelineWizardCadence = (draft: PipelineWizardDraft): string => {
-  if (draft.scheduleMode === "manual") return "Manual only"
+export const formatPipelineWizardCadence = (
+  draft: PipelineWizardDraft,
+  copy: PipelineWizardCadenceCopy = {}
+): string => {
+  if (draft.scheduleMode === "manual") return copy.manual || "Manual only"
   if (draft.scheduleMode === "interval") {
     const value = Math.max(1, Math.floor(Number(draft.scheduleIntervalValue) || 1))
+    if (copy.interval) return copy.interval(value, draft.scheduleIntervalUnit)
     const unit = draft.scheduleIntervalUnit === "minutes" ? "minute" : "hour"
     return `Every ${value} ${unit}${value === 1 ? "" : "s"}`
   }
   if (draft.scheduleMode === "weekly") {
-    return `Weekly on ${WEEKDAY_LABELS[draft.scheduleWeekday]} at ${formatTime(
-      draft.scheduleHour,
-      draft.scheduleMinute
-    )}`
+    const weekday = copy.weekdayLabels?.[draft.scheduleWeekday] || WEEKDAY_LABELS[draft.scheduleWeekday]
+    const time = formatTime(draft.scheduleHour, draft.scheduleMinute)
+    if (copy.weekly) return copy.weekly(weekday, time)
+    return `Weekly on ${weekday} at ${time}`
   }
-  return `Daily at ${formatTime(draft.scheduleHour, draft.scheduleMinute)}`
+  const time = formatTime(draft.scheduleHour, draft.scheduleMinute)
+  return copy.daily ? copy.daily(time) : `Daily at ${time}`
 }
 
 export const buildPipelineWizardReviewSummary = (
   draft: PipelineWizardDraft,
-  existingSources: SourceLabel[] = []
+  existingSources: SourceLabel[] = [],
+  copy: PipelineWizardReviewSummaryCopy = {}
 ): PipelineWizardReviewSummary => {
-  const sourceLookup = new Map(existingSources.map((source) => [source.id, trim(source.name) || `Feed #${source.id}`]))
+  const sourceLookup = new Map(
+    existingSources.map((source) => [
+      source.id,
+      trim(source.name) || (copy.feedLabel ? copy.feedLabel(source.id) : `Feed #${source.id}`)
+    ])
+  )
   const selectedSources = draft.sourceMode === "new"
-    ? trim(draft.sourceName) || "New feed"
+    ? trim(draft.sourceName) || copy.newFeed || "New feed"
     : (draft.sourceIds || [])
-      .map((id) => sourceLookup.get(id) || `Feed #${id}`)
-      .join(", ") || "No feeds selected"
+      .map((id) => sourceLookup.get(id) || (copy.feedLabel ? copy.feedLabel(id) : `Feed #${id}`))
+      .join(", ") || copy.noFeedsSelected || "No feeds selected"
   const delivery = [
-    draft.emailDeliveryEnabled ? "Email" : null,
-    draft.chatbookDeliveryEnabled ? "Chatbook" : null
-  ].filter(Boolean).join(", ") || "In-app reports"
+    draft.emailDeliveryEnabled ? copy.email || "Email" : null,
+    draft.chatbookDeliveryEnabled ? copy.chatbook || "Chatbook" : null
+  ].filter(Boolean).join(", ") || copy.inAppReports || "In-app reports"
   const speakers = draft.audioEnabled ? normalizePipelineWizardSpeakers(draft.audioSpeakers).length : 0
+  const templateName = trim(draft.templateName) || copy.noTemplate || "No template"
 
   return {
     sources: selectedSources,
-    cadence: formatPipelineWizardCadence(draft),
-    filters: "Monitor filters can be refined after creation",
-    output: `${trim(draft.templateName) || "No template"} digest`,
+    cadence: formatPipelineWizardCadence(draft, copy.cadence),
+    filters: copy.filters || "Monitor filters can be refined after creation",
+    output: copy.outputDigest ? copy.outputDigest(templateName) : `${templateName} digest`,
     delivery,
     audio: speakers > 0
-      ? `${speakers} speaker${speakers === 1 ? "" : "s"} audio briefing`
-      : "Audio disabled"
+      ? copy.audioBriefing
+        ? copy.audioBriefing(speakers)
+        : `${speakers} speaker${speakers === 1 ? "" : "s"} audio briefing`
+      : copy.audioDisabled || "Audio disabled"
   }
 }

--- a/backlog/tasks/task-432 - Implement-Watchlists-digest-audio-PR4-guided-pipeline-MVP.md
+++ b/backlog/tasks/task-432 - Implement-Watchlists-digest-audio-PR4-guided-pipeline-MVP.md
@@ -53,7 +53,7 @@ Baseline existing pipeline tests passed: OverviewTab.quick-setup.test.tsx + pipe
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the PR4 guided briefing pipeline MVP inside /watchlists. Added pure wizard state helpers, an additive five-step PipelineWizard (source, monitor, digest, optional audio, review), overview integration for existing or newly-created sources, variable cadence, optional 0-4 speaker audio contracts, preview/test-generation actions, and focused tests. Verification: focused Vitest suite passed (36 tests), watchlists static typecheck passed, and git diff --check passed. Bandit not run because this PR touches frontend/docs/backlog files only.
+Implemented PR4 guided briefing pipeline MVP and addressed PR #1851 review feedback. Review fixes: unknown template formats are no longer forced to Markdown, schedule validation now matches persisted cron bounds for intervals/hours/minutes, numeric interval/time controls expose matching bounds, wizard-created sources are rolled back for pre-run pipeline failures, and wizard option/review labels now use translation-backed copy helpers. Verification: focused Watchlists suite passed (41 tests across wizard, state, contract, static guard, and quick-setup coverage), and git diff --check passed. Bandit not run because this PR touches frontend/docs/backlog files only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-432 - Implement-Watchlists-digest-audio-PR4-guided-pipeline-MVP.md
+++ b/backlog/tasks/task-432 - Implement-Watchlists-digest-audio-PR4-guided-pipeline-MVP.md
@@ -1,0 +1,67 @@
+---
+id: TASK-432
+title: Implement Watchlists digest audio PR4 guided pipeline MVP
+status: Done
+labels:
+- watchlists
+- frontend
+- implementation
+- guided-pipeline
+priority: High
+references:
+- Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+- Docs/superpowers/specs/2026-05-18-watchlists-digest-audio-briefing-prd-design.md
+modified_files:
+- Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 8 / PR4 from the Watchlists digest/audio plan: guided pipeline MVP inside /watchlists. Scope includes pure wizard state helpers, an additive PipelineWizard component, source/monitor/digest/optional-audio/review steps, and focused frontend tests while preserving existing full controls and OSINT/CTI workflows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pure wizard state helpers validate source, monitor, digest, delivery, and optional 0-4 speaker audio configuration.
+- [x] #2 The /watchlists overview exposes a guided pipeline entry point that can create a new source or use existing sources, then create monitor/output settings without leaving /watchlists.
+- [x] #3 Optional audio supports no audio and 1-4 speaker cast configuration while preserving existing voice_map/audio_cast contracts.
+- [x] #4 Existing full controls, quick setup, and advanced tabs remain reachable and existing pipeline tests continue to pass.
+- [x] #5 Focused Vitest tests and diff checks pass; Bandit is documented as not applicable unless backend Python is touched.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Baseline existing pipeline tests passed: OverviewTab.quick-setup.test.tsx + pipeline-contract.test.ts, 24 tests. Red PR4 tests added for missing PipelineWizard and pipeline-wizard-state modules; focused run failed as expected on unresolved imports while existing pipeline-contract tests still passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the PR4 guided briefing pipeline MVP inside /watchlists. Added pure wizard state helpers, an additive five-step PipelineWizard (source, monitor, digest, optional audio, review), overview integration for existing or newly-created sources, variable cadence, optional 0-4 speaker audio contracts, preview/test-generation actions, and focused tests. Verification: focused Vitest suite passed (36 tests), watchlists static typecheck passed, and git diff --check passed. Bandit not run because this PR touches frontend/docs/backlog files only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: added the `/watchlists` guided briefing pipeline MVP as a five-step wizard for Source, Monitor, Digest, optional Audio, and Review.
- Why: keeps the digest/newsletter and optional 1-4 speaker briefing setup inside `/watchlists` while preserving existing full-control Watchlists workflows.

## Change Summary

Human-written summary required before merge. Please replace this section with the maintainer-owned explanation of what changed and why these implementation choices were made.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (implementation plan and Backlog task)

## Test Plan

- [x] `cd apps/packages/ui && bun run test -- src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.experimental-ia.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `cd apps/packages/ui && bun run test:watchlists:typecheck`
- [x] `git diff --check`
- [ ] Bandit not run: frontend/docs/backlog-only PR, no Python touched

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [ ] WebUI/extension parity validated for shared UI fixes
- [ ] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
- [ ] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
- [ ] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
- [x] If Watchlists UI behavior changed: keyboard-only path is covered by modal focus-restoration regression tests for quick setup and pipeline builder
- [ ] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
- [ ] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
- [ ] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
- [x] If Watchlists polling/notifications behavior changed: not applicable, no polling/notification behavior changed
- [x] If Watchlists Activity polling changed: not applicable, Activity polling unchanged
- [x] If Watchlists batch triage behavior changed: not applicable, batch triage unchanged
- [ ] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`

## Risk & Rollback

- Risk level: Medium
- Rollback plan: revert `3ff046ebf` to remove the additive wizard extraction and return OverviewTab to the prior inline pipeline builder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guided five-step briefing pipeline wizard in `/watchlists` to set up Source, Monitor, Digest, optional multi‑speaker Audio, and Review. Improves setup speed while keeping advanced Watchlists controls, and hardens the Review step.

- **New Features**
  - `PipelineWizard` with steps: Source, Monitor, Digest, Audio (0–4 speakers), Review.
  - Sources: use existing feeds or create a new feed inline.
  - Scheduling: manual, interval, daily, or weekly with timezone-aware cron.
  - Digest: choose template; optional email and Chatbook delivery.
  - Review: preview from latest completed run; “Run test generation” before create.
  - Integrated into the Overview tab; existing workflows unchanged.

- **Refactors**
  - Added `pipeline-wizard-state` for validation, schedule building, review summary, and mapping to contracts; tightened Review validation and summary.
  - Extended pipeline contracts with `schedule_expr`/`timezone`, `audio_cast`, `voice_map`, and output fields `generate_audio`, `audio_voice`, `target_audio_minutes`.
  - Replaced the old inline builder; added focused unit tests and docs; added failure cleanup via `deleteWatchlistSource`.

<sup>Written for commit d332cb446507fe459eee501cc300567ca393a26e. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1851?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

