### PR TITLE
Migrate ReportBuilderDrawer ready label to design-system registry

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3641,17 +3641,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "canonical-state-label:src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx:Ready",
-    "path": "src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx",
-    "rule": "canonical-state-label",
-    "subject": "Ready",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing canonical state label \"Ready\" in src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx before the stable duplicate-id guard.",
-    "replacement": "design-system state registry",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx:Alert",
     "path": "src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
@@ -458,7 +458,7 @@ export const ReportBuilderDrawer: React.FC<ReportBuilderDrawerProps> = ({
                 ))}
               </div>
             ) : (
-              <Tag color="green">{t("watchlists:reports.builder.ready", READY_STATE_LABEL)}</Tag>
+              <Tag color="success">{t("watchlists:reports.builder.ready", READY_STATE_LABEL)}</Tag>
             )}
           </div>
 

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
@@ -15,6 +15,7 @@ import type {
   WatchlistRun,
   WatchlistTemplate
 } from "@/types/watchlists"
+import { READY_STATE_LABEL } from "@/design-system/states"
 
 interface ReportBuilderDrawerProps {
   open: boolean
@@ -457,7 +458,7 @@ export const ReportBuilderDrawer: React.FC<ReportBuilderDrawerProps> = ({
                 ))}
               </div>
             ) : (
-              <Tag color="green">{t("watchlists:reports.builder.ready", "Ready")}</Tag>
+              <Tag color="green">{t("watchlists:reports.builder.ready", READY_STATE_LABEL)}</Tag>
             )}
           </div>
 

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
@@ -33,6 +33,10 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
+vi.mock("@/design-system/states", () => ({
+  READY_STATE_LABEL: "Registry Ready"
+}))
+
 vi.mock("antd", () => {
   const Select = ({ value, onChange, options = [], ...rest }: any) => (
     <select
@@ -265,6 +269,27 @@ describe("ReportBuilderDrawer", () => {
     expect(await screen.findByText("0 queued updates")).toBeInTheDocument()
     expect(screen.getByText("No queued updates found for this run.")).toBeInTheDocument()
     expect(screen.getByText("No included updates")).toBeInTheDocument()
+  })
+
+  it("uses the design-system registry label when report readiness is ready", async () => {
+    const readyItems: ScrapedItem[] = [
+      { ...queuedItem, reviewed: true, source_id: 11 },
+      { ...queuedItem, id: 103, reviewed: true, source_id: 12, title: "Second source update" }
+    ]
+    setupQueueMocks(readyItems, readyItems)
+
+    render(
+      <ReportBuilderDrawer
+        open
+        selectedWatchlist={newsWatchlist}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText("2 queued updates")).toBeInTheDocument()
+    expect(screen.getByText("Registry Ready")).toBeInTheDocument()
+    expect(screen.queryByText("Ready")).not.toBeInTheDocument()
   })
 
   it("submits Stage 5 report options with queued item ids and warning acknowledgement", async () => {

--- a/backlog/tasks/task-45.49 - Migrate-ReportBuilderDrawer-ready-label-to-design-system-registry.md
+++ b/backlog/tasks/task-45.49 - Migrate-ReportBuilderDrawer-ready-label-to-design-system-registry.md
@@ -1,0 +1,50 @@
+---
+id: TASK-45.49
+title: Migrate ReportBuilderDrawer ready label to design-system registry
+status: Done
+parent_task_id: TASK-45
+references:
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1858
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by routing the Watchlists ReportBuilderDrawer readiness success label through the canonical design-system state registry instead of a local hardcoded Ready fallback. Keep scope limited to the ready label, focused tests, and removal of the matching canonical-state-label baseline entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Routed ReportBuilderDrawer's readiness success fallback through READY_STATE_LABEL from the design-system state registry, added focused regression coverage with a mocked registry label, and removed the migrated canonical-state-label baseline row. Verification: focused ReportBuilderDrawer vitest passed; design-system product-state verifier passed with baseline exceptions reduced from 350 to 349 and no canonical-state-label exceptions; git diff --check passed. Full UI TypeScript still fails on inherited baseline debt outside the touched files. Bandit skipped because this slice only touches TypeScript, JSON, and Backlog metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Routes ReportBuilderDrawer readiness success fallback through READY_STATE_LABEL while preserving the existing watchlists i18n key.
- Adds focused regression coverage that proves the drawer reads the canonical ready label from the design-system registry.
- Removes the migrated canonical-state-label baseline exception, reducing guard debt from 350 to 349 entries.

## Verification
- bunx vitest run src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
- bun run verify:design-system-state
- git diff --check
- bunx tsc --noEmit --pretty false (fails on inherited baseline TypeScript debt outside touched files; no touched-file diagnostics observed)

## Change summary
TODO: human-authored summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the ReportBuilderDrawer ready label through `READY_STATE_LABEL` from `@/design-system/states` for consistent state text. Also updates the Tag to the `success` color, adds a focused test, and removes the legacy baseline exception.

- **Refactors**
  - Use `READY_STATE_LABEL` as the fallback for `watchlists:reports.builder.ready` in `ReportBuilderDrawer`.
  - Change Tag color from "green" to "success" to match the design system.

<sup>Written for commit edc66a029d65b653fbbacdf52c83ffa751f67b32. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1858?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

