### PR TITLE
test(vz): classify guest agent mismatches

### DIFF
--- a/backlog/tasks/task-435 - Add-VZ-guest-agent-mismatch-diagnostics-tests.md
+++ b/backlog/tasks/task-435 - Add-VZ-guest-agent-mismatch-diagnostics-tests.md
@@ -3,20 +3,15 @@ id: TASK-435
 title: Add VZ guest-agent mismatch diagnostics tests
 status: Done
 assignee:
-- codex
+  - codex
+created_date: ''
+updated_date: '2026-05-19 04:36'
 labels:
-- sandbox
-- vz-linux
-- diagnostics
+  - sandbox
+  - vz-linux
+  - diagnostics
+dependencies: []
 priority: medium
-modified_files:
-- tldw_Server_API/app/core/Sandbox/vz_guest_agent.py
-- tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
-- tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
-- tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
-- tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
-- tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
-- tldw_Server_API/app/core/Sandbox/README.md
 ---
 
 ## Description
@@ -27,9 +22,9 @@ Continue the VZ Linux lifecycle/recovery hardening track by adding host-independ
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Guest-agent mismatch conditions are represented in the VZ helper/runner diagnostic contract without requiring a real VZ host.
-- [ ] #2 Focused tests cover mismatch handling and verify diagnostics degrade to actionable stale/mismatch state instead of crashing or reusing an unhealthy VM.
-- [ ] #3 Implementation keeps changes minimal and aligned with existing sandbox lifecycle docs/tests.
+- [x] #1 Guest-agent mismatch conditions are represented in the VZ helper/runner diagnostic contract without requiring a real VZ host.
+- [x] #2 Focused tests cover mismatch handling and verify diagnostics degrade to actionable stale/mismatch state instead of crashing or reusing an unhealthy VM.
+- [x] #3 Implementation keeps changes minimal and aligned with existing sandbox lifecycle docs/tests.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -40,22 +35,26 @@ Continue the VZ Linux lifecycle/recovery hardening track by adding host-independ
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+PR review follow-up: added classifier docstrings/constants, aligned text coercion with diagnostics, refactored classifier to return the full guest observability payload, typed the new pytest parameters, and added direct classifier regression tests.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented host-independent guest-agent mismatch diagnostics and session reuse hardening for VZ Linux. Verification: focused red tests failed before implementation, then `python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q` passed with 56 tests; `git diff --check` passed; Bandit on touched production Python wrote `/tmp/bandit_vz_guest_agent_mismatch.json` with zero findings.
+Implemented host-independent guest-agent mismatch diagnostics and session reuse hardening for VZ Linux. PR review follow-up added classifier module/helper docstrings, centralized guest observability parsing in the classifier, aligned non-string workspace-root coercion with diagnostics, added direct classifier regression coverage, typed the new pytest parameters, and checked Backlog AC/DoD items. Verification: `python -m pytest tldw_Server_API/tests/sandbox/test_vz_guest_agent.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q` passed with 58 tests; `git diff --check` passed; Bandit on touched production Python wrote `/tmp/bandit_vz_guest_agent_mismatch_review_fix.json` with zero findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-435 - Add-VZ-guest-agent-mismatch-diagnostics-tests.md
+++ b/backlog/tasks/task-435 - Add-VZ-guest-agent-mismatch-diagnostics-tests.md
@@ -1,0 +1,61 @@
+---
+id: TASK-435
+title: Add VZ guest-agent mismatch diagnostics tests
+status: Done
+assignee:
+- codex
+labels:
+- sandbox
+- vz-linux
+- diagnostics
+priority: medium
+modified_files:
+- tldw_Server_API/app/core/Sandbox/vz_guest_agent.py
+- tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+- tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+- tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+- tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+- tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+- tldw_Server_API/app/core/Sandbox/README.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the VZ Linux lifecycle/recovery hardening track by adding host-independent coverage for guest-agent protocol/version mismatch diagnostics and cleanup behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Guest-agent mismatch conditions are represented in the VZ helper/runner diagnostic contract without requiring a real VZ host.
+- [ ] #2 Focused tests cover mismatch handling and verify diagnostics degrade to actionable stale/mismatch state instead of crashing or reusing an unhealthy VM.
+- [ ] #3 Implementation keeps changes minimal and aligned with existing sandbox lifecycle docs/tests.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current VZ Linux runner/helper diagnostics and existing lifecycle tests. 2. Add focused failing test(s) for guest-agent mismatch behavior. 3. Implement minimal diagnostic/status handling. 4. Run focused pytest plus diff/security checks on touched scope.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented host-independent guest-agent mismatch diagnostics and session reuse hardening for VZ Linux. Verification: focused red tests failed before implementation, then `python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q` passed with 56 tests; `git diff --check` passed; Bandit on touched production Python wrote `/tmp/bandit_vz_guest_agent_mismatch.json` with zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -720,6 +720,11 @@ class SandboxAdminMacOSGuestObservability(BaseModel):
     workspace_root: str | None = None
     capabilities_known: bool | None = None
     capabilities: list[str] = Field(default_factory=list)
