### PR TITLE
Harden Character Chat role-play setup controls

### DIFF
--- a/Docs/superpowers/plans/2026-05-20-character-chat-phase3-setup-safety-accessibility-plan.md
+++ b/Docs/superpowers/plans/2026-05-20-character-chat-phase3-setup-safety-accessibility-plan.md
@@ -1,0 +1,173 @@
+# Character Chat Phase 3 Setup Safety And Accessibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining Phase 3 PRD gaps in the existing Role-play setup surface: safe saved-setup deletion and valid generation-style radio semantics.
+
+**Architecture:** Reuse the shipped `RolePlaySetupDrawer` and `SavedRolePlaySetupsPanel`; do not introduce a new role-play state system or persistence model. Keep deletion safety local to the saved setup panel and keep generation style staging inside the existing drawer payload path.
+
+**Tech Stack:** React, TypeScript, Ant Design buttons/inputs, Testing Library, Vitest, existing Playground role-play setup helpers.
+
+---
+
+## Source Context
+
+- PRD: `Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md`
+- Backlog: `TASK-447`
+- Current implementation:
+  - `apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx`
+  - `apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx`
+  - `apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx`
+
+## Scope
+
+- In scope:
+  - Saved role-play setup delete confirmation or undo.
+  - Accessible radio semantics for the Role-play setup generation style selector.
+  - Focused component tests.
+  - Backlog closeout notes.
+- Out of scope:
+  - New Character Chat session rail.
+  - Extension sidepanel parity.
+  - Command palette shortcuts.
+  - Backend or persistence schema changes.
+  - Redesigning the existing Role-play setup drawer.
+
+## Task 1: Saved Setup Delete Safety
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx`
+- Test: `apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx`
+
+- [x] **Step 1: Add a failing test for delete confirmation**
+
+Add a test that renders one saved role-play setup, clicks `Delete`, verifies the setup is not deleted immediately, then clicks a confirmation button and verifies `onDeleteSavedSetup` is called.
+
+Expected assertion shape:
+
+```ts
+fireEvent.click(screen.getByRole("button", { name: "Delete Mira detective scene" }))
+expect(onDeleteSavedSetup).not.toHaveBeenCalled()
+expect(screen.getByRole("status")).toHaveTextContent("Delete Mira detective scene?")
+fireEvent.click(screen.getByRole("button", { name: "Confirm delete Mira detective scene" }))
+expect(onDeleteSavedSetup).toHaveBeenCalledWith("saved-role-play")
+```
+
+- [x] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx --reporter=verbose
+```
+
+Expected: the new test fails because delete currently calls `onDeleteSetup` immediately.
+
+- [x] **Step 3: Implement local pending-delete confirmation**
+
+In `SavedRolePlaySetupsPanel.tsx`:
+
+- add `pendingDeleteId` state;
+- first click sets `pendingDeleteId`;
+- render inline confirmation copy and `Confirm delete` / `Cancel` buttons for that setup only;
+- confirmation calls `onDeleteSetup(setup.id)` and clears pending state;
+- cancel clears pending state;
+- changing the setup list should clear stale pending ids.
+
+Keep copy routed through `t(...)` fallback calls.
+
+- [x] **Step 4: Re-run the focused test**
+
+Expected: the delete confirmation test passes.
+
+## Task 2: Generation Style Radio Semantics
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx`
+- Test: `apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx`
+
+- [x] **Step 1: Add a failing accessibility test**
+
+Add a test that locates the `Generation style` radiogroup in the Role-play setup drawer and verifies each preset is exposed as a `radio`, with the active preset checked.
+
+Expected assertion shape:
+
+```ts
+const group = screen.getByRole("radiogroup", { name: "Generation style" })
+expect(within(group).getByRole("radio", { name: "Creative" })).toBeChecked()
+expect(within(group).getByRole("radio", { name: "Precise" })).not.toBeChecked()
+```
+
+- [x] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx --reporter=verbose
+```
+
+Expected: the new test fails because the current children are buttons with `aria-pressed`.
+
+- [x] **Step 3: Implement radio semantics without changing staged behavior**
+
+In `RolePlaySetupDrawer.tsx`, change each generation style option from a pressed button to a radio input wrapped in a label or a button with `role="radio"` and `aria-checked`.
+
+Preferred implementation:
+
+- render a visually-hidden `input type="radio"` per preset;
+- keep the existing visual card styling on the label;
+- set `name="role-play-generation-style"`;
+- use `checked={selected}`;
+- call `selectGenerationPreset(preset.key)` on change.
+
+- [x] **Step 4: Re-run focused tests**
+
+Expected: Role-play setup tests pass.
+
+## Task 3: Verification And Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-447 - Implement-Character-Chat-Phase-3-role-play-setup-safety-and-accessibility.md`
+
+- [x] **Step 1: Run focused role-play setup tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/saved-role-play-setups.test.ts --reporter=verbose
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+- [x] **Step 3: Record TypeScript and Bandit applicability**
+
+Run `bunx tsc --noEmit --pretty false` if time permits. If the known repo-wide baseline still fails, verify no touched files are listed. Bandit is not applicable unless Python files are touched.
+
+- [x] **Step 4: Update `TASK-447`**
+
+Record touched files, verification commands, TypeScript/Bandit notes, and final summary.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add \
+  Docs/superpowers/plans/2026-05-20-character-chat-phase3-setup-safety-accessibility-plan.md \
+  "backlog/tasks/task-447 - Implement-Character-Chat-Phase-3-role-play-setup-safety-and-accessibility.md" \
+  apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx \
+  apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx \
+  apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+git commit -m "fix: harden character role-play setup controls"
+```

--- a/apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
@@ -535,24 +535,32 @@ export const RolePlaySetupDrawer: React.FC<RolePlaySetupDrawerProps> = ({
             className="grid gap-2 sm:grid-cols-4">
             {PRESETS.map((preset) => {
               const selected = activeGenerationKey === preset.key
+              const label = String(
+                t(
+                  `playground:presets.${preset.key}.label`,
+                  preset.label
+                )
+              )
               return (
-                <button
+                <label
                   key={preset.key}
-                  type="button"
-                  aria-pressed={selected}
-                  onClick={() => selectGenerationPreset(preset.key)}
-                  className={`rounded-md border px-3 py-2 text-left text-xs transition ${
+                  className={`flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-left text-xs transition ${
                     selected
                       ? "border-primary bg-primary/10 text-primaryStrong"
                       : "border-border bg-surface2 text-text-muted hover:border-primary/50 hover:text-text"
                   }`}>
+                  <input
+                    type="radio"
+                    name="role-play-generation-style"
+                    value={preset.key}
+                    checked={selected}
+                    onChange={() => selectGenerationPreset(preset.key)}
+                    className="h-3.5 w-3.5 accent-primary"
+                  />
                   <span className="font-medium">
-                    {t(
-                      `playground:presets.${preset.key}.label`,
-                      preset.label
-                    )}
+                    {label}
                   </span>
-                </button>
+                </label>
               )
             })}
           </div>

