### PR TITLE
Close out llama.cpp managed runtime rollout

### DIFF
--- a/Docs/API-related/llamacpp_integration_modes.md
+++ b/Docs/API-related/llamacpp_integration_modes.md
@@ -49,6 +49,28 @@ The `/admin/llamacpp` WebUI is an admin/operator surface for the managed plane. 
 
 After a managed server is running, the page shows **Use this in Chat**. This is intentionally explicit: it calls `POST /api/v1/llamacpp/use-in-chat` and updates the provider-plane `llama_api` endpoint only after the admin chooses it. Starting a managed server alone does not mutate chat provider settings.
 
+## Managed Runtime Profiles
+
+The managed plane now stores durable llama.cpp runtime profiles. A profile is a backend-owned service definition, not just a saved browser form. It records the profile ID, name, enabled state, mode, selected GGUF asset or model path, optional mmproj projector, host/port policy, structured server arguments, autostart setting, bounded restart policy, provider alias, and tags.
+
+Profile state is persisted in `llamacpp_profiles.json` next to the active tldw config file resolved by setup configuration. Treat this as a server-owned file: use the Admin UI or `/api/v1/llamacpp/profiles*` endpoints instead of editing it while the API server is running.
+
+The legacy one-server API remains a compatibility wrapper around the reserved `default` profile:
+
+- `POST /api/v1/llamacpp/start_server`
+- `POST /api/v1/llamacpp/start-by-model`
+- `GET /api/v1/llamacpp/status`
+- `GET /api/v1/llamacpp/logs/tail`
+- `POST /api/v1/llamacpp/use-in-chat`
+
+Those endpoints target only the default profile. Multi-profile operators should use `/api/v1/llamacpp/profiles` for desired service definitions and `/api/v1/llamacpp/instances` for observed runtime state across all profiles.
+
+Profiles can reference assets discovered by the asset inventory or direct model paths that pass the configured allowlist. Local registration and folder import are the preferred ways to make files visible before profile creation. Remote download and future catalog workflows belong to the acquisition path; they do not automatically create profiles, start runtimes, or rewire Chat.
+
+Vision profiles require an explicit mmproj pairing. Use `mmproj_model_id` for an inventory projector asset, or a backend-validated `server_args.mmproj` path. If both are supplied, they must resolve to the same projector file. The backend rejects missing or conflicting projector definitions while keeping resource-fit warnings advisory.
+
+Autostart and restart policy are intentionally bounded. On startup, the reconciler starts only enabled profiles with `autostart=true`. Paused profiles are not restarted until resumed. Restart attempts honor the stored limit, and the profile records bounded last-failure metadata such as state, exit code, model path, and error summary instead of raw logs or environment.
+
 ## Model Acquisition And Import
 
 The `/admin/llamacpp` **Assets** panel helps operators make local GGUF and mmproj files visible to the managed plane without changing runtime or provider-plane state by surprise.

--- a/Docs/API-related/llamacpp_integration_modes.md
+++ b/Docs/API-related/llamacpp_integration_modes.md
@@ -51,7 +51,13 @@ After a managed server is running, the page shows **Use this in Chat**. This is 
 
 ## Managed Runtime Profiles
 
-The managed plane now stores durable llama.cpp runtime profiles. A profile is a backend-owned service definition, not just a saved browser form. It records the profile ID, name, enabled state, mode, selected GGUF asset or model path, optional mmproj projector, host/port policy, structured server arguments, autostart setting, bounded restart policy, provider alias, and tags.
+The managed plane now stores durable llama.cpp runtime profiles. A profile is a backend-owned service definition, not just a saved browser form. It records attributes such as:
+
+- Profile ID, name, and enabled state
+- Mode, selected GGUF asset or model path, and optional mmproj projector
+- Host/port policy and structured server arguments
+- Autostart setting and bounded restart policy
+- Provider alias and tags
 
 Profile state is persisted in `llamacpp_profiles.json` next to the active tldw config file resolved by setup configuration. Treat this as a server-owned file: use the Admin UI or `/api/v1/llamacpp/profiles*` endpoints instead of editing it while the API server is running.
 