+    compatibility: Literal["compatible", "unknown", "mismatch"] = "unknown"
+    reasons: list[str] = Field(default_factory=list)
+    expected_workspace_root: str | None = None
+    required_capabilities: list[str] = Field(default_factory=list)
+    missing_required_capabilities: list[str] = Field(default_factory=list)
 
 
 class SandboxAdminMacOSVMObservability(BaseModel):

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -107,8 +107,11 @@ Current limitations:
 - `vz_linux` helper VM status details include guest-agent readiness metadata
   when available: `guest_version`, `guest_workspace_root`,
   `guest_capabilities_known`, and `guest_capabilities`. These fields are
-  diagnostic only; old images that omit capabilities remain compatible and are
-  reported as capability-unknown.
+  diagnostic only; old images that omit capabilities remain accepted and are
+  reported as guest-agent compatibility `unknown`. Diagnostics classify concrete
+  mismatches, such as a non-`/workspace` guest root or known capabilities missing
+  the required `exec` capability, as `mismatch`; same-session VM reuse treats
+  that explicit mismatch as unhealthy and provisions a fresh VM.
 - `vz_linux` artifact capture is bounded by `SANDBOX_MAX_ARTIFACT_FILE_BYTES`
   and `SANDBOX_MAX_ARTIFACT_TOTAL_BYTES`. Oversized or over-budget artifacts
   are skipped without failing an otherwise successful run, and aggregate skip

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -133,42 +133,6 @@ def _serial_log_pointer(vm_id: str, serial_log_dir: Path | None) -> dict[str, ob
     return _file_pointer(serial_log_dir / f"{_sanitize_serial_log_component(vm_id)}.serial.log")
 
 
-def _detail_text(details: dict[str, object], key: str) -> str | None:
-    """Extract a non-empty string detail from helper metadata."""
-
-    value = details.get(key)
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
-
-def _detail_bool(details: dict[str, object], key: str) -> bool | None:
-    """Coerce helper detail booleans without trusting arbitrary truthy strings."""
-
-    value = details.get(key)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"1", "true", "yes", "on"}:
-            return True
-        if normalized in {"0", "false", "no", "off", ""}:
-            return False
-    return None
-
-
-def _detail_csv(details: dict[str, object], key: str) -> list[str]:
-    """Extract a list-like helper detail from either a list or comma-separated string."""
-
-    value = details.get(key)
-    if isinstance(value, list):
-        return [str(item).strip() for item in value if str(item).strip()]
-    if isinstance(value, str):
-        return [item.strip() for item in value.split(",") if item.strip()]
-    return []
-
-
 def _detail_int(details: dict[str, object], key: str) -> int | None:
     """Extract an integer helper detail while rejecting booleans."""
 
@@ -184,13 +148,7 @@ def _detail_int(details: dict[str, object], key: str) -> int | None:
 def _guest_observability(details: dict[str, object]) -> dict[str, object]:
     """Project helper guest-agent details into the admin observability schema."""
 
-    return {
-        "version": _detail_text(details, "guest_version"),
-        "workspace_root": _detail_text(details, "guest_workspace_root"),
-        "capabilities_known": _detail_bool(details, "guest_capabilities_known"),
-        "capabilities": _detail_csv(details, "guest_capabilities"),
-        **classify_vz_linux_guest_agent(details),
-    }
+    return classify_vz_linux_guest_agent(details)
 
 
 def _resource_snapshot(details: dict[str, object]) -> dict[str, int]:

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -28,6 +28,7 @@ from .vz_reconciliation import (
     REASON_RECONCILIATION_UNAVAILABLE,
     collect_vz_reconciliation,
 )
