### PR TITLE
Add VZ host reboot validation drill

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -358,9 +358,11 @@ Direct helper mode:
 
 ```bash
 evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+socket_path="$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.sock"
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
   --evidence-dir "$evidence_dir" \
+  --socket "$socket_path" \
   --bundle /path/to/canonical/bundle \
   --create-evidence-dir
 
@@ -368,6 +370,7 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
   --evidence-dir "$evidence_dir" \
+  --socket "$socket_path" \
   --bundle /path/to/canonical/bundle \
   --run-smoke
 ```

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -353,6 +353,10 @@ post-reboot helper proof. The evidence directory is part of the acceptance
 record: it must survive reboot, must be private to the operator, and must not
 live under `/tmp`, `$TMPDIR`, or another volatile root. Prefer a run-specific
 directory under `~/Library/Logs/tldw/vz-host-reboot-drill/`.
+The drill records the host boot marker before and after reboot. Post validation
+fails if the marker is missing or unchanged, which prevents a no-reboot same
+helper process from passing as a reboot proof. The pre phase also records
+non-mutating lifecycle readiness checks and bundle dry-run validation.
 
 Direct helper mode:
 
@@ -363,6 +367,7 @@ socket_path="$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/help
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
   --evidence-dir "$evidence_dir" \
   --socket "$socket_path" \
+  --pid-file "$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.pid" \
   --bundle /path/to/canonical/bundle \
   --create-evidence-dir
 
@@ -371,6 +376,7 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
   --evidence-dir "$evidence_dir" \
   --socket "$socket_path" \
+  --pid-file "$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.pid" \
   --bundle /path/to/canonical/bundle \
   --run-smoke
 ```
@@ -405,8 +411,9 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
 path. It must not start a new helper process, because that would validate a
 fresh helper rather than reboot recovery. Expected blocking failures for an
 explicit manual drill include a missing, unsafe, or volatile evidence
-directory; invalid or mismatched pre/post metadata; helper ping or protocol
-failure; and post-reboot smoke failure when `--run-smoke` is requested.
+directory; unavailable or unchanged host boot marker; invalid or mismatched
+pre/post metadata; failed lifecycle readiness; helper ping or protocol failure;
+and post-reboot smoke failure when `--run-smoke` is requested.
 
 The broader manual recovery procedure remains:
 

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -346,22 +346,82 @@ If the helper is restarted directly or by a future launchd-managed workflow:
 After a host reboot, assume helper process identity, helper in-memory VM state,
 virtiofs state, and guest-agent readiness were lost until proven otherwise.
 Durable image-store manifests and persisted session-control rows may still
-exist, but they are provenance, not live VM proof. The recommended manual
-procedure is:
+exist, but they are provenance, not live VM proof.
 
-1. Start or verify the helper through the managed operator workflow.
-2. Run `vz-helperctl.py status` and confirm protocol-compatible helper ping.
-3. Run `/api/v1/sandbox/admin/macos-diagnostics`.
-4. Inspect stale, unhealthy, skipped-active, and orphan classifications.
-5. Run reconciliation repair in dry-run mode if stale inactive rows are
+Use `host-reboot-drill` when an operator needs a durable pre-reboot and
+post-reboot helper proof. The evidence directory is part of the acceptance
+record: it must survive reboot, must be private to the operator, and must not
+live under `/tmp`, `$TMPDIR`, or another volatile root. Prefer a run-specific
+directory under `~/Library/Logs/tldw/vz-host-reboot-drill/`.
+
+Direct helper mode:
+
+```bash
+evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --create-evidence-dir
+
+# Manually reboot the host. Do not run this from scheduled CI.
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --run-smoke
+```
+
+Launchd helper mode requires explicit LaunchAgent metadata in both phases:
+
+```bash
+label="org.tldw.macos-vz-helper.manual-reboot"
+plist="$HOME/Library/LaunchAgents/${label}.plist"
+evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
+  --helper-mode launchd \
+  --label "$label" \
+  --plist-output "$plist" \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --create-evidence-dir
+
+# Manually reboot the host. After login, verify launchd restored the helper.
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
+  --helper-mode launchd \
+  --label "$label" \
+  --plist-output "$plist" \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --run-smoke
+```
+
+`post --run-smoke` must prove the restored helper socket through the host smoke
+path. It must not start a new helper process, because that would validate a
+fresh helper rather than reboot recovery. Expected blocking failures for an
+explicit manual drill include a missing, unsafe, or volatile evidence
+directory; invalid or mismatched pre/post metadata; helper ping or protocol
+failure; and post-reboot smoke failure when `--run-smoke` is requested.
+
+The broader manual recovery procedure remains:
+
+1. Run the `host-reboot-drill pre` command into a durable evidence directory.
+2. Manually reboot the host.
+3. Restore or verify the intended direct or launchd helper socket.
+4. Run `host-reboot-drill post` against the same evidence directory.
+5. Run `/api/v1/sandbox/admin/macos-diagnostics`.
+6. Inspect stale, unhealthy, skipped-active, and orphan classifications.
+7. Run reconciliation repair in dry-run mode if stale inactive rows are
    reported.
-6. Apply mutating repair only after reviewing the dry-run plan.
-7. Run the real host smoke to verify fresh ephemeral execution and same-session
-   behavior.
+8. Apply mutating repair only after reviewing the dry-run plan.
 
 Diagnostics, startup warnings, and host smoke must not delete session-control
 rows or terminate VMs automatically. Host reboot is an operator procedure today,
-not a scheduled CI action or hidden startup repair path.
+not a scheduled CI action or hidden startup repair path. Scheduled and nightly
+CI must skip reboot validation; a prepared-host reboot drill is blocking only
+when an operator explicitly invokes it.
 
 Startup now also records bounded reconciliation/helper warnings during process
 boot through the shared startup warning framework. That startup path is

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -114,17 +114,30 @@ session-control row and restart only the helper process owned by the smoke
 harness restart lease. They then verify the next same-session command provisions
 a fresh VM and completes. Scheduled runs must not enable these drills by default.
 
-Host reboot and launchd-managed restart are not part of the current host-gated
-CI contract. Maintainers validating those paths should treat them as manual
-operator procedures. `tools/macos-vz-helper/scripts/vz-helperctl.py launchd ...`
-can inspect, bootstrap, kickstart, and bootout the helper through explicit
-operator commands, but host-gated CI should not run those actions unless the
-prepared runner is intentionally configured for LaunchAgent validation. Restore
-or verify helper readiness first, inspect
-`/api/v1/sandbox/admin/macos-diagnostics`, run reconciliation repair in dry-run
-mode before any mutation, and then run the real host smoke. A host reboot drill
-must not be added to scheduled CI until a dedicated prepared runner can tolerate
-disruptive reboot testing and preserve helper/stdout/serial logs reliably.
+Host reboot and launchd-managed restart are not part of the scheduled
+host-gated CI contract. Maintainers validating those paths should treat them as
+manual or explicitly operator-triggered procedures. Scheduled and nightly CI
+must never reboot prepared hosts.
+
+`tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre/post` is
+the manual reboot acceptance path. It records pre-reboot helper evidence in a
+durable private directory that survives reboot, requires the operator to reboot
+the host manually, and then validates the restored helper socket after login.
+The evidence directory must not be under `/tmp`, `$TMPDIR`, or another volatile
+root. Direct helper mode can use the managed socket defaults. Launchd helper
+mode must pass explicit `--label` and `--plist-output` in both `pre` and
+`post`, so the manifests identify the intended LaunchAgent.
+
+When `post --run-smoke` is requested, the smoke must target the restored helper
+socket through the host smoke path. It must not launch a separate helper
+process. Diagnostics and dry-run reconciliation repair are separate
+operator-reviewed steps after the drill; they remain non-mutating unless the
+operator later applies a reviewed repair.
+
+`tools/macos-vz-helper/scripts/vz-helperctl.py launchd ...` can inspect,
+bootstrap, kickstart, and bootout the helper through explicit operator
+commands, but host-gated CI should not run those actions unless the prepared
+runner is intentionally configured for LaunchAgent validation.
 
 `tools/macos-vz-helper/scripts/vz-helperctl.py launchd-drill` is the explicit
 LaunchAgent validation path. It may be run manually on a prepared runner, but
@@ -158,8 +171,9 @@ These are expected and should not block ordinary PRs:
   LaunchAgent validation runner
 - launchd operator validation skipped because the helper is managed through
   direct `vz-helperctl.py start` or no LaunchAgent plist has been prepared
-- host reboot validation handled through a manual operator procedure rather
-  than the workflow
+- scheduled host reboot validation skipped because CI must not reboot hosts
+- host reboot validation handled through a manual operator procedure or
+  explicit operator-triggered prepared-host run rather than scheduled workflow
 
 A manual run that fails before VM execution because the runner is missing the
 configured bundle path is an operator setup failure, not a sandbox runtime
@@ -187,6 +201,12 @@ prepared host and fails one of the accepted runtime guarantees:
 - a manually requested launchd drill fails after the runner was explicitly
   configured for LaunchAgent validation and helper/template readiness already
   passed
+- a manually requested host reboot drill uses a missing, unsafe, or volatile
+  evidence directory
+- a manually requested host reboot drill reports pre/post metadata mismatch,
+  helper ping failure, or helper protocol failure
+- a manually requested host reboot drill reports post-smoke failure after
+  `--run-smoke` was explicitly requested
 - cleanup leaves the helper process or accepted socket path behind
 - helper protocol mismatch is introduced without a matching compatibility plan
 - artifacts/logs are not uploaded when the job fails

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -127,6 +127,9 @@ The evidence directory must not be under `/tmp`, `$TMPDIR`, or another volatile
 root. Direct helper mode can use the managed socket defaults. Launchd helper
 mode must pass explicit `--label` and `--plist-output` in both `pre` and
 `post`, so the manifests identify the intended LaunchAgent.
+The drill also records a host boot marker, non-mutating lifecycle readiness
+checks, and bundle dry-run validation. A post phase with a missing or unchanged
+boot marker is a failed reboot proof, even if helper ping succeeds.
 
 When `post --run-smoke` is requested, the smoke must target the restored helper
 socket through the host smoke path. It must not launch a separate helper
@@ -203,8 +206,9 @@ prepared host and fails one of the accepted runtime guarantees:
   passed
 - a manually requested host reboot drill uses a missing, unsafe, or volatile
   evidence directory
-- a manually requested host reboot drill reports pre/post metadata mismatch,
-  helper ping failure, or helper protocol failure
+- a manually requested host reboot drill reports unavailable or unchanged host
+  boot marker, pre/post metadata mismatch, lifecycle readiness failure, helper
+  ping failure, or helper protocol failure
 - a manually requested host reboot drill reports post-smoke failure after
   `--run-smoke` was explicitly requested
 - cleanup leaves the helper process or accepted socket path behind

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -184,7 +184,7 @@ def ensure_host_reboot_evidence_dir(
 
 Run the same pytest command. Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -295,7 +295,7 @@ git commit -m "feat(vz): record host reboot preflight evidence"
 - Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
 - Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
 
-- [ ] **Step 1: Add failing post-phase tests**
+- [x] **Step 1: Add failing post-phase tests**
 
 Add tests for:
 
@@ -339,7 +339,7 @@ def test_host_reboot_post_reports_generation_changed(
     CASE.assertEqual(by_name["helper_generation"].reason, "helper_generation_changed")
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run:
 
@@ -350,7 +350,7 @@ python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py \
 
 Expected: fail because post helpers do not exist.
 
-- [ ] **Step 3: Implement post phase**
+- [x] **Step 3: Implement post phase**
 
 Add `run_host_reboot_post(...) -> list[tuple[str, CheckResult]]` that:
 
@@ -367,7 +367,7 @@ Return generation drift as a named ok result:
 ("helper_generation", CheckResult(ok=True, reason="helper_generation_changed"))
 ```
 
-- [ ] **Step 4: Run focused post tests**
+- [x] **Step 4: Run focused post tests**
 
 Expected: pass.
 

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -384,7 +384,7 @@ git commit -m "feat(vz): validate host reboot postflight evidence"
 - Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
 - Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
 
-- [ ] **Step 1: Add failing CLI tests**
+- [x] **Step 1: Add failing CLI tests**
 
 Add tests that assert:
 
@@ -393,7 +393,7 @@ Add tests that assert:
 - `post --run-smoke` calls `run_vz_linux_host_smoke` with the restored helper socket, not `smoke_helper`
 - launchd mode requires explicit label/plist or returns a clear reason
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run:
 
@@ -404,7 +404,7 @@ python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py \
 
 Expected: fail because CLI wiring does not exist.
 
-- [ ] **Step 3: Implement CLI parser**
+- [x] **Step 3: Implement CLI parser**
 
 Add subparser:
 
