### PR TITLE
Add Watchlists reuse and recovery controls

### DIFF
--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx
@@ -108,7 +108,8 @@ export const JobsTab: React.FC = () => {
 
   // Local state
   const [triggeringJobId, setTriggeringJobId] = useState<number | null>(null)
-  const [cloningJobId, setCloningJobId] = useState<number | null>(null)
+  const cloningJobIdsRef = useRef<Set<number>>(new Set())
+  const [cloningJobIds, setCloningJobIds] = useState<Set<number>>(() => new Set())
   const [previewJob, setPreviewJob] = useState<WatchlistJob | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
   const [sourceNamesById, setSourceNamesById] = useState<Record<number, string>>({})
@@ -349,8 +350,29 @@ export const JobsTab: React.FC = () => {
     }
   }
 
+  const startCloningJob = useCallback((jobId: number) => {
+    if (cloningJobIdsRef.current.has(jobId)) {
+      return false
+    }
+    const next = new Set(cloningJobIdsRef.current)
+    next.add(jobId)
+    cloningJobIdsRef.current = next
+    setCloningJobIds(next)
+    return true
+  }, [])
+
+  const finishCloningJob = useCallback((jobId: number) => {
+    if (!cloningJobIdsRef.current.has(jobId)) {
+      return
+    }
+    const next = new Set(cloningJobIdsRef.current)
+    next.delete(jobId)
+    cloningJobIdsRef.current = next
+    setCloningJobIds(next)
+  }, [])
+
   const handleCloneJob = async (job: WatchlistJob) => {
-    setCloningJobId(job.id)
+    if (!startCloningJob(job.id)) return
     try {
       const cloned = await createWatchlistJob(buildClonedWatchlistJobPayload(job))
       addJob(cloned)
@@ -365,7 +387,7 @@ export const JobsTab: React.FC = () => {
       console.error("Failed to clone job:", err)
       message.error(t("watchlists:jobs.cloneError", "Failed to clone monitor"))
     } finally {
-      setCloningJobId(null)
+      finishCloningJob(job.id)
     }
   }
 
@@ -598,7 +620,7 @@ export const JobsTab: React.FC = () => {
               aria-label={t("watchlists:jobs.cloneMonitorAria", "Clone {{name}}", { name: record.name })}
               icon={<Copy className="h-4 w-4" />}
               onClick={() => handleCloneJob(record)}
-              loading={cloningJobId === record.id}
+              loading={cloningJobIds.has(record.id)}
             />
           </Tooltip>
           <Tooltip title={t("common:delete", "Delete")}>
@@ -769,7 +791,7 @@ export const JobsTab: React.FC = () => {
                 aria-label={t("watchlists:jobs.cloneMonitorAria", "Clone {{name}}", { name: job.name })}
                 icon={<Copy className="h-4 w-4" />}
                 onClick={() => handleCloneJob(job)}
-                loading={cloningJobId === job.id}
+                loading={cloningJobIds.has(job.id)}
               />
               <Button
                 type="text"

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx
@@ -12,7 +12,7 @@ import {
   message
 } from "antd"
 import type { ColumnsType } from "antd/es/table"
-import { Edit2, Eye, Play, Plus, RefreshCw, Trash2 } from "lucide-react"
+import { Copy, Edit2, Eye, Play, Plus, RefreshCw, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useUndoNotification } from "@/hooks/useUndoNotification"
 import { useWatchlistsStore } from "@/store/watchlists"
@@ -22,6 +22,7 @@ import {
   fetchWatchlistGroups,
   fetchWatchlistJobs,
   fetchWatchlistSources,
+  createWatchlistJob,
   restoreWatchlistJob,
   triggerWatchlistRun,
   updateWatchlistJob
@@ -44,6 +45,7 @@ import {
 import { JobPreviewModal } from "./JobPreviewModal"
 import { mapWatchlistsError } from "../shared/watchlists-error"
 import { useWatchlistsViewport } from "../shared/useWatchlistsViewport"
+import { buildClonedWatchlistJobPayload } from "./clone-utils"
 
 const SCOPE_CATALOG_LIMIT = 200
 const JOBS_ADVANCED_COLUMNS_STORAGE_KEY = "watchlists:jobs:advanced-columns:v1"
@@ -106,6 +108,7 @@ export const JobsTab: React.FC = () => {
 
   // Local state
   const [triggeringJobId, setTriggeringJobId] = useState<number | null>(null)
+  const [cloningJobId, setCloningJobId] = useState<number | null>(null)
   const [previewJob, setPreviewJob] = useState<WatchlistJob | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
   const [sourceNamesById, setSourceNamesById] = useState<Record<number, string>>({})
@@ -346,6 +349,26 @@ export const JobsTab: React.FC = () => {
     }
   }
 
+  const handleCloneJob = async (job: WatchlistJob) => {
+    setCloningJobId(job.id)
+    try {
+      const cloned = await createWatchlistJob(buildClonedWatchlistJobPayload(job))
+      addJob(cloned)
+      message.success(
+        t(
+          "watchlists:jobs.cloneSuccess",
+          "Monitor cloned as a paused copy. Review and enable it when ready."
+        )
+      )
+      void loadJobs()
+    } catch (err) {
+      console.error("Failed to clone job:", err)
+      message.error(t("watchlists:jobs.cloneError", "Failed to clone monitor"))
+    } finally {
+      setCloningJobId(null)
+    }
+  }
+
   // Get job for editing
   const editingJob = jobFormEditId
     ? jobs.find((j) => j.id === jobFormEditId)
@@ -568,6 +591,16 @@ export const JobsTab: React.FC = () => {
               onClick={() => openJobForm(record.id)}
             />
           </Tooltip>
+          <Tooltip title={t("watchlists:jobs.clone", "Clone")}>
+            <Button
+              type="text"
+              size="small"
+              aria-label={t("watchlists:jobs.cloneMonitorAria", "Clone {{name}}", { name: record.name })}
+              icon={<Copy className="h-4 w-4" />}
+              onClick={() => handleCloneJob(record)}
+              loading={cloningJobId === record.id}
+            />
+          </Tooltip>
           <Tooltip title={t("common:delete", "Delete")}>
             <Button
               type="text"
@@ -729,6 +762,14 @@ export const JobsTab: React.FC = () => {
                 aria-label={t("watchlists:jobs.editMonitorAria", "Edit {{name}}", { name: job.name })}
                 icon={<Edit2 className="h-4 w-4" />}
                 onClick={() => openJobForm(job.id)}
+              />
+              <Button
+                type="text"
+                size="small"
+                aria-label={t("watchlists:jobs.cloneMonitorAria", "Clone {{name}}", { name: job.name })}
+                icon={<Copy className="h-4 w-4" />}
+                onClick={() => handleCloneJob(job)}
+                loading={cloningJobId === job.id}
               />
               <Button
                 type="text"

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/clone-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/clone-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+import { buildClonedWatchlistJobPayload } from "../clone-utils"
+import type { WatchlistJob } from "@/types/watchlists"
+
+const buildJob = (): WatchlistJob => ({
+  id: 42,
+  name: "Morning digest",
+  description: "Collects national security news",
+  watchlist_id: 7,
+  scope: {
+    sources: [10, 11],
+    groups: [5],
+    tags: ["news", "osint"]
+  },
+  schedule_expr: "0 */5 * * *",
+  timezone: "America/New_York",
+  active: true,
+  max_concurrency: 3,
+  per_host_delay_ms: 2500,
+  retry_policy: { max_attempts: 2, backoff_seconds: 60 },
+  job_filters: {
+    filters: [
+      { filter_type: "keyword", action: "include", value: "sanctions", case_sensitive: false },
+      { filter_type: "regex", action: "exclude", value: "sports", case_sensitive: false }
+    ],
+    default_action: "include"
+  },
+  output_prefs: {
+    auto_output: { enabled: true, format: "md" },
+    generate_audio: true,
+    audio_cast: {
+      speaker_count: 2,
+      speakers: [
+        { id: "host", label: "Host", role: "anchor", voice: "af_bella" },
+        { id: "analyst", label: "Analyst", role: "analysis", voice: "am_adam" }
+      ]
+    },
+    deliveries: {
+      email: { enabled: true, recipients: ["briefing@example.com"] },
+      chatbook: { enabled: true, title: "Daily brief" }
+    }
+  },
+  created_at: "2026-05-01T12:00:00Z",
+  updated_at: "2026-05-01T12:30:00Z",
+  last_run_at: "2026-05-01T13:00:00Z",
+  next_run_at: "2026-05-01T18:00:00Z",
+  wf_schedule_id: "wf-schedule-42"
+})
+
+describe("buildClonedWatchlistJobPayload", () => {
+  it("preserves monitor scope, cadence, filters, output, delivery, and audio config while resetting runtime state", () => {
+    const original = buildJob()
+
+    const clone = buildClonedWatchlistJobPayload(original)
+
+    expect(clone).toEqual({
+      name: "Morning digest copy",
+      description: "Collects national security news",
+      watchlist_id: 7,
+      scope: original.scope,
+      schedule_expr: "0 */5 * * *",
+      timezone: "America/New_York",
+      active: false,
+      max_concurrency: 3,
+      per_host_delay_ms: 2500,
+      retry_policy: original.retry_policy,
+      job_filters: original.job_filters,
+      output_prefs: original.output_prefs
+    })
+    expect(JSON.stringify(clone)).not.toContain("last_run_at")
+    expect(JSON.stringify(clone)).not.toContain("next_run_at")
+    expect(JSON.stringify(clone)).not.toContain("wf_schedule_id")
+  })
+
+  it("deep clones nested config so edits to the clone cannot mutate the original monitor", () => {
+    const original = buildJob()
+    const clone = buildClonedWatchlistJobPayload(original)
+
+    clone.scope.sources?.push(999)
+    clone.output_prefs!.deliveries!.email!.recipients!.push("copy@example.com")
+
+    expect(original.scope.sources).toEqual([10, 11])
+    expect(original.output_prefs?.deliveries?.email?.recipients).toEqual(["briefing@example.com"])
+  })
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/clone-utils.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/clone-utils.ts
@@ -1,0 +1,26 @@
+import type { WatchlistJob, WatchlistJobCreate } from "@/types/watchlists"
+
+const cloneValue = <T>(value: T): T => {
+  if (value == null) return value
+  if (typeof structuredClone === "function") {
+    return structuredClone(value)
+  }
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+export const buildClonedWatchlistJobPayload = (
+  job: WatchlistJob
+): WatchlistJobCreate => ({
+  name: `${job.name} copy`,
+  description: job.description || undefined,
+  watchlist_id: job.watchlist_id ?? undefined,
+  scope: cloneValue(job.scope),
+  schedule_expr: job.schedule_expr || undefined,
+  timezone: job.timezone || undefined,
+  active: false,
+  max_concurrency: job.max_concurrency ?? undefined,
+  per_host_delay_ms: job.per_host_delay_ms ?? undefined,
+  retry_policy: job.retry_policy ? cloneValue(job.retry_policy) : undefined,
+  output_prefs: job.output_prefs ? cloneValue(job.output_prefs) : undefined,
+  job_filters: job.job_filters ? cloneValue(job.job_filters) : undefined
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
@@ -118,6 +118,7 @@ export const OverviewTab: React.FC = () => {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const quickSetupTriggerRef = useRef<HTMLButtonElement | null>(null)
   const quickSetupRestoreFocusTargetRef = useRef<HTMLElement | null>(null)
+  const quickSetupFocusRestoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pipelineSetupRestoreFocusTargetRef = useRef<HTMLElement | null>(null)
   const quickSetupWasOpenRef = useRef(false)
   const pipelineSetupWasOpenRef = useRef(false)
@@ -194,6 +195,16 @@ export const OverviewTab: React.FC = () => {
 
   const quickSetupAutoShownWatchlistRef = useRef<number | null>(null)
 
+  const restoreQuickSetupFocus = useCallback(() => {
+    if (quickSetupFocusRestoreTimerRef.current) {
+      clearTimeout(quickSetupFocusRestoreTimerRef.current)
+      quickSetupFocusRestoreTimerRef.current = null
+    }
+    const target = quickSetupRestoreFocusTargetRef.current
+    quickSetupRestoreFocusTargetRef.current = null
+    restoreFocusToElement(target)
+  }, [])
+
   useLayoutEffect(() => {
     if (quickSetupOpen) {
       if (!quickSetupWasOpenRef.current) {
@@ -206,9 +217,18 @@ export const OverviewTab: React.FC = () => {
 
     if (quickSetupWasOpenRef.current) {
       quickSetupWasOpenRef.current = false
-      restoreFocusToElement(quickSetupRestoreFocusTargetRef.current)
+      quickSetupFocusRestoreTimerRef.current = setTimeout(restoreQuickSetupFocus, 0)
     }
-  }, [quickSetupOpen])
+  }, [quickSetupOpen, restoreQuickSetupFocus])
+
+  useEffect(() => {
+    return () => {
+      if (quickSetupFocusRestoreTimerRef.current) {
+        clearTimeout(quickSetupFocusRestoreTimerRef.current)
+        quickSetupFocusRestoreTimerRef.current = null
+      }
+    }
+  }, [])
 
   useLayoutEffect(() => {
     if (pipelineSetupOpen) {
@@ -1641,7 +1661,7 @@ export const OverviewTab: React.FC = () => {
         open={quickSetupOpen}
         title={t("watchlists:overview.onboarding.quickSetup.title", "Add initial collection")}
         onCancel={quickSetupSubmitting ? undefined : cancelQuickSetup}
-        afterClose={() => restoreFocusToElement(quickSetupRestoreFocusTargetRef.current)}
+        afterClose={restoreQuickSetupFocus}
         destroyOnHidden
         maskClosable={!quickSetupSubmitting}
         footer={[

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
@@ -116,6 +116,7 @@ export const OverviewTab: React.FC = () => {
     readWatchlistsOnboardingPath()
   )
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const quickSetupTriggerRef = useRef<HTMLButtonElement | null>(null)
   const quickSetupRestoreFocusTargetRef = useRef<HTMLElement | null>(null)
   const pipelineSetupRestoreFocusTargetRef = useRef<HTMLElement | null>(null)
   const quickSetupWasOpenRef = useRef(false)
@@ -196,7 +197,8 @@ export const OverviewTab: React.FC = () => {
   useLayoutEffect(() => {
     if (quickSetupOpen) {
       if (!quickSetupWasOpenRef.current) {
-        quickSetupRestoreFocusTargetRef.current = getFocusableActiveElement()
+        quickSetupRestoreFocusTargetRef.current =
+          quickSetupRestoreFocusTargetRef.current || getFocusableActiveElement()
       }
       quickSetupWasOpenRef.current = true
       return
@@ -278,12 +280,25 @@ export const OverviewTab: React.FC = () => {
     writeWatchlistsOnboardingPath(path)
   }, [])
 
-  const openQuickSetup = useCallback(() => {
+  const markQuickSetupAutoShown = useCallback(() => {
+    if (selectedWatchlistId == null) return
+    quickSetupAutoShownWatchlistRef.current = selectedWatchlistId
+    try {
+      localStorage.setItem(`watchlists:quickSetup:autoshown:v1:${selectedWatchlistId}`, "1")
+    } catch {
+      // Keep setup usable when storage is unavailable.
+    }
+  }, [selectedWatchlistId])
+
+  const openQuickSetup = useCallback((restoreTarget?: HTMLElement | null) => {
+    quickSetupRestoreFocusTargetRef.current =
+      restoreTarget || quickSetupTriggerRef.current || getFocusableActiveElement()
+    markQuickSetupAutoShown()
     quickSetupForm.setFieldsValue(QUICK_SETUP_DEFAULT_VALUES)
     setQuickSetupStep(0)
     setQuickSetupOpen(true)
     void trackWatchlistsOnboardingTelemetry({ type: "quick_setup_opened" })
-  }, [quickSetupForm])
+  }, [markQuickSetupAutoShown, quickSetupForm])
 
   // Auto-open Quick Setup for first-time users with no sources
   useEffect(() => {
@@ -325,6 +340,7 @@ export const OverviewTab: React.FC = () => {
   }, [data, quickSetupOpen, onboardingPath, openQuickSetup, selectedWatchlistId])
 
   const closeQuickSetup = useCallback(() => {
+    markQuickSetupAutoShown()
     quickSetupPreviewRequestRef.current += 1
     setQuickSetupOpen(false)
     setQuickSetupStep(0)
@@ -332,7 +348,7 @@ export const OverviewTab: React.FC = () => {
     setQuickSetupCandidatePreviewLoading(false)
     setQuickSetupCandidatePreviewError(null)
     quickSetupForm.resetFields()
-  }, [quickSetupForm])
+  }, [markQuickSetupAutoShown, quickSetupForm])
 
   const loadQuickSetupCandidatePreview = useCallback(async (draftValues?: Partial<QuickSetupValues>) => {
     const mergedValues = {
@@ -1234,7 +1250,8 @@ export const OverviewTab: React.FC = () => {
               <Space className="mt-4" wrap>
                 <Button
                   type={onboardingPath === "beginner" ? "primary" : "default"}
-                  onClick={openQuickSetup}
+                  ref={quickSetupTriggerRef}
+                  onClick={(event) => openQuickSetup(event.currentTarget)}
                   data-testid="watchlists-overview-cta-guided-setup"
                 >
                   {t("watchlists:overview.onboarding.cta.guidedSetup", "Add initial collection")}
@@ -1624,6 +1641,7 @@ export const OverviewTab: React.FC = () => {
         open={quickSetupOpen}
         title={t("watchlists:overview.onboarding.quickSetup.title", "Add initial collection")}
         onCancel={quickSetupSubmitting ? undefined : cancelQuickSetup}
+        afterClose={() => restoreFocusToElement(quickSetupRestoreFocusTargetRef.current)}
         destroyOnHidden
         maskClosable={!quickSetupSubmitting}
         footer={[

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
@@ -1017,7 +1017,7 @@ describe("OverviewTab quick setup flow", () => {
       runNow: true,
       destination: "outputs"
     })
-  })
+  }, 20_000)
 
   it("restores focus to guided setup trigger after quick setup modal closes", async () => {
     mockState.fetchOverviewMock.mockResolvedValue(createOverviewPayload())
@@ -1037,7 +1037,7 @@ describe("OverviewTab quick setup flow", () => {
     await waitFor(() => {
       expect(trigger).toHaveFocus()
     })
-  })
+  }, 20_000)
 
   it("restores focus to pipeline builder trigger after modal closes", async () => {
     mockState.fetchOverviewMock.mockResolvedValue(
@@ -1062,5 +1062,5 @@ describe("OverviewTab quick setup flow", () => {
     await waitFor(() => {
       expect(trigger).toHaveFocus()
     })
-  })
+  }, 20_000)
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
@@ -1021,6 +1021,12 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
     setRetryingDelivery(true)
     try {
       const result = await retryWatchlistRunDelivery(runId)
+      if (!result.retried) {
+        message.warning(
+          result.message || t("watchlists:runs.detail.deliveryRetrySkipped", "Delivery retry was not started.")
+        )
+        return
+      }
       message.success(
         t("watchlists:runs.detail.deliveryRetrySuccess", "Delivery retry completed for output #{{id}}.", {
           id: result.output_id ?? "-"
@@ -1038,9 +1044,17 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
   const handleRetryAudio = async () => {
     if (!runId || retryingAudio) return
     setRetryingAudio(true)
+    setAudioStatusError(null)
     try {
       const result = await retryWatchlistRunAudio(runId)
+      if (!result.retried) {
+        message.warning(
+          result.message || t("watchlists:runs.detail.audioRetrySkipped", "Audio retry was not started.")
+        )
+        return
+      }
       if (result.task_id) {
+        setAudioStatusError(null)
         setAudioStatus((prev) => ({
           ...(prev || { run_id: runId }),
           run_id: runId,

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
@@ -26,8 +26,11 @@ import {
   fetchWatchlistOutputs,
   fetchWatchlistSources,
   fetchScrapedItems,
+  getWatchlistRunDiagnostics,
   getWatchlistRunAudio,
   getRunDetails,
+  retryWatchlistRunAudio,
+  retryWatchlistRunDelivery,
   triggerWatchlistRun,
   updateScrapedItem
 } from "@/services/watchlists"
@@ -125,6 +128,9 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
   const [streamingEnabled, setStreamingEnabled] = useState(true)
   const [cancelState, setCancelState] = useState<"idle" | "cancelling" | "failed-to-cancel">("idle")
   const [retryingRun, setRetryingRun] = useState(false)
+  const [retryingDelivery, setRetryingDelivery] = useState(false)
+  const [retryingAudio, setRetryingAudio] = useState(false)
+  const [exportingDiagnostics, setExportingDiagnostics] = useState(false)
   const [sourceNamesById, setSourceNamesById] = useState<Record<number, string>>({})
   const [linkedOutputCount, setLinkedOutputCount] = useState<number | null>(null)
   const [linkedOutputsLoading, setLinkedOutputsLoading] = useState(false)
@@ -160,6 +166,20 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
 
   const downloadCsv = (content: string, filename: string): void => {
     const blob = new Blob([content], { type: "text/csv;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = filename
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(url)
+  }
+
+  const downloadJson = (content: unknown, filename: string): void => {
+    const blob = new Blob([JSON.stringify(content, null, 2)], {
+      type: "application/json;charset=utf-8"
+    })
     const url = URL.createObjectURL(blob)
     const anchor = document.createElement("a")
     anchor.href = url
@@ -996,6 +1016,68 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
     }
   }
 
+  const handleRetryDelivery = async () => {
+    if (!runId || retryingDelivery) return
+    setRetryingDelivery(true)
+    try {
+      const result = await retryWatchlistRunDelivery(runId)
+      message.success(
+        t("watchlists:runs.detail.deliveryRetrySuccess", "Delivery retry completed for output #{{id}}.", {
+          id: result.output_id ?? "-"
+        })
+      )
+      void loadRunDetails()
+    } catch (err) {
+      console.error("Failed to retry delivery:", err)
+      message.error(t("watchlists:runs.detail.deliveryRetryError", "Failed to retry delivery"))
+    } finally {
+      setRetryingDelivery(false)
+    }
+  }
+
+  const handleRetryAudio = async () => {
+    if (!runId || retryingAudio) return
+    setRetryingAudio(true)
+    try {
+      const result = await retryWatchlistRunAudio(runId)
+      if (result.task_id) {
+        setAudioStatus((prev) => ({
+          ...(prev || { run_id: runId }),
+          run_id: runId,
+          task_id: result.task_id,
+          status: "pending",
+          audio_uri: null,
+          download_url: null,
+          error: null
+        }))
+      }
+      message.success(
+        t("watchlists:runs.detail.audioRetrySuccess", "Audio retry queued.")
+      )
+      void loadRunDetails()
+    } catch (err) {
+      console.error("Failed to retry audio:", err)
+      message.error(t("watchlists:runs.detail.audioRetryError", "Failed to retry audio"))
+    } finally {
+      setRetryingAudio(false)
+    }
+  }
+
+  const handleDownloadDiagnostics = async () => {
+    if (!runId || exportingDiagnostics) return
+    setExportingDiagnostics(true)
+    try {
+      const diagnostics = await getWatchlistRunDiagnostics(runId)
+      downloadJson(diagnostics, `watchlists_run_${runId}_diagnostics_${Date.now()}.json`)
+      message.success(t("watchlists:runs.detail.diagnosticsExported", "Diagnostics downloaded"))
+    } catch (err) {
+      console.error("Failed to download run diagnostics:", err)
+      message.error(t("watchlists:runs.detail.diagnosticsExportError", "Failed to download diagnostics"))
+    } finally {
+      setExportingDiagnostics(false)
+    }
+  }
+
   const handleEditMonitor = () => {
     if (!data?.job_id) return
     setActiveTab("jobs")
@@ -1074,6 +1156,16 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
             )}
           </div>
         )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="small"
+            onClick={handleRetryAudio}
+            loading={retryingAudio}
+          >
+            {t("watchlists:runs.detail.retryAudio", "Retry audio")}
+          </Button>
+        </div>
       </div>
     )
   }
@@ -1112,6 +1204,22 @@ export const RunDetailDrawer: React.FC<RunDetailDrawerProps> = ({
                     onClick={handleOpenOutputs}
                   >
                     {t("watchlists:runs.detail.openRunOutputs", "Open reports for this run")}
+                  </Button>
+                  <Button
+                    size="small"
+                    loading={retryingDelivery}
+                    disabled={(linkedOutputCount ?? 0) <= 0}
+                    onClick={handleRetryDelivery}
+                  >
+                    {t("watchlists:runs.detail.retryDelivery", "Retry delivery")}
+                  </Button>
+                  <Button
+                    size="small"
+                    icon={<Download className="h-3.5 w-3.5" />}
+                    loading={exportingDiagnostics}
+                    onClick={handleDownloadDiagnostics}
+                  >
+                    {t("watchlists:runs.detail.downloadDiagnostics", "Download diagnostics")}
                   </Button>
                 </div>
               </div>

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
@@ -11,6 +11,9 @@ const mocks = vi.hoisted(() => ({
   fetchWatchlistSourcesMock: vi.fn(),
   fetchWatchlistOutputsMock: vi.fn(),
   getWatchlistRunAudioMock: vi.fn(),
+  getWatchlistRunDiagnosticsMock: vi.fn(),
+  retryWatchlistRunAudioMock: vi.fn(),
+  retryWatchlistRunDeliveryMock: vi.fn(),
   updateScrapedItemMock: vi.fn(),
   exportRunTalliesCsvMock: vi.fn(),
   triggerWatchlistRunMock: vi.fn(),
@@ -161,7 +164,10 @@ vi.mock("@/services/watchlists", () => ({
   fetchScrapedItems: (...args: any[]) => mocks.fetchScrapedItemsMock(...args),
   fetchWatchlistOutputs: (...args: any[]) => mocks.fetchWatchlistOutputsMock(...args),
   fetchWatchlistSources: (...args: any[]) => mocks.fetchWatchlistSourcesMock(...args),
+  getWatchlistRunDiagnostics: (...args: any[]) => mocks.getWatchlistRunDiagnosticsMock(...args),
   getWatchlistRunAudio: (...args: any[]) => mocks.getWatchlistRunAudioMock(...args),
+  retryWatchlistRunAudio: (...args: any[]) => mocks.retryWatchlistRunAudioMock(...args),
+  retryWatchlistRunDelivery: (...args: any[]) => mocks.retryWatchlistRunDeliveryMock(...args),
   getRunDetails: (...args: any[]) => mocks.getRunDetailsMock(...args),
   triggerWatchlistRun: (...args: any[]) => mocks.triggerWatchlistRunMock(...args),
   updateScrapedItem: (...args: any[]) => mocks.updateScrapedItemMock(...args)
@@ -255,6 +261,7 @@ describe("RunDetailDrawer stream lifecycle", () => {
     vi.clearAllMocks()
     MockWebSocket.reset()
     vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket)
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined)
     mocks.translateMock.mockImplementation(
       (key: string, defaultValue?: unknown, options?: Record<string, unknown>) => {
         if (typeof defaultValue !== "string") return key
@@ -294,6 +301,24 @@ describe("RunDetailDrawer stream lifecycle", () => {
       status: "unknown",
       download_url: null
     })
+    mocks.getWatchlistRunDiagnosticsMock.mockResolvedValue({
+      run_id: 10,
+      generated_at: "2026-05-19T04:00:00Z",
+      run: { id: 10, status: "completed" }
+    })
+    mocks.retryWatchlistRunAudioMock.mockResolvedValue({
+      run_id: 10,
+      stage: "audio",
+      retried: true,
+      task_id: "retry-audio-10"
+    })
+    mocks.retryWatchlistRunDeliveryMock.mockResolvedValue({
+      run_id: 10,
+      stage: "delivery",
+      retried: true,
+      output_id: 55,
+      delivery_results: [{ channel: "email", status: "sent" }]
+    })
     mocks.updateScrapedItemMock.mockResolvedValue({})
     mocks.exportRunTalliesCsvMock.mockResolvedValue("")
     mocks.triggerWatchlistRunMock.mockResolvedValue({ id: 999, status: "pending", job_id: 1 })
@@ -304,6 +329,7 @@ describe("RunDetailDrawer stream lifecycle", () => {
     cleanup()
     vi.useRealTimers()
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   const waitForFirstSocket = async (): Promise<MockWebSocket> => {
@@ -426,6 +452,51 @@ describe("RunDetailDrawer stream lifecycle", () => {
     })
     const link = screen.getByRole("link", { name: "Download final audio" })
     expect(link).toHaveAttribute("href", "/api/v1/watchlists/runs/10/audio/download")
+  })
+
+  it("offers stage-specific retry and diagnostics controls without triggering a full rerun", async () => {
+    mocks.getRunDetailsMock.mockResolvedValue({
+      ...baseRunDetails,
+      status: "completed",
+      finished_at: "2026-02-18T10:01:00Z",
+      stats: {
+        ...baseRunDetails.stats,
+        audio_briefing_task_id: "audio-task-10"
+      }
+    })
+    mocks.fetchWatchlistOutputsMock.mockResolvedValue({
+      items: [{ id: 55 }],
+      total: 1,
+      page: 1,
+      size: 1,
+      has_more: false
+    })
+    mocks.getWatchlistRunAudioMock.mockResolvedValue({
+      run_id: 10,
+      task_id: "audio-task-10",
+      status: "failed",
+      download_url: null,
+      error: "tts_failed"
+    })
+
+    render(<RunDetailDrawer open runId={10} onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Retry delivery" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Retry audio" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Download diagnostics" })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry delivery" }))
+    fireEvent.click(screen.getByRole("button", { name: "Retry audio" }))
+    fireEvent.click(screen.getByRole("button", { name: "Download diagnostics" }))
+
+    await waitFor(() => {
+      expect(mocks.retryWatchlistRunDeliveryMock).toHaveBeenCalledWith(10)
+      expect(mocks.retryWatchlistRunAudioMock).toHaveBeenCalledWith(10)
+      expect(mocks.getWatchlistRunDiagnosticsMock).toHaveBeenCalledWith(10)
+    })
+    expect(mocks.triggerWatchlistRunMock).not.toHaveBeenCalled()
   })
 
   it("reconnects after unexpected close when run is non-terminal", async () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   openJobFormMock: vi.fn(),
   messageErrorMock: vi.fn(),
   messageSuccessMock: vi.fn(),
+  messageWarningMock: vi.fn(),
   translateMock: vi.fn(
     (key: string, defaultValue?: unknown, options?: Record<string, unknown>) => {
       if (typeof defaultValue !== "string") return key
@@ -141,7 +142,7 @@ vi.mock("antd", () => {
     message: {
       error: mocks.messageErrorMock,
       success: mocks.messageSuccessMock,
-      warning: vi.fn()
+      warning: mocks.messageWarningMock
     }
   }
 })
@@ -496,6 +497,63 @@ describe("RunDetailDrawer stream lifecycle", () => {
       expect(mocks.retryWatchlistRunAudioMock).toHaveBeenCalledWith(10)
       expect(mocks.getWatchlistRunDiagnosticsMock).toHaveBeenCalledWith(10)
     })
+    expect(mocks.triggerWatchlistRunMock).not.toHaveBeenCalled()
+  })
+
+  it("does not report success when stage-specific retries are skipped", async () => {
+    mocks.getRunDetailsMock.mockResolvedValue({
+      ...baseRunDetails,
+      status: "completed",
+      finished_at: "2026-02-18T10:01:00Z",
+      stats: {
+        ...baseRunDetails.stats,
+        audio_briefing_task_id: "audio-task-10"
+      }
+    })
+    mocks.fetchWatchlistOutputsMock.mockResolvedValue({
+      items: [{ id: 55 }],
+      total: 1,
+      page: 1,
+      size: 1,
+      has_more: false
+    })
+    mocks.getWatchlistRunAudioMock.mockResolvedValue({
+      run_id: 10,
+      task_id: "audio-task-10",
+      status: "failed",
+      download_url: null,
+      error: "tts_failed"
+    })
+    mocks.retryWatchlistRunDeliveryMock.mockResolvedValue({
+      run_id: 10,
+      stage: "delivery",
+      retried: false,
+      message: "Delivery retry was skipped."
+    })
+    mocks.retryWatchlistRunAudioMock.mockResolvedValue({
+      run_id: 10,
+      stage: "audio",
+      retried: false,
+      message: "Audio retry was skipped."
+    })
+
+    render(<RunDetailDrawer open runId={10} onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Retry delivery" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Retry audio" })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry delivery" }))
+    fireEvent.click(screen.getByRole("button", { name: "Retry audio" }))
+
+    await waitFor(() => {
+      expect(mocks.retryWatchlistRunDeliveryMock).toHaveBeenCalledWith(10)
+      expect(mocks.retryWatchlistRunAudioMock).toHaveBeenCalledWith(10)
+    })
+    expect(mocks.messageWarningMock).toHaveBeenCalledWith("Delivery retry was skipped.")
+    expect(mocks.messageWarningMock).toHaveBeenCalledWith("Audio retry was skipped.")
+    expect(mocks.messageSuccessMock).not.toHaveBeenCalled()
     expect(mocks.triggerWatchlistRunMock).not.toHaveBeenCalled()
   })
 

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
@@ -19,6 +19,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   Circle,
+  Copy,
   Download,
   Edit2,
   ExternalLink,
@@ -73,6 +74,7 @@ import { getSourceStatusVisual, type SourceStatusIconToken } from "./sourceStatu
 import { findActiveSourceUsage, mapActiveSourceUsage } from "./source-usage"
 import { mapWatchlistsError } from "../shared/watchlists-error"
 import { useWatchlistsViewport } from "../shared/useWatchlistsViewport"
+import { buildClonedWatchlistSourcePayload } from "./clone-utils"
 
 const { Search } = Input
 
@@ -179,6 +181,7 @@ export const SourcesTab: React.FC = () => {
   )
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([])
   const [bulkWorking, setBulkWorking] = useState(false)
+  const [cloningSourceId, setCloningSourceId] = useState<number | null>(null)
   const [bulkMoveTargetValue, setBulkMoveTargetValue] = useState<BulkMoveTargetValue>(null)
   const [checkingSourceIds, setCheckingSourceIds] = useState<number[]>([])
   const [importOpen, setImportOpen] = useState(false)
@@ -1162,6 +1165,29 @@ export const SourcesTab: React.FC = () => {
     }
   }
 
+  const handleCloneSource = async (source: WatchlistSource) => {
+    setCloningSourceId(source.id)
+    try {
+      const cloned = await createWatchlistSource(
+        buildClonedWatchlistSourcePayload(source, selectedWatchlistId)
+      )
+      addSource(cloned)
+      message.success(
+        t(
+          "watchlists:sources.cloneSuccess",
+          "Feed cloned as an inactive copy. Review and enable it when ready."
+        )
+      )
+      void loadSources()
+      void loadTags()
+    } catch (err) {
+      console.error("Failed to clone source:", err)
+      message.error(t("watchlists:sources.cloneError", "Failed to clone feed"))
+    } finally {
+      setCloningSourceId(null)
+    }
+  }
+
   // Get source for editing
   const editingSource = sourceFormEditId
     ? sources.find((s) => s.id === sourceFormEditId)
@@ -1376,6 +1402,16 @@ export const SourcesTab: React.FC = () => {
               onClick={() => setSeenDrawerSourceId(record.id)}
             />
           </Tooltip>
+          <Tooltip title={t("watchlists:sources.clone", "Clone")}>
+            <Button
+              type="text"
+              size="small"
+              aria-label={t("watchlists:sources.cloneFeedAria", "Clone {{name}}", { name: record.name })}
+              icon={<Copy className="h-4 w-4" />}
+              loading={cloningSourceId === record.id}
+              onClick={() => handleCloneSource(record)}
+            />
+          </Tooltip>
           <Tooltip title={t("common:delete", "Delete")}>
             <Button
               type="text"
@@ -1523,6 +1559,14 @@ export const SourcesTab: React.FC = () => {
                   aria-label={t("watchlists:sources.seenInfoForSourceAria", "Source Health & Dedup Stats for {{name}}", { name: source.name })}
                   icon={<Eye className="h-4 w-4" />}
                   onClick={() => setSeenDrawerSourceId(source.id)}
+                />
+                <Button
+                  type="text"
+                  size="small"
+                  aria-label={t("watchlists:sources.cloneFeedAria", "Clone {{name}}", { name: source.name })}
+                  icon={<Copy className="h-4 w-4" />}
+                  loading={cloningSourceId === source.id}
+                  onClick={() => handleCloneSource(source)}
                 />
                 <Button
                   type="text"

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
@@ -181,7 +181,8 @@ export const SourcesTab: React.FC = () => {
   )
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([])
   const [bulkWorking, setBulkWorking] = useState(false)
-  const [cloningSourceId, setCloningSourceId] = useState<number | null>(null)
+  const cloningSourceIdsRef = useRef<Set<number>>(new Set())
+  const [cloningSourceIds, setCloningSourceIds] = useState<Set<number>>(() => new Set())
   const [bulkMoveTargetValue, setBulkMoveTargetValue] = useState<BulkMoveTargetValue>(null)
   const [checkingSourceIds, setCheckingSourceIds] = useState<number[]>([])
   const [importOpen, setImportOpen] = useState(false)
@@ -1165,8 +1166,29 @@ export const SourcesTab: React.FC = () => {
     }
   }
 
+  const startCloningSource = useCallback((sourceId: number) => {
+    if (cloningSourceIdsRef.current.has(sourceId)) {
+      return false
+    }
+    const next = new Set(cloningSourceIdsRef.current)
+    next.add(sourceId)
+    cloningSourceIdsRef.current = next
+    setCloningSourceIds(next)
+    return true
+  }, [])
+
+  const finishCloningSource = useCallback((sourceId: number) => {
+    if (!cloningSourceIdsRef.current.has(sourceId)) {
+      return
+    }
+    const next = new Set(cloningSourceIdsRef.current)
+    next.delete(sourceId)
+    cloningSourceIdsRef.current = next
+    setCloningSourceIds(next)
+  }, [])
+
   const handleCloneSource = async (source: WatchlistSource) => {
-    setCloningSourceId(source.id)
+    if (!startCloningSource(source.id)) return
     try {
       const cloned = await createWatchlistSource(
         buildClonedWatchlistSourcePayload(source, selectedWatchlistId)
@@ -1184,7 +1206,7 @@ export const SourcesTab: React.FC = () => {
       console.error("Failed to clone source:", err)
       message.error(t("watchlists:sources.cloneError", "Failed to clone feed"))
     } finally {
-      setCloningSourceId(null)
+      finishCloningSource(source.id)
     }
   }
 
@@ -1408,7 +1430,7 @@ export const SourcesTab: React.FC = () => {
               size="small"
               aria-label={t("watchlists:sources.cloneFeedAria", "Clone {{name}}", { name: record.name })}
               icon={<Copy className="h-4 w-4" />}
-              loading={cloningSourceId === record.id}
+              loading={cloningSourceIds.has(record.id)}
               onClick={() => handleCloneSource(record)}
             />
           </Tooltip>
@@ -1565,7 +1587,7 @@ export const SourcesTab: React.FC = () => {
                   size="small"
                   aria-label={t("watchlists:sources.cloneFeedAria", "Clone {{name}}", { name: source.name })}
                   icon={<Copy className="h-4 w-4" />}
-                  loading={cloningSourceId === source.id}
+                  loading={cloningSourceIds.has(source.id)}
                   onClick={() => handleCloneSource(source)}
                 />
                 <Button

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/clone-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/clone-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { buildClonedWatchlistSourcePayload } from "../clone-utils"
+import type { WatchlistSource } from "@/types/watchlists"
+
+const buildSource = (): WatchlistSource => ({
+  id: 9,
+  name: "Example News RSS",
+  url: "https://example.com/rss.xml",
+  source_type: "rss",
+  active: true,
+  tags: ["news", "daily"],
+  group_ids: [3, 4],
+  watchlist_ids: [2],
+  settings: {
+    fetch: { user_agent: "tldw-test" },
+    extraction: { title_selector: "h1" },
+    dedupe: { identity: ["canonical_url", "title"] }
+  },
+  last_scraped_at: "2026-05-01T12:00:00Z",
+  status: "healthy",
+  created_at: "2026-05-01T10:00:00Z",
+  updated_at: "2026-05-01T11:00:00Z"
+})
+
+describe("buildClonedWatchlistSourcePayload", () => {
+  it("preserves source rules and assignments while resetting runtime scrape state", () => {
+    const original = buildSource()
+
+    const clone = buildClonedWatchlistSourcePayload(original, 2)
+
+    expect(clone).toEqual({
+      name: "Example News RSS copy",
+      url: "https://example.com/rss.xml",
+      source_type: "rss",
+      active: false,
+      tags: ["news", "daily"],
+      settings: original.settings,
+      group_ids: [3, 4],
+      watchlist_id: 2
+    })
+    expect(JSON.stringify(clone)).not.toContain("last_scraped_at")
+    expect(JSON.stringify(clone)).not.toContain("status")
+    expect(JSON.stringify(clone)).not.toContain("seen")
+  })
+
+  it("deep clones nested settings and list fields", () => {
+    const original = buildSource()
+    const clone = buildClonedWatchlistSourcePayload(original, 2)
+
+    clone.tags!.push("copy")
+    ;(clone.settings!.dedupe as Record<string, string[]>).identity.push("published_at")
+    clone.group_ids!.push(5)
+
+    expect(original.tags).toEqual(["news", "daily"])
+    expect((original.settings!.dedupe as Record<string, string[]>).identity).toEqual([
+      "canonical_url",
+      "title"
+    ])
+    expect(original.group_ids).toEqual([3, 4])
+  })
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/clone-utils.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/clone-utils.ts
@@ -1,0 +1,23 @@
+import type { WatchlistSource, WatchlistSourceCreate } from "@/types/watchlists"
+
+const cloneValue = <T>(value: T): T => {
+  if (value == null) return value
+  if (typeof structuredClone === "function") {
+    return structuredClone(value)
+  }
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+export const buildClonedWatchlistSourcePayload = (
+  source: WatchlistSource,
+  watchlistId?: number | null
+): WatchlistSourceCreate => ({
+  name: `${source.name} copy`,
+  url: source.url,
+  source_type: source.source_type,
+  active: false,
+  tags: cloneValue(source.tags || []),
+  settings: source.settings ? cloneValue(source.settings) : source.settings ?? null,
+  group_ids: cloneValue(source.group_ids || []),
+  watchlist_id: watchlistId ?? source.watchlist_ids?.[0]
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
@@ -29,6 +29,8 @@ import {
   createWatchlist,
   createWatchlistJob,
   createWatchlistSource,
+  exportOpml,
+  exportRunsCsv,
   fetchWatchlistRuns,
   fetchWatchlists,
   triggerWatchlistRun,
@@ -702,6 +704,56 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
   const [refreshKey, setRefreshKey] = React.useState(0)
   const triggerRefresh = useCallback(() => setRefreshKey((k) => k + 1), [])
 
+  const downloadTextFile = useCallback((content: string, filename: string, type: string) => {
+    const blob = new Blob([content], { type })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = filename
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(url)
+  }, [])
+
+  const exportSourcesFromPalette = useCallback(async () => {
+    try {
+      const opml = await exportOpml()
+      downloadTextFile(opml, `watchlists_sources_${Date.now()}.opml`, "application/xml")
+      notification.success({
+        message: t("watchlists:sources.exported", "OPML exported"),
+        placement: "bottomRight",
+        duration: 5
+      })
+    } catch (err) {
+      console.error("Failed to export watchlist feeds from command palette:", err)
+      notification.error({
+        message: t("watchlists:sources.exportError", "Failed to export OPML"),
+        placement: "bottomRight",
+        duration: 5
+      })
+    }
+  }, [downloadTextFile, notification, t])
+
+  const exportRunsFromPalette = useCallback(async () => {
+    try {
+      const csv = await exportRunsCsv({ scope: "global", include_tallies: true })
+      downloadTextFile(csv, `watchlists_runs_${Date.now()}.csv`, "text/csv;charset=utf-8")
+      notification.success({
+        message: t("watchlists:runs.exported", "Activity CSV exported"),
+        placement: "bottomRight",
+        duration: 5
+      })
+    } catch (err) {
+      console.error("Failed to export watchlist activity from command palette:", err)
+      notification.error({
+        message: t("watchlists:runs.exportError", "Failed to export activity CSV"),
+        placement: "bottomRight",
+        duration: 5
+      })
+    }
+  }, [downloadTextFile, notification, t])
+
   const tabHelpLabels = {
     overview: t("watchlists:help.tabs.overview", "Overview guidance"),
     sources: t("watchlists:help.tabs.sources", "Feeds setup"),
@@ -1152,8 +1204,19 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
     openJobForm: () => openJobForm(),
     openSettings: () => setSettingsDrawerOpen(true),
     refreshCurrentView: triggerRefresh,
-    startGuidedTour
-  }), [navigateToTab, openSourceForm, openJobForm, triggerRefresh, startGuidedTour])
+    startGuidedTour,
+    createPipeline: () => setSetupWizardOpen(true),
+    exportSources: exportSourcesFromPalette,
+    exportRuns: exportRunsFromPalette
+  }), [
+    navigateToTab,
+    openSourceForm,
+    openJobForm,
+    triggerRefresh,
+    startGuidedTour,
+    exportSourcesFromPalette,
+    exportRunsFromPalette
+  ])
   const commandPaletteCommands = useWatchlistsCommands(commandPaletteActions)
 
   // Keyboard shortcuts — memoize actions to avoid event listener churn

--- a/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
@@ -24,6 +24,7 @@ import { useAntdNotification } from "@/hooks/useAntdNotification"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import { PageShell } from "@/components/Common/PageShell"
 import WorkspaceConnectionGate from "@/components/Common/WorkspaceConnectionGate"
+import { downloadBlob } from "@/utils/download-blob"
 import {
   bulkCreateSources,
   createWatchlist,
@@ -704,22 +705,10 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
   const [refreshKey, setRefreshKey] = React.useState(0)
   const triggerRefresh = useCallback(() => setRefreshKey((k) => k + 1), [])
 
-  const downloadTextFile = useCallback((content: string, filename: string, type: string) => {
-    const blob = new Blob([content], { type })
-    const url = URL.createObjectURL(blob)
-    const anchor = document.createElement("a")
-    anchor.href = url
-    anchor.download = filename
-    document.body.appendChild(anchor)
-    anchor.click()
-    document.body.removeChild(anchor)
-    URL.revokeObjectURL(url)
-  }, [])
-
   const exportSourcesFromPalette = useCallback(async () => {
     try {
       const opml = await exportOpml()
-      downloadTextFile(opml, `watchlists_sources_${Date.now()}.opml`, "application/xml")
+      downloadBlob(new Blob([opml], { type: "application/xml" }), `watchlists_sources_${Date.now()}.opml`)
       notification.success({
         message: t("watchlists:sources.exported", "OPML exported"),
         placement: "bottomRight",
@@ -733,12 +722,12 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
         duration: 5
       })
     }
-  }, [downloadTextFile, notification, t])
+  }, [notification, t])
 
   const exportRunsFromPalette = useCallback(async () => {
     try {
       const csv = await exportRunsCsv({ scope: "global", include_tallies: true })
-      downloadTextFile(csv, `watchlists_runs_${Date.now()}.csv`, "text/csv;charset=utf-8")
+      downloadBlob(new Blob([csv], { type: "text/csv;charset=utf-8" }), `watchlists_runs_${Date.now()}.csv`)
       notification.success({
         message: t("watchlists:runs.exported", "Activity CSV exported"),
         placement: "bottomRight",
@@ -752,7 +741,7 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
         duration: 5
       })
     }
-  }, [downloadTextFile, notification, t])
+  }, [notification, t])
 
   const tabHelpLabels = {
     overview: t("watchlists:help.tabs.overview", "Overview guidance"),

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsCommandPalette.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsCommandPalette.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useMemo, useState } from "react"
 import { Input, Modal } from "antd"
 import {
   CalendarClock,
+  Copy,
+  Download,
   FileOutput,
   FileText,
   Newspaper,
@@ -20,6 +22,7 @@ export interface CommandPaletteCommand {
   icon: React.ReactNode
   category: "navigate" | "create" | "action"
   keywords?: string[]
+  disabledReason?: string
   onExecute: () => void
 }
 
@@ -74,6 +77,7 @@ export const WatchlistsCommandPalette: React.FC<WatchlistsCommandPaletteProps> =
 
   const handleSelect = useCallback(
     (cmd: CommandPaletteCommand) => {
+      if (cmd.disabledReason) return
       onClose()
       setQuery("")
       cmd.onExecute()
@@ -124,17 +128,29 @@ export const WatchlistsCommandPalette: React.FC<WatchlistsCommandPaletteProps> =
               {cmds.map((cmd) => (
                 <div
                   key={cmd.id}
-                  className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-surface-hover"
+                  className={`flex items-center gap-2 rounded px-2 py-1.5 text-sm ${
+                    cmd.disabledReason
+                      ? "cursor-not-allowed opacity-60"
+                      : "cursor-pointer hover:bg-surface-hover"
+                  }`}
                   onClick={() => handleSelect(cmd)}
                   role="button"
                   tabIndex={0}
+                  aria-disabled={cmd.disabledReason ? true : undefined}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") handleSelect(cmd)
                   }}
                   data-testid={`watchlists-command-${cmd.id}`}
                 >
                   <span className="text-text-muted">{cmd.icon}</span>
-                  <span className="flex-1">{cmd.label}</span>
+                  <span className="flex-1">
+                    <span>{cmd.label}</span>
+                    {cmd.disabledReason && (
+                      <span className="block text-xs text-text-muted">
+                        {cmd.disabledReason}
+                      </span>
+                    )}
+                  </span>
                 </div>
               ))}
             </div>
@@ -156,6 +172,9 @@ export const useWatchlistsCommands = (actions: {
   openSettings: () => void
   refreshCurrentView: () => void
   startGuidedTour: () => void
+  createPipeline?: () => void
+  exportSources?: () => void
+  exportRuns?: () => void
 }): CommandPaletteCommand[] => {
   const { t } = useTranslation(["watchlists"])
 
@@ -210,6 +229,20 @@ export const useWatchlistsCommands = (actions: {
         onExecute: () => actions.setActiveTab("templates")
       },
       {
+        id: "create-pipeline",
+        label: t("watchlists:commandPalette.commands.createPipeline", "Create pipeline"),
+        icon: <Plus className="h-4 w-4" />,
+        category: "create" as const,
+        keywords: ["wizard", "pipeline", "digest", "audio", "briefing"],
+        disabledReason: actions.createPipeline
+          ? undefined
+          : t(
+              "watchlists:commandPalette.unavailable.createPipeline",
+              "Pipeline wizard is unavailable in this view."
+            ),
+        onExecute: actions.createPipeline || (() => undefined)
+      },
+      {
         id: "create-feed",
         label: t("watchlists:commandPalette.commands.createFeed", "Create feed"),
         icon: <Plus className="h-4 w-4" />,
@@ -238,6 +271,106 @@ export const useWatchlistsCommands = (actions: {
         category: "action" as const,
         keywords: ["reload", "update"],
         onExecute: actions.refreshCurrentView
+      },
+      {
+        id: "action-clone-feed",
+        label: t("watchlists:commandPalette.commands.cloneFeed", "Clone selected feed"),
+        icon: <Copy className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["copy", "duplicate", "source", "feed"],
+        disabledReason: t(
+          "watchlists:commandPalette.unavailable.cloneFeed",
+          "Choose a feed row to clone."
+        ),
+        onExecute: () => undefined
+      },
+      {
+        id: "action-clone-monitor",
+        label: t("watchlists:commandPalette.commands.cloneMonitor", "Clone selected monitor"),
+        icon: <Copy className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["copy", "duplicate", "job", "monitor"],
+        disabledReason: t(
+          "watchlists:commandPalette.unavailable.cloneMonitor",
+          "Choose a monitor row to clone."
+        ),
+        onExecute: () => undefined
+      },
+      {
+        id: "action-validate-feeds",
+        label: t("watchlists:commandPalette.commands.validateFeeds", "Validate feeds"),
+        icon: <RefreshCw className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["test", "check", "validate", "sources"],
+        disabledReason: t(
+          "watchlists:commandPalette.unavailable.validateFeeds",
+          "Select feeds in the Feeds table, then use Check Now."
+        ),
+        onExecute: () => undefined
+      },
+      {
+        id: "action-run-monitor",
+        label: t("watchlists:commandPalette.commands.runMonitor", "Run monitor"),
+        icon: <Play className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["run", "start", "monitor", "job"],
+        disabledReason: t(
+          "watchlists:commandPalette.unavailable.runMonitor",
+          "Choose a monitor row to run."
+        ),
+        onExecute: () => undefined
+      },
+      {
+        id: "action-preview-monitor",
+        label: t("watchlists:commandPalette.commands.previewMonitor", "Preview monitor"),
+        icon: <FileText className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["preview", "monitor", "job"],
+        disabledReason: t(
+          "watchlists:commandPalette.unavailable.previewMonitor",
+          "Choose a monitor row to preview."
+        ),
+        onExecute: () => undefined
+      },
+      {
+        id: "action-retry-run",
+        label: t("watchlists:commandPalette.commands.retryRun", "Retry failed run"),
+        icon: <RefreshCw className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["retry", "failed", "activity", "run"],
+        disabledReason: t(
+          "watchlists:commandPalette.unavailable.retryRun",
+          "Open a failed run to choose full, delivery, or audio retry."
+        ),
+        onExecute: () => undefined
+      },
+      {
+        id: "action-export-sources",
+        label: t("watchlists:commandPalette.commands.exportSources", "Export feeds OPML"),
+        icon: <Download className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["export", "opml", "feeds", "sources"],
+        disabledReason: actions.exportSources
+          ? undefined
+          : t(
+              "watchlists:commandPalette.unavailable.exportSources",
+              "Feed export is unavailable in this view."
+            ),
+        onExecute: actions.exportSources || (() => undefined)
+      },
+      {
+        id: "action-export-runs",
+        label: t("watchlists:commandPalette.commands.exportRuns", "Export activity CSV"),
+        icon: <Download className="h-4 w-4" />,
+        category: "action" as const,
+        keywords: ["export", "csv", "runs", "activity"],
+        disabledReason: actions.exportRuns
+          ? undefined
+          : t(
+              "watchlists:commandPalette.unavailable.exportRuns",
+              "Activity export is unavailable in this view."
+            ),
+        onExecute: actions.exportRuns || (() => undefined)
       },
       {
         id: "action-settings",

--- a/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsCommandPalette.commands.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/shared/__tests__/WatchlistsCommandPalette.commands.test.tsx
@@ -1,0 +1,96 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import {
+  WatchlistsCommandPalette,
+  useWatchlistsCommands,
+  type CommandPaletteCommand
+} from "../WatchlistsCommandPalette"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: unknown) =>
+      typeof defaultValue === "string" ? defaultValue : _key
+  })
+}))
+
+vi.mock("antd", () => {
+  const Input = ({ value, onChange, placeholder }: any) => (
+    <input
+      aria-label={placeholder}
+      value={value || ""}
+      onChange={(event) => onChange?.(event)}
+    />
+  )
+  const Modal = ({ open, children }: any) => (open ? <div>{children}</div> : null)
+  return { Input, Modal }
+})
+
+const HookProbe = ({ onCommands }: { onCommands: (commands: CommandPaletteCommand[]) => void }) => {
+  const commands = useWatchlistsCommands({
+    setActiveTab: vi.fn(),
+    openSourceForm: vi.fn(),
+    openJobForm: vi.fn(),
+    openSettings: vi.fn(),
+    refreshCurrentView: vi.fn(),
+    startGuidedTour: vi.fn(),
+    createPipeline: vi.fn(),
+    exportSources: vi.fn(),
+    exportRuns: vi.fn()
+  })
+  React.useEffect(() => {
+    onCommands(commands)
+  }, [commands, onCommands])
+  return null
+}
+
+describe("WatchlistsCommandPalette command coverage", () => {
+  it("exposes create, clone, validate, run, preview, retry, and export commands", async () => {
+    let commands: CommandPaletteCommand[] = []
+    render(<HookProbe onCommands={(value) => { commands = value }} />)
+
+    const commandIds = commands.map((command) => command.id)
+    expect(commandIds).toEqual(
+      expect.arrayContaining([
+        "create-pipeline",
+        "create-feed",
+        "create-monitor",
+        "action-clone-feed",
+        "action-clone-monitor",
+        "action-validate-feeds",
+        "action-run-monitor",
+        "action-preview-monitor",
+        "action-retry-run",
+        "action-export-sources",
+        "action-export-runs"
+      ])
+    )
+    expect(commands.find((command) => command.id === "action-clone-feed")?.disabledReason).toBeTruthy()
+    expect(commands.find((command) => command.id === "action-export-runs")?.disabledReason).toBeUndefined()
+  })
+
+  it("renders unavailable command reasons inline instead of silently executing impossible actions", () => {
+    const onExecute = vi.fn()
+    render(
+      <WatchlistsCommandPalette
+        open
+        onClose={vi.fn()}
+        commands={[
+          {
+            id: "action-clone-feed",
+            label: "Clone selected feed",
+            icon: <span />,
+            category: "action",
+            disabledReason: "Choose a feed row to clone.",
+            onExecute
+          }
+        ]}
+      />
+    )
+
+    expect(screen.getByText("Clone selected feed")).toBeInTheDocument()
+    expect(screen.getByText("Choose a feed row to clone.")).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId("watchlists-command-action-clone-feed"))
+    expect(onExecute).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts
+++ b/apps/packages/ui/src/services/__tests__/watchlists-audio.test.ts
@@ -11,7 +11,12 @@ vi.mock("@/services/background-proxy", () => ({
   bgUpload: (...args: unknown[]) => mocks.bgUpload(...args)
 }))
 
-import { getWatchlistRunAudio } from "@/services/watchlists"
+import {
+  getWatchlistRunAudio,
+  getWatchlistRunDiagnostics,
+  retryWatchlistRunAudio,
+  retryWatchlistRunDelivery
+} from "@/services/watchlists"
 
 describe("watchlists audio services", () => {
   beforeEach(() => {
@@ -48,6 +53,64 @@ describe("watchlists audio services", () => {
       size_bytes: 1024,
       mime_type: "audio/mpeg"
     })
+  })
+
+  it("retries only the audio briefing stage for a run", async () => {
+    mocks.bgRequest.mockResolvedValueOnce({
+      run_id: 123,
+      stage: "audio",
+      retried: true,
+      task_id: "task-retry"
+    })
+
+    const result = await retryWatchlistRunAudio(123)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/watchlists/runs/123/retry-audio",
+        method: "POST"
+      })
+    )
+    expect(result.task_id).toBe("task-retry")
+  })
+
+  it("retries only the output delivery stage for a run", async () => {
+    mocks.bgRequest.mockResolvedValueOnce({
+      run_id: 123,
+      stage: "delivery",
+      retried: true,
+      output_id: 55,
+      delivery_results: [{ channel: "email", status: "sent" }]
+    })
+
+    const result = await retryWatchlistRunDelivery(123)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/watchlists/runs/123/retry-delivery",
+        method: "POST"
+      })
+    )
+    expect(result.delivery_results).toEqual([{ channel: "email", status: "sent" }])
+  })
+
+  it("fetches a run diagnostic bundle without rerunning ingestion", async () => {
+    mocks.bgRequest.mockResolvedValueOnce({
+      run_id: 123,
+      generated_at: "2026-05-19T04:00:00Z",
+      run: { id: 123, status: "failed" },
+      outputs: [{ id: 55, delivery_status: "failed" }]
+    })
+
+    const result = await getWatchlistRunDiagnostics(123)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/watchlists/runs/123/diagnostics",
+        method: "GET"
+      })
+    )
+    expect(result.run_id).toBe(123)
   })
 
   it("accepts backend-supported audio fields on output creation payloads", () => {

--- a/apps/packages/ui/src/services/watchlists.ts
+++ b/apps/packages/ui/src/services/watchlists.ts
@@ -54,6 +54,8 @@ import type {
   WatchlistReportReadiness,
   WatchlistRun,
   WatchlistRunAudioStatus,
+  WatchlistRunDiagnostics,
+  WatchlistRunStageRetryResponse,
   WatchlistSettings,
   WatchlistSource,
   WatchlistSourceCreate,
@@ -678,6 +680,33 @@ export const getWatchlistRunAudio = async (
 ): Promise<WatchlistRunAudioStatus> => {
   return bgRequest<WatchlistRunAudioStatus>({
     path: `/api/v1/watchlists/runs/${runId}/audio` as any,
+    method: "GET"
+  })
+}
+
+export const retryWatchlistRunAudio = async (
+  runId: number
+): Promise<WatchlistRunStageRetryResponse> => {
+  return bgRequest<WatchlistRunStageRetryResponse>({
+    path: `/api/v1/watchlists/runs/${runId}/retry-audio` as any,
+    method: "POST"
+  })
+}
+
+export const retryWatchlistRunDelivery = async (
+  runId: number
+): Promise<WatchlistRunStageRetryResponse> => {
+  return bgRequest<WatchlistRunStageRetryResponse>({
+    path: `/api/v1/watchlists/runs/${runId}/retry-delivery` as any,
+    method: "POST"
+  })
+}
+
+export const getWatchlistRunDiagnostics = async (
+  runId: number
+): Promise<WatchlistRunDiagnostics> => {
+  return bgRequest<WatchlistRunDiagnostics>({
+    path: `/api/v1/watchlists/runs/${runId}/diagnostics` as any,
     method: "GET"
   })
 }

--- a/apps/packages/ui/src/types/watchlists.ts
+++ b/apps/packages/ui/src/types/watchlists.ts
@@ -333,6 +333,26 @@ export interface WatchlistRunAudioStatus {
   error?: string | null
 }
 
+export interface WatchlistRunStageRetryResponse {
+  run_id: number
+  stage: "audio" | "delivery" | string
+  retried: boolean
+  task_id?: string | null
+  output_id?: number | null
+  delivery_results?: Array<Record<string, unknown>>
+  message?: string | null
+}
+
+export interface WatchlistRunDiagnostics {
+  run_id: number
+  generated_at: string
+  run: Record<string, unknown>
+  job?: Record<string, unknown> | null
+  outputs?: Array<Record<string, unknown>>
+  audio?: Record<string, unknown> | null
+  recovery?: Record<string, unknown> | null
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Scraped Item Types
 // ─────────────────────────────────────────────────────────────────────────────

--- a/backlog/tasks/task-436 - Implement-Watchlists-digest-audio-PR5-power-user-reuse-and-operator-recovery.md
+++ b/backlog/tasks/task-436 - Implement-Watchlists-digest-audio-PR5-power-user-reuse-and-operator-recovery.md
@@ -31,12 +31,12 @@ Implement PR5 Tasks 9-10 from Docs/superpowers/plans/2026-05-18-watchlists-diges
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Clone monitor preserves scope, cadence, filters, output, delivery, and audio cast fields where supported while resetting runtime state.
-- [ ] #2 Clone source preserves fetch/extraction/dedupe identity rules while resetting runtime status and seen state.
-- [ ] #3 Command palette exposes create, clone, run, preview, retry, and export actions where backing operations exist or clearly reports unavailable actions.
-- [ ] #4 Batch test/validation actions reuse safe existing APIs unless a backend endpoint is required.
-- [ ] #5 Operator diagnostics/retry controls distinguish delivery/audio retries from full ingestion reruns.
-- [ ] #6 Focused frontend and backend tests cover the implemented behavior, or skipped coverage is documented with the blocker.
+- [x] #1 Clone monitor preserves scope, cadence, filters, output, delivery, and audio cast fields where supported while resetting runtime state.
+- [x] #2 Clone source preserves fetch/extraction/dedupe identity rules while resetting runtime status and seen state.
+- [x] #3 Command palette exposes create, clone, run, preview, retry, and export actions where backing operations exist or clearly reports unavailable actions.
+- [x] #4 Batch test/validation actions reuse safe existing APIs unless a backend endpoint is required.
+- [x] #5 Operator diagnostics/retry controls distinguish delivery/audio retries from full ingestion reruns.
+- [x] #6 Focused frontend and backend tests cover the implemented behavior, or skipped coverage is documented with the blocker.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -59,10 +59,10 @@ Watchlists PR5 power-user reuse and recovery slice is implemented on codex/watch
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-436 - Implement-Watchlists-digest-audio-PR5-power-user-reuse-and-operator-recovery.md
+++ b/backlog/tasks/task-436 - Implement-Watchlists-digest-audio-PR5-power-user-reuse-and-operator-recovery.md
@@ -1,0 +1,68 @@
+---
+id: TASK-436
+title: Implement Watchlists digest/audio PR5 power-user reuse and operator recovery
+status: Done
+labels:
+- watchlists
+- frontend
+- backend
+- prd-pr5
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/clone-utils.ts
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobsTab.tsx
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/clone-utils.ts
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
+- apps/packages/ui/src/components/Option/Watchlists/shared/WatchlistsCommandPalette.tsx
+- apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
+- apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunDetailDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+- apps/packages/ui/src/services/watchlists.ts
+- apps/packages/ui/src/types/watchlists.ts
+- tldw_Server_API/app/api/v1/endpoints/watchlists.py
+- tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+- tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement PR5 Tasks 9-10 from Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md: power-user reuse/batch operations plus operator recovery/diagnostics for the Watchlists digest and audio briefing workflow.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Clone monitor preserves scope, cadence, filters, output, delivery, and audio cast fields where supported while resetting runtime state.
+- [ ] #2 Clone source preserves fetch/extraction/dedupe identity rules while resetting runtime status and seen state.
+- [ ] #3 Command palette exposes create, clone, run, preview, retry, and export actions where backing operations exist or clearly reports unavailable actions.
+- [ ] #4 Batch test/validation actions reuse safe existing APIs unless a backend endpoint is required.
+- [ ] #5 Operator diagnostics/retry controls distinguish delivery/audio retries from full ingestion reruns.
+- [ ] #6 Focused frontend and backend tests cover the implemented behavior, or skipped coverage is documented with the blocker.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implemented in PR5 local commit: clone helpers/actions for feeds and monitors; command-palette discovery for create/clone/run/preview/retry/export with disabled reasons when row context is required; stage-specific delivery/audio retry APIs and UI controls; diagnostics JSON export; quick-setup focus recovery hardening discovered during a11y verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Watchlists PR5 power-user reuse and recovery slice is implemented on codex/watchlists-pr5-reuse-recovery, rebased onto origin/dev. Verification passed: focused PR5 Vitest 20 tests, watchlists scale 53 tests, watchlists a11y 84 tests, watchlists static guard 3 tests, targeted backend pytest 11 tests, git diff --check, and Bandit on touched backend files with zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-438 - Address-PR-1864-Watchlists-review-comments.md
+++ b/backlog/tasks/task-438 - Address-PR-1864-Watchlists-review-comments.md
@@ -1,0 +1,42 @@
+---
+id: TASK-438
+title: Address PR 1864 Watchlists review comments
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address live review comments and CI failures for PR #1864, including Watchlists recovery endpoint safety, frontend retry/focus behavior, Backlog checklist consistency, and targeted verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Live PR #1864 review findings are verified against current code before patching.
+- [x] #2 Delegated recovery operations use the target user's Watchlists DB and Collections DB.
+- [x] #3 Delivery retry and diagnostics output only sanitized delivery status summaries.
+- [x] #4 Frontend retry and focus states accurately reflect skipped retries and modal close behavior.
+- [x] #5 Focused backend/frontend tests, Watchlists gates, diff check, and Bandit are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Resolved review findings for PR #1864 by adding target-user Collections DB resolution, async threadpool wrapping for synchronous output DB work, canonical text-artifact selection for delivery retries, sanitized delivery metadata/diagnostics, cross-user email fallback prevention, retry-skip warning states, per-row clone loading state, shared download helper reuse, quick-setup focus restoration hardening, deterministic admin webhook timing, and stronger operator recovery tests. Also checked the completed PR5 task checkboxes in TASK-436.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all currently actionable PR #1864 review comments and the observed CI failures. Verification passed locally: `python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py -q`, `python -m pytest tldw_Server_API/tests/Admin/test_admin_ops_webhooks_reports.py::TestWebhookDeliveryRecording::test_record_and_list_deliveries -q`, `bunx vitest run src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx`, `bun run test:watchlists:typecheck`, `bun run test:watchlists:scale`, `bun run test:watchlists:a11y`, `git diff --check`, and Bandit on touched backend files with `-s B101` for test asserts. Known skip: Bandit B101 is intentionally skipped for test files only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -173,7 +173,9 @@ from tldw_Server_API.app.api.v1.schemas.watchlists_schemas import (  # noqa: E40
     PreviewResponse,
     Run,
     RunCancelResponse,
+    RunDiagnosticsResponse,
     RunDetail,
+    RunStageRetryResponse,
     RunsListResponse,
     ScrapedItem,
     ScrapedItemBatchUpdateRequest,
@@ -4715,6 +4717,337 @@ async def stream_run(
         logger.error(f"Watchlists WS error: {exc}")
         with contextlib.suppress(_WATCHLISTS_NONCRITICAL_EXCEPTIONS):
             await stream.ws.close(code=status.WS_1011_INTERNAL_ERROR)
+
+
+# --------------------
+# Operator Recovery
+# --------------------
+
+
+def _parse_json_object(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except _WATCHLISTS_NONCRITICAL_EXCEPTIONS:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _output_row_summary(row: Any) -> dict[str, Any]:
+    metadata = _parse_output_metadata(row)
+    return {
+        "id": int(getattr(row, "id", 0) or 0),
+        "run_id": getattr(row, "run_id", None),
+        "job_id": getattr(row, "job_id", None),
+        "title": getattr(row, "title", None),
+        "format": getattr(row, "format", None),
+        "type": getattr(row, "type", None),
+        "created_at": getattr(row, "created_at", None),
+        "deliveries": metadata.get("deliveries") if isinstance(metadata.get("deliveries"), list) else [],
+        "delivery_plan_present": isinstance(metadata.get("delivery_plan"), dict),
+        "audio_briefing_status": metadata.get("audio_briefing_status"),
+        "audio_briefing_task_id": metadata.get("audio_briefing_task_id"),
+    }
+
+
+def _list_run_watchlist_outputs(collections_db: Any, run_id: int, *, limit: int = 10) -> list[Any]:
+    rows, _total = collections_db.list_output_artifacts(
+        run_id=run_id,
+        limit=limit,
+        offset=0,
+        metadata_origin="watchlists",
+    )
+    return list(rows or [])
+
+
+@router.post(
+    "/runs/{run_id}/retry-audio",
+    response_model=RunStageRetryResponse,
+    summary="Retry only the audio briefing stage for a run",
+)
+async def retry_run_audio(
+    run_id: int = Path(..., ge=1),
+    target_user_id: int | None = Query(
+        None,
+        ge=1,
+        description="Admin-only: retry audio for another user ID.",
+    ),
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+):
+    _enforce_runs_admin_if_configured(current_user)
+    resolved_user_id, target_db = await _resolve_target_watchlists_context(
+        current_user=current_user,
+        current_db=db,
+        target_user_id=target_user_id,
+    )
+    try:
+        run = target_db.get_run(run_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="run_not_found") from None
+    try:
+        job = target_db.get_job(run.job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="job_not_found") from None
+
+    output_prefs = _parse_json_object(getattr(job, "output_prefs_json", None))
+    if not output_prefs.get("generate_audio"):
+        run_stats = _parse_json_object(getattr(run, "stats_json", None))
+        if not run_stats.get("audio_briefing_task_id"):
+            raise HTTPException(status_code=400, detail="audio_not_configured")
+    output_prefs["generate_audio"] = True
+
+    from tldw_Server_API.app.core.Watchlists.audio_briefing_workflow import (
+        trigger_audio_briefing,
+    )
+
+    task_id = await trigger_audio_briefing(
+        user_id=int(resolved_user_id),
+        job_id=int(run.job_id),
+        run_id=run_id,
+        output_prefs=output_prefs,
+        db=target_db,
+    )
+    if not task_id:
+        raise HTTPException(status_code=409, detail="audio_retry_not_queued")
+
+    run_stats = _parse_json_object(getattr(run, "stats_json", None))
+    run_stats["audio_briefing_task_id"] = task_id
+    run_stats["audio_briefing_retry_task_id"] = task_id
+    run_stats["audio_briefing_status"] = "pending"
+    with contextlib.suppress(_WATCHLISTS_NONCRITICAL_EXCEPTIONS):
+        target_db.update_run(run_id, stats_json=json.dumps(run_stats))
+
+    return RunStageRetryResponse(
+        run_id=run_id,
+        stage="audio",
+        retried=True,
+        task_id=str(task_id),
+    )
+
+
+@router.post(
+    "/runs/{run_id}/retry-delivery",
+    response_model=RunStageRetryResponse,
+    summary="Retry only the output delivery stage for a run",
+)
+async def retry_run_delivery(
+    run_id: int = Path(..., ge=1),
+    target_user_id: int | None = Query(
+        None,
+        ge=1,
+        description="Admin-only: retry delivery for another user ID.",
+    ),
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+    collections_db=Depends(get_collections_db_for_user),
+):
+    _enforce_runs_admin_if_configured(current_user)
+    resolved_user_id, target_db = await _resolve_target_watchlists_context(
+        current_user=current_user,
+        current_db=db,
+        target_user_id=target_user_id,
+    )
+    try:
+        run = target_db.get_run(run_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="run_not_found") from None
+
+    output_rows = _list_run_watchlist_outputs(collections_db, run_id, limit=20)
+    if not output_rows:
+        raise HTTPException(status_code=404, detail="output_not_found")
+
+    selected_row = None
+    selected_metadata: dict[str, Any] = {}
+    for row in output_rows:
+        metadata = _parse_output_metadata(row)
+        if isinstance(metadata.get("delivery_plan"), dict):
+            selected_row = row
+            selected_metadata = metadata
+            break
+    if selected_row is None:
+        raise HTTPException(status_code=400, detail="delivery_plan_not_found")
+
+    output = await _row_to_output(selected_row, user_id=int(resolved_user_id))
+    title = output.title or f"watchlist-output-{output.id}"
+    output_format = output.format or getattr(selected_row, "format", None) or "md"
+    delivery_plan = selected_metadata.get("delivery_plan") or {}
+    notifications = NotificationsService(
+        user_id=int(resolved_user_id),
+        user_email=getattr(current_user, "email", None),
+    )
+    delivery_results: list[dict[str, Any]] = []
+    chatbook_path_update: str | None = None
+
+    email_cfg = delivery_plan.get("email") if isinstance(delivery_plan.get("email"), dict) else None
+    if email_cfg and bool(email_cfg.get("enabled", True)):
+        html_body, text_body = _build_email_bodies(
+            output.content or "",
+            output_format,
+            title,
+            email_cfg.get("body_format", "auto"),
+        )
+        attachments = None
+        if email_cfg.get("attach_file", True) and output.content:
+            ext = "html" if output_format == "html" else "md"
+            safe_base = title.replace("/", "_")
+            attachments = [
+                {
+                    "filename": f"{safe_base}.{ext}",
+                    "content": (output.content or "").encode("utf-8"),
+                }
+            ]
+        email_result = await notifications.deliver_email(
+            subject=email_cfg.get("subject") or title,
+            html_body=html_body,
+            text_body=text_body or None,
+            recipients=email_cfg.get("recipients"),
+            attachments=attachments,
+            fallback_to_user_email=True,
+        )
+        delivery_results.append(
+            {
+                "channel": email_result.channel,
+                "status": email_result.status,
+                **email_result.details,
+            }
+        )
+
+    chat_cfg = delivery_plan.get("chatbook") if isinstance(delivery_plan.get("chatbook"), dict) else None
+    if chat_cfg and bool(chat_cfg.get("enabled", True)):
+        chat_metadata = dict(chat_cfg.get("metadata") or {})
+        chat_metadata.update(
+            {
+                "job_id": int(run.job_id),
+                "run_id": run_id,
+                "output_id": output.id,
+            }
+        )
+        chat_result = notifications.deliver_chatbook(
+            title=chat_cfg.get("title") or title,
+            content=output.content or "",
+            description=chat_cfg.get("description"),
+            metadata=chat_metadata,
+            provider=chat_cfg.get("provider", "watchlists"),
+            model=chat_cfg.get("model", "watchlists"),
+            conversation_id=chat_cfg.get("conversation_id"),
+        )
+        delivery_results.append(
+            {
+                "channel": chat_result.channel,
+                "status": chat_result.status,
+                **chat_result.details,
+            }
+        )
+        doc_id = chat_result.details.get("document_id")
+        if chat_result.status == "stored" and doc_id is not None:
+            chatbook_path_update = f"generated_document:{doc_id}"
+            selected_metadata["chatbook_document_id"] = doc_id
+
+    if not delivery_results:
+        raise HTTPException(status_code=400, detail="delivery_channels_not_enabled")
+
+    selected_metadata["deliveries"] = delivery_results
+    selected_metadata.setdefault("delivery_retry_results", [])
+    if isinstance(selected_metadata["delivery_retry_results"], list):
+        selected_metadata["delivery_retry_results"].extend(delivery_results)
+    selected_metadata["delivery_retry_at"] = _utcnow_iso()
+    collections_db.update_output_artifact_metadata(
+        output.id,
+        metadata_json=json.dumps({k: v for k, v in selected_metadata.items() if v is not None}),
+        chatbook_path=chatbook_path_update,
+    )
+
+    return RunStageRetryResponse(
+        run_id=run_id,
+        stage="delivery",
+        retried=True,
+        output_id=int(output.id),
+        delivery_results=delivery_results,
+    )
+
+
+@router.get(
+    "/runs/{run_id}/diagnostics",
+    response_model=RunDiagnosticsResponse,
+    summary="Download a diagnostic bundle for a watchlist run",
+)
+async def get_run_diagnostics(
+    run_id: int = Path(..., ge=1),
+    target_user_id: int | None = Query(
+        None,
+        ge=1,
+        description="Admin-only: fetch diagnostics for another user ID.",
+    ),
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+    collections_db=Depends(get_collections_db_for_user),
+):
+    _enforce_runs_admin_if_configured(current_user)
+    _resolved_user_id, target_db = await _resolve_target_watchlists_context(
+        current_user=current_user,
+        current_db=db,
+        target_user_id=target_user_id,
+    )
+    try:
+        run = target_db.get_run(run_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="run_not_found") from None
+
+    stats = _parse_json_object(getattr(run, "stats_json", None))
+    run_payload = {
+        "id": int(getattr(run, "id", run_id)),
+        "job_id": int(getattr(run, "job_id", 0) or 0),
+        "status": getattr(run, "status", None),
+        "started_at": getattr(run, "started_at", None),
+        "finished_at": getattr(run, "finished_at", None),
+        "stats": stats,
+        "error_msg": getattr(run, "error_msg", None),
+    }
+
+    job_payload: dict[str, Any] | None = None
+    output_prefs: dict[str, Any] = {}
+    with contextlib.suppress(_WATCHLISTS_NONCRITICAL_EXCEPTIONS):
+        job = target_db.get_job(run.job_id)
+        output_prefs = _parse_json_object(getattr(job, "output_prefs_json", None))
+        job_payload = {
+            "id": int(getattr(job, "id", run.job_id)),
+            "name": getattr(job, "name", None),
+            "schedule_expr": getattr(job, "schedule_expr", None),
+            "active": getattr(job, "active", None),
+            "watchlist_id": getattr(job, "watchlist_id", None),
+            "output_auto_enabled": bool(
+                isinstance(output_prefs.get("auto_output"), dict)
+                and output_prefs.get("auto_output", {}).get("enabled")
+            ),
+            "audio_enabled": bool(output_prefs.get("generate_audio")),
+            "delivery_configured": isinstance(output_prefs.get("deliveries"), dict),
+        }
+
+    output_rows = _list_run_watchlist_outputs(collections_db, run_id, limit=25)
+    outputs = [_output_row_summary(row) for row in output_rows]
+    audio_task_id = stats.get("audio_briefing_task_id")
+    audio_payload = {
+        "task_id": audio_task_id,
+        "status": stats.get("audio_briefing_status"),
+    } if audio_task_id else None
+
+    return RunDiagnosticsResponse(
+        run_id=run_id,
+        generated_at=_utcnow_iso(),
+        run=run_payload,
+        job=job_payload,
+        outputs=outputs,
+        audio=audio_payload,
+        recovery={
+            "can_retry_full_run": bool(run_payload.get("job_id")),
+            "can_retry_delivery": any(output.get("delivery_plan_present") for output in outputs),
+            "can_retry_audio": bool(audio_task_id or output_prefs.get("generate_audio")),
+        },
+    )
 
 
 # --------------------

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -4918,6 +4918,8 @@ async def retry_run_audio(
         trigger_audio_briefing,
     )
 
+    if str(getattr(run, "status", "")).lower() in {"running", "queued"}:
+        raise HTTPException(status_code=409, detail="audio_retry_run_in_progress")
     task_id = await trigger_audio_briefing(
         user_id=int(resolved_user_id),
         job_id=int(run.job_id),

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -855,6 +855,33 @@ def _resolve_watchlists_db_for_target_user(
         raise HTTPException(status_code=500, detail="watchlists_db_unavailable") from exc
 
 
+def _resolve_collections_db_for_target_user(
+    current_user: User,
+    current_db: CollectionsDatabase,
+    target_user_id: int,
+) -> CollectionsDatabase:
+    """Return a Collections DB bound to the already-authorized target user."""
+    current_user_id = _safe_int(getattr(current_user, "id", None), -1)
+    if target_user_id == current_user_id:
+        return current_db
+    try:
+        return CollectionsDatabase.for_user(user_id=target_user_id)
+    except _DatabaseError as exc:
+        logger.error(
+            "watchlists.resolve_target_collections_db failed for user={}: error_type={}",
+            target_user_id,
+            type(exc).__name__,
+        )
+        raise HTTPException(status_code=500, detail="collections_db_unavailable") from exc
+    except _WATCHLISTS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(
+            "watchlists.resolve_target_collections_db failed for user={}: error_type={}",
+            target_user_id,
+            type(exc).__name__,
+        )
+        raise HTTPException(status_code=500, detail="collections_db_unavailable") from exc
+
+
 async def _resolve_target_watchlists_context(
     *,
     current_user: User,
@@ -4725,6 +4752,7 @@ async def stream_run(
 
 
 def _parse_json_object(raw: Any) -> dict[str, Any]:
+    """Parse a JSON object payload without leaking malformed metadata errors."""
     if isinstance(raw, dict):
         return raw
     if isinstance(raw, str) and raw.strip():
@@ -4736,7 +4764,90 @@ def _parse_json_object(raw: Any) -> dict[str, Any]:
     return {}
 
 
+_TEXT_DELIVERY_FORMATS = {"html", "md", "markdown", "txt", "text"}
+_AUDIO_DELIVERY_FORMATS = {"aac", "flac", "m4a", "mp3", "ogg", "opus", "wav"}
+_AUDIO_DELIVERY_TYPES = {"audio", "audio_briefing", "podcast_audio", "tts_audio"}
+
+
+def _sanitize_delivery_result(raw: Any) -> dict[str, Any]:
+    """Return delivery status fields safe for output metadata and diagnostics."""
+    if not isinstance(raw, dict):
+        return {}
+    channel = str(raw.get("channel") or "").strip()
+    delivery_status = str(raw.get("status") or "").strip()
+    safe: dict[str, Any] = {}
+    if channel:
+        safe["channel"] = channel
+    if delivery_status:
+        safe["status"] = delivery_status
+
+    reason = raw.get("reason")
+    if isinstance(reason, str) and reason:
+        safe["reason"] = reason[:120]
+
+    document_id = raw.get("document_id")
+    if document_id is not None:
+        safe["document_id"] = document_id
+
+    deliveries = raw.get("deliveries")
+    if isinstance(deliveries, list):
+        status_counts: dict[str, int] = {}
+        for entry in deliveries:
+            if not isinstance(entry, dict):
+                continue
+            entry_status = str(entry.get("status") or "unknown")
+            status_counts[entry_status] = status_counts.get(entry_status, 0) + 1
+        safe["delivery_count"] = len(deliveries)
+        if status_counts:
+            safe["delivery_status_counts"] = status_counts
+    return safe
+
+
+def _sanitize_delivery_results(raw: Any) -> list[dict[str, Any]]:
+    """Sanitize delivery result lists from current and historical metadata."""
+    if not isinstance(raw, list):
+        return []
+    return [safe for entry in raw if (safe := _sanitize_delivery_result(entry))]
+
+
+def _notification_delivery_summary(result: Any) -> dict[str, Any]:
+    """Convert a NotificationResult-like object into a sanitized result summary."""
+    details = getattr(result, "details", None)
+    raw = dict(details) if isinstance(details, dict) else {}
+    raw["channel"] = getattr(result, "channel", raw.get("channel", ""))
+    raw["status"] = getattr(result, "status", raw.get("status", ""))
+    return _sanitize_delivery_result(raw)
+
+
+def _is_audio_output_row(row: Any, metadata: dict[str, Any]) -> bool:
+    """Return whether an output row is an audio artifact or audio-derived variant."""
+    output_format = str(getattr(row, "format", None) or metadata.get("format") or "").lower()
+    output_type = str(getattr(row, "type", None) or metadata.get("type") or "").lower()
+    variant_kind = str(metadata.get("variant_kind") or "").lower()
+    return (
+        output_format in _AUDIO_DELIVERY_FORMATS
+        or output_type in _AUDIO_DELIVERY_TYPES
+        or variant_kind in {"audio", "tts"}
+    )
+
+
+def _has_delivery_plan(metadata: dict[str, Any]) -> bool:
+    """Return whether metadata includes a persisted delivery plan."""
+    return isinstance(metadata.get("delivery_plan"), dict)
+
+
+def _is_canonical_delivery_output(row: Any, metadata: dict[str, Any]) -> bool:
+    """Prefer the base text artifact for delivery retries over derived outputs."""
+    if not _has_delivery_plan(metadata) or _is_audio_output_row(row, metadata):
+        return False
+    if metadata.get("variant_of") is not None or metadata.get("variant_kind"):
+        return False
+    output_format = str(getattr(row, "format", None) or metadata.get("format") or "").lower()
+    return not output_format or output_format in _TEXT_DELIVERY_FORMATS
+
+
 def _output_row_summary(row: Any) -> dict[str, Any]:
+    """Build the diagnostics-safe subset of an output artifact row."""
     metadata = _parse_output_metadata(row)
     return {
         "id": int(getattr(row, "id", 0) or 0),
@@ -4746,15 +4857,17 @@ def _output_row_summary(row: Any) -> dict[str, Any]:
         "format": getattr(row, "format", None),
         "type": getattr(row, "type", None),
         "created_at": getattr(row, "created_at", None),
-        "deliveries": metadata.get("deliveries") if isinstance(metadata.get("deliveries"), list) else [],
+        "deliveries": _sanitize_delivery_results(metadata.get("deliveries")),
         "delivery_plan_present": isinstance(metadata.get("delivery_plan"), dict),
         "audio_briefing_status": metadata.get("audio_briefing_status"),
         "audio_briefing_task_id": metadata.get("audio_briefing_task_id"),
     }
 
 
-def _list_run_watchlist_outputs(collections_db: Any, run_id: int, *, limit: int = 10) -> list[Any]:
-    rows, _total = collections_db.list_output_artifacts(
+async def _list_run_watchlist_outputs(collections_db: Any, run_id: int, *, limit: int = 10) -> list[Any]:
+    """List watchlist-origin output artifacts for a run without blocking the event loop."""
+    rows, _total = await run_in_threadpool(
+        collections_db.list_output_artifacts,
         run_id=run_id,
         limit=limit,
         offset=0,
@@ -4777,7 +4890,8 @@ async def retry_run_audio(
     ),
     current_user: User = Depends(get_request_user),
     db=Depends(get_watchlists_db_for_user),
-):
+) -> RunStageRetryResponse:
+    """Retry the audio briefing stage for a completed or failed watchlist run."""
     _enforce_runs_admin_if_configured(current_user)
     resolved_user_id, target_db = await _resolve_target_watchlists_context(
         current_user=current_user,
@@ -4818,8 +4932,11 @@ async def retry_run_audio(
     run_stats["audio_briefing_task_id"] = task_id
     run_stats["audio_briefing_retry_task_id"] = task_id
     run_stats["audio_briefing_status"] = "pending"
-    with contextlib.suppress(_WATCHLISTS_NONCRITICAL_EXCEPTIONS):
-        target_db.update_run(run_id, stats_json=json.dumps(run_stats))
+    try:
+        await run_in_threadpool(target_db.update_run, run_id, stats_json=json.dumps(run_stats))
+    except _WATCHLISTS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error("watchlists.retry_audio failed to persist retry state for run={}: {}", run_id, exc)
+        raise HTTPException(status_code=500, detail="audio_retry_state_update_failed") from exc
 
     return RunStageRetryResponse(
         run_id=run_id,
@@ -4844,30 +4961,46 @@ async def retry_run_delivery(
     current_user: User = Depends(get_request_user),
     db=Depends(get_watchlists_db_for_user),
     collections_db=Depends(get_collections_db_for_user),
-):
+) -> RunStageRetryResponse:
+    """Retry configured delivery channels for the latest watchlist output of a run."""
     _enforce_runs_admin_if_configured(current_user)
     resolved_user_id, target_db = await _resolve_target_watchlists_context(
         current_user=current_user,
         current_db=db,
         target_user_id=target_user_id,
     )
+    target_collections_db = _resolve_collections_db_for_target_user(
+        current_user=current_user,
+        current_db=collections_db,
+        target_user_id=resolved_user_id,
+    )
     try:
         run = target_db.get_run(run_id)
     except KeyError:
         raise HTTPException(status_code=404, detail="run_not_found") from None
 
-    output_rows = _list_run_watchlist_outputs(collections_db, run_id, limit=20)
+    output_rows = await _list_run_watchlist_outputs(target_collections_db, run_id, limit=20)
     if not output_rows:
         raise HTTPException(status_code=404, detail="output_not_found")
 
     selected_row = None
     selected_metadata: dict[str, Any] = {}
+    fallback_row = None
+    fallback_metadata: dict[str, Any] = {}
     for row in output_rows:
         metadata = _parse_output_metadata(row)
-        if isinstance(metadata.get("delivery_plan"), dict):
+        if not _has_delivery_plan(metadata):
+            continue
+        if _is_canonical_delivery_output(row, metadata):
             selected_row = row
             selected_metadata = metadata
             break
+        if fallback_row is None and not _is_audio_output_row(row, metadata):
+            fallback_row = row
+            fallback_metadata = metadata
+    if selected_row is None and fallback_row is not None:
+        selected_row = fallback_row
+        selected_metadata = fallback_metadata
     if selected_row is None:
         raise HTTPException(status_code=400, detail="delivery_plan_not_found")
 
@@ -4875,9 +5008,10 @@ async def retry_run_delivery(
     title = output.title or f"watchlist-output-{output.id}"
     output_format = output.format or getattr(selected_row, "format", None) or "md"
     delivery_plan = selected_metadata.get("delivery_plan") or {}
+    is_delegated_retry = resolved_user_id != _safe_int(getattr(current_user, "id", None), -1)
     notifications = NotificationsService(
         user_id=int(resolved_user_id),
-        user_email=getattr(current_user, "email", None),
+        user_email=None if is_delegated_retry else getattr(current_user, "email", None),
     )
     delivery_results: list[dict[str, Any]] = []
     chatbook_path_update: str | None = None
@@ -4906,27 +5040,22 @@ async def retry_run_delivery(
             text_body=text_body or None,
             recipients=email_cfg.get("recipients"),
             attachments=attachments,
-            fallback_to_user_email=True,
+            fallback_to_user_email=not is_delegated_retry,
         )
-        delivery_results.append(
-            {
-                "channel": email_result.channel,
-                "status": email_result.status,
-                **email_result.details,
-            }
-        )
+        delivery_results.append(_notification_delivery_summary(email_result))
 
     chat_cfg = delivery_plan.get("chatbook") if isinstance(delivery_plan.get("chatbook"), dict) else None
     if chat_cfg and bool(chat_cfg.get("enabled", True)):
         chat_metadata = dict(chat_cfg.get("metadata") or {})
         chat_metadata.update(
             {
-                "job_id": int(run.job_id),
+                "job_id": int(getattr(run, "job_id", 0) or 0),
                 "run_id": run_id,
                 "output_id": output.id,
             }
         )
-        chat_result = notifications.deliver_chatbook(
+        chat_result = await run_in_threadpool(
+            notifications.deliver_chatbook,
             title=chat_cfg.get("title") or title,
             content=output.content or "",
             description=chat_cfg.get("description"),
@@ -4935,13 +5064,7 @@ async def retry_run_delivery(
             model=chat_cfg.get("model", "watchlists"),
             conversation_id=chat_cfg.get("conversation_id"),
         )
-        delivery_results.append(
-            {
-                "channel": chat_result.channel,
-                "status": chat_result.status,
-                **chat_result.details,
-            }
-        )
+        delivery_results.append(_notification_delivery_summary(chat_result))
         doc_id = chat_result.details.get("document_id")
         if chat_result.status == "stored" and doc_id is not None:
             chatbook_path_update = f"generated_document:{doc_id}"
@@ -4955,7 +5078,8 @@ async def retry_run_delivery(
     if isinstance(selected_metadata["delivery_retry_results"], list):
         selected_metadata["delivery_retry_results"].extend(delivery_results)
     selected_metadata["delivery_retry_at"] = _utcnow_iso()
-    collections_db.update_output_artifact_metadata(
+    await run_in_threadpool(
+        target_collections_db.update_output_artifact_metadata,
         output.id,
         metadata_json=json.dumps({k: v for k, v in selected_metadata.items() if v is not None}),
         chatbook_path=chatbook_path_update,
@@ -4985,12 +5109,18 @@ async def get_run_diagnostics(
     current_user: User = Depends(get_request_user),
     db=Depends(get_watchlists_db_for_user),
     collections_db=Depends(get_collections_db_for_user),
-):
+) -> RunDiagnosticsResponse:
+    """Return run diagnostics, output summaries, and safe recovery affordances."""
     _enforce_runs_admin_if_configured(current_user)
-    _resolved_user_id, target_db = await _resolve_target_watchlists_context(
+    resolved_user_id, target_db = await _resolve_target_watchlists_context(
         current_user=current_user,
         current_db=db,
         target_user_id=target_user_id,
+    )
+    target_collections_db = _resolve_collections_db_for_target_user(
+        current_user=current_user,
+        current_db=collections_db,
+        target_user_id=resolved_user_id,
     )
     try:
         run = target_db.get_run(run_id)
@@ -5010,7 +5140,7 @@ async def get_run_diagnostics(
 
     job_payload: dict[str, Any] | None = None
     output_prefs: dict[str, Any] = {}
-    with contextlib.suppress(_WATCHLISTS_NONCRITICAL_EXCEPTIONS):
+    try:
         job = target_db.get_job(run.job_id)
         output_prefs = _parse_json_object(getattr(job, "output_prefs_json", None))
         job_payload = {
@@ -5026,8 +5156,10 @@ async def get_run_diagnostics(
             "audio_enabled": bool(output_prefs.get("generate_audio")),
             "delivery_configured": isinstance(output_prefs.get("deliveries"), dict),
         }
+    except _WATCHLISTS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning("watchlists.diagnostics failed to load job metadata for run={}: {}", run_id, exc)
 
-    output_rows = _list_run_watchlist_outputs(collections_db, run_id, limit=25)
+    output_rows = await _list_run_watchlist_outputs(target_collections_db, run_id, limit=25)
     outputs = [_output_row_summary(row) for row in output_rows]
     audio_task_id = stats.get("audio_briefing_task_id")
     audio_payload = {
@@ -6655,13 +6787,7 @@ async def create_output(
                 attachments=attachments,
                 fallback_to_user_email=True,
             )
-            delivery_results.append(
-                {
-                    "channel": email_result.channel,
-                    "status": email_result.status,
-                    **email_result.details,
-                }
-            )
+            delivery_results.append(_notification_delivery_summary(email_result))
             metadata_update_needed = True
 
         chat_cfg = delivery_plan.get("chatbook") if isinstance(delivery_plan.get("chatbook"), dict) else None
@@ -6684,13 +6810,7 @@ async def create_output(
                 model=chat_cfg.get("model", "watchlists"),
                 conversation_id=chat_cfg.get("conversation_id"),
             )
-            delivery_results.append(
-                {
-                    "channel": chat_result.channel,
-                    "status": chat_result.status,
-                    **chat_result.details,
-                }
-            )
+            delivery_results.append(_notification_delivery_summary(chat_result))
             doc_id = chat_result.details.get("document_id")
             if chat_result.status == "stored" and doc_id is not None:
                 chatbook_path_update = f"generated_document:{doc_id}"

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -515,6 +515,8 @@ class RunCancelResponse(BaseModel):
 
 
 class RunStageRetryResponse(BaseModel):
+    """Response returned after retrying a single recoverable run stage."""
+
     run_id: int
     stage: str
     retried: bool
@@ -525,6 +527,8 @@ class RunStageRetryResponse(BaseModel):
 
 
 class RunDiagnosticsResponse(BaseModel):
+    """Safe diagnostics bundle for a watchlist run and its recovery options."""
+
     run_id: int
     generated_at: str
     run: dict[str, Any]

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -514,6 +514,26 @@ class RunCancelResponse(BaseModel):
     message: str | None = None
 
 
+class RunStageRetryResponse(BaseModel):
+    run_id: int
+    stage: str
+    retried: bool
+    task_id: str | None = None
+    output_id: int | None = None
+    delivery_results: list[dict[str, Any]] = Field(default_factory=list)
+    message: str | None = None
+
+
+class RunDiagnosticsResponse(BaseModel):
+    run_id: int
+    generated_at: str
+    run: dict[str, Any]
+    job: dict[str, Any] | None = None
+    outputs: list[dict[str, Any]] = Field(default_factory=list)
+    audio: dict[str, Any] | None = None
+    recovery: dict[str, Any] = Field(default_factory=dict)
+
+
 class RunsListResponse(BaseModel):
     items: list[Run]
     total: int

--- a/tldw_Server_API/tests/Admin/test_admin_ops_webhooks_reports.py
+++ b/tldw_Server_API/tests/Admin/test_admin_ops_webhooks_reports.py
@@ -275,6 +275,11 @@ class TestWebhookDeliveryRecording:
     def test_record_and_list_deliveries(self, monkeypatch, tmp_path):
         """Record 5 deliveries and list them back, newest first."""
         service, _ = _configure_store(monkeypatch, tmp_path)
+        timestamps = iter(
+            f"2026-05-19T00:00:0{idx}.000000+00:00"
+            for idx in range(10)
+        )
+        monkeypatch.setattr(service, "_now_iso", lambda: next(timestamps))
 
         webhook = service.create_webhook(
             url="https://example.com/hook",

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,7 +14,9 @@ pytestmark = pytest.mark.unit
 
 @pytest.mark.asyncio
 async def test_retry_run_audio_reuses_job_audio_config_without_rerunning_ingestion(monkeypatch):
-    from tldw_Server_API.app.api.v1.endpoints.watchlists import retry_run_audio
+    from tldw_Server_API.app.api.v1.endpoints import watchlists
+
+    retry_run_audio = watchlists.retry_run_audio
 
     run = SimpleNamespace(id=10, job_id=7, stats_json=json.dumps({"items_ingested": 2}), error_msg=None)
     job = SimpleNamespace(
@@ -37,6 +40,8 @@ async def test_retry_run_audio_reuses_job_audio_config_without_rerunning_ingesti
     db.get_job.return_value = job
     db.update_run.return_value = run
     trigger = AsyncMock(return_value="task-retry-10")
+    rerun_job = AsyncMock()
+    monkeypatch.setattr(watchlists, "run_watchlist_job", rerun_job)
     monkeypatch.setattr(
         "tldw_Server_API.app.core.Watchlists.audio_briefing_workflow.trigger_audio_briefing",
         trigger,
@@ -58,6 +63,7 @@ async def test_retry_run_audio_reuses_job_audio_config_without_rerunning_ingesti
     assert result.retried is True
     assert result.task_id == "task-retry-10"
     trigger.assert_awaited_once()
+    rerun_job.assert_not_called()
     db.update_run.assert_called_once()
 
 
@@ -68,6 +74,22 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
     run = SimpleNamespace(id=10, job_id=7, stats_json="{}", error_msg=None)
     db = MagicMock()
     db.get_run.return_value = run
+    output_row_old = SimpleNamespace(
+        id=54,
+        run_id=10,
+        job_id=7,
+        title="Older Daily Digest",
+        format="md",
+        metadata_json=json.dumps(
+            {
+                "origin": "watchlists",
+                "delivery_plan": {
+                    "email": {"enabled": True, "recipients": ["old@example.com"], "attach_file": False}
+                },
+            }
+        ),
+        chatbook_path=None,
+    )
     output_row = SimpleNamespace(
         id=55,
         run_id=10,
@@ -84,8 +106,27 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
         ),
         chatbook_path=None,
     )
+    output_row_audio = SimpleNamespace(
+        id=56,
+        run_id=10,
+        job_id=7,
+        title="Daily Digest (Audio)",
+        format="mp3",
+        type="tts_audio",
+        metadata_json=json.dumps(
+            {
+                "origin": "watchlists",
+                "variant_of": 55,
+                "variant_kind": "tts",
+                "delivery_plan": {
+                    "email": {"enabled": True, "recipients": ["digest@example.com"], "attach_file": False}
+                },
+            }
+        ),
+        chatbook_path=None,
+    )
     collections_db = MagicMock()
-    collections_db.list_output_artifacts.return_value = ([output_row], 1)
+    collections_db.list_output_artifacts.return_value = ([output_row_audio, output_row, output_row_old], 3)
     collections_db.update_output_artifact_metadata.return_value = output_row
 
     monkeypatch.setattr(
@@ -96,19 +137,17 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
         "tldw_Server_API.app.api.v1.endpoints.watchlists.resolve_user_id_for_request",
         lambda *args, **kwargs: 945,
     )
-    monkeypatch.setattr(
-        "tldw_Server_API.app.api.v1.endpoints.watchlists._row_to_output",
-        AsyncMock(
-            return_value=SimpleNamespace(
-                id=55,
-                title="Daily Digest",
-                format="md",
-                content="# Digest",
-                metadata=json.loads(output_row.metadata_json),
-                chatbook_path=None,
-            )
-        ),
+    row_to_output = AsyncMock(
+        return_value=SimpleNamespace(
+            id=55,
+            title="Daily Digest",
+            format="md",
+            content="# Digest",
+            metadata=json.loads(output_row.metadata_json),
+            chatbook_path=None,
+        )
     )
+    monkeypatch.setattr("tldw_Server_API.app.api.v1.endpoints.watchlists._row_to_output", row_to_output)
 
     class FakeNotificationsService:
         def __init__(self, *, user_id: int, user_email: str | None = None) -> None:
@@ -116,7 +155,15 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
             self.user_email = user_email
 
         async def deliver_email(self, **kwargs):
-            return SimpleNamespace(channel="email", status="sent", details={"provider": "fake"})
+            return SimpleNamespace(
+                channel="email",
+                status="sent",
+                details={
+                    "provider": "fake",
+                    "subject": "Daily Digest",
+                    "deliveries": [{"recipient": "digest@example.com", "status": "sent"}],
+                },
+            )
 
         def deliver_chatbook(self, **kwargs):
             return SimpleNamespace(channel="chatbook", status="skipped", details={"reason": "disabled"})
@@ -139,9 +186,123 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
     assert result.stage == "delivery"
     assert result.retried is True
     assert result.output_id == 55
-    assert result.delivery_results == [{"channel": "email", "status": "sent", "provider": "fake"}]
+    row_to_output.assert_awaited_once()
+    assert row_to_output.await_args.args[0].id == 55
+    assert result.delivery_results == [
+        {
+            "channel": "email",
+            "status": "sent",
+            "delivery_count": 1,
+            "delivery_status_counts": {"sent": 1},
+        }
+    ]
     metadata_update = json.loads(collections_db.update_output_artifact_metadata.call_args.kwargs["metadata_json"])
     assert metadata_update["delivery_retry_results"][0]["channel"] == "email"
+    assert "provider" not in metadata_update["delivery_retry_results"][0]
+    assert "subject" not in metadata_update["delivery_retry_results"][0]
+
+
+@pytest.mark.asyncio
+async def test_retry_run_delivery_uses_target_collections_db_and_does_not_fallback_to_actor_email(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import watchlists
+
+    run = SimpleNamespace(id=10, job_id=None, stats_json="{}", error_msg=None)
+    db = MagicMock()
+    db.get_run.return_value = run
+    output_row = SimpleNamespace(
+        id=55,
+        run_id=10,
+        job_id=None,
+        title="Delegated Digest",
+        format="md",
+        metadata_json=json.dumps(
+            {
+                "origin": "watchlists",
+                "delivery_plan": {
+                    "email": {"enabled": True, "recipients": [], "attach_file": False},
+                    "chatbook": {"enabled": True, "metadata": {"source": "retry"}},
+                },
+            }
+        ),
+        chatbook_path=None,
+    )
+    current_collections_db = MagicMock()
+    current_collections_db.list_output_artifacts.return_value = ([], 0)
+    target_collections_db = MagicMock()
+    target_collections_db.list_output_artifacts.return_value = ([output_row], 1)
+    target_collections_db.update_output_artifact_metadata.return_value = output_row
+    monkeypatch.setattr(
+        watchlists.CollectionsDatabase,
+        "for_user",
+        classmethod(lambda cls, user_id: target_collections_db),
+    )
+    monkeypatch.setattr(
+        watchlists,
+        "_resolve_target_watchlists_context",
+        AsyncMock(return_value=(947, db)),
+    )
+    monkeypatch.setattr(
+        watchlists,
+        "_row_to_output",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                id=55,
+                title="Delegated Digest",
+                format="md",
+                content="# Digest",
+                metadata=json.loads(output_row.metadata_json),
+                chatbook_path=None,
+            )
+        ),
+    )
+    service_instances: list[Any] = []
+    email_kwargs: list[dict[str, Any]] = []
+    chatbook_kwargs: list[dict[str, Any]] = []
+
+    class FakeNotificationsService:
+        def __init__(self, *, user_id: int, user_email: str | None = None) -> None:
+            self.user_id = user_id
+            self.user_email = user_email
+            service_instances.append(self)
+
+        async def deliver_email(self, **kwargs):
+            email_kwargs.append(kwargs)
+            return SimpleNamespace(channel="email", status="skipped", details={"reason": "no_recipients"})
+
+        def deliver_chatbook(self, **kwargs):
+            chatbook_kwargs.append(kwargs)
+            return SimpleNamespace(
+                channel="chatbook",
+                status="stored",
+                details={"document_id": 222, "provider": "watchlists", "model": "watchlists"},
+            )
+
+    monkeypatch.setattr(watchlists, "NotificationsService", FakeNotificationsService)
+
+    user = SimpleNamespace(id=945, email="admin@example.com", roles=["admin"], permissions=[])
+    result = await watchlists.retry_run_delivery(
+        run_id=10,
+        target_user_id=947,
+        current_user=user,
+        db=db,
+        collections_db=current_collections_db,
+    )
+
+    assert result.output_id == 55
+    current_collections_db.list_output_artifacts.assert_not_called()
+    target_collections_db.list_output_artifacts.assert_called_once()
+    target_collections_db.update_output_artifact_metadata.assert_called_once()
+    assert service_instances[0].user_id == 947
+    assert service_instances[0].user_email is None
+    assert email_kwargs[0]["fallback_to_user_email"] is False
+    assert chatbook_kwargs[0]["metadata"]["job_id"] == 0
+    metadata_update = json.loads(target_collections_db.update_output_artifact_metadata.call_args.kwargs["metadata_json"])
+    assert metadata_update["chatbook_document_id"] == 222
+    assert metadata_update["delivery_retry_results"][1] == {
+        "channel": "chatbook",
+        "status": "stored",
+        "document_id": 222,
+    }
 
 
 @pytest.mark.asyncio
@@ -170,7 +331,15 @@ async def test_run_diagnostics_bundle_includes_run_and_latest_output_metadata(mo
         metadata_json=json.dumps(
             {
                 "origin": "watchlists",
-                "deliveries": [{"channel": "email", "status": "failed"}],
+                "deliveries": [
+                    {
+                        "channel": "email",
+                        "status": "failed",
+                        "provider": "smtp",
+                        "subject": "Daily Digest",
+                        "deliveries": [{"recipient": "digest@example.com", "status": "failed"}],
+                    }
+                ],
                 "audio_briefing_status": "enqueue_failed",
             }
         ),
@@ -196,4 +365,60 @@ async def test_run_diagnostics_bundle_includes_run_and_latest_output_metadata(mo
     assert result.job["id"] == 7
     assert result.outputs[0]["id"] == 55
     assert result.outputs[0]["deliveries"][0]["status"] == "failed"
+    assert result.outputs[0]["deliveries"][0]["delivery_count"] == 1
+    assert "provider" not in result.outputs[0]["deliveries"][0]
+    assert "subject" not in result.outputs[0]["deliveries"][0]
     assert "log_path" not in json.dumps(result.model_dump())
+
+
+@pytest.mark.asyncio
+async def test_run_diagnostics_uses_target_collections_db_for_delegated_user(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import watchlists
+
+    run = SimpleNamespace(
+        id=10,
+        job_id=7,
+        status="failed",
+        started_at="2026-05-19T04:00:00Z",
+        finished_at="2026-05-19T04:03:00Z",
+        stats_json=json.dumps({"items_found": 5}),
+        error_msg="delivery_failed",
+    )
+    db = MagicMock()
+    db.get_run.return_value = run
+    db.get_job.return_value = SimpleNamespace(id=7, name="Daily Digest", schedule_expr="0 */5 * * *")
+    output_row = SimpleNamespace(
+        id=55,
+        run_id=10,
+        job_id=7,
+        title="Daily Digest",
+        format="md",
+        metadata_json=json.dumps({"origin": "watchlists"}),
+    )
+    current_collections_db = MagicMock()
+    current_collections_db.list_output_artifacts.return_value = ([], 0)
+    target_collections_db = MagicMock()
+    target_collections_db.list_output_artifacts.return_value = ([output_row], 1)
+    monkeypatch.setattr(
+        watchlists.CollectionsDatabase,
+        "for_user",
+        classmethod(lambda cls, user_id: target_collections_db),
+    )
+    monkeypatch.setattr(
+        watchlists,
+        "_resolve_target_watchlists_context",
+        AsyncMock(return_value=(947, db)),
+    )
+
+    user = SimpleNamespace(id=945, roles=["admin"], permissions=[])
+    result = await watchlists.get_run_diagnostics(
+        run_id=10,
+        target_user_id=947,
+        current_user=user,
+        db=db,
+        collections_db=current_collections_db,
+    )
+
+    assert result.outputs[0]["id"] == 55
+    current_collections_db.list_output_artifacts.assert_not_called()
+    target_collections_db.list_output_artifacts.assert_called_once()

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
@@ -1,0 +1,199 @@
+"""Operator recovery endpoints for Watchlists runs."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_retry_run_audio_reuses_job_audio_config_without_rerunning_ingestion(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import retry_run_audio
+
+    run = SimpleNamespace(id=10, job_id=7, stats_json=json.dumps({"items_ingested": 2}), error_msg=None)
+    job = SimpleNamespace(
+        id=7,
+        output_prefs_json=json.dumps(
+            {
+                "generate_audio": True,
+                "target_audio_minutes": 8,
+                "audio_cast": {
+                    "speaker_count": 2,
+                    "speakers": [
+                        {"id": "host", "label": "Host", "voice": "af_bella"},
+                        {"id": "analyst", "label": "Analyst", "voice": "am_adam"},
+                    ],
+                },
+            }
+        ),
+    )
+    db = MagicMock()
+    db.get_run.return_value = run
+    db.get_job.return_value = job
+    db.update_run.return_value = run
+    trigger = AsyncMock(return_value="task-retry-10")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Watchlists.audio_briefing_workflow.trigger_audio_briefing",
+        trigger,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists.resolve_user_id_for_request",
+        lambda *args, **kwargs: 945,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists._resolve_target_watchlists_context",
+        AsyncMock(return_value=(945, db)),
+    )
+
+    user = SimpleNamespace(id=945, role="admin")
+    result = await retry_run_audio(run_id=10, target_user_id=None, current_user=user, db=db)
+
+    assert result.run_id == 10
+    assert result.stage == "audio"
+    assert result.retried is True
+    assert result.task_id == "task-retry-10"
+    trigger.assert_awaited_once()
+    db.update_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import retry_run_delivery
+
+    run = SimpleNamespace(id=10, job_id=7, stats_json="{}", error_msg=None)
+    db = MagicMock()
+    db.get_run.return_value = run
+    output_row = SimpleNamespace(
+        id=55,
+        run_id=10,
+        job_id=7,
+        title="Daily Digest",
+        format="md",
+        metadata_json=json.dumps(
+            {
+                "origin": "watchlists",
+                "delivery_plan": {
+                    "email": {"enabled": True, "recipients": ["digest@example.com"], "attach_file": False}
+                },
+            }
+        ),
+        chatbook_path=None,
+    )
+    collections_db = MagicMock()
+    collections_db.list_output_artifacts.return_value = ([output_row], 1)
+    collections_db.update_output_artifact_metadata.return_value = output_row
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists._resolve_target_watchlists_context",
+        AsyncMock(return_value=(945, db)),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists.resolve_user_id_for_request",
+        lambda *args, **kwargs: 945,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists._row_to_output",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                id=55,
+                title="Daily Digest",
+                format="md",
+                content="# Digest",
+                metadata=json.loads(output_row.metadata_json),
+                chatbook_path=None,
+            )
+        ),
+    )
+
+    class FakeNotificationsService:
+        def __init__(self, *, user_id: int, user_email: str | None = None) -> None:
+            self.user_id = user_id
+            self.user_email = user_email
+
+        async def deliver_email(self, **kwargs):
+            return SimpleNamespace(channel="email", status="sent", details={"provider": "fake"})
+
+        def deliver_chatbook(self, **kwargs):
+            return SimpleNamespace(channel="chatbook", status="skipped", details={"reason": "disabled"})
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists.NotificationsService",
+        FakeNotificationsService,
+    )
+
+    user = SimpleNamespace(id=945, email="wl@example.com", role="admin")
+    result = await retry_run_delivery(
+        run_id=10,
+        target_user_id=None,
+        current_user=user,
+        db=db,
+        collections_db=collections_db,
+    )
+
+    assert result.run_id == 10
+    assert result.stage == "delivery"
+    assert result.retried is True
+    assert result.output_id == 55
+    assert result.delivery_results == [{"channel": "email", "status": "sent", "provider": "fake"}]
+    metadata_update = json.loads(collections_db.update_output_artifact_metadata.call_args.kwargs["metadata_json"])
+    assert metadata_update["delivery_retry_results"][0]["channel"] == "email"
+
+
+@pytest.mark.asyncio
+async def test_run_diagnostics_bundle_includes_run_and_latest_output_metadata(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import get_run_diagnostics
+
+    run = SimpleNamespace(
+        id=10,
+        job_id=7,
+        status="failed",
+        started_at="2026-05-19T04:00:00Z",
+        finished_at="2026-05-19T04:03:00Z",
+        stats_json=json.dumps({"items_found": 5, "audio_briefing_task_id": "task-10"}),
+        error_msg="delivery_failed",
+        log_path="/private/tmp/watchlists.log",
+    )
+    db = MagicMock()
+    db.get_run.return_value = run
+    db.get_job.return_value = SimpleNamespace(id=7, name="Daily Digest", schedule_expr="0 */5 * * *")
+    output_row = SimpleNamespace(
+        id=55,
+        run_id=10,
+        job_id=7,
+        title="Daily Digest",
+        format="md",
+        metadata_json=json.dumps(
+            {
+                "origin": "watchlists",
+                "deliveries": [{"channel": "email", "status": "failed"}],
+                "audio_briefing_status": "enqueue_failed",
+            }
+        ),
+    )
+    collections_db = MagicMock()
+    collections_db.list_output_artifacts.return_value = ([output_row], 1)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists._resolve_target_watchlists_context",
+        AsyncMock(return_value=(945, db)),
+    )
+
+    user = SimpleNamespace(id=945, role="admin")
+    result = await get_run_diagnostics(
+        run_id=10,
+        target_user_id=None,
+        current_user=user,
+        db=db,
+        collections_db=collections_db,
+    )
+
+    assert result.run_id == 10
+    assert result.run["status"] == "failed"
+    assert result.job["id"] == 7
+    assert result.outputs[0]["id"] == 55
+    assert result.outputs[0]["deliveries"][0]["status"] == "failed"
+    assert "log_path" not in json.dumps(result.model_dump())


### PR DESCRIPTION
## Summary
- Add clone helpers and UI actions for Watchlists feeds and monitors so power users can duplicate configured source rules, cadence, filters, output, delivery, and audio briefing settings without carrying runtime state forward.
- Expand the Watchlists command palette with create/pipeline, clone, run, preview, retry, and export entries, including explicit disabled reasons when row context is required.
- Add operator recovery APIs and run-detail controls for delivery-only retry, audio-only retry, and sanitized diagnostics export.
- Harden quick setup focus recovery after the a11y suite exposed a modal auto-focus race.

## Change summary
Human-authored change summary required before merge.

## Test Plan
- [x] `bunx vitest run src/components/Option/Watchlists/JobsTab/__tests__/clone-utils.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/clone-utils.test.ts src/components/Option/Watchlists/shared/__tests__/WatchlistsCommandPalette.commands.test.tsx src/services/__tests__/watchlists-audio.test.ts src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `bun run test:watchlists:scale`
- [x] `bun run test:watchlists:a11y`
- [x] `bun run test:watchlists:typecheck`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py tldw_Server_API/tests/Watchlists/test_delivery_integrations.py tldw_Server_API/tests/Watchlists/test_runs_csv_export.py -q`
- [x] `git diff --check`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_pr5.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cloning for Watchlists feeds and monitors, stage‑specific recovery (delivery/audio) with safe diagnostics, and a stronger command palette with exports for faster reuse and troubleshooting. Also hardens Quick Setup focus and tightens recovery safety.

- **New Features**
  - Clone feeds and monitors from row actions; deep‑copy config and start inactive, with per‑row loading to prevent duplicates.
  - Command palette: create pipeline/feed/monitor, clone, run, preview, validate, retry, and export (`OPML`, activity `CSV`). Disabled reasons are shown and blocked when context is missing.
  - Operator recovery: `POST /api/v1/watchlists/runs/{id}/retry-delivery`, `POST /retry-audio`, `GET /diagnostics`. Delivery retry chooses the canonical text report and avoids full reruns; Run drawer adds Retry delivery, Retry audio, and Download diagnostics; skipped retries show warnings.

- **Bug Fixes**
  - Quick Setup focus restoration is deterministic via `afterClose` and timers to resolve a11y auto‑focus races.
  - Delegated recovery uses the target user’s Collections DB and returns sanitized delivery summaries (no provider/subject leakage); no cross‑user email fallback.

<sup>Written for commit bcf23c1e08962155491c17e093a210c9a6a3a722. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1864?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

