### PR TITLE
test(vz): cover stuck boot readiness cleanup

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -433,12 +433,26 @@ hostless cleanup contract currently covers:
 - `vz_linux` helper-execution failure after VM creation; this must terminate
   the helper VM, clear active VM/run-directory bookkeeping, and remove the
   auto-created workspace.
+- `vz_linux` helper boot-driver failure during `create_vm`; this must remove
+  the helper registry's booting record and leave no VM in status or list output.
+- `vz_linux` guest-readiness failure during `create_vm`; this must stop the
+  booted machine through the helper cleanup primitive, remove the helper
+  registry record, and leave no healthy session VM for reuse.
+- `vz_linux` session-mode `create_vm` failure after a stale or unhealthy
+  candidate was rejected; this must clear the stale session-control row, avoid
+  writing a replacement row, skip guest command execution, and leave no active
+  Python runner VM/run-directory bookkeeping.
 
 Real Virtualization.framework cleanup remains host-gated. The portable tests do
 not prove that a prepared Apple silicon host releases every VM process,
 virtiofs resource, serial log handle, or helper-side run clone. Operators should
 use the real host smoke below for VM process lifecycle coverage, including
 ephemeral VM teardown and same-session VM reuse.
+
+Stuck boot/readiness evidence should use stable helper or runner error codes
+such as boot failure or guest readiness timeout, helper stdout/stderr paths, and
+serial-log file pointers. Diagnostics and evidence packets should not read raw
+serial logs into API output or documentation entries.
 
 ## Real Host E2E Smoke
 

--- a/Docs/Sandbox/vz-linux-prepared-host-evidence.md
+++ b/Docs/Sandbox/vz-linux-prepared-host-evidence.md
@@ -44,6 +44,7 @@ Each prepared-host evidence packet should include these fields.
 | Failure drills | pass/fail/skip for drill-owned stale VM replacement and helper restart drill; include skip reason when `include_failure_drills` was not requested. |
 | Launchd drill | pass/fail/skip for `launchd-drill`; include skip reason unless a maintainer explicitly requested LaunchAgent validation. |
 | Stale socket drill | pass/fail/skip for `stale-socket-drill`; include runtime directory mode, socket path, command output, helper stdout/stderr paths, and skip reason when not requested. |
+| Stuck boot/readiness drills | pass/fail/skip for host-independent helper/runner stuck boot/readiness coverage and any later manual prepared-host drill; include stable failure reason or error code, create-path outcome, session-control outcome, helper stdout/stderr paths, serial-log pointers only, and skip reason when no manual drill was requested. |
 | Artifacts | workflow run URL or local artifact root, helper stdout/stderr files, serial logs, pytest logs, workflow logs, and checksums or sizes for retained artifacts. |
 | Expected skips | explicit non-blocking skips from the acceptance policy, including missing nightly opt-in, no launchd request, no failure-drill request, or local unprepared-host checks. |
 | Blocking regressions | any failed guarantee from the acceptance policy and the first failing command/log pointer. |
@@ -69,6 +70,7 @@ Use this checklist for a complete prepared-host acceptance entry.
 | Artifact upload or retention | Helper logs, serial logs, and pytest/workflow logs were retained or an early setup skip explains why none exist. | Yes |
 | Failure drills | Drill-owned stale VM replacement and helper restart drill results recorded. | Manual opt-in only |
 | Launchd drill | LaunchAgent bootstrap/kickstart/status/bootout drill results recorded. | Manual opt-in only |
+| Stuck boot/readiness drills | Host-independent helper/runner tests prove registry/session cleanup; any manual prepared-host drill records stable reason codes and artifact pointers without exposing raw serial logs. | Portable coverage only |
 | Host reboot drill | Post-reboot helper/session recovery evidence recorded. | Manual operator procedure only |
 
 ## Expected Skip Taxonomy
@@ -86,6 +88,8 @@ themselves:
 - managed helper `restart-drill` skipped because the helper was not started by
   `vz-helperctl.py start`
 - `launchd-drill` skipped because no maintainer requested LaunchAgent validation
+- manual stuck boot/readiness drill skipped because only host-independent
+  helper/runner coverage was requested for the current implementation slice
 - host reboot validation skipped because it remains a manual operator procedure
 
 If a prepared host passes preflight and then fails helper startup, real
