### PR TITLE
Add VZ stale socket lifecycle drill

### DIFF
--- a/Docs/Sandbox/vz-linux-prepared-host-evidence.md
+++ b/Docs/Sandbox/vz-linux-prepared-host-evidence.md
@@ -43,6 +43,7 @@ Each prepared-host evidence packet should include these fields.
 | Results | pass/fail/skip for daemon smoke, ephemeral command execution, same-session VM reuse, recovery diagnostics, dry-run reconciliation repair, helper shutdown, and artifact upload. |
 | Failure drills | pass/fail/skip for drill-owned stale VM replacement and helper restart drill; include skip reason when `include_failure_drills` was not requested. |
 | Launchd drill | pass/fail/skip for `launchd-drill`; include skip reason unless a maintainer explicitly requested LaunchAgent validation. |
+| Stale socket drill | pass/fail/skip for `stale-socket-drill`; include runtime directory mode, socket path, command output, helper stdout/stderr paths, and skip reason when not requested. |
 | Artifacts | workflow run URL or local artifact root, helper stdout/stderr files, serial logs, pytest logs, workflow logs, and checksums or sizes for retained artifacts. |
 | Expected skips | explicit non-blocking skips from the acceptance policy, including missing nightly opt-in, no launchd request, no failure-drill request, or local unprepared-host checks. |
 | Blocking regressions | any failed guarantee from the acceptance policy and the first failing command/log pointer. |
@@ -130,7 +131,7 @@ GitHub Actions run with the packet fields above.
 | Launchd-drill evidence | Manual opt-in only. | Record results only when a runner is intentionally configured for LaunchAgent validation. |
 | Host reboot recovery | Manual operator procedure only and out of scheduled CI. | Add a dedicated operator drill once a prepared host can tolerate disruptive reboot testing and preserve logs. |
 | Stuck boot/readiness and guest-agent mismatch | Not covered by the default smoke. | Use `Docs/superpowers/specs/2026-05-18-vz-linux-lifecycle-drill-gaps-design.md` to guide narrow manual drills or diagnostics checks before considering automated coverage. |
-| Stale socket handling | Covered by helper lifecycle docs and tests, but not yet recorded as prepared-host evidence in this tracker. | Use `Docs/superpowers/specs/2026-05-18-vz-linux-lifecycle-drill-gaps-design.md` before adding socket-path cleanup or status evidence. |
+| Stale socket handling | `tools/macos-vz-helper/scripts/vz-helperctl.py stale-socket-drill` provides a manual operator check for safe inactive socket recovery. | Record prepared-host evidence when a maintainer intentionally runs the drill; keep it manual-only and out of PR/push/scheduled destructive triggers. |
 
 ## Recording Guidance
 
@@ -141,6 +142,24 @@ tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
   --bundle /path/to/canonical/bundle \
   --entitlements /path/to/helper.entitlements
 ```
+
+For a manual stale-socket check, use an isolated private runtime directory:
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-stale-socket.XXXXXX")"
+chmod 700 "$runtime_dir"
+trap 'rm -rf "$runtime_dir"' EXIT
+
+tools/macos-vz-helper/scripts/vz-helperctl.py stale-socket-drill \
+  --helper tools/macos-vz-helper/.build/debug/macos-vz-helper \
+  --socket "$runtime_dir/helper.sock" \
+  --pid-file "$runtime_dir/helper.pid" \
+  --log-dir "$runtime_dir/logs"
+```
+
+Record the runtime directory mode, socket path result, command output, helper
+stdout/stderr paths, and whether this was skipped because no maintainer
+requested the manual drill.
 
 For a lower-level run, use a private runtime directory and cleanup trap:
 

