### PR TITLE
Watchlists PR6 end-to-end hardening

### DIFF
--- a/backlog/tasks/task-439 - Watchlists-PR6-end-to-end-verification-and-release-hardening.md
+++ b/backlog/tasks/task-439 - Watchlists-PR6-end-to-end-verification-and-release-hardening.md
@@ -30,13 +30,14 @@ Verification notes:
 - Bandit initially flagged B405 stdlib XML imports in Watchlists RSS/OPML/WebSub parser files. Those imports were replaced with `defusedxml.ElementTree`, then Bandit passed with 0 findings on `watchlists.py`, `watchlists_schemas.py`, and `app/core/Watchlists`.
 - Parser-adjacent regressions passed after the XML parser patch: OPML API/edge/export tests (6 passed) and RSS/fetcher/WebSub tests (42 passed).
 - Browser QA used an isolated backend on `127.0.0.1:18002` and WebUI on `127.0.0.1:8082`. `/watchlists` rendered the Watchlists page with `Imported Watchlist`; observed Watchlists API calls returned 200; no console errors, request failures, or page errors in the final page-load pass. Create Watchlist opened the guided setup modal without errors. Overview shortcuts opened Feeds and Monitors content; telemetry/notification stream requests aborted only during scripted navigation/teardown.
-- `git diff --check` passed before browser QA and should be rerun before commit.
+- `git diff --check` passed before browser QA and again before commit.
+- Pull request: https://github.com/rmusser01/tldw_server/pull/1867
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed PR6 release-hardening verification for Watchlists. The only code change required was removing remaining stdlib XML imports from Watchlists RSS, OPML, and WebSub parsing paths so Bandit no longer reports B405 while existing defusedxml parsing remains intact. Focused frontend, backend, parser-adjacent, Bandit, and browser-observed `/watchlists` checks passed.
+Completed PR6 release-hardening verification for Watchlists in PR #1867. The only code change required was removing remaining stdlib XML imports from Watchlists RSS, OPML, and WebSub parsing paths so Bandit no longer reports B405 while existing defusedxml parsing remains intact. Focused frontend, backend, parser-adjacent, Bandit, and browser-observed `/watchlists` checks passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-439 - Watchlists-PR6-end-to-end-verification-and-release-hardening.md
+++ b/backlog/tasks/task-439 - Watchlists-PR6-end-to-end-verification-and-release-hardening.md
@@ -1,0 +1,50 @@
+---
+id: TASK-439
+title: Watchlists PR6 end-to-end verification and release hardening
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 11 from the Watchlists digest/audio implementation plan: run focused frontend/backend/security verification, perform browser-observed /watchlists QA where feasible, and patch only verified release-hardening issues.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused Watchlists frontend gates pass or failures are classified with fixes/skips.
+- [x] #2 Focused Watchlists backend verification passes or failures are classified with fixes/skips.
+- [x] #3 Bandit runs on touched Watchlists backend scope or an explicit non-code skip is documented.
+- [x] #4 Browser-observed `/watchlists` QA is performed where local services can be started, or the blocker is documented.
+- [x] #5 Any release-hardening code changes are verified with targeted regression tests.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Branch started from `origin/dev` after PR #1864 merge commit `0a892b044`. Scope follows Task 11 in `Docs/superpowers/plans/2026-05-18-watchlists-digest-audio-briefing-implementation-plan.md`.
+
+Verification notes:
+- Frontend gates passed after `bun install` in `apps/`: `bun run test:watchlists:typecheck` (1 file, 3 tests), `bun run test:watchlists:scale` (7 files, 53 tests), and `bun run test:watchlists:a11y` (12 files, 85 tests). The a11y suite emitted expected negative-test stderr but passed.
+- Backend focused verification passed: `python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_api.py tldw_Server_API/tests/Watchlists/test_full_pipeline_integration.py tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py tldw_Server_API/tests/Watchlists/test_audio_output_delivery.py -q` -> 66 passed, 1 xpassed, 5 warnings.
+- Bandit initially flagged B405 stdlib XML imports in Watchlists RSS/OPML/WebSub parser files. Those imports were replaced with `defusedxml.ElementTree`, then Bandit passed with 0 findings on `watchlists.py`, `watchlists_schemas.py`, and `app/core/Watchlists`.
+- Parser-adjacent regressions passed after the XML parser patch: OPML API/edge/export tests (6 passed) and RSS/fetcher/WebSub tests (42 passed).
+- Browser QA used an isolated backend on `127.0.0.1:18002` and WebUI on `127.0.0.1:8082`. `/watchlists` rendered the Watchlists page with `Imported Watchlist`; observed Watchlists API calls returned 200; no console errors, request failures, or page errors in the final page-load pass. Create Watchlist opened the guided setup modal without errors. Overview shortcuts opened Feeds and Monitors content; telemetry/notification stream requests aborted only during scripted navigation/teardown.
+- `git diff --check` passed before browser QA and should be rerun before commit.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed PR6 release-hardening verification for Watchlists. The only code change required was removing remaining stdlib XML imports from Watchlists RSS, OPML, and WebSub parsing paths so Bandit no longer reports B405 while existing defusedxml parsing remains intact. Focused frontend, backend, parser-adjacent, Bandit, and browser-observed `/watchlists` checks passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-439 - Watchlists-PR6-end-to-end-verification-and-release-hardening.md
+++ b/backlog/tasks/task-439 - Watchlists-PR6-end-to-end-verification-and-release-hardening.md
@@ -32,12 +32,13 @@ Verification notes:
 - Browser QA used an isolated backend on `127.0.0.1:18002` and WebUI on `127.0.0.1:8082`. `/watchlists` rendered the Watchlists page with `Imported Watchlist`; observed Watchlists API calls returned 200; no console errors, request failures, or page errors in the final page-load pass. Create Watchlist opened the guided setup modal without errors. Overview shortcuts opened Feeds and Monitors content; telemetry/notification stream requests aborted only during scripted navigation/teardown.
 - `git diff --check` passed before browser QA and again before commit.
 - Pull request: https://github.com/rmusser01/tldw_server/pull/1867
