### PR TITLE
Migrate product-state guard drift to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2772,72 +2772,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Speech/SpeechPlaygroundPage.tsx:Alert#antd-alert-speechplaygroundpage-type-error-long-form-tts-1ot93bn",
-    "path": "src/components/Option/Speech/SpeechPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Speech/SpeechPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Speech/SpeechPlaygroundPage.tsx:Alert#antd-alert-speechplaygroundpage-type-error-streaming-err-z2c8os",
-    "path": "src/components/Option/Speech/SpeechPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Speech/SpeechPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Speech/SpeechPlaygroundPage.tsx:Alert#antd-alert-speechplaygroundpage-type-warning-line-2328-4ql4lv",
-    "path": "src/components/Option/Speech/SpeechPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Speech/SpeechPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Speech/SpeechPlaygroundPage.tsx:Alert#antd-alert-speechplaygroundpage-type-warning-line-2575-1rxjerz",
-    "path": "src/components/Option/Speech/SpeechPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Speech/SpeechPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/STT/SttPlaygroundPage.tsx:Alert#antd-alert-sttplaygroundpage-type-warning-line-354-hnht6x",
-    "path": "src/components/Option/STT/SttPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/STT/SttPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/STT/SttPlaygroundPage.tsx:Alert#antd-alert-sttplaygroundpage-type-warning-line-373-mdhcze",
-    "path": "src/components/Option/STT/SttPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/STT/SttPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/TTS/TtsPlaygroundPage.tsx:Alert#antd-alert-ttsplaygroundpage-type-info-line-548-1132c3s",
     "path": "src/components/Option/TTS/TtsPlaygroundPage.tsx",
     "rule": "antd-product-state-import",
@@ -3747,61 +3681,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx:Alert#antd-alert-watchlistsplaygroundpage-type-info-line-1903-1gxx9vr",
-    "path": "src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx:Alert#antd-alert-watchlistsplaygroundpage-type-error-line-1919-1240bbm",
-    "path": "src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx:Alert#antd-alert-watchlistsplaygroundpage-type-info-line-2225-1x102gx",
-    "path": "src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx:Alert#antd-alert-watchlistsplaygroundpage-type-info-line-2251-u6vdgi",
-    "path": "src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx:Alert#antd-alert-watchlistsplaygroundpage-type-success-line-22-1mzst3n",
-    "path": "src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx before the stable duplicate-id guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   }

--- a/apps/packages/ui/src/components/Option/Audio/AudioReadinessStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Audio/AudioReadinessStrip.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import { Tag, Tooltip, Typography } from "antd"
 
-import { getDesignSystemStateLabel } from "@/design-system/states"
+import {
+  BLOCKED_STATE_LABEL,
+  DEGRADED_STATE_LABEL,
+  READY_STATE_LABEL
+} from "@/design-system/states"
 import type { MetadataSource, ReadinessItem, ReadinessState } from "./audio-readiness"
 
 const { Text } = Typography
@@ -14,9 +18,9 @@ const STATE_COLOR: Record<ReadinessState, string | undefined> = {
 }
 
 const STATE_LABEL: Record<ReadinessState, string> = {
-  ready: getDesignSystemStateLabel("ready", ""),
-  warning: "Needs review",
-  blocked: getDesignSystemStateLabel("blocked", ""),
+  ready: READY_STATE_LABEL,
+  warning: DEGRADED_STATE_LABEL,
+  blocked: BLOCKED_STATE_LABEL,
   unknown: "Unknown"
 }
 

--- a/apps/packages/ui/src/components/Option/Audio/AudioReadinessStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Audio/AudioReadinessStrip.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Tag, Tooltip, Typography } from "antd"
 
+import { getDesignSystemStateLabel } from "@/design-system/states"
 import type { MetadataSource, ReadinessItem, ReadinessState } from "./audio-readiness"
 
 const { Text } = Typography
@@ -13,9 +14,9 @@ const STATE_COLOR: Record<ReadinessState, string | undefined> = {
 }
 
 const STATE_LABEL: Record<ReadinessState, string> = {
-  ready: "Ready",
+  ready: getDesignSystemStateLabel("ready", ""),
   warning: "Needs review",
-  blocked: "Blocked",
+  blocked: getDesignSystemStateLabel("blocked", ""),
   unknown: "Unknown"
 }
 