--- a/Docs/superpowers/plans/2026-05-19-vz-stale-socket-lifecycle-drill.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-stale-socket-lifecycle-drill.md
@@ -1,0 +1,316 @@
+# VZ Stale Socket Lifecycle Drill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bounded stale-socket lifecycle drill/check for the macOS VZ helper that proves stale Unix socket recovery is safe, diagnosable, and fail-closed.
+
+**Architecture:** Reuse the existing helper lifecycle primitives in `vz-helperctl.py` and `UnixSocketServer.swift`; do not add a second socket cleanup implementation. The operator-facing surface should be a manual `vz-helperctl.py stale-socket-drill` command that validates private directories, creates a controlled stale Unix socket only under that private runtime directory, starts the helper through the normal `start_helper()` path, verifies recovery, and reports evidence-friendly results. Swift helper coverage should remain focused on direct server socket-path safety because direct helper launch bypasses `vz-helperctl`.
+
+**Tech Stack:** Python 3.11 pytest for `vz-helperctl.py`; SwiftPM `swift test` for `tools/macos-vz-helper`; Markdown operator docs and prepared-host evidence tracker.
+
+---
+
+## Scope Notes
+
+- This is the first implementation slice from `Docs/superpowers/specs/2026-05-18-vz-linux-lifecycle-drill-gaps-design.md`.
+- Keep this host-independent by default. It may bind local Unix sockets, but it must not boot a VM or require Virtualization.framework execution.
+- Do not expand PR, push, scheduled, or destructive workflow triggers.
+- Do not add a broad cleanup command. The drill may only create/remove the socket it created or an identity-verified stale socket accepted by existing lifecycle code.
+
+## File Structure
+
+- Modify `tools/macos-vz-helper/scripts/vz-helperctl.py`.
+  Add a small `stale_socket_drill()` function and CLI command that composes existing validation/start/status helpers.
+- Modify `tools/macos-vz-helper/Tests/test_vz_helperctl.py`.
+  Add host-independent tests for the new command and for fail-closed path shapes.
+- Modify `tools/macos-vz-helper/Tests/UnixSocketServerTests.swift`.
+  Add one targeted Swift test for stale socket identity/replacement protection if current coverage is not explicit enough after review.
+- Modify `tools/macos-vz-helper/README.md`.
+  Document manual stale socket drill usage and evidence to capture.
+- Modify `Docs/Sandbox/vz-linux-prepared-host-evidence.md`.
+  Link the stale socket drill/check as the next evidence item without changing workflow triggers.
+- Modify `backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md`.
+  Track implementation notes, verification, and final summary.
+
+## Task 1: Add Python Failing Tests For The Manual Drill
+
+**Files:**
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+
+- [ ] **Step 1: Add a test for safe stale socket recovery through the normal start path**
+
+Add a test near the existing `start_helper` socket tests:
+
+```python
+def test_stale_socket_drill_recovers_controlled_stale_socket(tmp_path):
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    runtime_dir = tmp_path / "runtime"
+    socket_path = runtime_dir / "helper.sock"
+    pid_file = runtime_dir / "helper.pid"
+    log_dir = tmp_path / "logs"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+
+    created = []
+
+    def fake_socket_creator(path):
+        created.append(path)
+        runtime_dir.mkdir(mode=0o700, exist_ok=True)
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            server.bind(str(path))
+
+    result = helperctl.stale_socket_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        socket_creator=fake_socket_creator,
+        starter=lambda *args, **kwargs: helperctl.CheckResult(True),
+        status_collector=lambda *args, **kwargs: [("ping", helperctl.CheckResult(True, reason="helper_ping_ok"))],
+    )
+
+    CASE.assertEqual(created, [socket_path])
+    CASE.assertEqual(result[-1], ("stale_socket_drill", helperctl.CheckResult(True)))
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py::test_stale_socket_drill_recovers_controlled_stale_socket -q
+```
+
+Expected: fail with `AttributeError: module 'vz_helperctl' has no attribute 'stale_socket_drill'`.
+
+- [ ] **Step 3: Add tests for fail-closed path shapes**
+
+Add focused tests that assert the drill refuses:
+
+```python
+@pytest.mark.parametrize("shape", ["symlink", "regular_file", "directory", "unsafe_parent"])
+def test_stale_socket_drill_refuses_unsafe_socket_shapes(tmp_path, shape):
+    ...
+```
+
+Each test should verify:
+
+- The command returns `helper_socket_unsafe` or `helper_directory_not_private`.
+- The unsafe path is still present after the drill.
+- `starter` is not called.
+
+- [ ] **Step 4: Run those tests and verify they fail for the missing function**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -k stale_socket_drill
+```
+
+Expected: fail because `stale_socket_drill()` and the CLI command do not exist yet.
+
+## Task 2: Implement The Python Drill By Composing Existing Helpers
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Add a tiny controlled stale socket creator**
+
+Add a helper near `socket_accepts_connection()`:
+
+```python
+def create_stale_unix_socket(path: Path) -> None:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(str(path))
+```
+
+Do not call `listen()`. This creates a Unix socket path that is safe for the normal start path to identify as stale.
+
+- [ ] **Step 2: Add `stale_socket_drill()`**
+
+Implement a function with injectable collaborators:
+
+```python
+def stale_socket_drill(
+    helper_path: Path,
+    socket_path: Path,
+    pid_file: Path,
+    log_dir: Path,
+    *,
+    dry_run: bool = False,
+    socket_creator: Callable[[Path], None] = create_stale_unix_socket,
+    starter: Callable[..., CheckResult] = start_helper,
+    status_collector: Callable[..., list[tuple[str, CheckResult]]] = collect_status_results,
+) -> list[tuple[str, CheckResult]]:
+    ...
+```
+
+The implementation should:
+
+- Validate helper binary with `validate_helper_binary()`.
+- Validate socket path with `validate_socket_path()`.
+- Ensure `socket_path.parent`, `pid_file.parent`, `log_dir`, and `log_dir / "serial"` are private using `ensure_private_dir()`.
+- Refuse existing active or unsafe sockets using existing `validate_socket_path()` plus `socket_accepts_connection()`.
+- In dry-run mode, return only validation/check results and do not create a socket.
+- Create the stale socket with `socket_creator(socket_path)` only after validation succeeds.
+- Call `start_helper()` so actual cleanup remains identity-based in existing code.
+- Append post-start `collect_status_results()` entries.
+- Append final `("stale_socket_drill", CheckResult(...))`.
+
+- [ ] **Step 3: Add the CLI command**
+
+Add `_stale_socket_drill_command(args)` and register `stale-socket-drill` in `build_parser()` with:
+
+- `--helper` / `--helper-path`
+- `--socket` / `--socket-path`
+- `--pid-file`
+- `--log-dir`
+- `--dry-run`
+- `--json`
+
+Use `_print_results()` and return nonzero if any result is not ok.
+
+- [ ] **Step 4: Run focused Python tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -k stale_socket_drill
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Run full helperctl Python tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q
+```
+
+Expected: `134 passed, 1 skipped` or equivalent current count plus new tests.
+
+## Task 3: Add Or Confirm Swift Direct-Launch Socket Safety Coverage
+
+**Files:**
+- Modify: `tools/macos-vz-helper/Tests/UnixSocketServerTests.swift`
+
+- [ ] **Step 1: Review current coverage before adding tests**
+
+Confirm current tests cover:
+
+- existing regular file is refused and preserved
+- symlink socket path is refused and preserved
+- stale Unix socket is removed and replaced
+- active Unix socket is refused
+- replacement path is not removed on stop
+- unsafe parent directories are refused
+
+- [ ] **Step 2: Add only missing direct-launch coverage**
+
+If current coverage is missing identity-race protection during stale socket unlink, add a test that binds a socket, swaps the path before start can unlink, and expects `UnixSocketServerError` with the replacement preserved. If current coverage already proves this sufficiently, skip this step and record the skip in `TASK-433`.
+
+- [ ] **Step 3: Run Swift tests**
+
+Run:
+
+```bash
+swift test
+```
+
+Expected: all macOS helper Swift tests pass. If sandboxed SwiftPM cannot write module caches, rerun with host permissions and record that reason.
+
+## Task 4: Document Manual Operator Usage And Evidence
+
+**Files:**
+- Modify: `tools/macos-vz-helper/README.md`
+- Modify: `Docs/Sandbox/vz-linux-prepared-host-evidence.md`
+- Modify: `backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md`
+
+- [ ] **Step 1: Add README usage**
+
+Add a short section near the helper lifecycle/operator commands:
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-stale-socket.XXXXXX")"
+chmod 700 "${runtime_dir}"
+trap 'rm -rf "${runtime_dir}"' EXIT
+
+python tools/macos-vz-helper/scripts/vz-helperctl.py stale-socket-drill \
+  --helper tools/macos-vz-helper/.build/debug/macos-vz-helper \
+  --socket "${runtime_dir}/helper.sock" \
+  --pid-file "${runtime_dir}/helper.pid" \
+  --log-dir "${runtime_dir}/logs"
+```
+
+Include a note that the command is manual/operator-only and should not be wired into normal CI.
+
+- [ ] **Step 2: Update evidence tracker**
+
+In `Docs/Sandbox/vz-linux-prepared-host-evidence.md`, update the stale socket gap row to reference the new `stale-socket-drill` command and evidence fields:
+
+- runtime dir mode
+- socket path result
+- command output
+- helper stdout/stderr paths
+- skip reason if not run
+
+- [ ] **Step 3: Update task notes**
+
+Record:
+
+- implementation choices
+- any Swift coverage skip rationale
+- verification commands and results
+- known skips, especially no real VM boot in this slice
+
+## Task 5: Final Verification And Commit
+
+**Files:**
+- All touched files
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q
+swift test
+git diff --check
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+```
+
+Expected:
+
+- Python helperctl tests pass.
+- Swift tests pass.
+- `git diff --check` has no output.
+- Bandit has no new findings.
+
+- [ ] **Step 2: Self-review the diff**
+
+Check:
+
+- No broad deletion primitive was introduced.
+- All socket unlink behavior remains identity-based or inside Swift direct-launch `lstat` checks.
+- The command is manual-only and not referenced by normal CI workflows.
+- Docs do not imply a VM smoke was run.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py \
+  tools/macos-vz-helper/Tests/test_vz_helperctl.py \
+  tools/macos-vz-helper/Tests/UnixSocketServerTests.swift \
+  tools/macos-vz-helper/README.md \
+  Docs/Sandbox/vz-linux-prepared-host-evidence.md \
+  'backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md'
+git commit -m "Add VZ stale socket lifecycle drill"
+```
+
+Expected: one focused commit on `codex/vz-stale-socket-drill`.

--- a/backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md
+++ b/backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md
@@ -1,0 +1,57 @@
+---
+id: TASK-433
+title: Implement VZ stale socket lifecycle drill
+status: To Do
+labels:
+- sandbox
+- vz_linux
+- lifecycle
+- hardening
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next sandbox lifecycle slice from the merged drill-gaps design: a bounded stale-socket operator/check path that proves stale helper socket recovery is safe, diagnosable, and refuses symlinks/non-socket/user-controlled paths. Keep it host-independent first, with docs and focused tests; no workflow trigger expansion.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Host-independent tests cover stale Unix socket recovery under a private runtime directory.
+- [ ] #2 Tests cover fail-closed behavior for symlinks, non-socket files, directories, and unsafe parent paths.
+- [ ] #3 Implementation reuses existing vz-helperctl/helper socket-safety primitives instead of adding a parallel cleanup path.
+- [ ] #4 Operator docs or drill notes explain how to run the stale socket check manually and what evidence to capture.
+- [ ] #5 Prepared-host evidence tracker references the new stale socket drill/check without expanding PR/push/scheduled destructive triggers.
+- [ ] #6 Focused verification, diff hygiene, and Bandit for touched Python scope are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started from merged design PR #1850 / `Docs/superpowers/specs/2026-05-18-vz-linux-lifecycle-drill-gaps-design.md`.
+
+Plan: `Docs/superpowers/plans/2026-05-19-vz-stale-socket-lifecycle-drill.md`.
+
+Baseline verification before implementation:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 134 passed, 1 skipped.
+- `swift test` initially failed under the Codex filesystem sandbox because SwiftPM/Clang could not write `~/.cache/clang/ModuleCache`.
+- `swift test` passed after host permission for SwiftPM cache access: 88 tests passed.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md
+++ b/backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md
@@ -48,9 +48,13 @@ Implementation notes:
 - Swift direct-launch coverage was reviewed and not changed. Existing `UnixSocketServerTests.swift` already covers regular-file preservation, symlink preservation, stale socket replacement, active socket refusal, stop-time replacement preservation, and unsafe parent refusal. Direct identity-race testing would need production test hooks, so it remains documented rather than added in this slice.
 - Updated `tools/macos-vz-helper/README.md` with manual command usage and evidence guidance.
 - Updated `Docs/Sandbox/vz-linux-prepared-host-evidence.md` with stale-socket evidence fields and residual-gap guidance.
+- PR review follow-up:
+  - Added docstrings for the new stale socket helper and CLI entrypoint.
+  - Added a fail-closed guard when `socket_creator()` returns without materializing a Unix socket identity.
+  - Added a regression test for the no-socket false-positive path.
 - Final verification:
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -k stale_socket_drill` passed: 7 passed, 5 skipped.
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 141 passed, 6 skipped.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -k stale_socket_drill` passed: 8 passed, 5 skipped.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 142 passed, 6 skipped.
   - `swift test` under `tools/macos-vz-helper` passed with host SwiftPM cache access: 88 tests passed.
   - `git diff --check` passed.
   - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
@@ -62,7 +66,7 @@ Implementation notes:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a manual `vz-helperctl.py stale-socket-drill` operator command that creates a controlled inactive Unix socket under validated private helper paths, delegates recovery to the existing managed `start_helper()` path, verifies the helper is actually running afterward, and cleans up only the drill-created socket identity on operational startup failure.
+Added a manual `vz-helperctl.py stale-socket-drill` operator command that creates a controlled inactive Unix socket under validated private helper paths, verifies socket identity before reporting creation success, delegates recovery to the existing managed `start_helper()` path, verifies the helper is actually running afterward, and cleans up only the drill-created socket identity on operational startup failure.
 
 Added host-independent Python coverage for successful stale socket recovery, pre-existing inactive socket recovery, fail-closed unsafe path shapes, unsafe parent permissions, dry-run behavior, start failure cleanup, and CLI argument forwarding. Updated the helper README and prepared-host evidence tracker so operators know how to run the drill manually and what evidence to capture.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md
+++ b/backlog/tasks/task-433 - Implement-VZ-stale-socket-lifecycle-drill.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-433
 title: Implement VZ stale socket lifecycle drill
-status: To Do
+status: Done
 labels:
 - sandbox
 - vz_linux
@@ -18,12 +18,12 @@ Implement the next sandbox lifecycle slice from the merged drill-gaps design: a 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Host-independent tests cover stale Unix socket recovery under a private runtime directory.
-- [ ] #2 Tests cover fail-closed behavior for symlinks, non-socket files, directories, and unsafe parent paths.
-- [ ] #3 Implementation reuses existing vz-helperctl/helper socket-safety primitives instead of adding a parallel cleanup path.
-- [ ] #4 Operator docs or drill notes explain how to run the stale socket check manually and what evidence to capture.
-- [ ] #5 Prepared-host evidence tracker references the new stale socket drill/check without expanding PR/push/scheduled destructive triggers.
-- [ ] #6 Focused verification, diff hygiene, and Bandit for touched Python scope are recorded.
+- [x] #1 Host-independent tests cover stale Unix socket recovery under a private runtime directory.
+- [x] #2 Tests cover fail-closed behavior for symlinks, non-socket files, directories, and unsafe parent paths.
+- [x] #3 Implementation reuses existing vz-helperctl/helper socket-safety primitives instead of adding a parallel cleanup path.
+- [x] #4 Operator docs or drill notes explain how to run the stale socket check manually and what evidence to capture.
+- [x] #5 Prepared-host evidence tracker references the new stale socket drill/check without expanding PR/push/scheduled destructive triggers.
+- [x] #6 Focused verification, diff hygiene, and Bandit for touched Python scope are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -38,20 +38,41 @@ Baseline verification before implementation:
 - `swift test` initially failed under the Codex filesystem sandbox because SwiftPM/Clang could not write `~/.cache/clang/ModuleCache`.
 - `swift test` passed after host permission for SwiftPM cache access: 88 tests passed.
 
+Implementation notes:
+- Added `vz-helperctl.py stale-socket-drill` as a manual operator command.
+- The drill validates helper binary, socket path, private runtime/pid/log/serial directories, and active socket state before mutation.
+- The drill creates a controlled inactive Unix socket only when the accepted socket path is absent; pre-existing inactive Unix sockets are preserved for `start_helper()` recovery.
+- Recovery delegates to existing `start_helper()` and its identity-based stale socket cleanup instead of adding a parallel unlink path.
+- If startup returns or raises an operational failure after the drill created a socket, cleanup removes only the captured identity for the drill-created socket.
+- Post-start success uses `_managed_helper_running_result()` so all-ok but not-running status rows do not pass the drill.
+- Swift direct-launch coverage was reviewed and not changed. Existing `UnixSocketServerTests.swift` already covers regular-file preservation, symlink preservation, stale socket replacement, active socket refusal, stop-time replacement preservation, and unsafe parent refusal. Direct identity-race testing would need production test hooks, so it remains documented rather than added in this slice.
+- Updated `tools/macos-vz-helper/README.md` with manual command usage and evidence guidance.
+- Updated `Docs/Sandbox/vz-linux-prepared-host-evidence.md` with stale-socket evidence fields and residual-gap guidance.
+- Final verification:
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -k stale_socket_drill` passed: 7 passed, 5 skipped.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 141 passed, 6 skipped.
+  - `swift test` under `tools/macos-vz-helper` passed with host SwiftPM cache access: 88 tests passed.
+  - `git diff --check` passed.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
+  - Full Bandit scan of `tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py` still exits non-zero on pre-existing helperctl test baseline findings at `test_vz_helperctl.py` imports and older `/tmp`/subprocess examples outside the new stale-socket drill section. The new section's hardcoded `/tmp` tempdir findings were removed.
+- Final code-quality subagent review: approved.
+
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a manual `vz-helperctl.py stale-socket-drill` operator command that creates a controlled inactive Unix socket under validated private helper paths, delegates recovery to the existing managed `start_helper()` path, verifies the helper is actually running afterward, and cleans up only the drill-created socket identity on operational startup failure.
 
