### PR TITLE
Fix Character Chat readiness for unconfigured models

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -123,6 +123,7 @@ import {
 } from "@/utils/character-chat-mode-intent";
 import {
   buildCharacterChatReadiness,
+  getCharacterChatReadinessCopy,
   type CharacterChatReadinessAction,
 } from "@/utils/chat-model-availability";
 import type { Character } from "@/types/character";
@@ -249,7 +250,7 @@ export const Playground = () => {
   React.useEffect(() => {
     let cancelled = false;
 
-    void fetchChatModels({ returnEmpty: true })
+    void fetchChatModels({ returnEmpty: true, forceRefresh: true })
       .then((models) => {
         if (cancelled) return;
         setCharacterChatAvailableModels(Array.isArray(models) ? models : []);
@@ -2063,6 +2064,25 @@ export const Playground = () => {
       streaming,
     ],
   );
+  const characterChatBlocked =
+    characterWorkflowActive && characterChatReadiness.status === "blocked";
+  const characterChatModelBlocked =
+    characterChatBlocked &&
+    characterChatReadiness.missingRequirement === "chat-model";
+  const characterChatReadinessCopy = React.useMemo(
+    () =>
+      characterChatBlocked
+        ? getCharacterChatReadinessCopy(characterChatReadiness, t, {
+            characterName: activeCharacterModeLabel,
+          })
+        : null,
+    [
+      activeCharacterModeLabel,
+      characterChatBlocked,
+      characterChatReadiness,
+      t,
+    ],
+  );
   React.useEffect(() => {
     if (typeof setActiveSettingsScope === "function") {
       setActiveSettingsScope(providerRouteSummary.providerRouteLabel ?? null);
@@ -2408,6 +2428,8 @@ export const Playground = () => {
     toolSummary: cockpitToolSummary,
     compositionStatus,
     composition: null,
+    modelUnavailable: characterChatModelBlocked,
+    modelUnavailableDetail: characterChatReadinessCopy?.title ?? null,
   });
   const openModelSettingsFromCockpit = React.useCallback(() => {
     if (typeof setActiveSettingsScope === "function") {
@@ -2555,7 +2577,9 @@ export const Playground = () => {
       selectedModel={providerRouteSummary.selectedModel}
       providerRouteLabel={providerRouteSummary.providerRouteLabel}
       runtimeStatus={
-        serverReadinessState === "blocked"
+        characterChatBlocked
+          ? "error"
+          : serverReadinessState === "blocked"
           ? "error"
           : streaming
           ? "streaming"
@@ -2563,7 +2587,7 @@ export const Playground = () => {
             ? "degraded"
             : "ready"
       }
-      runtimeStatusDetail={runtimeStatusDetail}
+      runtimeStatusDetail={characterChatReadinessCopy?.title ?? runtimeStatusDetail}
       messageCount={cockpitMessageCount}
       threadSearchOpen={threadSearchOpen}
       assistantSummary={cockpitAssistantSummary}
@@ -2605,6 +2629,8 @@ export const Playground = () => {
       degradedChecks={serverDegradedChecks}
       errorMessage={null}
       serverBlocked={serverReadinessState === "blocked"}
+      modelUnavailable={characterChatModelBlocked}
+      modelUnavailableMessage={characterChatReadinessCopy?.title ?? null}
       compositionStatus={compositionStatus}
       onStopStreaming={() => stopStreamingRequest()}
       onOpenSearchContext={() => openSearchAndContext({ tab: "context" })}

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -2577,9 +2577,7 @@ export const Playground = () => {
       selectedModel={providerRouteSummary.selectedModel}
       providerRouteLabel={providerRouteSummary.providerRouteLabel}
       runtimeStatus={
-        characterChatBlocked
-          ? "error"
-          : serverReadinessState === "blocked"
+        characterChatBlocked || serverReadinessState === "blocked"
           ? "error"
           : streaming
           ? "streaming"

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -2577,7 +2577,7 @@ export const Playground = () => {
       selectedModel={providerRouteSummary.selectedModel}
       providerRouteLabel={providerRouteSummary.providerRouteLabel}
       runtimeStatus={
-        characterChatBlocked || serverReadinessState === "blocked"
+        characterChatModelBlocked || serverReadinessState === "blocked"
           ? "error"
           : streaming
           ? "streaming"

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -2066,9 +2066,10 @@ export const Playground = () => {
   );
   const characterChatBlocked =
     characterWorkflowActive && characterChatReadiness.status === "blocked";
-  const characterChatModelBlocked =
+  const characterChatModelUnavailable =
     characterChatBlocked &&
-    characterChatReadiness.missingRequirement === "chat-model";
+    (characterChatReadiness.reason === "selected-model-unavailable" ||
+      characterChatReadiness.reason === "no-models-available");
   const characterChatReadinessCopy = React.useMemo(
     () =>
       characterChatBlocked
@@ -2428,7 +2429,7 @@ export const Playground = () => {
     toolSummary: cockpitToolSummary,
     compositionStatus,
     composition: null,
-    modelUnavailable: characterChatModelBlocked,
+    modelUnavailable: characterChatModelUnavailable,
     modelUnavailableDetail: characterChatReadinessCopy?.title ?? null,
   });
   const openModelSettingsFromCockpit = React.useCallback(() => {
@@ -2577,7 +2578,7 @@ export const Playground = () => {
       selectedModel={providerRouteSummary.selectedModel}
       providerRouteLabel={providerRouteSummary.providerRouteLabel}
       runtimeStatus={
-        characterChatModelBlocked || serverReadinessState === "blocked"
+        characterChatModelUnavailable || serverReadinessState === "blocked"
           ? "error"
           : streaming
           ? "streaming"
@@ -2627,7 +2628,7 @@ export const Playground = () => {
       degradedChecks={serverDegradedChecks}
       errorMessage={null}
       serverBlocked={serverReadinessState === "blocked"}
-      modelUnavailable={characterChatModelBlocked}
+      modelUnavailable={characterChatModelUnavailable}
       modelUnavailableMessage={characterChatReadinessCopy?.title ?? null}
       compositionStatus={compositionStatus}
       onStopStreaming={() => stopStreamingRequest()}

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
@@ -31,6 +31,7 @@ type PlaygroundStatusStripRuntimeState =
   | "streaming"
   | "loading"
   | "missing-model"
+  | "model-unavailable"
   | "degraded"
   | "ready";
 
@@ -60,6 +61,8 @@ export type PlaygroundStatusStripProps = {
   degradedChecks?: string[];
   errorMessage?: string | null;
   serverBlocked?: boolean;
+  modelUnavailable?: boolean;
+  modelUnavailableMessage?: string | null;
   compositionStatus?: PlaygroundStatusStripCompositionStatus;
   onStopStreaming?: () => void;
   onOpenSearchContext?: () => void;
@@ -89,6 +92,8 @@ export const PlaygroundStatusStrip = ({
   degradedChecks = [],
   errorMessage,
   serverBlocked = false,
+  modelUnavailable = false,
+  modelUnavailableMessage = null,
   compositionStatus = "idle",
   onStopStreaming,
   onOpenSearchContext,
@@ -107,6 +112,8 @@ export const PlaygroundStatusStrip = ({
         ? "streaming"
         : isContextLoading
           ? "loading"
+          : modelUnavailable
+            ? "model-unavailable"
           : !hasSelectedModel
             ? "missing-model"
             : isDegraded
@@ -129,6 +136,8 @@ export const PlaygroundStatusStrip = ({
             ? t("cockpit.loadingContext", `${LOADING_STATE_LABEL} context`)
             : runtimeState === "missing-model"
               ? t("cockpit.noModelSelected", "No model selected")
+              : runtimeState === "model-unavailable"
+                ? t("cockpit.modelUnavailable", "Model unavailable")
               : runtimeState === "degraded"
                 ? t("cockpit.degraded", DEGRADED_STATE_LABEL)
                 : t("cockpit.ready", READY_STATE_LABEL);
@@ -156,6 +165,14 @@ export const PlaygroundStatusStrip = ({
       ? t(
           "cockpit.chooseModelBeforeSending",
           "Choose a model before sending.",
+        )
+      : null;
+  const modelUnavailableReason =
+    runtimeState === "model-unavailable"
+      ? modelUnavailableMessage ||
+        t(
+          "cockpit.reviewModelBeforeSending",
+          "Review model settings before sending.",
         )
       : null;
   const contextLoadingReason =
@@ -210,7 +227,8 @@ export const PlaygroundStatusStrip = ({
             runtimeState === "error" || runtimeState === "server-blocked"
               ? "border-error/40 bg-error/10 text-error"
               : runtimeState === "degraded" ||
-                  runtimeState === "missing-model"
+                  runtimeState === "missing-model" ||
+                  runtimeState === "model-unavailable"
                 ? "border-warning/40 bg-warning/10 text-warning"
                 : runtimeState === "streaming" || runtimeState === "loading"
                   ? "border-info/40 bg-info/10 text-info"
@@ -219,7 +237,8 @@ export const PlaygroundStatusStrip = ({
         >
           {runtimeState === "error" ||
           runtimeState === "server-blocked" ||
-          runtimeState === "missing-model" ? (
+          runtimeState === "missing-model" ||
+          runtimeState === "model-unavailable" ? (
             <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
           ) : runtimeState === "streaming" || runtimeState === "loading" ? (
             <Loader2 className="h-3.5 w-3.5" aria-hidden="true" />
@@ -264,6 +283,9 @@ export const PlaygroundStatusStrip = ({
             ) : null}
             {missingModelReason ? (
               <span className={pillClass}>{missingModelReason}</span>
+            ) : null}
+            {modelUnavailableReason ? (
+              <span className={pillClass}>{modelUnavailableReason}</span>
             ) : null}
             {contextLoadingReason ? (
               <span className={pillClass}>{contextLoadingReason}</span>
@@ -324,7 +346,9 @@ export const PlaygroundStatusStrip = ({
             <Settings2 className="h-3 w-3" aria-hidden="true" />
             {t("cockpit.reviewSettings", "Review settings")}
           </button>
-        ) : !hasSelectedModel && onOpenModelSettings ? (
+        ) : (runtimeState === "missing-model" ||
+            runtimeState === "model-unavailable") &&
+          onOpenModelSettings ? (
           <button
             type="button"
             className={actionClass}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx
@@ -123,7 +123,7 @@ describe("CharacterChatReadinessPanel", () => {
           isServerConnected: true,
           selectedCharacter: { id: "ariadne", name: "Ariadne" },
           selectedModel: "gpt-4o-mini",
-          availableModels: [{ model: "gpt-4o-mini" }],
+          availableModels: [{ model: "gpt-4o-mini", is_configured: true }],
         })}
         characterName="Ariadne"
         onAction={vi.fn()}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -87,6 +87,8 @@ const tldwServerState = vi.hoisted(() => ({
     {
       model: "openai:gpt-4.1-mini",
       provider: "openai",
+      is_configured: true,
+      provider_is_configured: true,
     },
   ]),
 }));
@@ -324,6 +326,8 @@ describe("Playground cockpit shell", () => {
       {
         model: "openai:gpt-4.1-mini",
         provider: "openai",
+        is_configured: true,
+        provider_is_configured: true,
       },
     ]);
     tldwClientState.getCharacter.mockImplementation(async (id: string | number) => ({
@@ -352,6 +356,12 @@ describe("Playground cockpit shell", () => {
     ).toHaveTextContent("Context and runtime rails visible.");
     expect(screen.getByTestId("playground-chat")).toBeInTheDocument();
     expect(screen.getByTestId("playground-form")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(tldwServerState.fetchChatModels).toHaveBeenCalledWith({
+        returnEmpty: true,
+        forceRefresh: true,
+      });
+    });
   });
 
   it("shows the starter deck for a true blank chat state", async () => {
@@ -530,7 +540,9 @@ describe("Playground cockpit shell", () => {
       render(<Playground />);
 
       expect(
-        await screen.findByText("Choose a chat model before chatting as Ariadne"),
+        within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
+          "Choose a chat model before chatting as Ariadne",
+        ),
       ).toBeInTheDocument();
 
       fireEvent.click(
@@ -566,13 +578,54 @@ describe("Playground cockpit shell", () => {
       {
         model: "openai:gpt-4.1-mini",
         provider: "openai",
+        is_configured: true,
+        provider_is_configured: true,
       },
     ]);
 
     render(<Playground />);
 
     expect(
-      await screen.findByText("Choose a chat model before chatting as Ariadne"),
+      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
+        "Choose a chat model before chatting as Ariadne",
+      ),
+    ).toBeInTheDocument();
+    const chatStatus = screen.getByRole("status", { name: "Chat status" });
+    expect(chatStatus).toHaveTextContent("Model unavailable");
+    expect(chatStatus).not.toHaveTextContent("Ready");
+  });
+
+  it("does not treat catalog-only backend models as ready for character chat", async () => {
+    storageState.values.set("playgroundChatWorkflowMode", "character");
+    messageOptionState.value.selectedCharacter = {
+      id: "char-1",
+      name: "Ariadne",
+    };
+    messageOptionState.value.selectedModel = "tldw:gpt-4o";
+    tldwServerState.fetchChatModels.mockResolvedValueOnce([
+      {
+        id: "gpt-4o",
+        model: "tldw:gpt-4o",
+        provider: "openai",
+        is_configured: false,
+        provider_is_configured: false,
+        catalog_only: true,
+      } as any,
+      {
+        id: "gemma3:1b",
+        model: "tldw:gemma3:1b",
+        provider: "ollama",
+        is_configured: true,
+        provider_is_configured: true,
+      } as any,
+    ]);
+
+    render(<Playground />);
+
+    expect(
+      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
+        "Choose a chat model before chatting as Ariadne",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -588,7 +641,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     expect(
-      await screen.findByText("Character chat is preparing"),
+      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
+        "Character chat is preparing",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -612,7 +667,9 @@ describe("Playground cockpit shell", () => {
       );
 
       expect(
-        await screen.findByText("Connect to tldw_server before starting character chat"),
+        within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
+          "Connect to tldw_server before starting character chat",
+        ),
       ).toBeInTheDocument();
 
       fireEvent.click(screen.getByRole("button", { name: "Open server settings" }));

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -645,6 +645,9 @@ describe("Playground cockpit shell", () => {
         "Character chat is preparing",
       ),
     ).toBeInTheDocument();
+    const runtimeRail = screen.getByTestId("playground-cockpit-right-rail");
+    expect(within(runtimeRail).getByText("Streaming")).toBeInTheDocument();
+    expect(within(runtimeRail).queryByText("Error")).not.toBeInTheDocument();
   });
 
   it("surfaces blocked server readiness locally in Character Chat mode", async () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -595,6 +595,26 @@ describe("Playground cockpit shell", () => {
     expect(chatStatus).not.toHaveTextContent("Ready");
   });
 
+  it("keeps empty character chat model selection in the missing-model status", async () => {
+    storageState.values.set("playgroundChatWorkflowMode", "character");
+    messageOptionState.value.selectedCharacter = {
+      id: "char-1",
+      name: "Ariadne",
+    };
+    messageOptionState.value.selectedModel = "";
+
+    render(<Playground />);
+
+    expect(
+      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
+        "Choose a chat model before chatting as Ariadne",
+      ),
+    ).toBeInTheDocument();
+    const chatStatus = screen.getByRole("status", { name: "Chat status" });
+    expect(chatStatus).toHaveTextContent("No model selected");
+    expect(chatStatus).not.toHaveTextContent("Model unavailable");
+  });
+
   it("does not treat catalog-only backend models as ready for character chat", async () => {
     storageState.values.set("playgroundChatWorkflowMode", "character");
     messageOptionState.value.selectedCharacter = {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
@@ -223,6 +223,37 @@ describe("PlaygroundStatusStrip first-slice state", () => {
     expect(openModelSettings).toHaveBeenCalledTimes(1);
   });
 
+  it("does not show Ready when the selected Character Chat model is unavailable", () => {
+    const openModelSettings = vi.fn();
+
+    render(
+      <PlaygroundStatusStrip
+        mode="cockpit"
+        streaming={false}
+        selectedProvider="tldw"
+        selectedModel="gpt-4o"
+        messageCount={1}
+        sessionLabel="Server chat"
+        hasContext={false}
+        contextSummary={[]}
+        temporaryChat={false}
+        characterChatActive
+        degradedChecks={[]}
+        errorMessage={null}
+        modelUnavailable
+        modelUnavailableMessage="Choose a chat model before chatting as Ada"
+        onOpenModelSettings={openModelSettings}
+      />,
+    );
+
+    const status = screen.getByRole("status", { name: "Chat status" });
+    expect(status).toHaveTextContent("Model unavailable");
+    expect(status).toHaveTextContent("Choose a chat model before chatting as Ada");
+    expect(status).not.toHaveTextContent("Ready");
+    fireEvent.click(screen.getByRole("button", { name: "Open model settings" }));
+    expect(openModelSettings).toHaveBeenCalledTimes(1);
+  });
+
   it("shows context preview loading without treating the chat route as degraded", () => {
     render(
       <PlaygroundStatusStrip

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/playground-composition-preview.test.ts
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/playground-composition-preview.test.ts
@@ -151,6 +151,27 @@ describe("playground composition preview summary", () => {
     });
   });
 
+  it("marks a selected model unavailable when readiness rejects the route", () => {
+    const summary = buildPlaygroundCompositionPreviewSummary(
+      baseInput({
+        providerRoute: {
+          selectedProvider: "tldw",
+          selectedModel: "gpt-4o",
+          providerRouteLabel: "tldw:gpt-4o",
+        },
+        modelUnavailable: true,
+        modelUnavailableDetail: "Choose a chat model before chatting as Ada",
+      }),
+    );
+
+    expect(summary.overallState).toBe("unavailable");
+    expect(summary.entries.find((entry) => entry.kind === "model")).toMatchObject({
+      state: "unavailable",
+      title: "tldw:gpt-4o",
+      detail: "Choose a chat model before chatting as Ada",
+    });
+  });
+
   it("keeps MCP unavailable distinct from empty context and preserves character context", () => {
     const summary = buildPlaygroundCompositionPreviewSummary(
       baseInput({

--- a/apps/packages/ui/src/components/Option/Playground/playground-composition-preview.ts
+++ b/apps/packages/ui/src/components/Option/Playground/playground-composition-preview.ts
@@ -61,6 +61,8 @@ export type PlaygroundCompositionPreviewInput = {
   toolSummary: RuntimeToolSummary | null;
   compositionStatus: "idle" | "loading" | "ready" | "error";
   composition: ConversationContextComposition | null;
+  modelUnavailable?: boolean;
+  modelUnavailableDetail?: string | null;
 };
 
 export type PlaygroundCompositionPreviewSummary = {
@@ -130,6 +132,8 @@ export const buildPlaygroundCompositionPreviewSummary = ({
   toolSummary,
   compositionStatus,
   composition,
+  modelUnavailable = false,
+  modelUnavailableDetail = null,
 }: PlaygroundCompositionPreviewInput): PlaygroundCompositionPreviewSummary => {
   const settingsScopeLabel = providerRoute.providerRouteLabel;
   const promptEntry: PlaygroundCompositionPreviewEntry = {
@@ -158,8 +162,11 @@ export const buildPlaygroundCompositionPreviewSummary = ({
     kind: "model",
     label: "Model",
     title: modelTitle,
-    detail: providerRoute.selectedProvider || null,
-    state: providerRoute.selectedModel ? "active" : "unavailable",
+    detail: modelUnavailableDetail || providerRoute.selectedProvider || null,
+    state:
+      providerRoute.selectedModel && !modelUnavailable
+        ? "active"
+        : "unavailable",
   };
   const settingsEntry: PlaygroundCompositionPreviewEntry = {
     id: "settings",

--- a/apps/packages/ui/src/services/tldw/TldwModels.ts
+++ b/apps/packages/ui/src/services/tldw/TldwModels.ts
@@ -80,7 +80,7 @@ export class TldwModelsService {
   private readonly CACHE_DURATION = 15 * 60 * 1000 // 15 minutes
   private readonly FORCE_REFRESH_COOLDOWN = 30 * 1000
   private readonly CACHE_KEY = "tldwModelsCache"
-  private readonly CACHE_SCHEMA_VERSION = 3
+  private readonly CACHE_SCHEMA_VERSION = 4
   private storage = createSafeStorage({ area: "local" })
   private storageLoaded = false
   private storageInitPromise: Promise<void> | null = null

--- a/apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
@@ -249,7 +249,7 @@ describe("TldwModelsService caching", () => {
 
   it("returns cached chat models without fetching provider metadata again", async () => {
     mocks.storageGet.mockResolvedValue({
-      version: 3,
+      version: 4,
       timestamp: Date.now(),
       scope: "http://127.0.0.1:8000|single-user|key|none",
       models: [

--- a/apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
@@ -106,6 +106,41 @@ describe("chat model availability utilities", () => {
     expect(ids.has("ollama:gemma3:1b")).toBe(true)
   })
 
+  it("does not count catalog-only false as a configured model flag", () => {
+    const ids = buildAvailableChatModelIds(
+      [
+        {
+          id: "gpt-4o",
+          model: "tldw:gpt-4o",
+          provider: "openai",
+          catalog_only: false
+        } as any
+      ],
+      { requireConfiguredFlags: true }
+    )
+
+    expect(ids.has("gpt-4o")).toBe(false)
+    expect(ids.has("openai:gpt-4o")).toBe(false)
+  })
+
+  it("treats any catalog-only true flag as unavailable", () => {
+    const ids = buildAvailableChatModelIds([
+      {
+        id: "gpt-4o",
+        model: "tldw:gpt-4o",
+        provider: "openai",
+        catalog_only: false,
+        is_configured: true,
+        details: {
+          catalog_only: true
+        }
+      } as any
+    ])
+
+    expect(ids.has("gpt-4o")).toBe(false)
+    expect(ids.has("openai:gpt-4o")).toBe(false)
+  })
+
   it("accepts provider-qualified selections when the available catalog only exposes the base model ID", () => {
     const ids = buildAvailableChatModelIds([
       {

--- a/apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
@@ -42,6 +42,70 @@ describe("chat model availability utilities", () => {
     expect(findUnavailableChatModel(["openai:gpt-4o-mini"], ids)).toBeNull()
   })
 
+  it("adds base IDs when backend descriptors expose provider-qualified model fields", () => {
+    const ids = buildAvailableChatModelIds([
+      {
+        model: "openai:gpt-4.1-mini",
+        provider: "openai",
+        is_configured: true
+      } as any
+    ])
+
+    expect(ids.has("openai:gpt-4.1-mini")).toBe(true)
+    expect(ids.has("gpt-4.1-mini")).toBe(true)
+    expect(findUnavailableChatModel(["gpt-4.1-mini"], ids)).toBeNull()
+  })
+
+  it("excludes catalog-only and unconfigured backend models from readiness availability", () => {
+    const ids = buildAvailableChatModelIds([
+      {
+        id: "gpt-4o",
+        model: "tldw:gpt-4o",
+        provider: "openai",
+        is_configured: false,
+        provider_is_configured: false,
+        catalog_only: true
+      } as any,
+      {
+        id: "gemma3:1b",
+        model: "tldw:gemma3:1b",
+        provider: "ollama",
+        is_configured: true,
+        provider_is_configured: true
+      } as any
+    ])
+
+    expect(ids.has("gpt-4o")).toBe(false)
+    expect(ids.has("openai:gpt-4o")).toBe(false)
+    expect(ids.has("gemma3:1b")).toBe(true)
+    expect(ids.has("ollama:gemma3:1b")).toBe(true)
+  })
+
+  it("can fail closed on descriptors without explicit configuration flags", () => {
+    const ids = buildAvailableChatModelIds(
+      [
+        {
+          id: "gpt-4o",
+          model: "tldw:gpt-4o",
+          provider: "openai"
+        } as any,
+        {
+          id: "gemma3:1b",
+          model: "tldw:gemma3:1b",
+          provider: "ollama",
+          is_configured: true,
+          provider_is_configured: true
+        } as any
+      ],
+      { requireConfiguredFlags: true }
+    )
+
+    expect(ids.has("gpt-4o")).toBe(false)
+    expect(ids.has("openai:gpt-4o")).toBe(false)
+    expect(ids.has("gemma3:1b")).toBe(true)
+    expect(ids.has("ollama:gemma3:1b")).toBe(true)
+  })
+
   it("accepts provider-qualified selections when the available catalog only exposes the base model ID", () => {
     const ids = buildAvailableChatModelIds([
       {
@@ -170,7 +234,39 @@ describe("character chat readiness", () => {
         isServerConnected: true,
         selectedCharacter: { id: 1, name: "Ariadne" },
         selectedModel: "missing-model",
-        availableModels: [{ model: "gpt-4o-mini" }]
+        availableModels: [{ model: "gpt-4o-mini", is_configured: true }]
+      })
+    ).toMatchObject({
+      status: "blocked",
+      missingRequirement: "chat-model",
+      reason: "selected-model-unavailable",
+      recommendedAction: "open-model-settings"
+    })
+  })
+
+  it("blocks selected catalog-only models from the real backend model catalog", () => {
+    expect(
+      buildCharacterChatReadiness({
+        isServerConnected: true,
+        selectedCharacter: { id: 1, name: "Ariadne" },
+        selectedModel: "tldw:gpt-4o",
+        availableModels: [
+          {
+            id: "gpt-4o",
+            model: "tldw:gpt-4o",
+            provider: "openai",
+            is_configured: false,
+            provider_is_configured: false,
+            catalog_only: true
+          } as any,
+          {
+            id: "gemma3:1b",
+            model: "tldw:gemma3:1b",
+            provider: "ollama",
+            is_configured: true,
+            provider_is_configured: true
+          } as any
+        ]
       })
     ).toMatchObject({
       status: "blocked",
@@ -186,7 +282,7 @@ describe("character chat readiness", () => {
         isServerConnected: true,
         selectedCharacter: { id: 1, name: "Ariadne" },
         selectedModel: "gpt-4o-mini",
-        availableModels: [{ model: "tldw:gpt-4o-mini" }]
+        availableModels: [{ model: "tldw:gpt-4o-mini", is_configured: true }]
       })
     ).toEqual({
       status: "ready",

--- a/apps/packages/ui/src/utils/chat-model-availability.ts
+++ b/apps/packages/ui/src/utils/chat-model-availability.ts
@@ -177,15 +177,36 @@ const toBooleanFlag = (value: unknown): boolean | null => {
   return null
 }
 
-function readBooleanFlag(
-  model: ModelDescriptor,
-  keys: string[]
-): boolean | null {
-  const records = [model, model.details, model.metadata].filter(
+const CATALOG_ONLY_FLAG_KEYS = [
+  "catalog_only",
+  "catalogOnly",
+  "is_catalog_only",
+  "isCatalogOnly"
+] as const
+
+const CONFIGURED_FLAG_KEYS = [
+  "is_configured",
+  "isConfigured",
+  "configured",
+  "provider_is_configured",
+  "providerIsConfigured",
+  "provider_configured",
+  "providerConfigured"
+] as const
+
+function getChatModelDescriptorRecords(
+  model: ModelDescriptor
+): Record<string, unknown>[] {
+  return [model, model.details, model.metadata].filter(
     (record): record is Record<string, unknown> =>
       Boolean(record && typeof record === "object")
   )
+}
 
+function readBooleanFlagFromRecords(
+  records: Record<string, unknown>[],
+  keys: readonly string[]
+): boolean | null {
   for (const record of records) {
     for (const key of keys) {
       if (!Object.prototype.hasOwnProperty.call(record, key)) continue
@@ -201,30 +222,22 @@ function isUsableChatModelDescriptor(
   model: ModelDescriptor,
   options: BuildAvailableChatModelIdsOptions = {}
 ): boolean {
-  const catalogOnly = readBooleanFlag(model, [
-    "catalog_only",
-    "catalogOnly",
-    "is_catalog_only",
-    "isCatalogOnly"
-  ])
+  const records = getChatModelDescriptorRecords(model)
+  const catalogOnly = readBooleanFlagFromRecords(
+    records,
+    CATALOG_ONLY_FLAG_KEYS
+  )
   if (catalogOnly === true) return false
 
   let hasConfiguredFlag = catalogOnly != null
-  const configuredFlags = [
-    "is_configured",
-    "isConfigured",
-    "configured",
-    "provider_is_configured",
-    "providerIsConfigured",
-    "provider_configured",
-    "providerConfigured"
-  ]
-  for (const key of configuredFlags) {
-    const flag = readBooleanFlag(model, [key])
-    if (flag != null) {
+  for (const record of records) {
+    for (const key of CONFIGURED_FLAG_KEYS) {
+      if (!Object.prototype.hasOwnProperty.call(record, key)) continue
+      const flag = toBooleanFlag(record[key])
+      if (flag == null) continue
       hasConfiguredFlag = true
+      if (flag === false) return false
     }
-    if (flag === false) return false
   }
 
   if (options.requireConfiguredFlags && !hasConfiguredFlag) {

--- a/apps/packages/ui/src/utils/chat-model-availability.ts
+++ b/apps/packages/ui/src/utils/chat-model-availability.ts
@@ -203,19 +203,20 @@ function getChatModelDescriptorRecords(
   )
 }
 
-function readBooleanFlagFromRecords(
-  records: Record<string, unknown>[],
-  keys: readonly string[]
+function readCatalogOnlyFlagFromRecords(
+  records: Record<string, unknown>[]
 ): boolean | null {
+  let hasCatalogFlag = false
   for (const record of records) {
-    for (const key of keys) {
+    for (const key of CATALOG_ONLY_FLAG_KEYS) {
       if (!Object.prototype.hasOwnProperty.call(record, key)) continue
       const flag = toBooleanFlag(record[key])
-      if (flag != null) return flag
+      if (flag === true) return true
+      if (flag === false) hasCatalogFlag = true
     }
   }
 
-  return null
+  return hasCatalogFlag ? false : null
 }
 
 function isUsableChatModelDescriptor(
@@ -223,13 +224,10 @@ function isUsableChatModelDescriptor(
   options: BuildAvailableChatModelIdsOptions = {}
 ): boolean {
   const records = getChatModelDescriptorRecords(model)
-  const catalogOnly = readBooleanFlagFromRecords(
-    records,
-    CATALOG_ONLY_FLAG_KEYS
-  )
+  const catalogOnly = readCatalogOnlyFlagFromRecords(records)
   if (catalogOnly === true) return false
 
-  let hasConfiguredFlag = catalogOnly != null
+  let hasConfiguredFlag = false
   for (const record of records) {
     for (const key of CONFIGURED_FLAG_KEYS) {
       if (!Object.prototype.hasOwnProperty.call(record, key)) continue

--- a/apps/packages/ui/src/utils/chat-model-availability.ts
+++ b/apps/packages/ui/src/utils/chat-model-availability.ts
@@ -12,12 +12,45 @@ type ModelDescriptor = {
   providerKey?: unknown
   api_provider?: unknown
   apiProvider?: unknown
+  is_configured?: unknown
+  isConfigured?: unknown
+  configured?: unknown
+  provider_is_configured?: unknown
+  providerIsConfigured?: unknown
+  provider_configured?: unknown
+  providerConfigured?: unknown
+  catalog_only?: unknown
+  catalogOnly?: unknown
+  is_catalog_only?: unknown
+  isCatalogOnly?: unknown
   details?: {
     provider?: unknown
     provider_key?: unknown
+    is_configured?: unknown
+    isConfigured?: unknown
+    configured?: unknown
+    provider_is_configured?: unknown
+    providerIsConfigured?: unknown
+    provider_configured?: unknown
+    providerConfigured?: unknown
+    catalog_only?: unknown
+    catalogOnly?: unknown
+    is_catalog_only?: unknown
+    isCatalogOnly?: unknown
   }
   metadata?: {
     provider?: unknown
+    is_configured?: unknown
+    isConfigured?: unknown
+    configured?: unknown
+    provider_is_configured?: unknown
+    providerIsConfigured?: unknown
+    provider_configured?: unknown
+    providerConfigured?: unknown
+    catalog_only?: unknown
+    catalogOnly?: unknown
+    is_catalog_only?: unknown
+    isCatalogOnly?: unknown
   }
 }
 
@@ -66,6 +99,10 @@ type CharacterChatReadinessInput = {
   selectedModel?: string | null
   availableModels?: ModelDescriptor[] | null
   isSendBlocked?: boolean
+}
+
+type BuildAvailableChatModelIdsOptions = {
+  requireConfiguredFlags?: boolean
 }
 
 type TranslationFn = (key: string, fallbackOrOptions?: any) => any
@@ -130,6 +167,73 @@ function normalizeProviderKey(model: ModelDescriptor): string | null {
   return provider && provider !== "unknown" ? provider : null
 }
 
+const toBooleanFlag = (value: unknown): boolean | null => {
+  if (typeof value === "boolean") return value
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === "true") return true
+    if (normalized === "false") return false
+  }
+  return null
+}
+
+function readBooleanFlag(
+  model: ModelDescriptor,
+  keys: string[]
+): boolean | null {
+  const records = [model, model.details, model.metadata].filter(
+    (record): record is Record<string, unknown> =>
+      Boolean(record && typeof record === "object")
+  )
+
+  for (const record of records) {
+    for (const key of keys) {
+      if (!Object.prototype.hasOwnProperty.call(record, key)) continue
+      const flag = toBooleanFlag(record[key])
+      if (flag != null) return flag
+    }
+  }
+
+  return null
+}
+
+function isUsableChatModelDescriptor(
+  model: ModelDescriptor,
+  options: BuildAvailableChatModelIdsOptions = {}
+): boolean {
+  const catalogOnly = readBooleanFlag(model, [
+    "catalog_only",
+    "catalogOnly",
+    "is_catalog_only",
+    "isCatalogOnly"
+  ])
+  if (catalogOnly === true) return false
+
+  let hasConfiguredFlag = catalogOnly != null
+  const configuredFlags = [
+    "is_configured",
+    "isConfigured",
+    "configured",
+    "provider_is_configured",
+    "providerIsConfigured",
+    "provider_configured",
+    "providerConfigured"
+  ]
+  for (const key of configuredFlags) {
+    const flag = readBooleanFlag(model, [key])
+    if (flag != null) {
+      hasConfiguredFlag = true
+    }
+    if (flag === false) return false
+  }
+
+  if (options.requireConfiguredFlags && !hasConfiguredFlag) {
+    return false
+  }
+
+  return true
+}
+
 function normalizeProviderQualifiedChatModelId(
   value: string | null | undefined
 ): string | null {
@@ -171,16 +275,29 @@ function normalizeBaseChatModelId(value: string | null | undefined): string {
 }
 
 export function buildAvailableChatModelIds(
-  models: ModelDescriptor[] | null | undefined
+  models: ModelDescriptor[] | null | undefined,
+  options: BuildAvailableChatModelIdsOptions = {}
 ): Set<string> {
   const ids = new Set<string>()
   for (const model of models || []) {
+    if (!isUsableChatModelDescriptor(model, options)) {
+      continue
+    }
+
     const modelId = normalizeAvailableModelId(model)
     if (modelId) {
       ids.add(modelId)
-      const provider = normalizeProviderKey(model)
+      const providerQualifiedModel = parseProviderQualifiedModelSelection(modelId)
+      const baseModelId = providerQualifiedModel.isProviderQualified
+        ? normalizeChatModelId(providerQualifiedModel.modelId)
+        : modelId
+      if (baseModelId && baseModelId !== modelId) {
+        ids.add(baseModelId)
+      }
+
+      const provider = normalizeProviderKey(model) ?? providerQualifiedModel.provider
       if (provider) {
-        ids.add(`${provider}:${modelId}`)
+        ids.add(`${provider}:${baseModelId || modelId}`)
       }
     }
   }
@@ -265,7 +382,9 @@ export function buildCharacterChatReadiness({
   }
 
   if (Array.isArray(availableModels)) {
-    const availableModelIds = buildAvailableChatModelIds(availableModels)
+    const availableModelIds = buildAvailableChatModelIds(availableModels, {
+      requireConfiguredFlags: true
+    })
     if (availableModelIds.size === 0) {
       return blockedCharacterChatReadiness(
         "chat-model",

--- a/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
+++ b/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
@@ -35,12 +35,18 @@ Follow-up after PR #1866 merged. Real-backend smoke on /chat?mode=character show
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Verification: focused Vitest suite passed with 9 files and 114 tests; git diff --check passed; real-backend browser smoke showed tldw:gpt-4o blocked with Model unavailable in the status strip and Error in the runtime rail. Full TypeScript still fails on existing repo-wide baseline debt, with no touched-file errors after fixing the local cockpit test typing issue. Bandit skipped because only frontend TypeScript/tests and Backlog docs were touched.
+
+Review follow-up: PR #1871 remained open/draft after the user reported "pr merged"; Gemini review comments requested removing repeated boolean-flag record allocations and simplifying runtime status logic.
+
+Review follow-up verification: the 9-file focused Vitest suite still passed with 114 tests, git diff --check passed, and bunx tsc --noEmit --pretty false still reports the existing repo-wide baseline TypeScript debt with no new touched-file errors.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Fixed Character Chat readiness so catalog-only or explicitly unconfigured backend model descriptors cannot make a role-play session look ready. The /chat cockpit now force-refreshes readiness-critical model metadata, fails closed on stale unflagged descriptors for Character Chat, invalidates the persisted model-cache schema, and propagates model-unavailable state into the readiness panel, composition preview, runtime rail, and bottom status strip.
+
+PR #1871 review follow-up removed repeated per-flag descriptor record allocation in the model availability helper and simplified equivalent runtime-status branching in Playground.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
+++ b/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
@@ -43,6 +43,8 @@ Review follow-up verification: the 9-file focused Vitest suite still passed with
 Cubic review follow-up: fixed catalog-only conflict precedence, kept catalog-only false from satisfying requireConfiguredFlags, and narrowed runtime-rail error mapping so streaming/send-blocked character readiness remains Streaming instead of Error.
 
 Cubic follow-up verification: the 9-file focused Vitest suite passed with 116 tests after adding regressions for catalog-only precedence, configured-flag enforcement, and streaming runtime status.
+
+Qodo review follow-up: narrowed the Character Chat model-unavailable flag to selected-model-unavailable and no-models-available reasons so an empty model selection remains in the existing missing-model status path.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -53,6 +55,8 @@ Fixed Character Chat readiness so catalog-only or explicitly unconfigured backen
 PR #1871 review follow-up removed repeated per-flag descriptor record allocation in the model availability helper and simplified equivalent runtime-status branching in Playground.
 
 PR #1871 cubic follow-up now treats any catalog-only true descriptor flag as unavailable, requires actual configured/provider flags for fail-closed Character Chat readiness, and avoids presenting active streaming as a runtime error.
+
+PR #1871 Qodo follow-up keeps "no selected model" distinct from "selected model unavailable" in the cockpit status strip and composition/runtime wiring.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
+++ b/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
@@ -39,6 +39,10 @@ Verification: focused Vitest suite passed with 9 files and 114 tests; git diff -
 Review follow-up: PR #1871 remained open/draft after the user reported "pr merged"; Gemini review comments requested removing repeated boolean-flag record allocations and simplifying runtime status logic.
 
 Review follow-up verification: the 9-file focused Vitest suite still passed with 114 tests, git diff --check passed, and bunx tsc --noEmit --pretty false still reports the existing repo-wide baseline TypeScript debt with no new touched-file errors.
+
+Cubic review follow-up: fixed catalog-only conflict precedence, kept catalog-only false from satisfying requireConfiguredFlags, and narrowed runtime-rail error mapping so streaming/send-blocked character readiness remains Streaming instead of Error.
+
+Cubic follow-up verification: the 9-file focused Vitest suite passed with 116 tests after adding regressions for catalog-only precedence, configured-flag enforcement, and streaming runtime status.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -47,6 +51,8 @@ Review follow-up verification: the 9-file focused Vitest suite still passed with
 Fixed Character Chat readiness so catalog-only or explicitly unconfigured backend model descriptors cannot make a role-play session look ready. The /chat cockpit now force-refreshes readiness-critical model metadata, fails closed on stale unflagged descriptors for Character Chat, invalidates the persisted model-cache schema, and propagates model-unavailable state into the readiness panel, composition preview, runtime rail, and bottom status strip.
 
 PR #1871 review follow-up removed repeated per-flag descriptor record allocation in the model availability helper and simplified equivalent runtime-status branching in Playground.
+
+PR #1871 cubic follow-up now treats any catalog-only true descriptor flag as unavailable, requires actual configured/provider flags for fail-closed Character Chat readiness, and avoids presenting active streaming as a runtime error.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
+++ b/backlog/tasks/task-446 - Fix-Character-Chat-readiness-for-unconfigured-model-catalogs.md
@@ -1,0 +1,54 @@
+---
+id: TASK-446
+title: Fix Character Chat readiness for unconfigured model catalogs
+status: Done
+ordinal: 446
+modified_files:
+- apps/packages/ui/src/utils/chat-model-availability.ts
+- apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts
+- apps/packages/ui/src/components/Option/Playground/Playground.tsx
+- apps/packages/ui/src/components/Option/Playground/PlaygroundStatusStrip.tsx
+- apps/packages/ui/src/components/Option/Playground/playground-composition-preview.ts
+- apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/playground-composition-preview.test.ts
+- apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx
+- apps/packages/ui/src/services/tldw/TldwModels.ts
+- apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up after PR #1866 merged. Real-backend smoke on /chat?mode=character showed a selected catalog-only OpenAI gpt-4o route could still make Character Chat surfaces appear ready. This task carries the dev-based follow-up fix.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Character Chat readiness does not report Ready when the selected chat model is catalog-only or explicitly unconfigured in backend model metadata.
+- [x] #2 Readiness recovery copy points the user toward model/provider settings instead of allowing an unusable role-play session.
+- [x] #3 Focused unit/integration tests cover catalog-only/unconfigured model metadata, stale unflagged descriptors, status propagation, and cache invalidation.
+- [x] #4 Real-backend smoke verifies /chat?mode=character no longer shows contradictory no-provider/model-unavailable and Ready states.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification: focused Vitest suite passed with 9 files and 114 tests; git diff --check passed; real-backend browser smoke showed tldw:gpt-4o blocked with Model unavailable in the status strip and Error in the runtime rail. Full TypeScript still fails on existing repo-wide baseline debt, with no touched-file errors after fixing the local cockpit test typing issue. Bandit skipped because only frontend TypeScript/tests and Backlog docs were touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed Character Chat readiness so catalog-only or explicitly unconfigured backend model descriptors cannot make a role-play session look ready. The /chat cockpit now force-refreshes readiness-critical model metadata, fails closed on stale unflagged descriptors for Character Chat, invalidates the persisted model-cache schema, and propagates model-unavailable state into the readiness panel, composition preview, runtime rail, and bottom status strip.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- fail closed for Character Chat readiness when backend model descriptors are catalog-only, explicitly unconfigured, or stale/unflagged
- propagate model-unavailable state into the readiness panel, composition preview, runtime rail, and bottom status strip
- force-refresh readiness-critical chat model metadata and bump the model-cache schema

## Verification
- bunx vitest run src/components/Option/Playground/__tests__/CharacterChatReadinessPanel.test.tsx src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx src/components/Common/__tests__/AssistantSelect.behavior.test.tsx src/components/Option/Playground/__tests__/PlaygroundStatusStrip.first-slice.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/playground-composition-preview.test.ts src/utils/__tests__/chat-model-availability.test.ts src/services/tldw/__tests__/TldwModels.test.ts src/services/__tests__/tldw-server.chat-models.test.ts --maxWorkers=1 --no-file-parallelism
- git diff --check
- real-backend browser smoke: /chat?mode=character now blocks catalog-only tldw:gpt-4o with Model unavailable / runtime Error instead of Ready
- bunx tsc --noEmit --pretty false (fails on existing repo-wide baseline TypeScript debt; no current errors in touched files after local cockpit test typing fix)

## Change summary
TODO: human owner must fill this in before merge, explaining what changed and why these implementation choices were made.

## Notes
- Bandit skipped: frontend TypeScript/tests and Backlog task only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks Character Chat when the selected model is catalog-only or not configured, and shows “Model unavailable” across the cockpit. Forces a model metadata refresh and bumps the `TldwModels` cache schema to avoid stale readiness.

- **Bug Fixes**
  - Fail closed: exclude catalog-only models (true in any descriptor/details/metadata) and require explicit configured/provider flags; do not treat `catalog_only: false` as configured; add base IDs so `openai:gpt-4.1-mini` and `gpt-4.1-mini` both resolve.
  - Keep missing-model distinct: empty selection shows “No model selected”; only unavailable selections show “Model unavailable” with “Review settings”.
  - Propagate model-unavailable to the readiness panel, runtime rail, composition preview (marks model “unavailable” with detail), and status strip with a new “model-unavailable” state; suppress “Ready” and keep “Streaming” when appropriate.
  - Force `fetchChatModels({ forceRefresh: true })`; bump `TldwModels` cache schema to `4`.
  - Expand tests for catalog-only precedence, configured-flag enforcement, missing-model vs unavailable, composition preview marking, status strip behavior, and the force-refresh call.

<sup>Written for commit 958a345825183b23b3dbdf69301f5519658fa5e8. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1871?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