@@ -434,7 +434,7 @@ For `post --run-smoke`, call `run_vz_linux_host_smoke(bundle_path=..., socket_pa
 Do not call `smoke_helper`, because `smoke_helper` delegates to the helper-owning
 script path and can start a separate helper.
 
-- [ ] **Step 4: Run focused CLI tests**
+- [x] **Step 4: Run focused CLI tests**
 
 Expected: pass.
 

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -522,6 +522,13 @@ Status: not run for Task 5 closeout because it requires a disruptive manual
 operator reboot. The docs record this as a manual or explicitly
 operator-triggered prepared-host validation only.
 
+Post-review hardening added a host boot marker to the pre/post manifests,
+non-mutating lifecycle readiness results for direct and launchd modes, bundle
+dry-run validation in the pre phase, and a blocking
+`host_reboot_not_detected` result when the post phase sees the same boot marker
+recorded before reboot. The host reboot drill now fails closed when it cannot
+prove the host reboot boundary it is meant to validate.
+
 - [x] **Step 6: Update Backlog and commit**
 
 Record verification and known host-gated skips in TASK-438 and TASK-443, then

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -497,7 +497,7 @@ python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py \
 
 Expected: `results=[]`, `errors=[]`.
 
-- [x] **Step 5: Optional prepared-host validation**
+- [x] **Step 5: Record optional prepared-host validation status**
 
 Only on a prepared Apple silicon host:
 

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -1,0 +1,550 @@
+# VZ Helper Host Reboot Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an operator-owned `vz-helperctl.py host-reboot-drill pre/post` workflow that records bounded pre-reboot evidence and validates helper readiness, diagnostics guidance, and optional real smoke after a manual host reboot.
+
+**Architecture:** Keep host reboot outside repo automation. Implement a thin helperctl evidence layer that reuses existing private path validation, helper ping/status, launchd drill, and restored-helper smoke seams. Treat diagnostics and repair as operator-reviewed steps, with dry-run repair remaining explicit and external to the drill unless a later authenticated API option is designed.
+
+**Tech Stack:** Python 3 helper CLI (`tools/macos-vz-helper/scripts/vz-helperctl.py`), pytest helperctl tests, existing `run_vz_linux_host_smoke`, Markdown operator docs, Backlog TASK-438.
+
+---
+
+## File Map
+
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+  - Add host-reboot evidence helpers.
+  - Extend helper ping state to preserve bounded helper `details` from the
+    existing helper protocol response.
+  - Add `host-reboot-drill pre` and `host-reboot-drill post` CLI paths.
+  - Reuse existing path hardening, ping, launchd, and restored-helper smoke helpers.
+- Modify: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+  - Add portable tests for evidence directory safety, manifest shape, pre/post behavior, smoke targeting, and JSON output.
+- Modify: `tools/macos-vz-helper/README.md`
+  - Document the operator command and durable evidence directory requirements.
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+  - Add the manual host reboot validation procedure.
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+  - Clarify host reboot validation remains manual and record expected skip/blocking criteria.
+- Modify: `backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md`
+  - Record implementation progress, verification, and final summary.
+
+## Task 1: Evidence Directory And Manifest Helpers
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Add failing tests for evidence directory safety**
+
+Add tests near the launchd/helperctl tests:
+
+```python
+def test_host_reboot_evidence_dir_rejects_world_readable(tmp_path: Path) -> None:
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    evidence.chmod(0o755)
+
+    result = helperctl.ensure_host_reboot_evidence_dir(evidence, create=False)
+
+    CASE.assertEqual(result.reason, "host_reboot_evidence_dir_not_private")
+    CASE.assertFalse(result.ok)
+```
+
+Also add a volatile path test by monkeypatching `helperctl.VOLATILE_EVIDENCE_ROOTS` to include a temp directory:
+
+```python
+def test_host_reboot_evidence_dir_rejects_volatile_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    volatile = tmp_path / "tmp"
+    evidence = volatile / "drill"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", (volatile,))
+
+    result = helperctl.ensure_host_reboot_evidence_dir(evidence, create=True)
+
+    CASE.assertEqual(result.reason, "host_reboot_evidence_dir_volatile")
+    CASE.assertFalse(result.ok)
+```
+
+Add a ping details regression because the host-reboot manifest needs helper
+generation details already returned by the Swift helper protocol:
+
+```python
+def test_ping_helper_state_preserves_helper_details(tmp_path: Path) -> None:
+    class FakeReply:
+        protocol_version = "1"
+        helper_version = "test-helper"
+        details = {
+            "helper_instance_id": "before",
+            "helper_started_at": "2026-05-19T00:00:00Z",
+            "ignored_number": 1,
+        }
+
+    class FakeClient:
+        def ping(self) -> FakeReply:
+            return FakeReply()
+
+    state = helperctl.ping_helper_state(
+        tmp_path / "helper.sock",
+        client_factory=lambda path: FakeClient(),
+    )
+
+    CASE.assertEqual(state.details["helper_instance_id"], "before")
+    CASE.assertEqual(state.details["helper_started_at"], "2026-05-19T00:00:00Z")
+    CASE.assertNotIn("ignored_number", state.details)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py \
+  -k "host_reboot_evidence_dir" -q
+```
+
+Expected: fail because the helper functions/constants and ping detail field do
+not exist.
+
+- [ ] **Step 3: Implement minimal evidence directory helper**
+
+Extend `PingState` first:
+
+```python
+@dataclass(frozen=True)
+class PingState:
+    result: CheckResult
+    protocol_version: str = ""
+    helper_version: str = ""
+    details: dict[str, str] | None = None
+```
+
+Then normalize helper details in `ping_helper_state()` from either the
+client-factory reply or raw helper JSON:
+
+```python
+def _string_details(value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    output: dict[str, str] = {}
+    for key, item in value.items():
+        if isinstance(key, str) and isinstance(item, str):
+            output[key] = item
+    return output
+```
+
+Use `details={}` or `details=_string_details(...)` when constructing
+`PingState`; do not keep non-string values.
+
+Add constants and helper functions in `vz-helperctl.py` near the other path helpers:
+
+```python
+VOLATILE_EVIDENCE_ROOTS = tuple(
+    Path(path).resolve()
+    for path in ("/tmp", "/private/tmp", os.getenv("TMPDIR") or "")
+    if path
+)
+
+
+def _is_under_path(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    except RuntimeError:
+        return False
+    return True
+
+
+def ensure_host_reboot_evidence_dir(
+    evidence_dir: Path,
+    *,
+    create: bool = False,
+    allow_volatile: bool = False,
+) -> CheckResult:
+    if not allow_volatile:
+        for root in VOLATILE_EVIDENCE_ROOTS:
+            if _is_under_path(evidence_dir, root):
+                return CheckResult(False, "host_reboot_evidence_dir_volatile", str(evidence_dir))
+    if not evidence_dir.exists():
+        if not create:
+            return CheckResult(False, "host_reboot_evidence_dir_missing", str(evidence_dir))
+        evidence_dir.mkdir(mode=0o700, parents=True)
+        evidence_dir.chmod(0o700)
+    result = ensure_private_dir(evidence_dir, dry_run=False)
+    if not result.ok:
+        return CheckResult(False, "host_reboot_evidence_dir_not_private", result.message or str(evidence_dir))
+    return CheckResult(True, "host_reboot_evidence_dir_ok", str(evidence_dir))
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run the same pytest command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "feat(vz): add host reboot evidence directory checks"
+```
+
+## Task 2: Pre-Reboot Manifest
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Add failing tests for `host-reboot-drill pre`**
+
+Test that dry-run/pre mode writes bounded manifest data when explicitly allowed
+to create the evidence directory:
+
+```python
+def test_host_reboot_pre_writes_bounded_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    evidence = tmp_path / "durable" / "drill"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.run_host_reboot_pre(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        create_evidence_dir=True,
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={
+                "helper_instance_id": "before",
+                "helper_started_at": "2026-05-19T00:00:00Z",
+            },
+        ),
+    )
+
+    CASE.assertTrue(result.ok)
+    payload = json.loads((evidence / "host-reboot-pre.json").read_text())
+    CASE.assertEqual(payload["phase"], "pre")
+    CASE.assertEqual(payload["helper_mode"], "direct")
+    CASE.assertNotIn("environment", payload)
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py \
+  -k "host_reboot_pre" -q
+```
+
+Expected: fail because `run_host_reboot_pre` does not exist.
+
+- [ ] **Step 3: Implement pre-phase manifest writer**
+
+Add:
+
+- `HOST_REBOOT_PRE_MANIFEST = "host-reboot-pre.json"`
+- `HOST_REBOOT_POST_MANIFEST = "host-reboot-post.json"`
+- `write_json_private(path: Path, payload: Mapping[str, Any]) -> CheckResult`
+- `run_host_reboot_pre(...) -> CheckResult`
+- `ping_state_payload(state: PingState) -> dict[str, Any]`
+
+Manifest payload should include only:
+
+- `phase`
+- `created_at`
+- `hostname`
+- `helper_mode`
+- `bundle_path`
+- `helper_path`
+- `socket_path`
+- `log_dir`
+- `serial_log_dir`
+- `launchd_label`
+- `launchd_plist_path`
+- `helper_ping_ok`
+- `helper_ping_reason`
+- `helper_protocol_version`
+- `helper_version`
+- `helper_details` from `PingState.details or {}`
+
+Do not include raw env vars, stdout/stderr, serial log contents, or workspace
+paths beyond configured helper/log/socket/bundle paths.
+
+- [ ] **Step 4: Run focused tests**
+
+Run the same `host_reboot_pre` pytest selection. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "feat(vz): record host reboot preflight evidence"
+```
+
+## Task 3: Post-Reboot Manifest And Generation Drift
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Add failing post-phase tests**
+
+Add tests for:
+
+- missing pre manifest returns `host_reboot_pre_manifest_missing`
+- malformed JSON returns `host_reboot_pre_manifest_invalid`
+- helper generation drift returns `helper_generation_changed` but overall result remains ok when ping/protocol are healthy
+
+Example:
+
+```python
+def test_host_reboot_post_reports_generation_changed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    evidence = tmp_path / "evidence"
+    evidence.mkdir(mode=0o700)
+    evidence.chmod(0o700)
+    (evidence / "host-reboot-pre.json").write_text(
+        json.dumps({
+            "phase": "pre",
+            "helper_mode": "direct",
+            "helper_details": {"helper_instance_id": "before"},
+        }),
+        encoding="utf-8",
+    )
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            details={"helper_instance_id": "after"},
+        ),
+    )
+
+    by_name = dict(results)
+    CASE.assertTrue(by_name["helper_status"].ok)
+    CASE.assertEqual(by_name["helper_generation"].reason, "helper_generation_changed")
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py \
+  -k "host_reboot_post" -q
+```
+
+Expected: fail because post helpers do not exist.
+
+- [ ] **Step 3: Implement post phase**
+
+Add `run_host_reboot_post(...) -> list[tuple[str, CheckResult]]` that:
+
+- validates evidence directory
+- reads pre manifest
+- pings helper using the selected socket
+- compares helper generation details from pre and post
+- writes `host-reboot-post.json`
+- returns named results suitable for human and JSON output
+
+Return generation drift as a named ok result:
+
+```python
+("helper_generation", CheckResult(ok=True, reason="helper_generation_changed"))
+```
+
+- [ ] **Step 4: Run focused post tests**
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "feat(vz): validate host reboot postflight evidence"
+```
+
+## Task 4: CLI Wiring And Restored-Helper Smoke
+
+**Files:**
+- Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
+- Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
+
+- [ ] **Step 1: Add failing CLI tests**
+
+Add tests that assert:
+
+- `host-reboot-drill pre --json` emits parseable JSON
+- `host-reboot-drill post --json` emits parseable JSON
+- `post --run-smoke` calls `run_vz_linux_host_smoke` with the restored helper socket, not `smoke_helper`
+- launchd mode requires explicit label/plist or returns a clear reason
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py \
+  -k "host_reboot_drill_cli or host_reboot_post_runs_smoke" -q
+```
+
+Expected: fail because CLI wiring does not exist.
+
+- [ ] **Step 3: Implement CLI parser**
+
+Add subparser:
+
+```text
+host-reboot-drill {pre,post}
+```
+
+Arguments:
+
+- `--evidence-dir` required
+- `--bundle`
+- `--helper-mode {direct,launchd}` default `direct`
+- `--helper`
+- `--socket`
+- `--log-dir`
+- `--serial-log-dir`
+- `--label`
+- `--plist-output`
+- `--create-evidence-dir`
+- `--allow-volatile-evidence-dir`
+- `--run-smoke`
+- `--python`
+- `--dry-run`
+- `--json`
+
+For `post --run-smoke`, call `run_vz_linux_host_smoke(bundle_path=..., socket_path=...)`.
+Do not call `smoke_helper`, because `smoke_helper` delegates to the helper-owning
+script path and can start a separate helper.
+
+- [ ] **Step 4: Run focused CLI tests**
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py
+git commit -m "feat(vz): add host reboot drill CLI"
+```
+
+## Task 5: Operator Docs And Task Closeout
+
+**Files:**
+- Modify: `tools/macos-vz-helper/README.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Modify: `backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md`
+
+- [ ] **Step 1: Add docs before final verification**
+
+Document:
+
+- durable evidence directory requirement
+- pre/reboot/post sequence
+- direct vs launchd helper mode
+- post-reboot smoke must target restored helper socket
+- diagnostics and dry-run repair remain operator-reviewed
+- scheduled CI must not reboot hosts
+- expected skip/blocking behavior
+
+- [ ] **Step 2: Run focused helperctl tests**
+
+Run:
+
+```bash
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q
+```
+
+Expected: all helperctl tests pass.
+
+- [ ] **Step 3: Run syntax and whitespace checks**
+
+Run:
+
+```bash
+python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py
+git diff --check
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Run Bandit on touched Python**
+
+Run:
+
+```bash
+python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py \
+  -f json -o /tmp/bandit_vz_host_reboot_drill.json
+```
+
+Expected: `results=[]`, `errors=[]`.
+
+- [ ] **Step 5: Optional prepared-host validation**
+
+Only on a prepared Apple silicon host:
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
+  --evidence-dir "$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)" \
+  --bundle /path/to/canonical/bundle \
+  --create-evidence-dir
+
+# manually reboot
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
+  --evidence-dir "$HOME/Library/Logs/tldw/vz-host-reboot-drill/<same-run-id>" \
+  --bundle /path/to/canonical/bundle \
+  --run-smoke
+```
+
+Expected: helper status/protocol pass, generation drift is reported as expected
+when applicable, and real smoke passes against the restored helper socket.
+
+- [ ] **Step 6: Update Backlog and commit**
+
+Record verification and known host-gated skips in TASK-438, then commit:
+
+```bash
+git add \
+  tools/macos-vz-helper/scripts/vz-helperctl.py \
+  tools/macos-vz-helper/Tests/test_vz_helperctl.py \
+  tools/macos-vz-helper/README.md \
+  Docs/Sandbox/macos-runtime-operator-notes.md \
+  Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
+  "backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md"
+git commit -m "feat(vz): add host reboot validation drill"
+```
+
+## Final Verification For PR
+
+Run before opening a PR:
+
+```bash
+source .venv/bin/activate
+python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q
+python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py
+python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_host_reboot_drill.json
+git diff --check
+```
+
+If the prepared host is available, also run the manual pre/post flow and record
+the evidence directory path in the PR notes. If it is not available, document
+that real reboot validation remains host-gated and was not run locally.

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -197,7 +197,7 @@ git commit -m "feat(vz): add host reboot evidence directory checks"
 - Modify: `tools/macos-vz-helper/scripts/vz-helperctl.py`
 - Test: `tools/macos-vz-helper/Tests/test_vz_helperctl.py`
 
-- [ ] **Step 1: Add failing tests for `host-reboot-drill pre`**
+- [x] **Step 1: Add failing tests for `host-reboot-drill pre`**
 
 Test that dry-run/pre mode writes bounded manifest data when explicitly allowed
 to create the evidence directory:
@@ -235,7 +235,7 @@ def test_host_reboot_pre_writes_bounded_manifest(
     CASE.assertNotIn("environment", payload)
 ```
 
-- [ ] **Step 2: Run test to verify failure**
+- [x] **Step 2: Run test to verify failure**
 
 Run:
 
@@ -246,7 +246,7 @@ python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py \
 
 Expected: fail because `run_host_reboot_pre` does not exist.
 
-- [ ] **Step 3: Implement pre-phase manifest writer**
+- [x] **Step 3: Implement pre-phase manifest writer**
 
 Add:
 
@@ -278,11 +278,11 @@ Manifest payload should include only:
 Do not include raw env vars, stdout/stderr, serial log contents, or workspace
 paths beyond configured helper/log/socket/bundle paths.
 
-- [ ] **Step 4: Run focused tests**
+- [x] **Step 4: Run focused tests**
 
 Run the same `host_reboot_pre` pytest selection. Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -371,7 +371,7 @@ Return generation drift as a named ok result:
 
 Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -438,7 +438,7 @@ script path and can start a separate helper.
 
 Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tools/macos-vz-helper/scripts/vz-helperctl.py tools/macos-vz-helper/Tests/test_vz_helperctl.py

--- a/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+++ b/Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
@@ -453,7 +453,7 @@ git commit -m "feat(vz): add host reboot drill CLI"
 - Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
 - Modify: `backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md`
 
-- [ ] **Step 1: Add docs before final verification**
+- [x] **Step 1: Add docs before final verification**
 
 Document:
 
@@ -465,7 +465,7 @@ Document:
 - scheduled CI must not reboot hosts
 - expected skip/blocking behavior
 
-- [ ] **Step 2: Run focused helperctl tests**
+- [x] **Step 2: Run focused helperctl tests**
 
 Run:
 
@@ -475,7 +475,7 @@ python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q
 
 Expected: all helperctl tests pass.
 
-- [ ] **Step 3: Run syntax and whitespace checks**
+- [x] **Step 3: Run syntax and whitespace checks**
 
 Run:
 
@@ -486,7 +486,7 @@ git diff --check
 
 Expected: both pass.
 
-- [ ] **Step 4: Run Bandit on touched Python**
+- [x] **Step 4: Run Bandit on touched Python**
 
 Run:
 
@@ -497,7 +497,7 @@ python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py \
 
 Expected: `results=[]`, `errors=[]`.
 
-- [ ] **Step 5: Optional prepared-host validation**
+- [x] **Step 5: Optional prepared-host validation**
 
 Only on a prepared Apple silicon host:
 
@@ -518,19 +518,24 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
 Expected: helper status/protocol pass, generation drift is reported as expected
 when applicable, and real smoke passes against the restored helper socket.
 
-- [ ] **Step 6: Update Backlog and commit**
+Status: not run for Task 5 closeout because it requires a disruptive manual
+operator reboot. The docs record this as a manual or explicitly
+operator-triggered prepared-host validation only.
 
-Record verification and known host-gated skips in TASK-438, then commit:
+- [x] **Step 6: Update Backlog and commit**
+
+Record verification and known host-gated skips in TASK-438 and TASK-443, then
+commit the docs/task closeout only:
 
 ```bash
 git add \
-  tools/macos-vz-helper/scripts/vz-helperctl.py \
-  tools/macos-vz-helper/Tests/test_vz_helperctl.py \
   tools/macos-vz-helper/README.md \
   Docs/Sandbox/macos-runtime-operator-notes.md \
   Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
-  "backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md"
-git commit -m "feat(vz): add host reboot validation drill"
+  Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md \
+  "backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md" \
+  "backlog/tasks/task-443 - Document-VZ-host-reboot-validation-drill-workflow.md"
+git commit -m "docs(vz): document host reboot validation drill"
 ```
 
 ## Final Verification For PR

--- a/Docs/superpowers/specs/2026-05-19-vz-helper-host-reboot-validation-design.md
+++ b/Docs/superpowers/specs/2026-05-19-vz-helper-host-reboot-validation-design.md
@@ -1,0 +1,267 @@
+# VZ Helper Host Reboot Validation Design
+
+**Status:** Proposed implementation slice.
+**Date:** 2026-05-19.
+**Backlog:** TASK-438.
+
+## Goal
+
+Turn the current host-reboot recovery guidance for `vz_linux` into a repeatable
+operator validation procedure without adding automatic reboot behavior to the
+application, default smoke path, or scheduled host-gated CI.
+
+The validation should prove that, after a real macOS host reboot, operators can
+restore or verify helper readiness, inspect stale runtime state, run dry-run
+repair planning, and prove fresh `vz_linux` execution plus same-session behavior
+through existing smoke surfaces.
+
+## Current State
+
+The repo already has these building blocks:
+
+- `vz-helperctl.py status`, `check`, `start`, `stop`, `restart-drill`, `launchd`,
+  `launchd-drill`, and `smoke`.
+- `launchd-drill` for explicit LaunchAgent bootstrap, kickstart, readiness,
+  bootout, and optional real `vz_linux` smoke through a launchd-managed socket.
+- host-gated smoke for real ephemeral execution, same-session VM reuse,
+  recovery diagnostics, and dry-run reconciliation repair planning.
+- generation-aware `vz_linux` session reuse that rejects stale helper/session
+  control metadata before provisioning a fresh VM.
+- read-only macOS diagnostics and explicit dry-run-first reconciliation repair.
+
+The remaining gap is host reboot as an operator procedure. Reboot can invalidate
+helper process identity, helper in-memory VM registry state, virtiofs resources,
+guest-agent readiness, and existing warm VM assumptions. Persisted
+session-control rows and image-store manifests survive reboot but are provenance,
+not live runtime proof.
+
+## Non-Goals
+
+- Do not reboot the host from repo code, CLI, tests, CI, or server startup.
+- Do not add scheduled host reboot CI.
+- Do not make launchd the default helper lifecycle.
+- Do not install, load, or unload launchd services implicitly from diagnostics
+  or server startup.
+- Do not automatically delete session-control rows or terminate VMs.
+- Do not broaden orphan repair behavior beyond the existing explicit repair
+  endpoint.
+- Do not read raw serial logs into API responses or committed evidence.
+
+## Proposed Operator Model
+
+Add a small host-reboot validation layer around existing commands. The preferred
+shape is a `vz-helperctl.py host-reboot-drill` command with two explicit phases
+and a reboot-surviving evidence directory. Operators should use a durable path
+such as `~/Library/Logs/tldw/vz-host-reboot-drill/<run-id>` or another
+operator-owned directory, not `/tmp`, because temporary directories may be
+purged across reboot.
+
+```bash
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
+  --evidence-dir ~/Library/Logs/tldw/vz-host-reboot-drill/<run-id> \
+  --bundle /path/to/canonical/bundle \
+  --helper-mode direct
+
+# Operator manually reboots the host.
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
+  --evidence-dir ~/Library/Logs/tldw/vz-host-reboot-drill/<run-id> \
+  --bundle /path/to/canonical/bundle \
+  --helper-mode direct
+```
+
+`helper-mode` should support `direct` and `launchd`:
+
+- `direct` means the operator restores helper readiness through
+  `vz-helperctl.py start`, `status`, `smoke`, and `stop`.
+- `launchd` means the operator restores helper readiness through explicit
+  `launchd` or `launchd-drill` commands.
+
+The command must never call `shutdown`, `reboot`, `launchctl bootstrap`, or
+mutating repair unless the operator passed a specific phase/action that already
+exists for that purpose. The host reboot step itself remains outside the repo.
+If the post phase runs real smoke against an already-restored helper, it should
+use the existing managed-helper smoke seam (`run_vz_linux_host_smoke`) that
+points pytest at the selected socket. It should not call the default
+`vz-helperctl.py smoke` path in a way that starts a second helper and validates
+the wrong process.
+
+## Pre-Reboot Phase
+
+The pre phase should:
+
+1. Require a durable private evidence directory (`0700`) or create it with
+   owner-only permissions when explicitly requested. Warn or fail when the path
+   is under volatile temp roots such as `/tmp`, `/private/tmp`, or `$TMPDIR`
+   unless an explicit override is provided.
+2. Record bounded metadata in a JSON manifest:
+   - timestamp
+   - hostname
+   - helper mode
+   - helper path
+   - socket path
+   - log directory
+   - serial-log directory
+   - bundle path or template id
+   - helper ping result
+   - helper protocol version
+   - helper version
+   - helper generation details when available
+   - launchd label/plist path when helper mode is `launchd`
+3. Run existing non-mutating preflight checks:
+   - `check` or `status`
+   - launchd service presence check when helper mode is `launchd`
+   - bundle/template validation through existing helper smoke dry-run paths
+4. Print the next manual step: reboot the host, then run the post phase.
+
+The pre phase may optionally run the existing real smoke before reboot when
+operators want a before/after comparison, but that should be explicit and
+host-gated. It should not create a new bespoke VM/session mechanism.
+The first implementation should not try to preserve a drill-owned warm VM across
+reboot. That requires a separate persistent-session drill because the existing
+host smoke owns and cleans up its own helper/VM lifecycle.
+
+## Post-Reboot Phase
+
+The post phase should:
+
+1. Read and validate the pre-phase manifest.
+2. Refuse world-readable evidence directories or malformed manifest data.
+3. Verify helper readiness using the selected helper mode:
+   - `direct`: explicit `status` or operator-requested `start` followed by
+     `status`.
+   - `launchd`: explicit `launchd status` or operator-requested
+     `launchd-drill`; never infer ownership of a production LaunchAgent.
+4. Record post-reboot helper ping, protocol, version, generation, socket, and
+   log-path facts.
+5. Tell the operator to inspect macOS sandbox diagnostics and dry-run repair.
+6. Optionally run existing real smoke against the restored helper socket:
+   - ephemeral command execution
+   - same-session VM reuse
+   - recovery diagnostics
+   - dry-run reconciliation repair planning
+7. Write a post-reboot evidence JSON next to the pre-reboot manifest.
+
+The post phase should treat helper generation changes as expected after reboot.
+It should fail only when helper readiness, protocol compatibility, diagnostics,
+or real smoke cannot be proven after the operator restores the helper.
+Stale pid files from before reboot should be reported as stale metadata and
+should not be trusted as process ownership. Existing helperctl start/status
+safety checks remain the source of truth for direct-helper process ownership.
+
+## Diagnostics And Repair Boundary
+
+The drill should not directly call admin APIs unless a later implementation adds
+an explicit authenticated API option. The initial implementation should print
+the existing API steps instead:
+
+```text
+GET  /api/v1/sandbox/admin/macos-diagnostics
+POST /api/v1/sandbox/admin/macos-reconciliation/repair?dry_run=true
+```
+
+If a future authenticated option is added, it must remain dry-run by default and
+must not apply mutating repair unless a separate explicit operator flag is used.
+
+## Evidence Contract
+
+Evidence files are local operator artifacts, not public API. They should be
+small, structured, and safe to attach to a bug report after review.
+
+Required files:
+
+- `host-reboot-pre.json`
+- `host-reboot-post.json`
+- optional helper stdout/stderr paths as references only
+- optional serial-log paths as references only
+
+The JSON should store paths and summary facts, not raw serial logs, guest
+stdout/stderr bodies, API keys, environment dumps, or user workspace contents.
+
+## Safety Rules
+
+- Evidence directory must be private (`0700`) and owned by the current user.
+- The command must validate configured socket and log directories using the
+  same helperctl path-hardening helpers as `status`, `check`, and
+  `launchd-drill`.
+- `launchd` mode must use an explicit label and plist path from the manifest or
+  from current arguments; it must not infer ownership of unrelated user
+  LaunchAgents.
+- Post-reboot smoke must target the restored helper socket. It must not silently
+  start a new helper and then claim that the preconfigured direct or launchd
+  helper recovered.
+- A post-reboot mismatch between pre and post helper generation is expected and
+  should be reported as `helper_generation_changed`, not as failure.
+- Missing helper readiness after reboot is a failure until the operator restores
+  helper status.
+- Mutating repair is outside the drill.
+
+## Portable Tests
+
+Normal CI should remain host-independent. Focused tests should cover:
+
+- pre phase creates or validates a private evidence directory
+- pre phase rejects volatile evidence directories by default
+- pre phase writes bounded JSON and rejects unsafe directories
+- post phase rejects missing, malformed, or world-readable evidence
+- post phase treats helper-generation drift as expected after reboot
+- direct helper mode constructs status/smoke steps without launchd mutation
+- launchd helper mode constructs launchd status/drill steps without using a
+  default production label accidentally
+- post phase smoke targets the restored helper socket instead of invoking a
+  helper-owning smoke path
+- dry-run output is deterministic and JSON output is parseable
+
+These tests should mock command runners and helper ping/status functions. They
+must not require a real reboot, real launchd, or Virtualization.framework.
+
+## Manual Host-Gated Validation
+
+Manual validation on a prepared Apple silicon host should be documented as:
+
+1. Run `host-reboot-drill pre` with a private evidence directory.
+2. Reboot the host manually.
+3. Restore or verify helper readiness through `direct` or `launchd` mode.
+4. Run `host-reboot-drill post`.
+5. Run `/api/v1/sandbox/admin/macos-diagnostics`.
+6. Run reconciliation repair dry-run.
+7. Run the real `vz_linux` smoke.
+8. Attach bounded evidence files and helper log paths to the operator record.
+
+This is not a scheduled CI gate until a dedicated prepared runner can tolerate
+disruptive reboot testing and preserve logs across reboot.
+
+## Design Risk Review
+
+The main implementation risk is accidentally turning a manual host lifecycle
+procedure into a hidden mutating repair path. The design avoids that by keeping
+the actual reboot outside the tool, keeping repair dry-run and manual, and
+reusing existing helperctl and smoke commands.
+
+The second risk is creating a false sense of proof. A post-reboot status check
+alone does not prove real VM execution. The drill therefore treats helper
+readiness, diagnostics, dry-run repair planning, and real smoke as separate
+evidence layers. The implementation must also avoid calling a helper-owning
+smoke wrapper that would start a fresh helper and validate the wrong lifecycle.
+
+The third risk is launchd ownership confusion. LaunchAgent labels and plist
+paths must be explicit in launchd mode and must not allow the drill to bootout
+an unrelated service.
+
+The fourth risk is evidence leakage. The evidence contract must store bounded
+metadata and path references only, not raw logs, environment dumps, or user
+workspace data.
+
+The fifth risk is losing the evidence directory during reboot. The design
+requires a durable operator-owned path and rejects temporary roots by default.
+
+## Open Questions For Implementation
+
+- Should the first implementation add only `pre`/`post` evidence commands, or
+  also a thin `--run-smoke` wrapper that invokes the existing host smoke during
+  post?
+- Should authenticated diagnostics/dry-run repair API calls stay out of
+  `vz-helperctl.py` permanently, or be added later behind explicit API URL/key
+  options?
+- Should host reboot evidence become part of the prepared-host tracker once a
+  maintainer has run the procedure successfully?

--- a/backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
+++ b/backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
@@ -74,8 +74,6 @@ Designed the next VZ Linux host-reboot validation slice and wrote an implementat
 Task 5 completed the operator documentation closeout for the implemented drill workflow and recorded verification/skip policy in TASK-443.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed

--- a/backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
+++ b/backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
@@ -46,12 +46,32 @@ Created the host reboot validation design spec at Docs/superpowers/specs/2026-05
 Created the execution-ready implementation plan at Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md. The plan scopes the future implementation to host-reboot-drill pre/post evidence, PingState helper details, portable helperctl tests, restored-helper smoke targeting, docs, Bandit, and optional prepared-host validation.
 
 Verification: git diff --check passed for the worktree after adding the task/spec/plan. Bandit skipped because this task only adds documentation and Backlog metadata; the implementation plan requires Bandit for future Python changes.
+
+Task 5 documentation closeout recorded the operator host reboot validation drill in the helper README, macOS operator notes, and host-gated CI policy. The docs now require durable private evidence outside `/tmp`/volatile roots, document the exact pre -> manual reboot -> post sequence for direct and launchd helper modes, require explicit launchd `--label` and `--plist-output` in both phases, clarify that post-reboot smoke targets the restored helper socket through the host smoke path, keep diagnostics and dry-run repair operator-reviewed and separate, and prohibit scheduled/nightly CI from rebooting hosts.
+
+Task 5 touched files:
+- tools/macos-vz-helper/README.md
+- Docs/Sandbox/macos-runtime-operator-notes.md
+- Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+- backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
+- backlog/tasks/task-443 - Document-VZ-host-reboot-validation-drill-workflow.md
+
+Task 5 verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 182 passed, 6 skipped, 2 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_host_reboot_drill.json` passed; JSON contains `results=[]` and `errors=[]`.
+- `git diff --check` passed.
+
+Prepared-host reboot validation was not run in Task 5 because it is disruptive and requires an operator reboot. Scheduled/nightly CI is expected to skip host reboot validation. A manual prepared-host drill is blocking only when explicitly invoked; blocking failures include missing, unsafe, or volatile evidence directories; pre/post metadata mismatch; helper ping/protocol failure; and post-smoke failure when `--run-smoke` is requested.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Designed the next VZ Linux host-reboot validation slice and wrote an implementation plan. The design keeps reboot manual/operator-owned, uses durable bounded evidence, reuses existing helperctl/status/launchd/smoke/diagnostics/dry-run repair surfaces, and avoids hidden reboot, repair, or launchd mutation. The plan is ready for a future implementation PR.
+
+Task 5 completed the operator documentation closeout for the implemented drill workflow and recorded verification/skip policy in TASK-443.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
+++ b/backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
@@ -1,0 +1,67 @@
+---
+id: TASK-438
+title: Design VZ helper host reboot validation procedure
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-19 04:59'
+labels:
+  - sandbox
+  - vz-linux
+  - operator-workflow
+  - host-reboot
+dependencies: []
+references:
+  - Docs/Sandbox/macos-runtime-operator-notes.md
+  - Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+  - Docs/Sandbox/sandbox-runtime-capability-inventory.md
+  - Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+  - tools/macos-vz-helper/scripts/vz-helperctl.py
+documentation:
+  - Docs/superpowers/specs/2026-05-19-vz-helper-host-reboot-validation-design.md
+  - Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design the next VZ Linux operator recovery slice after the merged launchd drill: a host-reboot validation procedure that proves reboot recovery through explicit operator steps, diagnostics, dry-run repair, helper readiness, and real smoke without adding automated reboot behavior to normal CI.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A focused design spec defines host-reboot validation scope, sequence, evidence, and non-goals.
+- [x] #2 The design keeps host reboot manual/operator-owned and does not add automatic reboot to scheduled CI or application startup.
+- [x] #3 The design reuses existing helperctl launchd/start/status/smoke, diagnostics, and dry-run repair surfaces instead of adding a parallel recovery path.
+- [x] #4 The design defines safe evidence capture before and after reboot, including logs, helper generation, stale session-control expectations, and cleanup boundaries.
+- [x] #5 An implementation plan is written after risk review with exact docs/tests/commands and host-gated validation expectations.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created the host reboot validation design spec at Docs/superpowers/specs/2026-05-19-vz-helper-host-reboot-validation-design.md. Risk review patched the design before planning: evidence must use a durable non-/tmp private directory, post-reboot smoke must target the restored helper socket instead of starting a second helper, launchd mode must use explicit ownership, and stale pre-reboot pid files must not be trusted after reboot.
+
+Created the execution-ready implementation plan at Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md. The plan scopes the future implementation to host-reboot-drill pre/post evidence, PingState helper details, portable helperctl tests, restored-helper smoke targeting, docs, Bandit, and optional prepared-host validation.
+
+Verification: git diff --check passed for the worktree after adding the task/spec/plan. Bandit skipped because this task only adds documentation and Backlog metadata; the implementation plan requires Bandit for future Python changes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Designed the next VZ Linux host-reboot validation slice and wrote an implementation plan. The design keeps reboot manual/operator-owned, uses durable bounded evidence, reuses existing helperctl/status/launchd/smoke/diagnostics/dry-run repair surfaces, and avoids hidden reboot, repair, or launchd mutation. The plan is ready for a future implementation PR.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-439 - Add-VZ-host-reboot-evidence-directory-helpers.md
+++ b/backlog/tasks/task-439 - Add-VZ-host-reboot-evidence-directory-helpers.md
@@ -1,0 +1,42 @@
+---
+id: TASK-439
+title: Add VZ host reboot evidence directory helpers
+status: Done
+documentation:
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+modified_files:
+- tools/macos-vz-helper/scripts/vz-helperctl.py
+- tools/macos-vz-helper/Tests/test_vz_helperctl.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 1 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md: add host reboot evidence directory validation helpers and preserve helper generation details in ping state. Scope is limited to vz-helperctl.py and its focused tests; no pre/post manifest writing or CLI wiring.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented host reboot evidence directory validation helpers in vz-helperctl.py and added focused tests for private-directory enforcement, volatile-root rejection, and string-only ping helper details preservation. Verification: RED tests failed before implementation for missing helper/constant/details support; GREEN focused pytest passed 3 selected tests; full helperctl test file passed 145 tests with 6 skips; Bandit on the touched script reported 0 results.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-439 - Add-VZ-host-reboot-evidence-directory-helpers.md
+++ b/backlog/tasks/task-439 - Add-VZ-host-reboot-evidence-directory-helpers.md
@@ -17,26 +17,33 @@ Implement Task 1 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-va
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] `ensure_host_reboot_evidence_dir(create=True)` returns stable `CheckResult` failures instead of raw filesystem exceptions for broken symlink paths and file-as-parent paths.
+- [x] Host reboot evidence directory creation keeps every newly-created path component owner-only (`0700`), including intermediate directories under a private parent.
+- [x] Import-time volatile evidence root construction ignores unresolvable `TMPDIR` values instead of failing module import.
+- [x] `ping_helper_state()` preserves only string-valued helper details from both client-factory replies and raw helper JSON responses.
+- [x] Scope remains limited to Task 1 evidence directory/detail helpers; Task 2 pre/post manifest behavior was not implemented.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- 2026-05-19 code-quality review fix: added red regression tests for unresolvable import-time `TMPDIR`, broken symlink evidence paths, file parent paths, nested evidence directory modes, and raw helper JSON details filtering.
+- Replaced the host-reboot wrapper's direct `mkdir(parents=True)` path with the existing component-by-component private directory helper, while preserving volatile-root rejection before creation and mapping operational filesystem failures to `host_reboot_evidence_dir_not_private`.
+- Added safe volatile-root construction so `/tmp`, `/private/tmp`, and `TMPDIR` entries that cannot be resolved are skipped instead of raising during import.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented host reboot evidence directory validation helpers in vz-helperctl.py and added focused tests for private-directory enforcement, volatile-root rejection, and string-only ping helper details preservation. Verification: RED tests failed before implementation for missing helper/constant/details support; GREEN focused pytest passed 3 selected tests; full helperctl test file passed 145 tests with 6 skips; Bandit on the touched script reported 0 results.
+Implemented Task 1 host reboot evidence directory helper hardening in vz-helperctl.py and added focused regressions for the code-quality review findings. Verification: RED focused pytest failed on the current behavior with import-time TMPDIR symlink-loop, broken symlink, file parent, and intermediate-mode failures; GREEN focused pytest passed 7 selected tests; full helperctl test file passed 150 tests with 6 skips; Bandit on the touched script reported 0 results; `git diff --check` passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-440 - Add-VZ-host-reboot-pre-reboot-manifest-writer.md
+++ b/backlog/tasks/task-440 - Add-VZ-host-reboot-pre-reboot-manifest-writer.md
@@ -1,0 +1,52 @@
+---
+id: TASK-440
+title: Add VZ host reboot pre-reboot manifest writer
+status: In Progress
+documentation:
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+modified_files:
+- tools/macos-vz-helper/scripts/vz-helperctl.py
+- tools/macos-vz-helper/Tests/test_vz_helperctl.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 2 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md: add a bounded host reboot preflight manifest writer and tests for `run_host_reboot_pre()`. Scope is limited to pre-phase manifest helpers in vz-helperctl.py and focused tests; no post-reboot comparison or CLI wiring.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Add failing focused tests for `run_host_reboot_pre()`, `write_json_private()`, and `ping_state_payload()`.
+- [x] Write `host-reboot-pre.json` only after validating/creating the evidence directory through `ensure_host_reboot_evidence_dir(...)`.
+- [x] Keep manifest payload bounded to the allowed pre-reboot fields and helper ping metadata.
+- [x] Write manifest JSON with owner-only file permissions.
+- [x] Do not add post-reboot comparison, CLI wiring, or restored-helper smoke execution.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `HOST_REBOOT_PRE_MANIFEST` and future `HOST_REBOOT_POST_MANIFEST` constants in `vz-helperctl.py`.
+- Added `write_json_private()` using a private `0600` JSON write path with stable `host_reboot_manifest_write_failed` failures.
+- Added `ping_state_payload()` and `run_host_reboot_pre()` callable helpers only; no `host-reboot-drill` parser wiring was added.
+- Verified the red phase first with the focused selector, which failed because the new helper APIs were absent.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Implemented Task 2 pre-reboot manifest helpers and tests. The pre helper validates the evidence directory through the existing host reboot safety helper, pings the configured helper socket through an injectable checker, writes only the approved manifest fields to `host-reboot-pre.json`, and records helper ping/version/details metadata without raw env, stdout/stderr, serial log contents, or arbitrary extra fields.
+- Verification: focused pytest selector passed, full helperctl test file passed (`153 passed, 6 skipped`), `py_compile` passed, Bandit on the touched script reported `results=0` and `errors=0`, and `git diff --check` passed.
+- Known skips: restored-helper smoke execution and real host reboot validation were not run because they are outside Task 2 scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-440 - Add-VZ-host-reboot-pre-reboot-manifest-writer.md
+++ b/backlog/tasks/task-440 - Add-VZ-host-reboot-pre-reboot-manifest-writer.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-440
 title: Add VZ host reboot pre-reboot manifest writer
-status: In Progress
+status: Done
 documentation:
 - Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
 modified_files:

--- a/backlog/tasks/task-440 - Add-VZ-host-reboot-pre-reboot-manifest-writer.md
+++ b/backlog/tasks/task-440 - Add-VZ-host-reboot-pre-reboot-manifest-writer.md
@@ -36,9 +36,10 @@ Implement Task 2 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-va
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-- Implemented Task 2 pre-reboot manifest helpers and tests. The pre helper validates the evidence directory through the existing host reboot safety helper, pings the configured helper socket through an injectable checker, writes only the approved manifest fields to `host-reboot-pre.json`, and records helper ping/version/details metadata without raw env, stdout/stderr, serial log contents, or arbitrary extra fields.
-- Verification: focused pytest selector passed, full helperctl test file passed (`153 passed, 6 skipped`), `py_compile` passed, Bandit on the touched script reported `results=0` and `errors=0`, and `git diff --check` passed.
-- Known skips: restored-helper smoke execution and real host reboot validation were not run because they are outside Task 2 scope.
+- Implemented Task 2 pre-reboot manifest helpers and review-fix hardening. The pre helper validates the evidence directory, captures helper ping state through an injectable checker, writes bounded `host-reboot-pre.json` evidence, and now returns non-ok when ping fails while preserving the successful `host_reboot_pre_manifest_written` reason for healthy pings.
+- Hardened `write_json_private()` to validate and modify the opened file descriptor only: final-component symlinks are refused via the open path, non-regular fd targets are rejected, existing manifests are set to `0600` before truncation/write, and operational failures keep the stable `host_reboot_manifest_write_failed` reason.
+- Verification: focused pytest selector passed after an expected red run (`6 passed`), full helperctl test file passed (`157 passed, 6 skipped`), `py_compile` passed, Bandit on the touched script reported `results=0` and `errors=0`, and `git diff --check` passed.
+- Known skips: restored-helper smoke execution, post-reboot comparison, CLI wiring, and real host reboot validation were not run because they are outside Task 2 scope.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-441 - Add-VZ-host-reboot-post-reboot-evidence-validation.md
+++ b/backlog/tasks/task-441 - Add-VZ-host-reboot-post-reboot-evidence-validation.md
@@ -7,7 +7,6 @@ documentation:
 modified_files:
 - tools/macos-vz-helper/scripts/vz-helperctl.py
 - tools/macos-vz-helper/Tests/test_vz_helperctl.py
-- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
 - backlog/tasks/task-441 - Add-VZ-host-reboot-post-reboot-evidence-validation.md
 ---
 
@@ -32,14 +31,16 @@ Implement Task 3 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-va
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Implemented `run_host_reboot_post(...)` plus private helpers for safe pre-manifest loading and helper generation comparison.
 - Added focused postflight tests for missing pre manifest, malformed pre manifest, helper generation drift, and ping exception handling.
-- Verification: focused `host_reboot_post` selector passed; full helperctl test file passed with 163 passed, 6 skipped; Bandit reported zero findings; `py_compile` passed; `git diff --check` passed.
+- Addressed Task 3 code-quality review findings: pre-manifest reads now use bounded fd-based loading that rejects symlinks, special files, oversized files, non-object payloads, and parse/read errors with stable reasons; host-reboot pre/post manifests now sanitize helper-provided detail fields to the reboot evidence allowlist.
+- Added regressions for FIFO, symlink, non-object, oversized pre manifests, and forbidden helper detail keys.
+- Verification: focused `host_reboot_pre or host_reboot_post or read_host_reboot_pre_manifest or host_reboot_manifests` selector passed with 12 passed; full helperctl test file passed with 168 passed, 6 skipped; Bandit reported zero findings; `py_compile` passed; `git diff --check` passed.
 - Scope intentionally excludes Task 4 CLI wiring and restored-helper smoke execution.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Task 3 implemented. run_host_reboot_post(...) now validates durable evidence state, safely reads the pre manifest, pings helper status, compares pre/post helper_instance_id generation signals, writes bounded host-reboot-post.json when appropriate, and returns stable named CheckResult entries for human/JSON output.
+Task 3 implemented and code-quality review findings addressed. run_host_reboot_post(...) now validates durable evidence state, safely reads the pre manifest through bounded fd-based checks that reject symlinks, special files, non-object payloads, oversized payloads, parse/read errors, and missing manifests with stable reasons, pings helper status, compares sanitized pre/post helper_instance_id generation signals, writes bounded host-reboot-post.json when appropriate, and returns stable named CheckResult entries for human/JSON output. Host-reboot pre/post evidence now allowlists helper_details to helper_instance_id/helper_started_at and drops forbidden helper-provided stdout/stderr/environment/serial content.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-441 - Add-VZ-host-reboot-post-reboot-evidence-validation.md
+++ b/backlog/tasks/task-441 - Add-VZ-host-reboot-post-reboot-evidence-validation.md
@@ -1,0 +1,53 @@
+---
+id: TASK-441
+title: Add VZ host reboot post-reboot evidence validation
+status: Done
+documentation:
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+modified_files:
+- tools/macos-vz-helper/scripts/vz-helperctl.py
+- tools/macos-vz-helper/Tests/test_vz_helperctl.py
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+- backlog/tasks/task-441 - Add-VZ-host-reboot-post-reboot-evidence-validation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 3 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md: add `run_host_reboot_post(...)` support that validates the evidence directory, reads the pre manifest, pings the helper after reboot, compares helper generation details, writes `host-reboot-post.json`, and returns named postflight results. Scope excludes CLI wiring and restored-helper smoke execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Post phase validates the evidence directory with `create=False` and returns stable named results.
+- [x] Missing `host-reboot-pre.json` returns `host_reboot_pre_manifest_missing` and does not write `host-reboot-post.json`.
+- [x] Malformed or non-object pre manifests return `host_reboot_pre_manifest_invalid` and do not write `host-reboot-post.json`.
+- [x] Post phase pings the selected socket through injectable `ping_checker`, coerces ping state, and maps ping exceptions to `helper_ping_failed`.
+- [x] Helper generation comparison uses `helper_details.helper_instance_id` and returns ok reasons for changed, matching, or unavailable generation state.
+- [x] Post manifest remains bounded to phase, host/path metadata, generation IDs/reason, and ping state payload fields without raw env/stdout/stderr/serial log content.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Implemented `run_host_reboot_post(...)` plus private helpers for safe pre-manifest loading and helper generation comparison.
+- Added focused postflight tests for missing pre manifest, malformed pre manifest, helper generation drift, and ping exception handling.
+- Verification: focused `host_reboot_post` selector passed; full helperctl test file passed with 163 passed, 6 skipped; Bandit reported zero findings; `py_compile` passed; `git diff --check` passed.
+- Scope intentionally excludes Task 4 CLI wiring and restored-helper smoke execution.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 3 implemented. run_host_reboot_post(...) now validates durable evidence state, safely reads the pre manifest, pings helper status, compares pre/post helper_instance_id generation signals, writes bounded host-reboot-post.json when appropriate, and returns stable named CheckResult entries for human/JSON output.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-442 - Add-VZ-host-reboot-drill-CLI-wiring.md
+++ b/backlog/tasks/task-442 - Add-VZ-host-reboot-drill-CLI-wiring.md
@@ -41,14 +41,21 @@ Implement Task 4 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-va
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented Task 4 only. Added `host-reboot-drill {pre,post}` CLI wiring, JSON-safe output, explicit launchd metadata validation, and post-reboot restored-helper smoke execution through `run_vz_linux_host_smoke(...)` instead of `smoke_helper`.
+Task 4 code-quality review findings fixed only; Task 5 docs/final closeout intentionally not implemented.
+
+Review fixes:
+- `host-reboot-drill pre/post --dry-run` now returns named dry-run results without creating evidence directories or writing pre/post manifests.
+- Host reboot CLI parser now keeps `--create-evidence-dir` pre-only and `--run-smoke`/`--python` post-only.
+- Added subprocess JSON coverage for `host-reboot-drill pre --json --dry-run`; helperctl now suppresses import-time stdout from the backend helper-client import path so JSON stdout remains parseable.
+- Post validation now compares `helper_mode`, `launchd_label`, `launchd_plist_path`, `socket_path`, `helper_path`, and `bundle_path` against the pre manifest before post evidence is written or smoke is considered.
+- `post --run-smoke` is gated on successful post validation and appends `host_reboot_smoke_skipped` when post validation fails; smoke failure still drives a nonzero CLI exit.
 
 Verification:
-- Red run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k "host_reboot_drill_cli or host_reboot_post_runs_smoke" -q` failed with `host-reboot-drill` missing from argparse choices.
-- Focused green: same selector passed with `4 passed, 174 deselected`.
-- Full helperctl file: `python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py` passed with `172 passed, 6 skipped`.
-- Bandit: `python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_task442.json` completed with zero findings.
-- Compile: `python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
+- Red run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k "host_reboot_drill_cli or host_reboot_post_runs_smoke or host_reboot_pre_dry_run or host_reboot_post_dry_run or metadata_mismatch" -q` failed with the expected seven review-finding failures.
+- Focused green: same selector passed with `12 passed, 174 deselected`.
+- Full helperctl file: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py` passed with `180 passed, 6 skipped`.
+- Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_task442_task4.json` completed with zero findings.
+- Compile: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
 - Whitespace: `git diff --check` passed.
 
 Known skips: full helperctl test file reported six existing platform/socket dependent skips; no Task 4 blocker.

--- a/backlog/tasks/task-442 - Add-VZ-host-reboot-drill-CLI-wiring.md
+++ b/backlog/tasks/task-442 - Add-VZ-host-reboot-drill-CLI-wiring.md
@@ -43,18 +43,25 @@ Implement Task 4 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-va
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Task 4 code-quality review findings fixed only; Task 5 docs/final closeout intentionally not implemented.
 
-Review fixes:
-- `host-reboot-drill pre/post --dry-run` now returns named dry-run results without creating evidence directories or writing pre/post manifests.
-- Host reboot CLI parser now keeps `--create-evidence-dir` pre-only and `--run-smoke`/`--python` post-only.
-- Added subprocess JSON coverage for `host-reboot-drill pre --json --dry-run`; helperctl now suppresses import-time stdout from the backend helper-client import path so JSON stdout remains parseable.
-- Post validation now compares `helper_mode`, `launchd_label`, `launchd_plist_path`, `socket_path`, `helper_path`, and `bundle_path` against the pre manifest before post evidence is written or smoke is considered.
+Prior Task 4 review fixes:
+- `host-reboot-drill pre/post --dry-run` returns named dry-run results without creating evidence directories or writing pre/post manifests.
+- Host reboot CLI parser keeps `--create-evidence-dir` pre-only and `--run-smoke`/`--python` post-only.
+- Subprocess JSON coverage for `host-reboot-drill pre --json --dry-run` keeps JSON stdout parseable despite helper-client import-time stdout.
+- Post validation compares `helper_mode`, `launchd_label`, `launchd_plist_path`, `socket_path`, `helper_path`, and `bundle_path` against the pre manifest before post evidence is written or smoke is considered.
 - `post --run-smoke` is gated on successful post validation and appends `host_reboot_smoke_skipped` when post validation fails; smoke failure still drives a nonzero CLI exit.
 
+Additional review fixes in this commit:
+- Host reboot metadata path fields (`bundle_path`, `helper_path`, `socket_path`, `launchd_plist_path`) are now canonicalized with `expanduser().resolve(strict=False)` before pre/post manifests are written or compared; omitted launchd plist remains the explicit empty string.
+- Post validation now rejects any loaded `host-reboot-pre.json` whose `phase` is not `pre` with `host_reboot_pre_manifest_invalid`.
+- Added regressions for equivalent relative/absolute metadata paths and for rejecting `phase: post` pre manifests.
+
 Verification:
-- Red run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k "host_reboot_drill_cli or host_reboot_post_runs_smoke or host_reboot_pre_dry_run or host_reboot_post_dry_run or metadata_mismatch" -q` failed with the expected seven review-finding failures.
-- Focused green: same selector passed with `12 passed, 174 deselected`.
-- Full helperctl file: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py` passed with `180 passed, 6 skipped`.
-- Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_task442_task4.json` completed with zero findings.
+- Prior red run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k "host_reboot_drill_cli or host_reboot_post_runs_smoke or host_reboot_pre_dry_run or host_reboot_post_dry_run or metadata_mismatch" -q` failed with the expected seven review-finding failures.
+- Prior focused green: same selector passed with `12 passed, 174 deselected`.
+- Current red run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k "post_phase or equivalent_relative_paths" -q` failed with the expected two review-finding failures on current behavior.
+- Current focused green: same selector passed with `2 passed, 186 deselected`.
+- Full helperctl file: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py` passed with `182 passed, 6 skipped`.
+- Bandit: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_task442_task4_final.json` completed; JSON check reported `results=0, errors=0`.
 - Compile: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
 - Whitespace: `git diff --check` passed.
 

--- a/backlog/tasks/task-442 - Add-VZ-host-reboot-drill-CLI-wiring.md
+++ b/backlog/tasks/task-442 - Add-VZ-host-reboot-drill-CLI-wiring.md
@@ -1,0 +1,65 @@
+---
+id: TASK-442
+title: Add VZ host reboot drill CLI wiring
+status: Done
+documentation:
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+modified_files:
+- tools/macos-vz-helper/scripts/vz-helperctl.py
+- tools/macos-vz-helper/Tests/test_vz_helperctl.py
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+- backlog/tasks/task-442 - Add-VZ-host-reboot-drill-CLI-wiring.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 4 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md: add `host-reboot-drill {pre,post}` CLI wiring, JSON output, launchd-mode validation, and post-reboot restored-helper smoke targeting via `run_vz_linux_host_smoke(...)`. Scope excludes operator documentation and final task closeout.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] `host-reboot-drill pre --json` emits parseable `_print_results` JSON.
+- [x] `host-reboot-drill post --json` emits parseable `_print_results` JSON.
+- [x] `post --run-smoke` appends `vz_linux_smoke` from `run_vz_linux_host_smoke(...)` using the restored helper socket.
+- [x] `post --run-smoke` does not call `smoke_helper`.
+- [x] Host reboot launchd mode requires explicit `--label` and `--plist-output` and fails clearly when missing.
+- [x] CLI exit code is zero only when all named results are ok.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added focused CLI tests first and verified they failed because `host-reboot-drill` was not a parser choice.
+- Added `host-reboot-drill {pre,post}` parser wiring with shared Task 4 arguments.
+- Routed `pre` to `run_host_reboot_pre(...)` and `post` to `run_host_reboot_post(...)`.
+- Routed `post --run-smoke` through `run_vz_linux_host_smoke(...)` with the restored helper socket and appended a `vz_linux_smoke` named result.
+- JSON mode redirects incidental stdout from delegated helpers and captured subprocess runners before printing `_print_results` JSON.
+- Launchd mode now rejects missing host-reboot metadata with `host_reboot_launchd_metadata_missing` instead of using unrelated defaults.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Task 4 only. Added `host-reboot-drill {pre,post}` CLI wiring, JSON-safe output, explicit launchd metadata validation, and post-reboot restored-helper smoke execution through `run_vz_linux_host_smoke(...)` instead of `smoke_helper`.
+
+Verification:
+- Red run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -k "host_reboot_drill_cli or host_reboot_post_runs_smoke" -q` failed with `host-reboot-drill` missing from argparse choices.
+- Focused green: same selector passed with `4 passed, 174 deselected`.
+- Full helperctl file: `python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py` passed with `172 passed, 6 skipped`.
+- Bandit: `python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_task442.json` completed with zero findings.
+- Compile: `python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
+- Whitespace: `git diff --check` passed.
+
+Known skips: full helperctl test file reported six existing platform/socket dependent skips; no Task 4 blocker.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-443 - Document-VZ-host-reboot-validation-drill-workflow.md
+++ b/backlog/tasks/task-443 - Document-VZ-host-reboot-validation-drill-workflow.md
@@ -21,6 +21,10 @@ Implement Task 5 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-va
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 README documents the durable evidence directory requirement and direct/launchd pre -> reboot -> post command sequence.
+- [x] #2 Operator notes explain restored-helper smoke targeting and keep diagnostics/dry-run repair separate and operator-reviewed.
+- [x] #3 Host-gated CI policy states scheduled/nightly CI must not reboot hosts and records skip/blocking behavior.
+- [x] #4 Task plan and Backlog records include verification results and the prepared-host reboot skip reason.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-443 - Document-VZ-host-reboot-validation-drill-workflow.md
+++ b/backlog/tasks/task-443 - Document-VZ-host-reboot-validation-drill-workflow.md
@@ -1,0 +1,67 @@
+---
+id: TASK-443
+title: Document VZ host reboot validation drill workflow
+status: Done
+documentation:
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+modified_files:
+- tools/macos-vz-helper/README.md
+- Docs/Sandbox/macos-runtime-operator-notes.md
+- Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+- backlog/tasks/task-438 - Design-VZ-helper-host-reboot-validation-procedure.md
+- Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md
+- backlog/tasks/task-443 - Document-VZ-host-reboot-validation-drill-workflow.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 5 from Docs/superpowers/plans/2026-05-19-vz-helper-host-reboot-validation.md: document the host reboot drill operator workflow, CI policy boundaries, durable evidence requirements, restored-helper smoke targeting, diagnostics/dry-run repair expectations, and close out parent tracking with verification results. Scope is docs/backlog plus final verification only; no new helper behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Documented the host reboot validation drill as an operator workflow in the helper README, macOS runtime operator notes, and host-gated CI acceptance policy.
+
+Key requirements captured:
+- evidence directories must be durable across reboot, private, and outside `/tmp`, `$TMPDIR`, or other volatile roots
+- direct helper mode uses the managed helper socket defaults
+- launchd helper mode requires explicit `--label` and `--plist-output` in both `pre` and `post`
+- the operator sequence is pre -> manual reboot -> post
+- `post --run-smoke` targets the restored helper socket through the host smoke path and must not start a new helper process
+- diagnostics and dry-run reconciliation repair are separate operator-reviewed steps
+- scheduled/nightly CI must not reboot hosts
+- scheduled CI skips reboot validation, while a manual prepared-host drill is blocking only when explicitly invoked
+- explicit drill failures include missing/unsafe/volatile evidence directories, pre/post metadata mismatch, helper ping/protocol failure, and post-smoke failure when requested
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 182 passed, 6 skipped, 2 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_host_reboot_drill.json` passed; JSON contains `results=[]` and `errors=[]`.
+- `git diff --check` passed.
+
+Prepared-host validation was not run because Task 5 must not perform a real host reboot. It remains manual or explicitly operator-triggered only.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed Task 5 docs/task closeout for the VZ helper host reboot validation drill. The documented workflow now covers durable evidence, direct and launchd command sequences, restored-helper smoke targeting, diagnostics/repair separation, CI reboot prohibition, expected skips, and explicit blocking failure modes.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-444 - Address-VZ-host-reboot-drill-final-review-findings.md
+++ b/backlog/tasks/task-444 - Address-VZ-host-reboot-drill-final-review-findings.md
@@ -27,7 +27,7 @@ Fix final review findings on the host-reboot-drill branch: add stronger pre/post
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Final review found that pre/post relied too heavily on helper ping and metadata. The fix adds non-mutating lifecycle readiness collection for direct and launchd modes, records bounded readiness results into evidence manifests, runs bundle validation through the existing host smoke dry-run path, records a host boot marker, and makes post validation fail with `host_reboot_not_detected` when the marker is unchanged.
+Final review found that pre/post relied too heavily on helper ping and metadata. The fix adds non-mutating lifecycle readiness collection for direct and launchd modes, records bounded readiness results into evidence manifests, runs bundle validation through the existing shell host-smoke `--dry-run` path so bundle input checks actually execute, records a host boot marker, and makes post validation fail with `host_reboot_not_detected` when the marker is unchanged.
 
 The host reboot drill still remains explicit operator workflow only. No workflow files or scheduled reboot automation were added.
 

--- a/backlog/tasks/task-444 - Address-VZ-host-reboot-drill-final-review-findings.md
+++ b/backlog/tasks/task-444 - Address-VZ-host-reboot-drill-final-review-findings.md
@@ -1,0 +1,57 @@
+---
+id: TASK-444
+title: Address VZ host reboot drill final review findings
+status: Done
+labels:
+- sandbox
+- vz-linux
+- review-fix
+- host-reboot
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix final review findings on the host-reboot-drill branch: add stronger pre/post lifecycle readiness checks for direct and launchd modes, add a reboot marker so post does not pass without an actual reboot when marker evidence is available, update tests/docs/tasks, and rerun verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pre phase records lifecycle readiness, host boot marker, and bundle dry-run validation evidence.
+- [x] #2 Post phase checks lifecycle readiness for the selected helper mode and fails if the host boot marker is missing or unchanged.
+- [x] #3 Launchd mode readiness checks explicit launchd status using the provided label/plist metadata.
+- [x] #4 Regression tests cover lifecycle readiness failure, launchd status checking, and no-reboot marker rejection.
+- [x] #5 Docs/task records explain the stronger blocking behavior and scheduled CI remains non-rebooting.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Final review found that pre/post relied too heavily on helper ping and metadata. The fix adds non-mutating lifecycle readiness collection for direct and launchd modes, records bounded readiness results into evidence manifests, runs bundle validation through the existing host smoke dry-run path, records a host boot marker, and makes post validation fail with `host_reboot_not_detected` when the marker is unchanged.
+
+The host reboot drill still remains explicit operator workflow only. No workflow files or scheduled reboot automation were added.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` passed: 185 passed, 6 skipped, 2 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_host_reboot_drill.json` passed with `results=[]` and `errors=[]`.
+- `git diff --check` passed.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed final review findings for the VZ host reboot drill. The drill now proves a stronger lifecycle boundary: pre records readiness/bundle/boot-marker evidence, post verifies selected-mode readiness and boot-marker drift before optional restored-socket smoke, and docs state unchanged/missing boot marker as a blocking failure.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-445 - Address-VZ-host-reboot-drill-PR-review-comments.md
+++ b/backlog/tasks/task-445 - Address-VZ-host-reboot-drill-PR-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-445
+title: Address VZ host reboot drill PR review comments
+status: Done
+labels:
+- sandbox
+- vz-linux
+- review-fix
+priority: high
+modified_files:
+- tools/macos-vz-helper/scripts/vz-helperctl.py
+- tools/macos-vz-helper/Tests/test_vz_helperctl.py
+- tools/macos-vz-helper/README.md
+- backlog/tasks/task-445 - Address-VZ-host-reboot-drill-PR-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address still-open review comments on PR #1868 after rebasing onto dev. Scope includes host reboot drill README command durability across reboot, bundle metadata normalization, manifest write atomicity, cleanup error handling, and docstrings for new security/operations helpers.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Open review findings are verified against current code before fixes are applied.
+- [x] #2 README host reboot drill examples remain copy/paste-safe across reboot boundaries.
+- [x] #3 Missing bundle metadata remains empty instead of becoming cwd-dependent.
+- [x] #4 Manifest writes are private and atomic enough to avoid partial final JSON on interruption.
+- [x] #5 Manifest reader cleanup cannot crash the CLI from fd close failures.
+- [x] #6 Focused tests and security checks pass after changes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verified live PR #1868 review threads after rebase. The cubic README variable persistence and bundle metadata findings were valid. The Qodo docstring, fd-close cleanup, and atomic manifest write findings were valid.
+- Updated README host-reboot drill examples so post-reboot commands rehydrate evidence/socket/launchd variables from durable run-id files instead of relying on shell state across reboot.
+- Changed missing bundle metadata normalization so `Path("")` remains an empty manifest value instead of resolving to the current working directory.
+- Made private JSON manifest writes use a same-directory temp file, `fsync()`, and `os.replace()` while preserving existing final manifest content on serialization failure.
+- Suppressed `OSError` from fd cleanup in pre-manifest reading and added docstrings for new host-reboot evidence helpers.
+- Verification: `py_compile` passed for `vz-helperctl.py`; focused helper tests passed with `188 passed, 6 skipped, 2 warnings`; `git diff --check` passed; Bandit reported no errors/results for `vz-helperctl.py`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all currently open PR #1868 review threads from cubic and Qodo with narrow helper/docs/test updates, and verified the focused helper suite plus compile, diff, and Bandit checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -118,6 +118,9 @@ and validates the restored helper after the machine comes back. The evidence
 directory must be durable across reboot and private to the operator; use a path
 such as `~/Library/Logs/tldw/vz-host-reboot-drill/<run-id>`, not `/tmp`,
 `$TMPDIR`, or another volatile root.
+The pre phase records a host boot marker, helper lifecycle preflight results,
+and bundle dry-run validation. The post phase fails if the host boot marker is
+missing or unchanged, because that means the drill did not prove a reboot.
 
 Direct helper mode uses the managed helper socket directly:
 
@@ -128,6 +131,7 @@ socket_path="$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/help
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
   --evidence-dir "$evidence_dir" \
   --socket "$socket_path" \
+  --pid-file "$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.pid" \
   --bundle /path/to/canonical/bundle \
   --create-evidence-dir
 
@@ -136,6 +140,7 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
   --evidence-dir "$evidence_dir" \
   --socket "$socket_path" \
+  --pid-file "$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.pid" \
   --bundle /path/to/canonical/bundle \
   --run-smoke
 ```
