### PR TITLE
Migrate Watchlists run detail product states

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3663,28 +3663,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx:Alert#antd-alert-reportevidencepanel-type-error-line-242-1qgfbqr",
-    "path": "src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx:Alert#antd-alert-reportevidencepanel-type-info-line-268-rd9wg7",
-    "path": "src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx:Alert#antd-alert-overviewtab-type-error-line-1286-1hrjmvr",
     "path": "src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3641,28 +3641,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/Watchlists/OutputsTab/outputMetadata.ts:Ready",
-    "path": "src/components/Option/Watchlists/OutputsTab/outputMetadata.ts",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing canonical state label \"Ready\" in src/components/Option/Watchlists/OutputsTab/outputMetadata.ts before the stable duplicate-id guard.",
-    "replacement": "design-system state registry",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "canonical-state-label:src/components/Option/Watchlists/OutputsTab/outputMetadata.ts:Blocked",
-    "path": "src/components/Option/Watchlists/OutputsTab/outputMetadata.ts",
-    "rule": "canonical-state-label",
-    "subject": "Blocked",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing canonical state label \"Blocked\" in src/components/Option/Watchlists/OutputsTab/outputMetadata.ts before the stable duplicate-id guard.",
-    "replacement": "design-system state registry",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "canonical-state-label:src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx:Ready",
     "path": "src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx",
     "rule": "canonical-state-label",
@@ -3736,72 +3714,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx:Alert#antd-alert-rundetaildrawer-type-info-line-957-131cg9a",
-    "path": "src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx:Alert#antd-alert-rundetaildrawer-type-warning-line-1024-u7a1r6",
-    "path": "src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx:Alert#antd-alert-rundetaildrawer-type-info-line-1064-12xicmk",
-    "path": "src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx:Alert#antd-alert-rundetaildrawer-type-info-line-1085-18smke5",
-    "path": "src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx:Alert#antd-alert-rundetaildrawer-type-error-line-1188-1y33y9h",
-    "path": "src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx:Alert#antd-alert-rundetaildrawer-type-warning-line-1197-1siapxj",
-    "path": "src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx before the stable duplicate-id guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/assets/locale/en/watchlists.json
+++ b/apps/packages/ui/src/assets/locale/en/watchlists.json
@@ -1468,6 +1468,12 @@
       "news": "News briefing",
       "general": "General research"
     },