--- a/apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
@@ -37,6 +37,7 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
     [setups]
   )
   const [renameDrafts, setRenameDrafts] = React.useState<Record<string, string>>({})
+  const [pendingDeleteId, setPendingDeleteId] = React.useState<string | null>(null)
 
   const getRenameDraft = React.useCallback(
     (setup: StartupTemplateBundle) => renameDrafts[setup.id] ?? setup.name,
@@ -49,6 +50,20 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
       [id]: name
     }))
   }, [])
+
+  React.useEffect(() => {
+    if (!pendingDeleteId) return
+    if (rolePlaySetups.some((setup) => setup.id === pendingDeleteId)) return
+    setPendingDeleteId(null)
+  }, [pendingDeleteId, rolePlaySetups])
+
+  const confirmDelete = React.useCallback(
+    (id: string) => {
+      onDeleteSetup(id)
+      setPendingDeleteId(null)
+    },
+    [onDeleteSetup]
+  )
 
   return (
     <section
@@ -100,6 +115,7 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
           {rolePlaySetups.map((setup) => {
             const preview = describeRolePlaySetupPreview(setup)
             const renameDraft = getRenameDraft(setup)
+            const deletePending = pendingDeleteId === setup.id
             return (
               <div
                 key={setup.id}
@@ -149,11 +165,47 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
                         "Delete {{name}}",
                         { name: setup.name }
                       )}
-                      onClick={() => onDeleteSetup(setup.id)}>
+                      onClick={() => setPendingDeleteId(setup.id)}>
                       {t("common:delete", "Delete")}
                     </Button>
                   </div>
                 </div>
+                {deletePending ? (
+                  <div
+                    role="status"
+                    className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-danger/40 bg-danger/10 p-2 text-xs text-danger">
+                    <span>
+                      {t(
+                        "playground:composer.confirmDeleteRolePlaySetup",
+                        "Delete {{name}}?",
+                        { name: setup.name }
+                      )}
+                    </span>
+                    <div className="flex flex-wrap gap-1">
+                      <Button
+                        size="small"
+                        danger
+                        aria-label={t(
+                          "playground:composer.confirmDeleteRolePlaySetupAction",
+                          "Confirm delete {{name}}",
+                          { name: setup.name }
+                        )}
+                        onClick={() => confirmDelete(setup.id)}>
+                        {t("common:confirm", "Confirm")}
+                      </Button>
+                      <Button
+                        size="small"
+                        aria-label={t(
+                          "playground:composer.cancelDeleteRolePlaySetup",
+                          "Cancel delete {{name}}",
+                          { name: setup.name }
+                        )}
+                        onClick={() => setPendingDeleteId(null)}>
+                        {t("common:cancel", "Cancel")}
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
                 <div className="flex flex-wrap items-center gap-2">
                   <Input
                     aria-label={t(

--- a/apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
@@ -38,6 +38,7 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
   )
   const [renameDrafts, setRenameDrafts] = React.useState<Record<string, string>>({})
   const [pendingDeleteId, setPendingDeleteId] = React.useState<string | null>(null)
+  const confirmDeleteButtonRefs = React.useRef<Record<string, HTMLElement | null>>({})
 
   const getRenameDraft = React.useCallback(
     (setup: StartupTemplateBundle) => renameDrafts[setup.id] ?? setup.name,
@@ -56,6 +57,11 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
     if (rolePlaySetups.some((setup) => setup.id === pendingDeleteId)) return
     setPendingDeleteId(null)
   }, [pendingDeleteId, rolePlaySetups])
+
+  React.useEffect(() => {
+    if (!pendingDeleteId) return
+    confirmDeleteButtonRefs.current[pendingDeleteId]?.focus()
+  }, [pendingDeleteId])
 
   const confirmDelete = React.useCallback(
     (id: string) => {
@@ -172,7 +178,7 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
                 </div>
                 {deletePending ? (
                   <div
-                    role="status"
+                    role="alert"
                     className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-danger/40 bg-danger/10 p-2 text-xs text-danger">
                     <span>
                       {t(
@@ -183,6 +189,9 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
                     </span>
                     <div className="flex flex-wrap gap-1">
                       <Button
+                        ref={(node) => {
+                          confirmDeleteButtonRefs.current[setup.id] = node
+                        }}
                         size="small"
                         danger
                         aria-label={t(

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -377,7 +377,7 @@ describe("RolePlaySetupDrawer", () => {
     await screen.findByText(/1 detail/)
     fireEvent.click(screen.getByRole("button", { name: "Choose behavior template" }))
     fireEvent.click(screen.getByRole("button", { name: "Use Detective" }))
-    fireEvent.click(screen.getByRole("button", { name: "Precise" }))
+    fireEvent.click(screen.getByRole("radio", { name: "Precise" }))
     fireEvent.click(screen.getByRole("button", { name: "Apply" }))
 
     await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1))
@@ -484,6 +484,71 @@ describe("RolePlaySetupDrawer", () => {
     expect(onPreviewSavedSetup).toHaveBeenCalledWith("saved-role-play")
   })
 
+  it("requires confirmation before deleting a saved role-play setup", async () => {
+    const savedSetup = createStartupTemplateBundle(
+      {
+        name: "Mira detective scene",
+        selectedModel: "openai:gpt-4.1",
+        systemPrompt: "Observe everything.",
+        source: "role-play-setup",
+        character: {
+          id: "char-mira",
+          name: "Mira"
+        } as any,
+        rolePlay: {
+          source: "role-play-setup",
+          identity: {
+            kind: "character",
+            id: "char-mira",
+            name: "Mira"
+          },
+          behavior: null,
+          scene: activeScene(),
+          generation: null,
+          context: null
+        }
+      },
+      { id: "saved-role-play", now: 1 }
+    )
+    const onDeleteSavedSetup = vi.fn()
+
+    renderDrawer({
+      savedRolePlaySetups: [savedSetup],
+      savedSetupDraftName: "",
+      savedSetupNameFallback: "Mira setup",
+      onSavedSetupDraftNameChange: vi.fn(),
+      onSaveRolePlaySetup: vi.fn(),
+      onPreviewSavedSetup: vi.fn(),
+      onApplySavedSetup: vi.fn(),
+      onRenameSavedSetup: vi.fn(),
+      onDeleteSavedSetup
+    })
+
+    await screen.findByText(/1 detail/)
+    fireEvent.click(screen.getByRole("button", { name: "Delete Mira detective scene" }))
+
+    expect(onDeleteSavedSetup).not.toHaveBeenCalled()
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Delete Mira detective scene?"
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm delete Mira detective scene" })
+    )
+    expect(onDeleteSavedSetup).toHaveBeenCalledWith("saved-role-play")
+  })
+
+  it("exposes generation style choices as radios", async () => {
+    renderDrawer()
+
+    await screen.findByText(/1 detail/)
+    const group = screen.getByRole("radiogroup", { name: "Generation style" })
+    expect(within(group).getByRole("radio", { name: "Creative" })).toBeChecked()
+    expect(within(group).getByRole("radio", { name: "Balanced" })).not.toBeChecked()
+    expect(within(group).getByRole("radio", { name: "Precise" })).not.toBeChecked()
+    expect(within(group).getByRole("radio", { name: "Custom" })).not.toBeChecked()
+  })
+
   it("applies saved role-play setup scene through the actor settings save path", async () => {
     const savedSetup = createStartupTemplateBundle(
       {
@@ -559,7 +624,7 @@ describe("RolePlaySetupDrawer", () => {
     await screen.findByText(/1 detail/)
     fireEvent.click(screen.getByRole("button", { name: "Choose behavior template" }))
     fireEvent.click(screen.getByRole("button", { name: "Use Detective" }))
-    fireEvent.click(screen.getByRole("button", { name: "Precise" }))
+    fireEvent.click(screen.getByRole("radio", { name: "Precise" }))
     fireEvent.click(screen.getByRole("button", { name: "Save setup" }))
 
     expect(onSaveRolePlaySetup).toHaveBeenCalledWith(

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
@@ -112,24 +112,25 @@ vi.mock("antd", () => ({
         {children}
       </section>
     ) : null,
-  Button: ({
-    children,
-    onClick,
-    htmlType,
-    "aria-label": ariaLabel
-  }: {
+  Button: React.forwardRef<HTMLButtonElement, {
     children: React.ReactNode
     onClick?: () => void
     htmlType?: string
     "aria-label"?: string
-  }) => (
+  }>(({
+    children,
+    onClick,
+    htmlType,
+    "aria-label": ariaLabel
+  }, ref) => (
     <button
+      ref={ref}
       type={htmlType === "submit" ? "submit" : "button"}
       aria-label={ariaLabel}
       onClick={onClick}>
       {children}
     </button>
-  ),
+  )),
   Checkbox: ({
     checked,
     onChange,
@@ -528,13 +529,16 @@ describe("RolePlaySetupDrawer", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete Mira detective scene" }))
 
     expect(onDeleteSavedSetup).not.toHaveBeenCalled()
-    expect(screen.getByRole("status")).toHaveTextContent(
+    const alert = screen.getByRole("alert")
+    expect(alert).toHaveTextContent(
       "Delete Mira detective scene?"
     )
+    const confirmButton = screen.getByRole("button", {
+      name: "Confirm delete Mira detective scene"
+    })
+    expect(confirmButton).toHaveFocus()
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Confirm delete Mira detective scene" })
-    )
+    fireEvent.click(confirmButton)
     expect(onDeleteSavedSetup).toHaveBeenCalledWith("saved-role-play")
   })
 

--- a/backlog/tasks/task-447 - Implement-Character-Chat-Phase-3-role-play-setup-safety-and-accessibility.md
+++ b/backlog/tasks/task-447 - Implement-Character-Chat-Phase-3-role-play-setup-safety-and-accessibility.md
@@ -1,0 +1,78 @@
+---
+id: TASK-447
+title: Implement Character Chat Phase 3 role-play setup safety and accessibility
+status: Done
+labels:
+- chat
+- characters
+- role-play
+- phase-3
+- frontend
+- accessibility
+priority: high
+ordinal: 447
+references:
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+- TASK-426
+- TASK-431
+- TASK-438
+documentation:
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+- Docs/superpowers/plans/2026-05-20-character-chat-phase3-setup-safety-accessibility-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-05-20-character-chat-phase3-setup-safety-accessibility-plan.md
+- apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
+- apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the remaining high-value Phase 3 hardening from the first-class Character Chat PRD without duplicating already-shipped role-play setup work. Scope: saved role-play setup destructive-action safety and accessible generation-style semantics inside the Role-play setup surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Saved role-play setup deletion requires explicit confirmation or offers undo before permanent deletion.
+- [x] #2 The Role-play setup generation style control exposes valid radio/radiogroup semantics and selected state to assistive tech.
+- [x] #3 Focused component tests cover delete safety and generation style semantics.
+- [x] #4 Verification, TypeScript/Bandit applicability, and residual risks are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-20-character-chat-phase3-setup-safety-accessibility-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the remaining Phase 3 setup hardening on the existing Role-play setup surface.
+
+- Saved role-play setup deletion now uses an inline pending-delete confirmation with confirm/cancel actions before invoking the destructive callback.
+- The drawer generation-style selector now uses native radio inputs inside the existing visual card layout, preserving the staged apply payload while exposing valid radiogroup/radio semantics and checked state.
+- Verification: initial focused RolePlaySetupDrawer test failed on immediate delete and missing radio roles before implementation.
+- Verification: `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx --reporter=verbose` passed with 13 tests after implementation.
+- Verification: `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/saved-role-play-setups.test.ts --reporter=verbose` passed with 2 files / 19 tests.
+- Verification: `git diff --check` passed.
+- TypeScript: `bunx tsc --noEmit --pretty false` still fails on existing baseline errors in MediaReadAlongPopover, EmbeddingsModelSelectionConfig, WorkspacePlayground StudioPane, useShortcutConfig, and admin-llamacpp E2E typing; none are touched files.
+- Bandit skipped because this slice touches only frontend TypeScript/TSX and Backlog/plan docs.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Phase 3 setup safety/accessibility hardening is complete. Saved role-play setup delete now requires explicit inline confirmation, and Role-play setup generation style choices expose real radio semantics while preserving the existing visual design and staged apply behavior. Focused Vitest coverage and diff hygiene pass; TypeScript remains blocked only by unrelated baseline debt, and Bandit is not applicable for this frontend-only slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-448 - Address-PR-1874-role-play-setup-review-comments.md
+++ b/backlog/tasks/task-448 - Address-PR-1874-role-play-setup-review-comments.md
@@ -1,0 +1,68 @@
+---
+id: TASK-448
+title: Address PR 1874 role-play setup review comments
+status: In Progress
+labels:
+- chat
+- characters
+- role-play
+- review
+- frontend
+- accessibility
+priority: high
+ordinal: 448
+references:
+- https://github.com/rmusser01/tldw_server/pull/1874
+- TASK-447
+documentation:
+- Docs/superpowers/plans/2026-05-20-character-chat-phase3-setup-safety-accessibility-plan.md
+modified_files:
+- apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the live PR #1874 review thread for Character Chat role-play setup controls. Scope is the Gemini inline accessibility finding on delete confirmation semantics and focus management; preserve the existing narrow Phase 3 implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Live PR #1874 review threads are verified before patching.
+- [x] #2 Saved role-play setup delete confirmation uses assertive alert semantics for the destructive confirmation.
+- [x] #3 Keyboard focus moves to the confirm-delete action when the confirmation prompt appears.
+- [x] #4 Focused tests cover the alert/focus behavior and pass.
+- [ ] #5 Verification and PR thread resolution are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Live review surface checked with `gh pr view`, GraphQL review threads, and `gh pr checks`.
+- Actionable thread: Gemini inline comment on `SavedRolePlaySetupsPanel.tsx` requested `role="alert"` and focus management for the confirm-delete action.
+- Implemented alert semantics for the destructive confirmation prompt.
+- Added confirm-delete focus management with per-setup refs, widened to `HTMLElement` because AntD Button may expose button or anchor elements.
+- Updated the focused test mock to forward refs and asserted the alert plus focus behavior.
+- Verification: `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx --reporter=verbose` passed with 13 tests.
+- Verification: `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/saved-role-play-setups.test.ts --reporter=verbose` passed with 2 files / 19 tests.
+- Verification: `git diff --check` passed.
+- TypeScript: `bunx tsc --noEmit --pretty false` still fails on existing baseline errors in MediaReadAlongPopover, EmbeddingsModelSelectionConfig, WorkspacePlayground StudioPane, useShortcutConfig, and admin-llamacpp E2E typing; no touched-file errors remain.
+- Bandit skipped because only frontend TypeScript/TSX and Backlog docs were touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the actionable PR #1874 Gemini review thread. The saved role-play setup delete confirmation now uses assertive alert semantics and moves keyboard focus to the confirm-delete action when the prompt appears. Focused tests and diff hygiene pass; TypeScript remains blocked only by unrelated baseline debt.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-448 - Address-PR-1874-role-play-setup-review-comments.md
+++ b/backlog/tasks/task-448 - Address-PR-1874-role-play-setup-review-comments.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-448
 title: Address PR 1874 role-play setup review comments
-status: In Progress
+status: Done
 labels:
 - chat
 - characters
@@ -33,7 +33,7 @@ Address the live PR #1874 review thread for Character Chat role-play setup contr
 - [x] #2 Saved role-play setup delete confirmation uses assertive alert semantics for the destructive confirmation.
 - [x] #3 Keyboard focus moves to the confirm-delete action when the confirmation prompt appears.
 - [x] #4 Focused tests cover the alert/focus behavior and pass.
-- [ ] #5 Verification and PR thread resolution are recorded.
+- [x] #5 Verification and PR thread resolution are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -49,17 +49,18 @@ Address the live PR #1874 review thread for Character Chat role-play setup contr
 - Verification: `git diff --check` passed.
 - TypeScript: `bunx tsc --noEmit --pretty false` still fails on existing baseline errors in MediaReadAlongPopover, EmbeddingsModelSelectionConfig, WorkspacePlayground StudioPane, useShortcutConfig, and admin-llamacpp E2E typing; no touched-file errors remain.
 - Bandit skipped because only frontend TypeScript/TSX and Backlog docs were touched.
+- PR thread `PRRT_kwDOL1aGf86DVuzw` was resolved after commit `5efab8e95` was pushed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed the actionable PR #1874 Gemini review thread. The saved role-play setup delete confirmation now uses assertive alert semantics and moves keyboard focus to the confirm-delete action when the prompt appears. Focused tests and diff hygiene pass; TypeScript remains blocked only by unrelated baseline debt.
+Addressed the actionable PR #1874 Gemini review thread. The saved role-play setup delete confirmation now uses assertive alert semantics and moves keyboard focus to the confirm-delete action when the prompt appears. Focused tests and diff hygiene pass; TypeScript remains blocked only by unrelated baseline debt. The review thread was resolved after the fix landed on the PR branch.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip


### PR DESCRIPTION
## Summary
- Adds inline confirmation before deleting a saved role-play setup from the Character Chat Role-play setup surface.
- Converts the Role-play setup generation style picker from pressed buttons to native radio inputs while keeping the existing staged apply behavior.
- Tracks the Phase 3 safety/accessibility slice in Backlog TASK-447 and its implementation plan.

## Change summary
Human-authored summary required before merge.

## Test Plan
- [x] `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx --reporter=verbose`
- [x] `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/saved-role-play-setups.test.ts --reporter=verbose`
- [x] `git diff --check`
- [x] `bunx tsc --noEmit --pretty false` fails only on unrelated baseline TypeScript errors outside touched files.
- [x] Bandit not applicable: frontend TypeScript/TSX and docs/task files only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Character Chat role‑play setup controls with inline delete confirmation and accessible generation‑style radios. Adds alert semantics and auto‑focus to Confirm, improving keyboard and screen reader support without changing staged Apply behavior.

- New Features
  - Require inline confirm/cancel before deleting a saved setup; prompt uses role="alert" and moves focus to Confirm.
  - Replace generation style pressed buttons with native radios and a labeled radiogroup; keep staged Apply flow.
  - Add focused tests for delete confirmation, focus handling, and radio semantics; update docs/tasks to close out TASK-447 and TASK-448.

<sup>Written for commit 0295df047c64119417b59f7ec3ce8f4ff4ce877e. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1874?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

