### PR TITLE
Fix audio preset Postgres boolean index predicates

### DIFF
--- a/backlog/tasks/task-446 - Fix-audio-preset-Postgres-boolean-partial-indexes.md
+++ b/backlog/tasks/task-446 - Fix-audio-preset-Postgres-boolean-partial-indexes.md
@@ -1,0 +1,48 @@
+---
+id: TASK-446
+title: Fix audio preset Postgres boolean partial indexes
+status: Done
+labels:
+- audio
+- postgres
+- review-fix
+- db-schema
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and fix the PR #1865 follow-up finding that audio preset partial indexes use SQLite integer boolean predicates which can survive SQLite-to-Postgres schema conversion as invalid PostgreSQL SQL. Keep the fix scoped to audio preset schema conversion/bootstrap and add focused regression coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Verify whether the reported PostgreSQL predicate issue is real.
+- [x] #2 Audio preset partial indexes use SQLite-compatible boolean literals that remain valid after PostgreSQL schema conversion.
+- [x] #3 Regression coverage proves converted audio preset index predicates use `TRUE`/`FALSE`, not integer boolean comparisons.
+- [x] #4 Focused schema/audio tests, Bandit, and diff checks are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Confirmed the issue is valid: `_AUDIO_PRESETS_TABLE_SQL` is converted for PostgreSQL bootstrap, and the converter only rewrites a narrow `WHERE deleted = 0` pattern. The composite `WHERE is_default = 1 AND deleted = 0` predicate survived conversion as integer comparisons against PostgreSQL boolean columns. Added a failing schema-conversion regression, then changed the audio preset partial index predicates to `deleted = FALSE` and `is_default = TRUE AND deleted = FALSE`; SQLite accepts these literals and PostgreSQL conversion now preserves valid boolean predicates.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the audio preset partial index predicates introduced by PR #1865 so PostgreSQL bootstrap SQL remains valid after SQLite-to-PostgreSQL conversion. Added regression coverage for the converted audio preset index SQL and verified adjacent audio preset endpoint behavior.
+
+Verification: the new regression failed before the schema fix, then passed. Focused pytest passed 9 tests across schema conversion and audio preset endpoint coverage. Bandit on the touched backend schema file reported 0 findings. `git diff --check` passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py
@@ -1292,10 +1292,10 @@ class MediaDatabase:
         ON audio_presets(user_id, kind, is_default, deleted);
     CREATE UNIQUE INDEX IF NOT EXISTS ux_audio_presets_user_kind_name_active
         ON audio_presets(user_id, kind, LOWER(name))
-        WHERE deleted = 0;
+        WHERE deleted = FALSE;
     CREATE UNIQUE INDEX IF NOT EXISTS ux_audio_presets_user_kind_default_active
         ON audio_presets(user_id, kind)
-        WHERE is_default = 1 AND deleted = 0;
+        WHERE is_default = TRUE AND deleted = FALSE;
     """
 
     _DATA_TABLES_SQL = """

--- a/tldw_Server_API/tests/DB_Management/test_media_db_schema_bootstrap.py
+++ b/tldw_Server_API/tests/DB_Management/test_media_db_schema_bootstrap.py
@@ -511,6 +511,24 @@ def test_transform_sqlite_statement_to_postgres_rewrites_insert_ignore_and_colla
 
 
 @pytest.mark.unit
+def test_audio_preset_partial_indexes_convert_to_postgres_boolean_predicates() -> None:
+    from tldw_Server_API.app.core.DB_Management.media_db.schema import (
+        postgres_sqlite_conversion as postgres_sqlite_conversion_module,
+    )
+
+    statements = postgres_sqlite_conversion_module._convert_sqlite_sql_to_postgres_statements(
+        SimpleNamespace(),
+        MediaDatabase._AUDIO_PRESETS_TABLE_SQL,
+    )
+    converted_sql = "\n".join(statements).upper()
+
+    assert "WHERE DELETED = FALSE" in converted_sql
+    assert "WHERE IS_DEFAULT = TRUE AND DELETED = FALSE" in converted_sql
+    assert "WHERE DELETED = 0" not in converted_sql
+    assert "WHERE IS_DEFAULT = 1" not in converted_sql
+
+
+@pytest.mark.unit
 def test_run_postgres_migrate_to_v11_swallows_per_statement_backend_errors_and_continues() -> None:
     from tldw_Server_API.app.core.DB_Management.media_db.schema.migration_bodies import (
         postgres_mediafiles as postgres_mediafiles_module,


### PR DESCRIPTION
## Change summary

Human-authored change summary required before merge.

## What changed

- Changed audio preset partial-index predicates in the shared SQLite schema to use `TRUE`/`FALSE` literals instead of integer boolean comparisons.
- Added a regression test proving the SQLite-to-PostgreSQL conversion emits valid boolean predicates for the audio preset unique indexes.
- Recorded the follow-up in Backlog task `TASK-446`.

## Root cause

The SQLite-to-PostgreSQL schema converter only rewrites the narrow `WHERE deleted = 0` pattern. The composite predicate `WHERE is_default = 1 AND deleted = 0` survived conversion unchanged, which is invalid once those columns are PostgreSQL booleans. SQLite accepts `TRUE`/`FALSE`, so using boolean literals at the schema source keeps both SQLite bootstrap and converted PostgreSQL SQL valid.

## Verification

- RED: `python -m pytest tldw_Server_API/tests/DB_Management/test_media_db_schema_bootstrap.py::test_audio_preset_partial_indexes_convert_to_postgres_boolean_predicates -q` failed before the schema change with `WHERE IS_DEFAULT = 1 AND DELETED = 0`.
- GREEN: `python -m pytest tldw_Server_API/tests/DB_Management/test_media_db_schema_bootstrap.py::test_convert_sqlite_sql_to_postgres_statements_filters_sqlite_only_lines_and_collects_statements tldw_Server_API/tests/DB_Management/test_media_db_schema_bootstrap.py::test_transform_sqlite_statement_to_postgres_rewrites_insert_ignore_and_collation tldw_Server_API/tests/DB_Management/test_media_db_schema_bootstrap.py::test_audio_preset_partial_indexes_convert_to_postgres_boolean_predicates tldw_Server_API/tests/Audio/test_audio_presets_endpoint.py -q` passed 9 tests.
- `python -m bandit -r tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py -f json -o /tmp/bandit_audio_preset_bool_index.json` reported 0 findings.
- `git diff --check` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes audio preset partial index predicates by switching SQLite comparisons to boolean literals so Postgres bootstrap stays valid. Prevents invalid SQL after SQLite-to-Postgres conversion and fulfills `TASK-446`.

- **Bug Fixes**
  - Updated `_AUDIO_PRESETS_TABLE_SQL` index predicates to `deleted = FALSE` and `is_default = TRUE AND deleted = FALSE`.
  - Added a regression test that confirms the converter outputs `TRUE`/`FALSE` and not `1`/`0`.

<sup>Written for commit 9d2c82de041410e2a1170f0c43d4af31cddaa5b7. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1872?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