+    "readiness": {
+      "ready": "Ready",
+      "needsReview": "Needs review",
+      "blocked": "Blocked",
+      "legacyLiveOnly": "Live provenance only"
+    },
     "table": {
       "sourceCount": "{{count}} sources",
       "alertCount": "{{count}} alerts",
@@ -1546,6 +1552,19 @@
       "pending": "Pending",
       "sent": "Sent",
       "stored": "Stored"
+    },
+    "audioStatus": {
+      "completed": "Completed",
+      "ready": "Ready",
+      "fallback": "Fallback",
+      "partial": "Partial",
+      "queued": "Queued",
+      "pending": "Pending",
+      "running": "Running",
+      "inProgress": "In progress",
+      "failed": "Failed",
+      "error": "Error",
+      "unknown": "Unknown"
     },
     "noContent": "No content available",
     "openInNewTab": "Open in new tab",

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx
@@ -42,6 +42,7 @@ import { OutputPreviewDrawer } from "./OutputPreviewDrawer"
 import {
   buildDeliveryDisclosureSummary,
   buildRegenerateOutputRequest,
+  createOutputMetadataLabels,
   getDeliveryStatusColor,
   getDeliveryStatusLabel,
   getOutputArtifactLabel,
@@ -112,6 +113,7 @@ const hasOutputDeliveryIssue = (output: WatchlistOutput): boolean =>
 export const OutputsTab: React.FC = () => {
   const { t } = useTranslation(["watchlists", "common"])
   const { isConstrained } = useWatchlistsViewport()
+  const outputMetadataLabels = useMemo(() => createOutputMetadataLabels(t), [t])
 
   // Store state
   const outputs = useWatchlistsStore((s) => s.outputs)
@@ -681,7 +683,7 @@ export const OutputsTab: React.FC = () => {
         return (
           <Space size={[4, 4]} wrap>
             <Tag color={getReadinessTagColor(readiness.state)}>
-              {getReadinessLabel(readiness.state)}
+              {getReadinessLabel(readiness.state, outputMetadataLabels)}
             </Tag>
             {getOutputReportSnapshotAvailable(record.metadata) ? (
               <Tooltip title={t("watchlists:reports.evidence.snapshotAvailable", "Immutable evidence snapshot is available")}>
@@ -901,7 +903,7 @@ export const OutputsTab: React.FC = () => {
                 </div>
                 <div className="flex flex-wrap gap-1">
                   <Tag color={getReadinessTagColor(readiness.state)}>
-                    {getReadinessLabel(readiness.state)}
+                    {getReadinessLabel(readiness.state, outputMetadataLabels)}
                   </Tag>
                   {getOutputReportSnapshotAvailable(output.metadata) ? (
                     <Tag color="blue">

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
-import { Alert, Button, Empty, Spin, Table, Tag, Tooltip } from "antd"
+import { Empty, Spin, Table, Tag, Tooltip } from "antd"
 import type { ColumnsType } from "antd/es/table"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui"
 import { getWatchlistOutputEvidence } from "@/services/watchlists"
 import type {
   WatchlistOutputEvidenceResponse,
@@ -9,6 +10,7 @@ import type {
   WatchlistReportExcludedItem
 } from "@/types/watchlists"
 import {
+  createOutputMetadataLabels,
   getReadinessLabel,
   getReadinessTagColor
 } from "./outputMetadata"
@@ -38,6 +40,7 @@ export const ReportEvidencePanel: React.FC<ReportEvidencePanelProps> = ({
 }) => {
   const { t } = useTranslation(["watchlists", "common"])
   const { isConstrained } = useWatchlistsViewport()
+  const outputMetadataLabels = useMemo(() => createOutputMetadataLabels(t), [t])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [response, setResponse] = useState<WatchlistOutputEvidenceResponse | null>(
@@ -240,16 +243,15 @@ export const ReportEvidencePanel: React.FC<ReportEvidencePanelProps> = ({
   if (error) {
     return (
       <Alert
-        type="error"
-        showIcon
+        variant="error"
         title={t("watchlists:reports.evidence.errorTitle", "Evidence snapshot unavailable")}
-        description={error}
-        action={(
-          <Button size="small" onClick={loadEvidence}>
-            {t("common:retry", "Retry")}
-          </Button>
-        )}
-      />
+        action={{
+          label: t("common:retry", "Retry"),
+          onClick: loadEvidence
+        }}
+      >
+        {error}
+      </Alert>
     )
   }
 
@@ -266,17 +268,15 @@ export const ReportEvidencePanel: React.FC<ReportEvidencePanelProps> = ({
     const warning = readinessWarnings[0]
     return (
       <Alert
-        type="info"
-        showIcon
+        variant="info"
         title={t("watchlists:reports.evidence.legacyTitle", "Live provenance only")}
-        description={
-          warning?.message ||
+      >
+        {warning?.message ||
           t(
             "watchlists:reports.evidence.legacyDescription",
             "This older report was created before evidence snapshots were available."
-          )
-        }
-      />
+          )}
+      </Alert>
     )
   }
 
@@ -295,7 +295,7 @@ export const ReportEvidencePanel: React.FC<ReportEvidencePanelProps> = ({
           </span>
           {readiness && (
             <Tag color={getReadinessTagColor(readiness.state)}>
-              {getReadinessLabel(readiness.state)}
+              {getReadinessLabel(readiness.state, outputMetadataLabels)}
             </Tag>
           )}
         </div>
@@ -332,8 +332,7 @@ export const ReportEvidencePanel: React.FC<ReportEvidencePanelProps> = ({
           {readinessWarnings.map((warning) => (
             <Alert
               key={`${warning.code}-${warning.message}`}
-              type={warning.severity === "blocking" ? "error" : "warning"}
-              showIcon
+              variant={warning.severity === "blocking" ? "error" : "warning"}
               title={warning.message}
             />
           ))}

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportEvidencePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportEvidencePanel.test.tsx
@@ -194,6 +194,7 @@ describe("ReportEvidencePanel", () => {
     render(<ReportEvidencePanel outputId={77} />)
 
     expect(await screen.findByText("Live provenance only")).toBeInTheDocument()
+    expect(screen.getByText("Live provenance only").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
     expect(
       screen.getByText("This older report was created before evidence snapshots were available.")
     ).toBeInTheDocument()
@@ -207,6 +208,7 @@ describe("ReportEvidencePanel", () => {
     render(<ReportEvidencePanel outputId={42} />)
 
     expect(await screen.findByText("Evidence snapshot unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Evidence snapshot unavailable").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
 
     await waitFor(() => {

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   buildDeliveryDisclosureSummary,
   buildRegenerateOutputRequest,
@@ -266,6 +266,23 @@ describe("outputMetadata helpers", () => {
 
     expect(getReadinessLabel("legacy_live_only")).toBe("Live provenance only")
     expect(getReadinessTagColor("legacy_live_only")).toBe("default")
+  })
+
+  it("uses design-system registry labels for canonical readiness and audio states", async () => {
+    vi.resetModules()
+    vi.doMock("@/design-system", () => ({
+      READY_STATE_LABEL: "Registry Ready",
+      BLOCKED_STATE_LABEL: "Registry Blocked",
+      LOADING_STATE_LABEL: "Registry Loading"
+    }))
+
+    const metadataModule = await import("../outputMetadata")
+
+    expect(metadataModule.getReadinessLabel("ready")).toBe("Registry Ready")
+    expect(metadataModule.getReadinessLabel("blocked")).toBe("Registry Blocked")
+    expect(metadataModule.getAudioStatusLabel("ready")).toBe("Registry Ready")
+
+    vi.doUnmock("@/design-system")
   })
 
   it("returns safe legacy defaults when report metadata is absent or malformed", () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest"
 import {
   buildDeliveryDisclosureSummary,
   buildRegenerateOutputRequest,
+  createOutputMetadataLabels,
+  getAudioStatusLabel,
   getDeliveryStatusColor,
   getDeliveryStatusLabel,
   getAudioStatusSummary,
@@ -268,6 +270,26 @@ describe("outputMetadata helpers", () => {
     expect(getReadinessTagColor("legacy_live_only")).toBe("default")
   })
 
+  it("accepts translated readiness and audio labels from call sites", () => {
+    const labels = createOutputMetadataLabels((key, fallback) => `${key}:${fallback}`)
+
+    expect(getReadinessLabel("warning", labels)).toBe(
+      "watchlists:reports.readiness.needsReview:Needs review"
+    )
+    expect(getReadinessLabel("legacy_live_only", labels)).toBe(
+      "watchlists:reports.readiness.legacyLiveOnly:Live provenance only"
+    )
+    expect(getAudioStatusLabel("completed", labels)).toBe(
+      "watchlists:outputs.audioStatus.completed:Completed"
+    )
+    expect(getAudioStatusLabel("fallback", labels)).toBe(
+      "watchlists:outputs.audioStatus.fallback:Fallback"
+    )
+    expect(getAudioStatusSummary({ status: "queued" }, labels).statusLabel).toBe(
+      "watchlists:outputs.audioStatus.queued:Queued"
+    )
+  })
+
   it("uses design-system registry labels for canonical readiness and audio states", async () => {
     vi.resetModules()
     vi.doMock("@/design-system", () => ({
@@ -276,13 +298,16 @@ describe("outputMetadata helpers", () => {
       LOADING_STATE_LABEL: "Registry Loading"
     }))
 
-    const metadataModule = await import("../outputMetadata")
+    try {
+      const metadataModule = await import("../outputMetadata")
 
-    expect(metadataModule.getReadinessLabel("ready")).toBe("Registry Ready")
-    expect(metadataModule.getReadinessLabel("blocked")).toBe("Registry Blocked")
-    expect(metadataModule.getAudioStatusLabel("ready")).toBe("Registry Ready")
-
-    vi.doUnmock("@/design-system")
+      expect(metadataModule.getReadinessLabel("ready")).toBe("Registry Ready")
+      expect(metadataModule.getReadinessLabel("blocked")).toBe("Registry Blocked")
+      expect(metadataModule.getAudioStatusLabel("ready")).toBe("Registry Ready")
+    } finally {
+      vi.doUnmock("@/design-system")
+      vi.resetModules()
+    }
   })
 
   it("returns safe legacy defaults when report metadata is absent or malformed", () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
@@ -13,6 +13,21 @@ import {
   READY_STATE_LABEL
 } from "@/design-system"
 
+export type OutputMetadataTranslator = (key: string, defaultValue: string) => string
+
+export type AudioStatusLabelKey =
+  | "completed"
+  | "ready"
+  | "fallback"
+  | "partial"
+  | "queued"
+  | "pending"
+  | "running"
+  | "in_progress"
+  | "failed"
+  | "error"
+  | "unknown"
+
 export interface DeliveryStatusSummary {
   channel: string
   status: string
@@ -46,6 +61,11 @@ export interface AudioStatusSummary {
   finalArtifact?: AudioArtifactSummary
 }
 
+export interface OutputMetadataLabels {
+  readiness?: Partial<Record<WatchlistReportReadinessState, string>>
+  audioStatus?: Partial<Record<AudioStatusLabelKey, string>>
+}
+
 const AUDIO_OUTPUT_FORMATS = new Set(["mp3", "wav", "ogg", "m4a", "aac", "flac", "opus"])
 const REPORT_PRESETS = new Set<WatchlistReportPreset>([
   "auto",
@@ -75,6 +95,55 @@ const OUTPUT_MIME_TYPES: Record<string, string> = {
   flac: "audio/flac",
   opus: "audio/ogg"
 }
+const DEFAULT_READINESS_LABELS: Record<WatchlistReportReadinessState, string> = {
+  ready: READY_STATE_LABEL,
+  warning: "Needs review",
+  blocked: BLOCKED_STATE_LABEL,
+  legacy_live_only: "Live provenance only"
+}
+const DEFAULT_AUDIO_STATUS_LABELS: Record<AudioStatusLabelKey, string> = {
+  completed: "Completed",
+  ready: READY_STATE_LABEL,
+  fallback: "Fallback",
+  partial: "Partial",
+  queued: "Queued",
+  pending: "Pending",
+  running: "Running",
+  in_progress: "In progress",
+  failed: "Failed",
+  error: "Error",
+  unknown: "Unknown"
+}
+
+export const createOutputMetadataLabels = (
+  t: OutputMetadataTranslator
+): OutputMetadataLabels => ({
+  readiness: {
+    ready: t("watchlists:reports.readiness.ready", READY_STATE_LABEL),
+    warning: t("watchlists:reports.readiness.needsReview", DEFAULT_READINESS_LABELS.warning),
+    blocked: t("watchlists:reports.readiness.blocked", BLOCKED_STATE_LABEL),
+    legacy_live_only: t(
+      "watchlists:reports.readiness.legacyLiveOnly",
+      DEFAULT_READINESS_LABELS.legacy_live_only
+    )
+  },
+  audioStatus: {
+    completed: t("watchlists:outputs.audioStatus.completed", DEFAULT_AUDIO_STATUS_LABELS.completed),
+    ready: t("watchlists:outputs.audioStatus.ready", READY_STATE_LABEL),
+    fallback: t("watchlists:outputs.audioStatus.fallback", DEFAULT_AUDIO_STATUS_LABELS.fallback),
+    partial: t("watchlists:outputs.audioStatus.partial", DEFAULT_AUDIO_STATUS_LABELS.partial),
+    queued: t("watchlists:outputs.audioStatus.queued", DEFAULT_AUDIO_STATUS_LABELS.queued),
+    pending: t("watchlists:outputs.audioStatus.pending", DEFAULT_AUDIO_STATUS_LABELS.pending),
+    running: t("watchlists:outputs.audioStatus.running", DEFAULT_AUDIO_STATUS_LABELS.running),
+    in_progress: t(
+      "watchlists:outputs.audioStatus.inProgress",
+      DEFAULT_AUDIO_STATUS_LABELS.in_progress
+    ),
+    failed: t("watchlists:outputs.audioStatus.failed", DEFAULT_AUDIO_STATUS_LABELS.failed),
+    error: t("watchlists:outputs.audioStatus.error", DEFAULT_AUDIO_STATUS_LABELS.error),
+    unknown: t("watchlists:outputs.audioStatus.unknown", DEFAULT_AUDIO_STATUS_LABELS.unknown)
+  }
+})
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
@@ -302,12 +371,10 @@ export const getReadinessTagColor = (state: WatchlistReportReadinessState): stri
   return "default"
 }
 
-export const getReadinessLabel = (state: WatchlistReportReadinessState): string => {
-  if (state === "ready") return READY_STATE_LABEL
-  if (state === "warning") return "Needs review"
-  if (state === "blocked") return BLOCKED_STATE_LABEL
-  return "Live provenance only"
-}
+export const getReadinessLabel = (
+  state: WatchlistReportReadinessState,
+  labels?: OutputMetadataLabels
+): string => labels?.readiness?.[state] ?? DEFAULT_READINESS_LABELS[state]
 
 const normalizeDelivery = (
   value: unknown,
@@ -417,19 +484,15 @@ export const getAudioStatusColor = (status: string): string => {
   return "default"
 }
 
-export const getAudioStatusLabel = (status: string): string => {
+export const getAudioStatusLabel = (
+  status: string,
+  labels?: OutputMetadataLabels
+): string => {
   const normalized = status.trim().toLowerCase()
-  if (normalized === "completed") return "Completed"
-  if (normalized === "ready") return READY_STATE_LABEL
-  if (normalized === "fallback") return "Fallback"
-  if (normalized === "partial") return "Partial"
-  if (normalized === "queued") return "Queued"
-  if (normalized === "pending") return "Pending"
-  if (normalized === "running") return "Running"
-  if (normalized === "in_progress") return "In progress"
-  if (normalized === "failed") return "Failed"
-  if (normalized === "error") return "Error"
-  if (normalized === "unknown") return "Unknown"
+  if (normalized in DEFAULT_AUDIO_STATUS_LABELS) {
+    const labelKey = normalized as AudioStatusLabelKey
+    return labels?.audioStatus?.[labelKey] ?? DEFAULT_AUDIO_STATUS_LABELS[labelKey]
+  }
   return status
 }
 
@@ -496,7 +559,8 @@ const getAudioMetadataRecord = (metadata: unknown): Record<string, unknown> | nu
 }
 
 export const getAudioStatusSummary = (
-  value: WatchlistRunAudioStatus | unknown
+  value: WatchlistRunAudioStatus | unknown,
+  labels?: OutputMetadataLabels
 ): AudioStatusSummary => {
   const record = getMetadataRecord(value)
   const status = asNonEmptyString(record?.status) || "unknown"
@@ -536,7 +600,7 @@ export const getAudioStatusSummary = (
   return {
     requested,
     status,
-    statusLabel: getAudioStatusLabel(status),
+    statusLabel: getAudioStatusLabel(status, labels),
     statusColor: getAudioStatusColor(status),
     fallbackReason,
     error,
@@ -547,8 +611,11 @@ export const getAudioStatusSummary = (
   }
 }
 
-export const getOutputAudioStatusSummary = (metadata: unknown): AudioStatusSummary => {
-  return getAudioStatusSummary(getAudioMetadataRecord(metadata))
+export const getOutputAudioStatusSummary = (
+  metadata: unknown,
+  labels?: OutputMetadataLabels
+): AudioStatusSummary => {
+  return getAudioStatusSummary(getAudioMetadataRecord(metadata), labels)
 }
 
 interface BuildRegenerateOptions {

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
@@ -8,6 +8,10 @@ import type {
   WatchlistReportReadinessWarningSeverity,
   WatchlistRunAudioStatus
 } from "@/types/watchlists"
+import {
+  BLOCKED_STATE_LABEL,
+  READY_STATE_LABEL
+} from "@/design-system"
 
 export interface DeliveryStatusSummary {
   channel: string
@@ -299,9 +303,9 @@ export const getReadinessTagColor = (state: WatchlistReportReadinessState): stri
 }
 
 export const getReadinessLabel = (state: WatchlistReportReadinessState): string => {
-  if (state === "ready") return "Ready"
+  if (state === "ready") return READY_STATE_LABEL
   if (state === "warning") return "Needs review"
-  if (state === "blocked") return "Blocked"
+  if (state === "blocked") return BLOCKED_STATE_LABEL
   return "Live provenance only"
 }
 
@@ -416,7 +420,7 @@ export const getAudioStatusColor = (status: string): string => {
 export const getAudioStatusLabel = (status: string): string => {
   const normalized = status.trim().toLowerCase()
   if (normalized === "completed") return "Completed"
-  if (normalized === "ready") return "Ready"
+  if (normalized === "ready") return READY_STATE_LABEL
   if (normalized === "fallback") return "Fallback"
   if (normalized === "partial") return "Partial"
   if (normalized === "queued") return "Queued"

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import {
-  Alert,
   Button,
   Descriptions,
   Drawer,
@@ -17,6 +16,9 @@ import {
 import type { ColumnsType } from "antd/es/table"
 import { Download } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { LOADING_STATE_LABEL } from "@/design-system"
+import { Alert } from "@/components/ui"
+import { RecoveryCallout } from "@/components/ui/state"
 import { useWatchlistsStore } from "@/store/watchlists"
 import {
   cancelWatchlistRun,
@@ -1008,7 +1010,7 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
 
     const hasFinalAudio = Boolean(audioSummary.downloadUrl || audioSummary.finalArtifact)
     const statusText = audioStatusLoading
-      ? t("watchlists:runs.detail.audioStatusLoading", "Loading")
+      ? t("watchlists:runs.detail.audioStatusLoading", LOADING_STATE_LABEL)
       : audioStatusError
         ? t("watchlists:runs.detail.audioStatusUnavailable", "Unknown")
         : audioSummary.statusLabel
@@ -1073,19 +1075,21 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
         <div className="space-y-4">
           {data && (
             <Alert
-              type="info"
-              showIcon
+              variant="info"
               title={t("watchlists:runs.detail.linkageTitle", "Run linkage")}
-              description={t(
-                "watchlists:runs.detail.linkageDescription",
-                "Monitor #{{jobId}} produced {{count}} report{{plural}} for this run.",
-                {
-                  jobId: data.job_id,
-                  count: linkedOutputCount ?? 0,
-                  plural: linkedOutputCount === 1 ? "" : "s"
-                }
-              )}
-              action={(
+            >
+              <div className="space-y-2">
+                <p>
+                  {t(
+                    "watchlists:runs.detail.linkageDescription",
+                    "Monitor #{{jobId}} produced {{count}} report{{plural}} for this run.",
+                    {
+                      jobId: data.job_id,
+                      count: linkedOutputCount ?? 0,
+                      plural: linkedOutputCount === 1 ? "" : "s"
+                    }
+                  )}
+                </p>
                 <div className="flex flex-wrap gap-2">
                   <Button size="small" onClick={handleEditMonitor}>
                     {t("watchlists:runs.detail.openMonitor", "Open monitor")}
@@ -1099,8 +1103,8 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
                     {t("watchlists:runs.detail.openRunOutputs", "Open reports for this run")}
                   </Button>
                 </div>
-              )}
-            />
+              </div>
+            </Alert>
           )}
 
           {renderAudioStatusPanel()}
@@ -1141,40 +1145,32 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
 
           {data?.error_msg && (
             <div className="mt-4 space-y-3">
-              <Alert
-                type="warning"
-                showIcon
+              <RecoveryCallout
+                state="error"
                 title={t("watchlists:runs.detail.remediationTitle", "Suggested recovery steps")}
-                description={remediationHint || t(
+                message={remediationHint || t(
                   "watchlists:runs.detail.remediationFallback",
                   "Open logs and adjust source or monitor settings, then retry."
                 )}
-                action={(
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      size="small"
-                      type="primary"
-                      onClick={handleRetryRun}
-                      loading={retryingRun}
-                    >
-                      {t("watchlists:runs.detail.retryRun", "Retry run")}
-                    </Button>
-                    <Button
-                      size="small"
-                      onClick={handleEditMonitor}
-                    >
-                      {t("watchlists:runs.detail.editMonitor", "Edit monitor schedule")}
-                    </Button>
-                    {showSourceRecoveryAction && (
-                      <Button
-                        size="small"
-                        onClick={handleOpenSources}
-                      >
-                        {t("watchlists:runs.detail.openSources", "Review source settings")}
-                      </Button>
-                    )}
-                  </div>
-                )}
+                primaryAction={{
+                  label: t("watchlists:runs.detail.retryRun", "Retry run"),
+                  onClick: handleRetryRun,
+                  loading: retryingRun
+                }}
+                secondaryActions={[
+                  {
+                    label: t("watchlists:runs.detail.editMonitor", "Edit monitor schedule"),
+                    onClick: handleEditMonitor
+                  },
+                  ...(showSourceRecoveryAction
+                    ? [
+                        {
+                          label: t("watchlists:runs.detail.openSources", "Review source settings"),
+                          onClick: handleOpenSources
+                        }
+                      ]
+                    : [])
+                ]}
               />
               <div className="p-3 bg-danger/10 border border-danger/30 rounded text-sm text-danger font-mono">
                 {data.error_msg}
@@ -1182,17 +1178,15 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
               {/* Common causes by failure kind */}
               {failureKind && failureKind !== "unknown" && (
                 <Alert
-                  type="info"
-                  showIcon
+                  variant="info"
                   title={t("watchlists:runs.detail.commonCausesTitle", "Common causes")}
-                  description={
-                    <ul className="list-disc pl-4 text-sm space-y-1">
-                      {(COMMON_CAUSES_BY_KIND[failureKind] ?? []).map(([key, fallback]) => (
-                        <li key={key}>{t(key, fallback)}</li>
-                      ))}
-                    </ul>
-                  }
-                />
+                >
+                  <ul className="list-disc pl-4 text-sm space-y-1">
+                    {(COMMON_CAUSES_BY_KIND[failureKind] ?? []).map(([key, fallback]) => (
+                      <li key={key}>{t(key, fallback)}</li>
+                    ))}
+                  </ul>
+                </Alert>
               )}
             </div>
           )}
@@ -1203,8 +1197,7 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
                 {t("watchlists:runs.detail.filteredSampleTitle", "Filtered item sample")}
               </div>
               <Alert
-                type="info"
-                showIcon
+                variant="info"
                 title={t(
                   "watchlists:runs.detail.filteredSampleSummary",
                   "Showing {{count}} recently filtered item{{plural}} for quick diagnosis.",
@@ -1213,11 +1206,12 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
                     plural: data.filtered_sample.length === 1 ? "" : "s"
                   }
                 )}
-                description={t(
+              >
+                {t(
                   "watchlists:runs.detail.filteredSampleHelp",
                   "Use this sample with filter tallies below to tune include/exclude rules."
                 )}
-              />
+              </Alert>
               <div className="space-y-2">
                 {data.filtered_sample.map((sample, index) => {
                   const record = typeof sample === "object" && sample !== null
@@ -1306,21 +1300,21 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
           </div>
           {streamError && (
             <Alert
-              type="error"
-              showIcon
+              variant="error"
               className="mb-3"
               title={t("watchlists:runs.detail.streamErrorTitle", "Stream error")}
-              description={streamError}
-            />
+            >
+              {streamError}
+            </Alert>
           )}
           {data?.truncated && (
             <Alert
-              type="warning"
-              showIcon
+              variant="warning"
               className="mb-3"
               title={t("watchlists:runs.detail.logsTruncated", "Logs truncated")}
-              description={t("watchlists:runs.detail.logsTruncatedDesc", "Showing the most recent log output.")}
-            />
+            >
+              {t("watchlists:runs.detail.logsTruncatedDesc", "Showing the most recent log output.")}
+            </Alert>
           )}
           {data?.log_text ? (
             <pre className="bg-bg text-text p-4 rounded-lg font-mono text-xs max-h-96 overflow-auto whitespace-pre-wrap border border-border">
@@ -1428,20 +1422,14 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
           <Spin size="large" />
         </div>
       ) : error ? (
-        <Alert
-          type={error.severity}
-          showIcon
+        <RecoveryCallout
+          state={error.severity === "warning" ? "degraded" : "error"}
           title={error.title}
-          description={error.description}
-          action={(
-            <Button
-              size="small"
-              type="primary"
-              onClick={() => void loadRunDetails()}
-            >
-              {t("watchlists:errors.retry", "Retry")}
-            </Button>
-          )}
+          message={error.description}
+          primaryAction={{
+            label: t("watchlists:errors.retry", "Retry"),
+            onClick: () => void loadRunDetails()
+          }}
         />
       ) : data ? (
         <Tabs items={tabItems} />

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
@@ -18,7 +18,7 @@ import { Download } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { LOADING_STATE_LABEL } from "@/design-system"
 import { Alert } from "@/components/ui"
-import { RecoveryCallout } from "@/components/ui/state"
+import { RecoveryCallout, type RecoveryState } from "@/components/ui/state"
 import { useWatchlistsStore } from "@/store/watchlists"
 import {
   cancelWatchlistRun,
@@ -41,7 +41,10 @@ import { formatRelativeTime } from "@/utils/dateFormatters"
 import { StatusTag } from "../shared"
 import { mapWatchlistsError } from "../shared/watchlists-error"
 import { classifyRunFailure, getRunFailureHint } from "./run-notifications"
-import { getAudioStatusSummary } from "../OutputsTab/outputMetadata"
+import {
+  createOutputMetadataLabels,
+  getAudioStatusSummary
+} from "../OutputsTab/outputMetadata"
 import { useWatchlistsViewport } from "../shared/useWatchlistsViewport"
 import {
   getFocusableActiveElement,
@@ -91,6 +94,13 @@ const COMMON_CAUSES_BY_KIND: Record<string, [string, string][]> = {
   ]
 }
 
+const getRecoveryStateForSeverity = (
+  severity: ReturnType<typeof mapWatchlistsError>["severity"] | string | null | undefined
+): RecoveryState => {
+  if (severity === "error") return "error"
+  return "degraded"
+}
+
 export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
   runId,
   open,
@@ -98,6 +108,7 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
 }) => {
   const { t } = useTranslation(["watchlists", "common"])
   const { isConstrained } = useWatchlistsViewport()
+  const outputMetadataLabels = useMemo(() => createOutputMetadataLabels(t), [t])
   const [loading, setLoading] = useState(false)
   const [data, setData] = useState<RunDetailResponse | null>(null)
   const [error, setError] = useState<ReturnType<typeof mapWatchlistsError> | null>(null)
@@ -144,8 +155,8 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
   }, [data?.stats])
 
   const audioSummary = useMemo(() => {
-    return getAudioStatusSummary(audioStatus)
-  }, [audioStatus])
+    return getAudioStatusSummary(audioStatus, outputMetadataLabels)
+  }, [audioStatus, outputMetadataLabels])
 
   const downloadCsv = (content: string, filename: string): void => {
     const blob = new Blob([content], { type: "text/csv;charset=utf-8" })
@@ -1146,7 +1157,7 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
           {data?.error_msg && (
             <div className="mt-4 space-y-3">
               <RecoveryCallout
-                state="error"
+                state="degraded"
                 title={t("watchlists:runs.detail.remediationTitle", "Suggested recovery steps")}
                 message={remediationHint || t(
                   "watchlists:runs.detail.remediationFallback",
@@ -1423,7 +1434,7 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
         </div>
       ) : error ? (
         <RecoveryCallout
-          state={error.severity === "warning" ? "degraded" : "error"}
+          state={getRecoveryStateForSeverity(error.severity)}
           title={error.title}
           message={error.description}
           primaryAction={{

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.source-column.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.source-column.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { RunDetailDrawer } from "../RunDetailDrawer"
 
@@ -289,6 +289,30 @@ describe("RunDetailDrawer source column", () => {
     })
   })
 
+  it("renders warning-level load failures as degraded recovery states", async () => {
+    mocks.fetchWatchlistSourcesMock.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      size: 200,
+      has_more: false
+    })
+    mocks.getRunDetailsMock.mockRejectedValue({
+      status: 400,
+      message: "invalid input"
+    })
+
+    render(<RunDetailDrawer open runId={10} onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      const callout = screen
+        .getByText("Could not load run details.")
+        .closest('[data-ds-component="RecoveryCallout"]')
+      expect(callout).toBeInTheDocument()
+      expect(within(callout as HTMLElement).getByText("Degraded")).toBeInTheDocument()
+    })
+  })
+
   it("falls back to source id when source lookup data is unavailable", async () => {
     mocks.fetchWatchlistSourcesMock.mockResolvedValue({
       items: [],
@@ -404,6 +428,11 @@ describe("RunDetailDrawer source column", () => {
       expect(screen.getByText("Suggested recovery steps")).toBeInTheDocument()
       expect(
         screen.getByText("Suggested recovery steps").closest('[data-ds-component="RecoveryCallout"]')
+      ).toBeInTheDocument()
+      expect(
+        within(
+          screen.getByText("Suggested recovery steps").closest('[data-ds-component="RecoveryCallout"]') as HTMLElement
+        ).getByText("Degraded")
       ).toBeInTheDocument()
       expect(screen.getByText("Common causes").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
       expect(screen.getByText("Edit monitor schedule")).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.source-column.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.source-column.test.tsx
@@ -255,6 +255,7 @@ describe("RunDetailDrawer source column", () => {
       expect(screen.getByText("TechCrunch")).toBeInTheDocument()
       expect(screen.getByText("Included in briefing")).toBeInTheDocument()
       expect(screen.getByText("Monitor #1 produced 1 report for this run.")).toBeInTheDocument()
+      expect(screen.getByText("Run linkage").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
     })
   })
 
@@ -401,6 +402,10 @@ describe("RunDetailDrawer source column", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Suggested recovery steps")).toBeInTheDocument()
+      expect(
+        screen.getByText("Suggested recovery steps").closest('[data-ds-component="RecoveryCallout"]')
+      ).toBeInTheDocument()
+      expect(screen.getByText("Common causes").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
       expect(screen.getByText("Edit monitor schedule")).toBeInTheDocument()
       expect(screen.getByText("Review source settings")).toBeInTheDocument()
     })
@@ -422,6 +427,7 @@ describe("RunDetailDrawer source column", () => {
     mocks.getRunDetailsMock.mockResolvedValue({
       ...baseRunDetails,
       filter_tallies: { "kw:earnings": 2 },
+      truncated: true,
       filtered_sample: [
         {
           id: 7001,
@@ -439,6 +445,12 @@ describe("RunDetailDrawer source column", () => {
       expect(
         screen.getByText("Showing 1 recently filtered item for quick diagnosis.")
       ).toBeInTheDocument()
+      expect(
+        screen
+          .getByText("Showing 1 recently filtered item for quick diagnosis.")
+          .closest('[data-ds-component="Alert"]')
+      ).toBeInTheDocument()
+      expect(screen.getByText("Logs truncated").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
     })
   })
 

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
@@ -470,6 +470,7 @@ describe("RunDetailDrawer stream lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Stream error")).toBeInTheDocument()
+      expect(screen.getByText("Stream error").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
       expect(screen.getByText("Live stream error")).toBeInTheDocument()
     })
 
@@ -542,6 +543,7 @@ describe("RunDetailDrawer stream lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Logs truncated")).toBeInTheDocument()
+      expect(screen.getByText("Logs truncated").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
     })
 
     const pre = document.querySelector("pre")

--- a/backlog/tasks/task-45.44.3.2 - Migrate-RunDetailDrawer-alerts-and-Watchlists-output-labels-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.3.2 - Migrate-RunDetailDrawer-alerts-and-Watchlists-output-labels-to-design-system-primitives.md
@@ -19,8 +19,12 @@ modified_files:
 - apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
 - apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.source-column.test.tsx
 - apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportEvidencePanel.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportEvidencePanel.test.tsx
 - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
 - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+- apps/packages/ui/src/assets/locale/en/watchlists.json
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 ---
 
@@ -53,7 +57,7 @@ Used TDD: first added failing marker assertions for RunDetailDrawer design-syste
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated RunDetailDrawer's flagged product-state alerts to the shared design-system Alert and RecoveryCallout primitives, including linkage, recovery, common-causes, filtered-sample, stream-error, truncated-log, and load-error surfaces. Routed Watchlists output Ready/Blocked and audio-ready labels through the design-system state registry. Removed stale/migrated baseline exceptions for RunDetailDrawer and outputMetadata. PR: https://github.com/rmusser01/tldw_server/pull/1855. Verification: focused Watchlists Vitest suite passed 33 tests; product-state guard tests passed 52 tests; bun run verify:design-system-state exited 0 with baseline exceptions reduced to 352; git diff --check passed; bunx tsc --noEmit --pretty false still exits 2 on existing unrelated UI TypeScript debt with no touched-file matches. Bandit skipped because this slice only changes frontend TypeScript/JSON and Backlog task metadata.
+Migrated RunDetailDrawer's flagged product-state alerts to the shared design-system Alert and RecoveryCallout primitives, including linkage, recovery, common-causes, filtered-sample, stream-error, truncated-log, and load-error surfaces. Routed Watchlists output Ready/Blocked and audio-ready labels through the design-system state registry, added translation-key label maps for remaining readiness/audio labels, and made mocked registry cleanup exception-safe. Preserved warning-level recovery as the degraded state and migrated ReportEvidencePanel's evidence error, legacy, and warning callouts to design-system Alert instead of rebaselining shifted AntD debt. Removed stale/migrated baseline exceptions for RunDetailDrawer, ReportEvidencePanel, and outputMetadata. PR: https://github.com/rmusser01/tldw_server/pull/1855. Verification: focused Watchlists Vitest suite passed 38 tests; product-state guard tests passed 52 tests; bun run verify:design-system-state exited 0 with baseline exceptions reduced to 350; git diff --check passed; bunx tsc --noEmit --pretty false still exits 2 on existing unrelated UI TypeScript debt with no touched-file matches. Bandit skipped because this slice only changes frontend TypeScript/JSON and Backlog task metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.3.2 - Migrate-RunDetailDrawer-alerts-and-Watchlists-output-labels-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.44.3.2 - Migrate-RunDetailDrawer-alerts-and-Watchlists-output-labels-to-design-system-primitives.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.3.2
+title: Migrate RunDetailDrawer alerts and Watchlists output labels to design-system
+  primitives
+status: Done
+labels:
+- design-system
+- webui
+- watchlists
+priority: medium
+parent_task_id: TASK-45.44.3
+references:
+- apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1660
+- https://github.com/rmusser01/tldw_server/pull/1855
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.source-column.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Watchlists design-system product-state migration by replacing RunDetailDrawer's remaining product-state AntD Alert usage with design-system primitives and routing Watchlists output Ready/Blocked/Loading labels through the shared design-system state registry. This also resolves the current verifier drift where RunDetailDrawer alert IDs became unbaselined and stale baseline entries remain.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 RunDetailDrawer linkage, recovery, common-causes, filtered-sample, stream-error, truncated-log, and load-error product-state surfaces render through design-system primitives.
+- [x] #2 Watchlists output Ready/Blocked and audio-ready labels are routed through the design-system state registry.
+- [x] #3 Migrated RunDetailDrawer and outputMetadata baseline exceptions are removed, with no new blocked product-state findings.
+- [x] #4 Focused tests, guard tests, verifier, diff check, and TypeScript debt classification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing design-system marker coverage for RunDetailDrawer linkage, remediation, filtered-sample, stream-error, and truncated-log product-state surfaces. 2. Add a registry-label regression for Watchlists output readiness/audio labels with a mocked design-system registry. 3. Replace RunDetailDrawer product-state AntD Alert usages with design-system Alert or RecoveryCallout and route Loading through LOADING_STATE_LABEL. 4. Route outputMetadata Ready/Blocked labels through the design-system state registry and remove migrated baseline exceptions. 5. Run focused tests, guard tests, verifier, diff check, and TypeScript debt classification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Used TDD: first added failing marker assertions for RunDetailDrawer design-system Alert/RecoveryCallout usage and a mocked-registry test for outputMetadata canonical labels. Then migrated the component/helper code and removed the corresponding stale baseline entries.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated RunDetailDrawer's flagged product-state alerts to the shared design-system Alert and RecoveryCallout primitives, including linkage, recovery, common-causes, filtered-sample, stream-error, truncated-log, and load-error surfaces. Routed Watchlists output Ready/Blocked and audio-ready labels through the design-system state registry. Removed stale/migrated baseline exceptions for RunDetailDrawer and outputMetadata. PR: https://github.com/rmusser01/tldw_server/pull/1855. Verification: focused Watchlists Vitest suite passed 33 tests; product-state guard tests passed 52 tests; bun run verify:design-system-state exited 0 with baseline exceptions reduced to 352; git diff --check passed; bunx tsc --noEmit --pretty false still exits 2 on existing unrelated UI TypeScript debt with no touched-file matches. Bandit skipped because this slice only changes frontend TypeScript/JSON and Backlog task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate RunDetailDrawer linkage, recovery, filtered-sample, stream-error, truncated-log, and load-error product-state surfaces to design-system Alert/RecoveryCallout primitives.
- Route Watchlists output Ready/Blocked/audio-ready labels through the design-system state registry.
- Remove stale/migrated product-state baseline entries and add focused design-system regression coverage.

## Verification
- `bunx vitest run src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.source-column.test.tsx src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check HEAD~1..HEAD`
- `bunx tsc --noEmit --pretty false` (expected existing UI TypeScript debt; 253 lines, no touched-file matches in `/tmp/tldw_ui_tsc_design_system_run_detail_post_rebase.txt`)
- Bandit skipped: frontend TypeScript/JSON/Backlog-only slice.

## Risk & rollback
- Risk: Low-to-medium UI surface change in Watchlists run detail drawer alert layout and action rendering.
- Rollback: Revert this PR to restore AntD Alert-backed drawer surfaces and previous baseline entries.

## Change summary
Maintainer-written summary required before merge per repo AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Watchlists Run Detail Drawer and Report Evidence Panel product-state UI to the design system, with registry-backed readiness/audio labels and standardized alerts/recovery callouts. Removes AntD usage across these surfaces and aligns i18n labels.

- **Refactors**
  - Replaced AntD Alert with design-system `Alert` and `RecoveryCallout` in RunDetailDrawer (linkage, remediation, common causes, filtered sample, stream error, truncated logs, load errors) and `ReportEvidencePanel`.
  - Routed readiness/audio labels through `@/design-system` (`READY_STATE_LABEL`, `BLOCKED_STATE_LABEL`, `LOADING_STATE_LABEL`) and a new `createOutputMetadataLabels`; updated `OutputsTab` and `ReportEvidencePanel` to consume.
  - Added readiness/audio i18n keys in `watchlists.json`.
  - Updated tests to assert design-system markers and mocked registry labels; removed stale baseline exceptions.

<sup>Written for commit 6d3f5e45b652c3cbf97019cb9bfeefcd5fc3ef8c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1855?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

