### PR TITLE
Add Character Chat readiness states

### DIFF
--- a/Docs/superpowers/plans/2026-05-19-character-chat-phase2-readiness-plan.md
+++ b/Docs/superpowers/plans/2026-05-19-character-chat-phase2-readiness-plan.md
@@ -1,0 +1,113 @@
+# Character Chat Phase 2 Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Phase 2 of the first-class Character Chat PRD by making incomplete setup, loading, provider/model failures, selector catalog failures, missing restored characters, and persistence state visible and actionable inside `/chat`.
+
+**Architecture:** Reuse the existing chat cockpit and shared selector surfaces instead of adding a parallel role-play UI. Character Chat readiness remains derived from `buildCharacterChatReadiness(...)`; the UI layer renders that derived state with local recovery actions and live-region semantics.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing tldw shared UI package, real `tldw_server` smoke verification when local backend/frontend can run.
+
+**Primary Files:**
+- `apps/packages/ui/src/utils/chat-model-availability.ts`
+- `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+- `apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx`
+- `apps/packages/ui/src/components/Common/AssistantSelect.tsx`
+- `apps/packages/ui/src/components/Common/PromptSelect.tsx`
+- Existing focused tests under `apps/packages/ui/src/components/**/__tests__/`
+
+---
+
+## Stage 1: Readiness Panel Contract
+
+**Goal:** Add a compact Character Chat readiness panel that renders the existing readiness model with accessible status semantics and recovery actions.
+
+**Success Criteria:**
+- Missing server, missing character, missing model, no models available, unavailable selected model, and send-blocked states produce distinct visible copy.
+- The panel uses `role="status"` or an equivalent polite live-region contract for non-destructive setup changes.
+- Recovery actions map to existing flows: server settings, character selector, model settings, retry.
+- Ready state is non-intrusive and does not add duplicate clutter to Standard Chat.
+
+**Tests:**
+- Unit tests for the panel's visible title/body/action per readiness reason.
+- Unit test that status changes are exposed with `aria-live="polite"`.
+
+**Status:** Complete
+
+## Stage 2: Wire Readiness Into Character Chat
+
+**Goal:** Render the readiness panel only when Character Chat mode is active and preserve selected character intent while the user fixes model/server setup.
+
+**Success Criteria:**
+- `/chat?mode=character&characterId=...` displays local setup guidance before the first send when setup is incomplete.
+- Clicking model/server recovery does not clear `selectedCharacter` or reset Character Chat mode.
+- Clicking choose-character opens the existing assistant selector on the Characters tab and restores focus to the Character Chat control after close.
+- Missing/deleted restored characters get a visible recovery state with choose-character and retry affordances.
+
+**Tests:**
+- `Playground.cockpit-shell` or equivalent integration test for missing character/model/server readiness.
+- Integration test that selected character copy survives opening model settings.
+- Integration test for a restored route character that cannot be loaded.
+
+**Status:** Complete
+
+## Stage 3: Prompt Selector Loading/Error/Empty States
+
+**Goal:** Keep `PromptSelect` present and understandable when the prompt library is loading, empty, or failed.
+
+**Success Criteria:**
+- The prompt trigger remains visible during loading/error instead of disappearing.
+- Loading state is announced and prevents accidental empty-selection interpretation.
+- Error state has visible local copy and a retry affordance through React Query.
+- Empty state distinguishes "no saved prompts" from "no matches" and still allows editing the current system prompt.
+
+**Tests:**
+- Prompt selector tests for loading trigger, query error content, empty prompt library content, and existing custom prompt recovery.
+
+**Status:** Complete
+
+## Stage 4: Assistant Selector Loading/Error/Empty States
+
+**Goal:** Make character/persona catalog state explicit without blocking partial success.
+
+**Success Criteria:**
+- Loading characters/personas is visible in the dropdown.
+- Character catalog failure is visible on the Characters tab and does not silently become "No characters available."
+- Persona catalog failure is isolated to the Personas tab when characters load successfully.
+- Empty state copy remains searchable and actionable, with a route/event path to manage actor settings where available.
+
+**Tests:**
+- Assistant selector behavior tests for loading, character catalog failure, persona-only failure, and empty character catalog.
+
+**Status:** Complete
+
+## Stage 5: Persistence State Messaging
+
+**Goal:** Make Character Chat persistence state legible in the status strip and local setup surfaces.
+
+**Success Criteria:**
+- Temporary Character Chat is labeled as temporary.
+- Saved/server-backed Character Chat is labeled as saved or linked to chat history.
+- Local draft/no-server state is labeled distinctly from saved history.
+- Copy avoids implying persistence when server readiness is blocked.
+
+**Tests:**
+- Status strip tests for temporary, saved/server-backed, and local draft Character Chat persistence labels.
+
+**Status:** Complete
+
+## Stage 6: Real Backend Smoke And Closeout
+
+**Goal:** Verify the implemented workflow against the real backend where possible and close the Backlog task with evidence.
+
+**Success Criteria:**
+- Focused Vitest suites pass.
+- Browser smoke uses the running WebUI and real backend when available; if unavailable, record exact blocker.
+- Bandit is run for touched Python scope or explicitly skipped because this slice touches only frontend/docs/task files.
+- Backlog task records touched files, verification, residual risks, and PR link.
+
+**Tests:**
+- Focused Vitest command covering changed components.
+- Real-backend browser smoke of Character Chat missing-model/character-selector flow.
+
+**Status:** In Progress

--- a/Docs/superpowers/plans/2026-05-19-character-chat-phase2-readiness-plan.md
+++ b/Docs/superpowers/plans/2026-05-19-character-chat-phase2-readiness-plan.md
@@ -110,4 +110,4 @@
 - Focused Vitest command covering changed components.
 - Real-backend browser smoke of Character Chat missing-model/character-selector flow.
 
-**Status:** In Progress
+**Status:** Complete

--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -115,6 +115,10 @@ export const AssistantSelect: React.FC<Props> = ({
   )
   const [characters, setCharacters] = React.useState<CharacterSummary[]>([])
   const [personas, setPersonas] = React.useState<PersonaInfo[]>([])
+  const [charactersLoading, setCharactersLoading] = React.useState(true)
+  const [personasLoading, setPersonasLoading] = React.useState(true)
+  const [charactersError, setCharactersError] = React.useState(false)
+  const [personasError, setPersonasError] = React.useState(false)
   const [favoriteCharacters, setFavoriteCharacters] = useStorage<
     FavoriteCharacter[]
   >("favoriteCharacters", [])
@@ -195,32 +199,76 @@ export const AssistantSelect: React.FC<Props> = ({
     }
   }, [open])
 
+  const loadCharacters = React.useCallback(
+    async (isCancelled: () => boolean = () => false) => {
+      setCharactersLoading(true)
+      setCharactersError(false)
+      try {
+        await tldwClient.initialize()
+        if (typeof tldwClient.listAllCharacters !== "function") {
+          if (!isCancelled()) {
+            setCharacters([])
+          }
+          return
+        }
+        const result = await tldwClient.listAllCharacters()
+        if (!isCancelled()) {
+          setCharacters(Array.isArray(result) ? (result as CharacterSummary[]) : [])
+        }
+      } catch {
+        if (!isCancelled()) {
+          setCharacters([])
+          setCharactersError(true)
+        }
+      } finally {
+        if (!isCancelled()) {
+          setCharactersLoading(false)
+        }
+      }
+    },
+    []
+  )
+
+  const loadPersonas = React.useCallback(
+    async (isCancelled: () => boolean = () => false) => {
+      setPersonasLoading(true)
+      setPersonasError(false)
+      try {
+        await tldwClient.initialize()
+        if (typeof tldwClient.listPersonaProfiles !== "function") {
+          if (!isCancelled()) {
+            setPersonas([])
+          }
+          return
+        }
+        const result = await tldwClient.listPersonaProfiles()
+        if (!isCancelled()) {
+          setPersonas(Array.isArray(result) ? (result as PersonaInfo[]) : [])
+        }
+      } catch {
+        if (!isCancelled()) {
+          setPersonas([])
+          setPersonasError(true)
+        }
+      } finally {
+        if (!isCancelled()) {
+          setPersonasLoading(false)
+        }
+      }
+    },
+    []
+  )
+
   React.useEffect(() => {
     let cancelled = false
+    const isCancelled = () => cancelled
 
-    const loadOptions = async () => {
-      await tldwClient.initialize().catch(() => null)
-
-      if (typeof tldwClient.listAllCharacters === "function") {
-        const result = await tldwClient.listAllCharacters().catch(() => [])
-        if (!cancelled && Array.isArray(result)) {
-          setCharacters(result as CharacterSummary[])
-        }
-      }
-
-      if (typeof tldwClient.listPersonaProfiles === "function") {
-        const result = await tldwClient.listPersonaProfiles().catch(() => [])
-        if (!cancelled && Array.isArray(result)) {
-          setPersonas(result as PersonaInfo[])
-        }
-      }
-    }
-
-    void loadOptions()
+    void loadCharacters(isCancelled)
+    void loadPersonas(isCancelled)
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loadCharacters, loadPersonas])
 
   const characterEntries = React.useMemo(
     () =>
@@ -407,9 +455,55 @@ export const AssistantSelect: React.FC<Props> = ({
     activeTabDefinition?.emptyLabel ??
     t("option:assistant.noAssistants", "No assistants available.")
   const activeTabShowsFavorites = activeTabDefinition?.showFavorites ?? false
+  const activeTabLoading =
+    activeTab === "character" ? charactersLoading : personasLoading
+  const activeTabError =
+    activeTab === "character" ? charactersError : personasError
+  const retryActiveTabLoad =
+    activeTab === "character" ? loadCharacters : loadPersonas
+  const activeTabErrorLabel =
+    activeTab === "character"
+      ? t(
+          "option:assistant.charactersLoadError",
+          "Could not load characters."
+        )
+      : t("option:assistant.personasLoadError", "Could not load personas.")
+  const activeTabRetryLabel =
+    activeTab === "character"
+      ? t("option:assistant.retryCharacters", "Retry characters")
+      : t("option:assistant.retryPersonas", "Retry personas")
+  const catalogLoadingLabel = t(
+    "option:assistant.catalogLoadingStatus",
+    "Loading character and persona catalogs"
+  )
+  const activeTabLoadingLabel = t(
+    "option:assistant.loadingCatalogs",
+    "Loading characters and personas"
+  )
 
   const activeTabContent =
-    activeTabEntries.length === 0 ? (
+    activeTabLoading ? (
+      <div
+        role="status"
+        aria-label={catalogLoadingLabel}
+        className="px-3 py-4 text-center text-sm text-text-subtle"
+      >
+        {activeTabLoadingLabel}
+      </div>
+    ) : activeTabError ? (
+      <div className="space-y-2 px-3 py-4 text-center text-sm text-text-subtle">
+        <p>{activeTabErrorLabel}</p>
+        <button
+          type="button"
+          className="rounded-md border border-border bg-surface px-2 py-1 text-xs font-medium text-text hover:bg-surface2"
+          onClick={() => {
+            void retryActiveTabLoad()
+          }}
+        >
+          {activeTabRetryLabel}
+        </button>
+      </div>
+    ) : activeTabEntries.length === 0 ? (
       <div className="px-3 py-4 text-center text-sm text-text-subtle">
         {activeTabEmptyLabel}
       </div>

--- a/apps/packages/ui/src/components/Common/PromptSelect.tsx
+++ b/apps/packages/ui/src/components/Common/PromptSelect.tsx
@@ -63,7 +63,12 @@ export const PromptSelect: React.FC<Props> = ({
     scheduleFocusFirstVisibleElement(returnFocusSelector)
   }, [])
 
-  const { data } = useQuery({
+  const {
+    data,
+    isLoading: promptsLoading,
+    isError: promptsError,
+    refetch: refetchPrompts
+  } = useQuery({
     queryKey: ["getAllPromptsForSelect"],
     queryFn: getAllPrompts
   })
@@ -101,6 +106,19 @@ export const PromptSelect: React.FC<Props> = ({
     const prompt = data.find((item) => item.id === selectedSystemPrompt)
     return prompt?.title || null
   }, [data, selectedSystemPrompt])
+
+  const promptLoadingLabel = t(
+    "promptSelect.loadingPrompts",
+    "Loading prompts"
+  )
+  const promptUnavailableLabel = t(
+    "promptSelect.libraryUnavailable",
+    "Prompt library unavailable"
+  )
+  const promptRetryLabel = t(
+    "promptSelect.retryPromptLibrary",
+    "Retry prompt library"
+  )
 
   const openSystemPromptEditor = React.useCallback(async () => {
     setDropdownOpen(false)
@@ -172,6 +190,44 @@ export const PromptSelect: React.FC<Props> = ({
           }
         ]
       : []
+
+    if (promptsLoading) {
+      return [
+        {
+          key: "__prompts_loading__",
+          label: (
+            <span role="status" aria-label={promptLoadingLabel}>
+              {promptLoadingLabel}
+            </span>
+          )
+        }
+      ]
+    }
+
+    if (promptsError) {
+      return [
+        {
+          key: "__prompts_error__",
+          label: promptUnavailableLabel
+        },
+        {
+          key: "__prompts_retry__",
+          label: promptRetryLabel,
+          onClick: () => {
+            void refetchPrompts()
+          }
+        },
+        ...(currentSystemPromptRecoveryItems.length > 0
+          ? [
+              {
+                key: "__current_system_prompt_divider__",
+                type: "divider" as const
+              },
+              ...currentSystemPromptRecoveryItems
+            ]
+          : [])
+      ]
+    }
 
     if (filteredData.length === 0) {
       return [
@@ -296,6 +352,12 @@ export const PromptSelect: React.FC<Props> = ({
     searchText,
     selectedSystemPrompt,
     systemPrompt,
+    promptsLoading,
+    promptsError,
+    promptLoadingLabel,
+    promptUnavailableLabel,
+    promptRetryLabel,
+    refetchPrompts,
     t,
     handlePromptChange,
     openSystemPromptEditor,
@@ -371,128 +433,140 @@ export const PromptSelect: React.FC<Props> = ({
     }
   }, [dropdownOpen, restorePromptSelectFocus])
 
+  const triggerLabel = promptsLoading
+    ? promptLoadingLabel
+    : promptsError
+      ? promptUnavailableLabel
+      : selectedPromptLabel || t("promptSelect.label", "Prompt")
+  const triggerAriaLabel = promptsLoading
+    ? promptLoadingLabel
+    : promptsError
+      ? promptUnavailableLabel
+      : (t("selectAPrompt") as string)
+
   return (
     <>
-      {data && (
-        <>
-          <Dropdown
-            open={dropdownOpen}
-            onOpenChange={(nextOpen) => {
-              setDropdownOpen(nextOpen)
-              if (!nextOpen) {
+      <Dropdown
+        open={dropdownOpen}
+        onOpenChange={(nextOpen) => {
+          setDropdownOpen(nextOpen)
+          if (!nextOpen) {
+            restorePromptSelectFocus()
+          }
+        }}
+        menu={{
+          items: groupedMenuItems,
+          style: {
+            maxHeight: 400,
+            overflowY: "auto"
+          },
+          className: `no-scrollbar ${menuDensity === 'compact' ? 'menu-density-compact' : 'menu-density-comfortable'}`,
+          activeKey: selectedSystemPrompt
+        }}
+        popupRender={(menu) => (
+          <div
+            className="bg-surface rounded-lg shadow-lg border border-border"
+            onKeyDown={(e) => {
+              if (e.key !== "Escape") return
+              setDropdownOpen(false)
+              restorePromptSelectFocus()
+              e.stopPropagation()
+            }}
+          >
+            <div
+              className="p-2 border-b border-border"
+              onKeyDownCapture={(e) => {
+                if (e.key !== "Escape") return
+                e.preventDefault()
+                setDropdownOpen(false)
                 restorePromptSelectFocus()
-              }
-            }}
-            menu={{
-              items: groupedMenuItems,
-              style: {
-                maxHeight: 400,
-                overflowY: "auto"
-              },
-              className: `no-scrollbar ${menuDensity === 'compact' ? 'menu-density-compact' : 'menu-density-comfortable'}`,
-              activeKey: selectedSystemPrompt
-            }}
-            popupRender={(menu) => (
-              <div
-                className="bg-surface rounded-lg shadow-lg border border-border"
+                e.stopPropagation()
+              }}
+            >
+              <Input
+                ref={searchInputRef}
+                placeholder={t("searchPrompts", "Search prompts...")}
+                prefix={<Search className="size-4 text-text-subtle" />}
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                allowClear
+                size="small"
                 onKeyDown={(e) => {
-                  if (e.key !== "Escape") return
-                  setDropdownOpen(false)
-                  restorePromptSelectFocus()
                   e.stopPropagation()
                 }}
-              >
-                <div
-                  className="p-2 border-b border-border"
-                  onKeyDownCapture={(e) => {
-                    if (e.key !== "Escape") return
-                    e.preventDefault()
-                    setDropdownOpen(false)
-                    restorePromptSelectFocus()
-                    e.stopPropagation()
-                  }}
-                >
-                  <Input
-                    ref={searchInputRef}
-                    placeholder={t("searchPrompts", "Search prompts...")}
-                    prefix={<Search className="size-4 text-text-subtle" />}
-                    value={searchText}
-                    onChange={(e) => setSearchText(e.target.value)}
-                    allowClear
-                    size="small"
-                    onKeyDown={(e) => {
-                      e.stopPropagation()
-                    }}
-                  />
-                </div>
-                {menu}
-              </div>
-            )}
-            placement={"topLeft"}
-            trigger={["click"]}>
-            <Tooltip title={t("selectAPrompt")}>
-              <IconButton
-                ariaLabel={t("selectAPrompt") as string}
-                hasPopup="menu"
-                dataTestId="chat-prompt-select"
-                className={className}>
-                <BookIcon className={iconClassName} />
-                <span className="ml-1 hidden max-w-[120px] truncate text-xs font-medium text-text sm:inline">
-                  {selectedPromptLabel ||
-                    t("promptSelect.label", "Prompt")}
-                </span>
-              </IconButton>
-            </Tooltip>
-          </Dropdown>
-          <Modal
-            open={editorOpen}
-            title={t("promptSelect.editSystemPrompt", "Edit system prompt")}
-            onCancel={() => setEditorOpen(false)}
-            footer={
-              <div className="flex items-center justify-end gap-2">
-                <button type="button" onClick={() => setEditorOpen(false)}>
-                  {t("common:cancel", "Cancel")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    void handleEditorReset()
-                  }}
-                >
-                  {t("common:reset", "Reset")}
-                </button>
-                <button type="button" onClick={handleEditorSave}>
-                  {t("common:save", "Save")}
-                </button>
-              </div>
-            }>
-            <div className="space-y-3">
-              {editorOverrideActive ? (
-                <div className="text-xs text-text-subtle">
-                  {t(
-                    "promptSelect.overrideActive",
-                    "Override active: this conversation is currently using a custom system prompt instead of the selected template."
-                  )}
-                </div>
-              ) : null}
-              <Input.TextArea
-                rows={6}
-                placeholder={t(
-                  "promptSelect.systemPromptPlaceholder",
-                  "Enter system prompt"
-                )}
-                value={editorDraft}
-                onChange={(event) => setEditorDraft(event.target.value)}
               />
-              {editorLoading ? (
-                <div className="text-xs text-text-subtle">
-                  {t("common:loading", getDesignSystemState("loading")?.label)}
-                </div>
-              ) : null}
             </div>
-          </Modal>
-        </>
-      )}
+            {menu}
+          </div>
+        )}
+        placement={"topLeft"}
+        trigger={["click"]}>
+        <Tooltip title={triggerAriaLabel}>
+          <IconButton
+            ariaLabel={triggerAriaLabel}
+            hasPopup="menu"
+            dataTestId="chat-prompt-select"
+            className={className}>
+            <BookIcon className={iconClassName} />
+            <span className="ml-1 hidden max-w-[120px] truncate text-xs font-medium text-text sm:inline">
+              {promptsLoading ? (
+                <span role="status" aria-label={promptLoadingLabel}>
+                  {promptLoadingLabel}
+                </span>
+              ) : (
+                triggerLabel
+              )}
+            </span>
+          </IconButton>
+        </Tooltip>
+      </Dropdown>
+      <Modal
+        open={editorOpen}
+        title={t("promptSelect.editSystemPrompt", "Edit system prompt")}
+        onCancel={() => setEditorOpen(false)}
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <button type="button" onClick={() => setEditorOpen(false)}>
+              {t("common:cancel", "Cancel")}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                void handleEditorReset()
+              }}
+            >
+              {t("common:reset", "Reset")}
+            </button>
+            <button type="button" onClick={handleEditorSave}>
+              {t("common:save", "Save")}
+            </button>
+          </div>
+        }>
+        <div className="space-y-3">
+          {editorOverrideActive ? (
+            <div className="text-xs text-text-subtle">
+              {t(
+                "promptSelect.overrideActive",
+                "Override active: this conversation is currently using a custom system prompt instead of the selected template."
+              )}
+            </div>
+          ) : null}
+          <Input.TextArea
+            rows={6}
+            placeholder={t(
+              "promptSelect.systemPromptPlaceholder",
+              "Enter system prompt"
+            )}
+            value={editorDraft}
+            onChange={(event) => setEditorDraft(event.target.value)}
+          />
+          {editorLoading ? (
+            <div className="text-xs text-text-subtle">
+              {t("common:loading", getDesignSystemState("loading")?.label)}
+            </div>
+          ) : null}
+        </div>
+      </Modal>
     </>
   )
 }

--- a/apps/packages/ui/src/components/Common/PromptSelect.tsx
+++ b/apps/packages/ui/src/components/Common/PromptSelect.tsx
@@ -509,13 +509,7 @@ export const PromptSelect: React.FC<Props> = ({
             className={className}>
             <BookIcon className={iconClassName} />
             <span className="ml-1 hidden max-w-[120px] truncate text-xs font-medium text-text sm:inline">
-              {promptsLoading ? (
-                <span role="status" aria-label={promptLoadingLabel}>
-                  {promptLoadingLabel}
-                </span>
-              ) : (
-                triggerLabel
-              )}
+              {triggerLabel}
             </span>
           </IconButton>
         </Tooltip>

--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -154,6 +154,58 @@ describe("AssistantSelect behavior", () => {
     expect(screen.queryByRole("button", { name: "Alpha" })).toBeNull()
   })
 
+  it("announces character and persona catalog loading in the selector", async () => {
+    mocks.listAllCharacters.mockReturnValue(new Promise(() => {}))
+    mocks.listPersonaProfiles.mockReturnValue(new Promise(() => {}))
+
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    await user.click(
+      await screen.findByRole("button", { name: "Select character or persona" })
+    )
+
+    const status = await screen.findByRole("status", {
+      name: /loading character and persona catalogs/i
+    })
+    expect(status).toHaveTextContent("Loading characters and personas")
+  })
+
+  it("shows a retryable character catalog failure instead of an empty list", async () => {
+    mocks.listAllCharacters.mockRejectedValueOnce(new Error("characters failed"))
+
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    await user.click(
+      await screen.findByRole("button", { name: "Select character or persona" })
+    )
+
+    expect(
+      await screen.findByText(/could not load characters/i)
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /retry characters/i }))
+
+    expect(mocks.listAllCharacters).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps loaded characters usable when persona catalog loading fails", async () => {
+    mocks.listPersonaProfiles.mockRejectedValueOnce(new Error("personas failed"))
+
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    await user.click(
+      await screen.findByRole("button", { name: "Select character or persona" })
+    )
+
+    expect(await screen.findByRole("button", { name: "Alpha" })).toBeInTheDocument()
+    await user.click(await screen.findByRole("tab", { name: "Personas" }))
+    expect(
+      await screen.findByText(/could not load personas/i)
+    ).toBeInTheDocument()
+  })
+
   it("uses solid design-token backgrounds for the selector panel", async () => {
     const user = userEvent.setup()
     renderAssistantSelect()

--- a/apps/packages/ui/src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx
@@ -196,6 +196,44 @@ describe("PromptSelect system prompt modal", () => {
     expect(await screen.findByDisplayValue("Template body")).toBeInTheDocument()
   })
 
+  it("keeps the prompt trigger visible while the prompt library is loading", async () => {
+    mocks.getAllPrompts.mockReturnValue(new Promise(() => {}))
+
+    renderPromptSelect({
+      selectedSystemPrompt: undefined
+    })
+
+    expect(
+      await screen.findByRole("button", { name: /loading prompts/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /loading prompts/i })).toHaveTextContent(
+      "Loading prompts"
+    )
+  })
+
+  it("shows prompt library errors with a retry action", async () => {
+    const user = userEvent.setup()
+    mocks.getAllPrompts.mockRejectedValueOnce(new Error("dexie unavailable"))
+    renderPromptSelect({
+      selectedSystemPrompt: undefined
+    })
+
+    await user.click(
+      await screen.findByRole("button", { name: /prompt library unavailable/i })
+    )
+
+    expect(
+      await screen.findByRole("menuitem", {
+        name: /prompt library unavailable/i
+      })
+    ).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("menuitem", { name: /retry prompt library/i })
+    )
+
+    expect(mocks.getAllPrompts).toHaveBeenCalledTimes(2)
+  })
+
   it("saves edited prompt content through setSystemPrompt", async () => {
     const user = userEvent.setup()
     const { props } = renderPromptSelect()

--- a/apps/packages/ui/src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx
@@ -206,9 +206,10 @@ describe("PromptSelect system prompt modal", () => {
     expect(
       await screen.findByRole("button", { name: /loading prompts/i })
     ).toBeInTheDocument()
-    expect(screen.getByRole("status", { name: /loading prompts/i })).toHaveTextContent(
-      "Loading prompts"
-    )
+    expect(screen.getByText("Loading prompts")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("status", { name: /loading prompts/i })
+    ).not.toBeInTheDocument()
   })
 
   it("shows prompt library errors with a retry action", async () => {

--- a/apps/packages/ui/src/components/Option/Playground/CharacterChatReadinessPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterChatReadinessPanel.tsx
@@ -41,11 +41,13 @@ export const CharacterChatReadinessPanel = ({
   );
 
   if (missingCharacter) {
-    const titleTemplate = t(
+    const title = t(
       "characterChatReadiness.missingRestoredCharacter.title",
-      "Character {{id}} could not be loaded",
+      {
+        id: missingCharacter.id,
+        defaultValue: "Character {{id}} could not be loaded",
+      },
     ) as string;
-    const title = titleTemplate.replace("{{id}}", missingCharacter.id);
     const description = t(
       "characterChatReadiness.missingRestoredCharacter.description",
       "Choose another character or retry loading it.",

--- a/apps/packages/ui/src/components/Option/Playground/CharacterChatReadinessPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterChatReadinessPanel.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { AlertTriangle, RefreshCw, Settings2, UserCircle2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  getCharacterChatReadinessCopy,
+  type CharacterChatReadiness,
+  type CharacterChatReadinessAction,
+} from "@/utils/chat-model-availability";
+
+export type MissingCharacterRecovery = {
+  id: string;
+  reason: "missing" | "load-error";
+};
+
+type CharacterChatReadinessPanelProps = {
+  readiness: CharacterChatReadiness;
+  characterName?: string | null;
+  missingCharacter?: MissingCharacterRecovery | null;
+  onAction: (action: CharacterChatReadinessAction) => void;
+  onChooseCharacter?: () => void;
+  onRetryMissingCharacter?: () => void;
+};
+
+const panelClass =
+  "mx-auto mt-2 flex w-full max-w-[64rem] flex-wrap items-start justify-between gap-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning";
+const actionClass =
+  "inline-flex min-h-[28px] items-center gap-1 rounded-md border border-warning/40 bg-surface px-2 text-xs font-medium text-text hover:bg-surface2 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus";
+
+export const CharacterChatReadinessPanel = ({
+  readiness,
+  characterName,
+  missingCharacter,
+  onAction,
+  onChooseCharacter,
+  onRetryMissingCharacter,
+}: CharacterChatReadinessPanelProps) => {
+  const { t } = useTranslation("playground");
+  const statusLabel = t(
+    "characterChatReadiness.statusLabel",
+    "Character Chat setup status",
+  );
+
+  if (missingCharacter) {
+    const titleTemplate = t(
+      "characterChatReadiness.missingRestoredCharacter.title",
+      "Character {{id}} could not be loaded",
+    ) as string;
+    const title = titleTemplate.replace("{{id}}", missingCharacter.id);
+    const description = t(
+      "characterChatReadiness.missingRestoredCharacter.description",
+      "Choose another character or retry loading it.",
+    ) as string;
+
+    return (
+      <section
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label={statusLabel}
+        data-testid="character-chat-readiness-panel"
+        className={panelClass}
+      >
+        <div className="flex min-w-0 flex-1 items-start gap-2">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="font-semibold text-text">{title}</p>
+            <p className="mt-0.5 text-text-muted">{description}</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className={actionClass}
+            onClick={onChooseCharacter}
+          >
+            <UserCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("characterChatReadiness.character.action", "Choose character")}
+          </button>
+          <button
+            type="button"
+            className={actionClass}
+            onClick={onRetryMissingCharacter}
+          >
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("common:retry", "Retry")}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (readiness.status === "ready") {
+    return null;
+  }
+
+  const copy = getCharacterChatReadinessCopy(readiness, t, {
+    characterName,
+  });
+
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-label={statusLabel}
+      data-testid="character-chat-readiness-panel"
+      className={panelClass}
+    >
+      <div className="flex min-w-0 flex-1 items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+        <div className="min-w-0">
+          <p className="font-semibold text-text">{copy.title}</p>
+          <p className="mt-0.5 text-text-muted">{copy.description}</p>
+        </div>
+      </div>
+      {readiness.recommendedAction ? (
+        <button
+          type="button"
+          className={actionClass}
+          onClick={() => onAction(readiness.recommendedAction!)}
+        >
+          {readiness.recommendedAction === "choose-character" ? (
+            <UserCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Settings2 className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          {copy.actionLabel}
+        </button>
+      ) : null}
+    </section>
+  );
+};

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -538,9 +538,6 @@ export const Playground = () => {
     if (routeCharacterIntentAppliedRef.current === routeCharacterIntentId) {
       return;
     }
-    if (routeCharacterIntentInFlightRef.current === routeCharacterIntentId) {
-      return;
-    }
 
     const requestId = routeCharacterIntentRequestRef.current + 1;
     routeCharacterIntentRequestRef.current = requestId;
@@ -608,6 +605,9 @@ export const Playground = () => {
 
   React.useEffect(() => {
     if (!routeCharacterRecovery || !selectedCharacter?.id) return;
+    if (routeCharacterIntentInFlightRef.current === routeCharacterRecovery.id) {
+      return;
+    }
     if (String(selectedCharacter.id) !== routeCharacterRecovery.id) {
       setRouteCharacterRecovery(null);
     }

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -17,6 +17,10 @@ import {
 } from "./PlaygroundRuntimeInspector";
 import { PlaygroundStatusStrip } from "./PlaygroundStatusStrip";
 import {
+  CharacterChatReadinessPanel,
+  type MissingCharacterRecovery,
+} from "./CharacterChatReadinessPanel";
+import {
   buildCockpitAssistantSummary,
   buildCockpitMcpSummary,
   buildCockpitPromptSummary,
@@ -116,6 +120,10 @@ import {
   CHARACTER_CHAT_MODE_INTENT_EVENT,
   getCharacterChatRouteIntent,
 } from "@/utils/character-chat-mode-intent";
+import {
+  buildCharacterChatReadiness,
+  type CharacterChatReadinessAction,
+} from "@/utils/chat-model-availability";
 import type { Character } from "@/types/character";
 
 const toText = (value: unknown): string =>
@@ -208,6 +216,10 @@ export const Playground = () => {
   >([]);
   const [serverReadinessState, setServerReadinessState] =
     React.useState<ServerReadinessState>(null);
+  const [routeCharacterRecovery, setRouteCharacterRecovery] =
+    React.useState<MissingCharacterRecovery | null>(null);
+  const [routeCharacterRetryToken, setRouteCharacterRetryToken] =
+    React.useState(0);
   const [composerDockMetrics, setComposerDockMetrics] =
     React.useState<ComposerDockLayoutMetrics | null>(null);
   const [composerHasDraft, setComposerHasDraft] = React.useState(false);
@@ -551,11 +563,24 @@ export const Playground = () => {
       .then((character) => {
         if (routeCharacterIntentRequestRef.current !== requestId) return;
         routeCharacterIntentAppliedRef.current = routeCharacterIntentId;
-        void setSelectedCharacter(character || fallbackCharacter);
+        if (character) {
+          setRouteCharacterRecovery(null);
+          void setSelectedCharacter(character);
+          return;
+        }
+        setRouteCharacterRecovery({
+          id: routeCharacterIntentId,
+          reason: "missing",
+        });
+        void setSelectedCharacter(fallbackCharacter);
       })
       .catch(() => {
         if (routeCharacterIntentRequestRef.current !== requestId) return;
         routeCharacterIntentAppliedRef.current = routeCharacterIntentId;
+        setRouteCharacterRecovery({
+          id: routeCharacterIntentId,
+          reason: "load-error",
+        });
         void setSelectedCharacter(fallbackCharacter);
       })
       .finally(() => {
@@ -569,6 +594,7 @@ export const Playground = () => {
     };
   }, [
     routeCharacterIntentId,
+    routeCharacterRetryToken,
     setSelectedCharacter,
   ]);
 
@@ -576,8 +602,16 @@ export const Playground = () => {
     if (!routeCharacterIntentId) {
       routeCharacterIntentAppliedRef.current = null;
       routeCharacterIntentInFlightRef.current = null;
+      setRouteCharacterRecovery(null);
     }
   }, [routeCharacterIntentId]);
+
+  React.useEffect(() => {
+    if (!routeCharacterRecovery || !selectedCharacter?.id) return;
+    if (String(selectedCharacter.id) !== routeCharacterRecovery.id) {
+      setRouteCharacterRecovery(null);
+    }
+  }, [routeCharacterRecovery, selectedCharacter?.id]);
 
   React.useEffect(() => {
     const handleReadinessState = (event: Event) => {
@@ -1987,6 +2021,19 @@ export const Playground = () => {
     selectedProvider: apiProvider,
     selectedModel,
   });
+  const characterChatReadiness = React.useMemo(
+    () =>
+      buildCharacterChatReadiness({
+        isServerConnected: serverReadinessState !== "blocked",
+        selectedCharacter,
+        selectedModel: providerRouteSummary.selectedModel,
+      }),
+    [
+      providerRouteSummary.selectedModel,
+      selectedCharacter,
+      serverReadinessState,
+    ],
+  );
   React.useEffect(() => {
     if (typeof setActiveSettingsScope === "function") {
       setActiveSettingsScope(providerRouteSummary.providerRouteLabel ?? null);
@@ -2342,6 +2389,34 @@ export const Playground = () => {
       settingsScope: providerRouteSummary.providerRouteLabel ?? null,
     });
   }, [providerRouteSummary.providerRouteLabel, setActiveSettingsScope]);
+  const openCharacterSelectorFromReadiness = React.useCallback(() => {
+    openAssistantSelector({
+      tab: "character",
+      returnFocusSelector: COCKPIT_ASSISTANT_SELECT_TRIGGER_SELECTOR,
+    });
+  }, []);
+  const retryRouteCharacterRecovery = React.useCallback(() => {
+    if (!routeCharacterRecovery) return;
+    routeCharacterIntentAppliedRef.current = null;
+    routeCharacterIntentInFlightRef.current = null;
+    setRouteCharacterRecovery(null);
+    setRouteCharacterRetryToken((previous) => previous + 1);
+  }, [routeCharacterRecovery]);
+  const handleCharacterChatReadinessAction = React.useCallback(
+    (action: CharacterChatReadinessAction) => {
+      if (action === "choose-character") {
+        openCharacterSelectorFromReadiness();
+        return;
+      }
+      if (
+        action === "open-model-settings" ||
+        action === "open-server-settings"
+      ) {
+        openModelSettingsFromCockpit();
+      }
+    },
+    [openCharacterSelectorFromReadiness, openModelSettingsFromCockpit],
+  );
   const openMcpSettingsFromCockpit = React.useCallback(() => {
     openMcpSettings({
       returnFocusSelector: COCKPIT_MCP_SETTINGS_TRIGGER_SELECTOR,
@@ -2482,6 +2557,7 @@ export const Playground = () => {
       hasContext={hasChatContext}
       contextSummary={statusContextSummary}
       temporaryChat={temporaryChat}
+      characterChatActive={characterWorkflowActive}
       degraded={serverReadinessState === "degraded"}
       degradedChecks={serverDegradedChecks}
       errorMessage={null}
@@ -2904,6 +2980,16 @@ export const Playground = () => {
                 )}
               </div>
             )}
+            {characterWorkflowActive ? (
+              <CharacterChatReadinessPanel
+                readiness={characterChatReadiness}
+                characterName={activeCharacterModeLabel}
+                missingCharacter={routeCharacterRecovery}
+                onAction={handleCharacterChatReadinessAction}
+                onChooseCharacter={openCharacterSelectorFromReadiness}
+                onRetryMissingCharacter={retryRouteCharacterRecovery}
+              />
+            ) : null}
           </div>
           <div
             ref={containerRef}

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -85,6 +85,7 @@ import {
   applyChatSettingsPatch,
   syncChatSettingsForServerChat,
 } from "@/services/chat-settings";
+import { fetchChatModels } from "@/services/tldw-server";
 import {
   buildResearchFollowUpPrompt,
   clearAttachedResearchContext,
@@ -125,6 +126,8 @@ import {
   type CharacterChatReadinessAction,
 } from "@/utils/chat-model-availability";
 import type { Character } from "@/types/character";
+
+type ChatModelCatalog = Awaited<ReturnType<typeof fetchChatModels>>;
 
 const toText = (value: unknown): string =>
   typeof value === "string" ? value : String(value);
@@ -220,6 +223,8 @@ export const Playground = () => {
     React.useState<MissingCharacterRecovery | null>(null);
   const [routeCharacterRetryToken, setRouteCharacterRetryToken] =
     React.useState(0);
+  const [characterChatAvailableModels, setCharacterChatAvailableModels] =
+    React.useState<ChatModelCatalog | null>(null);
   const [composerDockMetrics, setComposerDockMetrics] =
     React.useState<ComposerDockLayoutMetrics | null>(null);
   const [composerHasDraft, setComposerHasDraft] = React.useState(false);
@@ -240,6 +245,24 @@ export const Playground = () => {
       CHAT_WORKFLOW_MODE_STORAGE_KEY,
       "standard",
     );
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    void fetchChatModels({ returnEmpty: true })
+      .then((models) => {
+        if (cancelled) return;
+        setCharacterChatAvailableModels(Array.isArray(models) ? models : []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCharacterChatAvailableModels([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const [characterModeIntentActive, setCharacterModeIntentActive] =
     React.useState(false);
   const [chatLayoutMode, setChatLayoutMode] =
@@ -2027,11 +2050,17 @@ export const Playground = () => {
         isServerConnected: serverReadinessState !== "blocked",
         selectedCharacter,
         selectedModel: providerRouteSummary.selectedModel,
+        availableModels: characterChatAvailableModels,
+        isSendBlocked: Boolean(streaming || isProcessing || isLoading),
       }),
     [
+      characterChatAvailableModels,
+      isLoading,
+      isProcessing,
       providerRouteSummary.selectedModel,
       selectedCharacter,
       serverReadinessState,
+      streaming,
     ],
   );
   React.useEffect(() => {
@@ -2389,6 +2418,15 @@ export const Playground = () => {
       settingsScope: providerRouteSummary.providerRouteLabel ?? null,
     });
   }, [providerRouteSummary.providerRouteLabel, setActiveSettingsScope]);
+  const openServerSettingsFromCockpit = React.useCallback(() => {
+    if (typeof setActiveSettingsScope === "function") {
+      setActiveSettingsScope(null);
+    }
+    openModelSettings({
+      returnFocusSelector: COCKPIT_MODEL_SETTINGS_TRIGGER_SELECTOR,
+      settingsScope: null,
+    });
+  }, [setActiveSettingsScope]);
   const openCharacterSelectorFromReadiness = React.useCallback(() => {
     openAssistantSelector({
       tab: "character",
@@ -2408,14 +2446,19 @@ export const Playground = () => {
         openCharacterSelectorFromReadiness();
         return;
       }
-      if (
-        action === "open-model-settings" ||
-        action === "open-server-settings"
-      ) {
+      if (action === "open-model-settings") {
         openModelSettingsFromCockpit();
+        return;
+      }
+      if (action === "open-server-settings") {
+        openServerSettingsFromCockpit();
       }
     },
-    [openCharacterSelectorFromReadiness, openModelSettingsFromCockpit],
+    [
+      openCharacterSelectorFromReadiness,
+      openModelSettingsFromCockpit,
+      openServerSettingsFromCockpit,
+    ],
   );
   const openMcpSettingsFromCockpit = React.useCallback(() => {
     openMcpSettings({

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
@@ -55,6 +55,7 @@ export type PlaygroundStatusStripProps = {
   hasContext: boolean;
   contextSummary?: string[];
   temporaryChat?: boolean;
+  characterChatActive?: boolean;
   degraded?: boolean;
   degradedChecks?: string[];
   errorMessage?: string | null;
@@ -82,6 +83,8 @@ export const PlaygroundStatusStrip = ({
   sessionDetail,
   sessionError,
   hasContext,
+  temporaryChat,
+  characterChatActive = false,
   degraded = false,
   degradedChecks = [],
   errorMessage,
@@ -182,6 +185,15 @@ export const PlaygroundStatusStrip = ({
       normalizedSessionStatusLabel !== t("cockpit.idle", "Idle"),
   );
   const hasCriticalSessionState = showSessionStatusLabel || Boolean(sessionDetailLabel);
+  const characterPersistenceLabel = characterChatActive
+    ? serverBlocked
+      ? t("cockpit.characterLocalDraft", "Local character chat draft")
+      : temporaryChat
+        ? t("cockpit.characterTemporary", "Temporary character chat")
+        : sessionStatus === "loaded"
+          ? t("cockpit.characterSaved", "Saved character chat")
+          : t("cockpit.characterLocalDraft", "Local character chat draft")
+    : null;
 
   return (
     <footer
@@ -218,6 +230,9 @@ export const PlaygroundStatusStrip = ({
           )}
           {runtimeLabel}
         </span>
+        {characterPersistenceLabel ? (
+          <span className={pillClass}>{characterPersistenceLabel}</span>
+        ) : null}
         {hasCriticalSessionState ? (
           <>
             <span className={pillClass}>{sessionLabel}</span>

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx
@@ -12,6 +12,11 @@ vi.mock("react-i18next", () => ({
       _key: string,
       fallbackOrOptions?: string | { defaultValue?: string; [key: string]: unknown },
     ) => {
+      if (_key === "characterChatReadiness.missingRestoredCharacter.title") {
+        return typeof fallbackOrOptions === "string"
+          ? fallbackOrOptions
+          : `Translated restored character ${fallbackOrOptions?.id}`;
+      }
       if (typeof fallbackOrOptions === "string") return fallbackOrOptions;
       const template = fallbackOrOptions?.defaultValue || _key;
       return template.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
@@ -101,7 +106,7 @@ describe("CharacterChatReadinessPanel", () => {
       name: "Character Chat setup status",
     });
     expect(panel).toHaveTextContent(
-      "Character missing-character could not be loaded",
+      "Translated restored character missing-character",
     );
     expect(panel).toHaveTextContent("Choose another character or retry loading it.");
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { buildCharacterChatReadiness } from "@/utils/chat-model-availability";
+
+import { CharacterChatReadinessPanel } from "../CharacterChatReadinessPanel";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [key: string]: unknown },
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions;
+      const template = fallbackOrOptions?.defaultValue || _key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = fallbackOrOptions?.[token];
+        return value == null ? `{{${token}}}` : String(value);
+      });
+    },
+  }),
+}));
+
+describe("CharacterChatReadinessPanel", () => {
+  it("announces a missing model with selected character context", () => {
+    const action = vi.fn();
+
+    render(
+      <CharacterChatReadinessPanel
+        readiness={buildCharacterChatReadiness({
+          isServerConnected: true,
+          selectedCharacter: { id: "ariadne", name: "Ariadne" },
+          selectedModel: null,
+        })}
+        characterName="Ariadne"
+        onAction={action}
+      />,
+    );
+
+    const panel = screen.getByRole("status", {
+      name: "Character Chat setup status",
+    });
+    expect(panel).toHaveAttribute("aria-live", "polite");
+    expect(panel).toHaveTextContent(
+      "Choose a chat model before chatting as Ariadne",
+    );
+    expect(panel).toHaveTextContent(
+      "return here to continue with Ariadne",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open model settings" }));
+    expect(action).toHaveBeenCalledWith("open-model-settings");
+  });
+
+  it("shows an unavailable selected model as a model-settings recovery", () => {
+    const action = vi.fn();
+
+    render(
+      <CharacterChatReadinessPanel
+        readiness={buildCharacterChatReadiness({
+          isServerConnected: true,
+          selectedCharacter: { id: "ariadne", name: "Ariadne" },
+          selectedModel: "missing-model",
+          availableModels: [{ model: "gpt-4o-mini" }],
+        })}
+        characterName="Ariadne"
+        onAction={action}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Choose a chat model before chatting as Ariadne",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open model settings" }));
+    expect(action).toHaveBeenCalledWith("open-model-settings");
+  });
+
+  it("surfaces a restored route character that can no longer be loaded", () => {
+    const chooseCharacter = vi.fn();
+    const retry = vi.fn();
+
+    render(
+      <CharacterChatReadinessPanel
+        readiness={buildCharacterChatReadiness({
+          isServerConnected: true,
+          selectedCharacter: { id: "missing-character", name: "Character missing-character" },
+          selectedModel: "gpt-4o-mini",
+        })}
+        missingCharacter={{
+          id: "missing-character",
+          reason: "missing",
+        }}
+        onAction={vi.fn()}
+        onChooseCharacter={chooseCharacter}
+        onRetryMissingCharacter={retry}
+      />,
+    );
+
+    const panel = screen.getByRole("status", {
+      name: "Character Chat setup status",
+    });
+    expect(panel).toHaveTextContent(
+      "Character missing-character could not be loaded",
+    );
+    expect(panel).toHaveTextContent("Choose another character or retry loading it.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose character" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(chooseCharacter).toHaveBeenCalledTimes(1);
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render a panel for the ready state", () => {
+    const { container } = render(
+      <CharacterChatReadinessPanel
+        readiness={buildCharacterChatReadiness({
+          isServerConnected: true,
+          selectedCharacter: { id: "ariadne", name: "Ariadne" },
+          selectedModel: "gpt-4o-mini",
+          availableModels: [{ model: "gpt-4o-mini" }],
+        })}
+        characterName="Ariadne"
+        onAction={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -444,6 +444,47 @@ describe("Playground cockpit shell", () => {
     );
   });
 
+  it("keeps restored route character recovery visible when an old character was selected", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/chat?mode=character&characterId=missing-character",
+    );
+    messageOptionState.value.selectedCharacter = {
+      id: "old-character",
+      name: "Old Character",
+    };
+    tldwClientState.getCharacter.mockRejectedValueOnce(new Error("missing"));
+
+    render(<Playground />);
+
+    expect(
+      await screen.findByText("Character missing-character could not be loaded"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a character to start character chat"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps route character recovery valid through strict-mode effect replays", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/chat?mode=character&characterId=missing-character",
+    );
+    tldwClientState.getCharacter.mockRejectedValue(new Error("missing"));
+
+    render(
+      <React.StrictMode>
+        <Playground />
+      </React.StrictMode>,
+    );
+
+    expect(
+      await screen.findByText("Character missing-character could not be loaded"),
+    ).toBeInTheDocument();
+  });
+
   it("keeps the selected character while opening model settings from readiness recovery", async () => {
     storageState.values.set("playgroundChatWorkflowMode", "character");
     messageOptionState.value.selectedCharacter = {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -84,7 +84,17 @@ const tldwClientState = vi.hoisted(() => ({
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, defaultValue?: string) => defaultValue || key,
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [key: string]: unknown },
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions;
+      const template = fallbackOrOptions?.defaultValue || key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+        const value = fallbackOrOptions?.[token];
+        return value == null ? `{{${token}}}` : String(value);
+      });
+    },
   }),
 }));
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -415,6 +415,92 @@ describe("Playground cockpit shell", () => {
     });
   });
 
+  it("shows recovery when a restored route character can no longer be loaded", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/chat?mode=character&characterId=missing-character",
+    );
+    tldwClientState.getCharacter.mockResolvedValueOnce(null);
+    const assistantSelectListener = vi.fn();
+    window.addEventListener("tldw:open-assistant-select", assistantSelectListener);
+
+    render(<Playground />);
+
+    expect(
+      await screen.findByText("Character missing-character could not be loaded"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose character" }));
+    expect(assistantSelectListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ tab: "character" }),
+      }),
+    );
+
+    window.removeEventListener(
+      "tldw:open-assistant-select",
+      assistantSelectListener,
+    );
+  });
+
+  it("keeps the selected character while opening model settings from readiness recovery", async () => {
+    storageState.values.set("playgroundChatWorkflowMode", "character");
+    messageOptionState.value.selectedCharacter = {
+      id: "char-1",
+      name: "Ariadne",
+    };
+    messageOptionState.value.selectedModel = null;
+    const modelSettingsListener = vi.fn();
+    window.addEventListener("tldw:open-model-settings", modelSettingsListener);
+
+    render(<Playground />);
+
+    expect(
+      await screen.findByText("Choose a chat model before chatting as Ariadne"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(screen.getByTestId("character-chat-readiness-panel")).getByRole(
+        "button",
+        { name: "Open model settings" },
+      ),
+    );
+
+    expect(modelSettingsListener).toHaveBeenCalledTimes(1);
+    expect(messageOptionState.value.setSelectedCharacter).not.toHaveBeenCalled();
+    expect(messageOptionState.value.selectedCharacter).toEqual({
+      id: "char-1",
+      name: "Ariadne",
+    });
+
+    window.removeEventListener(
+      "tldw:open-model-settings",
+      modelSettingsListener,
+    );
+  });
+
+  it("surfaces blocked server readiness locally in Character Chat mode", async () => {
+    storageState.values.set("playgroundChatWorkflowMode", "character");
+    messageOptionState.value.selectedCharacter = {
+      id: "char-1",
+      name: "Ariadne",
+    };
+
+    render(<Playground />);
+
+    fireEvent(
+      window,
+      new CustomEvent("tldw:server-readiness-state", {
+        detail: { state: "blocked" },
+      }),
+    );
+
+    expect(
+      await screen.findByText("Connect to tldw_server before starting character chat"),
+    ).toBeInTheDocument();
+  });
+
   it("does not write a partial character when header intent only changes mode", async () => {
     render(<Playground />);
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -82,6 +82,15 @@ const tldwClientState = vi.hoisted(() => ({
   getResearchBundle: vi.fn(async () => null),
 }));
 
+const tldwServerState = vi.hoisted(() => ({
+  fetchChatModels: vi.fn(async () => [
+    {
+      model: "openai:gpt-4.1-mini",
+      provider: "openai",
+    },
+  ]),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (
@@ -163,6 +172,10 @@ vi.mock("@/services/chat-settings", () => ({
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: tldwClientState,
+}));
+
+vi.mock("@/services/tldw-server", () => ({
+  fetchChatModels: tldwServerState.fetchChatModels,
 }));
 
 vi.mock("@/db/dexie/helpers", () => ({
@@ -307,6 +320,12 @@ describe("Playground cockpit shell", () => {
     sessionPersistenceState.value.sessionScopeReady = true;
     chatSettingsState.syncChatSettingsForServerChat.mockClear();
     cockpitChatRenderState.starterDeckSignals = [];
+    tldwServerState.fetchChatModels.mockResolvedValue([
+      {
+        model: "openai:gpt-4.1-mini",
+        provider: "openai",
+      },
+    ]);
     tldwClientState.getCharacter.mockImplementation(async (id: string | number) => ({
       id,
       name: "Route Character",
@@ -435,23 +454,25 @@ describe("Playground cockpit shell", () => {
     const assistantSelectListener = vi.fn();
     window.addEventListener("tldw:open-assistant-select", assistantSelectListener);
 
-    render(<Playground />);
+    try {
+      render(<Playground />);
 
-    expect(
-      await screen.findByText("Character missing-character could not be loaded"),
-    ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Character missing-character could not be loaded"),
+      ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Choose character" }));
-    expect(assistantSelectListener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: expect.objectContaining({ tab: "character" }),
-      }),
-    );
-
-    window.removeEventListener(
-      "tldw:open-assistant-select",
-      assistantSelectListener,
-    );
+      fireEvent.click(screen.getByRole("button", { name: "Choose character" }));
+      expect(assistantSelectListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: expect.objectContaining({ tab: "character" }),
+        }),
+      );
+    } finally {
+      window.removeEventListener(
+        "tldw:open-assistant-select",
+        assistantSelectListener,
+      );
+    }
   });
 
   it("keeps restored route character recovery visible when an old character was selected", async () => {
@@ -505,30 +526,70 @@ describe("Playground cockpit shell", () => {
     const modelSettingsListener = vi.fn();
     window.addEventListener("tldw:open-model-settings", modelSettingsListener);
 
+    try {
+      render(<Playground />);
+
+      expect(
+        await screen.findByText("Choose a chat model before chatting as Ariadne"),
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        within(screen.getByTestId("character-chat-readiness-panel")).getByRole(
+          "button",
+          { name: "Open model settings" },
+        ),
+      );
+
+      expect(modelSettingsListener).toHaveBeenCalledTimes(1);
+      expect(messageOptionState.value.setSelectedCharacter).not.toHaveBeenCalled();
+      expect(messageOptionState.value.selectedCharacter).toEqual({
+        id: "char-1",
+        name: "Ariadne",
+      });
+
+    } finally {
+      window.removeEventListener(
+        "tldw:open-model-settings",
+        modelSettingsListener,
+      );
+    }
+  });
+
+  it("surfaces unavailable selected chat models from the model catalog", async () => {
+    storageState.values.set("playgroundChatWorkflowMode", "character");
+    messageOptionState.value.selectedCharacter = {
+      id: "char-1",
+      name: "Ariadne",
+    };
+    messageOptionState.value.selectedModel = "missing-model";
+    tldwServerState.fetchChatModels.mockResolvedValueOnce([
+      {
+        model: "openai:gpt-4.1-mini",
+        provider: "openai",
+      },
+    ]);
+
     render(<Playground />);
 
     expect(
       await screen.findByText("Choose a chat model before chatting as Ariadne"),
     ).toBeInTheDocument();
+  });
 
-    fireEvent.click(
-      within(screen.getByTestId("character-chat-readiness-panel")).getByRole(
-        "button",
-        { name: "Open model settings" },
-      ),
-    );
-
-    expect(modelSettingsListener).toHaveBeenCalledTimes(1);
-    expect(messageOptionState.value.setSelectedCharacter).not.toHaveBeenCalled();
-    expect(messageOptionState.value.selectedCharacter).toEqual({
+  it("surfaces send-blocked readiness while character chat is streaming", async () => {
+    storageState.values.set("playgroundChatWorkflowMode", "character");
+    messageOptionState.value.selectedCharacter = {
       id: "char-1",
       name: "Ariadne",
-    });
+    };
+    messageOptionState.value.selectedModel = "openai:gpt-4.1-mini";
+    messageOptionState.value.streaming = true;
 
-    window.removeEventListener(
-      "tldw:open-model-settings",
-      modelSettingsListener,
-    );
+    render(<Playground />);
+
+    expect(
+      await screen.findByText("Character chat is preparing"),
+    ).toBeInTheDocument();
   });
 
   it("surfaces blocked server readiness locally in Character Chat mode", async () => {
@@ -537,19 +598,35 @@ describe("Playground cockpit shell", () => {
       id: "char-1",
       name: "Ariadne",
     };
+    const modelSettingsListener = vi.fn();
+    window.addEventListener("tldw:open-model-settings", modelSettingsListener);
 
-    render(<Playground />);
+    try {
+      render(<Playground />);
 
-    fireEvent(
-      window,
-      new CustomEvent("tldw:server-readiness-state", {
-        detail: { state: "blocked" },
-      }),
-    );
+      fireEvent(
+        window,
+        new CustomEvent("tldw:server-readiness-state", {
+          detail: { state: "blocked" },
+        }),
+      );
 
-    expect(
-      await screen.findByText("Connect to tldw_server before starting character chat"),
-    ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Connect to tldw_server before starting character chat"),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Open server settings" }));
+
+      const event = modelSettingsListener.mock.calls[0]?.[0] as CustomEvent;
+      expect(event.detail).toMatchObject({
+        settingsScope: null,
+      });
+    } finally {
+      window.removeEventListener(
+        "tldw:open-model-settings",
+        modelSettingsListener,
+      );
+    }
   });
 
   it("does not write a partial character when header intent only changes mode", async () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
@@ -75,6 +75,75 @@ describe("PlaygroundStatusStrip first-slice state", () => {
     expect(status).not.toHaveTextContent("Not saved");
   });
 
+  it("labels temporary Character Chat persistence explicitly", () => {
+    render(
+      <PlaygroundStatusStrip
+        mode="cockpit"
+        streaming={false}
+        selectedProvider="openai"
+        selectedModel="gpt-4.1-mini"
+        messageCount={1}
+        sessionLabel="Temporary chat"
+        hasContext={false}
+        contextSummary={[]}
+        temporaryChat
+        characterChatActive
+        degradedChecks={[]}
+        errorMessage={null}
+      />,
+    );
+
+    const status = screen.getByRole("status", { name: "Chat status" });
+    expect(status).toHaveTextContent("Temporary character chat");
+  });
+
+  it("labels saved Character Chat persistence when session history is loaded", () => {
+    render(
+      <PlaygroundStatusStrip
+        mode="cockpit"
+        streaming={false}
+        selectedProvider="openai"
+        selectedModel="gpt-4.1-mini"
+        messageCount={4}
+        sessionLabel="Server chat"
+        sessionStatus="loaded"
+        sessionStatusLabel="Local history"
+        hasContext={false}
+        contextSummary={[]}
+        temporaryChat={false}
+        characterChatActive
+        degradedChecks={[]}
+        errorMessage={null}
+      />,
+    );
+
+    const status = screen.getByRole("status", { name: "Chat status" });
+    expect(status).toHaveTextContent("Saved character chat");
+  });
+
+  it("labels blocked-server Character Chat as a local draft", () => {
+    render(
+      <PlaygroundStatusStrip
+        mode="cockpit"
+        streaming={false}
+        selectedProvider="openai"
+        selectedModel="gpt-4.1-mini"
+        messageCount={0}
+        sessionLabel="Server chat"
+        hasContext={false}
+        contextSummary={[]}
+        temporaryChat={false}
+        characterChatActive
+        degradedChecks={[]}
+        errorMessage={null}
+        serverBlocked
+      />,
+    );
+
+    const status = screen.getByRole("status", { name: "Chat status" });
+    expect(status).toHaveTextContent("Local character chat draft");
+  });
+
   it("renders degraded checks as warning-only status", () => {
     render(
       <PlaygroundStatusStrip

--- a/apps/packages/ui/src/utils/chat-model-availability.ts
+++ b/apps/packages/ui/src/utils/chat-model-availability.ts
@@ -92,14 +92,7 @@ const translateReadinessCopy = (
     typeof fallbackOrOptions === "string"
       ? fallbackOrOptions
       : fallbackOrOptions.defaultValue
-  const fallbackText = String(fallback ?? key)
-  if (typeof fallbackOrOptions !== "string") {
-    return fallbackText.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
-      const value = fallbackOrOptions[token]
-      return value == null ? `{{${token}}}` : String(value)
-    })
-  }
-  return fallbackText
+  return String(fallback ?? key)
 }
 
 export function normalizeChatModelId(value: string | null | undefined): string {

--- a/apps/packages/ui/src/utils/chat-model-availability.ts
+++ b/apps/packages/ui/src/utils/chat-model-availability.ts
@@ -92,7 +92,14 @@ const translateReadinessCopy = (
     typeof fallbackOrOptions === "string"
       ? fallbackOrOptions
       : fallbackOrOptions.defaultValue
-  return String(fallback ?? key)
+  const fallbackText = String(fallback ?? key)
+  if (typeof fallbackOrOptions !== "string") {
+    return fallbackText.replace(/\{\{(\w+)\}\}/g, (_, token: string) => {
+      const value = fallbackOrOptions[token]
+      return value == null ? `{{${token}}}` : String(value)
+    })
+  }
+  return fallbackText
 }
 
 export function normalizeChatModelId(value: string | null | undefined): string {

--- a/backlog/tasks/task-438 - Implement-Character-Chat-Phase-2-readiness-errors-and-empty-states.md
+++ b/backlog/tasks/task-438 - Implement-Character-Chat-Phase-2-readiness-errors-and-empty-states.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-438
 title: Implement Character Chat Phase 2 readiness errors and empty states
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-05-19 04:18
 labels:
@@ -31,10 +31,10 @@ Implement Phase 2 from the first-class Character Chat PRD: make incomplete Chara
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Missing server, missing character, missing model, unavailable model, prompt load failure, and character catalog failure all have visible local Character Chat states.
-- [ ] #2 Selecting a character before model setup preserves character intent through settings handoff and retry.
-- [ ] #3 Character Chat setup/readiness status changes are exposed through appropriate live-region semantics.
-- [ ] #4 Focused unit/integration tests and real-backend browser smoke coverage are recorded; Bandit is run or explicitly skipped for non-Python scope.
+- [x] #1 Missing server, missing character, missing model, unavailable model, prompt load failure, and character catalog failure all have visible local Character Chat states.
+- [x] #2 Selecting a character before model setup preserves character intent through settings handoff and retry.
+- [x] #3 Character Chat setup/readiness status changes are exposed through appropriate live-region semantics.
+- [x] #4 Focused unit/integration tests and real-backend browser smoke coverage are recorded; Bandit is run or explicitly skipped for non-Python scope.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -45,10 +45,43 @@ Implement Phase 2 from the first-class Character Chat PRD: make incomplete Chara
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Touched Files
+
+- `apps/packages/ui/src/components/Option/Playground/CharacterChatReadinessPanel.tsx`
+- `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+- `apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx`
+- `apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx`
+- `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx`
+- `apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx`
+- `apps/packages/ui/src/components/Common/AssistantSelect.tsx`
+- `apps/packages/ui/src/components/Common/PromptSelect.tsx`
+- `apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx`
+- `apps/packages/ui/src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx`
+- `apps/packages/ui/src/utils/chat-model-availability.ts`
+- `apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts`
+- `Docs/superpowers/plans/2026-05-19-character-chat-phase2-readiness-plan.md`
+
+## Verification
+
+- `bun run test -- src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx src/components/Common/__tests__/AssistantSelect.behavior.test.tsx src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/utils/__tests__/chat-model-availability.test.ts --maxWorkers=1 --no-file-parallelism` passed: 6 files, 88 tests.
+- Real backend smoke used FastAPI on `127.0.0.1:8000` and WebUI on `127.0.0.1:8080`; `/chat?mode=character&characterId=missing-character` rendered `Character missing-character could not be loaded`, `Choose character`, and `Retry` after the real backend returned `404` for `/api/v1/characters/missing-character`.
+- Browser smoke also confirmed fallback character intent persisted in local storage as `selectedCharacter` and `selectedAssistant` with id `missing-character`.
+- `bunx tsc --noEmit --pretty false` still fails on existing repo-wide TypeScript debt; captured output in `/tmp/tldw_phase2_tsc_after_strict.txt` has 255 lines and no matches for the touched files listed above.
+- Bandit skipped: this slice only touches frontend TypeScript/tests plus Backlog/plan documentation, with no Python source changes.
+
+## Final Summary
+
+Implemented local Character Chat setup/readiness states, selector loading/error states, persistence labels, and restored-character recovery without adding a parallel role-play UI. A real-backend smoke found a strict-mode route recovery race; added strict-mode coverage and fixed the stale in-flight guard so restored missing characters keep their recovery panel visible.
+
+## Known Skips Or Blockers
+
+- Repo-wide TypeScript baseline remains red outside this slice.
+- Real browser console reports expected 404 warnings for the intentionally missing smoke-test character.

