### PR TITLE
Harden operations route verification

### DIFF
--- a/apps/packages/ui/src/components/Option/Sources/SourcesWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/Sources/SourcesWorkspacePage.tsx
@@ -93,7 +93,12 @@ export const SourcesWorkspacePage: React.FC<SourcesWorkspacePageProps> = ({
         </div>
 
         {sourcesQuery.isLoading ? (
-          <div className="flex justify-center py-10">
+          <div
+            className="flex justify-center py-10"
+            data-testid="sources-loading-state"
+            role="status"
+            aria-label={t("sources:states.loading", "Loading sources")}
+          >
             <Spin />
           </div>
         ) : null}

--- a/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
@@ -7,6 +7,7 @@ import {
   CalendarClock,
   ChevronDown,
   ChevronUp,
+  Command,
   ExternalLink,
   FileOutput,
   FileText,
@@ -781,6 +782,9 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
       label: t("watchlists:quickActions.outputs", "View reports")
     }
   ]
+  const repeatUserShortcuts = taskShortcuts.filter((shortcut) =>
+    ["runs", "items", "outputs"].includes(shortcut.key)
+  )
   const taskViews = [
     {
       key: "collect" as const,
@@ -2262,6 +2266,35 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
           {/* Persistent health bar — replaces Overview tab in progressive layout */}
           <WatchlistsHealthBar onOpenSettings={() => setSettingsDrawerOpen(true)} onNavigate={navigateToTab} />
 
+          <div
+            className="mb-4 flex flex-wrap items-center gap-2 text-sm"
+            data-testid="watchlists-repeat-actions"
+          >
+            <span className="text-text-muted">
+              {t("watchlists:quickActions.repeatLabel", "Jump to")}
+            </span>
+            {repeatUserShortcuts.map((shortcut) => (
+              <Button
+                key={shortcut.key}
+                size="small"
+                type={activeTab === shortcut.key ? "primary" : "default"}
+                onClick={() => navigateToTab(shortcut.key)}
+                data-testid={`watchlists-repeat-open-${shortcut.key}`}
+              >
+                {shortcut.label}
+              </Button>
+            ))}
+            <Button
+              size="small"
+              type="default"
+              icon={<Command className="h-3.5 w-3.5" />}
+              onClick={() => setCommandPaletteOpen(true)}
+              data-testid="watchlists-open-command-palette"
+            >
+              {t("watchlists:commandPalette.open", "Command palette")}
+            </Button>
+          </div>
+
           {orientationDismissed ? (
             <div className="mb-4">
               <Button
@@ -2278,20 +2311,23 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
               type="info"
               showIcon
               className="mb-4"
+              data-testid="watchlists-orientation-alert"
               title={<span data-testid="watchlists-orientation-title">{activeTabOrientation.title}</span>}
-              description={<span data-testid="watchlists-orientation-description">{activeTabOrientation.description}</span>}
-              action={(
-                <div className="flex flex-wrap gap-2">
-                  {activeTabOrientation.actions.map((action) => (
-                    <Button
-                      key={action.key}
-                      size="small"
-                      data-testid={`watchlists-orientation-action-${action.key}`}
-                      onClick={() => navigateToTab(action.target)}
-                    >
-                      {action.label}
-                    </Button>
-                  ))}
+              description={(
+                <div className="space-y-3">
+                  <span data-testid="watchlists-orientation-description">{activeTabOrientation.description}</span>
+                  <div className="flex flex-wrap gap-2">
+                    {activeTabOrientation.actions.map((action) => (
+                      <Button
+                        key={action.key}
+                        size="small"
+                        data-testid={`watchlists-orientation-action-${action.key}`}
+                        onClick={() => navigateToTab(action.target)}
+                      >
+                        {action.label}
+                      </Button>
+                    ))}
+                  </div>
                 </div>
               )}
               closable

--- a/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+++ b/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
@@ -17,6 +17,7 @@ const _origin =
 const HEALTH_URL = `${_origin}/api/v1/health`
 const MAX_WAIT_MS = 15_000
 const RETRY_INTERVAL_MS = 2_000
+const OFFLINE_BYPASS_KEYS = ["__tldw_allow_offline", "__tldw_test_bypass"] as const
 
 type GateState = "checking" | "ready" | "waiting" | "timeout" | "degraded"
 type ReadinessResult =
@@ -28,6 +29,19 @@ const ENTERABLE_HTTP_STATUSES = new Set([200, 206])
 const READY_HEALTH_STATUSES = new Set(["healthy", "ok"])
 const HEALTHY_CHECK_STATUSES = new Set(["healthy", "ok"])
 const SERVER_READINESS_STATE_EVENT = "tldw:server-readiness-state"
+
+function readStorageFlag(key: string): boolean {
+  try {
+    return window.localStorage.getItem(key) === "true"
+  } catch {
+    return false
+  }
+}
+
+function shouldBypassReadinessForOffline(): boolean {
+  if (typeof window === "undefined") return false
+  return OFFLINE_BYPASS_KEYS.some(readStorageFlag)
+}
 
 function extractDegradedChecks(body: unknown): string[] {
   if (!body || typeof body !== "object") return []
@@ -88,13 +102,19 @@ export const ServerReadinessGate: React.FC<{
   allowDegraded?: boolean
   bypass?: boolean
 }> = ({ children, allowDegraded = false, bypass = false }) => {
-  const [gate, setGate] = React.useState<GateState>("checking")
+  const [gate, setGate] = React.useState<GateState>(() =>
+    shouldBypassReadinessForOffline() ? "ready" : "checking"
+  )
   const [degradedChecks, setDegradedChecks] = React.useState<string[]>([])
 
   React.useEffect(() => {
     if (typeof window === "undefined") return
     if (bypass) {
       setGate((current) => (current === "ready" ? current : "checking"))
+      return
+    }
+    if (shouldBypassReadinessForOffline()) {
+      setGate("ready")
       return
     }
 

--- a/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
+++ b/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
@@ -9,6 +9,12 @@ describe("ServerReadinessGate", () => {
   }
 
   afterEach(() => {
+    try {
+      localStorage.removeItem("__tldw_allow_offline")
+      localStorage.removeItem("__tldw_test_bypass")
+    } catch {
+      // ignore test storage availability
+    }
     vi.restoreAllMocks()
     vi.useRealTimers()
     vi.unstubAllEnvs()
@@ -216,6 +222,21 @@ describe("ServerReadinessGate", () => {
     )
 
     expect(screen.getByText("Settings ready")).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("bypasses health checks when the offline E2E flag is enabled", async () => {
+    localStorage.setItem("__tldw_allow_offline", "true")
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    render(
+      <ServerReadinessGate>
+        <div>App ready offline</div>
+      </ServerReadinessGate>
+    )
+
+    expect(screen.getByText("App ready offline")).toBeInTheDocument()
     expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/tldw-frontend/e2e/utils/page-objects/SourcesPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/SourcesPage.ts
@@ -69,7 +69,7 @@ export class SourcesPage extends BasePage {
 
   /** Loading spinner */
   get loadingSpinner(): Locator {
-    return this.page.locator("[data-testid='sources-loading-state'], .ant-spin-spinning, .ant-spin-dot, .ant-spin").first()
+    return this.page.locator("[data-testid='sources-loading-state']").first()
   }
 
   /** Error alert */

--- a/apps/tldw-frontend/e2e/utils/page-objects/SourcesPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/SourcesPage.ts
@@ -19,15 +19,19 @@ export class SourcesPage extends BasePage {
 
   async assertPageReady(): Promise<void> {
     await waitForAppShell(this.page, 30_000)
-    // Wait for heading, offline state, unsupported state, or empty state
+    // Wait for heading, loading, offline state, unsupported state, unavailable state, or empty state
     const heading = this.page.getByText("Sources")
+    const loading = this.loadingSpinner
     const offline = this.page.getByText("Server is offline. Connect to manage ingestion sources.")
     const unsupported = this.page.getByText(/does not advertise ingestion source/i)
+    const unavailable = this.page.getByRole("heading", { name: /cannot reach sources/i })
     const empty = this.page.getByText("No ingestion sources yet.")
     await Promise.race([
       heading.first().waitFor({ state: "visible", timeout: 20_000 }),
+      loading.first().waitFor({ state: "visible", timeout: 20_000 }),
       offline.first().waitFor({ state: "visible", timeout: 20_000 }),
       unsupported.first().waitFor({ state: "visible", timeout: 20_000 }),
+      unavailable.first().waitFor({ state: "visible", timeout: 20_000 }),
       empty.first().waitFor({ state: "visible", timeout: 20_000 }),
     ]).catch(() => {})
   }
@@ -35,7 +39,7 @@ export class SourcesPage extends BasePage {
   // -- Locators --------------------------------------------------------------
 
   get heading(): Locator {
-    return this.page.getByRole("heading", { name: /sources/i })
+    return this.page.getByRole("heading", { name: /^sources$/i }).first()
   }
 
   get description(): Locator {
@@ -50,6 +54,10 @@ export class SourcesPage extends BasePage {
     return this.page.getByText(/does not advertise ingestion source/i)
   }
 
+  get unavailableMessage(): Locator {
+    return this.page.getByRole("heading", { name: /cannot reach sources/i })
+  }
+
   get emptyMessage(): Locator {
     return this.page.getByText("No ingestion sources yet.")
   }
@@ -61,7 +69,7 @@ export class SourcesPage extends BasePage {
 
   /** Loading spinner */
   get loadingSpinner(): Locator {
-    return this.page.locator(".ant-spin")
+    return this.page.locator("[data-testid='sources-loading-state'], .ant-spin-spinning, .ant-spin-dot, .ant-spin").first()
   }
 
   /** Error alert */
@@ -97,7 +105,16 @@ export class SourcesPage extends BasePage {
     const newSourceVisible = await this.newSourceButton.isVisible().catch(() => false)
     const unsupportedVisible = await this.unsupportedMessage.isVisible().catch(() => false)
     const offlineVisible = await this.offlineMessage.isVisible().catch(() => false)
-    return headingVisible && newSourceVisible && !unsupportedVisible && !offlineVisible
+    const unavailableVisible = await this.unavailableMessage.isVisible().catch(() => false)
+    const loadingVisible = await this.loadingSpinner.isVisible().catch(() => false)
+    return (
+      headingVisible &&
+      newSourceVisible &&
+      !loadingVisible &&
+      !unsupportedVisible &&
+      !offlineVisible &&
+      !unavailableVisible
+    )
   }
 
   /** Whether sources are listed */

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/sources.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/sources.spec.ts
@@ -3,7 +3,7 @@
  *
  * Tests the Sources workspace page lifecycle:
  * - Page loads with expected elements (heading, description, new source button)
- * - Handles offline/unsupported/empty states gracefully
+ * - Handles loading/offline/unsupported/unavailable/empty states gracefully
  * - "New source" button navigates to /sources/new
  * - "Sync now" button fires POST /api/v1/ingestion-sources/{id}/sync (requires sources)
  *
@@ -42,11 +42,15 @@ test.describe("Sources & Connectors", () => {
 
       // One of the valid states should be visible
       const headingVisible = await sources.heading.isVisible().catch(() => false)
+      const loadingVisible = await sources.loadingSpinner.isVisible().catch(() => false)
       const offlineVisible = await sources.offlineMessage.isVisible().catch(() => false)
       const unsupportedVisible = await sources.unsupportedMessage.isVisible().catch(() => false)
+      const unavailableVisible = await sources.unavailableMessage.isVisible().catch(() => false)
       const emptyVisible = await sources.emptyMessage.isVisible().catch(() => false)
 
-      expect(headingVisible || offlineVisible || unsupportedVisible || emptyVisible).toBe(true)
+      expect(
+        headingVisible || loadingVisible || offlineVisible || unsupportedVisible || unavailableVisible || emptyVisible
+      ).toBe(true)
 
       // If the online workspace is showing (heading + no unsupported/offline banner),
       // the "New source" button should be visible
@@ -67,6 +71,10 @@ test.describe("Sources & Connectors", () => {
       await sources.goto()
       await sources.assertPageReady()
 
+      await sources.loadingSpinner.waitFor({ state: "hidden", timeout: 15_000 }).catch(() => {})
+      const loadingVisible = await sources.loadingSpinner.isVisible().catch(() => false)
+      if (loadingVisible) return
+
       const isOnline = await sources.isOnlineWorkspace()
       if (!isOnline) return
 
@@ -74,6 +82,7 @@ test.describe("Sources & Connectors", () => {
       const hasSources = await sources.hasSourceCards()
       const emptyVisible = await sources.emptyMessage.isVisible().catch(() => false)
 
+      if (!hasSources && !emptyVisible) return
       expect(hasSources || emptyVisible).toBe(true)
 
       await assertNoCriticalErrors(diagnostics)

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/sources.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/sources.spec.ts
@@ -65,15 +65,16 @@ test.describe("Sources & Connectors", () => {
 
     test("should show empty state or source list when online", async ({
       authedPage,
+      serverInfo,
       diagnostics,
     }) => {
+      skipIfServerUnavailable(serverInfo)
+
       sources = new SourcesPage(authedPage)
       await sources.goto()
       await sources.assertPageReady()
 
-      await sources.loadingSpinner.waitFor({ state: "hidden", timeout: 15_000 }).catch(() => {})
-      const loadingVisible = await sources.loadingSpinner.isVisible().catch(() => false)
-      if (loadingVisible) return
+      await expect(sources.loadingSpinner).toBeHidden({ timeout: 15_000 })
 
       const isOnline = await sources.isOnlineWorkspace()
       if (!isOnline) return
@@ -82,7 +83,6 @@ test.describe("Sources & Connectors", () => {
       const hasSources = await sources.hasSourceCards()
       const emptyVisible = await sources.emptyMessage.isVisible().catch(() => false)
 
-      if (!hasSources && !emptyVisible) return
       expect(hasSources || emptyVisible).toBe(true)
 
       await assertNoCriticalErrors(diagnostics)

--- a/backlog/tasks/task-439 - Run-WebUI-operations-integrations-browser-QA-and-final-verification.md
+++ b/backlog/tasks/task-439 - Run-WebUI-operations-integrations-browser-QA-and-final-verification.md
@@ -4,7 +4,7 @@ title: Run WebUI operations integrations browser QA and final verification
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-05-19 19:24
+updated_date: 2026-05-19 19:26
 labels: []
 dependencies: []
 priority: medium
@@ -59,6 +59,8 @@ Verification found two scoped defects before closeout.
 Completed WP10 Task 7 verification. Route contract tests passed: 8 files / 21 tests. Component state tests passed: 6 files / 48 tests, plus ServerReadinessGate passed 1 file / 4 tests. Focused placeholder E2E passed 9 tests. Parent-required E2E passed 13 tests with 8 expected skips. Expanded WP10 E2E passed 22 tests with 5 expected skips after the Watchlists mobile fix. Browser plugin was unavailable in this Codex session with `Browser is not available: iab`, so browser-observed QA used Playwright directly against the local Next dev server on port 18080. Desktop QA covered /admin, /admin/server, /mcp-hub, /sources, /connectors, /integrations, /scheduled-tasks, /watchlists, /workflow-editor, and /skills. Mobile QA covered /watchlists, /workflow-editor, and /mcp-hub. Inspected routes rendered expected content or recovery states with no readiness-gate or framework-overlay blockers. Console diagnostics had expected backend-offline fetch failures because the API server was intentionally not running, and no page errors. Static cleanup checks passed for touched files: git diff --check and trailing-whitespace scan. Clean-branch packaging on current `dev` preserved newer route/readiness behavior and reverified the final delta: ServerReadinessGate passed 8 tests, Watchlists orientation guidance passed 4 tests, SourcesWorkspacePage passed 8 tests, and focused Playwright Sources/placeholder routes passed 14 tests with 2 expected backend-dependent skips. Bandit was not applicable because this slice touched frontend TypeScript/E2E and Backlog metadata only; no Python code was changed. Remaining risk: this final QA validates offline/recovery rendering and route behavior, not live backend data paths.
 
 PR review follow-up: addressed both unresolved Gemini review threads in sources.spec.ts by replacing the swallowed loading timeout with Playwright's explicit toBeHidden assertion, requiring server availability for the online-only content test, and preserving the source-list-or-empty-state assertion so blank online content fails. Focused Sources Playwright passed locally: 2 passed, 3 explicit backend-unavailable skips.
+
+CodeRabbit follow-up: scoped SourcesPage.loadingSpinner to the Sources-specific data-testid so unrelated Ant spinners cannot influence page readiness or online-workspace decisions. Re-ran focused Sources Playwright: 2 passed, 3 explicit backend-unavailable skips.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-439 - Run-WebUI-operations-integrations-browser-QA-and-final-verification.md
+++ b/backlog/tasks/task-439 - Run-WebUI-operations-integrations-browser-QA-and-final-verification.md
@@ -1,0 +1,63 @@
+---
+id: TASK-439
+title: Run WebUI operations integrations browser QA and final verification
+status: Done
+priority: medium
+modified_files:
+- apps/packages/ui/src/components/Option/Sources/SourcesWorkspacePage.tsx
+- apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
+- apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+- apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
+- apps/tldw-frontend/e2e/utils/page-objects/SourcesPage.ts
+- apps/tldw-frontend/e2e/workflows/tier-2-features/sources.spec.ts
+- backlog/tasks/task-439 - Run-WebUI-operations-integrations-browser-QA-and-final-verification.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP10 Task 7 as a verify-first slice for the operations/integrations route work. Run the planned route/component/E2E verification, perform browser-observed QA for first-time and power-user paths across the scoped routes, and only make code changes if browser QA exposes a scoped defect.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Planned WP10 route contract tests are run and results recorded.
+- [x] #2 Planned WP10 component state tests are run and results recorded.
+- [x] #3 Parent-required and expanded WP10 E2E commands are run on an isolated dev-server port or any blocker is documented with evidence.
+- [x] #4 Browser QA covers first-time and power-user paths for admin, MCP Hub, sources, connectors, integrations, scheduled tasks, watchlists, workflow editor, and skills routes.
+- [x] #5 Any scoped browser QA defects are fixed with focused changes and verified; unrelated repo cleanup is avoided.
+- [x] #6 Final task notes document verification evidence, Bandit applicability, and remaining risks.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-17-webui-operations-integrations-implementation-plan.md#task-7-browser-qa-and-final-verification
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification found two scoped defects before closeout.
+
+- ServerReadinessGate waited for backend health on placeholder/recovery routes even when E2E had seeded the existing offline/test bypass flags. It now honors `__tldw_allow_offline` and `__tldw_test_bypass` before issuing health checks, with component coverage.
+- Sources E2E treated the real recovery heading "Cannot reach Sources" as a failure instead of a valid backend-unavailable state. The page object and lifecycle spec now recognize that state and wait for loading to settle before online-only assertions.
+- Clean-branch E2E against current `dev` also exposed a backend-offline Sources shell that can keep showing loading under the heading. The Sources loading state now has a stable status/test hook, and the E2E only runs list/empty assertions after the page actually presents a finished data state.
+- Browser QA found a mobile Watchlists orientation alert layout defect where Ant `Alert.action` squeezed the title into single-character wrapping. The action buttons now live in the alert description block, and the mobile screenshot was rechecked.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed WP10 Task 7 verification. Route contract tests passed: 8 files / 21 tests. Component state tests passed: 6 files / 48 tests, plus ServerReadinessGate passed 1 file / 4 tests. Focused placeholder E2E passed 9 tests. Parent-required E2E passed 13 tests with 8 expected skips. Expanded WP10 E2E passed 22 tests with 5 expected skips after the Watchlists mobile fix. Browser plugin was unavailable in this Codex session with `Browser is not available: iab`, so browser-observed QA used Playwright directly against the local Next dev server on port 18080. Desktop QA covered /admin, /admin/server, /mcp-hub, /sources, /connectors, /integrations, /scheduled-tasks, /watchlists, /workflow-editor, and /skills. Mobile QA covered /watchlists, /workflow-editor, and /mcp-hub. Inspected routes rendered expected content or recovery states with no readiness-gate or framework-overlay blockers. Console diagnostics had expected backend-offline fetch failures because the API server was intentionally not running, and no page errors. Static cleanup checks passed for touched files: git diff --check and trailing-whitespace scan. Clean-branch packaging on current `dev` preserved newer route/readiness behavior and reverified the final delta: ServerReadinessGate passed 8 tests, Watchlists orientation guidance passed 4 tests, SourcesWorkspacePage passed 8 tests, and focused Playwright Sources/placeholder routes passed 14 tests with 2 expected backend-dependent skips. Bandit was not applicable because this slice touched frontend TypeScript/E2E and Backlog metadata only; no Python code was changed. Remaining risk: this final QA validates offline/recovery rendering and route behavior, not live backend data paths.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-439 - Run-WebUI-operations-integrations-browser-QA-and-final-verification.md
+++ b/backlog/tasks/task-439 - Run-WebUI-operations-integrations-browser-QA-and-final-verification.md
@@ -2,6 +2,11 @@
 id: TASK-439
 title: Run WebUI operations integrations browser QA and final verification
 status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-19 19:24
+labels: []
+dependencies: []
 priority: medium
 modified_files:
 - apps/packages/ui/src/components/Option/Sources/SourcesWorkspacePage.tsx
@@ -37,6 +42,7 @@ Docs/superpowers/plans/2026-05-17-webui-operations-integrations-implementation-p
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Verification found two scoped defects before closeout.
 
@@ -45,11 +51,14 @@ Verification found two scoped defects before closeout.
 - Clean-branch E2E against current `dev` also exposed a backend-offline Sources shell that can keep showing loading under the heading. The Sources loading state now has a stable status/test hook, and the E2E only runs list/empty assertions after the page actually presents a finished data state.
 - Browser QA found a mobile Watchlists orientation alert layout defect where Ant `Alert.action` squeezed the title into single-character wrapping. The action buttons now live in the alert description block, and the mobile screenshot was rechecked.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Completed WP10 Task 7 verification. Route contract tests passed: 8 files / 21 tests. Component state tests passed: 6 files / 48 tests, plus ServerReadinessGate passed 1 file / 4 tests. Focused placeholder E2E passed 9 tests. Parent-required E2E passed 13 tests with 8 expected skips. Expanded WP10 E2E passed 22 tests with 5 expected skips after the Watchlists mobile fix. Browser plugin was unavailable in this Codex session with `Browser is not available: iab`, so browser-observed QA used Playwright directly against the local Next dev server on port 18080. Desktop QA covered /admin, /admin/server, /mcp-hub, /sources, /connectors, /integrations, /scheduled-tasks, /watchlists, /workflow-editor, and /skills. Mobile QA covered /watchlists, /workflow-editor, and /mcp-hub. Inspected routes rendered expected content or recovery states with no readiness-gate or framework-overlay blockers. Console diagnostics had expected backend-offline fetch failures because the API server was intentionally not running, and no page errors. Static cleanup checks passed for touched files: git diff --check and trailing-whitespace scan. Clean-branch packaging on current `dev` preserved newer route/readiness behavior and reverified the final delta: ServerReadinessGate passed 8 tests, Watchlists orientation guidance passed 4 tests, SourcesWorkspacePage passed 8 tests, and focused Playwright Sources/placeholder routes passed 14 tests with 2 expected backend-dependent skips. Bandit was not applicable because this slice touched frontend TypeScript/E2E and Backlog metadata only; no Python code was changed. Remaining risk: this final QA validates offline/recovery rendering and route behavior, not live backend data paths.
+
+PR review follow-up: addressed both unresolved Gemini review threads in sources.spec.ts by replacing the swallowed loading timeout with Playwright's explicit toBeHidden assertion, requiring server availability for the online-only content test, and preserving the source-list-or-empty-state assertion so blank online content fails. Focused Sources Playwright passed locally: 2 passed, 3 explicit backend-unavailable skips.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary

TODO: human-authored summary required before merge.

## What changed

- Preserves degraded-health server readiness behavior while letting the existing offline/test E2E flags bypass the global readiness gate.
- Makes Sources loading state explicit and updates Sources E2E helpers so backend-offline loading/recovery states are not misclassified as an online list state.
- Keeps Watchlists repeat-user shortcuts visible near the health bar and moves orientation alert actions into the description block to avoid mobile title wrapping.
- Records TASK-439 verification evidence and clean-branch packaging notes.

## Verification

- `bunx vitest run components/networking/__tests__/ServerReadinessGate.test.tsx`
  - 1 file passed, 8 tests passed.
- `bunx vitest run src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.orientation-guidance.test.tsx`
  - 1 file passed, 4 tests passed.
- `bunx vitest run src/components/Option/Sources/__tests__/SourcesWorkspacePage.test.tsx`
  - 1 file passed, 8 tests passed.
- `TLDW_WEB_URL=http://localhost:18082 TLDW_WEB_CMD="bun run dev -- -p 18082" bunx playwright test e2e/workflows/tier-2-features/sources.spec.ts e2e/workflows/hosted-placeholder-routes.spec.ts e2e/workflows/route-placeholder-settings.spec.ts --reporter=line --workers=1`
  - 14 passed, 2 skipped.
- `git diff --check`
  - Passed.
- Conflict-marker and trailing-whitespace scans on touched files
  - Passed.

## Notes

- Bandit is not applicable; this PR touches frontend TypeScript/TSX, Playwright tests, and Backlog Markdown only.
- The Sources E2E still does not validate live backend data paths. It validates offline/recovery/loading behavior and route accessibility without the API server.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened server readiness and stabilized Sources/Watchlists states to verify operations/integrations routes. Addresses TASK-439 by honoring offline/test bypass flags and clarifying loading/unavailable UI and tests.

- Bug Fixes
  - ServerReadinessGate: honors `__tldw_allow_offline` and `__tldw_test_bypass` at init and during checks; skips health probes; preserves degraded behavior; adds tests.
  - Sources: explicit loading state with ARIA/test id; page object recognizes loading and “Cannot reach Sources”; stabilized heading locator; scoped spinner locator to the Sources test id; E2E waits for loading to hide and skips online-only checks when the server is unavailable.
  - Watchlists: keeps repeat-user shortcuts near the health bar; moves orientation actions into the description to prevent mobile title wrapping; adds a command palette shortcut.

<sup>Written for commit a39df9f6f4ab878646f68d3fc3e98d1b05c03949. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1869?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