+- Review follow-up: added `_gather_outlines()` documentation and replaced the broad `Any` annotation with a local protocol because `defusedxml.ElementTree` does not expose an `Element` attribute at runtime.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed PR6 release-hardening verification for Watchlists in PR #1867. The only code change required was removing remaining stdlib XML imports from Watchlists RSS, OPML, and WebSub parsing paths so Bandit no longer reports B405 while existing defusedxml parsing remains intact. Focused frontend, backend, parser-adjacent, Bandit, and browser-observed `/watchlists` checks passed.
+Completed PR6 release-hardening verification for Watchlists in PR #1867. The release-hardening changes remove remaining stdlib XML imports from Watchlists RSS, OPML, and WebSub parsing paths so Bandit no longer reports B405 while existing defusedxml parsing remains intact. Review follow-up tightened OPML helper typing and documentation. Focused frontend, backend, parser-adjacent, Bandit, and browser-observed `/watchlists` checks passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Watchlists/fetchers.py
+++ b/tldw_Server_API/app/core/Watchlists/fetchers.py
@@ -19,7 +19,6 @@ import asyncio
 import contextlib
 import os
 import re
-import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from collections.abc import Sequence
 from datetime import datetime, timezone
@@ -28,7 +27,7 @@ from threading import Lock
 from typing import Any
 from urllib.parse import urljoin
 
-from defusedxml import ElementTree as DET
+from defusedxml import ElementTree as ET
 from defusedxml.common import DefusedXmlException
 import regex
 from loguru import logger