+Added host-independent Python coverage for successful stale socket recovery, pre-existing inactive socket recovery, fail-closed unsafe path shapes, unsafe parent permissions, dry-run behavior, start failure cleanup, and CLI argument forwarding. Updated the helper README and prepared-host evidence tracker so operators know how to run the drill manually and what evidence to capture.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -41,6 +41,7 @@ tools/macos-vz-helper/scripts/vz-helperctl.py build
 tools/macos-vz-helper/scripts/vz-helperctl.py start
 tools/macos-vz-helper/scripts/vz-helperctl.py status
 tools/macos-vz-helper/scripts/vz-helperctl.py restart-drill
+tools/macos-vz-helper/scripts/vz-helperctl.py stale-socket-drill
 tools/macos-vz-helper/scripts/vz-helperctl.py stop
 tools/macos-vz-helper/scripts/vz-helperctl.py plist
 tools/macos-vz-helper/scripts/vz-helperctl.py launchd status --dry-run
@@ -115,6 +116,28 @@ started through `vz-helperctl.py start`. It verifies the current managed helper
 status, stops it through the pid-file/socket lease, starts a replacement on the
 same managed paths, and verifies status again. It does not manage launchd,
 reboot the host, or take ownership of helpers started outside this wrapper.
+
+`stale-socket-drill` is an operator-managed check for the helper socket recovery
+path. It validates private runtime/log directories, creates or preserves only a
+safe inactive Unix socket, starts the helper through the normal managed start
+path, and verifies helper status afterward. It is manual only and must not be
+wired into normal PR/push CI.
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/tldw-vz-stale-socket.XXXXXX")"
+chmod 700 "$runtime_dir"
+trap 'rm -rf "$runtime_dir"' EXIT
+
+tools/macos-vz-helper/scripts/vz-helperctl.py stale-socket-drill \
+  --helper tools/macos-vz-helper/.build/debug/macos-vz-helper \
+  --socket "$runtime_dir/helper.sock" \
+  --pid-file "$runtime_dir/helper.pid" \
+  --log-dir "$runtime_dir/logs"
+```
+
+For evidence, record the command output, runtime directory mode, socket path,
+helper stdout/stderr paths under the log directory, and whether the drill
+created a controlled stale socket or recovered a pre-existing inactive socket.
 
 For real host E2E smoke, prefer the managed wrapper:
 

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -3693,6 +3693,31 @@ def test_stale_socket_drill_removes_created_socket_when_starter_raises() -> None
         CASE.assertFalse(socket_path.exists())
 
 
+def test_stale_socket_drill_fails_when_socket_creator_leaves_no_socket(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    tmp_path.chmod(0o700)
+
+    results = helperctl.stale_socket_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        socket_creator=lambda path: None,
+        starter=lambda *args, **kwargs: pytest.fail("missing socket should not start helper"),
+        status_collector=lambda *args, **kwargs: pytest.fail("missing socket should not collect status"),
+    )
+
+    failed = helperctl.CheckResult(False, "helper_socket_create_failed", "socket not created")
+    CASE.assertIn(("stale_socket", failed), results)
+    CASE.assertEqual(results[-1], ("stale_socket_drill", failed))
+
+
 def test_stale_socket_drill_preserves_existing_inactive_socket_on_start_failure() -> None:
     helperctl = load_helperctl()
     with tempfile.TemporaryDirectory(prefix="vzsock-") as temp_dir:
@@ -3726,7 +3751,10 @@ def test_stale_socket_drill_preserves_existing_inactive_socket_on_start_failure(
         CASE.assertTrue(socket_path.exists())
 
 
-def test_stale_socket_drill_fails_when_post_status_is_not_running(tmp_path: Path) -> None:
+def test_stale_socket_drill_fails_when_post_status_is_not_running(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     helperctl = load_helperctl()
     helper = tmp_path / "macos-vz-helper"
     socket_path = tmp_path / "runtime" / "helper.sock"
@@ -3735,13 +3763,15 @@ def test_stale_socket_drill_fails_when_post_status_is_not_running(tmp_path: Path
     helper.write_text("#!/bin/sh\n", encoding="utf-8")
     helper.chmod(0o700)
     tmp_path.chmod(0o700)
+    created_identity = helperctl.SocketIdentity(device=1, inode=2)
+    monkeypatch.setattr(helperctl, "socket_identity", lambda path: created_identity)
 
     results = helperctl.stale_socket_drill(
         helper,
         socket_path,
         pid_file,
         log_dir,
-        socket_creator=lambda path: None,
+        socket_creator=lambda path: path.write_text("identity is supplied by the test", encoding="utf-8"),
         starter=lambda *args, **kwargs: helperctl.CheckResult(ok=True),
         status_collector=lambda *args, **kwargs: [
             ("process", helperctl.CheckResult(ok=True, reason="helper_not_running")),

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -3502,6 +3502,418 @@ def test_restart_drill_cli_passes_paths_and_prints_json(
     CASE.assertEqual(captured_paths["entitlements"], entitlements)
 
 
+def test_stale_socket_drill_recovers_controlled_stale_socket() -> None:
+    helperctl = load_helperctl()
+    with tempfile.TemporaryDirectory(prefix="vzsock-") as temp_dir:
+        root = Path(temp_dir)
+        root.chmod(0o700)
+        helper = root / "macos-vz-helper"
+        socket_path = root / "runtime" / "helper.sock"
+        pid_file = root / "runtime" / "helper.pid"
+        log_dir = root / "logs"
+        helper.write_text("#!/bin/sh\n", encoding="utf-8")
+        helper.chmod(0o700)
+        created: list[Path] = []
+        starts: list[tuple[Path, Path, Path, Path, bool]] = []
+
+        def fake_socket_creator(path: Path) -> None:
+            created.append(path)
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                try:
+                    server.bind(str(path))
+                except PermissionError:
+                    pytest.skip("AF_UNIX socket binding is not permitted in this sandbox")
+
+        def fake_starter(
+            helper_path: Path,
+            received_socket_path: Path,
+            received_pid_file: Path,
+            received_log_dir: Path,
+            *,
+            dry_run: bool = False,
+        ) -> Any:
+            CASE.assertTrue(received_socket_path.exists())
+            starts.append((helper_path, received_socket_path, received_pid_file, received_log_dir, dry_run))
+            received_socket_path.unlink()
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                try:
+                    server.bind(str(received_socket_path))
+                except PermissionError:
+                    pytest.skip("AF_UNIX socket binding is not permitted in this sandbox")
+            received_pid_file.write_text("1234\n", encoding="utf-8")
+            return helperctl.CheckResult(ok=True)
+
+        def fake_status_collector(*args: Any, **kwargs: Any) -> list[tuple[str, Any]]:
+            return [
+                ("process", helperctl.CheckResult(ok=True, reason="helper_pid_running")),
+                ("ping", helperctl.CheckResult(ok=True)),
+            ]
+
+        results = helperctl.stale_socket_drill(
+            helper,
+            socket_path,
+            pid_file,
+            log_dir,
+            socket_creator=fake_socket_creator,
+            starter=fake_starter,
+            status_collector=fake_status_collector,
+        )
+
+        CASE.assertEqual(created, [socket_path])
+        CASE.assertEqual(starts, [(helper, socket_path, pid_file, log_dir, False)])
+        CASE.assertIn(("stale_socket", helperctl.CheckResult(ok=True)), results)
+        CASE.assertIn(("after_process", helperctl.CheckResult(ok=True, reason="helper_pid_running")), results)
+        CASE.assertEqual(results[-1], ("stale_socket_drill", helperctl.CheckResult(ok=True)))
+
+
+def test_stale_socket_drill_recovers_existing_inactive_socket_without_recreate() -> None:
+    helperctl = load_helperctl()
+    with tempfile.TemporaryDirectory(prefix="vzsock-") as temp_dir:
+        root = Path(temp_dir)
+        root.chmod(0o700)
+        helper = root / "macos-vz-helper"
+        socket_path = root / "runtime" / "helper.sock"
+        pid_file = root / "runtime" / "helper.pid"
+        log_dir = root / "logs"
+        helper.write_text("#!/bin/sh\n", encoding="utf-8")
+        helper.chmod(0o700)
+        socket_path.parent.mkdir(mode=0o700)
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            try:
+                server.bind(str(socket_path))
+            except PermissionError:
+                pytest.skip("AF_UNIX socket binding is not permitted in this sandbox")
+        starts: list[tuple[Path, Path, Path, Path, bool]] = []
+
+        def fake_starter(
+            helper_path: Path,
+            received_socket_path: Path,
+            received_pid_file: Path,
+            received_log_dir: Path,
+            *,
+            dry_run: bool = False,
+        ) -> Any:
+            CASE.assertTrue(received_socket_path.exists())
+            starts.append((helper_path, received_socket_path, received_pid_file, received_log_dir, dry_run))
+            received_pid_file.write_text("1234\n", encoding="utf-8")
+            return helperctl.CheckResult(ok=True)
+
+        results = helperctl.stale_socket_drill(
+            helper,
+            socket_path,
+            pid_file,
+            log_dir,
+            socket_creator=lambda path: pytest.fail("existing inactive socket should not be re-created"),
+            starter=fake_starter,
+            status_collector=lambda *args, **kwargs: [
+                ("process", helperctl.CheckResult(ok=True, reason="helper_pid_running")),
+                ("ping", helperctl.CheckResult(ok=True)),
+            ],
+        )
+
+        CASE.assertEqual(starts, [(helper, socket_path, pid_file, log_dir, False)])
+        CASE.assertIn(("stale_socket", helperctl.CheckResult(ok=True, reason="helper_socket_present")), results)
+        CASE.assertEqual(results[-1], ("stale_socket_drill", helperctl.CheckResult(ok=True)))
+
+
+def test_stale_socket_drill_removes_created_socket_on_start_failure() -> None:
+    helperctl = load_helperctl()
+    with tempfile.TemporaryDirectory(prefix="vzsock-") as temp_dir:
+        root = Path(temp_dir)
+        root.chmod(0o700)
+        helper = root / "macos-vz-helper"
+        socket_path = root / "runtime" / "helper.sock"
+        pid_file = root / "runtime" / "helper.pid"
+        log_dir = root / "logs"
+        helper.write_text("#!/bin/sh\n", encoding="utf-8")
+        helper.chmod(0o700)
+
+        def fake_socket_creator(path: Path) -> None:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                try:
+                    server.bind(str(path))
+                except PermissionError:
+                    pytest.skip("AF_UNIX socket binding is not permitted in this sandbox")
+
+        results = helperctl.stale_socket_drill(
+            helper,
+            socket_path,
+            pid_file,
+            log_dir,
+            socket_creator=fake_socket_creator,
+            starter=lambda *args, **kwargs: helperctl.CheckResult(False, "helper_already_running"),
+            status_collector=lambda *args, **kwargs: pytest.fail("failed start should not collect status"),
+        )
+
+        CASE.assertIn(("stale_socket", helperctl.CheckResult(ok=True)), results)
+        CASE.assertEqual(results[-1], ("stale_socket_drill", helperctl.CheckResult(False, "helper_already_running")))
+        CASE.assertFalse(socket_path.exists())
+
+
+def test_stale_socket_drill_removes_created_socket_when_starter_raises() -> None:
+    helperctl = load_helperctl()
+    with tempfile.TemporaryDirectory(prefix="vzsock-") as temp_dir:
+        root = Path(temp_dir)
+        root.chmod(0o700)
+        helper = root / "macos-vz-helper"
+        socket_path = root / "runtime" / "helper.sock"
+        pid_file = root / "runtime" / "helper.pid"
+        log_dir = root / "logs"
+        helper.write_text("#!/bin/sh\n", encoding="utf-8")
+        helper.chmod(0o700)
+
+        def fake_socket_creator(path: Path) -> None:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                try:
+                    server.bind(str(path))
+                except PermissionError:
+                    pytest.skip("AF_UNIX socket binding is not permitted in this sandbox")
+
+        def raising_starter(*args: Any, **kwargs: Any) -> Any:
+            raise OSError("popen failed")
+
+        results = helperctl.stale_socket_drill(
+            helper,
+            socket_path,
+            pid_file,
+            log_dir,
+            socket_creator=fake_socket_creator,
+            starter=raising_starter,
+            status_collector=lambda *args, **kwargs: pytest.fail("failed start should not collect status"),
+        )
+
+        CASE.assertIn(
+            ("start", helperctl.CheckResult(False, "helper_start_failed", "popen failed")),
+            results,
+        )
+        CASE.assertEqual(
+            results[-1],
+            ("stale_socket_drill", helperctl.CheckResult(False, "helper_start_failed", "popen failed")),
+        )
+        CASE.assertFalse(socket_path.exists())
+
+
+def test_stale_socket_drill_preserves_existing_inactive_socket_on_start_failure() -> None:
+    helperctl = load_helperctl()
+    with tempfile.TemporaryDirectory(prefix="vzsock-") as temp_dir:
+        root = Path(temp_dir)
+        root.chmod(0o700)
+        helper = root / "macos-vz-helper"
+        socket_path = root / "runtime" / "helper.sock"
+        pid_file = root / "runtime" / "helper.pid"
+        log_dir = root / "logs"
+        helper.write_text("#!/bin/sh\n", encoding="utf-8")
+        helper.chmod(0o700)
+        socket_path.parent.mkdir(mode=0o700)
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            try:
+                server.bind(str(socket_path))
+            except PermissionError:
+                pytest.skip("AF_UNIX socket binding is not permitted in this sandbox")
+
+        results = helperctl.stale_socket_drill(
+            helper,
+            socket_path,
+            pid_file,
+            log_dir,
+            socket_creator=lambda path: pytest.fail("existing inactive socket should not be re-created"),
+            starter=lambda *args, **kwargs: helperctl.CheckResult(False, "helper_already_running"),
+            status_collector=lambda *args, **kwargs: pytest.fail("failed start should not collect status"),
+        )
+
+        CASE.assertIn(("stale_socket", helperctl.CheckResult(ok=True, reason="helper_socket_present")), results)
+        CASE.assertEqual(results[-1], ("stale_socket_drill", helperctl.CheckResult(False, "helper_already_running")))
+        CASE.assertTrue(socket_path.exists())
+
+
+def test_stale_socket_drill_fails_when_post_status_is_not_running(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    tmp_path.chmod(0o700)
+
+    results = helperctl.stale_socket_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        socket_creator=lambda path: None,
+        starter=lambda *args, **kwargs: helperctl.CheckResult(ok=True),
+        status_collector=lambda *args, **kwargs: [
+            ("process", helperctl.CheckResult(ok=True, reason="helper_not_running")),
+            ("ping", helperctl.CheckResult(ok=True, reason="helper_not_running")),
+        ],
+    )
+
+    CASE.assertIn(("after_process", helperctl.CheckResult(ok=True, reason="helper_not_running")), results)
+    CASE.assertEqual(results[-1], ("stale_socket_drill", helperctl.CheckResult(False, "helper_not_running")))
+
+
+@pytest.mark.parametrize("shape", ["symlink", "regular_file", "directory"])
+def test_stale_socket_drill_refuses_unsafe_socket_shapes(tmp_path: Path, shape: str) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    socket_path.parent.mkdir(mode=0o700)
+    pid_file.parent.mkdir(mode=0o700, exist_ok=True)
+    log_dir.mkdir(mode=0o700)
+    (log_dir / "serial").mkdir(mode=0o700)
+    if shape == "symlink":
+        target = tmp_path / "target.sock"
+        socket_path.symlink_to(target)
+    elif shape == "regular_file":
+        socket_path.write_text("not a socket", encoding="utf-8")
+    else:
+        socket_path.mkdir(mode=0o700)
+
+    results = helperctl.stale_socket_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        socket_creator=lambda path: pytest.fail("unsafe drill should not create a socket"),
+        starter=lambda *args, **kwargs: pytest.fail("unsafe drill should not start helper"),
+        status_collector=lambda *args, **kwargs: pytest.fail("unsafe drill should not collect status"),
+    )
+
+    CASE.assertEqual(dict(results)["socket_path"].reason, "helper_socket_unsafe")
+    CASE.assertEqual(results[-1], ("stale_socket_drill", helperctl.CheckResult(False, "helper_socket_unsafe")))
+    if shape == "symlink":
+        CASE.assertTrue(socket_path.is_symlink())
+    elif shape == "regular_file":
+        CASE.assertEqual(socket_path.read_text(encoding="utf-8"), "not a socket")
+    else:
+        CASE.assertTrue(socket_path.is_dir())
+
+
+def test_stale_socket_drill_refuses_unsafe_parent_without_starting(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_dir = tmp_path / "runtime"
+    socket_path = socket_dir / "helper.sock"
+    pid_file = tmp_path / "pid" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    socket_dir.mkdir(mode=0o755)
+    socket_dir.chmod(0o755)
+    pid_file.parent.mkdir(mode=0o700)
+    log_dir.mkdir(mode=0o700)
+    (log_dir / "serial").mkdir(mode=0o700)
+
+    results = helperctl.stale_socket_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        socket_creator=lambda path: pytest.fail("unsafe drill should not create a socket"),
+        starter=lambda *args, **kwargs: pytest.fail("unsafe drill should not start helper"),
+        status_collector=lambda *args, **kwargs: pytest.fail("unsafe drill should not collect status"),
+    )
+
+    CASE.assertEqual(dict(results)["socket_directory"].reason, "helper_directory_not_private")
+    CASE.assertEqual(
+        results[-1],
+        ("stale_socket_drill", helperctl.CheckResult(False, "helper_directory_not_private")),
+    )
+    CASE.assertFalse(socket_path.exists())
+    CASE.assertEqual(socket_dir.stat().st_mode & 0o777, 0o755)
+
+
+def test_stale_socket_drill_dry_run_is_non_mutating(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    helper.chmod(0o700)
+    tmp_path.chmod(0o700)
+
+    results = helperctl.stale_socket_drill(
+        helper,
+        socket_path,
+        pid_file,
+        log_dir,
+        dry_run=True,
+        socket_creator=lambda path: pytest.fail("dry-run should not create a socket"),
+        starter=lambda *args, **kwargs: pytest.fail("dry-run should not start helper"),
+        status_collector=lambda *args, **kwargs: pytest.fail("dry-run should not collect status"),
+    )
+
+    CASE.assertEqual(results[-1], ("stale_socket_drill", helperctl.CheckResult(ok=True, reason="dry_run")))
+    CASE.assertFalse(socket_path.parent.exists())
+    CASE.assertFalse(pid_file.parent.exists())
+    CASE.assertFalse(log_dir.exists())
+
+
+def test_stale_socket_drill_cli_passes_paths_and_prints_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    helper = tmp_path / "macos-vz-helper"
+    socket_path = tmp_path / "runtime" / "helper.sock"
+    pid_file = tmp_path / "runtime" / "helper.pid"
+    log_dir = tmp_path / "logs"
+    captured_paths: dict[str, Any] = {}
+
+    def fake_stale_socket_drill(
+        helper_path: Path,
+        received_socket_path: Path,
+        received_pid_file: Path,
+        received_log_dir: Path,
+        *,
+        dry_run: bool = False,
+    ) -> list[tuple[str, Any]]:
+        captured_paths.update(
+            {
+                "helper": helper_path,
+                "socket": received_socket_path,
+                "pid_file": received_pid_file,
+                "log_dir": received_log_dir,
+                "dry_run": dry_run,
+            }
+        )
+        return [("stale_socket_drill", helperctl.CheckResult(ok=True))]
+
+    monkeypatch.setattr(helperctl, "stale_socket_drill", fake_stale_socket_drill)
+
+    code = helperctl.main(
+        [
+            "stale-socket-drill",
+            "--helper-path",
+            str(helper),
+            "--socket-path",
+            str(socket_path),
+            "--pid-file",
+            str(pid_file),
+            "--log-dir",
+            str(log_dir),
+            "--dry-run",
+            "--json",
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(output[0]["name"], "stale_socket_drill")
+    CASE.assertEqual(captured_paths["helper"], helper)
+    CASE.assertEqual(captured_paths["socket"], socket_path)
+    CASE.assertEqual(captured_paths["pid_file"], pid_file)
+    CASE.assertEqual(captured_paths["log_dir"], log_dir)
+    CASE.assertIs(captured_paths["dry_run"], True)
+
+
 def test_smoke_dry_run_delegates_to_host_smoke_script(tmp_path, capsys):
     helperctl = load_helperctl()
     bundle = tmp_path / "bundle"

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -153,6 +153,11 @@ def socket_accepts_connection(path: Path, *, timeout_sec: float = 0.1) -> bool:
         return False
 
 
+def create_stale_unix_socket(path: Path) -> None:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(str(path))
+
+
 def remove_socket_if_identity(path: Path, identity: SocketIdentity | None) -> None:
     if identity is None:
         return
@@ -1620,6 +1625,72 @@ def status_helper(
     return CheckResult(ok=True, reason="helper_not_running")
 
 
+def stale_socket_drill(
+    helper_path: Path,
+    socket_path: Path,
+    pid_file: Path,
+    log_dir: Path,
+    *,
+    dry_run: bool = False,
+    socket_creator: Callable[[Path], None] = create_stale_unix_socket,
+    starter: Callable[..., CheckResult] = start_helper,
+    status_collector: Callable[..., list[tuple[str, CheckResult]]] = collect_status_results,
+) -> list[tuple[str, CheckResult]]:
+    """Create a controlled stale socket, then recover through the normal start path."""
+    results: list[tuple[str, CheckResult]] = []
+    for name, result in (
+        ("helper_binary", validate_helper_binary(helper_path)),
+        ("socket_path", validate_socket_path(socket_path)),
+        ("socket_directory", ensure_private_dir(socket_path.parent, dry_run=dry_run)),
+        ("pid_directory", ensure_private_dir(pid_file.parent, dry_run=dry_run)),
+        ("log_directory", ensure_private_dir(log_dir, dry_run=dry_run)),
+        ("serial_log_directory", ensure_private_dir(log_dir / "serial", dry_run=dry_run)),
+    ):
+        results.append((name, result))
+        if not result.ok:
+            results.append(("stale_socket_drill", result))
+            return results
+
+    if socket_accepts_connection(socket_path):
+        active = CheckResult(ok=False, reason="helper_already_running")
+        results.append(("socket", active))
+        results.append(("stale_socket_drill", active))
+        return results
+
+    if dry_run:
+        results.append(("stale_socket_drill", CheckResult(ok=True, reason="dry_run")))
+        return results
+
+    created_socket_identity: SocketIdentity | None = None
+    if socket_path.exists():
+        results.append(("stale_socket", CheckResult(ok=True, reason="helper_socket_present")))
+    else:
+        try:
+            socket_creator(socket_path)
+        except OSError as exc:
+            failed_create = CheckResult(ok=False, reason="helper_socket_create_failed", message=str(exc))
+            results.append(("stale_socket", failed_create))
+            results.append(("stale_socket_drill", failed_create))
+            return results
+        created_socket_identity = socket_identity(socket_path)
+        results.append(("stale_socket", CheckResult(ok=True)))
+
+    try:
+        start_result = starter(helper_path, socket_path, pid_file, log_dir, dry_run=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        start_result = CheckResult(ok=False, reason="helper_start_failed", message=str(exc))
+    results.append(("start", start_result))
+    if not start_result.ok:
+        remove_socket_if_identity(socket_path, created_socket_identity)
+        results.append(("stale_socket_drill", start_result))
+        return results
+
+    status_results = status_collector(helper_path, socket_path, pid_file, log_dir)
+    results.extend(_prefixed_results("after", status_results))
+    results.append(("stale_socket_drill", _managed_helper_running_result(status_results)))
+    return results
+
+
 def _prefixed_results(
     prefix: str,
     results: Iterable[tuple[str, CheckResult]],
@@ -1929,6 +2000,19 @@ def _restart_drill_command(args: argparse.Namespace) -> int:
     return 0 if all(result.ok for _, result in results) else 1
 
 
+def _stale_socket_drill_command(args: argparse.Namespace) -> int:
+    paths = default_paths()
+    results = stale_socket_drill(
+        Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
+        Path(args.socket_path) if args.socket_path else paths.socket_path,
+        Path(args.pid_file) if args.pid_file else paths.pid_file,
+        Path(args.log_dir) if args.log_dir else paths.log_dir,
+        dry_run=args.dry_run,
+    )
+    _print_results(results, as_json=args.json)
+    return 0 if all(result.ok for _, result in results) else 1
+
+
 def _launchd_command(args: argparse.Namespace) -> int:
     paths = default_paths()
     result = run_launchd_action(
@@ -2087,6 +2171,18 @@ def build_parser() -> argparse.ArgumentParser:
     restart_drill.add_argument("--dry-run", action="store_true")
     restart_drill.add_argument("--json", action="store_true")
     restart_drill.set_defaults(func=_restart_drill_command)
+
+    stale_socket_drill_parser = subparsers.add_parser(
+        "stale-socket-drill",
+        help="create and recover a controlled stale helper socket",
+    )
+    stale_socket_drill_parser.add_argument("--helper", "--helper-path", dest="helper_path")
+    stale_socket_drill_parser.add_argument("--socket", "--socket-path", dest="socket_path")
+    stale_socket_drill_parser.add_argument("--pid-file")
+    stale_socket_drill_parser.add_argument("--log-dir")
+    stale_socket_drill_parser.add_argument("--dry-run", action="store_true")
+    stale_socket_drill_parser.add_argument("--json", action="store_true")
+    stale_socket_drill_parser.set_defaults(func=_stale_socket_drill_command)
 
     launchd = subparsers.add_parser("launchd", help="run explicit launchctl helper lifecycle actions")
     launchd.add_argument("action", choices=sorted(LAUNCHD_ACTIONS))

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -154,6 +154,7 @@ def socket_accepts_connection(path: Path, *, timeout_sec: float = 0.1) -> bool:
 
 
 def create_stale_unix_socket(path: Path) -> None:
+    """Bind and close an inactive AF_UNIX socket for stale-socket recovery drills."""
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
         server.bind(str(path))
 
@@ -1673,6 +1674,15 @@ def stale_socket_drill(
             results.append(("stale_socket_drill", failed_create))
             return results
         created_socket_identity = socket_identity(socket_path)
+        if created_socket_identity is None:
+            failed_create = CheckResult(
+                ok=False,
+                reason="helper_socket_create_failed",
+                message="socket not created",
+            )
+            results.append(("stale_socket", failed_create))
+            results.append(("stale_socket_drill", failed_create))
+            return results
         results.append(("stale_socket", CheckResult(ok=True)))
 
     try:
@@ -2001,6 +2011,7 @@ def _restart_drill_command(args: argparse.Namespace) -> int:
 
 
 def _stale_socket_drill_command(args: argparse.Namespace) -> int:
+    """Run the stale-socket drill CLI and return success only when every check passes."""
     paths = default_paths()
     results = stale_socket_drill(
         Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,


### PR DESCRIPTION
## Summary
- Adds a manual `vz-helperctl.py stale-socket-drill` operator command that creates a controlled inactive Unix socket and recovers through the existing managed helper startup path.
- Adds host-independent regression coverage for stale socket recovery, unsafe socket shapes, unsafe parent permissions, dry-run behavior, startup failure cleanup, and CLI forwarding.
- Updates helper docs, prepared-host evidence tracking, and Backlog task TASK-433.

## Verification
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q -k stale_socket_drill` passed: 7 passed, 5 skipped.
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 141 passed, 6 skipped.
- [x] `swift test` under `tools/macos-vz-helper` passed: 88 tests passed.
- [x] `git diff --check` passed.
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tools/macos-vz-helper/scripts/vz-helperctl.py` passed.

## Bandit note
A full scan of `tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py` still reports pre-existing helperctl test-file baseline warnings outside the new stale-socket drill section. The new section's hardcoded `/tmp` tempdir findings were removed.

## Change summary
Human-authored change summary to be added before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual stale-socket drill to `vz-helperctl.py` that safely creates or preserves an inactive Unix socket and verifies recovery through the normal managed helper startup. Includes focused tests and docs so operators can run the check and record prepared-host evidence (fulfills TASK-433).

- New Features
  - New `stale-socket-drill` command: validates helper and private dirs (runtime/pid/log/serial), refuses unsafe or active sockets, creates a controlled stale socket only when needed, fails if no socket was created, starts via `start_helper()`, verifies the helper is running, and cleans up only drill-created state on failure.
  - Added host-independent tests for recovery (including pre-existing sockets), unsafe shapes and parents, dry-run, startup failure cleanup and error propagation, post-start running status, and CLI forwarding/JSON output.
  - Updated docs: `tools/macos-vz-helper/README.md` with usage; evidence tracker fields (runtime dir mode, socket path, command output, helper stdout/stderr, skip reason); added plan and `backlog/tasks/TASK-433`.

<sup>Written for commit c4b5f7f4678687f634e85cf4e7766b86d18a85e4. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1856?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