--- a/backlog/tasks/task-438 - Implement-Character-Chat-Phase-2-readiness-errors-and-empty-states.md
+++ b/backlog/tasks/task-438 - Implement-Character-Chat-Phase-2-readiness-errors-and-empty-states.md
@@ -18,6 +18,7 @@ references:
 - TASK-428
 - TASK-429
 - TASK-431
+- https://github.com/rmusser01/tldw_server/pull/1866
 documentation:
 - Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
 priority: high
@@ -76,6 +77,7 @@ Implement Phase 2 from the first-class Character Chat PRD: make incomplete Chara
 - Browser smoke also confirmed fallback character intent persisted in local storage as `selectedCharacter` and `selectedAssistant` with id `missing-character`.
 - `bunx tsc --noEmit --pretty false` still fails on existing repo-wide TypeScript debt; captured output in `/tmp/tldw_phase2_tsc_after_strict.txt` has 255 lines and no matches for the touched files listed above.
 - Bandit skipped: this slice only touches frontend TypeScript/tests plus Backlog/plan documentation, with no Python source changes.
+- Draft PR: https://github.com/rmusser01/tldw_server/pull/1866
 
 ## Final Summary
 

--- a/backlog/tasks/task-438 - Implement-Character-Chat-Phase-2-readiness-errors-and-empty-states.md
+++ b/backlog/tasks/task-438 - Implement-Character-Chat-Phase-2-readiness-errors-and-empty-states.md
@@ -1,0 +1,54 @@
+---
+id: TASK-438
+title: Implement Character Chat Phase 2 readiness errors and empty states
+status: In Progress
+assignee: []
+created_date: 2026-05-19 04:18
+labels:
+- chat
+- characters
+- role-play
+- phase-2
+- frontend
+- accessibility
+dependencies: []
+references:
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+- TASK-426
+- TASK-428
+- TASK-429
+- TASK-431
+documentation:
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Phase 2 from the first-class Character Chat PRD: make incomplete Character Chat setup, loading, no-provider, deleted/missing character, prompt/assistant catalog failures, and persistence state local and actionable on /chat. Preserve selected character intent through model/settings recovery and expose setup status changes to assistive tech.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Missing server, missing character, missing model, unavailable model, prompt load failure, and character catalog failure all have visible local Character Chat states.
+- [ ] #2 Selecting a character before model setup preserves character intent through settings handoff and retry.
+- [ ] #3 Character Chat setup/readiness status changes are exposed through appropriate live-region semantics.
+- [ ] #4 Focused unit/integration tests and real-backend browser smoke coverage are recorded; Bandit is run or explicitly skipped for non-Python scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Follow `Docs/superpowers/plans/2026-05-19-character-chat-phase2-readiness-plan.md`. 2. Add failing tests for readiness panel, selector failure states, persistence labels, and restored missing character recovery. 3. Implement minimal existing-surface UI changes. 4. Verify with focused Vitest, real-backend browser smoke where available, Bandit skip note for frontend-only scope, and closeout evidence.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-439 - Address-PR-1866-Character-Chat-review-comments.md
+++ b/backlog/tasks/task-439 - Address-PR-1866-Character-Chat-review-comments.md
@@ -1,0 +1,47 @@
+---
+id: TASK-439
+title: Address PR 1866 Character Chat review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-19 19:14'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address live PR #1866 review comments for Character Chat Phase 2 readiness, including i18next interpolation usage and redundant PromptSelect loading status markup, with focused frontend regression tests and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Verify live PR #1866 review comments before patching.
+- [x] #2 PromptSelect loading trigger avoids redundant nested status announcements while keeping visible loading copy.
+- [x] #3 Character Chat missing restored character copy uses i18next interpolation options.
+- [x] #4 Character readiness copy delegates interpolation to the translation layer without manual placeholder replacement.
+- [x] #5 Focused frontend tests pass and verification results are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified live PR #1866 review threads via GitHub GraphQL. Addressed Gemini comments by removing the nested prompt-loading role=status span, switching missing restored character copy to i18next interpolation options, and removing manual placeholder interpolation from the readiness copy helper. Updated local test translation mocks to support i18next-style options.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all currently actionable PR #1866 review comments. Verification: red tests failed before the fix for PromptSelect redundant status markup and missing-character interpolation; focused Vitest suite passed with 6 files and 88 tests; git diff --check passed. TypeScript still fails on existing repo-wide baseline debt, and captured output in /tmp/tldw_pr1866_review_tsc.txt has no errors matching the files touched in this review pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-440 - Address-PR-1866-readiness-wiring-review-comments.md
+++ b/backlog/tasks/task-440 - Address-PR-1866-readiness-wiring-review-comments.md
@@ -1,0 +1,47 @@
+---
+id: TASK-440
+title: Address PR 1866 readiness wiring review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-19 19:22'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the second live PR #1866 review batch for Character Chat readiness wiring, including model catalog/send-blocked readiness inputs, server recovery settings routing, and robust test listener cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Verify Qodo and CodeRabbit comments against current code before patching.
+- [x] #2 Playground passes chat model catalog and send-blocked state into Character Chat readiness.
+- [x] #3 Server recovery action opens the unscoped server settings target instead of provider-scoped model settings.
+- [x] #4 Playground cockpit listener tests clean up global listeners even if assertions fail.
+- [x] #5 Focused frontend tests pass and verification results are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified Qodo and CodeRabbit comments against current Playground wiring. Added Character Chat readiness catalog loading in Playground via fetchChatModels({ returnEmpty: true }), passed availableModels and send-blocked state into buildCharacterChatReadiness, split model settings and server settings recovery so server recovery dispatches an unscoped settings event, and wrapped global listener assertions in try/finally.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the second live PR #1866 review batch. Verification: red cockpit-shell tests failed for unavailable model, send-blocked readiness, and scoped server recovery before the fix; focused Vitest suite passed with 6 files and 90 tests; git diff --check passed. TypeScript still fails on existing repo-wide baseline debt, and /tmp/tldw_pr1866_review2_tsc.txt has no errors matching the files touched in this review pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds a Character Chat readiness panel for incomplete setup, restored missing characters, missing/unavailable models, and server-blocked states.
- Keeps Prompt and Assistant selectors visible through loading/error/empty catalog states with retry affordances.
- Labels Character Chat persistence state in the status strip and fixes strict-mode route recovery so missing restored characters keep their recovery panel visible.