--- a/apps/packages/ui/src/components/Option/Audio/__tests__/AudioReadinessStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/Audio/__tests__/AudioReadinessStrip.test.tsx
@@ -1,12 +1,24 @@
 // @vitest-environment jsdom
 
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+
+const getDesignSystemStateLabelMock = vi.hoisted(() =>
+  vi.fn((key: string, fallback: string) => {
+    if (key === "ready") return "Registry ready"
+    if (key === "blocked") return "Registry blocked"
+    return fallback
+  })
+)
+
+vi.mock("@/design-system/states", () => ({
+  getDesignSystemStateLabel: getDesignSystemStateLabelMock
+}))
 
 import { AudioReadinessStrip } from "../AudioReadinessStrip"
 
 describe("AudioReadinessStrip", () => {
-  it("renders accessible readiness status labels and source details", () => {
+  it("renders accessible readiness status labels from the state registry", () => {
     render(
       <AudioReadinessStrip
         label="STT readiness"
@@ -17,17 +29,32 @@ describe("AudioReadinessStrip", () => {
             state: "ready",
             detail: "2 listed, 1 ready, 1 unknown",
             source: "health"
+          },
+          {
+            id: "blocked",
+            label: "Streaming",
+            state: "blocked",
+            detail: "Missing API credentials",
+            source: "provider"
           }
         ]}
       />
     )
 
     expect(screen.getByRole("status", { name: "STT readiness" })).toHaveTextContent(
-      "STT models: Ready"
+      "STT models: Registry ready"
+    )
+    expect(screen.getByRole("status", { name: "STT readiness" })).toHaveTextContent(
+      "Streaming: Registry blocked"
     )
     expect(
       screen.getByLabelText(
-        "STT models: Ready. 2 listed, 1 ready, 1 unknown Source: model health."
+        "STT models: Registry ready. 2 listed, 1 ready, 1 unknown Source: model health."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(
+        "Streaming: Registry blocked. Missing API credentials Source: provider metadata."
       )
     ).toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/Option/Audio/__tests__/AudioReadinessStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/Audio/__tests__/AudioReadinessStrip.test.tsx
@@ -3,16 +3,10 @@
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
-const getDesignSystemStateLabelMock = vi.hoisted(() =>
-  vi.fn((key: string, fallback: string) => {
-    if (key === "ready") return "Registry ready"
-    if (key === "blocked") return "Registry blocked"
-    return fallback
-  })
-)
-
 vi.mock("@/design-system/states", () => ({
-  getDesignSystemStateLabel: getDesignSystemStateLabelMock
+  READY_STATE_LABEL: "Registry ready",
+  DEGRADED_STATE_LABEL: "Registry degraded",
+  BLOCKED_STATE_LABEL: "Registry blocked"
 }))
 
 import { AudioReadinessStrip } from "../AudioReadinessStrip"
@@ -36,6 +30,20 @@ describe("AudioReadinessStrip", () => {
             state: "blocked",
             detail: "Missing API credentials",
             source: "provider"
+          },
+          {
+            id: "warning",
+            label: "Server catalog",
+            state: "warning",
+            detail: "Server returned partial metadata",
+            source: "response_schema"
+          },
+          {
+            id: "unknown",
+            label: "Provider",
+            state: "unknown",
+            detail: "No provider metadata yet",
+            source: "unknown"
           }
         ]}
       />
@@ -47,6 +55,12 @@ describe("AudioReadinessStrip", () => {
     expect(screen.getByRole("status", { name: "STT readiness" })).toHaveTextContent(
       "Streaming: Registry blocked"
     )
+    expect(screen.getByRole("status", { name: "STT readiness" })).toHaveTextContent(
+      "Server catalog: Registry degraded"
+    )
+    expect(screen.getByRole("status", { name: "STT readiness" })).toHaveTextContent(
+      "Provider: Unknown"
+    )
     expect(
       screen.getByLabelText(
         "STT models: Registry ready. 2 listed, 1 ready, 1 unknown Source: model health."
@@ -55,6 +69,16 @@ describe("AudioReadinessStrip", () => {
     expect(
       screen.getByLabelText(
         "Streaming: Registry blocked. Missing API credentials Source: provider metadata."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(
+        "Server catalog: Registry degraded. Server returned partial metadata Source: response schema."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(
+        "Provider: Unknown. No provider metadata yet Source: unknown source."
       )
     ).toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
@@ -2,9 +2,10 @@ import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { useStorage } from "@plasmohq/storage/hook"
 import { Trans, useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
-import { Alert, Button, Typography } from "antd"
+import { Button, Typography } from "antd"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { PageShell } from "@/components/Common/PageShell"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
 import { useTranscriptionModelsCatalog } from "@/hooks/useTranscriptionModelsCatalog"
 import { RecordingStrip } from "./RecordingStrip"
@@ -439,32 +440,26 @@ export const SttPlaygroundPage: React.FC = () => {
           </p>
         )}
         {serverModelsError && (
-          <Alert
-            type="warning"
-            showIcon
+          <DesignSystemAlert
+            variant="warning"
             title={t("playground:stt.modelsLoadError", "Model load failed")}
-            description={serverModelsError}
-            action={
-              <Button
-                size="small"
-                onClick={() => {
-                  retryServerModels()
-                }}
-                disabled={serverModelsLoading}
-              >
-                {t("common:retry", "Retry")}
-              </Button>
-            }
-          />
+            action={{
+              label: t("common:retry", "Retry"),
+              onClick: retryServerModels,
+              disabled: serverModelsLoading
+            }}
+          >
+            {serverModelsError}
+          </DesignSystemAlert>
         )}
         {!serverModelsLoading && !serverModelsError && serverModels.length === 0 && (
-          <Alert
-            type="warning"
-            showIcon
+          <DesignSystemAlert
+            variant="warning"
             className="mb-4"
-            message={t("playground:stt.noModelsTitle", "No transcription models available")}
-            description={t("playground:stt.noModelsBody", "Configure STT models in your server settings. Check the Audio Setup Guide for instructions.")}
-          />
+            title={t("playground:stt.noModelsTitle", "No transcription models available")}
+          >
+            {t("playground:stt.noModelsBody", "Configure STT models in your server settings. Check the Audio Setup Guide for instructions.")}
+          </DesignSystemAlert>
         )}
         <div data-testid="stt-record-strip">
           <RecordingStrip

--- a/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
@@ -327,6 +327,9 @@ describe("SttPlaygroundPage", () => {
 
     render(<SttPlaygroundPage />)
 
+    const loadingErrorAlert = await screen.findByText("Model load failed")
+    expect(loadingErrorAlert.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
     const retryButton = await screen.findByRole("button", { name: "Retry" })
     fireEvent.click(retryButton)
 
@@ -336,5 +339,17 @@ describe("SttPlaygroundPage", () => {
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "Retry" })).toBeNull()
     })
+  })
+
+  it("uses the canonical alert for an empty server model catalog", async () => {
+    getTranscriptionModelsMock.mockResolvedValue({
+      categories: {},
+      all_models: []
+    })
+
+    render(<SttPlaygroundPage />)
+
+    const noModelsAlert = await screen.findByText("No transcription models available")
+    expect(noModelsAlert.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
@@ -3,7 +3,6 @@ import { useStorage } from "@plasmohq/storage/hook"
 import { useTranslation } from "react-i18next"
 import {
   Button,
-  Alert,
   Card,
   Input,
   List,
@@ -26,6 +25,7 @@ import {
 } from "@/audio"
 import { AudioSourcePicker } from "@/components/Common/AudioSourcePicker"
 import { PageShell } from "@/components/Common/PageShell"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import WaveformCanvas from "@/components/Common/WaveformCanvas"
 import { inferTldwProviderFromModel, resolveTtsProviderContext } from "@/services/tts-provider"
 import { getTtsProviderLabel } from "@/services/tts-providers"
@@ -2615,19 +2615,14 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                       )}
                     </div>
                     {serverModelsError && (
-                      <Alert
-                        type="warning"
-                        showIcon
+                      <DesignSystemAlert
+                        variant="warning"
                         title={serverModelsError}
-                        action={
-                          <Button
-                            size="small"
-                            onClick={retryServerModels}
-                            disabled={serverModelsLoading}
-                          >
-                            {t("common:retry", "Retry")}
-                          </Button>
-                        }
+                        action={{
+                          label: t("common:retry", "Retry"),
+                          onClick: retryServerModels,
+                          disabled: serverModelsLoading
+                        }}
                       />
                     )}
                   </div>
@@ -2876,103 +2871,100 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
 
                     {/* Error banners */}
                     {isTldw && !hasAudio && (
-                      <Alert
-                        type="warning"
-                        showIcon
+                      <DesignSystemAlert
+                        variant="warning"
                         title={t(
                           "playground:tts.tldwWarningTitle",
                           "tldw audio/speech API not detected"
                         )}
-                        description={t(
+                      >
+                        {t(
                           "playground:tts.tldwWarningBody",
                           "Ensure your tldw_server version includes /api/v1/audio/speech and that your extension is connected with a valid API key."
                         )}
-                      />
+                      </DesignSystemAlert>
                     )}
 
                     {showElevenLabsHint && (
-                      <Alert
-                        type={hasElevenLabsKey ? "warning" : "info"}
-                        showIcon
+                      <DesignSystemAlert
+                        variant={hasElevenLabsKey ? "warning" : "info"}
                         title={elevenLabsHintTitle}
-                        description={
-                          <div className="space-y-3">
-                            <span>
-                              {hasElevenLabsLoadError && isTimeoutLikeError(elevenLabsError)
-                                ? elevenLabsTimeoutBody
-                                : elevenLabsHintBody}
-                            </span>
-                            {hasElevenLabsKey ? (
-                              <div>
-                                <Button
-                                  size="small"
-                                  type="link"
-                                  onClick={() => {
-                                    void refetchElevenLabs()
-                                  }}
-                                >
-                                  {t("common:retry", "Retry")}
-                                </Button>
-                              </div>
-                            ) : (
-                              <details
-                                open={inlineElevenLabsDetailsOpen}
-                                onToggle={(event) => {
-                                  setInlineElevenLabsDetailsOpen(event.currentTarget.open)
+                      >
+                        <div className="space-y-3">
+                          <span>
+                            {hasElevenLabsLoadError && isTimeoutLikeError(elevenLabsError)
+                              ? elevenLabsTimeoutBody
+                              : elevenLabsHintBody}
+                          </span>
+                          {hasElevenLabsKey ? (
+                            <div>
+                              <Button
+                                size="small"
+                                type="link"
+                                onClick={() => {
+                                  void refetchElevenLabs()
                                 }}
-                                className="rounded-md border border-border bg-background/60 px-3 py-2"
                               >
-                                <summary className="cursor-pointer text-sm font-medium text-text">
-                                  {t(
-                                    "playground:tts.elevenLabsInlineKeySummary",
-                                    "Enter API key"
-                                  )}
-                                </summary>
-                                <div className="mt-3 space-y-2">
-                                  <Space.Compact className="w-full max-w-xl">
-                                    <Input.Password
-                                      id="elevenlabs-api-key"
-                                      aria-label={t(
-                                        "playground:tts.elevenLabsInlineKeyLabel",
-                                        "ElevenLabs API key"
-                                      ) as string}
-                                      placeholder="sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-                                      value={inlineElevenLabsApiKey}
-                                      onChange={(event) => {
-                                        setInlineElevenLabsApiKey(event.target.value)
-                                        setInlineElevenLabsResult(null)
-                                      }}
-                                      onPressEnter={() => {
-                                        void handleInlineElevenLabsSave()
-                                      }}
-                                    />
-                                    <Button
-                                      type="primary"
-                                      loading={inlineElevenLabsSaving}
-                                      disabled={!inlineElevenLabsApiKey.trim()}
-                                      onClick={() => {
-                                        void handleInlineElevenLabsSave()
-                                      }}
-                                    >
-                                      {t(
-                                        "playground:tts.elevenLabsInlineKeySave",
-                                        "Test & Save"
-                                      )}
-                                    </Button>
-                                  </Space.Compact>
-                                  {inlineElevenLabsResult && (
-                                    <Alert
-                                      type={inlineElevenLabsResult.ok ? "success" : "error"}
-                                      showIcon
-                                      title={inlineElevenLabsResult.message}
-                                    />
-                                  )}
-                                </div>
-                              </details>
-                            )}
-                          </div>
-                        }
-                      />
+                                {t("common:retry", "Retry")}
+                              </Button>
+                            </div>
+                          ) : (
+                            <details
+                              open={inlineElevenLabsDetailsOpen}
+                              onToggle={(event) => {
+                                setInlineElevenLabsDetailsOpen(event.currentTarget.open)
+                              }}
+                              className="rounded-md border border-border bg-background/60 px-3 py-2"
+                            >
+                              <summary className="cursor-pointer text-sm font-medium text-text">
+                                {t(
+                                  "playground:tts.elevenLabsInlineKeySummary",
+                                  "Enter API key"
+                                )}
+                              </summary>
+                              <div className="mt-3 space-y-2">
+                                <Space.Compact className="w-full max-w-xl">
+                                  <Input.Password
+                                    id="elevenlabs-api-key"
+                                    aria-label={t(
+                                      "playground:tts.elevenLabsInlineKeyLabel",
+                                      "ElevenLabs API key"
+                                    ) as string}
+                                    placeholder="sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                    value={inlineElevenLabsApiKey}
+                                    onChange={(event) => {
+                                      setInlineElevenLabsApiKey(event.target.value)
+                                      setInlineElevenLabsResult(null)
+                                    }}
+                                    onPressEnter={() => {
+                                      void handleInlineElevenLabsSave()
+                                    }}
+                                  />
+                                  <Button
+                                    type="primary"
+                                    loading={inlineElevenLabsSaving}
+                                    disabled={!inlineElevenLabsApiKey.trim()}
+                                    onClick={() => {
+                                      void handleInlineElevenLabsSave()
+                                    }}
+                                  >
+                                    {t(
+                                      "playground:tts.elevenLabsInlineKeySave",
+                                      "Test & Save"
+                                    )}
+                                  </Button>
+                                </Space.Compact>
+                                {inlineElevenLabsResult && (
+                                  <DesignSystemAlert
+                                    variant={inlineElevenLabsResult.ok ? "success" : "error"}
+                                    title={inlineElevenLabsResult.message}
+                                  />
+                                )}
+                              </div>
+                            </details>
+                          )}
+                        </div>
+                      </DesignSystemAlert>
                     )}
 
                     {/* Text input area */}
@@ -3182,20 +3174,20 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                       />
                     )}
                     {ttsJobStatus === "error" && ttsJobError && (
-                      <Alert
-                        type="error"
-                        showIcon
+                      <DesignSystemAlert
+                        variant="error"
                         title="Long-form TTS error"
-                        description={ttsJobError}
-                      />
+                      >
+                        {ttsJobError}
+                      </DesignSystemAlert>
                     )}
                     {activeStreamError && (
-                      <Alert
-                        type="error"
-                        showIcon
+                      <DesignSystemAlert
+                        variant="error"
                         title="Streaming error"
-                        description={activeStreamError}
-                      />
+                      >
+                        {activeStreamError}
+                      </DesignSystemAlert>
                     )}
 
                     {/* Waveform + Segments */}

--- a/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
@@ -2617,13 +2617,15 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                     {serverModelsError && (
                       <DesignSystemAlert
                         variant="warning"
-                        title={serverModelsError}
+                        title={t("playground:stt.modelsLoadError", "Model load failed")}
                         action={{
                           label: t("common:retry", "Retry"),
                           onClick: retryServerModels,
                           disabled: serverModelsLoading
                         }}
-                      />
+                      >
+                        {serverModelsError}
+                      </DesignSystemAlert>
                     )}
                   </div>
                   <div className="flex flex-col gap-3">
@@ -3176,7 +3178,7 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                     {ttsJobStatus === "error" && ttsJobError && (
                       <DesignSystemAlert
                         variant="error"
-                        title="Long-form TTS error"
+                        title={t("playground:tts.longFormError", "Long-form TTS error")}
                       >
                         {ttsJobError}
                       </DesignSystemAlert>
@@ -3184,7 +3186,7 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                     {activeStreamError && (
                       <DesignSystemAlert
                         variant="error"
-                        title="Streaming error"
+                        title={t("playground:tts.streamingError", "Streaming error")}
                       >
                         {activeStreamError}
                       </DesignSystemAlert>

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
@@ -77,14 +77,15 @@ const {
     },
   }))
 
-const { storageValues, setSpeechModeMock, setSpeechHistoryMock } = vi.hoisted(() => ({
+const { storageValues, setSpeechModeMock, setSpeechHistoryMock, tMock } = vi.hoisted(() => ({
   storageValues: new Map<string, unknown>(),
   setSpeechModeMock: vi.fn(),
   setSpeechHistoryMock: vi.fn(),
+  tMock: vi.fn((_key: string, fallback?: string) => fallback || _key),
 }))
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback || _key,
+    t: tMock,
   }),
 }))
 
@@ -406,6 +407,7 @@ describe("SpeechPlaygroundPage", () => {
     storageValues.set("speechPlaygroundHistory", [])
     setSpeechModeMock.mockReset()
     setSpeechHistoryMock.mockReset()
+    tMock.mockClear()
   })
 
   it("renders without triggering a temporal dead zone error", (): void => {
@@ -584,9 +586,32 @@ describe("SpeechPlaygroundPage", () => {
       )
     ).toBeInTheDocument()
     expect(
+      screen
+        .getByText(
+          "Enter your ElevenLabs API key below to load voices and models. You can also manage it in Settings."
+        )
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(
       screen.getByRole("button", { name: "Test & Save" })
     ).toBeDisabled()
     expect(screen.queryByText("Set API key in Settings")).not.toBeInTheDocument()
+  })
+
+  it("uses the canonical alert when transcription model loading fails", async (): Promise<void> => {
+    getTranscriptionModelsMock.mockRejectedValueOnce(new Error("catalog unavailable"))
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+
+    try {
+      render(<SpeechPlaygroundPage />)
+
+      const modelError = await screen.findByText(
+        "Unable to load transcription models. Retry or check server settings."
+      )
+      expect(modelError.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it("validates and saves the inline ElevenLabs API key to local TTS settings", async (): Promise<void> => {

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
@@ -608,7 +608,9 @@ describe("SpeechPlaygroundPage", () => {
       const modelError = await screen.findByText(
         "Unable to load transcription models. Retry or check server settings."
       )
-      expect(modelError.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+      const modelAlert = modelError.closest('[data-ds-component="Alert"]')
+      expect(modelAlert).toBeInTheDocument()
+      expect(modelAlert).toHaveTextContent("Model load failed")
     } finally {
       warnSpy.mockRestore()
     }

--- a/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useCallback, useEffect, useMemo, useRef } from "react"
-import { Alert, Button, Drawer, Input, Modal, Select, Switch, Tabs, Tag, Tooltip } from "antd"
+import { Button, Drawer, Input, Modal, Select, Switch, Tabs, Tag, Tooltip } from "antd"
 import { DismissibleBetaAlert } from "@/components/Common/DismissibleBetaAlert"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import type { TabsProps } from "antd"
 import {
   BellRing,
@@ -1956,35 +1957,34 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
   const renderWatchlistContainerShell = (): React.ReactNode => {
     if (watchlistsLoading && (!Array.isArray(watchlists) || watchlists.length === 0)) {
       return (
-        <Alert
-          type="info"
-          showIcon
+        <DesignSystemAlert
+          variant="info"
           className="mb-4"
           data-testid="watchlists-container-loading"
           title={t("watchlists:containers.loading", "Loading Watchlists")}
-          description={t(
+        >
+          {t(
             "watchlists:containers.loadingDescription",
             "Preparing your monitoring workspaces."
           )}
-        />
+        </DesignSystemAlert>
       )
     }
 
     if (watchlistsError && (!Array.isArray(watchlists) || watchlists.length === 0)) {
       return (
-        <Alert
-          type="error"
-          showIcon
+        <DesignSystemAlert
+          variant="error"
           className="mb-4"
           data-testid="watchlists-container-error"
           title={t("watchlists:containers.errorTitle", "Watchlists unavailable")}
-          description={watchlistsError}
-          action={(
-            <Button size="small" onClick={() => void loadWatchlists()}>
-              {t("watchlists:errors.retry", "Retry")}
-            </Button>
-          )}
-        />
+          action={{
+            label: t("watchlists:errors.retry", "Retry"),
+            onClick: () => void loadWatchlists()
+          }}
+        >
+          {watchlistsError}
+        </DesignSystemAlert>
       )
     }
 
@@ -2307,43 +2307,43 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
               </Button>
             </div>
           ) : (
-            <Alert
-              type="info"
-              showIcon
+            <DesignSystemAlert
+              variant="info"
               className="mb-4"
               data-testid="watchlists-orientation-alert"
               title={<span data-testid="watchlists-orientation-title">{activeTabOrientation.title}</span>}
-              description={(
-                <div className="space-y-3">
-                  <span data-testid="watchlists-orientation-description">{activeTabOrientation.description}</span>
-                  <div className="flex flex-wrap gap-2">
-                    {activeTabOrientation.actions.map((action) => (
-                      <Button
-                        key={action.key}
-                        size="small"
-                        data-testid={`watchlists-orientation-action-${action.key}`}
-                        onClick={() => navigateToTab(action.target)}
-                      >
-                        {action.label}
-                      </Button>
-                    ))}
-                  </div>
+              dismissible
+              onDismiss={dismissOrientationForActiveTab}
+            >
+              <div className="space-y-3">
+                <span data-testid="watchlists-orientation-description">{activeTabOrientation.description}</span>
+                <div className="flex flex-wrap gap-2">
+                  {activeTabOrientation.actions.map((action) => (
+                    <Button
+                      key={action.key}
+                      size="small"
+                      data-testid={`watchlists-orientation-action-${action.key}`}
+                      onClick={() => navigateToTab(action.target)}
+                    >
+                      {action.label}
+                    </Button>
+                  ))}
                 </div>
-              )}
-              closable
-              onClose={dismissOrientationForActiveTab}
-            />
+              </div>
+            </DesignSystemAlert>
           )}
 
           {activeTeachPoint && (
-            <Alert
-              type="info"
-              showIcon
+            <DesignSystemAlert
+              variant="info"
               className="mb-4"
               data-testid="watchlists-teach-point-alert"
               title={<span data-testid="watchlists-teach-point-title">{activeTeachPoint.title}</span>}
-              description={<span data-testid="watchlists-teach-point-description">{activeTeachPoint.description}</span>}
-              action={(
+              dismissible
+              onDismiss={() => dismissTeachPoint(activeTeachPoint.key)}
+            >
+              <div className="space-y-3">
+                <span data-testid="watchlists-teach-point-description">{activeTeachPoint.description}</span>
                 <Button
                   size="small"
                   data-testid={`watchlists-teach-point-action-${activeTeachPoint.key}`}
@@ -2351,25 +2351,27 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
                 >
                   {activeTeachPoint.actionLabel}
                 </Button>
-              )}
-              closable
-              onClose={() => dismissTeachPoint(activeTeachPoint.key)}
-            />
+              </div>
+            </DesignSystemAlert>
           )}
         </>
       )}
 
       {showGuidedTourCompletion && (
-        <Alert
-          type="success"
-          showIcon
+        <DesignSystemAlert
+          variant="success"
           className="mb-4"
           title={t("watchlists:guide.completedTitle", "Guided tour complete")}
-          description={t(
-            "watchlists:guide.completedDescription",
-            "Next: monitor Activity for monitor health, review Updates for captured content, and open Reports for generated briefings."
-          )}
-          action={(
+          dismissible
+          onDismiss={() => setShowGuidedTourCompletion(false)}
+        >
+          <div className="space-y-3">
+            <span>
+              {t(
+                "watchlists:guide.completedDescription",
+                "Next: monitor Activity for monitor health, review Updates for captured content, and open Reports for generated briefings."
+              )}
+            </span>
             <div className="flex flex-wrap gap-2">
               <Button size="small" onClick={() => navigateToTab("runs")}>
                 {t("watchlists:guide.openActivity", "Open Activity")}
@@ -2378,10 +2380,8 @@ export const WatchlistsPlaygroundPage: React.FC = () => {
                 {t("watchlists:guide.openArticles", "Open Updates")}
               </Button>
             </div>
-          )}
-          closable
-          onClose={() => setShowGuidedTourCompletion(false)}
-        />
+          </div>
+        </DesignSystemAlert>
       )}
 
       <DismissibleBetaAlert

--- a/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.first-class.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.first-class.test.tsx
@@ -325,6 +325,25 @@ describe("WatchlistsPlaygroundPage first-class Watchlist shell", () => {
     expect(screen.getByTestId("watchlists-tab-alerts")).toBeInTheDocument()
   })
 
+  it("uses the canonical alert for container loading and error states", () => {
+    mocks.state.watchlists = []
+    mocks.state.selectedWatchlistId = null
+    mocks.state.watchlistsLoading = true
+
+    const view = render(<WatchlistsPlaygroundPage />)
+
+    const loadingTitle = screen.getByText("Loading Watchlists")
+    expect(loadingTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
+    mocks.state.watchlistsLoading = false
+    mocks.state.watchlistsError = "Backend is offline"
+    view.rerender(<WatchlistsPlaygroundPage />)
+
+    const errorTitle = screen.getByText("Watchlists unavailable")
+    expect(errorTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expect(screen.getByText("Backend is offline")).toBeInTheDocument()
+  })
+
   it("creates a topic-only Watchlist from the shell wizard, selects it, and opens Feeds", async () => {
     const created = {
       ...container,

--- a/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.orientation-guidance.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.orientation-guidance.test.tsx
@@ -257,6 +257,7 @@ describe("WatchlistsPlaygroundPage orientation guidance", () => {
     localStorage.removeItem("watchlists:ia-experiment:v1")
     localStorage.removeItem("watchlists:orientation-dismissed:v1")
     localStorage.removeItem("watchlists:secondary-expanded:v1")
+    localStorage.removeItem("watchlists:teach-points:v1")
   })
 
   afterEach(() => {
@@ -266,6 +267,7 @@ describe("WatchlistsPlaygroundPage orientation guidance", () => {
     localStorage.removeItem("watchlists:ia-experiment:v1")
     localStorage.removeItem("watchlists:orientation-dismissed:v1")
     localStorage.removeItem("watchlists:secondary-expanded:v1")
+    localStorage.removeItem("watchlists:teach-points:v1")
   })
 
   it("shows per-tab orientation and explicit Activity to Reports next action", () => {
@@ -273,10 +275,29 @@ describe("WatchlistsPlaygroundPage orientation guidance", () => {
     render(<WatchlistsPlaygroundPage />)
 
     expect(screen.getByTestId("watchlists-orientation-title")).toHaveTextContent("Activity")
+    expect(
+      screen
+        .getByTestId("watchlists-orientation-title")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
     expect(screen.getByTestId("watchlists-orientation-description")).toHaveTextContent("Reports")
 
     fireEvent.click(screen.getByTestId("watchlists-orientation-action-open-reports"))
     expect(mocks.state.setActiveTab).toHaveBeenCalledWith("outputs")
+  })
+
+  it("uses the canonical alert for tab teach points", () => {
+    mocks.state.activeTab = "jobs"
+    render(<WatchlistsPlaygroundPage />)
+
+    expect(screen.getByTestId("watchlists-teach-point-title")).toHaveTextContent(
+      "Monitor setup tip"
+    )
+    expect(
+      screen
+        .getByTestId("watchlists-teach-point-title")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
   })
 
   it("supports the primary workflow journey from overview through reports", () => {

--- a/backlog/tasks/task-447 - Stabilize-design-system-product-state-guard-drift.md
+++ b/backlog/tasks/task-447 - Stabilize-design-system-product-state-guard-drift.md
@@ -17,6 +17,8 @@ modified_files:
 - apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.first-class.test.tsx
 - apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.orientation-guidance.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
+references:
+- https://github.com/rmusser01/tldw_server/pull/1873
 ---
 
 ## Description
@@ -38,7 +40,7 @@ Migrate the current blocked product-state guard findings on dev to canonical des
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the current Speech/STT/Watchlists guard drift to design-system Alert, registry-backed Audio readiness canonical labels, and pruned stale baseline entries. Verification: focused Vitest suite passed; verify:design-system-state passed; TypeScript full check still fails on existing repo-wide debt outside this slice; Bandit skipped because touched code is TypeScript/JSON/Backlog only.
+Migrated the current Speech/STT/Watchlists guard drift to design-system Alert, registry-backed Audio readiness canonical labels, and pruned stale baseline entries. Draft PR: https://github.com/rmusser01/tldw_server/pull/1873. Verification: focused Vitest suite passed; verify:design-system-state passed; git diff --check passed; TypeScript full check still fails on existing repo-wide debt outside this slice; Bandit skipped because touched code is TypeScript/JSON/Backlog only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-447 - Stabilize-design-system-product-state-guard-drift.md
+++ b/backlog/tasks/task-447 - Stabilize-design-system-product-state-guard-drift.md
@@ -1,0 +1,52 @@
+---
+id: TASK-447
+title: Stabilize design-system product-state guard drift
+status: Done
+labels:
+- design-system
+- product-state
+- ui
+modified_files:
+- apps/packages/ui/src/components/Option/Audio/AudioReadinessStrip.tsx
+- apps/packages/ui/src/components/Option/Audio/__tests__/AudioReadinessStrip.test.tsx
+- apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
+- apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
+- apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+- apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/WatchlistsPlaygroundPage.tsx
+- apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.first-class.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.orientation-guidance.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the current blocked product-state guard findings on dev to canonical design-system primitives and registry-backed labels. Scope: SpeechPlaygroundPage, SttPlaygroundPage, WatchlistsPlaygroundPage, and AudioReadinessStrip. Also remove stale baseline entries produced by the migration and verify the design-system guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the current Speech/STT/Watchlists guard drift to design-system Alert, registry-backed Audio readiness canonical labels, and pruned stale baseline entries. Verification: focused Vitest suite passed; verify:design-system-state passed; TypeScript full check still fails on existing repo-wide debt outside this slice; Bandit skipped because touched code is TypeScript/JSON/Backlog only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-447 - Stabilize-design-system-product-state-guard-drift.md
+++ b/backlog/tasks/task-447 - Stabilize-design-system-product-state-guard-drift.md
@@ -40,7 +40,7 @@ Migrate the current blocked product-state guard findings on dev to canonical des
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the current Speech/STT/Watchlists guard drift to design-system Alert, registry-backed Audio readiness canonical labels, and pruned stale baseline entries. Draft PR: https://github.com/rmusser01/tldw_server/pull/1873. Verification: focused Vitest suite passed; verify:design-system-state passed; git diff --check passed; TypeScript full check still fails on existing repo-wide debt outside this slice; Bandit skipped because touched code is TypeScript/JSON/Backlog only.
+Migrated the current Speech/STT/Watchlists guard drift to design-system Alert, registry-backed Audio readiness canonical labels, and pruned stale baseline entries. Addressed PR #1873 review feedback by moving Speech model-load details into the alert body, translating TTS error titles, and replacing Audio readiness canonical strings with registry-backed exported labels. Verification: focused Vitest suite passed; verify:design-system-state passed with 335 allowed legacy exceptions and no blocked findings; git diff --check passed; full TypeScript still fails on existing repo-wide debt with no diagnostics in touched files; Bandit skipped because touched code is TypeScript/JSON/Backlog only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Migrate Speech, STT, and Watchlists product-state callouts from AntD Alert to the canonical design-system Alert primitive.
- Resolve Audio readiness ready/blocked labels through the design-system state registry.
- Remove stale product-state baseline entries for the migrated alerts and track the slice in TASK-447.

## Verification
- bunx vitest run src/components/Option/Audio/__tests__/AudioReadinessStrip.test.tsx src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.orientation-guidance.test.tsx src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.first-class.test.tsx
- bun run verify:design-system-state
- git diff --check

## Known Checks
- bunx tsc --noEmit --pretty false still fails on existing repo-wide TypeScript debt outside this slice; no diagnostics were in the touched files.
- Bandit skipped: touched implementation is TypeScript/JSON/Backlog only.

## Change summary
Human-authored merge summary required before this PR is marked ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Speech, STT, and Watchlists alerts from `antd` to the design-system `Alert`, and routed Audio readiness labels through the design-system state registry. Addressed review feedback by localizing TTS error titles and moving Speech model-load details into the alert body.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` across STT, Speech, and Watchlists, including action mapping and dismissible behavior.
  - Switched Audio readiness to registry-exported labels (`READY_STATE_LABEL`, `DEGRADED_STATE_LABEL`, `BLOCKED_STATE_LABEL`).
  - Pruned migrated entries from `design-system-product-state-baseline.json`.
  - Updated tests to assert the canonical `Alert` (via data attribute) and registry-backed labels; documented under TASK-447.

<sup>Written for commit 3805017e2f1d33de3cbb3f649dfb4dfdce032170. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1873?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