+from .vz_guest_agent import classify_vz_linux_guest_agent
 
 _VZ_LINUX_TEMPLATE_MISSING_REASON = "vz_linux_template_missing"
 _VZ_MACOS_TEMPLATE_MISSING_REASON = "macos_template_missing"
@@ -188,6 +189,7 @@ def _guest_observability(details: dict[str, object]) -> dict[str, object]:
         "workspace_root": _detail_text(details, "guest_workspace_root"),
         "capabilities_known": _detail_bool(details, "guest_capabilities_known"),
         "capabilities": _detail_csv(details, "guest_capabilities"),
+        **classify_vz_linux_guest_agent(details),
     }
 
 

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -23,6 +23,7 @@ from ..policy import SandboxPolicyConfig
 from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
 from ..utils import coerce_optional_nonempty_string
+from ..vz_guest_agent import vz_linux_guest_agent_mismatched
 from .resource_limits import log_limit_counters
 from .vz_common import _VZ_NONCRITICAL_EXCEPTIONS, VZBaseRunner, vz_host_facts
 
@@ -274,6 +275,8 @@ class VZLinuxRunner(VZBaseRunner):
     ) -> bool:
         """Return true only when live VM metadata proves safe same-session reuse."""
         if not bool(getattr(status, "healthy", False)):
+            return False
+        if vz_linux_guest_agent_mismatched(getattr(status, "details", None)):
             return False
 
         metadata = getattr(status, "metadata", None)