--- a/Docs/User_Guides/Integrations_Experiments/Setting_up_a_local_LLM.md
+++ b/Docs/User_Guides/Integrations_Experiments/Setting_up_a_local_LLM.md
@@ -17,6 +17,15 @@ https://github.com/ggerganov/llama.cpp/blob/cddae4884c853b1a7ab420458236d666e2e3
       3. cd to `llama.cpp` folder make` in the `llama.cpp` folder
       4. `server.exe -m ..\path\to\model -c <context_size>`
         * Example: `./server -m ../path/to/model -c 8192 -ngl 999` - This will run the model with a context size of 8192 tokens and offload all layers to the GPU.
+    - **tldw managed llama.cpp WebUI**
+      1. Build or install `llama-server`, then open the tldw WebUI at `/admin/llamacpp`.
+      2. In **Readiness**, set the executable path, models directory, allowed paths, and default host/port. Some changes require restarting the tldw API server before the active handler sees them.
+      3. In **Assets**, register an existing GGUF or mmproj file, or preview and confirm a local folder import. Local registration/import only updates the managed asset inventory; it does not create a profile, start a runtime, or change Chat routing.
+      4. In **Profiles**, create a durable runtime profile. Profiles store mode, model asset, optional mmproj projector, host/port, structured server arguments, provider alias, tags, autostart, and bounded restart policy. Profile state is stored by the backend in `llamacpp_profiles.json` next to the active tldw config file.
+      5. For multimodal or vision profiles, select a matching mmproj asset. The backend rejects missing or conflicting projector definitions, but hardware and VRAM fit messages stay warnings rather than hard blockers.
+      6. In **Runtime instances**, start the profile you want. Autostart profiles are reconciled on server startup, paused profiles stay paused, and restart attempts are bounded by the saved policy.
+      7. Use **Use in Chat** only after the desired runtime is running. This explicit action points the llama.cpp provider endpoint at that runtime; starting a profile alone does not silently rewire Chat.
+      8. Remote downloads and future catalog workflows live in the asset acquisition flow. They are not part of profile launch and do not automatically create profiles or start runtimes.
   - **Kobold.cpp** - c/p'd from: https://github.com/LostRuins/koboldcpp/wiki
     - **Windows**
       1. Download from here: https://github.com/LostRuins/koboldcpp/releases/latest

--- a/Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
@@ -428,14 +428,12 @@ git commit -m "feat: harden llama.cpp runtime admin console"
 
 **Files:**
 - Modify: `Docs/User_Guides/Integrations_Experiments/Setting_up_a_local_LLM.md`
-- Modify: `Docs/Published/User_Guides/Integrations_Experiments/Setting_up_a_local_LLM.md`
 - Modify: `Docs/API-related/llamacpp_integration_modes.md`
-- Modify: `Docs/Published/API-related/llamacpp_integration_modes.md`
 - Create or modify: `apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts`
 - Modify: `backlog/tasks/task-418 - Plan-llama.cpp-managed-runtime-closeout-implementation.md` only for task closeout if this implementation happens in the same branch family
 - Test: focused backend, frontend, E2E, Bandit, diff checks
 
-- [ ] **Step 1: Write E2E smoke coverage**
+- [x] **Step 1: Write E2E smoke coverage**
 
 Use mocked backend responses unless the existing E2E server fixture can safely expose llama.cpp admin stubs. Cover:
 - assets load;
@@ -445,7 +443,9 @@ Use mocked backend responses unless the existing E2E server fixture can safely e
 - `Use in Chat` is not offered for stopped profiles;
 - backend warnings display as warnings, not hard-blocking full page load.
 
-- [ ] **Step 2: Update docs**
+Result: added `apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts` with mocked assets, profiles, runtimes, runtime warnings, and running-only Chat wiring assertions.
+
+- [x] **Step 2: Update docs**
 
 Document:
 - profile store location and purpose;
@@ -455,7 +455,9 @@ Document:
 - autostart/restart policy limitations;
 - remote downloads/catalogs are deferred to the acquisition workflow.
 
-- [ ] **Step 3: Run backend verification**
+Result: updated the source llama.cpp integration/user-guide docs with the managed runtime profile contract, default-profile compatibility, local register/import semantics, mmproj pairing, bounded autostart/restart behavior, and deferred download/catalog boundaries. `Docs/Published` files are intentionally left untouched because they are generated from the source docs.
+
+- [x] **Step 3: Run backend verification**
 
 ```bash
 python -m pytest \
@@ -471,7 +473,9 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 4: Run frontend verification**
+Result: PASS, 163 passed, 5 warnings.
+
+- [x] **Step 4: Run frontend verification**
 
 ```bash
 cd apps/packages/ui
@@ -484,7 +488,9 @@ bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 5: Run E2E smoke if environment is available**
+Result: PASS, 42 passed across 4 files.
+
+- [x] **Step 5: Run E2E smoke if environment is available**
 
 ```bash
 # Set TLDW_E2E_API_KEY in your shell from your local test configuration first.
@@ -494,7 +500,9 @@ bunx playwright test apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spe
 
 Expected: PASS, or document the missing server/browser environment blocker.
 
-- [ ] **Step 6: Run Bandit on touched backend paths**
+Result: PASS with `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000` set so the Next dev server can start in advanced deployment mode. Command used from `apps/tldw-frontend`: `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx playwright test e2e/workflows/llamacpp-runtime-admin.spec.ts --reporter=line`.
+
+- [x] **Step 6: Run Bandit on touched backend paths**
 
 ```bash
 python -m bandit \
@@ -510,7 +518,9 @@ python -m bandit \
 
 Expected: no high/medium findings in touched code. Fix new findings before closeout.
 
-- [ ] **Step 7: Run diff checks**
+Result: PASS, no findings. Output written to `/tmp/bandit_llamacpp_runtime_rollout.json`.
+
+- [x] **Step 7: Run diff checks**
 
 ```bash
 git diff --check