@@ -173,7 +178,9 @@ through the host smoke path. It must not start a new helper process for the
 post-reboot proof. Diagnostics and dry-run reconciliation repair remain
 operator-reviewed follow-up steps and are separate from this drill. Scheduled
 or nightly CI must not reboot hosts; this validation is manual or explicitly
-operator-triggered only.
+operator-triggered only. Blocking post failures include unchanged host boot
+marker, missing boot marker, failed lifecycle readiness, metadata mismatch,
+helper ping/protocol failure, and requested post-smoke failure.
 
 `restart-drill` is an operator-managed lifecycle drill for helpers already
 started through `vz-helperctl.py start`. It verifies the current managed helper

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -111,6 +111,67 @@ These commands never run automatically from `plist`, `status`, `smoke`, or
 server startup. They are operator-owned scaffolding and do not validate host
 reboot behavior.
 
+### Host Reboot Validation Drill
+
+`host-reboot-drill` records bounded helper evidence before a manual host reboot
+and validates the restored helper after the machine comes back. The evidence
+directory must be durable across reboot and private to the operator; use a path
+such as `~/Library/Logs/tldw/vz-host-reboot-drill/<run-id>`, not `/tmp`,
+`$TMPDIR`, or another volatile root.
+
+Direct helper mode uses the managed helper socket directly:
+
+```bash
+evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --create-evidence-dir
+
+# Manually reboot the host, then restore or verify the same helper socket path.
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --run-smoke
+```
+
+Launchd helper mode is explicit in both phases. Provide the same `--label` and
+`--plist-output` before and after reboot so the manifests can bind evidence to
+the intended LaunchAgent instead of an implicit default:
+
+```bash
+label="org.tldw.macos-vz-helper.manual-reboot"
+plist="$HOME/Library/LaunchAgents/${label}.plist"
+evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
+  --helper-mode launchd \
+  --label "$label" \
+  --plist-output "$plist" \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --create-evidence-dir
+
+# Manually reboot the host, then verify launchd restored the helper.
+
+tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
+  --helper-mode launchd \
+  --label "$label" \
+  --plist-output "$plist" \
+  --evidence-dir "$evidence_dir" \
+  --bundle /path/to/canonical/bundle \
+  --run-smoke
+```
+
+When `post --run-smoke` is used, the smoke targets the restored helper socket
+through the host smoke path. It must not start a new helper process for the
+post-reboot proof. Diagnostics and dry-run reconciliation repair remain
+operator-reviewed follow-up steps and are separate from this drill. Scheduled
+or nightly CI must not reboot hosts; this validation is manual or explicitly
+operator-triggered only.
+
 `restart-drill` is an operator-managed lifecycle drill for helpers already
 started through `vz-helperctl.py start`. It verifies the current managed helper
 status, stops it through the pid-file/socket lease, starts a replacement on the

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -123,9 +123,11 @@ Direct helper mode uses the managed helper socket directly:
 
 ```bash
 evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+socket_path="$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.sock"
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
   --evidence-dir "$evidence_dir" \
+  --socket "$socket_path" \
   --bundle /path/to/canonical/bundle \
   --create-evidence-dir
 
@@ -133,6 +135,7 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
   --evidence-dir "$evidence_dir" \
+  --socket "$socket_path" \
   --bundle /path/to/canonical/bundle \
   --run-smoke
 ```

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -125,7 +125,13 @@ missing or unchanged, because that means the drill did not prove a reboot.
 Direct helper mode uses the managed helper socket directly:
 
 ```bash
-evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+evidence_root="$HOME/Library/Logs/tldw/vz-host-reboot-drill"
+mkdir -p "$evidence_root"
+chmod 700 "$evidence_root"
+run_id="manual-$(date +%Y%m%d-%H%M%S)"
+printf '%s\n' "$run_id" > "$evidence_root/latest-run-id"
+chmod 600 "$evidence_root/latest-run-id"
+evidence_dir="$evidence_root/$run_id"
 socket_path="$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.sock"
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
@@ -136,6 +142,11 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
   --create-evidence-dir
 
 # Manually reboot the host, then restore or verify the same helper socket path.
+
+evidence_root="$HOME/Library/Logs/tldw/vz-host-reboot-drill"
+run_id="$(cat "$evidence_root/latest-run-id")"
+evidence_dir="$evidence_root/$run_id"
+socket_path="$HOME/Library/Application Support/tldw/sandbox/macos-vz-helper/helper.sock"
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
   --evidence-dir "$evidence_dir" \
@@ -152,7 +163,13 @@ the intended LaunchAgent instead of an implicit default:
 ```bash
 label="org.tldw.macos-vz-helper.manual-reboot"
 plist="$HOME/Library/LaunchAgents/${label}.plist"
