### PR TITLE
Lock WebUI audio route ownership

### DIFF
--- a/apps/packages/ui/src/routes/__tests__/audio-route-jobs.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/audio-route-jobs.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+import { AUDIO_ROUTE_JOBS } from "../audio-route-jobs"
+
+const routes = [
+  "/audio",
+  "/speech",
+  "/stt",
+  "/tts",
+  "/audiobook-studio"
+] as const
+
+const findings = [
+  "F2 support",
+  "F9 support",
+  "F15 support",
+  "F18 support",
+  "F19 support"
+] as const
+
+describe("audio route jobs", () => {
+  it("covers every WP11A root audio route once", () => {
+    expect(AUDIO_ROUTE_JOBS.map((job) => job.route).sort()).toEqual(
+      Array.from(routes).sort()
+    )
+  })
+
+  it("keeps route labels and primary jobs usable", () => {
+    for (const job of AUDIO_ROUTE_JOBS) {
+      expect(job.label).not.toHaveLength(0)
+      expect(job.primaryJob).not.toHaveLength(0)
+      expect(job.primaryActionLabel).not.toHaveLength(0)
+      expect(job.canonicalComponent).not.toHaveLength(0)
+    }
+  })
+
+  it("maps the audit findings into implementation coverage", () => {
+    const covered = new Set(AUDIO_ROUTE_JOBS.flatMap((job) => job.findings))
+
+    for (const finding of findings) {
+      expect(covered.has(finding)).toBe(true)
+    }
+  })
+
+  it("preserves canonical ownership for overlapping audio routes", () => {
+    expect(AUDIO_ROUTE_JOBS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          route: "/audio",
+          concept: "audio_alias",
+          routeOwner: "next_alias",
+          canonicalComponent: "RouteRedirect:/speech",
+          routeStatePolicy: "alias"
+        }),
+        expect.objectContaining({
+          route: "/speech",
+          concept: "speech_combined",
+          routeOwner: "shared_route",
+          canonicalComponent: "SpeechPlaygroundPage",
+          routeStatePolicy: "ready_or_recoverable"
+        }),
+        expect.objectContaining({
+          route: "/stt",
+          concept: "stt",
+          routeOwner: "shared_route",
+          canonicalComponent: "SttPlaygroundPage",
+          routeStatePolicy: "ready_or_recoverable"
+        }),
+        expect.objectContaining({
+          route: "/tts",
+          concept: "tts",
+          routeOwner: "shared_route",
+          canonicalComponent: "SpeechPlaygroundPage:listen",
+          routeStatePolicy: "ready_or_recoverable"
+        }),
+        expect.objectContaining({
+          route: "/audiobook-studio",
+          concept: "audiobook",
+          routeOwner: "shared_route",
+          canonicalComponent: "AudiobookStudioPage",
+          routeStatePolicy: "beta_ready_or_recoverable"
+        })
+      ])
+    )
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/audio-route-jobs.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/audio-route-jobs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { AUDIO_ROUTE_JOBS } from "../audio-route-jobs"
+import { AUDIO_ROUTE_FINDINGS, AUDIO_ROUTE_JOBS } from "../audio-route-jobs"
+import { getRouteMetadata } from "../route-metadata"
 
 const routes = [
   "/audio",
@@ -9,14 +10,6 @@ const routes = [
   "/audiobook-studio"
 ] as const
 
-const findings = [
-  "F2 support",
-  "F9 support",
-  "F15 support",
-  "F18 support",
-  "F19 support"
-] as const
-
 describe("audio route jobs", () => {
   it("covers every WP11A root audio route once", () => {
     expect(AUDIO_ROUTE_JOBS.map((job) => job.route).sort()).toEqual(
@@ -24,11 +17,24 @@ describe("audio route jobs", () => {
     )
   })
 
-  it("keeps route labels and primary jobs usable", () => {
+  it("keeps route labels aligned with route metadata", () => {
     for (const job of AUDIO_ROUTE_JOBS) {
-      expect(job.label).not.toHaveLength(0)
-      expect(job.primaryJob).not.toHaveLength(0)
-      expect(job.primaryActionLabel).not.toHaveLength(0)
+      expect(job.copy.label.fallback).toBe(getRouteMetadata(job.route)?.label)
+    }
+  })
+
+  it("keeps route copy behind stable translation keys and fallbacks", () => {
+    for (const job of AUDIO_ROUTE_JOBS) {
+      const copyPrefix = `routes.audio.${job.concept}`
+
+      expect(job.copy.label.key).toBe(`${copyPrefix}.label`)
+      expect(job.copy.primaryJob.key).toBe(`${copyPrefix}.primaryJob`)
+      expect(job.copy.primaryActionLabel.key).toBe(
+        `${copyPrefix}.primaryActionLabel`
+      )
+      expect(job.copy.label.fallback).not.toHaveLength(0)
+      expect(job.copy.primaryJob.fallback).not.toHaveLength(0)
+      expect(job.copy.primaryActionLabel.fallback).not.toHaveLength(0)
       expect(job.canonicalComponent).not.toHaveLength(0)
     }
   })
@@ -36,7 +42,7 @@ describe("audio route jobs", () => {
   it("maps the audit findings into implementation coverage", () => {
     const covered = new Set(AUDIO_ROUTE_JOBS.flatMap((job) => job.findings))
 
-    for (const finding of findings) {
+    for (const finding of AUDIO_ROUTE_FINDINGS) {
       expect(covered.has(finding)).toBe(true)
     }
   })
@@ -47,8 +53,8 @@ describe("audio route jobs", () => {
         expect.objectContaining({
           route: "/audio",
           concept: "audio_alias",
-          routeOwner: "next_alias",
-          canonicalComponent: "RouteRedirect:/speech",
+          routeOwner: "shared_alias",
+          canonicalComponent: "RouteAliasNavigate:/speech",
           routeStatePolicy: "alias"
         }),
         expect.objectContaining({

--- a/apps/packages/ui/src/routes/__tests__/route-registry.visibility.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.visibility.test.ts
@@ -183,6 +183,15 @@ describe("route registry visibility metadata", () => {
     }
   })
 
+  it("registers the legacy audio redirect alias in the shared WebUI router", () => {
+    expect(optionRegistryPaths).toContain("/audio")
+    expect(getRouteMetadata("/audio")).toMatchObject({
+      canonicalPath: "/speech",
+      redirectsTo: "/speech",
+      surface: "redirect"
+    })
+  })
+
   it("keeps internal QA and debug routes out of primary navigation", () => {
     for (const metadata of ROUTE_METADATA) {
       if (metadata.surface !== "internal_qa_debug") {

--- a/apps/packages/ui/src/routes/audio-route-jobs.ts
+++ b/apps/packages/ui/src/routes/audio-route-jobs.ts
@@ -5,10 +5,7 @@ export type AudioRouteConcept =
   | "tts"
   | "audiobook"
 
-export type AudioRouteOwner =
-  | "next_alias"
-  | "shared_route"
-  | "extension_route"
+export type AudioRouteOwner = "shared_alias" | "shared_route"
 
 export type AudioRouteCapability =
   | "hosted_gate"
@@ -20,19 +17,37 @@ export type AudioRouteCapability =
   | "project_state"
   | "generation_state"
 
-export type AudioRouteFinding =
-  | "F2 support"
-  | "F9 support"
-  | "F15 support"
-  | "F18 support"
-  | "F19 support"
+export const AUDIO_ROUTE_FINDINGS = [
+  "F2 support",
+  "F9 support",
+  "F15 support",
+  "F18 support",
+  "F19 support"
+] as const
+
+export type AudioRouteFinding = (typeof AUDIO_ROUTE_FINDINGS)[number]
+export type AudioRouteCopyField =
+  | "label"
+  | "primaryJob"
+  | "primaryActionLabel"
+export type AudioRouteCopyKey =
+  `routes.audio.${AudioRouteConcept}.${AudioRouteCopyField}`
+
+export type AudioRouteCopyText = {
+  key: AudioRouteCopyKey
+  fallback: string
+}
+
+export type AudioRouteCopy = {
+  label: AudioRouteCopyText
+  primaryJob: AudioRouteCopyText
+  primaryActionLabel: AudioRouteCopyText
+}
 
 export type AudioRouteJob = {
   route: "/audio" | "/speech" | "/stt" | "/tts" | "/audiobook-studio"
   concept: AudioRouteConcept
-  label: string
-  primaryJob: string
-  primaryActionLabel: string
+  copy: AudioRouteCopy
   routeOwner: AudioRouteOwner
   canonicalComponent: string
   capabilities: AudioRouteCapability[]
@@ -40,15 +55,38 @@ export type AudioRouteJob = {
   findings: AudioRouteFinding[]
 }
 
+const audioRouteCopy = (
+  concept: AudioRouteConcept,
+  labelFallback: string,
+  primaryJobFallback: string,
+  primaryActionLabelFallback: string
+): AudioRouteCopy => ({
+  label: {
+    key: `routes.audio.${concept}.label`,
+    fallback: labelFallback
+  },
+  primaryJob: {
+    key: `routes.audio.${concept}.primaryJob`,
+    fallback: primaryJobFallback
+  },
+  primaryActionLabel: {
+    key: `routes.audio.${concept}.primaryActionLabel`,
+    fallback: primaryActionLabelFallback
+  }
+})
+
 export const AUDIO_ROUTE_JOBS: AudioRouteJob[] = [
   {
     route: "/audio",
     concept: "audio_alias",
-    label: "Audio",
-    primaryJob: "Open the canonical combined speech route from old links and bookmarks.",
-    primaryActionLabel: "Open Speech Playground",
-    routeOwner: "next_alias",
-    canonicalComponent: "RouteRedirect:/speech",
+    copy: audioRouteCopy(
+      "audio_alias",
+      "Audio",
+      "Open the canonical combined speech route from old links and bookmarks.",
+      "Open Speech"
+    ),
+    routeOwner: "shared_alias",
+    canonicalComponent: "RouteAliasNavigate:/speech",
     capabilities: [],
     routeStatePolicy: "alias",
     findings: ["F2 support", "F18 support", "F19 support"]
@@ -56,9 +94,12 @@ export const AUDIO_ROUTE_JOBS: AudioRouteJob[] = [
   {
     route: "/speech",
     concept: "speech_combined",
-    label: "Speech Playground",
-    primaryJob: "Record, transcribe, edit, and synthesize audio in one workspace.",
-    primaryActionLabel: "Start audio workflow",
+    copy: audioRouteCopy(
+      "speech_combined",
+      "Speech",
+      "Record, transcribe, edit, and synthesize audio in one workspace.",
+      "Start audio workflow"
+    ),
     routeOwner: "shared_route",
     canonicalComponent: "SpeechPlaygroundPage",
     capabilities: [
@@ -80,9 +121,12 @@ export const AUDIO_ROUTE_JOBS: AudioRouteJob[] = [
   {
     route: "/stt",
     concept: "stt",
-    label: "STT Playground",
-    primaryJob: "Transcribe audio and compare transcription results.",
-    primaryActionLabel: "Start transcription",
+    copy: audioRouteCopy(
+      "stt",
+      "Speech to Text",
+      "Transcribe audio and compare transcription results.",
+      "Start transcription"
+    ),
     routeOwner: "shared_route",
     canonicalComponent: "SttPlaygroundPage",
     capabilities: [
@@ -103,9 +147,12 @@ export const AUDIO_ROUTE_JOBS: AudioRouteJob[] = [
   {
     route: "/tts",
     concept: "tts",
-    label: "TTS Playground",
-    primaryJob: "Generate audio from text with provider, voice, and model controls.",
-    primaryActionLabel: "Generate speech",
+    copy: audioRouteCopy(
+      "tts",
+      "Text to Speech",
+      "Generate audio from text with provider, voice, and model controls.",
+      "Generate speech"
+    ),
     routeOwner: "shared_route",
     canonicalComponent: "SpeechPlaygroundPage:listen",
     capabilities: [
@@ -126,9 +173,12 @@ export const AUDIO_ROUTE_JOBS: AudioRouteJob[] = [
   {
     route: "/audiobook-studio",
     concept: "audiobook",
-    label: "Audiobook Studio",
-    primaryJob: "Create long-form audiobook projects from text and generated speech.",
-    primaryActionLabel: "Create project",
+    copy: audioRouteCopy(
+      "audiobook",
+      "Audiobook Studio",
+      "Create long-form audiobook projects from text and generated speech.",
+      "Create project"
+    ),
     routeOwner: "shared_route",
     canonicalComponent: "AudiobookStudioPage",
     capabilities: [

--- a/apps/packages/ui/src/routes/audio-route-jobs.ts
+++ b/apps/packages/ui/src/routes/audio-route-jobs.ts
@@ -1,0 +1,154 @@
+export type AudioRouteConcept =
+  | "audio_alias"
+  | "speech_combined"
+  | "stt"
+  | "tts"
+  | "audiobook"
+
+export type AudioRouteOwner =
+  | "next_alias"
+  | "shared_route"
+  | "extension_route"
+
+export type AudioRouteCapability =
+  | "hosted_gate"
+  | "server_capability"
+  | "provider_config"
+  | "model_catalog"
+  | "voice_catalog"
+  | "recording_source"
+  | "project_state"
+  | "generation_state"
+
+export type AudioRouteFinding =
+  | "F2 support"
+  | "F9 support"
+  | "F15 support"
+  | "F18 support"
+  | "F19 support"
+
+export type AudioRouteJob = {
+  route: "/audio" | "/speech" | "/stt" | "/tts" | "/audiobook-studio"
+  concept: AudioRouteConcept
+  label: string
+  primaryJob: string
+  primaryActionLabel: string
+  routeOwner: AudioRouteOwner
+  canonicalComponent: string
+  capabilities: AudioRouteCapability[]
+  routeStatePolicy: "alias" | "ready_or_recoverable" | "beta_ready_or_recoverable"
+  findings: AudioRouteFinding[]
+}
+
+export const AUDIO_ROUTE_JOBS: AudioRouteJob[] = [
+  {
+    route: "/audio",
+    concept: "audio_alias",
+    label: "Audio",
+    primaryJob: "Open the canonical combined speech route from old links and bookmarks.",
+    primaryActionLabel: "Open Speech Playground",
+    routeOwner: "next_alias",
+    canonicalComponent: "RouteRedirect:/speech",
+    capabilities: [],
+    routeStatePolicy: "alias",
+    findings: ["F2 support", "F18 support", "F19 support"]
+  },
+  {
+    route: "/speech",
+    concept: "speech_combined",
+    label: "Speech Playground",
+    primaryJob: "Record, transcribe, edit, and synthesize audio in one workspace.",
+    primaryActionLabel: "Start audio workflow",
+    routeOwner: "shared_route",
+    canonicalComponent: "SpeechPlaygroundPage",
+    capabilities: [
+      "server_capability",
+      "provider_config",
+      "model_catalog",
+      "voice_catalog",
+      "recording_source"
+    ],
+    routeStatePolicy: "ready_or_recoverable",
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ]
+  },
+  {
+    route: "/stt",
+    concept: "stt",
+    label: "STT Playground",
+    primaryJob: "Transcribe audio and compare transcription results.",
+    primaryActionLabel: "Start transcription",
+    routeOwner: "shared_route",
+    canonicalComponent: "SttPlaygroundPage",
+    capabilities: [
+      "hosted_gate",
+      "server_capability",
+      "model_catalog",
+      "recording_source"
+    ],
+    routeStatePolicy: "ready_or_recoverable",
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ]
+  },
+  {
+    route: "/tts",
+    concept: "tts",
+    label: "TTS Playground",
+    primaryJob: "Generate audio from text with provider, voice, and model controls.",
+    primaryActionLabel: "Generate speech",
+    routeOwner: "shared_route",
+    canonicalComponent: "SpeechPlaygroundPage:listen",
+    capabilities: [
+      "hosted_gate",
+      "server_capability",
+      "provider_config",
+      "voice_catalog"
+    ],
+    routeStatePolicy: "ready_or_recoverable",
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ]
+  },
+  {
+    route: "/audiobook-studio",
+    concept: "audiobook",
+    label: "Audiobook Studio",
+    primaryJob: "Create long-form audiobook projects from text and generated speech.",
+    primaryActionLabel: "Create project",
+    routeOwner: "shared_route",
+    canonicalComponent: "AudiobookStudioPage",
+    capabilities: [
+      "provider_config",
+      "voice_catalog",
+      "project_state",
+      "generation_state"
+    ],
+    routeStatePolicy: "beta_ready_or_recoverable",
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ]
+  }
+]
+
+export const getAudioRouteJob = (
+  route: AudioRouteJob["route"]
+): AudioRouteJob | undefined =>
+  AUDIO_ROUTE_JOBS.find((job) => job.route === route)

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -407,6 +407,7 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
   { kind: "options", path: "/prompts", element: <OptionPromptsWorkspace /> },
   // Legacy route - redirect to unified Prompts page
   { kind: "options", path: "/prompt-studio", element: <Navigate to="/prompts?tab=studio" replace /> },
+  { kind: "options", path: "/audio", element: <RouteAliasNavigate to="/speech" /> },
   { kind: "options", path: "/tts", element: <OptionTts /> },
   { kind: "options", path: "/stt", element: <OptionStt /> },
   { kind: "options", path: "/speech", element: <OptionSpeech /> },

--- a/backlog/tasks/task-446 - Implement-WebUI-audio-route-ownership-contract.md
+++ b/backlog/tasks/task-446 - Implement-WebUI-audio-route-ownership-contract.md
@@ -1,0 +1,54 @@
+---
+id: TASK-446
+title: Implement WebUI audio route ownership contract
+status: Done
+labels:
+- webui
+- ux-audit
+- audio
+- wp11a
+priority: medium
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-audio-routes-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/routes/audio-route-jobs.ts
+- apps/packages/ui/src/routes/__tests__/audio-route-jobs.test.ts
+- backlog/tasks/task-446 - Implement-WebUI-audio-route-ownership-contract.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP11A Task 1 from the WebUI audio routes implementation plan. Add a pure audio route-job contract and focused route identity coverage for /audio, /speech, /stt, /tts, and /audiobook-studio. Keep the slice frontend metadata/test-only unless existing tests prove a route boundary or ownership mismatch that must be fixed in the same narrow scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Audio route-job inventory covers /audio, /speech, /stt, /tts, and /audiobook-studio exactly once.
+- [x] #2 Route-job contract records canonical route concept, owner, component, capability, route-state policy, and audit finding coverage for WP11A.
+- [x] #3 Focused route identity tests preserve /tts as SpeechPlaygroundPage locked to listen mode and keep /speech as the combined route.
+- [x] #4 The first route-job test is verified red before the contract is added, then green after implementation.
+- [x] #5 Relevant focused Vitest checks and git diff checks are recorded in the task final summary.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Red/green TDD cycle completed for the WP11A audio route-job contract. The initial focused Vitest run first failed because fresh worktree dependencies were not installed; after running bun install in apps, the route-job test failed for the expected missing ../audio-route-jobs import. Added a pure typed route metadata module covering /audio, /speech, /stt, /tts, and /audiobook-studio, including canonical concepts, owners, components, capability inputs, route-state policy, primary action labels, and audit finding coverage.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the WP11A audio route ownership contract as a frontend metadata/test-only slice. Added AUDIO_ROUTE_JOBS and getAudioRouteJob in apps/packages/ui/src/routes/audio-route-jobs.ts, plus focused tests covering the five root audio routes, user-facing labels/jobs, audit finding coverage, and canonical ownership for overlapping /audio, /speech, /stt, /tts, and /audiobook-studio behavior. Verification passed: audio-route-jobs test 4/4, audio route identity plus route-job tests 7/7, and related hosted/metadata/visibility checks 9/9. Bandit is not applicable because this slice only touched frontend TypeScript tests/data and Backlog metadata; no Python code changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-446 - Implement-WebUI-audio-route-ownership-contract.md
+++ b/backlog/tasks/task-446 - Implement-WebUI-audio-route-ownership-contract.md
@@ -12,7 +12,9 @@ documentation:
 - Docs/superpowers/plans/2026-05-17-webui-audio-routes-implementation-plan.md
 modified_files:
 - apps/packages/ui/src/routes/audio-route-jobs.ts
+- apps/packages/ui/src/routes/route-registry.tsx
 - apps/packages/ui/src/routes/__tests__/audio-route-jobs.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.visibility.test.ts
 - backlog/tasks/task-446 - Implement-WebUI-audio-route-ownership-contract.md
 ---
 
@@ -40,7 +42,7 @@ Red/green TDD cycle completed for the WP11A audio route-job contract. The initia
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the WP11A audio route ownership contract as a frontend metadata/test-only slice. Added AUDIO_ROUTE_JOBS and getAudioRouteJob in apps/packages/ui/src/routes/audio-route-jobs.ts, plus focused tests covering the five root audio routes, user-facing labels/jobs, audit finding coverage, and canonical ownership for overlapping /audio, /speech, /stt, /tts, and /audiobook-studio behavior. Verification passed: audio-route-jobs test 4/4, audio route identity plus route-job tests 7/7, and related hosted/metadata/visibility checks 9/9. Bandit is not applicable because this slice only touched frontend TypeScript tests/data and Backlog metadata; no Python code changed.
+Implemented PR #1870 review fixes for the WP11A audio route ownership contract. /audio is now registered in the shared WebUI route registry as a RouteAliasNavigate alias to /speech, preventing the previous 404 fallback for legacy audio links. AUDIO_ROUTE_JOBS now derives finding values from AUDIO_ROUTE_FINDINGS, removes the unused extension_route owner, uses typed translation-key copy records with metadata-aligned fallback labels, and reflects the actual /audio alias mechanism. Verification passed: red-focused Vitest failures reproduced before implementation; focused audio-route/registry tests passed 10/10; adjacent audio route, metadata, visibility, and RouteAliasNavigate tests passed 25/25; git diff --check passed. Direct package tsc still fails on existing unrelated TypeScript debt across tests/components, including a pre-existing OptionPublicShare prop issue in route-registry.tsx; no errors referenced audio-route-jobs or the new /audio alias line. Bandit is not applicable because only frontend TypeScript/tests and task metadata changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- add a pure WP11A audio route-job contract for /audio, /speech, /stt, /tts, and /audiobook-studio
- cover canonical route ownership, primary jobs/actions, capability inputs, route-state policy, and audit finding mapping
- record TASK-446 red/green verification and focused route checks

## Verification
- bunx vitest run src/routes/__tests__/audio-route-jobs.test.ts
- bunx vitest run src/routes/__tests__/audio-route-jobs.test.ts src/routes/__tests__/option-audio-route-identity.test.tsx
- bunx vitest run src/routes/__tests__/option-audio-hosted-message.test.tsx src/routes/__tests__/route-metadata.coverage.test.ts src/routes/__tests__/option-route-visibility.test.ts
- git diff --check

## Change summary
TODO: human-authored summary required before merge.

## Notes
Bandit is not applicable; this slice changes frontend TypeScript route metadata/tests and Backlog metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks WebUI audio route ownership with a typed route-job contract and a router alias for legacy `/audio`. Keeps `/audio` → `/speech` redirect, `/speech` as the combined workspace, and `/tts` listen mode consistent. Addresses TASK-446.

- New Features
  - Added `AUDIO_ROUTE_JOBS` and `getAudioRouteJob` with typed i18n copy (stable keys + fallbacks), canonical components, capabilities, and route-state policies for `/audio`, `/speech`, `/stt`, `/tts`, `/audiobook-studio`.
  - Registered `/audio` in the shared router as `RouteAliasNavigate:/speech` and added a visibility test to lock redirect metadata.
  - Introduced `AUDIO_ROUTE_FINDINGS` and mapped F2, F9, F15, F18, F19 to coverage via tests; preserved canonical ownership across overlapping routes.

<sup>Written for commit 21c53db7cf4c1a040b98adc963e6aaa958e0e65a. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1870?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

