### PR TITLE
Add Character Chat DB health recovery gate

### DIFF
--- a/Docs/Operations/ChaChaNotes_DB_Recovery.md
+++ b/Docs/Operations/ChaChaNotes_DB_Recovery.md
@@ -16,7 +16,7 @@ When corruption is detected, `/api/v1/health` includes a sanitized failure paylo
       "last_error": "sqlite_corruption",
       "last_failure": {
         "reason_code": "sqlite_corruption",
-        "affected_db": "user:42/ChaChaNotes.db",
+        "affected_db": "ChaChaNotes.db",
         "recovery": {
           "automatic_repair": false,
           "documentation": "Docs/Operations/ChaChaNotes_DB_Recovery.md"
@@ -27,7 +27,7 @@ When corruption is detected, `/api/v1/health` includes a sanitized failure paylo
 }
 ```
 
-`affected_db` intentionally avoids absolute host paths. Resolve it by checking the configured `USER_DB_BASE_DIR` and the user id in the health payload.
+`affected_db` intentionally avoids absolute host paths and user identifiers because the aggregate health endpoint may be reachable without user authentication. Use the server log entry for the matching corruption event, authenticated user context, or an operator-side scan under `USER_DB_BASE_DIR` to identify the exact user directory.
 
 ## Recovery Steps
 

--- a/Docs/Operations/ChaChaNotes_DB_Recovery.md
+++ b/Docs/Operations/ChaChaNotes_DB_Recovery.md
@@ -1,0 +1,66 @@
+# ChaChaNotes DB Recovery
+
+ChaChaNotes stores character cards, character chat conversations, notes, and related per-user data in each user's `ChaChaNotes.db` file. If the SQLite integrity preflight reports corruption, the API keeps starting and reports a degraded `chacha_notes` check from `/api/v1/health`.
+
+The server does not automatically repair or replace a corrupted ChaChaNotes database. Automatic mutation could destroy the only copy of a user's character chat history, so recovery is operator-driven.
+
+## Health Signal
+
+When corruption is detected, `/api/v1/health` includes a sanitized failure payload:
+
+```json
+{
+  "checks": {
+    "chacha_notes": {
+      "status": "degraded",
+      "last_error": "sqlite_corruption",
+      "last_failure": {
+        "reason_code": "sqlite_corruption",
+        "affected_db": "user:42/ChaChaNotes.db",
+        "recovery": {
+          "automatic_repair": false,
+          "documentation": "Docs/Operations/ChaChaNotes_DB_Recovery.md"
+        }
+      }
+    }
+  }
+}
+```
+
+`affected_db` intentionally avoids absolute host paths. Resolve it by checking the configured `USER_DB_BASE_DIR` and the user id in the health payload.
+
+## Recovery Steps
+
+1. Stop the API process or block new character chat traffic for the affected user.
+2. Locate the affected file under `USER_DB_BASE_DIR/<user_id>/ChaChaNotes.db`.
+3. Copy the corrupted DB and any sidecar files (`-wal`, `-shm`) to a safe backup location before making changes.
+4. Restore `ChaChaNotes.db` and its sidecar files from the newest known-good backup.
+5. If no backup exists and partial salvage is acceptable, attempt SQLite recovery into a new file:
+
+```bash
+sqlite3 /path/to/ChaChaNotes.db ".recover" | sqlite3 /path/to/ChaChaNotes.recovered.db
+sqlite3 /path/to/ChaChaNotes.recovered.db "PRAGMA integrity_check;"
+```
+
+6. Only replace the live `ChaChaNotes.db` with the recovered DB after validation succeeds and a backup copy of the original exists.
+7. If recovery is not possible, move the corrupted DB and sidecar files aside. The server will create a fresh empty ChaChaNotes DB on next access, but previous character chat data will not be present.
+8. Restart the API or retry character chat access for that user.
+9. Confirm `/api/v1/health` no longer reports a new `sqlite_corruption` failure for `chacha_notes`.
+10. If the restored or recovered DB fails validation or causes new errors, roll back by stopping the API and restoring the backup copy made in step 3.
+
+## Verification Commands
+
+Use SQLite's integrity check before putting a restored DB back into service:
+
+```bash
+sqlite3 /path/to/ChaChaNotes.db "PRAGMA quick_check;"
+sqlite3 /path/to/ChaChaNotes.db "PRAGMA integrity_check;"
+```
+
+Both commands should report `ok` for a healthy SQLite file.
+
+## Notes
+
+- Do not delete a corrupted DB until a backup copy has been made.
+- Keep `ChaChaNotes.db`, `ChaChaNotes.db-wal`, and `ChaChaNotes.db-shm` together when copying or restoring.
+- The degraded health status is a release blocker for first-class Character Chat because role-play sessions depend on this database for characters and conversation state.

--- a/Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+++ b/Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
@@ -321,14 +321,25 @@ Character Chat depends on the per-user chat/notes database. The earlier audit ve
 
 Requirements:
 
-- Add or link a startup health check that identifies the affected per-user chat DB and failure reason.
-- Prefer quarantine or degraded startup where safe, so one corrupt per-user chat DB does not prevent reaching setup, diagnostics, or recovery UI.
-- Provide a documented doctor/recovery path for backup, SQLite `.recover`, integrity validation, and restore.
+- Add or link a startup health check that identifies the affected per-user chat DB and failure reason. Backend gate: `/api/v1/health` exposes `checks.chacha_notes.last_failure` with a sanitized `affected_db`, `reason_code`, and recovery metadata when ChaChaNotes corruption is detected.
+- Prefer quarantine or degraded startup where safe, so one corrupt per-user chat DB does not prevent reaching setup, diagnostics, or recovery UI. Backend gate: startup warm-up fails open and records a degraded ChaChaNotes health snapshot instead of aborting app startup.
+- Provide a documented doctor/recovery path for backup, SQLite `.recover`, integrity validation, and restore. Recovery guide: `Docs/Operations/ChaChaNotes_DB_Recovery.md`.
 - Surface user-facing recovery copy from setup or diagnostics without implying data was silently changed.
 - Treat this as a release dependency for Character Chat GA, even if implemented in a separate backend-focused task.
 
+Backend acceptance evidence:
+
+- Corrupt existing per-user `ChaChaNotes.db` returns a sanitized 503 to character DB callers and records `last_failure.reason_code = sqlite_corruption`.
+- `/api/v1/health` degrades to 206 with `checks.chacha_notes.last_failure.recovery.automatic_repair = false`.
+- Health payloads do not expose absolute temp or host filesystem paths.
+- Startup warm-up against a corrupt DB does not raise out of the warm-up path.
+
 Likely files:
 
+- `tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/health.py`
+- `tldw_Server_API/app/services/startup_chacha_warmup.py`
+- `Docs/Operations/ChaChaNotes_DB_Recovery.md`
 - `tldw_Server_API/app/core/DB_Management`
 - `tldw_Server_API/app/core/Character_Chat`
 - `tldw_Server_API/app/main.py`

--- a/Docs/RELEASE_NOTES.md
+++ b/Docs/RELEASE_NOTES.md
@@ -2,4 +2,15 @@
 
 This page is the release notes index placeholder for published versions.
 
+## Unreleased
+
+### Character Chat
+
+- Resolved the Character Chat GA database-health release dependency tracked by
+  `TASK-429` and PR #1862: corrupt per-user `ChaChaNotes` databases are reported
+  through sanitized health metadata, startup warm-up fails open, and operators
+  are directed to `Docs/Operations/ChaChaNotes_DB_Recovery.md` for recovery
+  steps. This removes the release-blocking R11 backend recovery gap for
+  first-class character chat.
+
 For release process details, see `Docs/Release_Checklist.md`.

--- a/Docs/superpowers/plans/2026-05-19-character-chat-db-health-release-gate-plan.md
+++ b/Docs/superpowers/plans/2026-05-19-character-chat-db-health-release-gate-plan.md
@@ -1,0 +1,112 @@
+# Character Chat DB Health Release Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make corrupt per-user ChaChaNotes databases diagnosable and recoverable enough to unblock first-class Character Chat GA.
+
+**Architecture:** Extend the existing ChaChaNotes dependency health snapshot instead of adding a parallel health service. Keep raw filesystem paths out of generic health responses, but expose a sanitized affected database identifier, reason code, and user-action recovery guidance. Document manual recovery as an explicit backup/recover/validate/restore operation; do not mutate user data automatically.
+
+**Tech Stack:** FastAPI, pytest, SQLite, existing ChaChaNotes dependency module, existing `/api/v1/health` aggregate health endpoint, Backlog.md.
+
+---
+
+### Task 1: Sanitized ChaChaNotes Failure Details
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py`
+- Test: `tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py`
+- Test: `tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py`
+
+- [x] **Step 1: Write failing dependency diagnostics tests**
+
+Add tests proving a corrupt existing user DB records a sanitized `last_failure` with:
+- `reason_code: sqlite_corruption`
+- affected database identifier such as `user:987/ChaChaNotes.db`
+- no raw `/private` or temp path leakage
+- recovery documentation/action metadata
+
+- [x] **Step 2: Verify the new tests fail**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py::test_create_and_prepare_db_records_corrupt_db_recovery_details \
+  tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py::test_api_health_exposes_chacha_recovery_details_without_path_leak \
+  -q
+```
+
+Expected: fail because `last_failure` and recovery metadata do not exist.
+
+- [x] **Step 3: Implement the minimal health metadata**
+
+Update `ChaChaDatabaseCorruptionError` and `_record_init` so corruption preflight failures carry sanitized affected-DB and recovery fields into `get_chacha_health_snapshot()`.
+
+- [x] **Step 4: Verify focused tests pass**
+
+Run the same focused pytest command. Expected: pass.
+
+### Task 2: Startup Fail-Open Contract
+
+**Files:**
+- Test: `tldw_Server_API/tests/Services/test_startup_chacha_warmup.py`
+- Modify only if needed: `tldw_Server_API/app/services/startup_chacha_warmup.py`
+- Modify only if needed: `tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py`
+
+- [x] **Step 1: Write startup warm-up regression test**
+
+Add a test that schedules/runs warm-up against a corrupt user DB and verifies:
+- no exception escapes the startup warm-up path
+- health snapshot records the corrupt `ChaChaNotes.db`
+- no raw path is exposed in the snapshot
+
+- [x] **Step 2: Verify failure, then implement only if needed**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Services/test_startup_chacha_warmup.py::test_warm_chacha_db_for_user_records_corrupt_db_and_fails_open \
+  -q
+```
+
+Expected: fail until Task 1 metadata exists. If Task 1 already makes this pass, do not change startup code.
+
+### Task 3: Recovery Documentation And Task Closeout
+
+**Files:**
+- Create: `Docs/Operations/ChaChaNotes_DB_Recovery.md`
+- Modify: `Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md`
+- Modify: `backlog/tasks/task-429 - Add-Character-Chat-DB-health-and-recovery-release-gate.md`
+
+- [x] **Step 1: Document recovery flow**
+
+Create a recovery guide covering backup, `PRAGMA quick_check`, `PRAGMA integrity_check`, `sqlite3 .recover`, validation of recovered DB, intentional restore, and rollback.
+
+- [x] **Step 2: Link the release gate**
+
+Update the Character Chat PRD R11 section and `TASK-429` with the recovery guide, verification commands, and remaining risk.
+
+- [x] **Step 3: Final verification**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py \
+  tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py \
+  tldw_Server_API/tests/Services/test_startup_chacha_warmup.py \
+  -q
+```
+
+Run touched-scope Bandit:
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py \
+  tldw_Server_API/app/services/startup_chacha_warmup.py \
+  -f json -o /tmp/bandit_character_chat_db_health.json
+```
+
+Run:
+```bash
+git diff --check
+```
+
+Expected: tests pass, Bandit has no new findings in touched production code, and diff check is clean.

--- a/backlog/tasks/task-429 - Add-Character-Chat-DB-health-and-recovery-release-gate.md
+++ b/backlog/tasks/task-429 - Add-Character-Chat-DB-health-and-recovery-release-gate.md
@@ -4,7 +4,7 @@ title: Add Character Chat DB health and recovery release gate
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-19 03:20'
+updated_date: '2026-05-19 04:00'
 labels:
   - chat
   - characters
@@ -15,9 +15,11 @@ dependencies: []
 references:
   - Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
   - TASK-428
+  - Docs/RELEASE_NOTES.md#unreleased
 documentation:
   - Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
   - Docs/Operations/ChaChaNotes_DB_Recovery.md
+  - Docs/RELEASE_NOTES.md
 priority: high
 ---
 
@@ -47,8 +49,9 @@ Docs/superpowers/plans/2026-05-19-character-chat-db-health-release-gate-plan.md
 <!-- SECTION:NOTES:BEGIN -->
 - Extended ChaChaNotes init health with sanitized sqlite_corruption last_failure metadata and recovery docs pointer.
 - Startup warm-up remains fail-open; corrupt DB warm-up records degraded health and does not escape an exception.
+- Release notes traceability: Docs/RELEASE_NOTES.md#unreleased now links TASK-429 and PR #1862 as resolved for the Character Chat GA R11 backend recovery gate.
 - Verification: python -m pytest tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py tldw_Server_API/tests/Services/test_startup_chacha_warmup.py -q (19 passed, after activating the project virtualenv).
-- Security: Bandit touched production scope reported zero findings in /tmp/bandit_character_chat_db_health.json.
+- Security: source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py tldw_Server_API/app/services/startup_chacha_warmup.py -f json -o /tmp/bandit_character_chat_db_health.json (reported zero findings).
 - Diff hygiene: git diff --check passed.
 - Known blockers/skips: no known blockers for this backend release gate; no browser/UI test was run because this slice only changes backend health/recovery and documentation.
 <!-- SECTION:NOTES:END -->
@@ -56,7 +59,7 @@ Docs/superpowers/plans/2026-05-19-character-chat-db-health-release-gate-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Character Chat DB health release gate by extending the existing ChaChaNotes health snapshot with sanitized corruption details, recovery metadata, and no automatic data repair. Added tests covering corrupt DB diagnostics, aggregate /api/v1/health exposure, startup warm-up fail-open behavior, and path sanitization. Added the ChaChaNotes recovery guide and linked the R11 PRD backend gate. Verification: focused pytest passed (19 tests), Bandit passed with zero findings on touched production code, and git diff --check passed.
+Implemented the Character Chat DB health release gate by extending the existing ChaChaNotes health snapshot with sanitized corruption details, recovery metadata, and no automatic data repair. Added tests covering corrupt DB diagnostics, aggregate /api/v1/health exposure, startup warm-up fail-open behavior, and path sanitization. Added the ChaChaNotes recovery guide, linked the R11 PRD backend gate, and added a draft release-note entry in Docs/RELEASE_NOTES.md#unreleased that marks TASK-429/PR #1862 as resolved for Character Chat GA. Verification: focused pytest passed (19 tests), Bandit passed with zero findings on touched production code using the command recorded in Implementation Notes, and git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-429 - Add-Character-Chat-DB-health-and-recovery-release-gate.md
+++ b/backlog/tasks/task-429 - Add-Character-Chat-DB-health-and-recovery-release-gate.md
@@ -1,19 +1,24 @@
 ---
 id: TASK-429
 title: Add Character Chat DB health and recovery release gate
-status: To Do
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-19 03:20'
 labels:
-- chat
-- characters
-- database
-- recovery
-- release-gate
-priority: High
+  - chat
+  - characters
+  - database
+  - recovery
+  - release-gate
+dependencies: []
 references:
-- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
-- TASK-428
+  - Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+  - TASK-428
 documentation:
-- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+  - Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+  - Docs/Operations/ChaChaNotes_DB_Recovery.md
+priority: high
 ---
 
 ## Description
@@ -24,31 +29,42 @@ Backend-focused release dependency for first-class Character Chat GA: detect cor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Startup or diagnostics identifies the affected per-user chat DB and failure reason when ChaChaNotes/chat DB integrity fails.
-- [ ] #2 A documented doctor/recovery path covers backup, SQLite integrity_check or recover, validation, and restore.
-- [ ] #3 Where safe, one corrupt per-user chat DB does not prevent setup, diagnostics, or recovery UI from loading.
-- [ ] #4 User-facing recovery copy avoids implying data was silently changed.
-- [ ] #5 Character Chat GA release notes link this task as resolved or explicitly release-blocking.
+- [x] #1 Startup or diagnostics identifies the affected per-user chat DB and failure reason when ChaChaNotes/chat DB integrity fails.
+- [x] #2 A documented doctor/recovery path covers backup, SQLite integrity_check or recover, validation, and restore.
+- [x] #3 Where safe, one corrupt per-user chat DB does not prevent setup, diagnostics, or recovery UI from loading.
+- [x] #4 User-facing recovery copy avoids implying data was silently changed.
+- [x] #5 Character Chat GA release notes link this task as resolved or explicitly release-blocking.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-19-character-chat-db-health-release-gate-plan.md
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+- Extended ChaChaNotes init health with sanitized sqlite_corruption last_failure metadata and recovery docs pointer.
+- Startup warm-up remains fail-open; corrupt DB warm-up records degraded health and does not escape an exception.
+- Verification: python -m pytest tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py tldw_Server_API/tests/Services/test_startup_chacha_warmup.py -q (19 passed, after activating the project virtualenv).
+- Security: Bandit touched production scope reported zero findings in /tmp/bandit_character_chat_db_health.json.
+- Diff hygiene: git diff --check passed.
+- Known blockers/skips: no known blockers for this backend release gate; no browser/UI test was run because this slice only changes backend health/recovery and documentation.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented the Character Chat DB health release gate by extending the existing ChaChaNotes health snapshot with sanitized corruption details, recovery metadata, and no automatic data repair. Added tests covering corrupt DB diagnostics, aggregate /api/v1/health exposure, startup warm-up fail-open behavior, and path sanitization. Added the ChaChaNotes recovery guide and linked the R11 PRD backend gate. Verification: focused pytest passed (19 tests), Bandit passed with zero findings on touched production code, and git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-435 - Address-PR-1862-Character-Chat-DB-health-review-comments.md
+++ b/backlog/tasks/task-435 - Address-PR-1862-Character-Chat-DB-health-review-comments.md
@@ -1,0 +1,68 @@
+---
+id: TASK-435
+title: Address PR 1862 Character Chat DB health review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-19 03:40'
+labels:
+  - chat
+  - characters
+  - database
+  - recovery
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1862'
+  - TASK-429
+documentation:
+  - Docs/Operations/ChaChaNotes_DB_Recovery.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up task for PR #1862 review feedback: add helper docstrings, avoid numeric user-id exposure in public ChaChaNotes health details by default, make current health recover to healthy after successful init, and include warm-up/cache snapshot details with thread-safe cache sizing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Qodo docstring finding is addressed for new ChaCha health helpers.
+- [x] #2 Public /api/v1/health no longer exposes numeric user ids in chacha_notes.last_failure by default.
+- [x] #3 ChaChaNotes health returns to healthy after a successful init following a prior corruption failure while retaining lifetime failure counters.
+- [x] #4 Gemini health snapshot feedback is addressed: warm_startups is exposed and cached instance count is read under the cache lock.
+- [x] #5 Focused pytest, Bandit touched-scope, and diff hygiene verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for default user-id redaction, optional current-state recovery, warm_startups exposure, and stale last_failure clearing. 2. Update ChaCha_Notes_DB_Deps health helpers with docstrings, redaction-by-default, current health fields, and locked cached count. 3. Update docs/task notes if semantics change. 4. Run focused pytest, Bandit, git diff --check, commit, push, and respond to PR threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented PR #1862 review fixes in ChaChaNotes health handling. Added helper docstrings, default public redaction for affected_db, current-state health fields (last_init_success and consecutive_failures), stale last_failure clearing on successful init, locked cached-instance counting, and warm_startups exposure in the snapshot. Updated tests and ChaChaNotes recovery docs to reflect redacted public health payloads.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Focused verification completed on 2026-05-18:
+- pytest: tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py tldw_Server_API/tests/Services/test_startup_chacha_warmup.py tldw_Server_API/tests/Chat/test_chacha_db_deps_error_mapping.py -q => 40 passed, 5 warnings.
+- Bandit: tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py and tldw_Server_API/app/services/startup_chacha_warmup.py => 0 findings in /tmp/bandit_character_chat_db_health_pr1862_review.json.
+- git diff --check => clean.
+No known skips or blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-435 - Address-PR-1862-Character-Chat-DB-health-review-comments.md
+++ b/backlog/tasks/task-435 - Address-PR-1862-Character-Chat-DB-health-review-comments.md
@@ -4,7 +4,7 @@ title: Address PR 1862 Character Chat DB health review comments
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-19 03:40'
+updated_date: '2026-05-19 04:00'
 labels:
   - chat
   - characters
@@ -45,14 +45,18 @@ Follow-up task for PR #1862 review feedback: add helper docstrings, avoid numeri
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented PR #1862 review fixes in ChaChaNotes health handling. Added helper docstrings, default public redaction for affected_db, current-state health fields (last_init_success and consecutive_failures), stale last_failure clearing on successful init, locked cached-instance counting, and warm_startups exposure in the snapshot. Updated tests and ChaChaNotes recovery docs to reflect redacted public health payloads.
+
+Follow-up PR sweep after commit 9e3b43178 found additional CodeRabbit comments on TASK-429 traceability, helper docstring specificity, test isolation, and test assertion precision. Reopened this review-fix task to address those comments in the same PR.
+
+Second review-fix pass addressed CodeRabbit follow-up comments: added Docs/RELEASE_NOTES.md#unreleased and TASK-429 traceability, recorded reproducible Bandit command text, expanded helper docstrings, restored _CHACHA_HEALTH after the health sanitizer test, validated warm-up path user_id in test monkeypatches, and asserted reason_code/documentation metadata.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Focused verification completed on 2026-05-18:
+PR #1862 review comments addressed across two commits. Latest verification completed on 2026-05-18:
 - pytest: tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py tldw_Server_API/tests/Services/test_startup_chacha_warmup.py tldw_Server_API/tests/Chat/test_chacha_db_deps_error_mapping.py -q => 40 passed, 5 warnings.
-- Bandit: tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py and tldw_Server_API/app/services/startup_chacha_warmup.py => 0 findings in /tmp/bandit_character_chat_db_health_pr1862_review.json.
+- Bandit: source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py tldw_Server_API/app/services/startup_chacha_warmup.py -f json -o /tmp/bandit_character_chat_db_health_pr1862_review.json => 0 findings.
 - git diff --check => clean.
 No known skips or blockers.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py
@@ -56,8 +56,10 @@ _CHACHA_HEALTH: dict[str, Any] = {
     "init_failures": 0,
     "last_init_ms": None,
     "last_error": None,
+    "last_init_success": None,
     "last_warn_dump": None,
     "cached_instances": 0,
+    "consecutive_failures": 0,
     "default_char_ensures": 0,
     "default_char_failures": 0,
     "warm_startups": 0,
@@ -100,14 +102,24 @@ def _safe_chacha_health_error(error: Exception | None) -> str:
 
 
 def _sanitize_chacha_db_identifier(user_id: int | None, db_path: Path | None = None) -> str:
-    if isinstance(user_id, int) and user_id > 0:
-        return f"user:{user_id}/ChaChaNotes.db"
-    if db_path is not None:
-        return Path(db_path).name or "ChaChaNotes.db"
+    """Return a public-safe DB label for ChaChaNotes health payloads.
+
+    Aggregate health is unauthenticated, so the default label must not expose
+    numeric user IDs, absolute paths, or nonstandard filenames. The context
+    arguments are accepted only so callers can pass corruption context
+    consistently; they are intentionally not encoded in the returned value.
+    """
     return "ChaChaNotes.db"
 
 
 def _build_chacha_failure_details(error: Exception | None) -> dict[str, Any] | None:
+    """Build sanitized recovery metadata for current ChaChaNotes failures.
+
+    Returns None for non-corruption failures so generic runtime errors are not
+    copied into health responses. Corruption failures include a stable reason
+    code, a redacted database label, and recovery guidance without raw exception
+    text, filesystem paths, or user identifiers.
+    """
     if not _is_sqlite_corruption_error(error):
         return None
 
@@ -126,16 +138,30 @@ def _build_chacha_failure_details(error: Exception | None) -> dict[str, Any] | N
 
 
 def _copy_chacha_failure_details(failure: Any) -> dict[str, Any] | None:
+    """Copy stored failure metadata while preserving public redaction rules.
+
+    Tests and older in-process state can seed dictionaries directly, so this
+    helper normalizes affected_db through the same public-safe label path before
+    returning a snapshot copy to callers.
+    """
     if not isinstance(failure, dict):
         return None
 
     recovery = failure.get("recovery")
     recovery_details = dict(recovery) if isinstance(recovery, dict) else {}
+    affected_db = failure.get("affected_db")
+    safe_db = _sanitize_chacha_db_identifier(None, Path(str(affected_db))) if affected_db else "ChaChaNotes.db"
     return {
         "reason_code": str(failure.get("reason_code") or "unknown"),
-        "affected_db": str(failure.get("affected_db") or "ChaChaNotes.db"),
+        "affected_db": safe_db,
         "recovery": recovery_details,
     }
+
+
+def _get_chacha_cached_instance_count() -> int:
+    """Return the cached DB instance count under the cache lock."""
+    with _chacha_db_lock:
+        return len(_chacha_db_instances)
 
 
 def _set_chacha_shutting_down(value: bool) -> None:
@@ -174,14 +200,20 @@ def _get_chacha_executor() -> ThreadPoolExecutor:
 
 
 def _record_init(duration_ms: float, success: bool, error: Exception | None = None) -> None:
+    """Record one ChaChaNotes initialization attempt and current health state."""
+    cached_count = _get_chacha_cached_instance_count()
     with _CHACHA_HEALTH_LOCK:
         _CHACHA_HEALTH["init_attempts"] += 1
         _CHACHA_HEALTH["last_init_ms"] = duration_ms
-        _CHACHA_HEALTH["cached_instances"] = len(_chacha_db_instances)
+        _CHACHA_HEALTH["cached_instances"] = cached_count
+        _CHACHA_HEALTH["last_init_success"] = success
         if success:
             _CHACHA_HEALTH["last_error"] = None
+            _CHACHA_HEALTH["last_failure"] = None
+            _CHACHA_HEALTH["consecutive_failures"] = 0
         else:
             _CHACHA_HEALTH["init_failures"] += 1
+            _CHACHA_HEALTH["consecutive_failures"] = int(_CHACHA_HEALTH.get("consecutive_failures") or 0) + 1
             _CHACHA_HEALTH["last_error"] = _safe_chacha_health_error(error)
             _CHACHA_HEALTH["last_failure"] = _build_chacha_failure_details(error)
 
@@ -220,26 +252,40 @@ def _track_default_character_future(future: asyncio.Future) -> None:
 
 
 def get_chacha_health_snapshot() -> dict[str, Any]:
+    """Return current ChaChaNotes health plus lifetime counters.
+
+    `status` reflects the latest/current initialization state, not the lifetime
+    failure counter. `init_failures` remains a monotonic diagnostic counter while
+    `consecutive_failures` and `last_init_success` drive recovery back to healthy
+    after an operator fixes the database and a later init succeeds.
+    """
     with _CHACHA_HEALTH_LOCK:
         init_attempts = _CHACHA_HEALTH.get("init_attempts")
         init_failures = _CHACHA_HEALTH.get("init_failures")
         last_init_ms = _CHACHA_HEALTH.get("last_init_ms")
         last_error = _CHACHA_HEALTH.get("last_error")
+        last_init_success = _CHACHA_HEALTH.get("last_init_success")
+        consecutive_failures = int(_CHACHA_HEALTH.get("consecutive_failures") or 0)
         default_char_ensures = _CHACHA_HEALTH.get("default_char_ensures")
         default_char_failures = _CHACHA_HEALTH.get("default_char_failures")
+        warm_startups = _CHACHA_HEALTH.get("warm_startups")
         last_failure = _copy_chacha_failure_details(_CHACHA_HEALTH.get("last_failure"))
+    cached_instances = _get_chacha_cached_instance_count()
 
-    status = "degraded" if init_failures else "healthy"
+    status = "degraded" if consecutive_failures else "healthy"
     return {
         "status": status,
         "init_attempts": init_attempts,
         "init_failures": init_failures,
         "last_init_ms": last_init_ms,
         "last_error": last_error,
+        "last_init_success": last_init_success,
+        "consecutive_failures": consecutive_failures,
         "last_failure": last_failure,
-        "cached_instances": len(_chacha_db_instances),
+        "cached_instances": cached_instances,
         "default_char_ensures": default_char_ensures,
         "default_char_failures": default_char_failures,
+        "warm_startups": warm_startups,
     }
 
 
@@ -527,15 +573,18 @@ async def _get_or_init_db_instance(user_id: int, client_id: str) -> CharactersRA
     wait_for_existing_init = False
     with _chacha_db_lock:
         cached_instance = _chacha_db_instances.get(cache_key)
-        if cached_instance is not None:
-            _CHACHA_HEALTH["cached_instances"] = len(_chacha_db_instances)
-            return cached_instance
-        init_event = _chacha_db_init_events.get(cache_key)
-        if init_event is None:
-            init_event = threading.Event()
-            _chacha_db_init_events[cache_key] = init_event
-        else:
-            wait_for_existing_init = True
+        cached_count = len(_chacha_db_instances)
+        if cached_instance is None:
+            init_event = _chacha_db_init_events.get(cache_key)
+            if init_event is None:
+                init_event = threading.Event()
+                _chacha_db_init_events[cache_key] = init_event
+            else:
+                wait_for_existing_init = True
+    if cached_instance is not None:
+        with _CHACHA_HEALTH_LOCK:
+            _CHACHA_HEALTH["cached_instances"] = cached_count
+        return cached_instance
 
     if wait_for_existing_init:
         wait_timeout = max(_CHACHA_WATCHDOG_SECS * 3, 5)
@@ -613,7 +662,9 @@ async def _get_or_init_db_instance(user_id: int, client_id: str) -> CharactersRA
         with _chacha_db_lock:
             _chacha_db_instances[cache_key] = db_instance
             _chacha_db_init_errors.pop(cache_key, None)
-            _CHACHA_HEALTH["cached_instances"] = len(_chacha_db_instances)
+            cached_count = len(_chacha_db_instances)
+        with _CHACHA_HEALTH_LOCK:
+            _CHACHA_HEALTH["cached_instances"] = cached_count
         return db_instance
     finally:
         with _chacha_db_lock:
@@ -628,7 +679,8 @@ async def warm_chacha_db_for_user(user_id: int, client_id: str | None = None) ->
         return
     try:
         db_instance = await _get_or_init_db_instance(user_id, client_id or str(user_id))
-        _CHACHA_HEALTH["warm_startups"] += 1
+        with _CHACHA_HEALTH_LOCK:
+            _CHACHA_HEALTH["warm_startups"] += 1
         task = asyncio.create_task(_ensure_default_character_async(db_instance, user_id))
         _chacha_default_char_tasks.add(task)
         task.add_done_callback(_chacha_default_char_tasks.discard)

--- a/tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py
@@ -108,6 +108,17 @@ def _sanitize_chacha_db_identifier(user_id: int | None, db_path: Path | None = N
     numeric user IDs, absolute paths, or nonstandard filenames. The context
     arguments are accepted only so callers can pass corruption context
     consistently; they are intentionally not encoded in the returned value.
+
+    Args:
+        user_id: Optional owner id from a corruption exception. Ignored to avoid
+            leaking per-user identifiers in public health responses.
+        db_path: Optional filesystem path from a corruption exception. Ignored
+            to avoid leaking path or filename details.
+
+    Returns:
+        The constant public label ``"ChaChaNotes.db"``. For example, both
+        ``user_id=42`` and ``db_path=/private/user/42/ChaChaNotes.db`` return
+        ``"ChaChaNotes.db"``.
     """
     return "ChaChaNotes.db"
 
@@ -115,10 +126,19 @@ def _sanitize_chacha_db_identifier(user_id: int | None, db_path: Path | None = N
 def _build_chacha_failure_details(error: Exception | None) -> dict[str, Any] | None:
     """Build sanitized recovery metadata for current ChaChaNotes failures.
 
-    Returns None for non-corruption failures so generic runtime errors are not
-    copied into health responses. Corruption failures include a stable reason
-    code, a redacted database label, and recovery guidance without raw exception
-    text, filesystem paths, or user identifiers.
+    Args:
+        error: Exception raised while opening a ChaChaNotes database. Only
+            exceptions recognized by ``_is_sqlite_corruption_error`` are exposed.
+
+    Returns:
+        ``None`` for non-corruption failures so generic runtime errors are not
+        copied into health responses. For corruption failures, returns a dict
+        with ``reason_code`` from the exception or ``"sqlite_corruption"``,
+        ``affected_db`` from ``_sanitize_chacha_db_identifier``, and ``recovery``
+        containing ``automatic_repair=False``, ``documentation`` from
+        ``_CHACHA_RECOVERY_DOC``, and ``message`` from
+        ``_CHACHA_RECOVERY_MESSAGE``. The payload avoids raw exception text,
+        filesystem paths, and user identifiers.
     """
     if not _is_sqlite_corruption_error(error):
         return None
@@ -140,9 +160,16 @@ def _build_chacha_failure_details(error: Exception | None) -> dict[str, Any] | N
 def _copy_chacha_failure_details(failure: Any) -> dict[str, Any] | None:
     """Copy stored failure metadata while preserving public redaction rules.
 
-    Tests and older in-process state can seed dictionaries directly, so this
-    helper normalizes affected_db through the same public-safe label path before
-    returning a snapshot copy to callers.
+    Args:
+        failure: Candidate failure dict from shared health state.
+
+    Returns:
+        ``None`` when the input is not a dict. Otherwise returns a new dict with
+        a string ``reason_code``, a re-sanitized ``affected_db`` fallback of
+        ``"ChaChaNotes.db"``, and a shallow copy of the ``recovery`` dict. The
+        copy prevents callers from mutating shared health state and also
+        normalizes dictionaries seeded directly by tests or older in-process
+        state.
     """
     if not isinstance(failure, dict):
         return None

--- a/tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py
@@ -43,6 +43,8 @@ _CHACHA_EXECUTOR_MAX_WORKERS = max(1, int(os.getenv("CHACHA_EXECUTOR_MAX_WORKERS
 _CHACHA_WATCHDOG_SECS = float(os.getenv("CHACHA_INIT_WATCHDOG_SECS", "5"))
 _CHACHA_SHUTDOWN_INIT_ERROR_DETAIL = "ChaChaNotes shutdown in progress"
 _CHACHA_CORRUPTION_ERROR_DETAIL = "ChaChaNotes DB corruption detected; repair or restore required"
+_CHACHA_RECOVERY_DOC = "Docs/Operations/ChaChaNotes_DB_Recovery.md"
+_CHACHA_RECOVERY_MESSAGE = "Restore the affected ChaChaNotes DB from backup or move it aside before retrying."
 _SQLITE_CORRUPTION_SIGNATURES = (
     "database disk image is malformed",
     "malformed database schema",
@@ -59,6 +61,7 @@ _CHACHA_HEALTH: dict[str, Any] = {
     "default_char_ensures": 0,
     "default_char_failures": 0,
     "warm_startups": 0,
+    "last_failure": None,
 }
 _CHACHA_SHUTTING_DOWN = False
 _CHACHA_SHUTDOWN_LOCK = threading.Lock()
@@ -66,6 +69,19 @@ _CHACHA_SHUTDOWN_LOCK = threading.Lock()
 
 class ChaChaDatabaseCorruptionError(CharactersRAGDBError):
     """Raised when an existing ChaChaNotes SQLite DB fails integrity preflight."""
+
+    def __init__(
+        self,
+        detail: str = _CHACHA_CORRUPTION_ERROR_DETAIL,
+        *,
+        user_id: int | None = None,
+        db_path: Path | None = None,
+        reason_code: str = "sqlite_corruption",
+    ) -> None:
+        super().__init__(detail)
+        self.user_id = user_id
+        self.db_path = db_path
+        self.reason_code = reason_code
 
 
 def _is_sqlite_corruption_error(error: Exception | None) -> bool:
@@ -81,6 +97,45 @@ def _safe_chacha_health_error(error: Exception | None) -> str:
     if _is_sqlite_corruption_error(error):
         return "sqlite_corruption"
     return type(error).__name__ if error else "unknown error"
+
+
+def _sanitize_chacha_db_identifier(user_id: int | None, db_path: Path | None = None) -> str:
+    if isinstance(user_id, int) and user_id > 0:
+        return f"user:{user_id}/ChaChaNotes.db"
+    if db_path is not None:
+        return Path(db_path).name or "ChaChaNotes.db"
+    return "ChaChaNotes.db"
+
+
+def _build_chacha_failure_details(error: Exception | None) -> dict[str, Any] | None:
+    if not _is_sqlite_corruption_error(error):
+        return None
+
+    user_id = getattr(error, "user_id", None)
+    db_path = getattr(error, "db_path", None)
+    reason_code = getattr(error, "reason_code", "sqlite_corruption")
+    return {
+        "reason_code": str(reason_code or "sqlite_corruption"),
+        "affected_db": _sanitize_chacha_db_identifier(user_id, db_path),
+        "recovery": {
+            "automatic_repair": False,
+            "documentation": _CHACHA_RECOVERY_DOC,
+            "message": _CHACHA_RECOVERY_MESSAGE,
+        },
+    }
+
+
+def _copy_chacha_failure_details(failure: Any) -> dict[str, Any] | None:
+    if not isinstance(failure, dict):
+        return None
+
+    recovery = failure.get("recovery")
+    recovery_details = dict(recovery) if isinstance(recovery, dict) else {}
+    return {
+        "reason_code": str(failure.get("reason_code") or "unknown"),
+        "affected_db": str(failure.get("affected_db") or "ChaChaNotes.db"),
+        "recovery": recovery_details,
+    }
 
 
 def _set_chacha_shutting_down(value: bool) -> None:
@@ -128,6 +183,7 @@ def _record_init(duration_ms: float, success: bool, error: Exception | None = No
         else:
             _CHACHA_HEALTH["init_failures"] += 1
             _CHACHA_HEALTH["last_error"] = _safe_chacha_health_error(error)
+            _CHACHA_HEALTH["last_failure"] = _build_chacha_failure_details(error)
 
 
 def _record_default_character(success: bool) -> None:
@@ -164,18 +220,26 @@ def _track_default_character_future(future: asyncio.Future) -> None:
 
 
 def get_chacha_health_snapshot() -> dict[str, Any]:
-    status = "healthy"
-    if _CHACHA_HEALTH.get("init_failures"):
-        status = "degraded"
+    with _CHACHA_HEALTH_LOCK:
+        init_attempts = _CHACHA_HEALTH.get("init_attempts")
+        init_failures = _CHACHA_HEALTH.get("init_failures")
+        last_init_ms = _CHACHA_HEALTH.get("last_init_ms")
+        last_error = _CHACHA_HEALTH.get("last_error")
+        default_char_ensures = _CHACHA_HEALTH.get("default_char_ensures")
+        default_char_failures = _CHACHA_HEALTH.get("default_char_failures")
+        last_failure = _copy_chacha_failure_details(_CHACHA_HEALTH.get("last_failure"))
+
+    status = "degraded" if init_failures else "healthy"
     return {
         "status": status,
-        "init_attempts": _CHACHA_HEALTH.get("init_attempts"),
-        "init_failures": _CHACHA_HEALTH.get("init_failures"),
-        "last_init_ms": _CHACHA_HEALTH.get("last_init_ms"),
-        "last_error": _CHACHA_HEALTH.get("last_error"),
+        "init_attempts": init_attempts,
+        "init_failures": init_failures,
+        "last_init_ms": last_init_ms,
+        "last_error": last_error,
+        "last_failure": last_failure,
         "cached_instances": len(_chacha_db_instances),
-        "default_char_ensures": _CHACHA_HEALTH.get("default_char_ensures"),
-        "default_char_failures": _CHACHA_HEALTH.get("default_char_failures"),
+        "default_char_ensures": default_char_ensures,
+        "default_char_failures": default_char_failures,
     }
 
 
@@ -237,7 +301,7 @@ def _get_chacha_db_path_for_user(user_id: int) -> Path:
     return db_file
 
 
-def _verify_existing_chacha_db_integrity(db_path: Path) -> None:
+def _verify_existing_chacha_db_integrity(db_path: Path, *, user_id: int | None = None) -> None:
     """Run a read-only quick check before opening an existing SQLite DB for writes."""
     if not db_path.exists():
         return
@@ -250,13 +314,21 @@ def _verify_existing_chacha_db_integrity(db_path: Path) -> None:
         )
     except sqlite3.Error as exc:
         if _is_sqlite_corruption_error(exc):
-            raise ChaChaDatabaseCorruptionError(_CHACHA_CORRUPTION_ERROR_DETAIL) from exc
+            raise ChaChaDatabaseCorruptionError(
+                _CHACHA_CORRUPTION_ERROR_DETAIL,
+                user_id=user_id,
+                db_path=db_path,
+            ) from exc
         raise
 
     if check_values and all(value.lower() == "ok" for value in check_values):
         return
 
-    raise ChaChaDatabaseCorruptionError(_CHACHA_CORRUPTION_ERROR_DETAIL)
+    raise ChaChaDatabaseCorruptionError(
+        _CHACHA_CORRUPTION_ERROR_DETAIL,
+        user_id=user_id,
+        db_path=db_path,
+    )
 
 
 def _apply_sqlite_tuning(db_instance: CharactersRAGDB) -> None:
@@ -301,11 +373,12 @@ def _create_and_prepare_db(user_id: int, client_id: str) -> CharactersRAGDB:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     except OSError as _mk2:
         logger.debug("Secondary ensure for ChaChaNotes parent failed softly ({})", type(_mk2).__name__)
-    logger.info(f"Initializing CharactersRAGDB instance for user {user_id} at path: {db_path}")
+    affected_db = _sanitize_chacha_db_identifier(user_id, db_path)
+    logger.info("Initializing CharactersRAGDB instance for user {} ({})", user_id, affected_db)
     try:
-        _verify_existing_chacha_db_integrity(db_path)
+        _verify_existing_chacha_db_integrity(db_path, user_id=user_id)
     except ChaChaDatabaseCorruptionError:
-        logger.error("ChaChaNotes DB corruption preflight failed for user {} at path: {}", user_id, db_path)
+        logger.error("ChaChaNotes DB corruption preflight failed for user {} ({})", user_id, affected_db)
         raise
     db_instance = CharactersRAGDB(db_path=str(db_path), client_id=str(client_id))
     _apply_sqlite_tuning(db_instance)

--- a/tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py
+++ b/tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py
@@ -24,8 +24,10 @@ def clear_chacha_dependency_state() -> Iterator[None]:
                 "init_failures": 0,
                 "last_init_ms": None,
                 "last_error": None,
+                "last_init_success": None,
                 "last_warn_dump": None,
                 "cached_instances": 0,
+                "consecutive_failures": 0,
                 "default_char_ensures": 0,
                 "default_char_failures": 0,
                 "warm_startups": 0,
@@ -103,11 +105,40 @@ async def test_create_and_prepare_db_records_corrupt_db_recovery_details(monkeyp
     assert snapshot["status"] == "degraded"
     assert snapshot["last_error"] == "sqlite_corruption"
     assert failure["reason_code"] == "sqlite_corruption"
-    assert failure["affected_db"] == "user:987/ChaChaNotes.db"
+    assert failure["affected_db"] == "ChaChaNotes.db"
     assert failure["recovery"]["automatic_repair"] is False
     assert failure["recovery"]["documentation"] == "Docs/Operations/ChaChaNotes_DB_Recovery.md"
+    assert "user:987" not in str(snapshot)
+    assert '"987"' not in str(snapshot)
     assert str(tmp_path) not in str(snapshot)
     assert "not a sqlite database" not in str(snapshot)
+
+
+def test_chacha_health_recovers_current_status_after_success(tmp_path):
+    corrupt_db = tmp_path / "987" / "ChaChaNotes.db"
+    corruption_error = chacha_deps.ChaChaDatabaseCorruptionError(
+        user_id=987,
+        db_path=corrupt_db,
+    )
+
+    chacha_deps._record_init(1.0, False, corruption_error)
+    failed_snapshot = chacha_deps.get_chacha_health_snapshot()
+
+    assert failed_snapshot["status"] == "degraded"
+    assert failed_snapshot["init_failures"] == 1
+    assert failed_snapshot["consecutive_failures"] == 1
+    assert failed_snapshot["last_init_success"] is False
+    assert failed_snapshot["last_failure"]["reason_code"] == "sqlite_corruption"
+
+    chacha_deps._record_init(2.0, True)
+    recovered_snapshot = chacha_deps.get_chacha_health_snapshot()
+
+    assert recovered_snapshot["status"] == "healthy"
+    assert recovered_snapshot["init_failures"] == 1
+    assert recovered_snapshot["consecutive_failures"] == 0
+    assert recovered_snapshot["last_init_success"] is True
+    assert recovered_snapshot["last_error"] is None
+    assert recovered_snapshot["last_failure"] is None
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py
+++ b/tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py
@@ -17,6 +17,21 @@ def clear_chacha_dependency_state() -> Iterator[None]:
         chacha_deps._chacha_db_instances.clear()
         chacha_deps._chacha_db_init_events.clear()
         chacha_deps._chacha_db_init_errors.clear()
+    with chacha_deps._CHACHA_HEALTH_LOCK:
+        chacha_deps._CHACHA_HEALTH.update(
+            {
+                "init_attempts": 0,
+                "init_failures": 0,
+                "last_init_ms": None,
+                "last_error": None,
+                "last_warn_dump": None,
+                "cached_instances": 0,
+                "default_char_ensures": 0,
+                "default_char_failures": 0,
+                "warm_startups": 0,
+                "last_failure": None,
+            }
+        )
     yield
     with chacha_deps._chacha_db_lock:
         chacha_deps._chacha_db_instances.clear()
@@ -58,6 +73,41 @@ async def test_chacha_init_classifies_sqlite_corruption_without_path_leak(monkey
     assert exc_info.value.detail == chacha_deps._CHACHA_CORRUPTION_ERROR_DETAIL
     assert "/private/db/path" not in exc_info.value.detail
     assert chacha_deps.get_chacha_health_snapshot()["last_error"] == "sqlite_corruption"
+
+
+@pytest.mark.asyncio
+async def test_create_and_prepare_db_records_corrupt_db_recovery_details(monkeypatch, tmp_path):
+    user_id = 987
+    db_path = tmp_path / "user-987" / "ChaChaNotes.db"
+    db_path.parent.mkdir(parents=True)
+    db_path.write_bytes(b"not a sqlite database")
+
+    monkeypatch.setattr(
+        chacha_deps.DatabasePaths,
+        "get_user_base_directory",
+        lambda _user_id: db_path.parent,
+    )
+    monkeypatch.setattr(
+        chacha_deps.DatabasePaths,
+        "get_chacha_db_path",
+        lambda _user_id: db_path,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await chacha_deps._get_or_init_db_instance(user_id, "client-987")
+
+    snapshot = chacha_deps.get_chacha_health_snapshot()
+    failure = snapshot["last_failure"]
+
+    assert exc_info.value.status_code == 503
+    assert snapshot["status"] == "degraded"
+    assert snapshot["last_error"] == "sqlite_corruption"
+    assert failure["reason_code"] == "sqlite_corruption"
+    assert failure["affected_db"] == "user:987/ChaChaNotes.db"
+    assert failure["recovery"]["automatic_repair"] is False
+    assert failure["recovery"]["documentation"] == "Docs/Operations/ChaChaNotes_DB_Recovery.md"
+    assert str(tmp_path) not in str(snapshot)
+    assert "not a sqlite database" not in str(snapshot)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Chat/test_chacha_db_deps_error_mapping.py
+++ b/tldw_Server_API/tests/Chat/test_chacha_db_deps_error_mapping.py
@@ -447,11 +447,14 @@ def test_chacha_health_last_error_uses_safe_error_type():
                 "init_failures": 0,
                 "last_init_ms": None,
                 "last_error": None,
+                "last_init_success": None,
                 "last_warn_dump": None,
                 "cached_instances": 0,
+                "consecutive_failures": 0,
                 "default_char_ensures": 0,
                 "default_char_failures": 0,
                 "warm_startups": 0,
+                "last_failure": None,
             }
         )
 

--- a/tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py
+++ b/tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py
@@ -150,10 +150,12 @@ async def test_api_health_exposes_chacha_recovery_details_without_path_leak(monk
                 "init_failures": 1,
                 "last_init_ms": 2.5,
                 "last_error": "sqlite_corruption",
+                "last_init_success": False,
                 "cached_instances": 0,
+                "consecutive_failures": 1,
                 "default_char_ensures": 0,
                 "default_char_failures": 0,
-                "warm_startups": 0,
+                "warm_startups": 2,
                 "last_failure": {
                     "reason_code": "sqlite_corruption",
                     "affected_db": "user:42/ChaChaNotes.db",
@@ -171,11 +173,15 @@ async def test_api_health_exposes_chacha_recovery_details_without_path_leak(monk
     assert response.status_code == 206
     assert body["status"] == "degraded"
     assert body["checks"]["chacha_notes"]["status"] == "degraded"
-    assert body["checks"]["chacha_notes"]["last_failure"]["affected_db"] == "user:42/ChaChaNotes.db"
+    assert body["checks"]["chacha_notes"]["last_init_success"] is False
+    assert body["checks"]["chacha_notes"]["consecutive_failures"] == 1
+    assert body["checks"]["chacha_notes"]["warm_startups"] == 2
+    assert body["checks"]["chacha_notes"]["last_failure"]["affected_db"] == "ChaChaNotes.db"
     assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["automatic_repair"] is False
     assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["documentation"] == (
         "Docs/Operations/ChaChaNotes_DB_Recovery.md"
     )
+    assert "user:42" not in str(body)
     assert str(tmp_path) not in str(body)
     assert "/private/" not in str(body)
 

--- a/tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py
+++ b/tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py
@@ -128,6 +128,59 @@ async def test_api_health_sanitizes_chacha_notes_probe_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_api_health_exposes_chacha_recovery_details_without_path_leak(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.API_Deps import ChaCha_Notes_DB_Deps as chacha_deps
+    from tldw_Server_API.app.core.AuthNZ import database as auth_database
+    from tldw_Server_API.app.core.Metrics import metrics_manager
+
+    class _HealthyPool:
+        async def health_check(self):
+            return {"status": "healthy"}
+
+    async def _healthy_pool():
+        return _HealthyPool()
+
+    monkeypatch.setattr(auth_database, "get_db_pool", _healthy_pool)
+    monkeypatch.setattr(metrics_manager, "get_metrics_registry", lambda: object())
+
+    with chacha_deps._CHACHA_HEALTH_LOCK:
+        chacha_deps._CHACHA_HEALTH.update(
+            {
+                "init_attempts": 1,
+                "init_failures": 1,
+                "last_init_ms": 2.5,
+                "last_error": "sqlite_corruption",
+                "cached_instances": 0,
+                "default_char_ensures": 0,
+                "default_char_failures": 0,
+                "warm_startups": 0,
+                "last_failure": {
+                    "reason_code": "sqlite_corruption",
+                    "affected_db": "user:42/ChaChaNotes.db",
+                    "recovery": {
+                        "automatic_repair": False,
+                        "documentation": "Docs/Operations/ChaChaNotes_DB_Recovery.md",
+                    },
+                },
+            }
+        )
+
+    response = await health_mod.api_health()
+    body = json.loads(response.body.decode("utf-8"))
+
+    assert response.status_code == 206
+    assert body["status"] == "degraded"
+    assert body["checks"]["chacha_notes"]["status"] == "degraded"
+    assert body["checks"]["chacha_notes"]["last_failure"]["affected_db"] == "user:42/ChaChaNotes.db"
+    assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["automatic_repair"] is False
+    assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["documentation"] == (
+        "Docs/Operations/ChaChaNotes_DB_Recovery.md"
+    )
+    assert str(tmp_path) not in str(body)
+    assert "/private/" not in str(body)
+
+
+@pytest.mark.asyncio
 async def test_api_health_sanitizes_rg_policy_snapshot_failure(monkeypatch, tmp_path):
     from tldw_Server_API.app import main as app_main
     from tldw_Server_API.app.api.v1.API_Deps import ChaCha_Notes_DB_Deps as chacha_deps

--- a/tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py
+++ b/tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py
@@ -144,6 +144,7 @@ async def test_api_health_exposes_chacha_recovery_details_without_path_leak(monk
     monkeypatch.setattr(metrics_manager, "get_metrics_registry", lambda: object())
 
     with chacha_deps._CHACHA_HEALTH_LOCK:
+        previous_health = dict(chacha_deps._CHACHA_HEALTH)
         chacha_deps._CHACHA_HEALTH.update(
             {
                 "init_attempts": 1,
@@ -167,23 +168,28 @@ async def test_api_health_exposes_chacha_recovery_details_without_path_leak(monk
             }
         )
 
-    response = await health_mod.api_health()
-    body = json.loads(response.body.decode("utf-8"))
+    try:
+        response = await health_mod.api_health()
+        body = json.loads(response.body.decode("utf-8"))
 
-    assert response.status_code == 206
-    assert body["status"] == "degraded"
-    assert body["checks"]["chacha_notes"]["status"] == "degraded"
-    assert body["checks"]["chacha_notes"]["last_init_success"] is False
-    assert body["checks"]["chacha_notes"]["consecutive_failures"] == 1
-    assert body["checks"]["chacha_notes"]["warm_startups"] == 2
-    assert body["checks"]["chacha_notes"]["last_failure"]["affected_db"] == "ChaChaNotes.db"
-    assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["automatic_repair"] is False
-    assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["documentation"] == (
-        "Docs/Operations/ChaChaNotes_DB_Recovery.md"
-    )
-    assert "user:42" not in str(body)
-    assert str(tmp_path) not in str(body)
-    assert "/private/" not in str(body)
+        assert response.status_code == 206
+        assert body["status"] == "degraded"
+        assert body["checks"]["chacha_notes"]["status"] == "degraded"
+        assert body["checks"]["chacha_notes"]["last_init_success"] is False
+        assert body["checks"]["chacha_notes"]["consecutive_failures"] == 1
+        assert body["checks"]["chacha_notes"]["warm_startups"] == 2
+        assert body["checks"]["chacha_notes"]["last_failure"]["affected_db"] == "ChaChaNotes.db"
+        assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["automatic_repair"] is False
+        assert body["checks"]["chacha_notes"]["last_failure"]["recovery"]["documentation"] == (
+            "Docs/Operations/ChaChaNotes_DB_Recovery.md"
+        )
+        assert "user:42" not in str(body)
+        assert str(tmp_path) not in str(body)
+        assert "/private/" not in str(body)
+    finally:
+        with chacha_deps._CHACHA_HEALTH_LOCK:
+            chacha_deps._CHACHA_HEALTH.clear()
+            chacha_deps._CHACHA_HEALTH.update(previous_health)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
+++ b/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
@@ -157,15 +157,23 @@ async def test_warm_chacha_db_for_user_records_corrupt_db_and_fails_open(
             }
         )
 
+    def _get_user_base_directory(request_user_id: int):
+        assert request_user_id == user_id
+        return db_path.parent
+
+    def _get_chacha_db_path(request_user_id: int):
+        assert request_user_id == user_id
+        return db_path
+
     monkeypatch.setattr(
         chacha_deps.DatabasePaths,
         "get_user_base_directory",
-        lambda _user_id: db_path.parent,
+        _get_user_base_directory,
     )
     monkeypatch.setattr(
         chacha_deps.DatabasePaths,
         "get_chacha_db_path",
-        lambda _user_id: db_path,
+        _get_chacha_db_path,
     )
 
     await chacha_deps.warm_chacha_db_for_user(user_id, str(user_id))
@@ -177,7 +185,11 @@ async def test_warm_chacha_db_for_user_records_corrupt_db_and_fails_open(
     assert snapshot["consecutive_failures"] == 1
     assert snapshot["warm_startups"] == 0
     assert snapshot["last_failure"]["affected_db"] == "ChaChaNotes.db"
+    assert snapshot["last_failure"]["reason_code"] == "sqlite_corruption"
     assert snapshot["last_failure"]["recovery"]["automatic_repair"] is False
+    assert snapshot["last_failure"]["recovery"]["documentation"] == (
+        "Docs/Operations/ChaChaNotes_DB_Recovery.md"
+    )
     assert "user:43" not in str(snapshot)
     assert str(tmp_path) not in str(snapshot)
     assert "not a sqlite database" not in str(snapshot)

--- a/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
+++ b/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
@@ -146,8 +146,10 @@ async def test_warm_chacha_db_for_user_records_corrupt_db_and_fails_open(
                 "init_failures": 0,
                 "last_init_ms": None,
                 "last_error": None,
+                "last_init_success": None,
                 "last_warn_dump": None,
                 "cached_instances": 0,
+                "consecutive_failures": 0,
                 "default_char_ensures": 0,
                 "default_char_failures": 0,
                 "warm_startups": 0,
@@ -171,7 +173,11 @@ async def test_warm_chacha_db_for_user_records_corrupt_db_and_fails_open(
     snapshot = chacha_deps.get_chacha_health_snapshot()
     assert snapshot["status"] == "degraded"
     assert snapshot["last_error"] == "sqlite_corruption"
-    assert snapshot["last_failure"]["affected_db"] == "user:43/ChaChaNotes.db"
+    assert snapshot["last_init_success"] is False
+    assert snapshot["consecutive_failures"] == 1
+    assert snapshot["warm_startups"] == 0
+    assert snapshot["last_failure"]["affected_db"] == "ChaChaNotes.db"
     assert snapshot["last_failure"]["recovery"]["automatic_repair"] is False
+    assert "user:43" not in str(snapshot)
     assert str(tmp_path) not in str(snapshot)
     assert "not a sqlite database" not in str(snapshot)

--- a/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
+++ b/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
@@ -121,3 +121,57 @@ async def test_warm_chacha_notes_on_startup_logs_best_effort_failure(
     )
 
     assert logger.warning_messages == ["ChaChaNotes warm-up scheduling failed: boom"]
+
+
+@pytest.mark.asyncio
+async def test_warm_chacha_db_for_user_records_corrupt_db_and_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.api.v1.API_Deps import ChaCha_Notes_DB_Deps as chacha_deps
+
+    user_id = 43
+    db_path = tmp_path / "43" / "ChaChaNotes.db"
+    db_path.parent.mkdir(parents=True)
+    db_path.write_bytes(b"not a sqlite database")
+
+    with chacha_deps._chacha_db_lock:
+        chacha_deps._chacha_db_instances.clear()
+        chacha_deps._chacha_db_init_events.clear()
+        chacha_deps._chacha_db_init_errors.clear()
+    with chacha_deps._CHACHA_HEALTH_LOCK:
+        chacha_deps._CHACHA_HEALTH.update(
+            {
+                "init_attempts": 0,
+                "init_failures": 0,
+                "last_init_ms": None,
+                "last_error": None,
+                "last_warn_dump": None,
+                "cached_instances": 0,
+                "default_char_ensures": 0,
+                "default_char_failures": 0,
+                "warm_startups": 0,
+                "last_failure": None,
+            }
+        )
+
+    monkeypatch.setattr(
+        chacha_deps.DatabasePaths,
+        "get_user_base_directory",
+        lambda _user_id: db_path.parent,
+    )
+    monkeypatch.setattr(
+        chacha_deps.DatabasePaths,
+        "get_chacha_db_path",
+        lambda _user_id: db_path,
+    )
+
+    await chacha_deps.warm_chacha_db_for_user(user_id, str(user_id))
+
+    snapshot = chacha_deps.get_chacha_health_snapshot()
+    assert snapshot["status"] == "degraded"
+    assert snapshot["last_error"] == "sqlite_corruption"
+    assert snapshot["last_failure"]["affected_db"] == "user:43/ChaChaNotes.db"
+    assert snapshot["last_failure"]["recovery"]["automatic_repair"] is False
+    assert str(tmp_path) not in str(snapshot)
+    assert "not a sqlite database" not in str(snapshot)


### PR DESCRIPTION
## Summary
- Adds sanitized ChaChaNotes corruption details to the existing health snapshot and /api/v1/health response.
- Keeps startup warm-up fail-open while recording degraded Character Chat DB health.
- Adds recovery documentation, PRD R11 backend evidence, and TASK-429 closeout.

## Test Plan
- [x] `python -m pytest tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py tldw_Server_API/tests/Health/test_readiness_health_sanitizers.py tldw_Server_API/tests/Services/test_startup_chacha_warmup.py -q`
- [x] `python -m bandit -r tldw_Server_API/app/api/v1/API_Deps/ChaCha_Notes_DB_Deps.py tldw_Server_API/app/services/startup_chacha_warmup.py -f json -o /tmp/bandit_character_chat_db_health.json`
- [x] `git diff --check`

## Change summary
Human-authored summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a recovery gate for Character Chat by exposing sanitized ChaChaNotes corruption details in `/api/v1/health` and keeping startup fail-open while marking health as degraded. Satisfies TASK-429 (PRD R11 backend gate), addresses follow-up review feedback (TASK-435), and adds release notes and an ops recovery guide.

- **New Features**
  - Health snapshot includes `checks.chacha_notes.last_failure` with `reason_code`, redacted `affected_db` (`ChaChaNotes.db`), and recovery metadata (`automatic_repair: false`, docs link, message).
  - Current-state fields: `last_init_success`, `consecutive_failures` (drives status back to healthy after a good init), `warm_startups`; `cached_instances` counted under a lock.
  - Startup warm-up handles corrupt DBs without crashing; `/api/v1/health` degrades to 206 on corruption and returns to healthy after a successful init; character DB callers get a sanitized 503.
  - Stronger sanitization: no absolute paths, user IDs, or raw SQLite error text in health payloads.
  - Docs and release: added `Docs/Operations/ChaChaNotes_DB_Recovery.md`, PRD acceptance evidence, plan doc, and release notes; tests cover error mapping, sanitization, startup fail-open, and recovery to healthy.

<sup>Written for commit 9fba47ad101c3f6e1a3e1f3dcebdbc79c596bfad. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1862?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