## Verification
- `bun run test -- src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx src/components/Common/__tests__/AssistantSelect.behavior.test.tsx src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/utils/__tests__/chat-model-availability.test.ts --maxWorkers=1 --no-file-parallelism`
- Real-backend browser smoke: FastAPI on `127.0.0.1:8000`, WebUI on `127.0.0.1:8080`, `/chat?mode=character&characterId=missing-character` showed `Character missing-character could not be loaded`, `Choose character`, and `Retry` after a real 404 from `/api/v1/characters/missing-character`.
- `bunx tsc --noEmit --pretty false` still fails on existing repo-wide TypeScript baseline debt; `/tmp/tldw_phase2_tsc_after_strict.txt` has no matches for touched files.
- Bandit skipped: frontend TypeScript/tests/docs/task-only slice.

## Change summary
TODO: human-authored change summary required before merge.

## Notes
- Leaves generated untracked watchlist template files unstaged; they were emitted by backend startup during smoke verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Character Chat readiness to make setup issues visible and actionable in /chat. Wires in model catalog and send‑blocked state, improves selector loading/error UX and persistence labels, and fixes strict‑mode route recovery and accessibility.

- **New Features**
  - Readiness panel for incomplete setup: missing server/character, no/unavailable model (via catalog), and send‑blocked; actions to choose character, open settings, or retry.
  - `PromptSelect` stays visible through loading/error/empty with clear copy and a retry.
  - `AssistantSelect` shows per‑tab loading/error with retry; Characters remain usable if Personas fail.
  - Status strip labels Character Chat persistence (temporary, saved, local draft).
  - Polite live‑region announcements. Meets TASK-438 Phase 2 readiness.

- **Bug Fixes**
  - Fixed strict‑mode route recovery so a restored missing character keeps its recovery panel.
  - Opening model/server settings from readiness preserves the selected character; server recovery now opens unscoped server settings.
  - `PromptSelect` accessibility: removed redundant status announcements; fixed i18n interpolation for restored‑character copy.

<sup>Written for commit 05ed8ffa710db9cfc9ba8bb1b99b1421f9d4c94f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1866?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

