### PR TITLE
Migrate ReportBuilderDrawer ready badge to design-system Badge

### DIFF
--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
@@ -15,6 +15,7 @@ import type {
   WatchlistRun,
   WatchlistTemplate
 } from "@/types/watchlists"
+import { Badge } from "@/components/ui/primitives/Badge"
 import { READY_STATE_LABEL } from "@/design-system/states"
 
 interface ReportBuilderDrawerProps {
@@ -458,7 +459,7 @@ export const ReportBuilderDrawer: React.FC<ReportBuilderDrawerProps> = ({
                 ))}
               </div>
             ) : (
-              <Tag color="success">{t("watchlists:reports.builder.ready", READY_STATE_LABEL)}</Tag>
+              <Badge variant="success">{t("watchlists:reports.builder.ready", READY_STATE_LABEL)}</Badge>
             )}
           </div>
 

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
@@ -288,7 +288,12 @@ describe("ReportBuilderDrawer", () => {
     )
 
     expect(await screen.findByText("2 queued updates")).toBeInTheDocument()
-    expect(screen.getByText("Registry Ready")).toBeInTheDocument()
+    const readyBadge = screen.getByText("Registry Ready")
+    expect(readyBadge).toBeInTheDocument()
+    expect(readyBadge.closest("[data-ds-component='Badge']")).toHaveAttribute(
+      "data-ds-variant",
+      "success"
+    )
     expect(screen.queryByText("Ready")).not.toBeInTheDocument()
   })
 

--- a/backlog/tasks/task-45.50 - Migrate-ReportBuilderDrawer-ready-badge-to-design-system-Badge.md
+++ b/backlog/tasks/task-45.50 - Migrate-ReportBuilderDrawer-ready-badge-to-design-system-Badge.md
@@ -1,0 +1,49 @@
+---
+id: TASK-45.50
+title: Migrate ReportBuilderDrawer ready badge to design-system Badge
+status: Done
+parent_task_id: TASK-45
+references:
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+- apps/packages/ui/scripts/verify-design-system-product-state.mjs
+- https://github.com/rmusser01/tldw_server/pull/1860
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by replacing ReportBuilderDrawer's readiness success AntD Tag with the shared design-system Badge primitive while preserving the canonical ready label and existing report-readiness behavior. Keep scope limited to the ready readiness badge and focused tests so the product-state guard returns to the accepted baseline.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced ReportBuilderDrawer's ready readiness AntD Tag with the shared design-system Badge primitive while preserving READY_STATE_LABEL and the existing watchlists i18n key. Added focused test coverage that asserts the ready label renders inside a design-system Badge with the success variant. Verification: focused ReportBuilderDrawer vitest passed; design-system product-state verifier passed at the accepted 349 legacy AntD exceptions; git diff --check passed. Full UI TypeScript still fails on inherited baseline debt outside the touched files. Bandit skipped because this slice only touches TypeScript and Backlog metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replaces ReportBuilderDrawer readiness success AntD Tag with the shared design-system Badge primitive.
- Keeps READY_STATE_LABEL and the existing watchlists i18n key from the prior registry-label slice.
- Adds focused coverage that asserts the ready state renders as a design-system Badge with the success variant.

## Verification
- bunx vitest run src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
- bun run verify:design-system-state
- git diff --check
- bunx tsc --noEmit --pretty false (fails on inherited baseline TypeScript debt outside touched files; no touched-file diagnostics observed)

## Change summary
TODO: human-authored summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the ReportBuilderDrawer ready indicator from AntD `Tag` to the design-system `Badge` for consistency. Preserves `READY_STATE_LABEL` and `watchlists:reports.builder.ready`, and updates tests to assert the `Badge` renders with the `success` variant via data attributes.

<sup>Written for commit 9400ac36250da74e01c003e7d0395190433b2f0b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1860?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