-evidence_dir="$HOME/Library/Logs/tldw/vz-host-reboot-drill/manual-$(date +%Y%m%d-%H%M%S)"
+evidence_root="$HOME/Library/Logs/tldw/vz-host-reboot-drill"
+mkdir -p "$evidence_root"
+chmod 700 "$evidence_root"
+run_id="manual-$(date +%Y%m%d-%H%M%S)"
+printf '%s\n' "$run_id" > "$evidence_root/latest-launchd-run-id"
+chmod 600 "$evidence_root/latest-launchd-run-id"
+evidence_dir="$evidence_root/$run_id"
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
   --helper-mode launchd \
@@ -163,6 +180,12 @@ tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill pre \
   --create-evidence-dir
 
 # Manually reboot the host, then verify launchd restored the helper.
+
+label="org.tldw.macos-vz-helper.manual-reboot"
+plist="$HOME/Library/LaunchAgents/${label}.plist"
+evidence_root="$HOME/Library/Logs/tldw/vz-host-reboot-drill"
+run_id="$(cat "$evidence_root/latest-launchd-run-id")"
+evidence_dir="$evidence_root/$run_id"
 
 tools/macos-vz-helper/scripts/vz-helperctl.py host-reboot-drill post \
   --helper-mode launchd \

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -444,6 +444,18 @@ def test_host_reboot_evidence_dir_creates_nested_components_owner_only(
     CASE.assertEqual(evidence.stat().st_mode & 0o777, 0o700)
 
 
+def _host_reboot_ok_readiness(helperctl: Any) -> Any:
+    return lambda **kwargs: [("helper_readiness", helperctl.CheckResult(True, "host_reboot_helper_ready"))]
+
+
+def _host_reboot_ok_bundle_validator(helperctl: Any) -> Any:
+    return lambda **kwargs: helperctl.CheckResult(True, "dry_run")
+
+
+def _host_reboot_boot_marker(helperctl: Any, marker: str = "boot-2") -> Any:
+    return lambda: helperctl.CheckResult(True, "host_boot_marker", marker)
+
+
 def test_host_reboot_pre_writes_bounded_manifest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -471,6 +483,9 @@ def test_host_reboot_pre_writes_bounded_manifest(
         create_evidence_dir=True,
         created_at_factory=lambda: "2026-05-19T00:00:00Z",
         hostname_provider=lambda: "test-host",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        bundle_validator=_host_reboot_ok_bundle_validator(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-1"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(True),
             protocol_version="1",
@@ -504,6 +519,12 @@ def test_host_reboot_pre_writes_bounded_manifest(
             "helper_protocol_version",
             "helper_version",
             "helper_details",
+            "host_boot_marker_ok",
+            "host_boot_marker_reason",
+            "host_boot_marker",
+            "lifecycle_results",
+            "bundle_validation_ok",
+            "bundle_validation_reason",
         },
     )
     CASE.assertEqual(payload["phase"], "pre")
@@ -521,6 +542,20 @@ def test_host_reboot_pre_writes_bounded_manifest(
     CASE.assertEqual(payload["helper_ping_reason"], "ok")
     CASE.assertEqual(payload["helper_protocol_version"], "1")
     CASE.assertEqual(payload["helper_version"], "test")
+    CASE.assertIs(payload["host_boot_marker_ok"], True)
+    CASE.assertEqual(payload["host_boot_marker"], "boot-1")
+    CASE.assertIs(payload["bundle_validation_ok"], True)
+    CASE.assertEqual(
+        payload["lifecycle_results"],
+        [
+            {
+                "name": "helper_readiness",
+                "ok": True,
+                "reason": "host_reboot_helper_ready",
+                "message": "",
+            }
+        ],
+    )
     CASE.assertEqual(
         payload["helper_details"],
         {
@@ -532,6 +567,63 @@ def test_host_reboot_pre_writes_bounded_manifest(
     CASE.assertNotIn("stdout", payload)
     CASE.assertNotIn("stderr", payload)
     CASE.assertNotIn("serial_log_contents", payload)
+
+
+def test_host_reboot_pre_writes_manifest_and_fails_lifecycle_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.run_host_reboot_pre(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        create_evidence_dir=True,
+        readiness_checker=lambda **kwargs: [
+            ("helper_readiness", helperctl.CheckResult(False, "host_reboot_helper_not_ready"))
+        ],
+        bundle_validator=_host_reboot_ok_bundle_validator(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-1"),
+        ping_checker=lambda path: helperctl.PingState(result=helperctl.CheckResult(True)),
+    )
+
+    CASE.assertEqual(result.reason, "host_reboot_helper_not_ready")
+    CASE.assertFalse(result.ok)
+    payload = json.loads((evidence / "host-reboot-pre.json").read_text(encoding="utf-8"))
+    CASE.assertEqual(payload["lifecycle_results"][0]["reason"], "host_reboot_helper_not_ready")
+
+
+def test_host_reboot_lifecycle_readiness_checks_launchd_status(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    calls: list[tuple[str, str, Path | None]] = []
+
+    def fake_launchd_status(action: str, **kwargs: Any) -> helperctl.CheckResult:
+        calls.append((action, kwargs["label"], kwargs["plist_path"]))
+        return helperctl.CheckResult(True)
+
+    def fake_check_collector(*args: Any, **kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        return [("ping", helperctl.CheckResult(True))]
+
+    results = helperctl.host_reboot_lifecycle_readiness_results(
+        helper_mode="launchd",
+        helper_path=tmp_path / "helper",
+        socket_path=tmp_path / "helper.sock",
+        pid_file=tmp_path / "helper.pid",
+        log_dir=tmp_path / "logs",
+        launchd_label="org.tldw.test-helper",
+        launchd_plist_path=tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist",
+        launchd_status_checker=fake_launchd_status,
+        check_collector=fake_check_collector,
+    )
+
+    CASE.assertEqual(calls, [("status", "org.tldw.test-helper", tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist")])
+    CASE.assertEqual(dict(results)["helper_readiness"].reason, "host_reboot_helper_ready")
 
 
 def test_host_reboot_pre_dry_run_does_not_create_evidence_or_manifest(
@@ -551,6 +643,9 @@ def test_host_reboot_pre_dry_run_does_not_create_evidence_or_manifest(
         log_dir=tmp_path / "logs",
         create_evidence_dir=True,
         dry_run=True,
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        bundle_validator=_host_reboot_ok_bundle_validator(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-1"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(True),
             protocol_version="1",
@@ -582,6 +677,9 @@ def test_host_reboot_pre_writes_manifest_and_returns_failed_ping(
         create_evidence_dir=True,
         created_at_factory=lambda: "2026-05-19T00:00:00Z",
         hostname_provider=lambda: "test-host",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        bundle_validator=_host_reboot_ok_bundle_validator(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-1"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(False, "helper_ping_failed", "socket unavailable"),
             protocol_version="",
@@ -621,6 +719,9 @@ def test_host_reboot_pre_wraps_raising_ping_checker_and_writes_manifest(
         create_evidence_dir=True,
         created_at_factory=lambda: "2026-05-19T00:00:00Z",
         hostname_provider=lambda: "test-host",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        bundle_validator=_host_reboot_ok_bundle_validator(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-1"),
         ping_checker=raising_ping_checker,
     )
 
@@ -812,6 +913,9 @@ def test_host_reboot_manifests_drop_forbidden_helper_detail_keys(
         create_evidence_dir=True,
         created_at_factory=lambda: "2026-05-19T00:00:00Z",
         hostname_provider=lambda: "test-host",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        bundle_validator=_host_reboot_ok_bundle_validator(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-1"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(True),
             protocol_version="1",
@@ -828,6 +932,8 @@ def test_host_reboot_manifests_drop_forbidden_helper_detail_keys(
         log_dir=tmp_path / "logs",
         created_at_factory=lambda: "2026-05-19T01:00:00Z",
         hostname_provider=lambda: "test-host",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-2"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(True),
             protocol_version="1",
@@ -879,6 +985,8 @@ def test_host_reboot_post_reports_generation_changed(
                 "launchd_label": "org.tldw.test-helper",
                 "launchd_plist_path": str(tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist"),
                 "helper_details": {"helper_instance_id": "before"},
+                "host_boot_marker_ok": True,
+                "host_boot_marker": "boot-1",
             }
         ),
         encoding="utf-8",
@@ -897,6 +1005,8 @@ def test_host_reboot_post_reports_generation_changed(
         launchd_plist_path=tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist",
         created_at_factory=lambda: "2026-05-19T01:00:00Z",
         hostname_provider=lambda: "test-host",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-2"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(True),
             protocol_version="1",
@@ -936,6 +1046,11 @@ def test_host_reboot_post_reports_generation_changed(
             "helper_protocol_version",
             "helper_version",
             "helper_details",
+            "host_boot_marker_ok",
+            "host_boot_marker_reason",
+            "host_boot_marker",
+            "host_reboot_marker_reason",
+            "lifecycle_results",
         },
     )
     CASE.assertEqual(payload["phase"], "post")
@@ -945,11 +1060,65 @@ def test_host_reboot_post_reports_generation_changed(
     CASE.assertEqual(payload["pre_helper_instance_id"], "before")
     CASE.assertEqual(payload["post_helper_instance_id"], "after")
     CASE.assertEqual(payload["helper_generation_reason"], "helper_generation_changed")
+    CASE.assertEqual(payload["host_boot_marker"], "boot-2")
+    CASE.assertEqual(payload["host_reboot_marker_reason"], "host_reboot_detected")
     CASE.assertIs(payload["helper_ping_ok"], True)
     CASE.assertNotIn("environment", payload)
     CASE.assertNotIn("stdout", payload)
     CASE.assertNotIn("stderr", payload)
     CASE.assertNotIn("serial_log_contents", payload)
+
+
+def test_host_reboot_post_rejects_unchanged_host_boot_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    (evidence / "host-reboot-pre.json").write_text(
+        json.dumps(
+            {
+                "phase": "pre",
+                "helper_mode": "direct",
+                "bundle_path": str(tmp_path / "bundle"),
+                "helper_path": str(tmp_path / "bundle" / "macos-vz-helper"),
+                "socket_path": str(tmp_path / "helper.sock"),
+                "launchd_label": "",
+                "launchd_plist_path": "",
+                "helper_details": {"helper_instance_id": "same-helper"},
+                "host_boot_marker_ok": True,
+                "host_boot_marker": "boot-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-1"),
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={"helper_instance_id": "same-helper"},
+        ),
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["host_reboot_marker"].reason, "host_reboot_not_detected")
+    CASE.assertFalse(by_name["host_reboot_marker"].ok)
+    CASE.assertEqual(results[-1], ("host_reboot_post", by_name["host_reboot_marker"]))
+    payload = json.loads((evidence / "host-reboot-post.json").read_text(encoding="utf-8"))
+    CASE.assertEqual(payload["host_reboot_marker_reason"], "host_reboot_not_detected")
 
 
 def test_host_reboot_post_reports_metadata_mismatch_before_writing_manifest(
@@ -1030,6 +1199,8 @@ def test_host_reboot_metadata_matches_equivalent_relative_paths(
                 "phase": "pre",
                 **pre_metadata,
                 "helper_details": {"helper_instance_id": "before"},
+                "host_boot_marker_ok": True,
+                "host_boot_marker": "boot-1",
             }
         ),
         encoding="utf-8",
@@ -1044,6 +1215,8 @@ def test_host_reboot_metadata_matches_equivalent_relative_paths(
         helper_mode="direct",
         socket_path=Path("./helper.sock"),
         log_dir=logs,
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-2"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(True),
             protocol_version="1",
@@ -1086,6 +1259,8 @@ def test_host_reboot_post_dry_run_does_not_write_post_manifest(
                 "launchd_label": "org.tldw.test-helper",
                 "launchd_plist_path": str(plist_path),
                 "helper_details": {"helper_instance_id": "before"},
+                "host_boot_marker_ok": True,
+                "host_boot_marker": "boot-1",
             }
         ),
         encoding="utf-8",
@@ -1102,6 +1277,8 @@ def test_host_reboot_post_dry_run_does_not_write_post_manifest(
         launchd_label="org.tldw.test-helper",
         launchd_plist_path=plist_path,
         dry_run=True,
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-2"),
         ping_checker=lambda path: helperctl.PingState(
             result=helperctl.CheckResult(True),
             protocol_version="1",
@@ -1136,6 +1313,8 @@ def test_host_reboot_post_wraps_raising_ping_checker_and_writes_manifest(
                 "launchd_label": "",
                 "launchd_plist_path": "",
                 "helper_details": {"helper_instance_id": "before"},
+                "host_boot_marker_ok": True,
+                "host_boot_marker": "boot-1",
             }
         ),
         encoding="utf-8",
@@ -1154,6 +1333,8 @@ def test_host_reboot_post_wraps_raising_ping_checker_and_writes_manifest(
         log_dir=tmp_path / "logs",
         created_at_factory=lambda: "2026-05-19T01:00:00Z",
         hostname_provider=lambda: "test-host",
+        readiness_checker=_host_reboot_ok_readiness(helperctl),
+        boot_marker_provider=_host_reboot_boot_marker(helperctl, "boot-2"),
         ping_checker=raising_ping_checker,
     )
 

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -534,6 +534,35 @@ def test_host_reboot_pre_writes_bounded_manifest(
     CASE.assertNotIn("serial_log_contents", payload)
 
 
+def test_host_reboot_pre_dry_run_does_not_create_evidence_or_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.run_host_reboot_pre(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        create_evidence_dir=True,
+        dry_run=True,
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+        ),
+    )
+
+    CASE.assertEqual(result, helperctl.CheckResult(True, "host_reboot_pre_dry_run", str(evidence)))
+    CASE.assertFalse(evidence.exists())
+    CASE.assertFalse((evidence / "host-reboot-pre.json").exists())
+
+
 def test_host_reboot_pre_writes_manifest_and_returns_failed_ping(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -831,6 +860,11 @@ def test_host_reboot_post_reports_generation_changed(
             {
                 "phase": "pre",
                 "helper_mode": "direct",
+                "bundle_path": str(tmp_path / "bundle"),
+                "helper_path": str(tmp_path / "bundle" / "macos-vz-helper"),
+                "socket_path": str(tmp_path / "helper.sock"),
+                "launchd_label": "org.tldw.test-helper",
+                "launchd_plist_path": str(tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist"),
                 "helper_details": {"helper_instance_id": "before"},
             }
         ),
@@ -905,6 +939,110 @@ def test_host_reboot_post_reports_generation_changed(
     CASE.assertNotIn("serial_log_contents", payload)
 
 
+def test_host_reboot_post_reports_metadata_mismatch_before_writing_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    (evidence / "host-reboot-pre.json").write_text(
+        json.dumps(
+            {
+                "phase": "pre",
+                "helper_mode": "direct",
+                "bundle_path": str(tmp_path / "bundle"),
+                "helper_path": str(tmp_path / "bundle" / "macos-vz-helper"),
+                "socket_path": str(tmp_path / "helper.sock"),
+                "launchd_label": "org.tldw.test-helper",
+                "launchd_plist_path": str(tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist"),
+                "helper_details": {"helper_instance_id": "before"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "different-bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        launchd_label="org.tldw.test-helper",
+        launchd_plist_path=tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist",
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={"helper_instance_id": "after"},
+        ),
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["metadata_match"].reason, "host_reboot_metadata_mismatch")
+    CASE.assertFalse(by_name["metadata_match"].ok)
+    CASE.assertEqual(by_name["metadata_match"].message, "bundle_path")
+    CASE.assertEqual(results[-1], ("host_reboot_post", by_name["metadata_match"]))
+    CASE.assertFalse((evidence / "host-reboot-post.json").exists())
+
+
+def test_host_reboot_post_dry_run_does_not_write_post_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    bundle = tmp_path / "bundle"
+    helper_path = bundle / "macos-vz-helper"
+    socket_path = tmp_path / "helper.sock"
+    plist_path = tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    (evidence / "host-reboot-pre.json").write_text(
+        json.dumps(
+            {
+                "phase": "pre",
+                "helper_mode": "direct",
+                "bundle_path": str(bundle),
+                "helper_path": str(helper_path),
+                "socket_path": str(socket_path),
+                "launchd_label": "org.tldw.test-helper",
+                "launchd_plist_path": str(plist_path),
+                "helper_details": {"helper_instance_id": "before"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=bundle,
+        helper_path=helper_path,
+        helper_mode="direct",
+        socket_path=socket_path,
+        log_dir=tmp_path / "logs",
+        launchd_label="org.tldw.test-helper",
+        launchd_plist_path=plist_path,
+        dry_run=True,
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={"helper_instance_id": "after"},
+        ),
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["post_manifest"].reason, "host_reboot_post_dry_run")
+    CASE.assertTrue(by_name["post_manifest"].ok)
+    CASE.assertEqual(results[-1], ("host_reboot_post", helperctl.CheckResult(ok=True)))
+    CASE.assertFalse((evidence / "host-reboot-post.json").exists())
+
+
 def test_host_reboot_post_wraps_raising_ping_checker_and_writes_manifest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -918,6 +1056,11 @@ def test_host_reboot_post_wraps_raising_ping_checker_and_writes_manifest(
             {
                 "phase": "pre",
                 "helper_mode": "direct",
+                "bundle_path": str(tmp_path / "bundle"),
+                "helper_path": str(tmp_path / "bundle" / "macos-vz-helper"),
+                "socket_path": str(tmp_path / "helper.sock"),
+                "launchd_label": "",
+                "launchd_plist_path": "",
                 "helper_details": {"helper_instance_id": "before"},
             }
         ),
@@ -1029,6 +1172,74 @@ def test_host_reboot_drill_cli_post_json_outputs_parseable_json(
     CASE.assertEqual(output, [{"name": "host_reboot_post", "ok": True, "reason": "ok", "message": ""}])
 
 
+def test_host_reboot_drill_cli_pre_rejects_post_only_smoke_flag(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+
+    with pytest.raises(SystemExit) as exc_info:
+        helperctl.main(
+            [
+                "host-reboot-drill",
+                "pre",
+                "--evidence-dir",
+                str(tmp_path / "durable" / "drill"),
+                "--run-smoke",
+            ]
+        )
+
+    CASE.assertEqual(exc_info.value.code, 2)
+
+
+def test_host_reboot_drill_cli_post_rejects_pre_only_create_evidence_flag(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+
+    with pytest.raises(SystemExit) as exc_info:
+        helperctl.main(
+            [
+                "host-reboot-drill",
+                "post",
+                "--evidence-dir",
+                str(tmp_path / "durable" / "drill"),
+                "--create-evidence-dir",
+            ]
+        )
+
+    CASE.assertEqual(exc_info.value.code, 2)
+
+
+def test_host_reboot_drill_cli_pre_json_subprocess_is_clean_and_dry_run_does_not_write(
+    tmp_path: Path,
+) -> None:
+    evidence = tmp_path / "durable" / "drill"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "host-reboot-drill",
+            "pre",
+            "--evidence-dir",
+            str(evidence),
+            "--bundle",
+            str(tmp_path / "bundle"),
+            "--socket",
+            str(tmp_path / "helper.sock"),
+            "--create-evidence-dir",
+            "--allow-volatile-evidence-dir",
+            "--dry-run",
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    CASE.assertEqual(completed.returncode, 0, completed.stderr)
+    output = json.loads(completed.stdout)
+    CASE.assertEqual(output[0]["name"], "host_reboot_pre")
+    CASE.assertEqual(output[0]["reason"], "host_reboot_pre_dry_run")
+    CASE.assertFalse(evidence.exists())
+    CASE.assertFalse((evidence / "host-reboot-pre.json").exists())
+
+
 def test_host_reboot_post_runs_smoke_against_restored_helper_socket(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1079,6 +1290,81 @@ def test_host_reboot_post_runs_smoke_against_restored_helper_socket(
     CASE.assertEqual(calls[0]["python_path"], python_path)
     CASE.assertIs(calls[0]["dry_run"], True)
     CASE.assertIn("vz_linux_smoke: ok dry_run", capsys.readouterr().out)
+
+
+def test_host_reboot_post_runs_smoke_skips_when_post_validation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_host_reboot_post(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        return [("host_reboot_post", helperctl.CheckResult(False, "helper_ping_failed"))]
+
+    def fake_run_vz_linux_host_smoke(**kwargs: Any) -> helperctl.CheckResult:
+        calls.append(kwargs)
+        return helperctl.CheckResult(ok=True)
+
+    monkeypatch.setattr(helperctl, "run_host_reboot_post", fake_run_host_reboot_post)
+    monkeypatch.setattr(helperctl, "run_vz_linux_host_smoke", fake_run_vz_linux_host_smoke)
+
+    code = helperctl.main(
+        [
+            "host-reboot-drill",
+            "post",
+            "--evidence-dir",
+            str(tmp_path / "durable" / "drill"),
+            "--bundle",
+            str(tmp_path / "bundle"),
+            "--run-smoke",
+            "--json",
+        ]
+    )
+
+    CASE.assertEqual(code, 1)
+    CASE.assertEqual(calls, [])
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(output[-1]["name"], "vz_linux_smoke")
+    CASE.assertEqual(output[-1]["reason"], "host_reboot_smoke_skipped")
+    CASE.assertFalse(output[-1]["ok"])
+
+
+def test_host_reboot_post_runs_smoke_reports_smoke_failure_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+
+    def fake_run_host_reboot_post(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        return [("host_reboot_post", helperctl.CheckResult(ok=True))]
+
+    def fake_run_vz_linux_host_smoke(**kwargs: Any) -> helperctl.CheckResult:
+        return helperctl.CheckResult(False, "vz_linux_smoke_failed", "7")
+
+    monkeypatch.setattr(helperctl, "run_host_reboot_post", fake_run_host_reboot_post)
+    monkeypatch.setattr(helperctl, "run_vz_linux_host_smoke", fake_run_vz_linux_host_smoke)
+
+    code = helperctl.main(
+        [
+            "host-reboot-drill",
+            "post",
+            "--evidence-dir",
+            str(tmp_path / "durable" / "drill"),
+            "--bundle",
+            str(tmp_path / "bundle"),
+            "--run-smoke",
+            "--json",
+        ]
+    )
+
+    CASE.assertEqual(code, 1)
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(output[-1]["name"], "vz_linux_smoke")
+    CASE.assertEqual(output[-1]["reason"], "vz_linux_smoke_failed")
+    CASE.assertEqual(output[-1]["message"], "7")
 
 
 def test_host_reboot_drill_cli_launchd_requires_explicit_metadata(

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -347,6 +347,37 @@ def test_ensure_private_dir_refuses_non_owner(monkeypatch, tmp_path):
     CASE.assertEqual(result, helperctl.CheckResult(ok=False, reason="helper_directory_owner_mismatch"))
 
 
+def test_host_reboot_evidence_dir_rejects_world_readable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    evidence.chmod(0o755)
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.ensure_host_reboot_evidence_dir(evidence, create=False)
+
+    CASE.assertEqual(result.reason, "host_reboot_evidence_dir_not_private")
+    CASE.assertFalse(result.ok)
+
+
+def test_host_reboot_evidence_dir_rejects_volatile_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    volatile = tmp_path / "tmp"
+    evidence = volatile / "drill"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", (volatile,))
+
+    result = helperctl.ensure_host_reboot_evidence_dir(evidence, create=True)
+
+    CASE.assertEqual(result.reason, "host_reboot_evidence_dir_volatile")
+    CASE.assertFalse(result.ok)
+
+
 def test_render_launchd_plist_includes_required_fields(tmp_path):
     helperctl = load_helperctl()
     helper_path = tmp_path / "macos-vz-helper"
@@ -2933,6 +2964,32 @@ def test_ping_helper_reports_protocol_mismatch(monkeypatch, tmp_path):
     )
 
     CASE.assertEqual(result.result, helperctl.CheckResult(ok=False, reason="helper_protocol_mismatch", message="macos_virtualization_helper_protocol_mismatch"))
+
+
+def test_ping_helper_state_preserves_helper_details(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+
+    class FakeReply:
+        protocol_version = "1"
+        helper_version = "test-helper"
+        details = {
+            "helper_instance_id": "before",
+            "helper_started_at": "2026-05-19T00:00:00Z",
+            "ignored_number": 1,
+        }
+
+    class FakeClient:
+        def ping(self) -> FakeReply:
+            return FakeReply()
+
+    state = helperctl.ping_helper_state(
+        tmp_path / "helper.sock",
+        client_factory=lambda path: FakeClient(),
+    )
+
+    CASE.assertEqual(state.details["helper_instance_id"], "before")
+    CASE.assertEqual(state.details["helper_started_at"], "2026-05-19T00:00:00Z")
+    CASE.assertNotIn("ignored_number", state.details)
 
 
 def test_ping_helper_falls_back_to_socket_when_helper_client_import_breaks(monkeypatch):

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -444,6 +444,131 @@ def test_host_reboot_evidence_dir_creates_nested_components_owner_only(
     CASE.assertEqual(evidence.stat().st_mode & 0o777, 0o700)
 
 
+def test_host_reboot_pre_writes_bounded_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    bundle_path = tmp_path / "bundle"
+    helper_path = tmp_path / "bundle" / "macos-vz-helper"
+    socket_path = tmp_path / "helper.sock"
+    log_dir = tmp_path / "logs"
+    serial_log_dir = log_dir / "serial"
+    launchd_plist_path = tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.run_host_reboot_pre(
+        evidence_dir=evidence,
+        bundle_path=bundle_path,
+        helper_path=helper_path,
+        helper_mode="direct",
+        socket_path=socket_path,
+        log_dir=log_dir,
+        serial_log_dir=serial_log_dir,
+        launchd_label="org.tldw.test-helper",
+        launchd_plist_path=launchd_plist_path,
+        create_evidence_dir=True,
+        created_at_factory=lambda: "2026-05-19T00:00:00Z",
+        hostname_provider=lambda: "test-host",
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={
+                "helper_instance_id": "before",
+                "helper_started_at": "2026-05-19T00:00:00Z",
+            },
+        ),
+    )
+
+    CASE.assertTrue(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_pre_manifest_written")
+    payload = json.loads((evidence / "host-reboot-pre.json").read_text(encoding="utf-8"))
+    CASE.assertEqual(
+        set(payload),
+        {
+            "phase",
+            "created_at",
+            "hostname",
+            "helper_mode",
+            "bundle_path",
+            "helper_path",
+            "socket_path",
+            "log_dir",
+            "serial_log_dir",
+            "launchd_label",
+            "launchd_plist_path",
+            "helper_ping_ok",
+            "helper_ping_reason",
+            "helper_protocol_version",
+            "helper_version",
+            "helper_details",
+        },
+    )
+    CASE.assertEqual(payload["phase"], "pre")
+    CASE.assertEqual(payload["created_at"], "2026-05-19T00:00:00Z")
+    CASE.assertEqual(payload["hostname"], "test-host")
+    CASE.assertEqual(payload["helper_mode"], "direct")
+    CASE.assertEqual(payload["bundle_path"], str(bundle_path))
+    CASE.assertEqual(payload["helper_path"], str(helper_path))
+    CASE.assertEqual(payload["socket_path"], str(socket_path))
+    CASE.assertEqual(payload["log_dir"], str(log_dir))
+    CASE.assertEqual(payload["serial_log_dir"], str(serial_log_dir))
+    CASE.assertEqual(payload["launchd_label"], "org.tldw.test-helper")
+    CASE.assertEqual(payload["launchd_plist_path"], str(launchd_plist_path))
+    CASE.assertIs(payload["helper_ping_ok"], True)
+    CASE.assertEqual(payload["helper_ping_reason"], "ok")
+    CASE.assertEqual(payload["helper_protocol_version"], "1")
+    CASE.assertEqual(payload["helper_version"], "test")
+    CASE.assertEqual(
+        payload["helper_details"],
+        {
+            "helper_instance_id": "before",
+            "helper_started_at": "2026-05-19T00:00:00Z",
+        },
+    )
+    CASE.assertNotIn("environment", payload)
+    CASE.assertNotIn("stdout", payload)
+    CASE.assertNotIn("stderr", payload)
+    CASE.assertNotIn("serial_log_contents", payload)
+
+
+def test_write_json_private_creates_owner_only_file(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    manifest = tmp_path / "manifest.json"
+
+    result = helperctl.write_json_private(manifest, {"phase": "pre"})
+
+    CASE.assertTrue(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_manifest_written")
+    CASE.assertEqual(manifest.stat().st_mode & 0o777, 0o600)
+    CASE.assertEqual(json.loads(manifest.read_text(encoding="utf-8")), {"phase": "pre"})
+
+
+def test_ping_state_payload_maps_helper_manifest_fields() -> None:
+    helperctl = load_helperctl()
+    state = helperctl.PingState(
+        result=helperctl.CheckResult(False, "helper_ping_failed", "unavailable"),
+        protocol_version="1",
+        helper_version="test",
+        details={"helper_instance_id": "before"},
+    )
+
+    payload = helperctl.ping_state_payload(state)
+
+    CASE.assertEqual(
+        payload,
+        {
+            "helper_ping_ok": False,
+            "helper_ping_reason": "helper_ping_failed",
+            "helper_protocol_version": "1",
+            "helper_version": "test",
+            "helper_details": {"helper_instance_id": "before"},
+        },
+    )
+
+
 def test_render_launchd_plist_includes_required_fields(tmp_path):
     helperctl = load_helperctl()
     helper_path = tmp_path / "macos-vz-helper"

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -604,6 +604,193 @@ def test_host_reboot_pre_wraps_raising_ping_checker_and_writes_manifest(
     CASE.assertEqual(payload["helper_ping_reason"], "helper_ping_failed")
 
 
+def test_host_reboot_post_reports_missing_pre_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+    )
+
+    by_name = dict(results)
+    CASE.assertTrue(by_name["evidence_directory"].ok)
+    CASE.assertEqual(by_name["pre_manifest"].reason, "host_reboot_pre_manifest_missing")
+    CASE.assertFalse(by_name["pre_manifest"].ok)
+    CASE.assertEqual(results[-1], ("host_reboot_post", by_name["pre_manifest"]))
+    CASE.assertFalse((evidence / "host-reboot-post.json").exists())
+
+
+def test_host_reboot_post_reports_invalid_pre_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    (evidence / "host-reboot-pre.json").write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["pre_manifest"].reason, "host_reboot_pre_manifest_invalid")
+    CASE.assertFalse(by_name["pre_manifest"].ok)
+    CASE.assertEqual(results[-1], ("host_reboot_post", by_name["pre_manifest"]))
+    CASE.assertFalse((evidence / "host-reboot-post.json").exists())
+
+
+def test_host_reboot_post_reports_generation_changed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    (evidence / "host-reboot-pre.json").write_text(
+        json.dumps(
+            {
+                "phase": "pre",
+                "helper_mode": "direct",
+                "helper_details": {"helper_instance_id": "before"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        serial_log_dir=tmp_path / "logs" / "serial",
+        launchd_label="org.tldw.test-helper",
+        launchd_plist_path=tmp_path / "LaunchAgents" / "org.tldw.test-helper.plist",
+        created_at_factory=lambda: "2026-05-19T01:00:00Z",
+        hostname_provider=lambda: "test-host",
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={"helper_instance_id": "after"},
+        ),
+    )
+
+    by_name = dict(results)
+    CASE.assertTrue(by_name["helper_status"].ok)
+    CASE.assertEqual(
+        by_name["helper_generation"],
+        helperctl.CheckResult(ok=True, reason="helper_generation_changed"),
+    )
+    CASE.assertEqual(by_name["post_manifest"].reason, "host_reboot_post_manifest_written")
+    CASE.assertEqual(results[-1], ("host_reboot_post", helperctl.CheckResult(ok=True)))
+    payload = json.loads((evidence / "host-reboot-post.json").read_text(encoding="utf-8"))
+    CASE.assertEqual(
+        set(payload),
+        {
+            "phase",
+            "created_at",
+            "hostname",
+            "helper_mode",
+            "bundle_path",
+            "helper_path",
+            "socket_path",
+            "log_dir",
+            "serial_log_dir",
+            "launchd_label",
+            "launchd_plist_path",
+            "pre_helper_instance_id",
+            "post_helper_instance_id",
+            "helper_generation_reason",
+            "helper_ping_ok",
+            "helper_ping_reason",
+            "helper_protocol_version",
+            "helper_version",
+            "helper_details",
+        },
+    )
+    CASE.assertEqual(payload["phase"], "post")
+    CASE.assertEqual(payload["created_at"], "2026-05-19T01:00:00Z")
+    CASE.assertEqual(payload["hostname"], "test-host")
+    CASE.assertEqual(payload["helper_mode"], "direct")
+    CASE.assertEqual(payload["pre_helper_instance_id"], "before")
+    CASE.assertEqual(payload["post_helper_instance_id"], "after")
+    CASE.assertEqual(payload["helper_generation_reason"], "helper_generation_changed")
+    CASE.assertIs(payload["helper_ping_ok"], True)
+    CASE.assertNotIn("environment", payload)
+    CASE.assertNotIn("stdout", payload)
+    CASE.assertNotIn("stderr", payload)
+    CASE.assertNotIn("serial_log_contents", payload)
+
+
+def test_host_reboot_post_wraps_raising_ping_checker_and_writes_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    (evidence / "host-reboot-pre.json").write_text(
+        json.dumps(
+            {
+                "phase": "pre",
+                "helper_mode": "direct",
+                "helper_details": {"helper_instance_id": "before"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    def raising_ping_checker(path: Path) -> helperctl.PingState:
+        raise RuntimeError("helper socket refused connection")
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        created_at_factory=lambda: "2026-05-19T01:00:00Z",
+        hostname_provider=lambda: "test-host",
+        ping_checker=raising_ping_checker,
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["helper_status"].reason, "helper_ping_failed")
+    CASE.assertFalse(by_name["helper_status"].ok)
+    CASE.assertEqual(results[-1], ("host_reboot_post", by_name["helper_status"]))
+    payload = json.loads((evidence / "host-reboot-post.json").read_text(encoding="utf-8"))
+    CASE.assertIs(payload["helper_ping_ok"], False)
+    CASE.assertEqual(payload["helper_ping_reason"], "helper_ping_failed")
+    CASE.assertEqual(payload["pre_helper_instance_id"], "before")
+    CASE.assertEqual(payload["post_helper_instance_id"], "")
+
+
 def test_write_json_private_creates_owner_only_file(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     manifest = tmp_path / "manifest.json"

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -98,6 +98,16 @@ def test_protocol_version_surfaces_unexpected_import_errors(monkeypatch):
         load_helperctl("vz_helperctl_import_bug")
 
 
+def test_volatile_roots_ignore_unresolvable_tmpdir(monkeypatch, tmp_path):
+    loop = tmp_path / "loop"
+    loop.symlink_to(loop, target_is_directory=True)
+    monkeypatch.setenv("TMPDIR", str(loop))
+
+    helperctl = load_helperctl("vz_helperctl_tmpdir_loop")
+
+    CASE.assertTrue(hasattr(helperctl, "VOLATILE_EVIDENCE_ROOTS"))
+
+
 def test_lookup_process_uses_single_wide_ps_call(monkeypatch):
     helperctl = load_helperctl()
     calls = []
@@ -376,6 +386,62 @@ def test_host_reboot_evidence_dir_rejects_volatile_root(
 
     CASE.assertEqual(result.reason, "host_reboot_evidence_dir_volatile")
     CASE.assertFalse(result.ok)
+
+
+def test_host_reboot_evidence_dir_reports_broken_symlink_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "evidence"
+    evidence.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.ensure_host_reboot_evidence_dir(evidence, create=True)
+
+    CASE.assertEqual(result.reason, "host_reboot_evidence_dir_not_private")
+    CASE.assertFalse(result.ok)
+    CASE.assertTrue(evidence.is_symlink())
+
+
+def test_host_reboot_evidence_dir_reports_file_parent_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    parent = tmp_path / "evidence-parent"
+    parent.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.ensure_host_reboot_evidence_dir(parent / "drill", create=True)
+
+    CASE.assertEqual(result.reason, "host_reboot_evidence_dir_not_private")
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(parent.read_text(encoding="utf-8"), "not a directory")
+
+
+def test_host_reboot_evidence_dir_creates_nested_components_owner_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    private_root = tmp_path / "private"
+    private_root.mkdir(mode=0o700)
+    private_root.chmod(0o700)
+    evidence = private_root / "host-reboot" / "run-1" / "evidence"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    previous_umask = os.umask(0o022)
+    try:
+        result = helperctl.ensure_host_reboot_evidence_dir(evidence, create=True)
+    finally:
+        os.umask(previous_umask)
+
+    CASE.assertEqual(result.reason, "host_reboot_evidence_dir_ok")
+    CASE.assertTrue(result.ok)
+    CASE.assertEqual((private_root / "host-reboot").stat().st_mode & 0o777, 0o700)
+    CASE.assertEqual((private_root / "host-reboot" / "run-1").stat().st_mode & 0o777, 0o700)
+    CASE.assertEqual(evidence.stat().st_mode & 0o777, 0o700)
 
 
 def test_render_launchd_plist_includes_required_fields(tmp_path):
@@ -2990,6 +3056,33 @@ def test_ping_helper_state_preserves_helper_details(tmp_path: Path) -> None:
     CASE.assertEqual(state.details["helper_instance_id"], "before")
     CASE.assertEqual(state.details["helper_started_at"], "2026-05-19T00:00:00Z")
     CASE.assertNotIn("ignored_number", state.details)
+
+
+def test_ping_helper_state_preserves_raw_helper_json_string_details(monkeypatch, tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+
+    monkeypatch.setattr(
+        helperctl,
+        "_request_helper_ping",
+        lambda path: {
+            "protocol_version": helperctl.EXPECTED_HELPER_PROTOCOL_VERSION,
+            "helper_version": "test-helper",
+            "details": {
+                "helper_instance_id": "after",
+                "helper_started_at": "2026-05-19T01:00:00Z",
+                "ignored_number": 1,
+                123: "ignored key",
+            },
+        },
+    )
+
+    state = helperctl.ping_helper_state(tmp_path / "helper.sock")
+
+    CASE.assertEqual(state.result, helperctl.CheckResult(ok=True))
+    CASE.assertEqual(state.details["helper_instance_id"], "after")
+    CASE.assertEqual(state.details["helper_started_at"], "2026-05-19T01:00:00Z")
+    CASE.assertNotIn("ignored_number", state.details)
+    CASE.assertNotIn(123, state.details)
 
 
 def test_ping_helper_falls_back_to_socket_when_helper_client_import_breaks(monkeypatch):

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -645,6 +645,42 @@ def test_write_json_private_refuses_final_symlink_without_touching_target(tmp_pa
     CASE.assertEqual(target.read_text(encoding="utf-8"), '{"target": true}\n')
 
 
+@pytest.mark.skipif(not hasattr(os, "O_NONBLOCK"), reason="requires nonblocking open support")
+def test_write_json_private_uses_nonblocking_open_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+
+    def fake_open(path: Path, flags: int, mode: int) -> int:
+        CASE.assertTrue(flags & os.O_NONBLOCK)
+        raise OSError("stop after flag check")
+
+    monkeypatch.setattr(helperctl.os, "open", fake_open)
+
+    result = helperctl.write_json_private(tmp_path / "manifest.json", {"phase": "pre"})
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_manifest_write_failed")
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "mkfifo") or not hasattr(os, "O_NONBLOCK"),
+    reason="requires fifo and nonblocking open support",
+)
+def test_write_json_private_rejects_fifo_without_blocking(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    manifest = tmp_path / "manifest.json"
+    os.mkfifo(manifest, 0o600)
+
+    started_at = time.monotonic()
+    result = helperctl.write_json_private(manifest, {"phase": "pre"})
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_manifest_write_failed")
+    CASE.assertLess(time.monotonic() - started_at, 1.0)
+
+
 def test_ping_state_payload_maps_helper_manifest_fields() -> None:
     helperctl = load_helperctl()
     state = helperctl.PingState(

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -626,6 +626,21 @@ def test_host_reboot_lifecycle_readiness_checks_launchd_status(tmp_path: Path) -
     CASE.assertEqual(dict(results)["helper_readiness"].reason, "host_reboot_helper_ready")
 
 
+def test_host_reboot_bundle_dry_run_validation_rejects_missing_kernel(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "rootfs.img").write_text("rootfs", encoding="utf-8")
+
+    result = helperctl.host_reboot_bundle_dry_run_validation(
+        bundle_path=bundle,
+        socket_path=tmp_path / "helper.sock",
+    )
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_bundle_validation_failed")
+
+
 def test_host_reboot_pre_dry_run_does_not_create_evidence_or_manifest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -534,6 +534,76 @@ def test_host_reboot_pre_writes_bounded_manifest(
     CASE.assertNotIn("serial_log_contents", payload)
 
 
+def test_host_reboot_pre_writes_manifest_and_returns_failed_ping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    socket_path = tmp_path / "helper.sock"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    result = helperctl.run_host_reboot_pre(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=socket_path,
+        log_dir=tmp_path / "logs",
+        create_evidence_dir=True,
+        created_at_factory=lambda: "2026-05-19T00:00:00Z",
+        hostname_provider=lambda: "test-host",
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(False, "helper_ping_failed", "socket unavailable"),
+            protocol_version="",
+            helper_version="",
+            details={"helper_instance_id": "before"},
+        ),
+    )
+
+    manifest = evidence / "host-reboot-pre.json"
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "helper_ping_failed")
+    CASE.assertEqual(result.message, "socket unavailable")
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    CASE.assertIs(payload["helper_ping_ok"], False)
+    CASE.assertEqual(payload["helper_ping_reason"], "helper_ping_failed")
+    CASE.assertEqual(payload["helper_details"], {"helper_instance_id": "before"})
+
+
+def test_host_reboot_pre_wraps_raising_ping_checker_and_writes_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    def raising_ping_checker(path: Path) -> helperctl.PingState:
+        raise RuntimeError("helper socket refused connection")
+
+    result = helperctl.run_host_reboot_pre(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=tmp_path / "helper.sock",
+        log_dir=tmp_path / "logs",
+        create_evidence_dir=True,
+        created_at_factory=lambda: "2026-05-19T00:00:00Z",
+        hostname_provider=lambda: "test-host",
+        ping_checker=raising_ping_checker,
+    )
+
+    manifest = evidence / "host-reboot-pre.json"
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "helper_ping_failed")
+    CASE.assertEqual(result.message, "helper socket refused connection")
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    CASE.assertIs(payload["helper_ping_ok"], False)
+    CASE.assertEqual(payload["helper_ping_reason"], "helper_ping_failed")
+
+
 def test_write_json_private_creates_owner_only_file(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     manifest = tmp_path / "manifest.json"
@@ -544,6 +614,35 @@ def test_write_json_private_creates_owner_only_file(tmp_path: Path) -> None:
     CASE.assertEqual(result.reason, "host_reboot_manifest_written")
     CASE.assertEqual(manifest.stat().st_mode & 0o777, 0o600)
     CASE.assertEqual(json.loads(manifest.read_text(encoding="utf-8")), {"phase": "pre"})
+
+
+def test_write_json_private_hardens_existing_manifest_before_serialization_failure(
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text('{"old": true}\n', encoding="utf-8")
+    manifest.chmod(0o644)
+
+    result = helperctl.write_json_private(manifest, {"bad": object()})
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_manifest_write_failed")
+    CASE.assertEqual(manifest.stat().st_mode & 0o777, 0o600)
+
+
+def test_write_json_private_refuses_final_symlink_without_touching_target(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    target = tmp_path / "target.json"
+    target.write_text('{"target": true}\n', encoding="utf-8")
+    link = tmp_path / "manifest.json"
+    link.symlink_to(target)
+
+    result = helperctl.write_json_private(link, {"phase": "pre"})
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_manifest_write_failed")
+    CASE.assertEqual(target.read_text(encoding="utf-8"), '{"target": true}\n')
 
 
 def test_ping_state_payload_maps_helper_manifest_fields() -> None:

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -658,6 +658,7 @@ def test_host_reboot_post_reports_invalid_pre_manifest(
     CASE.assertFalse((evidence / "host-reboot-post.json").exists())
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires fifo support")
 def test_read_host_reboot_pre_manifest_rejects_fifo_without_unsafe_read(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -688,11 +689,13 @@ def test_read_host_reboot_pre_manifest_rejects_fifo_without_unsafe_read(
     CASE.assertFalse(result.ok)
     CASE.assertEqual(result.reason, "host_reboot_pre_manifest_invalid")
     CASE.assertIsNone(payload)
-    CASE.assertTrue(observed_flags)
     if hasattr(helperctl.os, "O_NONBLOCK"):
+        CASE.assertTrue(observed_flags)
         CASE.assertTrue(observed_flags[0] & helperctl.os.O_NONBLOCK)
-    if hasattr(helperctl.os, "O_NOFOLLOW"):
-        CASE.assertTrue(observed_flags[0] & helperctl.os.O_NOFOLLOW)
+        if hasattr(helperctl.os, "O_NOFOLLOW"):
+            CASE.assertTrue(observed_flags[0] & helperctl.os.O_NOFOLLOW)
+    else:
+        CASE.assertEqual(observed_flags, [])
 
 
 def test_read_host_reboot_pre_manifest_rejects_symlink(tmp_path: Path) -> None:

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -658,6 +658,163 @@ def test_host_reboot_post_reports_invalid_pre_manifest(
     CASE.assertFalse((evidence / "host-reboot-post.json").exists())
 
 
+def test_read_host_reboot_pre_manifest_rejects_fifo_without_unsafe_read(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    manifest = evidence / "host-reboot-pre.json"
+    os.mkfifo(manifest)
+    observed_flags: list[int] = []
+    real_open = helperctl.os.open
+    real_read_text = Path.read_text
+
+    def tracking_open(path: str | bytes | os.PathLike[str] | os.PathLike[bytes], flags: int, mode: int = 0o777) -> int:
+        observed_flags.append(flags)
+        return real_open(path, flags, mode)
+
+    def fail_if_manifest_read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+        if path == manifest:
+            raise AssertionError("pre manifest reader must not use Path.read_text on FIFO")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(helperctl.os, "open", tracking_open)
+    monkeypatch.setattr(Path, "read_text", fail_if_manifest_read_text)
+
+    result, payload = helperctl._read_host_reboot_pre_manifest(evidence)
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_pre_manifest_invalid")
+    CASE.assertIsNone(payload)
+    CASE.assertTrue(observed_flags)
+    if hasattr(helperctl.os, "O_NONBLOCK"):
+        CASE.assertTrue(observed_flags[0] & helperctl.os.O_NONBLOCK)
+    if hasattr(helperctl.os, "O_NOFOLLOW"):
+        CASE.assertTrue(observed_flags[0] & helperctl.os.O_NOFOLLOW)
+
+
+def test_read_host_reboot_pre_manifest_rejects_symlink(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    target = tmp_path / "outside.json"
+    target.write_text('{"phase": "pre"}', encoding="utf-8")
+    (evidence / "host-reboot-pre.json").symlink_to(target)
+
+    result, payload = helperctl._read_host_reboot_pre_manifest(evidence)
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_pre_manifest_invalid")
+    CASE.assertIsNone(payload)
+
+
+def test_read_host_reboot_pre_manifest_rejects_non_object(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    (evidence / "host-reboot-pre.json").write_text("[]", encoding="utf-8")
+
+    result, payload = helperctl._read_host_reboot_pre_manifest(evidence)
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_pre_manifest_invalid")
+    CASE.assertIsNone(payload)
+
+
+def test_read_host_reboot_pre_manifest_rejects_oversized(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    manifest = evidence / "host-reboot-pre.json"
+    manifest.write_text(
+        json.dumps({"phase": "pre", "padding": "x" * helperctl.HOST_REBOOT_PRE_MANIFEST_MAX_BYTES}),
+        encoding="utf-8",
+    )
+
+    result, payload = helperctl._read_host_reboot_pre_manifest(evidence)
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_pre_manifest_invalid")
+    CASE.assertIsNone(payload)
+
+
+def test_host_reboot_manifests_drop_forbidden_helper_detail_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    socket_path = tmp_path / "helper.sock"
+    forbidden_details = {
+        "helper_instance_id": "before",
+        "helper_started_at": "2026-05-19T00:00:00Z",
+        "stdout": "secret stdout",
+        "stderr": "secret stderr",
+        "environment": {"TOKEN": "secret"},
+        "serial_log_contents": "secret serial",
+    }
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+
+    pre_result = helperctl.run_host_reboot_pre(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=socket_path,
+        log_dir=tmp_path / "logs",
+        create_evidence_dir=True,
+        created_at_factory=lambda: "2026-05-19T00:00:00Z",
+        hostname_provider=lambda: "test-host",
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details=forbidden_details,
+        ),
+    )
+    post_results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=tmp_path / "bundle",
+        helper_path=tmp_path / "bundle" / "macos-vz-helper",
+        helper_mode="direct",
+        socket_path=socket_path,
+        log_dir=tmp_path / "logs",
+        created_at_factory=lambda: "2026-05-19T01:00:00Z",
+        hostname_provider=lambda: "test-host",
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={
+                **forbidden_details,
+                "helper_instance_id": "after",
+                "helper_started_at": "2026-05-19T01:00:00Z",
+            },
+        ),
+    )
+
+    CASE.assertTrue(pre_result.ok)
+    CASE.assertEqual(post_results[-1], ("host_reboot_post", helperctl.CheckResult(ok=True)))
+    pre_payload = json.loads((evidence / "host-reboot-pre.json").read_text(encoding="utf-8"))
+    post_payload = json.loads((evidence / "host-reboot-post.json").read_text(encoding="utf-8"))
+    CASE.assertEqual(
+        pre_payload["helper_details"],
+        {
+            "helper_instance_id": "before",
+            "helper_started_at": "2026-05-19T00:00:00Z",
+        },
+    )
+    CASE.assertEqual(
+        post_payload["helper_details"],
+        {
+            "helper_instance_id": "after",
+            "helper_started_at": "2026-05-19T01:00:00Z",
+        },
+    )
+
+
 def test_host_reboot_post_reports_generation_changed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -687,6 +687,19 @@ def test_host_reboot_post_reports_invalid_pre_manifest(
     CASE.assertFalse((evidence / "host-reboot-post.json").exists())
 
 
+def test_read_host_reboot_pre_manifest_rejects_post_phase(tmp_path: Path) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    (evidence / "host-reboot-pre.json").write_text('{"phase": "post"}', encoding="utf-8")
+
+    result, payload = helperctl._read_host_reboot_pre_manifest(evidence)
+
+    CASE.assertFalse(result.ok)
+    CASE.assertEqual(result.reason, "host_reboot_pre_manifest_invalid")
+    CASE.assertIsNone(payload)
+
+
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires fifo support")
 def test_read_host_reboot_pre_manifest_rejects_fifo_without_unsafe_read(
     monkeypatch: pytest.MonkeyPatch,
@@ -987,6 +1000,67 @@ def test_host_reboot_post_reports_metadata_mismatch_before_writing_manifest(
     CASE.assertEqual(by_name["metadata_match"].message, "bundle_path")
     CASE.assertEqual(results[-1], ("host_reboot_post", by_name["metadata_match"]))
     CASE.assertFalse((evidence / "host-reboot-post.json").exists())
+
+
+def test_host_reboot_metadata_matches_equivalent_relative_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    evidence.chmod(0o700)
+    runtime_dir = tmp_path / "runtime"
+    bundle = runtime_dir / "bundle"
+    helper = bundle / "macos-vz-helper"
+    socket_path = runtime_dir / "helper.sock"
+    logs = runtime_dir / "logs"
+    runtime_dir.mkdir()
+    pre_metadata = helperctl._host_reboot_metadata_payload(
+        bundle_path=bundle,
+        helper_path=helper,
+        helper_mode="direct",
+        socket_path=socket_path,
+        launchd_label="",
+        launchd_plist_path=None,
+    )
+    (evidence / "host-reboot-pre.json").write_text(
+        json.dumps(
+            {
+                "phase": "pre",
+                **pre_metadata,
+                "helper_details": {"helper_instance_id": "before"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(helperctl, "VOLATILE_EVIDENCE_ROOTS", ())
+    monkeypatch.chdir(runtime_dir)
+
+    results = helperctl.run_host_reboot_post(
+        evidence_dir=evidence,
+        bundle_path=Path("./bundle"),
+        helper_path=Path("./bundle/macos-vz-helper"),
+        helper_mode="direct",
+        socket_path=Path("./helper.sock"),
+        log_dir=logs,
+        ping_checker=lambda path: helperctl.PingState(
+            result=helperctl.CheckResult(True),
+            protocol_version="1",
+            helper_version="test",
+            details={"helper_instance_id": "after"},
+        ),
+    )
+
+    by_name = dict(results)
+    CASE.assertEqual(by_name["metadata_match"].reason, "host_reboot_metadata_match")
+    CASE.assertTrue(by_name["metadata_match"].ok)
+    CASE.assertEqual(results[-1], ("host_reboot_post", helperctl.CheckResult(ok=True)))
+    post_payload = json.loads((evidence / "host-reboot-post.json").read_text(encoding="utf-8"))
+    CASE.assertEqual(post_payload["bundle_path"], str(bundle.resolve(strict=False)))
+    CASE.assertEqual(post_payload["helper_path"], str(helper.resolve(strict=False)))
+    CASE.assertEqual(post_payload["socket_path"], str(socket_path.resolve(strict=False)))
+    CASE.assertEqual(post_payload["launchd_plist_path"], "")
 
 
 def test_host_reboot_post_dry_run_does_not_write_post_manifest(

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -951,6 +951,168 @@ def test_host_reboot_post_wraps_raising_ping_checker_and_writes_manifest(
     CASE.assertEqual(payload["post_helper_instance_id"], "")
 
 
+def test_host_reboot_drill_cli_pre_json_outputs_parseable_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    bundle = tmp_path / "bundle"
+    socket_path = tmp_path / "helper.sock"
+
+    def fake_run_host_reboot_pre(**kwargs: Any) -> helperctl.CheckResult:
+        print("incidental pre noise")
+        CASE.assertEqual(kwargs["evidence_dir"], evidence)
+        CASE.assertEqual(kwargs["bundle_path"], bundle)
+        CASE.assertEqual(kwargs["socket_path"], socket_path)
+        return helperctl.CheckResult(ok=True, reason="host_reboot_pre_manifest_written")
+
+    monkeypatch.setattr(helperctl, "run_host_reboot_pre", fake_run_host_reboot_pre)
+
+    code = helperctl.main(
+        [
+            "host-reboot-drill",
+            "pre",
+            "--evidence-dir",
+            str(evidence),
+            "--bundle",
+            str(bundle),
+            "--socket",
+            str(socket_path),
+            "--json",
+        ]
+    )
+
+    CASE.assertEqual(code, 0)
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(
+        output,
+        [
+            {
+                "name": "host_reboot_pre",
+                "ok": True,
+                "reason": "host_reboot_pre_manifest_written",
+                "message": "",
+            }
+        ],
+    )
+
+
+def test_host_reboot_drill_cli_post_json_outputs_parseable_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+
+    def fake_run_host_reboot_post(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        print("incidental post noise")
+        CASE.assertEqual(kwargs["evidence_dir"], evidence)
+        return [("host_reboot_post", helperctl.CheckResult(ok=True))]
+
+    monkeypatch.setattr(helperctl, "run_host_reboot_post", fake_run_host_reboot_post)
+
+    code = helperctl.main(
+        [
+            "host-reboot-drill",
+            "post",
+            "--evidence-dir",
+            str(evidence),
+            "--json",
+        ]
+    )
+
+    CASE.assertEqual(code, 0)
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(output, [{"name": "host_reboot_post", "ok": True, "reason": "ok", "message": ""}])
+
+
+def test_host_reboot_post_runs_smoke_against_restored_helper_socket(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    bundle = tmp_path / "bundle"
+    socket_path = tmp_path / "restored-helper.sock"
+    python_path = tmp_path / "python"
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_host_reboot_post(**kwargs: Any) -> list[tuple[str, helperctl.CheckResult]]:
+        return [("host_reboot_post", helperctl.CheckResult(ok=True))]
+
+    def fake_run_vz_linux_host_smoke(**kwargs: Any) -> helperctl.CheckResult:
+        calls.append(kwargs)
+        return helperctl.CheckResult(ok=True, reason="dry_run")
+
+    def forbidden_smoke_helper(**kwargs: Any) -> helperctl.CheckResult:
+        raise AssertionError("host-reboot-drill post must not call smoke_helper")
+
+    monkeypatch.setattr(helperctl, "run_host_reboot_post", fake_run_host_reboot_post)
+    monkeypatch.setattr(helperctl, "run_vz_linux_host_smoke", fake_run_vz_linux_host_smoke)
+    monkeypatch.setattr(helperctl, "smoke_helper", forbidden_smoke_helper)
+
+    code = helperctl.main(
+        [
+            "host-reboot-drill",
+            "post",
+            "--evidence-dir",
+            str(evidence),
+            "--bundle",
+            str(bundle),
+            "--socket",
+            str(socket_path),
+            "--python",
+            str(python_path),
+            "--run-smoke",
+            "--dry-run",
+        ]
+    )
+
+    CASE.assertEqual(code, 0)
+    CASE.assertEqual(len(calls), 1)
+    CASE.assertEqual(calls[0]["bundle_path"], bundle)
+    CASE.assertEqual(calls[0]["socket_path"], socket_path)
+    CASE.assertEqual(calls[0]["python_path"], python_path)
+    CASE.assertIs(calls[0]["dry_run"], True)
+    CASE.assertIn("vz_linux_smoke: ok dry_run", capsys.readouterr().out)
+
+
+def test_host_reboot_drill_cli_launchd_requires_explicit_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+
+    def fail_if_called(**kwargs: Any) -> helperctl.CheckResult:
+        raise AssertionError("launchd mode without explicit metadata must not run pre phase")
+
+    monkeypatch.setattr(helperctl, "run_host_reboot_pre", fail_if_called)
+
+    code = helperctl.main(
+        [
+            "host-reboot-drill",
+            "pre",
+            "--evidence-dir",
+            str(evidence),
+            "--helper-mode",
+            "launchd",
+            "--json",
+        ]
+    )
+
+    CASE.assertEqual(code, 1)
+    output = json.loads(capsys.readouterr().out)
+    CASE.assertEqual(output[0]["reason"], "host_reboot_launchd_metadata_missing")
+    CASE.assertIn("--label", output[0]["message"])
+    CASE.assertIn("--plist-output", output[0]["message"])
+
+
 def test_write_json_private_creates_owner_only_file(tmp_path: Path) -> None:
     helperctl = load_helperctl()
     manifest = tmp_path / "manifest.json"

--- a/tools/macos-vz-helper/Tests/test_vz_helperctl.py
+++ b/tools/macos-vz-helper/Tests/test_vz_helperctl.py
@@ -901,6 +901,28 @@ def test_read_host_reboot_pre_manifest_rejects_oversized(tmp_path: Path) -> None
     CASE.assertIsNone(payload)
 
 
+def test_read_host_reboot_pre_manifest_suppresses_close_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helperctl = load_helperctl()
+    evidence = tmp_path / "durable" / "drill"
+    evidence.mkdir(parents=True, mode=0o700)
+    (evidence / "host-reboot-pre.json").write_text('{"phase": "pre"}\n', encoding="utf-8")
+    real_close = helperctl.os.close
+
+    def close_then_raise(fd: int) -> None:
+        real_close(fd)
+        raise OSError("close failed")
+
+    monkeypatch.setattr(helperctl.os, "close", close_then_raise)
+
+    result, payload = helperctl._read_host_reboot_pre_manifest(evidence)
+
+    CASE.assertTrue(result.ok)
+    CASE.assertEqual(payload, {"phase": "pre"})
+
+
 def test_host_reboot_manifests_drop_forbidden_helper_detail_keys(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -979,6 +1001,21 @@ def test_host_reboot_manifests_drop_forbidden_helper_detail_keys(
             "helper_started_at": "2026-05-19T01:00:00Z",
         },
     )
+
+
+def test_host_reboot_metadata_keeps_missing_bundle_empty() -> None:
+    helperctl = load_helperctl()
+
+    metadata = helperctl._host_reboot_metadata_payload(
+        bundle_path=Path(""),
+        helper_path=Path("/helper"),
+        helper_mode="direct",
+        socket_path=Path("/helper.sock"),
+        launchd_label="",
+        launchd_plist_path=None,
+    )
+
+    CASE.assertEqual(metadata["bundle_path"], "")
 
 
 def test_host_reboot_post_reports_generation_changed(
@@ -1694,6 +1731,7 @@ def test_write_json_private_hardens_existing_manifest_before_serialization_failu
     CASE.assertFalse(result.ok)
     CASE.assertEqual(result.reason, "host_reboot_manifest_write_failed")
     CASE.assertEqual(manifest.stat().st_mode & 0o777, 0o600)
+    CASE.assertEqual(manifest.read_text(encoding="utf-8"), '{"old": true}\n')
 
 
 def test_write_json_private_refuses_final_symlink_without_touching_target(tmp_path: Path) -> None:

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -239,6 +239,8 @@ def write_json_private(path: Path, payload: Mapping[str, Any]) -> CheckResult:
     flags = os.O_WRONLY | os.O_CREAT
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
     fd: int | None = None
     try:
         fd = os.open(path, flags, 0o600)

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -33,9 +33,10 @@ if sys.version_info < (3, 10):
     EXPECTED_HELPER_PROTOCOL_VERSION = "1"
 else:
     try:
-        from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
-            EXPECTED_HELPER_PROTOCOL_VERSION,
-        )
+        with contextlib.redirect_stdout(io.StringIO()):
+            from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+                EXPECTED_HELPER_PROTOCOL_VERSION,
+            )
     except ModuleNotFoundError as exc:
         missing_name = str(exc.name or "")
         if missing_name != "tldw_Server_API" and not missing_name.startswith("tldw_Server_API."):
@@ -51,6 +52,14 @@ HOST_REBOOT_POST_MANIFEST = "host-reboot-post.json"
 HOST_REBOOT_PRE_MANIFEST_MAX_BYTES = 64 * 1024
 HOST_REBOOT_HELPER_DETAIL_KEYS = frozenset({"helper_instance_id", "helper_started_at"})
 HOST_REBOOT_HELPER_DETAIL_VALUE_MAX_LENGTH = 256
+HOST_REBOOT_METADATA_MATCH_KEYS = (
+    "helper_mode",
+    "launchd_label",
+    "launchd_plist_path",
+    "socket_path",
+    "helper_path",
+    "bundle_path",
+)
 
 
 def _resolve_operational_path(path: Path) -> Path | None:
@@ -219,6 +228,7 @@ def ensure_host_reboot_evidence_dir(
     evidence_dir: Path,
     *,
     create: bool = False,
+    dry_run: bool = False,
     allow_volatile: bool = False,
 ) -> CheckResult:
     try:
@@ -230,7 +240,7 @@ def ensure_host_reboot_evidence_dir(
             return CheckResult(False, "host_reboot_evidence_dir_not_private", str(evidence_dir))
         if not evidence_dir.exists() and not create:
             return CheckResult(False, "host_reboot_evidence_dir_missing", str(evidence_dir))
-        result = ensure_private_dir(evidence_dir, dry_run=not create)
+        result = ensure_private_dir(evidence_dir, dry_run=dry_run or not create)
     except (FileExistsError, NotADirectoryError, PermissionError, OSError, RuntimeError, ValueError) as exc:
         return CheckResult(False, "host_reboot_evidence_dir_not_private", str(exc))
     if not result.ok:
@@ -978,6 +988,7 @@ def run_host_reboot_pre(
     launchd_plist_path: Path | None = None,
     create_evidence_dir: bool = False,
     allow_volatile_evidence_dir: bool = False,
+    dry_run: bool = False,
     ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
     created_at_factory: Callable[[], str] = _host_reboot_created_at,
     hostname_provider: Callable[[], str] = socket.gethostname,
@@ -985,10 +996,13 @@ def run_host_reboot_pre(
     evidence_result = ensure_host_reboot_evidence_dir(
         evidence_dir,
         create=create_evidence_dir,
+        dry_run=dry_run,
         allow_volatile=allow_volatile_evidence_dir,
     )
     if not evidence_result.ok:
         return evidence_result
+    if dry_run:
+        return CheckResult(True, "host_reboot_pre_dry_run", str(evidence_dir))
 
     try:
         ping_state = _coerce_ping_state(ping_checker(socket_path))
@@ -998,15 +1012,19 @@ def run_host_reboot_pre(
         "phase": "pre",
         "created_at": created_at_factory(),
         "hostname": hostname_provider(),
-        "helper_mode": helper_mode,
-        "bundle_path": str(bundle_path),
-        "helper_path": str(helper_path),
-        "socket_path": str(socket_path),
         "log_dir": str(log_dir),
         "serial_log_dir": str(serial_log_dir if serial_log_dir is not None else log_dir / "serial"),
-        "launchd_label": launchd_label,
-        "launchd_plist_path": str(launchd_plist_path) if launchd_plist_path is not None else "",
     }
+    payload.update(
+        _host_reboot_metadata_payload(
+            bundle_path=bundle_path,
+            helper_path=helper_path,
+            helper_mode=helper_mode,
+            socket_path=socket_path,
+            launchd_label=launchd_label,
+            launchd_plist_path=launchd_plist_path,
+        )
+    )
     payload.update(_host_reboot_ping_state_payload(ping_state))
 
     manifest_path = evidence_dir / HOST_REBOOT_PRE_MANIFEST
@@ -1082,6 +1100,39 @@ def _helper_generation_result(pre_instance_id: str, post_instance_id: str) -> Ch
     return CheckResult(True, "helper_generation_changed")
 
 
+def _host_reboot_metadata_payload(
+    *,
+    bundle_path: Path,
+    helper_path: Path,
+    helper_mode: str,
+    socket_path: Path,
+    launchd_label: str,
+    launchd_plist_path: Path | None,
+) -> dict[str, str]:
+    return {
+        "helper_mode": helper_mode,
+        "launchd_label": launchd_label,
+        "launchd_plist_path": str(launchd_plist_path) if launchd_plist_path is not None else "",
+        "socket_path": str(socket_path),
+        "helper_path": str(helper_path),
+        "bundle_path": str(bundle_path),
+    }
+
+
+def _host_reboot_metadata_match_result(
+    pre_manifest: Mapping[str, Any],
+    current_metadata: Mapping[str, str],
+) -> CheckResult:
+    mismatched_keys = [
+        key
+        for key in HOST_REBOOT_METADATA_MATCH_KEYS
+        if str(pre_manifest.get(key, "")) != current_metadata[key]
+    ]
+    if mismatched_keys:
+        return CheckResult(False, "host_reboot_metadata_mismatch", ",".join(mismatched_keys))
+    return CheckResult(True, "host_reboot_metadata_match")
+
+
 def run_host_reboot_post(
     *,
     evidence_dir: Path,
@@ -1094,6 +1145,7 @@ def run_host_reboot_post(
     launchd_label: str = "",
     launchd_plist_path: Path | None = None,
     allow_volatile_evidence_dir: bool = False,
+    dry_run: bool = False,
     ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
     created_at_factory: Callable[[], str] = _host_reboot_created_at,
     hostname_provider: Callable[[], str] = socket.gethostname,
@@ -1103,6 +1155,7 @@ def run_host_reboot_post(
     evidence_result = ensure_host_reboot_evidence_dir(
         evidence_dir,
         create=False,
+        dry_run=dry_run,
         allow_volatile=allow_volatile_evidence_dir,
     )
     results.append(("evidence_directory", evidence_result))
@@ -1114,6 +1167,20 @@ def run_host_reboot_post(
     results.append(("pre_manifest", pre_result))
     if not pre_result.ok or pre_manifest is None:
         results.append(("host_reboot_post", pre_result))
+        return results
+
+    current_metadata = _host_reboot_metadata_payload(
+        bundle_path=bundle_path,
+        helper_path=helper_path,
+        helper_mode=helper_mode,
+        socket_path=socket_path,
+        launchd_label=launchd_label,
+        launchd_plist_path=launchd_plist_path,
+    )
+    metadata_result = _host_reboot_metadata_match_result(pre_manifest, current_metadata)
+    results.append(("metadata_match", metadata_result))
+    if not metadata_result.ok:
+        results.append(("host_reboot_post", metadata_result))
         return results
 
     try:
@@ -1131,23 +1198,21 @@ def run_host_reboot_post(
         "phase": "post",
         "created_at": created_at_factory(),
         "hostname": hostname_provider(),
-        "helper_mode": helper_mode,
-        "bundle_path": str(bundle_path),
-        "helper_path": str(helper_path),
-        "socket_path": str(socket_path),
         "log_dir": str(log_dir),
         "serial_log_dir": str(serial_log_dir if serial_log_dir is not None else log_dir / "serial"),
-        "launchd_label": launchd_label,
-        "launchd_plist_path": str(launchd_plist_path) if launchd_plist_path is not None else "",
         "pre_helper_instance_id": pre_instance_id,
         "post_helper_instance_id": post_instance_id,
         "helper_generation_reason": generation_result.reason,
     }
+    payload.update(current_metadata)
     payload.update(_host_reboot_ping_state_payload(ping_state))
 
     manifest_path = evidence_dir / HOST_REBOOT_POST_MANIFEST
-    write_result = write_json_private(manifest_path, payload)
-    if write_result.ok:
+    if dry_run:
+        write_result = CheckResult(True, "host_reboot_post_dry_run", str(manifest_path))
+    else:
+        write_result = write_json_private(manifest_path, payload)
+    if write_result.ok and not dry_run:
         write_result = CheckResult(True, "host_reboot_post_manifest_written", write_result.message)
     results.append(("post_manifest", write_result))
 
@@ -2451,6 +2516,7 @@ def _host_reboot_drill_command(args: argparse.Namespace) -> int:
         return 1
 
     common_kwargs = _host_reboot_drill_common_kwargs(args)
+    common_kwargs["dry_run"] = args.dry_run
     if args.phase == "pre":
         pre_kwargs = dict(common_kwargs)
         pre_kwargs["create_evidence_dir"] = args.create_evidence_dir
@@ -2471,7 +2537,15 @@ def _host_reboot_drill_command(args: argparse.Namespace) -> int:
         results = run_host_reboot_post(**post_kwargs)
 
     if args.run_smoke:
-        if not args.bundle:
+        post_result = results[-1][1] if results else CheckResult(False, "host_reboot_post_missing")
+        if not post_result.ok:
+            results.append(
+                (
+                    "vz_linux_smoke",
+                    CheckResult(False, "host_reboot_smoke_skipped", post_result.reason),
+                )
+            )
+        elif not args.bundle:
             results.append(
                 (
                     "vz_linux_smoke",
@@ -2662,10 +2736,7 @@ def build_parser() -> argparse.ArgumentParser:
     host_reboot_parent.add_argument("--serial-log-dir")
     host_reboot_parent.add_argument("--label")
     host_reboot_parent.add_argument("--plist-output")
-    host_reboot_parent.add_argument("--create-evidence-dir", action="store_true")
     host_reboot_parent.add_argument("--allow-volatile-evidence-dir", action="store_true")
-    host_reboot_parent.add_argument("--run-smoke", action="store_true")
-    host_reboot_parent.add_argument("--python")
     host_reboot_parent.add_argument("--dry-run", action="store_true")
     host_reboot_parent.add_argument("--json", action="store_true")
     host_reboot_pre = host_reboot_subparsers.add_parser(
@@ -2673,12 +2744,15 @@ def build_parser() -> argparse.ArgumentParser:
         parents=[host_reboot_parent],
         help="record bounded pre-reboot helper evidence",
     )
+    host_reboot_pre.add_argument("--create-evidence-dir", action="store_true")
     host_reboot_pre.set_defaults(func=_host_reboot_drill_command)
     host_reboot_post = host_reboot_subparsers.add_parser(
         "post",
         parents=[host_reboot_parent],
         help="validate helper state after a manual host reboot",
     )
+    host_reboot_post.add_argument("--run-smoke", action="store_true")
+    host_reboot_post.add_argument("--python")
     host_reboot_post.set_defaults(func=_host_reboot_drill_command)
 
     start = subparsers.add_parser("start", help="start the helper")

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -20,7 +20,7 @@ import sys
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable, Mapping
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -46,6 +46,8 @@ else:
 INVALID_LIFECYCLE_LOCK_GRACE_SEC = 1.0
 DEFAULT_LAUNCHD_LABEL = "org.tldw.macos-vz-helper"
 LAUNCHD_ACTIONS = {"bootstrap", "bootout", "kickstart", "status"}
+HOST_REBOOT_PRE_MANIFEST = "host-reboot-pre.json"
+HOST_REBOOT_POST_MANIFEST = "host-reboot-post.json"
 
 
 def _resolve_operational_path(path: Path) -> Path | None:
@@ -231,6 +233,26 @@ def ensure_host_reboot_evidence_dir(
     if not result.ok:
         return CheckResult(False, "host_reboot_evidence_dir_not_private", result.message or str(evidence_dir))
     return CheckResult(True, "host_reboot_evidence_dir_ok", str(evidence_dir))
+
+
+def write_json_private(path: Path, payload: Mapping[str, Any]) -> CheckResult:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd: int | None = None
+    try:
+        fd = os.open(path, flags, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        path.chmod(0o600)
+    except (OSError, TypeError, ValueError) as exc:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        return CheckResult(False, "host_reboot_manifest_write_failed", str(exc))
+    return CheckResult(True, "host_reboot_manifest_written", str(path))
 
 
 def ensure_private_dir(path: Path, dry_run: bool = False) -> CheckResult:
@@ -900,6 +922,68 @@ def ping_helper_state(
 
 def _ping_helper(socket_path: Path) -> CheckResult:
     return ping_helper_state(socket_path).result
+
+
+def ping_state_payload(state: PingState) -> dict[str, Any]:
+    return {
+        "helper_ping_ok": state.result.ok,
+        "helper_ping_reason": state.result.reason,
+        "helper_protocol_version": state.protocol_version,
+        "helper_version": state.helper_version,
+        "helper_details": state.details or {},
+    }
+
+
+def _host_reboot_created_at() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def run_host_reboot_pre(
+    *,
+    evidence_dir: Path,
+    bundle_path: Path,
+    helper_mode: str,
+    socket_path: Path,
+    log_dir: Path,
+    helper_path: Path = DEFAULT_HELPER,
+    serial_log_dir: Path | None = None,
+    launchd_label: str = "",
+    launchd_plist_path: Path | None = None,
+    create_evidence_dir: bool = False,
+    allow_volatile_evidence_dir: bool = False,
+    ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
+    created_at_factory: Callable[[], str] = _host_reboot_created_at,
+    hostname_provider: Callable[[], str] = socket.gethostname,
+) -> CheckResult:
+    evidence_result = ensure_host_reboot_evidence_dir(
+        evidence_dir,
+        create=create_evidence_dir,
+        allow_volatile=allow_volatile_evidence_dir,
+    )
+    if not evidence_result.ok:
+        return evidence_result
+
+    ping_state = _coerce_ping_state(ping_checker(socket_path))
+    payload: dict[str, Any] = {
+        "phase": "pre",
+        "created_at": created_at_factory(),
+        "hostname": hostname_provider(),
+        "helper_mode": helper_mode,
+        "bundle_path": str(bundle_path),
+        "helper_path": str(helper_path),
+        "socket_path": str(socket_path),
+        "log_dir": str(log_dir),
+        "serial_log_dir": str(serial_log_dir if serial_log_dir is not None else log_dir / "serial"),
+        "launchd_label": launchd_label,
+        "launchd_plist_path": str(launchd_plist_path) if launchd_plist_path is not None else "",
+    }
+    payload.update(ping_state_payload(ping_state))
+
+    manifest_path = evidence_dir / HOST_REBOOT_PRE_MANIFEST
+    write_result = write_json_private(manifest_path, payload)
+    if not write_result.ok:
+        return write_result
+    return CheckResult(True, "host_reboot_pre_manifest_written", str(manifest_path))
 
 
 def wait_for_ping(

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -1084,6 +1084,8 @@ def _read_host_reboot_pre_manifest(evidence_dir: Path) -> tuple[CheckResult, dic
             os.close(fd)
     if not isinstance(raw_payload, dict):
         return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
+    if raw_payload.get("phase") != "pre":
+        return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
     return CheckResult(True, "host_reboot_pre_manifest_loaded", str(manifest_path)), raw_payload
 
 
@@ -1112,11 +1114,20 @@ def _host_reboot_metadata_payload(
     return {
         "helper_mode": helper_mode,
         "launchd_label": launchd_label,
-        "launchd_plist_path": str(launchd_plist_path) if launchd_plist_path is not None else "",
-        "socket_path": str(socket_path),
-        "helper_path": str(helper_path),
-        "bundle_path": str(bundle_path),
+        "launchd_plist_path": _host_reboot_metadata_path(launchd_plist_path),
+        "socket_path": _host_reboot_metadata_path(socket_path),
+        "helper_path": _host_reboot_metadata_path(helper_path),
+        "bundle_path": _host_reboot_metadata_path(bundle_path),
     }
+
+
+def _host_reboot_metadata_path(path: Path | None) -> str:
+    if path is None:
+        return ""
+    try:
+        return str(path.expanduser().resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return str(path.expanduser())
 
 
 def _host_reboot_metadata_match_result(

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -232,6 +232,12 @@ def ensure_host_reboot_evidence_dir(
     dry_run: bool = False,
     allow_volatile: bool = False,
 ) -> CheckResult:
+    """Validate and optionally create the durable host-reboot evidence directory.
+
+    The directory is the trust boundary for pre/post reboot manifests, so it
+    must not live under a volatile root unless explicitly allowed and must pass
+    the same owner-only directory checks used by helper runtime paths.
+    """
     try:
         if not allow_volatile:
             for root in VOLATILE_EVIDENCE_ROOTS:
@@ -250,27 +256,76 @@ def ensure_host_reboot_evidence_dir(
 
 
 def write_json_private(path: Path, payload: Mapping[str, Any]) -> CheckResult:
+    """Atomically write a private JSON manifest without exposing partial data.
+
+    Existing regular manifests are hardened to owner-only permissions before the
+    write. The new payload is written to a private temp file in the same
+    directory, flushed, fsynced, and atomically replaced into place so an
+    interrupted write does not leave truncated final evidence.
+    """
+    try:
+        existing_stat = os.lstat(path)
+        if stat.S_ISLNK(existing_stat.st_mode) or not stat.S_ISREG(existing_stat.st_mode):
+            raise OSError(f"manifest target is not a regular file: {path}")
+        harden_flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            harden_flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_NONBLOCK"):
+            harden_flags |= os.O_NONBLOCK
+        harden_fd: int | None = None
+        try:
+            harden_fd = os.open(path, harden_flags, 0o600)
+            harden_stat = os.fstat(harden_fd)
+            if not stat.S_ISREG(harden_stat.st_mode):
+                raise OSError(f"manifest target is not a regular file: {path}")
+            os.fchmod(harden_fd, 0o600)
+        finally:
+            if harden_fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(harden_fd)
+    except FileNotFoundError:
+        pass
+    except (OSError, TypeError, ValueError) as exc:
+        return CheckResult(False, "host_reboot_manifest_write_failed", str(exc))
+
     flags = os.O_WRONLY | os.O_CREAT
+    if hasattr(os, "O_EXCL"):
+        flags |= os.O_EXCL
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     if hasattr(os, "O_NONBLOCK"):
         flags |= os.O_NONBLOCK
     fd: int | None = None
+    temp_path: Path | None = path.with_name(f".{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
     try:
-        fd = os.open(path, flags, 0o600)
+        fd = os.open(temp_path, flags, 0o600)
         path_stat = os.fstat(fd)
         if not stat.S_ISREG(path_stat.st_mode):
-            raise OSError(f"manifest target is not a regular file: {path}")
+            raise OSError(f"manifest temp target is not a regular file: {temp_path}")
         os.fchmod(fd, 0o600)
-        os.ftruncate(fd, 0)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             fd = None
             json.dump(payload, handle, indent=2, sort_keys=True)
             handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        temp_path = None
+        dir_fd: int | None = None
+        with contextlib.suppress(OSError):
+            try:
+                dir_fd = os.open(path.parent, os.O_RDONLY, 0o700)
+                os.fsync(dir_fd)
+            finally:
+                if dir_fd is not None:
+                    os.close(dir_fd)
     except (OSError, TypeError, ValueError) as exc:
         if fd is not None:
             with contextlib.suppress(OSError):
                 os.close(fd)
+        if temp_path is not None:
+            with contextlib.suppress(OSError):
+                temp_path.unlink()
         return CheckResult(False, "host_reboot_manifest_write_failed", str(exc))
     return CheckResult(True, "host_reboot_manifest_written", str(path))
 
@@ -1220,7 +1275,8 @@ def _read_host_reboot_pre_manifest(evidence_dir: Path) -> tuple[CheckResult, dic
         return CheckResult(False, "host_reboot_pre_manifest_invalid", str(exc)), None
     finally:
         if fd is not None:
-            os.close(fd)
+            with contextlib.suppress(OSError):
+                os.close(fd)
     if not isinstance(raw_payload, dict):
         return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
     if raw_payload.get("phase") != "pre":
@@ -1262,6 +1318,8 @@ def _host_reboot_metadata_payload(
 
 def _host_reboot_metadata_path(path: Path | None) -> str:
     if path is None:
+        return ""
+    if not str(path) or str(path) == ".":
         return ""
     try:
         return str(path.expanduser().resolve(strict=False))

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -46,15 +46,27 @@ else:
 INVALID_LIFECYCLE_LOCK_GRACE_SEC = 1.0
 DEFAULT_LAUNCHD_LABEL = "org.tldw.macos-vz-helper"
 LAUNCHD_ACTIONS = {"bootstrap", "bootout", "kickstart", "status"}
-VOLATILE_EVIDENCE_ROOTS = tuple(
-    Path(path).resolve()
-    for path in (
-        Path(os.sep) / "tmp",
-        Path(os.sep) / "private" / "tmp",
-        os.getenv("TMPDIR") or "",
-    )
-    if path
-)
+
+
+def _resolve_operational_path(path: Path) -> Path | None:
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _volatile_evidence_roots() -> tuple[Path, ...]:
+    roots: list[Path] = []
+    for path in (Path(os.sep) / "tmp", Path(os.sep) / "private" / "tmp", os.getenv("TMPDIR") or ""):
+        if not path:
+            continue
+        resolved = _resolve_operational_path(Path(path))
+        if resolved is not None:
+            roots.append(resolved)
+    return tuple(roots)
+
+
+VOLATILE_EVIDENCE_ROOTS = _volatile_evidence_roots()
 
 
 @dataclass(frozen=True)
@@ -204,16 +216,18 @@ def ensure_host_reboot_evidence_dir(
     create: bool = False,
     allow_volatile: bool = False,
 ) -> CheckResult:
-    if not allow_volatile:
-        for root in VOLATILE_EVIDENCE_ROOTS:
-            if _is_under_path(evidence_dir, root):
-                return CheckResult(False, "host_reboot_evidence_dir_volatile", str(evidence_dir))
-    if not evidence_dir.exists():
-        if not create:
+    try:
+        if not allow_volatile:
+            for root in VOLATILE_EVIDENCE_ROOTS:
+                if _is_under_path(evidence_dir, root):
+                    return CheckResult(False, "host_reboot_evidence_dir_volatile", str(evidence_dir))
+        if evidence_dir.is_symlink():
+            return CheckResult(False, "host_reboot_evidence_dir_not_private", str(evidence_dir))
+        if not evidence_dir.exists() and not create:
             return CheckResult(False, "host_reboot_evidence_dir_missing", str(evidence_dir))
-        evidence_dir.mkdir(mode=0o700, parents=True)
-        evidence_dir.chmod(0o700)
-    result = ensure_private_dir(evidence_dir, dry_run=False)
+        result = ensure_private_dir(evidence_dir, dry_run=not create)
+    except (FileExistsError, NotADirectoryError, PermissionError, OSError, RuntimeError, ValueError) as exc:
+        return CheckResult(False, "host_reboot_evidence_dir_not_private", str(exc))
     if not result.ok:
         return CheckResult(False, "host_reboot_evidence_dir_not_private", result.message or str(evidence_dir))
     return CheckResult(True, "host_reboot_evidence_dir_ok", str(evidence_dir))

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -48,6 +48,9 @@ DEFAULT_LAUNCHD_LABEL = "org.tldw.macos-vz-helper"
 LAUNCHD_ACTIONS = {"bootstrap", "bootout", "kickstart", "status"}
 HOST_REBOOT_PRE_MANIFEST = "host-reboot-pre.json"
 HOST_REBOOT_POST_MANIFEST = "host-reboot-post.json"
+HOST_REBOOT_PRE_MANIFEST_MAX_BYTES = 64 * 1024
+HOST_REBOOT_HELPER_DETAIL_KEYS = frozenset({"helper_instance_id", "helper_started_at"})
+HOST_REBOOT_HELPER_DETAIL_VALUE_MAX_LENGTH = 256
 
 
 def _resolve_operational_path(path: Path) -> Path | None:
@@ -940,6 +943,24 @@ def ping_state_payload(state: PingState) -> dict[str, Any]:
     }
 
 
+def _host_reboot_helper_details(details: Mapping[str, Any] | None) -> dict[str, str]:
+    sanitized: dict[str, str] = {}
+    if not details:
+        return sanitized
+    for key in HOST_REBOOT_HELPER_DETAIL_KEYS:
+        value = details.get(key)
+        if not isinstance(value, str):
+            continue
+        sanitized[key] = value[:HOST_REBOOT_HELPER_DETAIL_VALUE_MAX_LENGTH]
+    return sanitized
+
+
+def _host_reboot_ping_state_payload(state: PingState) -> dict[str, Any]:
+    payload = ping_state_payload(state)
+    payload["helper_details"] = _host_reboot_helper_details(state.details)
+    return payload
+
+
 def _host_reboot_created_at() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
@@ -986,7 +1007,7 @@ def run_host_reboot_pre(
         "launchd_label": launchd_label,
         "launchd_plist_path": str(launchd_plist_path) if launchd_plist_path is not None else "",
     }
-    payload.update(ping_state_payload(ping_state))
+    payload.update(_host_reboot_ping_state_payload(ping_state))
 
     manifest_path = evidence_dir / HOST_REBOOT_PRE_MANIFEST
     write_result = write_json_private(manifest_path, payload)
@@ -1003,12 +1024,46 @@ def run_host_reboot_pre(
 
 def _read_host_reboot_pre_manifest(evidence_dir: Path) -> tuple[CheckResult, dict[str, Any] | None]:
     manifest_path = evidence_dir / HOST_REBOOT_PRE_MANIFEST
+    flags = os.O_RDONLY
+    nofollow_flag = getattr(os, "O_NOFOLLOW", 0)
+    nonblock_flag = getattr(os, "O_NONBLOCK", 0)
+    flags |= nofollow_flag | nonblock_flag
+    if not nofollow_flag or not nonblock_flag:
+        try:
+            pre_open_stat = os.lstat(manifest_path)
+        except FileNotFoundError:
+            return CheckResult(False, "host_reboot_pre_manifest_missing", str(manifest_path)), None
+        except OSError as exc:
+            return CheckResult(False, "host_reboot_pre_manifest_invalid", str(exc)), None
+        if stat.S_ISLNK(pre_open_stat.st_mode) or (not nonblock_flag and not stat.S_ISREG(pre_open_stat.st_mode)):
+            return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
+    fd: int | None = None
     try:
-        raw_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        fd = os.open(manifest_path, flags)
+        fd_stat = os.fstat(fd)
+        if not stat.S_ISREG(fd_stat.st_mode):
+            return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
+        if fd_stat.st_size > HOST_REBOOT_PRE_MANIFEST_MAX_BYTES:
+            return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
+        chunks: list[bytes] = []
+        bytes_read = 0
+        while True:
+            chunk = os.read(fd, min(8192, HOST_REBOOT_PRE_MANIFEST_MAX_BYTES + 1 - bytes_read))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            bytes_read += len(chunk)
+            if bytes_read > HOST_REBOOT_PRE_MANIFEST_MAX_BYTES:
+                return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
+        raw_bytes = b"".join(chunks)
+        raw_payload = json.loads(raw_bytes.decode("utf-8"))
     except FileNotFoundError:
         return CheckResult(False, "host_reboot_pre_manifest_missing", str(manifest_path)), None
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         return CheckResult(False, "host_reboot_pre_manifest_invalid", str(exc)), None
+    finally:
+        if fd is not None:
+            os.close(fd)
     if not isinstance(raw_payload, dict):
         return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
     return CheckResult(True, "host_reboot_pre_manifest_loaded", str(manifest_path)), raw_payload
@@ -1068,7 +1123,7 @@ def run_host_reboot_post(
     results.append(("helper_status", ping_state.result))
 
     pre_instance_id = _manifest_helper_instance_id(pre_manifest)
-    post_instance_id = (ping_state.details or {}).get("helper_instance_id", "")
+    post_instance_id = _host_reboot_helper_details(ping_state.details).get("helper_instance_id", "")
     generation_result = _helper_generation_result(pre_instance_id, post_instance_id)
     results.append(("helper_generation", generation_result))
 
@@ -1088,7 +1143,7 @@ def run_host_reboot_post(
         "post_helper_instance_id": post_instance_id,
         "helper_generation_reason": generation_result.reason,
     }
-    payload.update(ping_state_payload(ping_state))
+    payload.update(_host_reboot_ping_state_payload(ping_state))
 
     manifest_path = evidence_dir / HOST_REBOOT_POST_MANIFEST
     write_result = write_json_private(manifest_path, payload)

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -1001,6 +1001,111 @@ def run_host_reboot_pre(
     return CheckResult(True, "host_reboot_pre_manifest_written", str(manifest_path))
 
 
+def _read_host_reboot_pre_manifest(evidence_dir: Path) -> tuple[CheckResult, dict[str, Any] | None]:
+    manifest_path = evidence_dir / HOST_REBOOT_PRE_MANIFEST
+    try:
+        raw_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return CheckResult(False, "host_reboot_pre_manifest_missing", str(manifest_path)), None
+    except (OSError, json.JSONDecodeError) as exc:
+        return CheckResult(False, "host_reboot_pre_manifest_invalid", str(exc)), None
+    if not isinstance(raw_payload, dict):
+        return CheckResult(False, "host_reboot_pre_manifest_invalid", str(manifest_path)), None
+    return CheckResult(True, "host_reboot_pre_manifest_loaded", str(manifest_path)), raw_payload
+
+
+def _manifest_helper_instance_id(manifest: Mapping[str, Any]) -> str:
+    details = _string_details(manifest.get("helper_details"))
+    return details.get("helper_instance_id", "")
+
+
+def _helper_generation_result(pre_instance_id: str, post_instance_id: str) -> CheckResult:
+    if not pre_instance_id or not post_instance_id:
+        return CheckResult(True, "helper_generation_unavailable")
+    if pre_instance_id == post_instance_id:
+        return CheckResult(True, "helper_generation_match")
+    return CheckResult(True, "helper_generation_changed")
+
+
+def run_host_reboot_post(
+    *,
+    evidence_dir: Path,
+    bundle_path: Path,
+    helper_mode: str,
+    socket_path: Path,
+    log_dir: Path,
+    helper_path: Path = DEFAULT_HELPER,
+    serial_log_dir: Path | None = None,
+    launchd_label: str = "",
+    launchd_plist_path: Path | None = None,
+    allow_volatile_evidence_dir: bool = False,
+    ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
+    created_at_factory: Callable[[], str] = _host_reboot_created_at,
+    hostname_provider: Callable[[], str] = socket.gethostname,
+) -> list[tuple[str, CheckResult]]:
+    results: list[tuple[str, CheckResult]] = []
+
+    evidence_result = ensure_host_reboot_evidence_dir(
+        evidence_dir,
+        create=False,
+        allow_volatile=allow_volatile_evidence_dir,
+    )
+    results.append(("evidence_directory", evidence_result))
+    if not evidence_result.ok:
+        results.append(("host_reboot_post", evidence_result))
+        return results
+
+    pre_result, pre_manifest = _read_host_reboot_pre_manifest(evidence_dir)
+    results.append(("pre_manifest", pre_result))
+    if not pre_result.ok or pre_manifest is None:
+        results.append(("host_reboot_post", pre_result))
+        return results
+
+    try:
+        ping_state = _coerce_ping_state(ping_checker(socket_path))
+    except Exception as exc:
+        ping_state = PingState(CheckResult(False, "helper_ping_failed", str(exc)))
+    results.append(("helper_status", ping_state.result))
+
+    pre_instance_id = _manifest_helper_instance_id(pre_manifest)
+    post_instance_id = (ping_state.details or {}).get("helper_instance_id", "")
+    generation_result = _helper_generation_result(pre_instance_id, post_instance_id)
+    results.append(("helper_generation", generation_result))
+
+    payload: dict[str, Any] = {
+        "phase": "post",
+        "created_at": created_at_factory(),
+        "hostname": hostname_provider(),
+        "helper_mode": helper_mode,
+        "bundle_path": str(bundle_path),
+        "helper_path": str(helper_path),
+        "socket_path": str(socket_path),
+        "log_dir": str(log_dir),
+        "serial_log_dir": str(serial_log_dir if serial_log_dir is not None else log_dir / "serial"),
+        "launchd_label": launchd_label,
+        "launchd_plist_path": str(launchd_plist_path) if launchd_plist_path is not None else "",
+        "pre_helper_instance_id": pre_instance_id,
+        "post_helper_instance_id": post_instance_id,
+        "helper_generation_reason": generation_result.reason,
+    }
+    payload.update(ping_state_payload(ping_state))
+
+    manifest_path = evidence_dir / HOST_REBOOT_POST_MANIFEST
+    write_result = write_json_private(manifest_path, payload)
+    if write_result.ok:
+        write_result = CheckResult(True, "host_reboot_post_manifest_written", write_result.message)
+    results.append(("post_manifest", write_result))
+
+    if not ping_state.result.ok:
+        final_result = ping_state.result
+    elif not write_result.ok:
+        final_result = write_result
+    else:
+        final_result = CheckResult(True)
+    results.append(("host_reboot_post", final_result))
+    return results
+
+
 def wait_for_ping(
     socket_path: Path,
     *,

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -52,6 +52,7 @@ HOST_REBOOT_POST_MANIFEST = "host-reboot-post.json"
 HOST_REBOOT_PRE_MANIFEST_MAX_BYTES = 64 * 1024
 HOST_REBOOT_HELPER_DETAIL_KEYS = frozenset({"helper_instance_id", "helper_started_at"})
 HOST_REBOOT_HELPER_DETAIL_VALUE_MAX_LENGTH = 256
+HOST_REBOOT_RESULT_MESSAGE_MAX_LENGTH = 512
 HOST_REBOOT_METADATA_MATCH_KEYS = (
     "helper_mode",
     "launchd_label",
@@ -971,8 +972,107 @@ def _host_reboot_ping_state_payload(state: PingState) -> dict[str, Any]:
     return payload
 
 
+def _host_reboot_result_payload(name: str, result: CheckResult) -> dict[str, object]:
+    return {
+        "name": name[:HOST_REBOOT_HELPER_DETAIL_VALUE_MAX_LENGTH],
+        "ok": result.ok,
+        "reason": result.reason[:HOST_REBOOT_HELPER_DETAIL_VALUE_MAX_LENGTH],
+        "message": result.message[:HOST_REBOOT_RESULT_MESSAGE_MAX_LENGTH],
+    }
+
+
+def _host_reboot_results_payload(results: Iterable[tuple[str, CheckResult]]) -> list[dict[str, object]]:
+    return [_host_reboot_result_payload(name, result) for name, result in results]
+
+
 def _host_reboot_created_at() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def host_boot_marker() -> CheckResult:
+    """Return a stable host boot marker for proving a reboot occurred."""
+    sysctl_path = Path("/usr/sbin/sysctl")
+    if sysctl_path.exists():
+        try:
+            completed = subprocess.run(  # nosec B603
+                [str(sysctl_path), "-n", "kern.boottime"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, PermissionError, OSError):
+            completed = None
+        if completed is not None and completed.returncode == 0:
+            marker = " ".join((completed.stdout or "").split())
+            if marker:
+                return CheckResult(True, "host_boot_marker", marker[:HOST_REBOOT_RESULT_MESSAGE_MAX_LENGTH])
+
+    linux_boot_id = Path("/proc/sys/kernel/random/boot_id")
+    try:
+        marker = linux_boot_id.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, PermissionError, OSError):
+        marker = ""
+    if marker:
+        return CheckResult(True, "host_boot_marker", marker[:HOST_REBOOT_RESULT_MESSAGE_MAX_LENGTH])
+    return CheckResult(False, "host_boot_marker_unavailable")
+
+
+def _host_reboot_boot_marker_payload(result: CheckResult) -> dict[str, Any]:
+    return {
+        "host_boot_marker_ok": result.ok,
+        "host_boot_marker_reason": result.reason,
+        "host_boot_marker": result.message[:HOST_REBOOT_RESULT_MESSAGE_MAX_LENGTH],
+    }
+
+
+def host_reboot_bundle_dry_run_validation(
+    *,
+    bundle_path: Path,
+    socket_path: Path,
+    python_path: Path | None = None,
+) -> CheckResult:
+    if not str(bundle_path) or str(bundle_path) == ".":
+        return CheckResult(False, "host_reboot_bundle_missing")
+    return run_vz_linux_host_smoke(
+        bundle_path=bundle_path,
+        socket_path=socket_path,
+        python_path=python_path,
+        dry_run=True,
+        command_runner=run_command_captured,
+    )
+
+
+def _host_reboot_bundle_payload(result: CheckResult) -> dict[str, Any]:
+    return {
+        "bundle_validation_ok": result.ok,
+        "bundle_validation_reason": result.reason,
+    }
+
+
+def _host_reboot_readiness_result(results: Iterable[tuple[str, CheckResult]]) -> CheckResult:
+    collected = list(results)
+    for name, result in collected:
+        if name == "helper_readiness":
+            return result
+    for name, result in collected:
+        if not result.ok:
+            return CheckResult(False, "host_reboot_lifecycle_check_failed", f"{name}:{result.reason}")
+    return CheckResult(False, "host_reboot_helper_not_ready")
+
+
+def _host_reboot_marker_result(pre_manifest: Mapping[str, Any], post_boot_marker: CheckResult) -> CheckResult:
+    if not bool(pre_manifest.get("host_boot_marker_ok")):
+        return CheckResult(False, "host_boot_marker_missing")
+    pre_marker = str(pre_manifest.get("host_boot_marker", ""))
+    if not pre_marker:
+        return CheckResult(False, "host_boot_marker_missing")
+    if not post_boot_marker.ok:
+        return post_boot_marker
+    if not post_boot_marker.message:
+        return CheckResult(False, "host_boot_marker_unavailable")
+    if pre_marker == post_boot_marker.message:
+        return CheckResult(False, "host_reboot_not_detected")
+    return CheckResult(True, "host_reboot_detected")
 
 
 def run_host_reboot_pre(
@@ -983,12 +1083,17 @@ def run_host_reboot_pre(
     socket_path: Path,
     log_dir: Path,
     helper_path: Path = DEFAULT_HELPER,
+    pid_file: Path | None = None,
+    entitlements_path: Path | None = None,
     serial_log_dir: Path | None = None,
     launchd_label: str = "",
     launchd_plist_path: Path | None = None,
     create_evidence_dir: bool = False,
     allow_volatile_evidence_dir: bool = False,
     dry_run: bool = False,
+    readiness_checker: Callable[..., list[tuple[str, CheckResult]]] | None = None,
+    bundle_validator: Callable[..., CheckResult] = host_reboot_bundle_dry_run_validation,
+    boot_marker_provider: Callable[[], CheckResult] = host_boot_marker,
     ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
     created_at_factory: Callable[[], str] = _host_reboot_created_at,
     hostname_provider: Callable[[], str] = socket.gethostname,
@@ -1003,6 +1108,23 @@ def run_host_reboot_pre(
         return evidence_result
     if dry_run:
         return CheckResult(True, "host_reboot_pre_dry_run", str(evidence_dir))
+
+    resolved_pid_file = pid_file or default_paths().pid_file
+    checker = readiness_checker or host_reboot_lifecycle_readiness_results
+    lifecycle_results = checker(
+        helper_mode=helper_mode,
+        helper_path=helper_path,
+        socket_path=socket_path,
+        pid_file=resolved_pid_file,
+        log_dir=log_dir,
+        launchd_label=launchd_label,
+        launchd_plist_path=launchd_plist_path,
+        entitlements_path=entitlements_path,
+        ping_checker=ping_checker,
+    )
+    readiness_result = _host_reboot_readiness_result(lifecycle_results)
+    boot_marker_result = boot_marker_provider()
+    bundle_result = bundle_validator(bundle_path=bundle_path, socket_path=socket_path)
 
     try:
         ping_state = _coerce_ping_state(ping_checker(socket_path))
@@ -1026,11 +1148,20 @@ def run_host_reboot_pre(
         )
     )
     payload.update(_host_reboot_ping_state_payload(ping_state))
+    payload.update(_host_reboot_boot_marker_payload(boot_marker_result))
+    payload["lifecycle_results"] = _host_reboot_results_payload(lifecycle_results)
+    payload.update(_host_reboot_bundle_payload(bundle_result))
 
     manifest_path = evidence_dir / HOST_REBOOT_PRE_MANIFEST
     write_result = write_json_private(manifest_path, payload)
     if not write_result.ok:
         return write_result
+    if not boot_marker_result.ok:
+        return boot_marker_result
+    if not readiness_result.ok:
+        return readiness_result
+    if not bundle_result.ok:
+        return bundle_result
     if not ping_state.result.ok:
         return CheckResult(
             False,
@@ -1152,11 +1283,15 @@ def run_host_reboot_post(
     socket_path: Path,
     log_dir: Path,
     helper_path: Path = DEFAULT_HELPER,
+    pid_file: Path | None = None,
+    entitlements_path: Path | None = None,
     serial_log_dir: Path | None = None,
     launchd_label: str = "",
     launchd_plist_path: Path | None = None,
     allow_volatile_evidence_dir: bool = False,
     dry_run: bool = False,
+    readiness_checker: Callable[..., list[tuple[str, CheckResult]]] | None = None,
+    boot_marker_provider: Callable[[], CheckResult] = host_boot_marker,
     ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
     created_at_factory: Callable[[], str] = _host_reboot_created_at,
     hostname_provider: Callable[[], str] = socket.gethostname,
@@ -1194,6 +1329,28 @@ def run_host_reboot_post(
         results.append(("host_reboot_post", metadata_result))
         return results
 
+    resolved_pid_file = pid_file or default_paths().pid_file
+    checker = readiness_checker or host_reboot_lifecycle_readiness_results
+    lifecycle_results = checker(
+        helper_mode=helper_mode,
+        helper_path=helper_path,
+        socket_path=socket_path,
+        pid_file=resolved_pid_file,
+        log_dir=log_dir,
+        launchd_label=launchd_label,
+        launchd_plist_path=launchd_plist_path,
+        entitlements_path=entitlements_path,
+        ping_checker=ping_checker,
+    )
+    results.extend((f"lifecycle_{name}", result) for name, result in lifecycle_results)
+    readiness_result = _host_reboot_readiness_result(lifecycle_results)
+    results.append(("helper_readiness", readiness_result))
+
+    boot_marker_result = boot_marker_provider()
+    results.append(("host_boot_marker", boot_marker_result))
+    reboot_marker_result = _host_reboot_marker_result(pre_manifest, boot_marker_result)
+    results.append(("host_reboot_marker", reboot_marker_result))
+
     try:
         ping_state = _coerce_ping_state(ping_checker(socket_path))
     except Exception as exc:
@@ -1214,9 +1371,12 @@ def run_host_reboot_post(
         "pre_helper_instance_id": pre_instance_id,
         "post_helper_instance_id": post_instance_id,
         "helper_generation_reason": generation_result.reason,
+        "host_reboot_marker_reason": reboot_marker_result.reason,
     }
     payload.update(current_metadata)
     payload.update(_host_reboot_ping_state_payload(ping_state))
+    payload.update(_host_reboot_boot_marker_payload(boot_marker_result))
+    payload["lifecycle_results"] = _host_reboot_results_payload(lifecycle_results)
 
     manifest_path = evidence_dir / HOST_REBOOT_POST_MANIFEST
     if dry_run:
@@ -1227,7 +1387,13 @@ def run_host_reboot_post(
         write_result = CheckResult(True, "host_reboot_post_manifest_written", write_result.message)
     results.append(("post_manifest", write_result))
 
-    if not ping_state.result.ok:
+    if not boot_marker_result.ok:
+        final_result = boot_marker_result
+    elif not reboot_marker_result.ok:
+        final_result = reboot_marker_result
+    elif not readiness_result.ok:
+        final_result = readiness_result
+    elif not ping_state.result.ok:
         final_result = ping_state.result
     elif not write_result.ok:
         final_result = write_result
@@ -1997,6 +2163,64 @@ def collect_check_results(
     return results
 
 
+def host_reboot_lifecycle_readiness_results(
+    *,
+    helper_mode: str,
+    helper_path: Path,
+    socket_path: Path,
+    pid_file: Path,
+    log_dir: Path,
+    launchd_label: str = "",
+    launchd_plist_path: Path | None = None,
+    entitlements_path: Path | None = None,
+    dry_run: bool = False,
+    ping_checker: Callable[[Path], CheckResult | PingState] = ping_helper_state,
+    check_collector: Callable[..., list[tuple[str, CheckResult]]] = collect_check_results,
+    launchd_status_checker: Callable[..., CheckResult] = run_launchd_action,
+) -> list[tuple[str, CheckResult]]:
+    results: list[tuple[str, CheckResult]] = []
+    if helper_mode == "launchd":
+        launchd_result = launchd_status_checker(
+            "status",
+            label=launchd_label,
+            plist_path=launchd_plist_path,
+            helper_path=helper_path,
+            socket_path=socket_path,
+            log_dir=log_dir,
+            dry_run=dry_run,
+        )
+        results.append(("launchd_status", launchd_result))
+
+    check_results = check_collector(
+        helper_path,
+        socket_path,
+        pid_file,
+        log_dir,
+        entitlements_path=entitlements_path,
+        dry_run=True,
+        ping_checker=ping_checker,
+    )
+    results.extend(check_results)
+
+    for name, result in results:
+        if not result.ok:
+            results.append(
+                (
+                    "helper_readiness",
+                    CheckResult(False, "host_reboot_lifecycle_check_failed", f"{name}:{result.reason}"),
+                )
+            )
+            return results
+
+    ping_result = next((result for name, result in results if name == "ping"), None)
+    if ping_result is None or ping_result.reason == "helper_not_running":
+        results.append(("helper_readiness", CheckResult(False, "host_reboot_helper_not_ready")))
+        return results
+
+    results.append(("helper_readiness", CheckResult(True, "host_reboot_helper_ready")))
+    return results
+
+
 def status_helper(
     helper_path: Path,
     socket_path: Path,
@@ -2509,6 +2733,8 @@ def _host_reboot_drill_common_kwargs(args: argparse.Namespace) -> dict[str, Any]
         "evidence_dir": Path(args.evidence_dir),
         "bundle_path": Path(args.bundle) if args.bundle else Path(""),
         "helper_path": Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
+        "pid_file": Path(args.pid_file) if args.pid_file else paths.pid_file,
+        "entitlements_path": Path(args.entitlements) if args.entitlements else None,
         "helper_mode": args.helper_mode,
         "socket_path": Path(args.socket_path) if args.socket_path else paths.socket_path,
         "log_dir": log_dir,
@@ -2743,10 +2969,12 @@ def build_parser() -> argparse.ArgumentParser:
     host_reboot_parent.add_argument("--helper-mode", choices=("direct", "launchd"), default="direct")
     host_reboot_parent.add_argument("--helper", "--helper-path", dest="helper_path")
     host_reboot_parent.add_argument("--socket", "--socket-path", dest="socket_path")
+    host_reboot_parent.add_argument("--pid-file")
     host_reboot_parent.add_argument("--log-dir")
     host_reboot_parent.add_argument("--serial-log-dir")
     host_reboot_parent.add_argument("--label")
     host_reboot_parent.add_argument("--plist-output")
+    host_reboot_parent.add_argument("--entitlements")
     host_reboot_parent.add_argument("--allow-volatile-evidence-dir", action="store_true")
     host_reboot_parent.add_argument("--dry-run", action="store_true")
     host_reboot_parent.add_argument("--json", action="store_true")

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -236,17 +236,21 @@ def ensure_host_reboot_evidence_dir(
 
 
 def write_json_private(path: Path, payload: Mapping[str, Any]) -> CheckResult:
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags = os.O_WRONLY | os.O_CREAT
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     fd: int | None = None
     try:
         fd = os.open(path, flags, 0o600)
+        path_stat = os.fstat(fd)
+        if not stat.S_ISREG(path_stat.st_mode):
+            raise OSError(f"manifest target is not a regular file: {path}")
+        os.fchmod(fd, 0o600)
+        os.ftruncate(fd, 0)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             fd = None
             json.dump(payload, handle, indent=2, sort_keys=True)
             handle.write("\n")
-        path.chmod(0o600)
     except (OSError, TypeError, ValueError) as exc:
         if fd is not None:
             with contextlib.suppress(OSError):
@@ -963,7 +967,10 @@ def run_host_reboot_pre(
     if not evidence_result.ok:
         return evidence_result
 
-    ping_state = _coerce_ping_state(ping_checker(socket_path))
+    try:
+        ping_state = _coerce_ping_state(ping_checker(socket_path))
+    except Exception as exc:
+        ping_state = PingState(CheckResult(False, "helper_ping_failed", str(exc)))
     payload: dict[str, Any] = {
         "phase": "pre",
         "created_at": created_at_factory(),
@@ -983,6 +990,12 @@ def run_host_reboot_pre(
     write_result = write_json_private(manifest_path, payload)
     if not write_result.ok:
         return write_result
+    if not ping_state.result.ok:
+        return CheckResult(
+            False,
+            ping_state.result.reason,
+            ping_state.result.message or str(manifest_path),
+        )
     return CheckResult(True, "host_reboot_pre_manifest_written", str(manifest_path))
 
 

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -46,6 +46,15 @@ else:
 INVALID_LIFECYCLE_LOCK_GRACE_SEC = 1.0
 DEFAULT_LAUNCHD_LABEL = "org.tldw.macos-vz-helper"
 LAUNCHD_ACTIONS = {"bootstrap", "bootout", "kickstart", "status"}
+VOLATILE_EVIDENCE_ROOTS = tuple(
+    Path(path).resolve()
+    for path in (
+        Path(os.sep) / "tmp",
+        Path(os.sep) / "private" / "tmp",
+        os.getenv("TMPDIR") or "",
+    )
+    if path
+)
 
 
 @dataclass(frozen=True)
@@ -101,6 +110,7 @@ class PingState:
     result: CheckResult
     protocol_version: str = ""
     helper_version: str = ""
+    details: dict[str, str] | None = None
 
 
 def default_paths() -> HelperPaths:
@@ -176,6 +186,37 @@ def validate_helper_binary(path: Path) -> CheckResult:
     if not os.access(path, os.X_OK):
         return CheckResult(ok=False, reason="helper_binary_not_executable", message=str(path))
     return CheckResult(ok=True, message=str(path))
+
+
+def _is_under_path(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    except RuntimeError:
+        return False
+    return True
+
+
+def ensure_host_reboot_evidence_dir(
+    evidence_dir: Path,
+    *,
+    create: bool = False,
+    allow_volatile: bool = False,
+) -> CheckResult:
+    if not allow_volatile:
+        for root in VOLATILE_EVIDENCE_ROOTS:
+            if _is_under_path(evidence_dir, root):
+                return CheckResult(False, "host_reboot_evidence_dir_volatile", str(evidence_dir))
+    if not evidence_dir.exists():
+        if not create:
+            return CheckResult(False, "host_reboot_evidence_dir_missing", str(evidence_dir))
+        evidence_dir.mkdir(mode=0o700, parents=True)
+        evidence_dir.chmod(0o700)
+    result = ensure_private_dir(evidence_dir, dry_run=False)
+    if not result.ok:
+        return CheckResult(False, "host_reboot_evidence_dir_not_private", result.message or str(evidence_dir))
+    return CheckResult(True, "host_reboot_evidence_dir_ok", str(evidence_dir))
 
 
 def ensure_private_dir(path: Path, dry_run: bool = False) -> CheckResult:
@@ -787,16 +828,28 @@ def _request_helper_ping(socket_path: Path, *, timeout_sec: float = 5.0) -> dict
     return response
 
 
+def _string_details(value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    output: dict[str, str] = {}
+    for key, item in value.items():
+        if isinstance(key, str) and isinstance(item, str):
+            output[key] = item
+    return output
+
+
 def ping_helper_state(
     socket_path: Path,
     *,
     client_factory: Callable[[Path], object] | None = None,
 ) -> PingState:
+    details: dict[str, str] = {}
     try:
         if client_factory is not None:
             reply = client_factory(socket_path).ping()
             protocol_version = str(getattr(reply, "protocol_version", "") or "")
             helper_version = str(getattr(reply, "helper_version", "") or "")
+            details = _string_details(getattr(reply, "details", None))
         else:
             payload = _request_helper_ping(socket_path)
             error_code = str(payload.get("error_code") or "").strip()
@@ -805,6 +858,7 @@ def ping_helper_state(
                 raise RuntimeError(f"{error_code}: {message}")
             protocol_version = str(payload.get("protocol_version") or "")
             helper_version = str(payload.get("helper_version") or "")
+            details = _string_details(payload.get("details"))
     except Exception as exc:
         if (
             exc.__class__.__name__ == "MacOSVirtualizationHelperProtocolError"
@@ -812,18 +866,21 @@ def ping_helper_state(
         ):
             return PingState(
                 result=CheckResult(ok=False, reason="helper_protocol_mismatch", message=str(exc)),
+                details=details,
             )
-        return PingState(result=CheckResult(ok=False, reason="helper_ping_failed", message=str(exc)))
+        return PingState(result=CheckResult(ok=False, reason="helper_ping_failed", message=str(exc)), details=details)
     if protocol_version != str(EXPECTED_HELPER_PROTOCOL_VERSION):
         return PingState(
             result=CheckResult(ok=False, reason="helper_protocol_mismatch"),
             protocol_version=protocol_version,
             helper_version=helper_version,
+            details=details,
         )
     return PingState(
         result=CheckResult(ok=True),
         protocol_version=protocol_version,
         helper_version=helper_version,
+        details=details,
     )
 
 

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -1030,16 +1030,24 @@ def host_reboot_bundle_dry_run_validation(
     bundle_path: Path,
     socket_path: Path,
     python_path: Path | None = None,
+    command_runner: Callable[..., int] = run_command_captured,
 ) -> CheckResult:
     if not str(bundle_path) or str(bundle_path) == ".":
         return CheckResult(False, "host_reboot_bundle_missing")
-    return run_vz_linux_host_smoke(
-        bundle_path=bundle_path,
-        socket_path=socket_path,
-        python_path=python_path,
-        dry_run=True,
-        command_runner=run_command_captured,
-    )
+    argv = [
+        str(host_smoke_script_path()),
+        "--bundle",
+        str(bundle_path),
+        "--socket",
+        str(socket_path),
+        "--dry-run",
+    ]
+    if python_path is not None:
+        argv.extend(["--python", str(python_path)])
+    code = command_runner(argv, dry_run=False)
+    if code != 0:
+        return CheckResult(False, "host_reboot_bundle_validation_failed", str(code))
+    return CheckResult(True, "dry_run")
 
 
 def _host_reboot_bundle_payload(result: CheckResult) -> dict[str, Any]:

--- a/tools/macos-vz-helper/scripts/vz-helperctl.py
+++ b/tools/macos-vz-helper/scripts/vz-helperctl.py
@@ -2409,6 +2409,94 @@ def _launchd_drill_command(args: argparse.Namespace) -> int:
     return 0 if all(result.ok for _, result in results) else 1
 
 
+def _host_reboot_drill_launchd_metadata_result(args: argparse.Namespace) -> CheckResult | None:
+    if args.helper_mode != "launchd":
+        return None
+    missing: list[str] = []
+    if not args.label:
+        missing.append("--label")
+    if not args.plist_output:
+        missing.append("--plist-output")
+    if not missing:
+        return None
+    return CheckResult(
+        False,
+        "host_reboot_launchd_metadata_missing",
+        f"launchd host reboot drill requires explicit {', '.join(missing)}",
+    )
+
+
+def _host_reboot_drill_common_kwargs(args: argparse.Namespace) -> dict[str, Any]:
+    paths = default_paths()
+    log_dir = Path(args.log_dir) if args.log_dir else paths.log_dir
+    return {
+        "evidence_dir": Path(args.evidence_dir),
+        "bundle_path": Path(args.bundle) if args.bundle else Path(""),
+        "helper_path": Path(args.helper_path) if args.helper_path else DEFAULT_HELPER,
+        "helper_mode": args.helper_mode,
+        "socket_path": Path(args.socket_path) if args.socket_path else paths.socket_path,
+        "log_dir": log_dir,
+        "serial_log_dir": Path(args.serial_log_dir) if args.serial_log_dir else log_dir / "serial",
+        "launchd_label": args.label or "",
+        "launchd_plist_path": Path(args.plist_output) if args.plist_output else None,
+        "allow_volatile_evidence_dir": args.allow_volatile_evidence_dir,
+    }
+
+
+def _host_reboot_drill_command(args: argparse.Namespace) -> int:
+    metadata_result = _host_reboot_drill_launchd_metadata_result(args)
+    if metadata_result is not None:
+        results = [("host_reboot_launchd_metadata", metadata_result)]
+        _print_results(results, as_json=args.json)
+        return 1
+
+    common_kwargs = _host_reboot_drill_common_kwargs(args)
+    if args.phase == "pre":
+        pre_kwargs = dict(common_kwargs)
+        pre_kwargs["create_evidence_dir"] = args.create_evidence_dir
+        if args.json:
+            with contextlib.redirect_stdout(io.StringIO()):
+                result = run_host_reboot_pre(**pre_kwargs)
+        else:
+            result = run_host_reboot_pre(**pre_kwargs)
+        results = [("host_reboot_pre", result)]
+        _print_results(results, as_json=args.json)
+        return 0 if result.ok else 1
+
+    post_kwargs = dict(common_kwargs)
+    if args.json:
+        with contextlib.redirect_stdout(io.StringIO()):
+            results = run_host_reboot_post(**post_kwargs)
+    else:
+        results = run_host_reboot_post(**post_kwargs)
+
+    if args.run_smoke:
+        if not args.bundle:
+            results.append(
+                (
+                    "vz_linux_smoke",
+                    CheckResult(False, "host_reboot_smoke_bundle_missing", "--bundle is required with --run-smoke"),
+                )
+            )
+        else:
+            smoke_kwargs = {
+                "bundle_path": Path(args.bundle),
+                "socket_path": post_kwargs["socket_path"],
+                "python_path": Path(args.python) if args.python else None,
+                "dry_run": args.dry_run,
+            }
+            if args.json:
+                smoke_kwargs["command_runner"] = run_command_captured
+                with contextlib.redirect_stdout(io.StringIO()):
+                    smoke_result = run_vz_linux_host_smoke(**smoke_kwargs)
+            else:
+                smoke_result = run_vz_linux_host_smoke(**smoke_kwargs)
+            results.append(("vz_linux_smoke", smoke_result))
+
+    _print_results(results, as_json=args.json)
+    return 0 if all(result.ok for _, result in results) else 1
+
+
 def _start_command(args: argparse.Namespace) -> int:
     paths = default_paths()
     result = start_helper(
@@ -2558,6 +2646,40 @@ def build_parser() -> argparse.ArgumentParser:
     launchd_drill.add_argument("--dry-run", action="store_true")
     launchd_drill.add_argument("--json", action="store_true")
     launchd_drill.set_defaults(func=_launchd_drill_command)
+
+    host_reboot_drill = subparsers.add_parser(
+        "host-reboot-drill",
+        help="record and validate manual host reboot helper evidence",
+    )
+    host_reboot_subparsers = host_reboot_drill.add_subparsers(dest="phase", required=True)
+    host_reboot_parent = argparse.ArgumentParser(add_help=False)
+    host_reboot_parent.add_argument("--evidence-dir", required=True)
+    host_reboot_parent.add_argument("--bundle")
+    host_reboot_parent.add_argument("--helper-mode", choices=("direct", "launchd"), default="direct")
+    host_reboot_parent.add_argument("--helper", "--helper-path", dest="helper_path")
+    host_reboot_parent.add_argument("--socket", "--socket-path", dest="socket_path")
+    host_reboot_parent.add_argument("--log-dir")
+    host_reboot_parent.add_argument("--serial-log-dir")
+    host_reboot_parent.add_argument("--label")
+    host_reboot_parent.add_argument("--plist-output")
+    host_reboot_parent.add_argument("--create-evidence-dir", action="store_true")
+    host_reboot_parent.add_argument("--allow-volatile-evidence-dir", action="store_true")
+    host_reboot_parent.add_argument("--run-smoke", action="store_true")
+    host_reboot_parent.add_argument("--python")
+    host_reboot_parent.add_argument("--dry-run", action="store_true")
+    host_reboot_parent.add_argument("--json", action="store_true")
+    host_reboot_pre = host_reboot_subparsers.add_parser(
+        "pre",
+        parents=[host_reboot_parent],
+        help="record bounded pre-reboot helper evidence",
+    )
+    host_reboot_pre.set_defaults(func=_host_reboot_drill_command)
+    host_reboot_post = host_reboot_subparsers.add_parser(
+        "post",
+        parents=[host_reboot_parent],
+        help="validate helper state after a manual host reboot",
+    )
+    host_reboot_post.set_defaults(func=_host_reboot_drill_command)
 
     start = subparsers.add_parser("start", help="start the helper")
     start.add_argument("--helper", "--helper-path", dest="helper_path")


### PR DESCRIPTION
## Summary
- Adds `vz-helperctl.py host-reboot-drill pre/post` for operator-owned VZ helper host reboot validation.
- Records durable private evidence, lifecycle readiness, host boot marker drift, helper generation metadata, and bundle dry-run validation.
- Documents direct vs launchd workflows, restored-socket smoke targeting, expected skips/blockers, and keeps scheduled CI non-rebooting.

## Change summary
Human-authored change summary required before merge.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/macos-vz-helper/Tests/test_vz_helperctl.py -q` (`186 passed, 6 skipped`)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tools/macos-vz-helper/scripts/vz-helperctl.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/macos-vz-helper/scripts/vz-helperctl.py -f json -o /tmp/bandit_vz_host_reboot_drill.json` (`results=[]`, `errors=[]`)
- [x] `git diff --check`
- [ ] Real prepared-host reboot drill not run here because it is disruptive and requires an operator reboot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operator-owned host reboot validation drill to `vz-helperctl.py` that records pre-reboot evidence and validates the helper after reboot. Proves lifecycle readiness, enforces real reboot via a boot marker, supports direct and `launchd` modes, and stays opt-in without automatic reboots or scheduled CI.

- **New Features**
  - `host-reboot-drill {pre,post}` with `--json` output.
  - Pre: writes bounded `host-reboot-pre.json` with helper ping/protocol/generation, lifecycle readiness, boot marker, and bundle dry-run validation.
  - Post: validates durable evidence dir, requires changed boot marker, compares helper generation, writes `host-reboot-post.json`, and can target restored-helper smoke.
  - Evidence dir helpers block volatile roots, unsafe paths, and symlink/loop issues; return stable errors.
  - `launchd` mode validates label/plist metadata and explicit readiness.

- **Bug Fixes**
  - Stronger lifecycle readiness checks across direct and `launchd`.
  - Normalized bundle/metadata comparisons; copy/paste-safe CLI examples.
  - Atomic, non-blocking manifest writes; improved error handling and stable JSON.
  - Safer socket/path validation and evidence dir creation.
  - Expanded tests and docs on workflow, CI boundaries, and operator steps.

<sup>Written for commit a6214f46f38d475246918d5aa9c6c8c1c68e963b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1868?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

