### PR TITLE
Migrate Watchlists overview alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -3652,39 +3652,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx:Alert#antd-alert-overviewtab-type-error-line-1286-1hrjmvr",
-    "path": "src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx:Alert#antd-alert-overviewtab-type-info-line-1563-dudo5",
-    "path": "src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx:Alert#antd-alert-overviewtab-type-warning-line-2628-1o6tbua",
-    "path": "src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/SettingsTab/SettingsTab.tsx:Alert#antd-alert-settingstab-type-info-line-367-m37220",
     "path": "src/components/Option/Watchlists/SettingsTab/SettingsTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Setup/ReadinessSetupScreen.tsx
+++ b/apps/packages/ui/src/components/Option/Setup/ReadinessSetupScreen.tsx
@@ -1,10 +1,8 @@
 import React from "react"
 import {
-  Alert,
   Button,
   Card,
   Descriptions,
-  Empty,
   Radio,
   Space,
   Tag,
@@ -26,6 +24,7 @@ import type {
   SetupReadinessLane,
   SetupReadinessProfile
 } from "@/services/tldw/setup-readiness"
+import { Alert as DesignSystemAlert, EmptyState } from "@/components/ui"
 
 const { Paragraph, Text, Title } = Typography
 
@@ -250,25 +249,23 @@ export const ReadinessSetupScreen: React.FC<ReadinessSetupScreenProps> = ({
   if (guard === "remote_setup_blocked") {
     return (
       <section className="mx-auto w-full max-w-5xl px-4 py-6">
-        <Alert
-          type="warning"
-          showIcon
+        <DesignSystemAlert
+          variant="warning"
           title={t("setupReadiness.errors.localSetupRequiredTitle", "Local setup required")}
-          description={
-            <Space orientation="vertical" size="small">
-              <span>
-                {error ||
-                  t(
-                    "setupReadiness.errors.localSetupRequiredDescription",
-                    "First-run setup is restricted to local requests."
-                  )}
-              </span>
-              <Button href={fallbackUrl} icon={<ExternalLink className="h-4 w-4" />}>
-                {t("setupReadiness.actions.openBackendSetup", "Open backend setup")}
-              </Button>
-            </Space>
-          }
-        />
+        >
+          <Space orientation="vertical" size="small">
+            <span>
+              {error ||
+                t(
+                  "setupReadiness.errors.localSetupRequiredDescription",
+                  "First-run setup is restricted to local requests."
+                )}
+            </span>
+            <Button href={fallbackUrl} icon={<ExternalLink className="h-4 w-4" />}>
+              {t("setupReadiness.actions.openBackendSetup", "Open backend setup")}
+            </Button>
+          </Space>
+        </DesignSystemAlert>
       </section>
     )
   }
@@ -299,16 +296,16 @@ export const ReadinessSetupScreen: React.FC<ReadinessSetupScreenProps> = ({
         </div>
 
         {error && (
-          <Alert
-            type={guard === "admin_required" ? "warning" : "error"}
-            showIcon
+          <DesignSystemAlert
+            variant={guard === "admin_required" ? "warning" : "error"}
             title={
               guard === "admin_required"
                 ? t("setupReadiness.errors.adminRequiredTitle", "Admin access required")
                 : t("setupReadiness.errors.requestFailedTitle", "Readiness request failed")
             }
-            description={errorDescription}
-          />
+          >
+            {errorDescription}
+          </DesignSystemAlert>
         )}
 
         <Card loading={loading} size="small">
@@ -353,8 +350,10 @@ export const ReadinessSetupScreen: React.FC<ReadinessSetupScreenProps> = ({
                 </Space>
               </Radio.Group>
             ) : (
-              <Empty
-                description={t(
+              <EmptyState
+                variant="inline"
+                size="sm"
+                title={t(
                   "setupReadiness.profile.empty",
                   "No setup readiness profiles are available."
                 )}
@@ -422,55 +421,53 @@ export const ReadinessSetupScreen: React.FC<ReadinessSetupScreenProps> = ({
                 </div>
               </div>
             ) : (
-              <Alert
-                type="info"
-                showIcon
+              <DesignSystemAlert
+                variant="info"
                 title={t("setupReadiness.preview.reviewTitle", "Review before provisioning")}
-                description={t(
+              >
+                {t(
                   "setupReadiness.preview.reviewDescription",
                   "Select a profile or preview the current selection before running Provision now."
                 )}
-              />
+              </DesignSystemAlert>
             )}
 
             {consequences.length > 0 && (
-              <Alert
-                type="warning"
-                showIcon
+              <DesignSystemAlert
+                variant="warning"
                 title={t("setupReadiness.consequences.title", "Skipped-lane consequences")}
-                description={renderList(consequences)}
-              />
+              >
+                {renderList(consequences)}
+              </DesignSystemAlert>
             )}
 
             {provisionResult && (
-              <Alert
-                type="success"
-                showIcon
+              <DesignSystemAlert
+                variant="success"
                 title={t("setupReadiness.provision.statusTitle", "Provision status: {{status}}", {
                   status: t(
                     statusKey(provisionResult.operation_status || provisionResult.status),
                     formatStatus(provisionResult.operation_status || provisionResult.status)
                   )
                 })}
-                description={t(
+              >
+                {t(
                   "setupReadiness.provision.description",
                   "Readiness provisioning has started. Refresh or watch the status cards for progress."
                 )}
-              />
+              </DesignSystemAlert>
             )}
 
             {verification && (
-              <Alert
-                type="info"
-                showIcon
+              <DesignSystemAlert
+                variant="info"
                 title={t("setupReadiness.verification.statusTitle", "Verification: {{status}}", {
                   status: t(statusKey(verification.status), formatStatus(verification.status))
                 })}
-                description={
-                  verification.verified_at ||
-                  t("setupReadiness.verification.description", "Verification completed.")
-                }
-              />
+              >
+                {verification.verified_at ||
+                  t("setupReadiness.verification.description", "Verification completed.")}
+              </DesignSystemAlert>
             )}
 
             <Space wrap>

--- a/apps/packages/ui/src/components/Option/Setup/__tests__/ReadinessSetupScreen.test.tsx
+++ b/apps/packages/ui/src/components/Option/Setup/__tests__/ReadinessSetupScreen.test.tsx
@@ -166,6 +166,16 @@ describe("ReadinessSetupScreen", () => {
     expect(screen.getByText("Embeddings/RAG")).toBeInTheDocument()
     expect(screen.getByText("Speech")).toBeInTheDocument()
     expect(screen.getByText(/TTS: kokoro/i)).toHaveClass("secondary")
+    expect(
+      screen
+        .getByText("Review before provisioning")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Skipped-lane consequences")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
     expect(screen.getByRole("link", { name: /Open backend setup/i })).toHaveAttribute(
       "href",
       "/setup"
@@ -247,6 +257,9 @@ describe("ReadinessSetupScreen", () => {
     render(<ReadinessSetupScreen />)
 
     expect(await screen.findByText("Local setup required")).toBeInTheDocument()
+    expect(
+      screen.getByText("Local setup required").closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
     expect(screen.getByText("Setup access is restricted to local requests.")).toBeInTheDocument()
     expect(screen.getByRole("link", { name: /Open backend setup/i })).toHaveAttribute(
       "href",
@@ -269,6 +282,11 @@ describe("ReadinessSetupScreen", () => {
 
     expect(screen.queryByText("/api/v1/setup/readiness/status")).not.toBeInTheDocument()
     expect(screen.getByText(/watch the status cards/i)).toBeInTheDocument()
+    expect(
+      screen
+        .getByText(/watch the status cards/i)
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
   })
 
   it("prefers localized error copy when the readiness hook exposes an error key", async () => {
@@ -281,7 +299,27 @@ describe("ReadinessSetupScreen", () => {
     render(<ReadinessSetupScreen />)
 
     expect(screen.getByText("Localized setup readiness load failure.")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Readiness request failed")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
     expect(screen.queryByText("Request failed: 500 backend detail")).not.toBeInTheDocument()
+  })
+
+  it("renders the profile-empty state with the design-system EmptyState", async () => {
+    mocks.useSetupReadiness.mockReturnValue({
+      ...baseHookState,
+      profiles: {
+        ...readinessProfiles,
+        profiles: []
+      }
+    })
+
+    render(<ReadinessSetupScreen />)
+
+    const emptyTitle = await screen.findByText("No setup readiness profiles are available.")
+    expect(emptyTitle.closest('[data-ds-component="EmptyState"]')).toBeInTheDocument()
   })
 
   it("passes admin mode through to the setup readiness hook", () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import {
-  Alert,
   Button,
   Card,
   Empty,
@@ -57,6 +56,7 @@ import {
   toQuickSetupSourcePayload
 } from "./quick-setup"
 import type { JobPreviewResult } from "@/types/watchlists"
+import { Alert as DesignSystemAlert } from "@/components/ui"
 import {
   toPipelineJobCreatePayload,
   toPipelineOutputCreatePayload
@@ -1149,7 +1149,7 @@ export const OverviewTab: React.FC = () => {
       </div>
 
       {error && (
-        <Alert type="error" showIcon title={error} />
+        <DesignSystemAlert variant="error" title={error} />
       )}
 
       {data && (
@@ -1277,26 +1277,24 @@ export const OverviewTab: React.FC = () => {
             </Card>
           )}
 
-          <Alert
-            showIcon
-            type={data.systemHealth === "degraded" ? "warning" : "success"}
+          <DesignSystemAlert
+            variant={data.systemHealth === "degraded" ? "warning" : "success"}
             title={
               data.systemHealth === "degraded"
                 ? t("watchlists:overview.health.degradedTitle", "System requires attention")
                 : t("watchlists:overview.health.healthyTitle", "System healthy")
             }
-            description={
-              data.systemHealth === "degraded"
-                ? t(
-                    "watchlists:overview.health.degradedDescription",
-                    "Some sources or recent runs show failures. Open failed runs to investigate."
-                  )
-                : t(
-                    "watchlists:overview.health.healthyDescription",
-                    "No recent failed runs and source health is stable."
-                  )
-            }
-          />
+          >
+            {data.systemHealth === "degraded"
+              ? t(
+                  "watchlists:overview.health.degradedDescription",
+                  "Some sources or recent runs show failures. Open failed runs to investigate."
+                )
+              : t(
+                  "watchlists:overview.health.healthyDescription",
+                  "No recent failed runs and source health is stable."
+                )}
+          </DesignSystemAlert>
 
           <Card
             size="small"
@@ -1426,28 +1424,25 @@ export const OverviewTab: React.FC = () => {
           )}
 
           {data.sources.total > 0 && data.jobs.total > 0 && (
-            <Alert
-              showIcon
-              type="info"
+            <DesignSystemAlert
+              variant="info"
               title={t("watchlists:overview.setupComplete.title", "Setup complete")}
-              description={
-                data.jobs.nextRunAt
-                  ? t(
-                      "watchlists:overview.setupComplete.nextRunDescription",
-                      "Your next monitor run is {{time}}. New content will appear in Updates and Activity.",
-                      { time: formatRelativeTime(data.jobs.nextRunAt, t) }
-                    )
-                  : t(
-                      "watchlists:overview.setupComplete.runNowDescription",
-                      "Run a monitor from Monitors to generate your first Updates and Activity entries."
-                    )
-              }
-              action={
-                <Button size="small" onClick={handleOpenRuns}>
-                  {t("watchlists:overview.setupComplete.openActivity", "Open Activity")}
-                </Button>
-              }
-            />
+              action={{
+                label: t("watchlists:overview.setupComplete.openActivity", "Open Activity"),
+                onClick: handleOpenRuns
+              }}
+            >
+              {data.jobs.nextRunAt
+                ? t(
+                    "watchlists:overview.setupComplete.nextRunDescription",
+                    "Your next monitor run is {{time}}. New content will appear in Updates and Activity.",
+                    { time: formatRelativeTime(data.jobs.nextRunAt, t) }
+                  )
+                : t(
+                    "watchlists:overview.setupComplete.runNowDescription",
+                    "Run a monitor from Monitors to generate your first Updates and Activity entries."
+                  )}
+            </DesignSystemAlert>
           )}
 
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react"
 import {
-  Alert,
   Button,
   Checkbox,
   Form,
@@ -14,6 +13,7 @@ import {
   Switch
 } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert as DesignSystemAlert } from "@/components/ui"
 import type { WatchlistSource } from "@/types/watchlists"
 import {
   INTERVAL_HOURS_MAX,
@@ -358,9 +358,8 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
       <div className="space-y-4">
         <Steps size="small" current={currentStep} items={stepItems} />
         {stepErrors.length > 0 && (
-          <Alert
-            type="warning"
-            showIcon
+          <DesignSystemAlert
+            variant="warning"
             title={t(
               "watchlists:overview.pipelineSetup.validationError",
               "Review the highlighted pipeline fields."
@@ -727,9 +726,8 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                 </Button>
               </div>
               {previewError && (
-                <Alert
-                  type="warning"
-                  showIcon
+                <DesignSystemAlert
+                  variant="warning"
                   data-testid="watchlists-pipeline-preview-error"
                   title={previewError}
                 />

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   createWatchlistSourceMock: vi.fn(),
   createWatchlistJobMock: vi.fn(),
   deleteWatchlistJobMock: vi.fn(),
+  deleteWatchlistSourceMock: vi.fn(),
   triggerWatchlistRunMock: vi.fn(),
   createWatchlistOutputMock: vi.fn(),
   getWatchlistTemplateMock: vi.fn(),
@@ -68,6 +69,7 @@ vi.mock("@/services/watchlists", () => ({
   createWatchlistSource: (...args: unknown[]) => mocks.createWatchlistSourceMock(...args),
   createWatchlistJob: (...args: unknown[]) => mocks.createWatchlistJobMock(...args),
   deleteWatchlistJob: (...args: unknown[]) => mocks.deleteWatchlistJobMock(...args),
+  deleteWatchlistSource: (...args: unknown[]) => mocks.deleteWatchlistSourceMock(...args),
   triggerWatchlistRun: (...args: unknown[]) => mocks.triggerWatchlistRunMock(...args),
   createWatchlistOutput: (...args: unknown[]) => mocks.createWatchlistOutputMock(...args),
   getWatchlistTemplate: (...args: unknown[]) => mocks.getWatchlistTemplateMock(...args),
@@ -223,5 +225,27 @@ describe("OverviewTab alert and health summary", () => {
 
     fireEvent.click(within(contentAlerts).getByRole("button", { name: "Create content alert rule" }))
     expect(mocks.setActiveTabMock).toHaveBeenCalledWith("alerts")
+  })
+
+  it("renders Overview health and setup callouts with the design-system Alert", async () => {
+    mocks.fetchOverviewMock.mockResolvedValue(createOverviewPayload())
+
+    render(<OverviewTab />)
+
+    const healthTitle = await screen.findByText("System healthy")
+    expect(healthTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
+    const setupTitle = screen.getByText("Setup complete")
+    expect(setupTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
+  it("renders Overview load failures with the design-system Alert", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+    mocks.fetchOverviewMock.mockRejectedValue(new Error("overview unavailable"))
+
+    render(<OverviewTab />)
+
+    const failureTitle = await screen.findByText("Failed to load overview")
+    expect(failureTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx
@@ -240,12 +240,17 @@ describe("OverviewTab alert and health summary", () => {
   })
 
   it("renders Overview load failures with the design-system Alert", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined)
-    mocks.fetchOverviewMock.mockRejectedValue(new Error("overview unavailable"))
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
 
-    render(<OverviewTab />)
+    try {
+      mocks.fetchOverviewMock.mockRejectedValue(new Error("overview unavailable"))
 
-    const failureTitle = await screen.findByText("Failed to load overview")
-    expect(failureTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+      render(<OverviewTab />)
+
+      const failureTitle = await screen.findByText("Failed to load overview")
+      expect(failureTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
@@ -3,8 +3,6 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { describe, expect, it, vi } from "vitest"
 import { PipelineWizard } from "../PipelineWizard"
 
-vi.setConfig({ testTimeout: 10_000 })
-
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string, options?: Record<string, unknown>) =>

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { describe, expect, it, vi } from "vitest"
 import { PipelineWizard } from "../PipelineWizard"
 
+vi.setConfig({ testTimeout: 10_000 })
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string, options?: Record<string, unknown>) =>
@@ -62,6 +64,19 @@ const getDialog = () => screen.getByRole("dialog", { name: "Briefing pipeline bu
 const getDialogQueries = () => within(getDialog())
 
 describe("PipelineWizard", () => {
+  it("renders validation feedback with the design-system Alert", async () => {
+    renderWizard()
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("AI Feed")).toBeInTheDocument()
+    })
+
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    const validationTitle = await screen.findByText("Review the highlighted pipeline fields.")
+    expect(validationTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
   it("creates a pipeline from an existing source with digest and two-speaker audio", async () => {
     const { onSubmit } = renderWizard()
 
@@ -212,5 +227,36 @@ describe("PipelineWizard", () => {
 
     expect(getDialogQueries().getByLabelText("Every")).toHaveAttribute("aria-valuemin", "5")
     expect(getDialogQueries().getByLabelText("Every")).toHaveAttribute("aria-valuemax", "59")
+  })
+
+  it("renders preview failures with the design-system Alert", async () => {
+    renderWizard({ previewError: "Preview context unavailable" })
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("AI Feed")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByLabelText("AI Feed"))
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Monitor name")).toBeInTheDocument()
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Monitor name"), {
+      target: { value: "Preview Brief" }
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Template")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Audio briefing")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    const previewTitle = await screen.findByText("Preview context unavailable")
+    expect(previewTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/utils/__tests__/watchlists-onboarding-telemetry.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/watchlists-onboarding-telemetry.test.ts
@@ -273,16 +273,24 @@ describe("watchlists-onboarding-telemetry", () => {
       mode: "test",
       runNow: true
     })
+    await telemetry.trackWatchlistsOnboardingTelemetry({
+      type: "pipeline_setup_failed",
+      stage: "source_create",
+      mode: "create",
+      runNow: false
+    })
 
     const state = await telemetry.getWatchlistsOnboardingTelemetryState()
     expect(state.uc2_pipeline.preview_by_status.no_run_context).toBe(1)
     expect(state.uc2_pipeline.failed_by_stage.run_trigger).toBe(1)
+    expect(state.uc2_pipeline.failed_by_stage.source_create).toBe(1)
 
     const snapshot = telemetry.buildWatchlistsUc2PipelineDashboardSnapshot(state)
     expect(snapshot.funnel.opened).toBe(1)
     expect(snapshot.funnel.completed).toBe(0)
     expect(snapshot.rates.completionPerOpened).toBe(0)
     expect(snapshot.failures.run_trigger).toBe(1)
+    expect(snapshot.failures.source_create).toBe(1)
     expect(snapshot.preview.no_run_context).toBe(1)
   })
 })

--- a/apps/packages/ui/src/utils/watchlists-onboarding-telemetry.ts
+++ b/apps/packages/ui/src/utils/watchlists-onboarding-telemetry.ts
@@ -61,6 +61,7 @@ export type WatchlistsPipelinePreviewStatus =
   | "error"
 export type WatchlistsPipelineFailureStage =
   | "validation"
+  | "source_create"
   | "job_create"
   | "run_trigger"
   | "output_create"
@@ -294,6 +295,7 @@ const DEFAULT_PIPELINE_PREVIEW_COUNTERS: PipelinePreviewCounters = {
 
 const DEFAULT_PIPELINE_FAILURE_COUNTERS: PipelineFailureCounters = {
   validation: 0,
+  source_create: 0,
   job_create: 0,
   run_trigger: 0,
   output_create: 0,

--- a/backlog/tasks/task-436 - Migrate-Watchlists-Overview-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-436 - Migrate-Watchlists-Overview-alerts-to-design-system-Alert.md
@@ -1,0 +1,54 @@
+---
+id: TASK-436
+title: Migrate Watchlists Overview alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- watchlists
+- ui
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+- apps/packages/ui/src/components/Option/Setup/ReadinessSetupScreen.tsx
+- apps/packages/ui/src/components/Option/Setup/__tests__/ReadinessSetupScreen.test.tsx
+- apps/packages/ui/src/utils/watchlists-onboarding-telemetry.ts
+- apps/packages/ui/src/utils/__tests__/watchlists-onboarding-telemetry.test.ts
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+references:
+- https://github.com/rmusser01/tldw_server/pull/1863
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Guard-backed design-system slice: replace remaining AntD product-state Alert surfaces in Watchlists OverviewTab and PipelineWizard with canonical design-system Alert primitives, add focused coverage, remove stale baseline entries, and initialize the source_create telemetry failure bucket exposed by the touched Overview pipeline path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation completed in branch codex/design-system-next-slice-10 and opened as draft PR #1863. After rebasing onto current origin/dev, the design-system guard exposed new unbaselined Setup Readiness Alert/Empty findings from upstream; migrated that small ReadinessSetupScreen surface in the same PR instead of adding new baseline debt. Verification: focused Vitest passed for OverviewTab alerts, PipelineWizard, ReadinessSetupScreen, and watchlists onboarding telemetry (23 tests); design-system product-state guard passed with 346 allowed legacy exceptions and no blocked/stale findings for this slice; git diff --check passed; full UI tsc remains red from inherited package-wide TypeScript debt, and a filtered tsc pass confirmed no diagnostics for touched files. Bandit skipped because this is TypeScript/JSON/Backlog-only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated Watchlists OverviewTab, PipelineWizard, and rebased Setup Readiness product-state callouts from AntD Alert/Empty to canonical design-system Alert/EmptyState primitives. Added regression coverage for health/setup/load failure/validation/preview/setup-readiness alert wrappers and profile-empty state wrappers, removed stale Overview Alert baseline entries, and initialized the source_create pipeline failure telemetry bucket so source-creation failures are counted instead of producing NaN.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-436 - Migrate-Watchlists-Overview-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-436 - Migrate-Watchlists-Overview-alerts-to-design-system-Alert.md
@@ -45,10 +45,10 @@ Migrated Watchlists OverviewTab, PipelineWizard, and rebased Setup Readiness pro
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate Watchlists OverviewTab, PipelineWizard, and Setup Readiness product-state Alert/Empty surfaces to design-system Alert/EmptyState.
- Remove stale Overview Alert product-state baseline entries.
- Initialize the `source_create` pipeline setup failure telemetry bucket surfaced by the touched Overview pipeline path.
- Add focused regression coverage for the migrated alert/empty wrappers.

## Verification
- `bunx vitest run src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.alerts-health.test.tsx src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx src/components/Option/Setup/__tests__/ReadinessSetupScreen.test.tsx src/utils/__tests__/watchlists-onboarding-telemetry.test.ts --maxWorkers=1 --no-file-parallelism`
- `bun run verify:design-system-state`
- `git diff --check origin/dev`
- `bunx tsc --noEmit --pretty false` still fails on inherited package-wide TypeScript debt; filtered tsc output for touched files is empty.
- Bandit skipped: TypeScript/JSON/Backlog-only change.

## Change summary
TODO (human): explain what changed and why these implementation choices were made before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Watchlists Overview, Pipeline Wizard, and Setup Readiness callouts to the design-system `Alert`/`EmptyState` from `@/components/ui`. Aligns with TASK-436 and adds a telemetry bucket for `source_create` failures.

- **Refactors**
  - Replaced AntD `Alert`/`Empty` with design-system `Alert`/`EmptyState` in `OverviewTab`, `PipelineWizard`, and `ReadinessSetupScreen` (including DS `action` usage where applicable).
  - Updated tests to assert design-system wrappers (`Alert` and `EmptyState`) and removed stale product-state baseline entries.

- **Bug Fixes**
  - Initialized `source_create` failure bucket in watchlists onboarding telemetry to correctly count source-creation failures.

<sup>Written for commit ea5b6ae6d07ab9255d0d4d2c0283f231aa448d55. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1863?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