--- a/tldw_Server_API/app/core/Sandbox/vz_guest_agent.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_guest_agent.py
@@ -1,3 +1,5 @@
+"""VZ Linux guest-agent compatibility helpers for diagnostics and reuse gates."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -5,19 +7,27 @@ from typing import Any, Literal
 
 VZ_LINUX_EXPECTED_GUEST_WORKSPACE_ROOT = "/workspace"
 VZ_LINUX_REQUIRED_GUEST_CAPABILITIES = ("exec",)
+VZ_LINUX_GUEST_AGENT_WORKSPACE_MISMATCH = "vz_linux_guest_agent_workspace_mismatch"
+VZ_LINUX_GUEST_AGENT_REQUIRED_CAPABILITY_MISSING = (
+    "vz_linux_guest_agent_required_capability_missing"
+)
 
 GuestAgentCompatibility = Literal["compatible", "unknown", "mismatch"]
 
 
 def _detail_text(details: Mapping[str, object], key: str) -> str | None:
+    """Extract a non-empty text detail from helper metadata."""
+
     value = details.get(key)
-    if isinstance(value, str):
-        stripped = value.strip()
-        return stripped or None
-    return None
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def _detail_bool(details: Mapping[str, object], key: str) -> bool | None:
+    """Coerce helper detail booleans without trusting arbitrary truthy strings."""
+
     value = details.get(key)
     if isinstance(value, bool):
         return value
@@ -31,6 +41,8 @@ def _detail_bool(details: Mapping[str, object], key: str) -> bool | None:
 
 
 def _detail_csv(details: Mapping[str, object], key: str) -> list[str]:
+    """Extract a list-like helper detail from a list or comma-separated string."""
+
     value = details.get(key)
     if isinstance(value, list):
         return [str(item).strip() for item in value if str(item).strip()]
@@ -43,6 +55,7 @@ def classify_vz_linux_guest_agent(details: Mapping[str, Any] | None) -> dict[str
     """Classify guest-agent metadata without rejecting older metadata-light guests."""
 
     payload: Mapping[str, object] = details if isinstance(details, Mapping) else {}
+    version = _detail_text(payload, "guest_version")
     workspace_root = _detail_text(payload, "guest_workspace_root")
     capabilities_known = _detail_bool(payload, "guest_capabilities_known")
     capabilities = _detail_csv(payload, "guest_capabilities")
@@ -55,9 +68,9 @@ def classify_vz_linux_guest_agent(details: Mapping[str, Any] | None) -> dict[str
 
     reasons: list[str] = []
     if workspace_root and workspace_root != VZ_LINUX_EXPECTED_GUEST_WORKSPACE_ROOT:
-        reasons.append("vz_linux_guest_agent_workspace_mismatch")
+        reasons.append(VZ_LINUX_GUEST_AGENT_WORKSPACE_MISMATCH)
     if capabilities_known is True and missing_required:
-        reasons.append("vz_linux_guest_agent_required_capability_missing")
+        reasons.append(VZ_LINUX_GUEST_AGENT_REQUIRED_CAPABILITY_MISSING)
 
     if reasons:
         compatibility: GuestAgentCompatibility = "mismatch"
@@ -67,6 +80,10 @@ def classify_vz_linux_guest_agent(details: Mapping[str, Any] | None) -> dict[str
         compatibility = "unknown"
 
     return {
+        "version": version,
+        "workspace_root": workspace_root,
+        "capabilities_known": capabilities_known,
+        "capabilities": capabilities,
         "compatibility": compatibility,
         "reasons": reasons,
         "expected_workspace_root": VZ_LINUX_EXPECTED_GUEST_WORKSPACE_ROOT,

--- a/tldw_Server_API/app/core/Sandbox/vz_guest_agent.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_guest_agent.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+VZ_LINUX_EXPECTED_GUEST_WORKSPACE_ROOT = "/workspace"
+VZ_LINUX_REQUIRED_GUEST_CAPABILITIES = ("exec",)
+
+GuestAgentCompatibility = Literal["compatible", "unknown", "mismatch"]
+
+
+def _detail_text(details: Mapping[str, object], key: str) -> str | None:
+    value = details.get(key)
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _detail_bool(details: Mapping[str, object], key: str) -> bool | None:
+    value = details.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return None
+
+
+def _detail_csv(details: Mapping[str, object], key: str) -> list[str]:
+    value = details.get(key)
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return []
+
+
+def classify_vz_linux_guest_agent(details: Mapping[str, Any] | None) -> dict[str, object]:
+    """Classify guest-agent metadata without rejecting older metadata-light guests."""
+
+    payload: Mapping[str, object] = details if isinstance(details, Mapping) else {}
+    workspace_root = _detail_text(payload, "guest_workspace_root")
+    capabilities_known = _detail_bool(payload, "guest_capabilities_known")
+    capabilities = _detail_csv(payload, "guest_capabilities")
+    capability_set = set(capabilities)
+    missing_required = [
+        capability
+        for capability in VZ_LINUX_REQUIRED_GUEST_CAPABILITIES
+        if capability not in capability_set
+    ]
+
+    reasons: list[str] = []
+    if workspace_root and workspace_root != VZ_LINUX_EXPECTED_GUEST_WORKSPACE_ROOT:
+        reasons.append("vz_linux_guest_agent_workspace_mismatch")
+    if capabilities_known is True and missing_required:
+        reasons.append("vz_linux_guest_agent_required_capability_missing")
+
+    if reasons:
+        compatibility: GuestAgentCompatibility = "mismatch"
+    elif capabilities_known is True and not missing_required:
+        compatibility = "compatible"
+    else:
+        compatibility = "unknown"
+
+    return {
+        "compatibility": compatibility,
+        "reasons": reasons,
+        "expected_workspace_root": VZ_LINUX_EXPECTED_GUEST_WORKSPACE_ROOT,
+        "required_capabilities": list(VZ_LINUX_REQUIRED_GUEST_CAPABILITIES),
+        "missing_required_capabilities": missing_required if capabilities_known is True else [],
+    }
+
+
+def vz_linux_guest_agent_mismatched(details: Mapping[str, Any] | None) -> bool:
+    """Return true only for explicit guest-agent contract mismatches."""
+
+    return classify_vz_linux_guest_agent(details).get("compatibility") == "mismatch"

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -160,6 +160,11 @@ def _sample_diagnostics_payload() -> dict:
                         "workspace_root": "/workspace",
                         "capabilities_known": True,
                         "capabilities": ["exec", "output_cap_v1"],
+                        "compatibility": "compatible",
+                        "reasons": [],
+                        "expected_workspace_root": "/workspace",
+                        "required_capabilities": ["exec"],
+                        "missing_required_capabilities": [],
                     },
                     "resource_snapshot": {"cpu_time_sec": 1},
                 }
@@ -442,6 +447,8 @@ def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
     assert model.observability.live_vms == 1
     assert model.observability.vms[0].serial_log.path == "/tmp/vz-serial/vm-live.serial.log"
     assert model.observability.vms[0].guest.capabilities == ["exec", "output_cap_v1"]
+    assert model.observability.vms[0].guest.compatibility == "compatible"
+    assert model.observability.vms[0].guest.reasons == []
     assert model.observability.vms[0].resource_snapshot == {"cpu_time_sec": 1}
     assert model.recovery_summary is not None
     assert model.recovery_summary.status == "healthy"
@@ -1033,6 +1040,11 @@ def test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources(
         "workspace_root": "/workspace",
         "capabilities_known": True,
         "capabilities": ["exec", "output_cap_v1"],
+        "compatibility": "compatible",
+        "reasons": [],
+        "expected_workspace_root": "/workspace",
+        "required_capabilities": ["exec"],
+        "missing_required_capabilities": [],
     }
     assert vm["resource_snapshot"] == {
         "cpu_time_sec": 7,
@@ -1041,6 +1053,50 @@ def test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources(
         "peak_rss_mb": 128,
         "disk_read_bytes": 2048,
     }
+
+
+def test_probe_vz_linux_observability_classifies_guest_agent_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeHelper:
+        def list_vms(self) -> HelperVMListReply:
+            return HelperVMListReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                vms=[
+                    HelperVMStatusReply(
+                        protocol_version="1",
+                        helper_version="0.1.0",
+                        vm_id="vm-mismatch",
+                        state="running",
+                        healthy=True,
+                        details={
+                            "guest_version": "0.9.0",
+                            "guest_workspace_root": "/var/empty",
+                            "guest_capabilities_known": "true",
+                            "guest_capabilities": "output_cap_v1",
+                        },
+                    )
+                ],
+            )
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+
+    data = diagnostics_module.probe_vz_linux_observability()
+
+    guest = data["vms"][0]["guest"]
+    assert guest["version"] == "0.9.0"
+    assert guest["workspace_root"] == "/var/empty"
+    assert guest["capabilities_known"] is True
+    assert guest["capabilities"] == ["output_cap_v1"]
+    assert guest["compatibility"] == "mismatch"
+    assert guest["expected_workspace_root"] == "/workspace"
+    assert guest["required_capabilities"] == ["exec"]
+    assert guest["missing_required_capabilities"] == ["exec"]
+    assert guest["reasons"] == [
+        "vz_linux_guest_agent_workspace_mismatch",
+        "vz_linux_guest_agent_required_capability_missing",
+    ]
 
 
 def test_probe_vz_linux_observability_handles_helper_unavailable(

--- a/tldw_Server_API/tests/sandbox/test_vz_guest_agent.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_guest_agent.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.vz_guest_agent import (
+    classify_vz_linux_guest_agent,
+    vz_linux_guest_agent_mismatched,
+)
+
+
+def test_vz_guest_agent_classifier_returns_full_compatible_payload() -> None:
+    result = classify_vz_linux_guest_agent(
+        {
+            "guest_version": "1.0.0",
+            "guest_workspace_root": "/workspace",
+            "guest_capabilities_known": "true",
+            "guest_capabilities": "exec,output_cap_v1",
+        }
+    )
+
+    assert result == {
+        "version": "1.0.0",
+        "workspace_root": "/workspace",
+        "capabilities_known": True,
+        "capabilities": ["exec", "output_cap_v1"],
+        "compatibility": "compatible",
+        "reasons": [],
+        "expected_workspace_root": "/workspace",
+        "required_capabilities": ["exec"],
+        "missing_required_capabilities": [],
+    }
+
+
+def test_vz_guest_agent_classifier_treats_malformed_workspace_root_as_mismatch() -> None:
+    details = {
+        "guest_workspace_root": ["/workspace"],
+        "guest_capabilities_known": "true",
+        "guest_capabilities": "exec",
+    }
+
+    result = classify_vz_linux_guest_agent(details)
+
+    assert result["workspace_root"] == "['/workspace']"
+    assert result["compatibility"] == "mismatch"
+    assert result["reasons"] == ["vz_linux_guest_agent_workspace_mismatch"]
+    assert vz_linux_guest_agent_mismatched(details) is True

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -936,7 +936,10 @@ def test_vz_linux_session_reuse_metadata_mismatch_recreates_vm(
     assert stored and stored[0]["vm_id"] == f"vm-new-{case_name}"
 
 
-def test_vz_linux_session_reuse_guest_agent_mismatch_recreates_vm(monkeypatch, tmp_path) -> None:
+def test_vz_linux_session_reuse_guest_agent_mismatch_recreates_vm(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     calls: list[str] = []
     deleted: list[str] = []

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -936,6 +936,104 @@ def test_vz_linux_session_reuse_metadata_mismatch_recreates_vm(
     assert stored and stored[0]["vm_id"] == f"vm-new-{case_name}"
 
 
+def test_vz_linux_session_reuse_guest_agent_mismatch_recreates_vm(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
+    deleted: list[str] = []
+    stored: list[dict[str, object]] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> dict[str, object]:
+            assert session_id == "sess-guest-agent-mismatch"
+            return {
+                "runtime": "vz_linux",
+                "vm_id": "vm-stale-guest-agent",
+                "template_id": "vz_linux:existing",
+                "workspace_mount": str(tmp_path),
+                "agent_ready": True,
+                "helper_instance_id": "helper-a",
+                "helper_started_at": "2026-05-09T00:00:00Z",
+            }
+
+        def delete_vz_session_control(self, session_id: str) -> bool:
+            deleted.append(session_id)
+            return True
+
+        def put_vz_session_control(self, **kwargs) -> None:
+            stored.append(dict(kwargs))
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
+            calls.append("get_vm_status")
+            return HelperVMStatusReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                vm_id=vm_id,
+                state="running",
+                healthy=True,
+                metadata=HelperVMMetadata(
+                    owner="tldw",
+                    runtime="vz_linux",
+                    session_id="sess-guest-agent-mismatch",
+                    session_mode=True,
+                ),
+                details={
+                    "helper_instance_id": "helper-a",
+                    "helper_started_at": "2026-05-09T00:00:00Z",
+                    "guest_version": "0.9.0",
+                    "guest_workspace_root": "/var/empty",
+                    "guest_capabilities_known": "true",
+                    "guest_capabilities": "output_cap_v1",
+                },
+            )
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["session_id"] == "sess-guest-agent-mismatch"
+            assert request["session_mode"] is True
+            return HelperVMReply(
+                vm_id="vm-new-guest-agent",
+                state="created",
+                details={
+                    "helper_instance_id": "helper-a",
+                    "helper_started_at": "2026-05-09T00:00:00Z",
+                },
+            )
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append("exec_guest")
+            assert vm_id == "vm-new-guest-agent"
+            return HelperExecReply(exit_code=0, stdout=b"recreated\n")
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(
+        run_id="vz-run-guest-agent-mismatch",
+        spec=RunSpec(
+            session_id="sess-guest-agent-mismatch",
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=str(tmp_path),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0
+    assert calls == ["get_vm_status", "validate_template", "create_vm", "exec_guest"]
+    assert deleted == ["sess-guest-agent-mismatch"]
+    assert stored and stored[0]["vm_id"] == "vm-new-guest-agent"
+
+
 def test_vz_linux_session_reuse_helper_unavailable_fails_closed(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     calls: list[str] = []


### PR DESCRIPTION
## Summary
- Adds a shared VZ Linux guest-agent compatibility classifier for diagnostics and reuse gating.
- Surfaces guest compatibility, mismatch reasons, expected workspace root, and missing required capabilities in macOS sandbox diagnostics.
- Prevents same-session VZ Linux reuse when live helper details show an explicit guest-agent contract mismatch, while keeping older metadata-light guests as compatibility `unknown`.

## Change summary
Human-authored summary required before merge.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q`
- [x] `git diff --check HEAD`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/Sandbox/vz_guest_agent.py tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_vz_guest_agent_mismatch_pr.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared VZ Linux guest-agent compatibility classifier and integrates it into macOS diagnostics and the VZ Linux runner. Centralizes guest metadata parsing, flags clear mismatch reasons, and prevents unsafe same-session VM reuse while older guests stay "unknown".

- **New Features**
  - Added `vz_guest_agent` classifier returning version, workspace_root, capabilities(_known), and compatibility details (reasons, expected root, required/missing caps).
  - macOS VZ diagnostics now include these fields and reuse the classifier.
  - VZ Linux runner blocks same-session reuse on explicit mismatch via `vz_linux_guest_agent_mismatched` and recreates the VM.
  - Extended `SandboxAdminMacOSGuestObservability` schema; updated sandbox docs and added focused tests (including classifier tests). Satisfies TASK-435.

<sup>Written for commit 5e299f5aaf5ab3b1e9ea2f5b0ccf90af1b738c5c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1861?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