@@ -130,7 +134,8 @@ GitHub Actions run with the packet fields above.
 | Failure-drill evidence | Manual opt-in only. | Record results when a maintainer runs with `include_failure_drills=true`. |
 | Launchd-drill evidence | Manual opt-in only. | Record results only when a runner is intentionally configured for LaunchAgent validation. |
 | Host reboot recovery | Manual operator procedure only and out of scheduled CI. | Add a dedicated operator drill once a prepared host can tolerate disruptive reboot testing and preserve logs. |
-| Stuck boot/readiness and guest-agent mismatch | Not covered by the default smoke. | Use `Docs/superpowers/specs/2026-05-18-vz-linux-lifecycle-drill-gaps-design.md` to guide narrow manual drills or diagnostics checks before considering automated coverage. |
+| Stuck boot/readiness | Host-independent helper and runner coverage verifies boot-driver failure cleanup, guest-readiness failure cleanup, and no reusable session state after create failure. The default prepared-host smoke still does not inject real boot faults. | Record manual prepared-host evidence only after a separate reviewed fault-injection plan; diagnostics/evidence should report stable reason codes and artifact pointers, not raw serial log contents. |
+| Guest-agent mismatch | Not covered by the default smoke. | Use `Docs/superpowers/specs/2026-05-18-vz-linux-lifecycle-drill-gaps-design.md` to guide narrow tests or diagnostics checks before considering automated coverage. |
 | Stale socket handling | `tools/macos-vz-helper/scripts/vz-helperctl.py stale-socket-drill` provides a manual operator check for safe inactive socket recovery. | Record prepared-host evidence when a maintainer intentionally runs the drill; keep it manual-only and out of PR/push/scheduled destructive triggers. |
 
 ## Recording Guidance

--- a/backlog/tasks/task-434 - Implement-VZ-stuck-boot-and-readiness-lifecycle-tests.md
+++ b/backlog/tasks/task-434 - Implement-VZ-stuck-boot-and-readiness-lifecycle-tests.md
@@ -1,0 +1,64 @@
+---
+id: TASK-434
+title: Implement VZ stuck boot and readiness lifecycle tests
+status: Done
+labels:
+- sandbox
+- vz_linux
+- lifecycle
+- hardening
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next slice from the VZ Linux lifecycle drill gaps design: host-independent coverage for stuck boot and stuck guest-readiness behavior. Verify helper and Python runner cleanup paths do not leave reusable VM/session state after boot/readiness failures, preserve manual/host-gated boundaries, and update operator/evidence docs as needed without adding workflow trigger expansion.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Host-independent helper or runner tests cover boot-driver failure cleanup without requiring a real VZ VM.
+- [x] #2 Host-independent helper or runner tests cover guest-readiness timeout/failure cleanup without marking a session VM reusable.
+- [x] #3 Diagnostics or evidence docs identify the stuck boot/readiness contract and expected evidence without exposing raw serial logs through API output.
+- [x] #4 Implementation reuses existing helper/runner cleanup primitives rather than adding broad repair automation.
+- [x] #5 Focused verification, git diff hygiene, and Bandit for touched Python scope are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the host-independent stuck boot/readiness slice:
+
+- Added Swift helper coverage for boot-driver failure cleanup before a VM reaches readiness.
+- Added Swift service-level coverage for boot-driver failure and guest-readiness failure through the same `HelperService.createVM` path used by real execution.
+- Added Python runner coverage for a session-mode readiness failure after a stale/unhealthy reuse candidate is rejected. The test verifies the stale session-control row is deleted, no replacement row is stored, guest execution is skipped, helper termination is not attempted without a returned `vm_id`, and active runner maps are clear.
+- Updated operator/evidence docs and doc-contract tests to require stable reason/error evidence, session-control outcome, helper stdout/stderr paths, serial-log pointers only, and no raw serial log exposure through diagnostics/docs.
+
+Verification:
+
+- `swift test --filter 'createVMRemovesBootingRecordWhenBootDriverFails|helperServiceCreateVMClearsRegistryWhenBootDriverFails|helperServiceCreateVMClearsRegistryWhenReadinessFails'` passed.
+- `swift test` passed: 91 tests. Existing warning: SwiftPM reports `Tests/test_vz_helperctl.py` as an unhandled file.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q` passed: 28 tests.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` passed: 18 tests.
+- `git diff --check` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py` passed.
+- Bandit on touched test files reports the existing pytest `assert` and hardcoded temp-path baseline; rerunning with `B101,B108` skipped passed.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed host-independent stuck boot/readiness lifecycle coverage and documentation. The slice adds Swift helper/service cleanup tests, a Python session-mode readiness failure cleanup test, and evidence/doc-contract updates for stable reason codes and artifact-pointer-only diagnostics.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-434 - Implement-VZ-stuck-boot-and-readiness-lifecycle-tests.md
+++ b/backlog/tasks/task-434 - Implement-VZ-stuck-boot-and-readiness-lifecycle-tests.md
@@ -44,6 +44,8 @@ Verification:
 - `git diff --check` passed.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py` passed.
 - Bandit on touched test files reports the existing pytest `assert` and hardcoded temp-path baseline; rerunning with `B101,B108` skipped passed.
