### PR TITLE
WP11A: preserve audio alias speech coverage

### DIFF
--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/audio-alias.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/audio-alias.spec.ts
@@ -6,7 +6,8 @@
  * Run: npx playwright test e2e/workflows/tier-2-features/audio-alias.spec.ts
  */
 import { assertNoCriticalErrors, expect, test } from "../../utils/fixtures"
-import { waitForAppShell } from "../../utils/helpers"
+import { SpeechPage } from "../../utils/page-objects/SpeechPage"
+import { waitForConnection } from "../../utils/helpers"
 
 const LOAD_TIMEOUT = 30_000
 
@@ -15,6 +16,8 @@ test.describe("Audio Alias", () => {
     authedPage,
     diagnostics,
   }) => {
+    const speech = new SpeechPage(authedPage)
+
     await authedPage.goto("/audio?source=e2e-alias#voice", {
       waitUntil: "domcontentloaded",
       timeout: LOAD_TIMEOUT,
@@ -27,14 +30,13 @@ test.describe("Audio Alias", () => {
         url.hash === "#voice",
       { timeout: LOAD_TIMEOUT }
     )
-    await waitForAppShell(authedPage, LOAD_TIMEOUT)
+    await waitForConnection(authedPage, LOAD_TIMEOUT)
+    await speech.assertPageReady()
 
-    await expect(authedPage.getByRole("heading", { name: /^Speech Playground$/i })).toBeVisible({
-      timeout: LOAD_TIMEOUT,
-    })
-    await expect(authedPage.getByRole("radio", { name: /^Round-trip$/i })).toBeVisible()
-    await expect(authedPage.getByRole("radio", { name: /^Speak$/i })).toBeVisible()
-    await expect(authedPage.getByRole("radio", { name: /^Listen$/i })).toBeVisible()
+    await expect(speech.heading).toBeVisible({ timeout: LOAD_TIMEOUT })
+    await expect(speech.roundTripOption).toBeVisible()
+    await expect(speech.speakOption).toBeVisible()
+    await expect(speech.listenOption).toBeVisible()
     await expect(authedPage.getByTestId("route-redirect-panel")).toHaveCount(0)
 
     await assertNoCriticalErrors(diagnostics)

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/audio-alias.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/audio-alias.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Audio alias E2E Tests (Tier 2)
+ *
+ * Locks /audio as a UI-free alias to the canonical /speech route.
+ *
+ * Run: npx playwright test e2e/workflows/tier-2-features/audio-alias.spec.ts
+ */
+import { assertNoCriticalErrors, expect, test } from "../../utils/fixtures"
+import { waitForAppShell } from "../../utils/helpers"
+
+const LOAD_TIMEOUT = 30_000
+
+test.describe("Audio Alias", () => {
+  test("opens the canonical speech playground and preserves route context", async ({
+    authedPage,
+    diagnostics,
+  }) => {
+    await authedPage.goto("/audio?source=e2e-alias#voice", {
+      waitUntil: "domcontentloaded",
+      timeout: LOAD_TIMEOUT,
+    })
+
+    await authedPage.waitForURL(
+      (url) =>
+        url.pathname === "/speech" &&
+        url.searchParams.get("source") === "e2e-alias" &&
+        url.hash === "#voice",
+      { timeout: LOAD_TIMEOUT }
+    )
+    await waitForAppShell(authedPage, LOAD_TIMEOUT)
+
+    await expect(authedPage.getByRole("heading", { name: /^Speech Playground$/i })).toBeVisible({
+      timeout: LOAD_TIMEOUT,
+    })
+    await expect(authedPage.getByRole("radio", { name: /^Round-trip$/i })).toBeVisible()
+    await expect(authedPage.getByRole("radio", { name: /^Speak$/i })).toBeVisible()
+    await expect(authedPage.getByRole("radio", { name: /^Listen$/i })).toBeVisible()
+    await expect(authedPage.getByTestId("route-redirect-panel")).toHaveCount(0)
+
+    await assertNoCriticalErrors(diagnostics)
+  })
+})

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
@@ -50,12 +50,25 @@ test.describe("Speech Playground", () => {
 
       // Heading visible
       await expect(speech.heading).toBeVisible()
+      await expect(authedPage.getByRole("heading", { name: /^Speech Playground$/i })).toBeVisible()
+      await expect(
+        authedPage.getByText(
+          /Record speech, edit transcripts, and synthesize audio in one place\./i
+        )
+      ).toBeVisible()
 
       // Mode selector visible with all three options
       await expect(speech.modeSelector).toBeVisible()
       await expect(speech.roundTripOption).toBeVisible()
       await expect(speech.speakOption).toBeVisible()
       await expect(speech.listenOption).toBeVisible()
+
+      // TTS readiness and output history stay visible on the first screen.
+      await expect(authedPage.getByRole("status", { name: /^TTS readiness$/i })).toBeVisible()
+      await expect(authedPage.getByText(/^Speech history$/i)).toBeVisible()
+      await expect(
+        authedPage.getByText(/Start a recording or generate audio to see history here\./i)
+      ).toBeVisible()
 
       // Playback toolbar visible
       await expect(speech.playbackToolbar).toBeVisible()

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
@@ -50,7 +50,6 @@ test.describe("Speech Playground", () => {
 
       // Heading visible
       await expect(speech.heading).toBeVisible()
-      await expect(authedPage.getByRole("heading", { name: /^Speech Playground$/i })).toBeVisible()
       await expect(
         authedPage.getByText(
           /Record speech, edit transcripts, and synthesize audio in one place\./i

--- a/backlog/tasks/task-418.8.1 - Preserve-WebUI-audio-alias-and-speech-route-coverage.md
+++ b/backlog/tasks/task-418.8.1 - Preserve-WebUI-audio-alias-and-speech-route-coverage.md
@@ -36,13 +36,13 @@ Execute WP11A Task 2 from the WebUI audio routes implementation plan. Preserve /
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Added focused Tier 2 Playwright coverage for /audio as a UI-free alias to /speech. Extended /speech page-load coverage to assert first-screen route identity, combined workflow modes, input source readiness, TTS readiness status, and empty speech history state. No production UI, backend API, or unrelated route files changed.
+Added focused Tier 2 Playwright coverage for /audio as a UI-free alias to /speech. Extended /speech page-load coverage to assert first-screen route identity, combined workflow modes, input source readiness, TTS readiness status, and empty speech history state. Review fix pass for PR #1875 added the shared waitForConnection gate after the /audio redirect, reused SpeechPage locators in the alias test, and removed the redundant direct heading assertion from the speech page-load spec. No production UI, backend API, or unrelated route files changed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implementation: added e2e/workflows/tier-2-features/audio-alias.spec.ts and extended speech-playground.spec.ts page-load assertions. Verification: bunx playwright test e2e/workflows/tier-2-features/audio-alias.spec.ts e2e/workflows/tier-2-features/speech-playground.spec.ts --reporter=line (3 passed, 1 skipped by existing TTS API guard); git diff --check (passed). Bandit skipped: touched files are frontend Playwright/Backlog markdown only.
+Implementation: added e2e/workflows/tier-2-features/audio-alias.spec.ts and extended speech-playground.spec.ts page-load assertions. Review fixes addressed PR #1875 feedback by adding waitForConnection to the alias path, reusing SpeechPage for alias route assertions, and removing a duplicate heading assertion. Verification: bunx playwright test e2e/workflows/tier-2-features/audio-alias.spec.ts e2e/workflows/tier-2-features/speech-playground.spec.ts --reporter=line (3 passed, 1 skipped by existing TTS API guard); git diff --check (passed). Bandit skipped: touched files are frontend Playwright/Backlog markdown only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-418.8.1 - Preserve-WebUI-audio-alias-and-speech-route-coverage.md
+++ b/backlog/tasks/task-418.8.1 - Preserve-WebUI-audio-alias-and-speech-route-coverage.md
@@ -1,0 +1,56 @@
+---
+id: TASK-418.8.1
+title: Preserve WebUI audio alias and speech route coverage
+status: Done
+labels:
+- webui
+- ux-audit
+- audio
+- wp11a
+- e2e
+priority: medium
+parent_task_id: TASK-418.8
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-audio-routes-implementation-plan.md
+modified_files:
+- apps/tldw-frontend/e2e/workflows/tier-2-features/audio-alias.spec.ts
+- apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
+- backlog/tasks/task-418.8.1 - Preserve-WebUI-audio-alias-and-speech-route-coverage.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP11A Task 2 from the WebUI audio routes implementation plan. Preserve /audio as a UI-free alias to /speech and add focused browser coverage for the /speech first-screen route identity, combined workflow modes, recording/source readiness, provider readiness, and output/history state without changing backend APIs or redesigning the audio UI.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /audio has focused E2E coverage proving it lands on the canonical /speech route and renders the speech playground.
+- [x] #2 /audio remains UI-free unless browser coverage exposes a real alias failure.
+- [x] #3 /speech E2E coverage verifies first-screen identity, combined workflow modes, source or recording readiness, TTS provider readiness near synthesis controls, and generated audio history or empty output state.
+- [x] #4 Focused Playwright verification and git diff checks are recorded in the task final summary.
+- [x] #5 No backend APIs or unrelated routes are changed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added focused Tier 2 Playwright coverage for /audio as a UI-free alias to /speech. Extended /speech page-load coverage to assert first-screen route identity, combined workflow modes, input source readiness, TTS readiness status, and empty speech history state. No production UI, backend API, or unrelated route files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implementation: added e2e/workflows/tier-2-features/audio-alias.spec.ts and extended speech-playground.spec.ts page-load assertions. Verification: bunx playwright test e2e/workflows/tier-2-features/audio-alias.spec.ts e2e/workflows/tier-2-features/speech-playground.spec.ts --reporter=line (3 passed, 1 skipped by existing TTS API guard); git diff --check (passed). Bandit skipped: touched files are frontend Playwright/Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Added focused Tier 2 coverage that opens `/audio?source=e2e-alias#voice`, asserts it lands on `/speech` with query/hash preserved, and verifies the speech playground renders without the redirect panel.
- Extended `/speech` first-load coverage for route identity, subtitle, mode selector, TTS readiness status, input source readiness, playback controls, and empty speech history state.
- Recorded TASK-418.8.1 and kept production route/UI/backend files untouched.

## Test Plan
- [x] `bunx playwright test e2e/workflows/tier-2-features/audio-alias.spec.ts e2e/workflows/tier-2-features/speech-playground.spec.ts --reporter=line` (3 passed, 1 skipped by existing TTS API guard)
- [x] `git diff --cached --check`

## Change summary
TODO: human maintainer to fill in before merge per AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Playwright E2E coverage to confirm `/audio` is a UI-free alias of `/speech`, preserving query and hash, and rendering the Speech Playground without the redirect panel. Stabilizes the alias flow with a connection wait and extends first-load checks on `/speech` for route identity, subtitle, mode selector, TTS readiness, input readiness, playback controls, and empty history to satisfy TASK-418.8.1; no production changes.

<sup>Written for commit 4b267b2fab222a82c89be876be822a4217271ce9. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1875?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