@@ -519,23 +529,28 @@ git status --short
 
 Expected: no whitespace errors; only expected files are modified.
 
-- [ ] **Step 8: Commit Task 6**
+Result: `git diff --check` passed; `git status --short` showed only the expected docs, E2E smoke, and Backlog closeout task changes before final task tracking updates.
+
+- [x] **Step 8: Commit Task 6**
 
 ```bash
 git add \
-  Docs \
+  Docs/API-related/llamacpp_integration_modes.md \
+  Docs/User_Guides/Integrations_Experiments/Setting_up_a_local_LLM.md \
+  Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md \
   apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts \
-  backlog/tasks/task-418\ -\ Plan-llama.cpp-managed-runtime-closeout-implementation.md
+  backlog/tasks/task-418\ -\ Plan-llama.cpp-managed-runtime-closeout-implementation.md \
+  backlog/completed/task-418.15\ -\ Finalize-llama.cpp-managed-runtime-rollout.md
 git commit -m "docs: close out llama.cpp managed runtime rollout"
 ```
 
 ## Final PR Checklist
 
-- [ ] Backend focused tests pass.
-- [ ] Frontend focused tests pass.
-- [ ] E2E smoke passes or blocker is documented.
-- [ ] Bandit runs on touched backend Python paths.
-- [ ] `git diff --check` passes.
-- [ ] Backlog child tasks are current.
-- [ ] PR body includes a human-owned `Change summary` placeholder for maintainer completion.
-- [ ] Remote downloads/catalogs remain deferred and are not partially implemented in this runtime PR.
+- [x] Backend focused tests pass.
+- [x] Frontend focused tests pass.
+- [x] E2E smoke passes or blocker is documented.
+- [x] Bandit runs on touched backend Python paths.
+- [x] `git diff --check` passes.
+- [x] Backlog child tasks are current.
+- [x] PR body includes a human-owned `Change summary` placeholder for maintainer completion.
+- [x] Remote downloads/catalogs remain deferred and are not partially implemented in this runtime PR.

--- a/apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts
@@ -14,6 +14,9 @@ const fulfillJson = async (
   });
 };
 