+- PR review follow-up: changed the new stuck boot/readiness doc-contract test to use `_normalized_existing_text(...)` for both docs, preserving this module's targeted missing-file failure messages.
+- PR review verification: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` passed; Bandit on that test file passed; `git diff --check` passed.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "vz-linux-host-gated.yml"
 POLICY_PATH = REPO_ROOT / "Docs" / "Sandbox" / "vz-linux-host-gated-ci-acceptance-policy.md"
 EVIDENCE_TRACKER_PATH = REPO_ROOT / "Docs" / "Sandbox" / "vz-linux-prepared-host-evidence.md"
+OPERATOR_NOTES_PATH = REPO_ROOT / "Docs" / "Sandbox" / "macos-runtime-operator-notes.md"
 ROADMAP_PATH = (
     REPO_ROOT
     / "Docs"
@@ -229,6 +230,7 @@ def test_vz_linux_prepared_host_evidence_tracker_defines_packet() -> None:
         "Helper build/signing",
         "Real `vz_linux` ephemeral execution",
         "Same-session VM reuse",
+        "Stuck boot/readiness drills",
         "Artifacts",
         "Expected skips",
         "Residual gaps",
@@ -237,6 +239,34 @@ def test_vz_linux_prepared_host_evidence_tracker_defines_packet() -> None:
         _require(
             required_term in tracker,
             f"Evidence tracker should include packet term {required_term}",
+        )
+
+
+def test_vz_linux_stuck_boot_readiness_contract_records_pointers_not_raw_logs() -> None:
+    """Stuck boot/readiness evidence should be stable and avoid raw log exposure."""
+    tracker = _normalized_text(EVIDENCE_TRACKER_PATH)
+    operator_notes = _normalized_text(OPERATOR_NOTES_PATH)
+
+    for required_term in (
+        "stable failure reason or error code",
+        "session-control outcome",
+        "serial-log pointers only",
+        "without exposing raw serial logs",
+    ):
+        _require(
+            required_term in tracker,
+            f"Evidence tracker should capture stuck boot/readiness term {required_term}",
+        )
+
+    for required_term in (
+        "boot-driver failure",
+        "guest-readiness failure",
+        "avoid writing a replacement row",
+        "should not read raw serial logs into API output",
+    ):
+        _require(
+            required_term in operator_notes,
+            f"Operator notes should document stuck boot/readiness cleanup term {required_term}",
         )
 
 

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -244,8 +244,8 @@ def test_vz_linux_prepared_host_evidence_tracker_defines_packet() -> None:
 
 def test_vz_linux_stuck_boot_readiness_contract_records_pointers_not_raw_logs() -> None:
     """Stuck boot/readiness evidence should be stable and avoid raw log exposure."""
-    tracker = _normalized_text(EVIDENCE_TRACKER_PATH)
-    operator_notes = _normalized_text(OPERATOR_NOTES_PATH)
+    tracker = _normalized_existing_text(EVIDENCE_TRACKER_PATH, "Prepared-host evidence tracker")
+    operator_notes = _normalized_existing_text(OPERATOR_NOTES_PATH, "macOS runtime operator notes")
 
     for required_term in (
         "stable failure reason or error code",

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -10,6 +10,7 @@ import tldw_Server_API.app.core.Sandbox.runners.vz_common as vz_common
 import tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner as vz_linux_module
 from tldw_Server_API.app.core.Sandbox.image_store import SandboxImageStore
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperFailure,
     MacOSVirtualizationHelperProtocolError,
     MacOSVirtualizationHelperUnavailable,
 )
@@ -360,6 +361,102 @@ def test_vz_linux_image_store_does_not_persist_manifest_when_create_vm_fails(
     assert status.phase == RunPhase.failed
     assert "create_vm_failed" in status.message
     assert SandboxImageStore(root_path=store_root).get_run_clone_manifest("vz-run-create-fails") is None
+
+
+def test_vz_linux_session_create_vm_readiness_failure_does_not_persist_reuse_state(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
+    deleted: list[str] = []
+    stored: list[dict[str, object]] = []
+    terminated: list[str] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> dict[str, object]:
+            assert session_id == "sess-readiness-timeout"
+            return {
+                "runtime": "vz_linux",
+                "vm_id": "vm-stale",
+                "template_id": "vz_linux:stale",
+                "workspace_mount": str(tmp_path),
+                "agent_ready": True,
+            }
+
+        def delete_vz_session_control(self, session_id: str) -> bool:
+            deleted.append(session_id)
+            return True
+
+        def put_vz_session_control(self, **kwargs: object) -> None:
+            stored.append(dict(kwargs))
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
+            assert vm_id == "vm-stale"
+            calls.append("get_vm_status")
+            return HelperVMStatusReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                vm_id=vm_id,
+                state="booting",
+                healthy=False,
+            )
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["run_id"] == "vz-run-readiness-timeout"
+            assert request["session_id"] == "sess-readiness-timeout"
+            assert request["session_mode"] is True
+            raise MacOSVirtualizationHelperFailure(
+                "guest_readiness_timed_out",
+                "guest readiness timed out",
+            )
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            raise AssertionError(f"exec_guest should not run after readiness failure: {vm_id} {request}")
+
+        def terminate_vm(self, vm_id: str) -> bool:
+            terminated.append(vm_id)
+            return True
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    run_id = "vz-run-readiness-timeout"
+    try:
+        status = VZLinuxRunner(session_control_store=_Store()).start_run(
+            run_id=run_id,
+            spec=RunSpec(
+                session_id="sess-readiness-timeout",
+                runtime=RuntimeType.vz_linux,
+                base_image="ubuntu-24.04",
+                command=["/bin/echo", "ok"],
+                network_policy="deny_all",
+            ),
+            session_workspace=str(tmp_path),
+        )
+
+        assert status.phase == RunPhase.failed
+        assert "guest_readiness_timed_out" in status.message
+        assert calls == ["get_vm_status", "validate_template", "create_vm"]
+        assert deleted == ["sess-readiness-timeout"]
+        assert stored == []
+        assert terminated == []
+        with VZLinuxRunner._active_lock:  # type: ignore[attr-defined]
+            assert run_id not in VZLinuxRunner._active_vm  # type: ignore[attr-defined]
+            assert run_id not in VZLinuxRunner._active_run_dir  # type: ignore[attr-defined]
+    finally:
+        with VZLinuxRunner._active_lock:  # type: ignore[attr-defined]
+            VZLinuxRunner._active_vm.pop(run_id, None)  # type: ignore[attr-defined]
+            VZLinuxRunner._active_run_dir.pop(run_id, None)  # type: ignore[attr-defined]
 
 
 def test_vz_linux_raw_template_path_ignores_unavailable_image_store(monkeypatch, tmp_path) -> None:

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -31,6 +31,62 @@ import Testing
     #expect(response.details["helper_started_at"] == "2026-05-09T00:00:00Z")
 }
 
+@Test func helperServiceCreateVMClearsRegistryWhenBootDriverFails() throws {
+    let registry = VMRegistry()
+    let bootDriver = FailingBootDriver()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: bootDriver,
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    #expect(throws: TestBootDriverError.self) {
+        _ = try service.createVM(
+            vmID: "vm-service-boot-failed",
+            templatePath: "/tmp/template.img",
+            workspacePath: "/tmp/workspace",
+            readinessTimeoutSeconds: 5
+        )
+    }
+
+    #expect(service.getVMStatus(vmID: "vm-service-boot-failed") == nil)
+    #expect(service.listVMs().vms.isEmpty)
+    #expect(bootDriver.stoppedVMIDs == ["vm-service-boot-failed"])
+}
+
+@Test func helperServiceCreateVMClearsRegistryWhenReadinessFails() throws {
+    let registry = VMRegistry()
+    let bootDriver = RecordingBootDriver()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: bootDriver,
+        guestBridge: FailingGuestBridge(error: VSockSessionError.requestTimedOut("vm-service-readiness-failed"))
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    #expect(throws: VSockSessionError.self) {
+        _ = try service.createVM(
+            vmID: "vm-service-readiness-failed",
+            templatePath: "/tmp/template.img",
+            workspacePath: "/tmp/workspace",
+            readinessTimeoutSeconds: 5
+        )
+    }
+
+    #expect(service.getVMStatus(vmID: "vm-service-readiness-failed") == nil)
+    #expect(service.listVMs().vms.isEmpty)
+    #expect(bootDriver.stoppedVMIDs == ["vm-service-readiness-failed"])
+}
+
 @Test func helperServiceSurfacesResourceSnapshotInCreateStatusAndList() throws {
     let registry = VMRegistry()
     let manager = VZLinuxVMManager(

--- a/tools/macos-vz-helper/Tests/TestDoubles.swift
+++ b/tools/macos-vz-helper/Tests/TestDoubles.swift
@@ -27,6 +27,30 @@ final class RecordingBootDriver: VZBootDriving {
     }
 }
 
+enum TestBootDriverError: Error {
+    case bootFailed
+}
+
+final class FailingBootDriver: VZBootDriving {
+    private let error: Error
+    private(set) var lastReadinessTimeoutSeconds: TimeInterval?
+    private(set) var stoppedVMIDs: [String] = []
+
+    init(error: Error = TestBootDriverError.bootFailed) {
+        self.error = error
+    }
+
+    @discardableResult
+    func boot(vmID: String, templatePath: String, workspacePath: String, startupTimeoutSeconds: TimeInterval) throws -> VMResourceSnapshot {
+        lastReadinessTimeoutSeconds = startupTimeoutSeconds
+        throw error
+    }
+
+    func stop(vmID: String) throws {
+        stoppedVMIDs.append(vmID)
+    }
+}
+
 final class ReadyGuestBridge: GuestBridging {
     private let info: GuestAgentInfo?
 

--- a/tools/macos-vz-helper/Tests/VMBootTests.swift
+++ b/tools/macos-vz-helper/Tests/VMBootTests.swift
@@ -112,6 +112,29 @@ import Testing
     #expect(bootDriver.lastReadinessTimeoutSeconds == 12)
 }
 
+@Test func createVMRemovesBootingRecordWhenBootDriverFails() throws {
+    let registry = VMRegistry()
+    let bootDriver = FailingBootDriver()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: bootDriver,
+        guestBridge: ReadyGuestBridge()
+    )
+
+    #expect(throws: TestBootDriverError.self) {
+        _ = try manager.createVM(
+            vmID: "vm-boot-failed",
+            templatePath: "/tmp/template.img",
+            workspacePath: "/tmp/workspace",
+            readinessTimeoutSeconds: 7
+        )
+    }
+
+    #expect(registry.status(vmID: "vm-boot-failed") == nil)
+    #expect(bootDriver.stoppedVMIDs == ["vm-boot-failed"])
+    #expect(bootDriver.lastReadinessTimeoutSeconds == 7)
+}
+
 @Test func createVMStopsBootedMachineWhenReadinessFails() throws {
     let registry = VMRegistry()
     let bootDriver = RecordingBootDriver()


### PR DESCRIPTION
## Summary
- Add host-independent Swift helper/service tests for VZ Linux boot-driver and guest-readiness cleanup through `createVM`.
- Add Python runner coverage proving session-mode readiness failure does not persist reusable VM/session state or execute guest commands.
- Update operator/evidence docs and doc-contract tests for stable reason/error evidence, session-control outcomes, serial-log pointers only, and no raw serial log exposure.

## Test Plan
- [x] `swift test` from `tools/macos-vz-helper`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q`
- [x] `git diff --check`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
- [x] Bandit touched-test baseline checked: full scan reports existing pytest assert/temp-path test baseline; `-s B101,B108` passes.

## Change summary
Human-authored summary pending.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds host-independent tests to verify VZ Linux cleans up correctly on stuck boot and guest-readiness failures, and that no reusable VM/session state persists after create failures. Hardens prepared-host evidence and operator docs to require stable reason codes and artifact pointers only (no raw serial logs). Addresses TASK-434.

- **Test Coverage**
  - Swift helper/service: boot-driver and readiness failures clear registry and stop the VM.
  - Python runner: session-mode readiness failure deletes stale session-control, writes no replacement, skips guest exec, and leaves no active run/VM state.
  - Host-gated doc-contract tests: evidence tracker and operator notes require stable reason/error codes, session-control outcomes, and serial-log pointers only.

- **Docs**
  - Operator notes updated for stuck boot/readiness: record boot-driver/guest-readiness failures, avoid writing a replacement row, and never read raw serial logs into API/docs.
  - Prepared-host evidence tracker adds “Stuck boot/readiness drills” with required fields and pointer-only artifacts.

<sup>Written for commit bbe468d9859be6da37e3531708ba7d2d6c4d72cf. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1857?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