@@ -1749,7 +1748,7 @@ async def fetch_rss_feed(
             return {"status": status, "items": []}
 
         try:
-            root = DET.fromstring(text)
+            root = ET.fromstring(text)
         except _WATCHLISTS_FETCHERS_NONCRITICAL_EXCEPTIONS:
             return {
                 "status": status,
@@ -1869,7 +1868,7 @@ def discover_hub_url(
 
     # Phase 2: Parse XML for <link rel="hub"> and <link rel="self">
     try:
-        root = DET.fromstring(xml_text)
+        root = ET.fromstring(xml_text)
         atom_link_tag = "{http://www.w3.org/2005/Atom}link"
         # Search both direct children and descendants (RSS puts atom:link inside <channel>)
         for ln in list(root.findall(atom_link_tag)) + list(root.findall(".//" + atom_link_tag)) + list(root.findall("link")) + list(root.findall(".//link")):

--- a/tldw_Server_API/app/core/Watchlists/opml.py
+++ b/tldw_Server_API/app/core/Watchlists/opml.py
@@ -9,9 +9,18 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 from defusedxml import ElementTree as ET
+
+
+class _OutlineElement(Protocol):
+    attrib: dict[str, str]
+
+    def findall(self, match: str) -> list["_OutlineElement"]:
+        """Return matching child outline elements."""
+        ...
+
 
 @dataclass
 class OPMLSource:
@@ -20,7 +29,8 @@ class OPMLSource:
     html_url: str | None = None
 
 
-def _gather_outlines(elem: Any, out: list[OPMLSource]) -> None:
+def _gather_outlines(elem: _OutlineElement, out: list[OPMLSource]) -> None:
+    """Recursively collect feed outlines from an OPML subtree into ``out``."""
     for child in elem.findall("outline"):
         xml_url = child.attrib.get("xmlUrl") or child.attrib.get("xmlurl")
         title = child.attrib.get("title") or child.attrib.get("text")

--- a/tldw_Server_API/app/core/Watchlists/opml.py
+++ b/tldw_Server_API/app/core/Watchlists/opml.py
@@ -7,12 +7,11 @@ attributes xmlUrl (feed URL), optional htmlUrl, and title/text for the name.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
-from defusedxml import ElementTree as DET
+from defusedxml import ElementTree as ET
 
 @dataclass
 class OPMLSource:
@@ -21,7 +20,7 @@ class OPMLSource:
     html_url: str | None = None
 
 
-def _gather_outlines(elem: ET.Element, out: list[OPMLSource]) -> None:
+def _gather_outlines(elem: Any, out: list[OPMLSource]) -> None:
     for child in elem.findall("outline"):
         xml_url = child.attrib.get("xmlUrl") or child.attrib.get("xmlurl")
         title = child.attrib.get("title") or child.attrib.get("text")
@@ -36,7 +35,7 @@ def parse_opml(opml_bytes: bytes) -> list[OPMLSource]:
     """Parse OPML content and return a flat list of OPMLSource entries."""
     sources: list[OPMLSource] = []
     try:
-        root = DET.fromstring(opml_bytes)
+        root = ET.fromstring(opml_bytes)
     except Exception:
         return sources
     # Standard path: opml -> body

--- a/tldw_Server_API/app/core/Watchlists/websub.py
+++ b/tldw_Server_API/app/core/Watchlists/websub.py
@@ -16,12 +16,11 @@ import hashlib
 import hmac
 import os
 import secrets
-import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlencode
 
-from defusedxml import ElementTree as DET
+from defusedxml import ElementTree as ET
 from defusedxml.common import DefusedXmlException
 from loguru import logger
 
@@ -208,7 +207,7 @@ def parse_push_items(xml_bytes: bytes) -> list[dict[str, Any]]:
     """
     try:
         text = xml_bytes.decode("utf-8", errors="replace")
-        root = DET.fromstring(text)
+        root = ET.fromstring(text)
     except _WEBSUB_NONCRITICAL_EXCEPTIONS:
         return []
 


### PR DESCRIPTION
Change summary: _Human-authored summary required before merge._

## Summary
- Switch Watchlists RSS, OPML, and WebSub XML parsing to use `defusedxml.ElementTree` directly instead of importing stdlib ElementTree aliases.
- Add a local OPML outline protocol and `_gather_outlines()` docstring to address review feedback without reintroducing stdlib XML imports or Bandit B405.
- Record PR6 verification and browser QA completion in Backlog TASK-439.

## Risk / Rollback
- Risk level: Low. This is a parser-import hardening slice plus Backlog documentation; it does not change `/watchlists` UX behavior or API contracts.
- Main risk: OPML helper typing/documentation changes accidentally changing runtime parser behavior. Covered by focused OPML parser/export tests.
- Rollback plan: revert this PR branch/merge commit. If reverting only the review follow-up, restore `_gather_outlines()` to the previous broad annotation while keeping `defusedxml` imports.

## UX Audit Checklist
- [x] `/watchlists` browser QA performed against isolated local backend/frontend.
- [x] Steady page load showed Watchlists content and observed Watchlists API calls returned 200.
- [x] Browser page-load pass had no console errors, request failures, or page errors.
- [x] Create Watchlist guided setup modal opened successfully.
- [x] Overview shortcuts opened Feeds and Monitors content.
- [x] No intentional UI, navigation, copy, or interaction behavior changes in this PR.

## Watchlists Accessibility Checklist
- [x] `bun run test:watchlists:a11y` passed: 12 files, 85 tests.
- [x] Existing negative-path stderr from failed source/job load and save-error tests was observed and classified as expected test behavior.
- [x] No new frontend components, focus paths, or ARIA surfaces were introduced.

## Watchlists Scale Checklist
- [x] `bun run test:watchlists:scale` passed: 7 files, 53 tests.
- [x] No changes to client-side list rendering, pagination, polling, saved views, or batch controls.
- [x] Backend parser changes remain synchronous with the same call sites and result shapes.

## Verification
- `git diff --check`
- `bun run test:watchlists:typecheck` -> 1 file, 3 tests passed
- `bun run test:watchlists:scale` -> 7 files, 53 tests passed
- `bun run test:watchlists:a11y` -> 12 files, 85 tests passed
- `python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_api.py tldw_Server_API/tests/Watchlists/test_full_pipeline_integration.py tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py tldw_Server_API/tests/Watchlists/test_audio_output_delivery.py -q` -> 66 passed, 1 xpassed
- `python -m pytest tldw_Server_API/tests/Watchlists/test_opml_api.py tldw_Server_API/tests/Watchlists/test_opml_edge_cases.py tldw_Server_API/tests/Watchlists/test_opml_export_group.py tldw_Server_API/tests/Watchlists/test_opml_export_group_more.py tldw_Server_API/tests/Watchlists/test_rss_history_fetchers.py tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Collections/test_websub.py -q` -> 48 passed
- Review follow-up: `python -m compileall -q tldw_Server_API/app/core/Watchlists/opml.py`
- Review follow-up: `python -m pytest tldw_Server_API/tests/Watchlists/test_opml_api.py tldw_Server_API/tests/Watchlists/test_opml_edge_cases.py tldw_Server_API/tests/Watchlists/test_opml_export_group.py tldw_Server_API/tests/Watchlists/test_opml_export_group_more.py -q` -> 6 passed
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py tldw_Server_API/app/core/Watchlists -f json -o /tmp/bandit_watchlists_digest_audio_pr6_review_fix.json` -> 0 results, 0 errors
- Browser QA against isolated local backend/frontend: `/watchlists` loaded, observed Watchlists API calls returned 200, no browser console/page/request errors on steady page load, create modal and overview shortcuts opened successfully.

## Notes
- Browser QA used port 18002 for the PR6 backend and 8082 for the frontend to avoid unrelated existing local services; both were stopped after verification.
- The frontend a11y suite emits expected stderr from negative-path tests for failed source/job loads and save errors while still passing.