+const MB = 1_000_000;
+const GB = 1_000 * MB;
+
 const savedConfig = {
   enabled: true,
   executable_path: '/opt/llama-server',
@@ -41,7 +44,7 @@ const ggufAsset = {
   resolved_path: '/srv/models/toy-chat.gguf',
   display_name: 'Toy Chat GGUF',
   source: 'models_dir',
-  size_bytes: 2_200_000_000,
+  size_bytes: 2.2 * GB,
   modified_at: '2026-05-18T10:00:00Z',
   metadata: {
     quantization: 'Q4_K_M',
@@ -63,7 +66,7 @@ const mmprojAsset = {
   resolved_path: '/srv/models/toy-mmproj.gguf',
   display_name: 'Toy Vision Projector',
   source: 'models_dir',
-  size_bytes: 320_000_000,
+  size_bytes: 320 * MB,
   modified_at: '2026-05-18T10:05:00Z',
   metadata: {
     family_hint: 'toy',
@@ -275,7 +278,7 @@ async function mockManagedRuntimeAdmin(page: Page): Promise<{
           basename: 'toy-chat.gguf',
           source: 'models_dir',
           path: '/srv/models/toy-chat.gguf',
-          size_bytes: 2_200_000_000,
+          size_bytes: 2.2 * GB,
           modified_at: '2026-05-18T10:00:00Z',
           metadata: {
             quantization: 'Q4_K_M',
@@ -292,8 +295,8 @@ async function mockManagedRuntimeAdmin(page: Page): Promise<{
 
   await page.route('**/api/v1/llamacpp/hardware', (route) =>
     fulfillJson(route, {
-      ram_total_bytes: 16_000_000_000,
-      ram_available_bytes: 8_000_000_000,
+      ram_total_bytes: 16 * GB,
+      ram_available_bytes: 8 * GB,
       cpu_count: 8,
       gpus: [],
       warnings: ['GPU probe unavailable.'],
@@ -313,8 +316,25 @@ async function mockManagedRuntimeAdmin(page: Page): Promise<{
   );
 
   await page.route('**/api/v1/llamacpp/profiles/*/use-in-chat', (route) => {
-    const match = route.request().url().match(/\/llamacpp\/profiles\/([^/]+)\/use-in-chat$/);
-    useInChatProfileIds.push(decodeURIComponent(match?.[1] || ''));
+    if (route.request().method() !== 'POST') {
+      return fulfillJson(
+        route,
+        { error: 'Method not allowed in use-in-chat mock' },
+        405
+      );
+    }
+    const match = route
+      .request()
+      .url()
+      .match(/\/llamacpp\/profiles\/([^/]+)\/use-in-chat$/);
+    if (!match?.[1]) {
+      return fulfillJson(
+        route,
+        { error: 'Invalid profile ID in URL for use-in-chat mock' },
+        400
+      );
+    }
+    useInChatProfileIds.push(decodeURIComponent(match[1]));
     return fulfillJson(route, {
       provider: 'llamacpp',
       endpoint: 'http://127.0.0.1:8181',
@@ -378,8 +398,14 @@ test.describe('llama.cpp managed runtime admin smoke', () => {
       authedPage.getByRole('button', { name: 'Use Embedding runtime in Chat' })
     ).toHaveCount(0);
 
+    const useInChatResponse = authedPage.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/api/v1/llamacpp/profiles/chat-runtime/use-in-chat')
+    );
     await authedPage.getByRole('button', { name: 'Use Chat runtime in Chat' }).click();
-    expect(api.useInChatProfileIds).toEqual(['chat-runtime']);
+    await useInChatResponse;
+    await expect.poll(() => api.useInChatProfileIds).toEqual(['chat-runtime']);
 
     await assertNoCriticalErrors(diagnostics);
   });

--- a/apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts
@@ -1,0 +1,386 @@
+import type { Page, Route } from '@playwright/test';
+import { test, expect, assertNoCriticalErrors } from '../utils/fixtures';
+import { AdminPage } from '../utils/page-objects';
+
+const fulfillJson = async (
+  route: Route,
+  data: unknown,
+  status = 200
+): Promise<void> => {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(data),
+  });
+};
+
+const savedConfig = {
+  enabled: true,
+  executable_path: '/opt/llama-server',
+  models_dir: '/srv/models',
+  default_host: '127.0.0.1',
+  default_port: 8080,
+  default_threads: 8,
+  default_n_gpu_layers: 0,
+  default_ctx_size: 4096,
+  allow_unvalidated_args: false,
+  allow_cli_secrets: false,
+  port_autoselect: true,
+  port_probe_max: 10,
+  allowed_paths: ['/srv/models'],
+  registered_model_paths: [],
+  imported_asset_folders: ['/srv/models/imported'],
+  log_output_file: null,
+};
+
+const ggufAsset = {
+  asset_id: 'gguf:toy-chat',
+  kind: 'gguf',
+  identity_basis: 'resolved_path',
+  path: '/srv/models/toy-chat.gguf',
+  resolved_path: '/srv/models/toy-chat.gguf',
+  display_name: 'Toy Chat GGUF',
+  source: 'models_dir',
+  size_bytes: 2_200_000_000,
+  modified_at: '2026-05-18T10:00:00Z',
+  metadata: {
+    quantization: 'Q4_K_M',
+    parameter_hint: '7B',
+    context_hint: 4096,
+    family_hint: 'toy',
+  },
+  capabilities: ['chat'],
+  mmproj_asset_ids: ['mmproj:toy-vision'],
+  base_model_asset_ids: [],
+  warnings: ['Filename metadata only.'],
+};
+
+const mmprojAsset = {
+  asset_id: 'mmproj:toy-vision',
+  kind: 'mmproj',
+  identity_basis: 'resolved_path',
+  path: '/srv/models/toy-mmproj.gguf',
+  resolved_path: '/srv/models/toy-mmproj.gguf',
+  display_name: 'Toy Vision Projector',
+  source: 'models_dir',
+  size_bytes: 320_000_000,
+  modified_at: '2026-05-18T10:05:00Z',
+  metadata: {
+    family_hint: 'toy',
+  },
+  capabilities: ['vision'],
+  mmproj_asset_ids: [],
+  base_model_asset_ids: ['gguf:toy-chat'],
+  warnings: [],
+};
+
+const profiles = [
+  {
+    profile_id: 'chat-runtime',
+    name: 'Chat runtime',
+    enabled: true,
+    mode: 'chat',
+    model_id: 'gguf:toy-chat',
+    model_path: null,
+    mmproj_model_id: null,
+    mmproj_path: null,
+    mmproj_display_name: null,
+    capabilities: { chat: true },
+    modalities: { input: ['text'], output: ['text'] },
+    capability_warnings: [],
+    host: '127.0.0.1',
+    port: 8181,
+    port_policy: 'explicit',
+    server_args: { ctx_size: 4096 },
+    autostart: true,
+    restart_policy: { max_restarts: 2 },
+    provider_alias: 'llamacpp-chat-runtime',
+    tags: ['chat'],
+  },
+  {
+    profile_id: 'vision-runtime',
+    name: 'Vision runtime',
+    enabled: true,
+    mode: 'vision',
+    model_id: 'gguf:toy-chat',
+    model_path: null,
+    mmproj_model_id: 'mmproj:toy-vision',
+    mmproj_path: '/srv/models/toy-mmproj.gguf',
+    mmproj_display_name: 'Toy Vision Projector',
+    capabilities: { chat: true, vision: true },
+    modalities: { input: ['text', 'image'], output: ['text'] },
+    capability_warnings: ['Projector pairing is inferred from local assets.'],
+    host: '127.0.0.1',
+    port: 8182,
+    port_policy: 'explicit',
+    server_args: {},
+    autostart: false,
+    restart_policy: { max_restarts: 1 },
+    provider_alias: 'llamacpp-vision-runtime',
+    tags: ['vision'],
+  },
+  {
+    profile_id: 'embedding-runtime',
+    name: 'Embedding runtime',
+    enabled: true,
+    mode: 'embedding',
+    model_id: 'gguf:toy-chat',
+    model_path: null,
+    mmproj_model_id: null,
+    mmproj_path: null,
+    mmproj_display_name: null,
+    capabilities: { embeddings: true },
+    modalities: { input: ['text'], output: ['embedding'] },
+    capability_warnings: [],
+    host: '127.0.0.1',
+    port: 8183,
+    port_policy: 'explicit',
+    server_args: { embedding: true },
+    autostart: false,
+    restart_policy: { max_restarts: 1 },
+    provider_alias: 'llamacpp-embedding-runtime',
+    tags: ['embedding'],
+  },
+];
+
+const runtimes = [
+  {
+    profile_id: 'chat-runtime',
+    state: 'running',
+    pid: 4242,
+    host: '127.0.0.1',
+    port: 8181,
+    endpoint: 'http://127.0.0.1:8181',
+    model_id: 'gguf:toy-chat',
+    model_path: '/srv/models/toy-chat.gguf',
+    mmproj_model_id: null,
+    mmproj_path: null,
+    mmproj_display_name: null,
+    capabilities: { chat: true },
+    modalities: { input: ['text'], output: ['text'] },
+    capability_warnings: [],
+    resolved_args: ['--model', '/srv/models/toy-chat.gguf', '--port', '8181'],
+    started_at: '2026-05-18T10:10:00Z',
+    stopped_at: null,
+    last_health_at: '2026-05-18T10:11:00Z',
+    restart_count: 0,
+    next_restart_at: null,
+    exit_code: null,
+    last_error: null,
+    log_tail_available: true,
+    warnings: ['GPU probe unavailable.'],
+    health: { ok: true },
+    message: null,
+  },
+  {
+    profile_id: 'vision-runtime',
+    state: 'stopped',
+    pid: null,
+    host: '127.0.0.1',
+    port: 8182,
+    endpoint: null,
+    model_id: 'gguf:toy-chat',
+    model_path: '/srv/models/toy-chat.gguf',
+    mmproj_model_id: 'mmproj:toy-vision',
+    mmproj_path: '/srv/models/toy-mmproj.gguf',
+    mmproj_display_name: 'Toy Vision Projector',
+    capabilities: { chat: true, vision: true },
+    modalities: { input: ['text', 'image'], output: ['text'] },
+    capability_warnings: ['Projector pairing is inferred from local assets.'],
+    resolved_args: [],
+    started_at: null,
+    stopped_at: '2026-05-18T10:12:00Z',
+    last_health_at: null,
+    restart_count: 0,
+    next_restart_at: null,
+    exit_code: 0,
+    last_error: null,
+    log_tail_available: false,
+    warnings: ['Hardware fit warning only.'],
+    health: {},
+    message: 'Stopped by operator.',
+  },
+  {
+    profile_id: 'embedding-runtime',
+    state: 'failed',
+    pid: null,
+    host: '127.0.0.1',
+    port: 8183,
+    endpoint: null,
+    model_id: 'gguf:toy-chat',
+    model_path: '/srv/models/toy-chat.gguf',
+    mmproj_model_id: null,
+    mmproj_path: null,
+    mmproj_display_name: null,
+    capabilities: { embeddings: true },
+    modalities: { input: ['text'], output: ['embedding'] },
+    capability_warnings: [],
+    resolved_args: [],
+    started_at: '2026-05-18T10:13:00Z',
+    stopped_at: '2026-05-18T10:14:00Z',
+    last_health_at: null,
+    restart_count: 2,
+    next_restart_at: null,
+    exit_code: 1,
+    last_error: 'llama-server exited with code 1',
+    log_tail_available: true,
+    warnings: ['Restart limit reached.'],
+    health: { ok: false },
+    message: 'Startup failed.',
+  },
+];
+
+async function mockManagedRuntimeAdmin(page: Page): Promise<{
+  useInChatProfileIds: string[];
+}> {
+  const useInChatProfileIds: string[] = [];
+
+  await page.route('**/api/v1/llamacpp/config', (route) =>
+    fulfillJson(route, {
+      saved_config: savedConfig,
+      active_config: {
+        handler_configured: true,
+        enabled: true,
+        executable_path: '/opt/llama-server',
+        models_dir: '/srv/models',
+        default_host: '127.0.0.1',
+        default_port: 8080,
+        active_model: null,
+        active_host: null,
+        active_port: null,
+        active_pid: null,
+      },
+      restart_required: false,
+      restart_reasons: [],
+      env_overrides: {},
+      warnings: [],
+    })
+  );
+
+  await page.route('**/api/v1/llamacpp/status', (route) =>
+    fulfillJson(route, {
+      state: 'stopped',
+      model: null,
+      port: 8080,
+      backend: 'llamacpp',
+    })
+  );
+
+  await page.route('**/api/v1/llamacpp/inventory', (route) =>
+    fulfillJson(route, {
+      models: [
+        {
+          model_id: 'gguf:toy-chat',
+          display_name: 'Toy Chat GGUF',
+          basename: 'toy-chat.gguf',
+          source: 'models_dir',
+          path: '/srv/models/toy-chat.gguf',
+          size_bytes: 2_200_000_000,
+          modified_at: '2026-05-18T10:00:00Z',
+          metadata: {
+            quantization: 'Q4_K_M',
+            parameter_hint: '7B',
+            context_hint: 4096,
+          },
+          warnings: [],
+        },
+      ],
+      warnings: [],
+      scan_limited: false,
+    })
+  );
+
+  await page.route('**/api/v1/llamacpp/hardware', (route) =>
+    fulfillJson(route, {
+      ram_total_bytes: 16_000_000_000,
+      ram_available_bytes: 8_000_000_000,
+      cpu_count: 8,
+      gpus: [],
+      warnings: ['GPU probe unavailable.'],
+    })
+  );
+
+  await page.route('**/api/v1/llamacpp/assets', (route) =>
+    fulfillJson(route, {
+      assets: [ggufAsset, mmprojAsset],
+      warnings: ['One asset had filename-derived metadata.'],
+      scan_limited: false,
+    })
+  );
+
+  await page.route('**/api/v1/llamacpp/assets/downloads', (route) =>
+    fulfillJson(route, { jobs: [] })
+  );
+
+  await page.route('**/api/v1/llamacpp/profiles/*/use-in-chat', (route) => {
+    const match = route.request().url().match(/\/llamacpp\/profiles\/([^/]+)\/use-in-chat$/);
+    useInChatProfileIds.push(decodeURIComponent(match?.[1] || ''));
+    return fulfillJson(route, {
+      provider: 'llamacpp',
+      endpoint: 'http://127.0.0.1:8181',
+      updated: true,
+      effective: true,
+      warnings: [],
+    });
+  });
+
+  await page.route('**/api/v1/llamacpp/profiles', (route) =>
+    fulfillJson(route, { profiles })
+  );
+
+  await page.route('**/api/v1/llamacpp/instances', (route) =>
+    fulfillJson(route, {
+      runtimes,
+      warnings: ['Runtime reconciliation is using bounded restart policy.'],
+    })
+  );
+
+  return { useInChatProfileIds };
+}
+
+test.describe('llama.cpp managed runtime admin smoke', () => {
+  test('shows assets, profile runtimes, warnings, and running-only chat wiring', async ({
+    authedPage,
+    diagnostics,
+  }) => {
+    const api = await mockManagedRuntimeAdmin(authedPage);
+    const admin = new AdminPage(authedPage);
+
+    await admin.gotoSection('llamacpp');
+    await admin.assertSectionReady('llamacpp');
+
+    await expect(authedPage.getByText('Assets', { exact: true })).toBeVisible();
+    await expect(authedPage.getByText('Toy Chat GGUF').first()).toBeVisible();
+    await expect(authedPage.getByText('One asset had filename-derived metadata.')).toBeVisible();
+
+    const runtimePanel = authedPage.getByLabel('Runtime instances');
+    await expect(runtimePanel).toBeVisible();
+    await expect(runtimePanel.getByText('Chat runtime')).toBeVisible();
+    await expect(runtimePanel.getByText('Vision runtime')).toBeVisible();
+    await expect(runtimePanel.getByText('Embedding runtime')).toBeVisible();
+    await expect(runtimePanel.getByText('running')).toBeVisible();
+    await expect(runtimePanel.getByText('stopped')).toBeVisible();
+    await expect(runtimePanel.getByText('failed')).toBeVisible();
+    await expect(runtimePanel.getByText('Toy Vision Projector').first()).toBeVisible();
+    await expect(runtimePanel.getByText('GPU probe unavailable.')).toBeVisible();
+    await expect(runtimePanel.getByText('Restart limit reached.')).toBeVisible();
+    await expect(
+      runtimePanel.getByText('Projector pairing is inferred from local assets.')
+    ).toBeVisible();
+
+    await expect(
+      authedPage.getByRole('button', { name: 'Use Chat runtime in Chat' })
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('button', { name: 'Use Vision runtime in Chat' })
+    ).toHaveCount(0);
+    await expect(
+      authedPage.getByRole('button', { name: 'Use Embedding runtime in Chat' })
+    ).toHaveCount(0);
+
+    await authedPage.getByRole('button', { name: 'Use Chat runtime in Chat' }).click();
+    expect(api.useInChatProfileIds).toEqual(['chat-runtime']);
+
+    await assertNoCriticalErrors(diagnostics);
+  });
+});

--- a/backlog/completed/task-418.15 - Finalize-llama.cpp-managed-runtime-rollout.md
+++ b/backlog/completed/task-418.15 - Finalize-llama.cpp-managed-runtime-rollout.md
@@ -1,0 +1,75 @@
+---
+id: TASK-418.15
+title: Finalize llama.cpp managed runtime rollout
+status: Done
+labels:
+- llamacpp
+- backend
+- webui
+- docs
+- e2e
+priority: medium
+parent_task_id: TASK-418
+documentation:
+- Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+- Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+modified_files:
+- Docs/API-related/llamacpp_integration_modes.md
+- Docs/User_Guides/Integrations_Experiments/Setting_up_a_local_LLM.md
+- Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+- apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts
+- backlog/completed/task-418.15 - Finalize-llama.cpp-managed-runtime-rollout.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 6 from the llama.cpp managed runtime closeout plan: add final documentation and E2E smoke coverage, run focused backend/frontend/security verification, and update rollout tracking without changing runtime semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 llama.cpp docs describe managed runtime profiles, default-profile compatibility, local import/register, mmproj pairing, autostart/restart limitations, and deferred remote catalogs/downloads.
+- [x] #2 E2E smoke coverage exercises the llama.cpp runtime admin page with mocked backend responses for assets, profiles, runtimes, warnings, and stopped-profile Chat wiring controls.
+- [x] #3 Focused backend and frontend verification are run and recorded, with any environment-limited E2E blocker documented.
+- [x] #4 Bandit and git diff checks are run for the touched scope.
+- [x] #5 Parent rollout tracking is updated with final summary and known skips/blockers.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Closeout implementation completed for Task 6.
+
+Implemented:
+- Added mocked Playwright smoke coverage for `/admin/llamacpp` managed runtime assets, profiles, runtime instances, warnings, and running-only Chat wiring.
+- Updated source llama.cpp docs with managed runtime profiles, default-profile compatibility, local register/import semantics, mmproj pairing, bounded autostart/restart behavior, and deferred download/catalog boundaries. `Docs/Published` files are generated and intentionally left untouched.
+- Updated the managed runtime implementation plan final Task 6 evidence and checklist.
+
+Verification:
+- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx playwright test e2e/workflows/llamacpp-runtime-admin.spec.ts --reporter=line` from `apps/tldw-frontend`: 1 passed.
+- `bunx vitest run src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx` from `apps/packages/ui`: 42 passed.
+- Focused backend pytest set for llama.cpp profile store, supervisor, runner, runtime API, provider/logs API, profile capabilities, model metadata, and AuthNZ claims: 163 passed, 5 warnings.
+- `python -m bandit -r ... -f json -o /tmp/bandit_llamacpp_runtime_rollout.json`: no findings.
+- `git diff --check`: passed.
+
+Known notes:
+- The Playwright smoke requires `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000` so the frontend dev server satisfies advanced-mode networking validation.
+- Remote downloads/catalogs remain deferred to the acquisition workflow and were not implemented in this runtime closeout.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 6 closeout is complete. The llama.cpp docs now describe backend-owned managed runtime profiles, default-profile compatibility, local register/import behavior, explicit mmproj pairing, bounded autostart/restart behavior, and deferred acquisition boundaries. A mocked Playwright smoke covers the admin runtime page across assets, profiles, runtime states, warnings, and running-only Chat wiring. Focused frontend/backend tests, E2E smoke, Bandit, and diff checks all passed; the only environment note is that the Playwright dev server needs `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000` in advanced deployment mode.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/completed/task-418.16 - Address-PR-1854-llama.cpp-rollout-review-comments.md
+++ b/backlog/completed/task-418.16 - Address-PR-1854-llama.cpp-rollout-review-comments.md
@@ -1,0 +1,70 @@
+---
+id: TASK-418.16
+title: Address PR 1854 llama.cpp rollout review comments
+status: Done
+labels:
+- llamacpp
+- pr-review
+- docs
+- e2e
+priority: medium
+parent_task_id: TASK-418
+references:
+- https://github.com/rmusser01/tldw_server/pull/1854
+- https://github.com/rmusser01/tldw_server/pull/1854#pullrequestreview-4314972815
+documentation:
+- Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+modified_files:
+- Docs/API-related/llamacpp_integration_modes.md
+- apps/tldw-frontend/e2e/workflows/llamacpp-runtime-admin.spec.ts
+- backlog/completed/task-418.16 - Address-PR-1854-llama.cpp-rollout-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the still-valid Gemini review comments on PR #1854 for the llama.cpp rollout closeout docs and E2E smoke test.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Still-valid PR #1854 review comments are addressed or explicitly skipped with reason.
+- [x] #2 Docs/Published feedback is skipped as obsolete because generated files are not in the PR diff.
+- [x] #3 Focused verification for changed docs/E2E files is run and recorded.
+- [x] #4 Changes are committed and pushed to PR #1854.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Review sweep:
+- Gemini source-doc readability comment addressed by converting the managed profile attribute sentence into a short bullet list.
+- Gemini E2E byte-size comment addressed with `MB` and `GB` constants in the smoke fixture.
+- Gemini E2E `use-in-chat` mock parsing comment addressed by returning a 400 mock response when the expected profile ID is missing instead of recording an empty string.
+- Gemini `Docs/Published` comment skipped as obsolete because generated published docs are not in the PR diff.
+- Qodo flaky chat-wiring assertion comment addressed by waiting for the profile-scoped `use-in-chat` POST response before asserting the recorded profile id.
+- CodeRabbit `use-in-chat` mock method-validation comment addressed by returning a 405 mock response for non-POST requests.
+- CodeRabbit polling comment addressed by polling `api.useInChatProfileIds` after the profile-scoped POST response completes.
+
+Verification:
+- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx playwright test e2e/workflows/llamacpp-runtime-admin.spec.ts --reporter=line` from `apps/tldw-frontend`: 1 passed.
+- `git diff --check`: passed.
+- `git diff --name-status origin/dev...HEAD`: confirmed no `Docs/Published` files in the branch diff.
+- Bandit skipped because this review-fix slice changes docs, E2E TypeScript, and Backlog metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR #1854 review comments are addressed. The source docs now use a scannable attribute list, the E2E fixture uses byte-size constants, the `use-in-chat` mock fails fast on unexpected URLs and non-POST requests, and the smoke waits for the async Chat wiring request before polling the recorded mock state. The generated `Docs/Published` feedback was skipped as obsolete because those files are not in the PR diff.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418 - Plan-llama.cpp-managed-runtime-closeout-implementation.md
+++ b/backlog/tasks/task-418 - Plan-llama.cpp-managed-runtime-closeout-implementation.md
@@ -37,6 +37,8 @@ Write a consolidation implementation plan for the remaining llama.cpp managed ru
 
 <!-- SECTION:NOTES:BEGIN -->
 Created Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md as a consolidation and closeout plan grounded in current origin/dev. The plan references the landed Stage 1, Asset Inventory V2, mmproj/model-family, saved profile editor, and acquisition/import plans; it decomposes remaining runtime work into supervision reconciliation, validation hardening, V1/API compatibility, provider metadata, Admin UI, and rollout verification. Bandit not run because this task changes docs/backlog only. Standalone tracking is intentional because origin/dev has a duplicate TASK-397 ID collision. PR #1815 review follow-up replaced a fake key-like TLDW_E2E_API_KEY assignment with a note to supply the value from local test configuration.
+
+Rollout closeout follow-through completed under TASK-418.15: source docs now cover managed runtime profile behavior, default-profile compatibility, local import/register, mmproj pairing, bounded restart/autostart behavior, and deferred acquisition boundaries. `Docs/Published` files are generated and intentionally left untouched. The new admin E2E smoke plus focused frontend/backend/Bandit/diff verification passed. The Playwright smoke requires `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000` when starting the advanced-mode frontend dev server.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Document managed llama.cpp runtime profile behavior in the source API/user docs.
- Add a mocked `/admin/llamacpp` Playwright smoke for assets, profiles, runtime states, warnings, and running-only Chat wiring.
- Close out the managed-runtime rollout plan and Backlog tracking for Task 6, with `Docs/Published` left to the generation pipeline.

## Change Summary
Human-authored summary required before merge:
- [ ] Maintainer: explain what changed and why these implementation choices were made.

## Test Plan
- [x] `bunx vitest run src/components/Option/Admin/__tests__/LlamacppAdminPage.test.tsx src/components/Option/Admin/__tests__/LlamacppAssetsPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppProfilesPanel.test.tsx src/components/Option/Admin/__tests__/LlamacppRuntimePanel.test.tsx` from `apps/packages/ui` - 42 passed.
- [x] `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_store.py tldw_Server_API/tests/LLM_Local/test_llamacpp_supervisor_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py tldw_Server_API/tests/LLM_Local/test_llamacpp_runtime_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_provider_and_logs_api.py tldw_Server_API/tests/LLM_Local/test_llamacpp_profile_capabilities.py tldw_Server_API/tests/LLM_Local/test_llm_models_metadata_llamacpp_profiles.py tldw_Server_API/tests/AuthNZ_Unit/test_llamacpp_permissions_claims.py -v` - 163 passed, 5 warnings.
- [x] `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx playwright test e2e/workflows/llamacpp-runtime-admin.spec.ts --reporter=line` from `apps/tldw-frontend` - 1 passed.
- [x] `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_models.py tldw_Server_API/app/core/Local_LLM/llamacpp_profile_store.py tldw_Server_API/app/core/Local_LLM/llamacpp_supervisor_service.py tldw_Server_API/app/core/Local_LLM/llamacpp_runtime_reconciler.py tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py tldw_Server_API/app/core/Local_LLM/llamacpp_profile_capabilities.py tldw_Server_API/app/api/v1/endpoints/llamacpp.py -f json -o /tmp/bandit_llamacpp_runtime_rollout.json` - no findings.
- [x] `git diff --check origin/dev...HEAD`

## Notes
- Remote downloads/catalogs remain deferred to the acquisition workflow and are not implemented in this runtime closeout.
- The Playwright smoke needs `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000` so the advanced-mode frontend dev server satisfies networking validation.
- `Docs/Published` files are intentionally not edited in this PR because they are generated from the base docs.
