### PR TITLE
chore(backlog): complete Quick Ingest task hygiene

### DIFF
--- a/backlog/completed/task-403 - Implement-Quick-Ingest-batch-conference-metadata.md
+++ b/backlog/completed/task-403 - Implement-Quick-Ingest-batch-conference-metadata.md
@@ -34,6 +34,7 @@ Task 3 for the bulk conference ingestion workflow plan. Add shared conference me
 - Updated direct and background Quick Ingest submission paths to create collections/items, attach planned item IDs to job fields, and patch item status on submit/progress/failure.
 - Verification: focused Vitest suite passed, 74 tests across wizard integration/session, conference collection service, and batch submission. `git diff --check` passed. Shared UI `tsc` still fails on the existing repo-wide baseline; a touched-file filter for Quick Ingest/conference/background paths produced no matches.
 - Bandit was not run because this slice only touched TypeScript/TSX, plan docs, and Backlog task files.
+- Backlog hygiene follow-up on 2026-05-19: moved this already-completed Quick Ingest record from `backlog/tasks` to `backlog/completed` by exact path so active-board checks do not mistake it for remaining sprint work. ID-based completion was intentionally avoided because unrelated `TASK-403` records also exist.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/completed/task-406 - Complete-Quick-Ingest-duplicate-ID-closeout-tasks.md
+++ b/backlog/completed/task-406 - Complete-Quick-Ingest-duplicate-ID-closeout-tasks.md
@@ -12,7 +12,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Move completed Quick Ingest parent/planning/review Backlog records out of active tasks by exact file path because their TASK-392 through TASK-395 IDs collide with unrelated active records. Do not use ID-based completion for the duplicate records.
+Move completed Quick Ingest parent/planning/review Backlog records out of active tasks by exact file path because their TASK-392 through TASK-395 IDs collide with unrelated active records. A follow-up also moves completed Quick Ingest TASK-403 and TASK-407 records for the same reason. Do not use ID-based completion for duplicate records.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -20,18 +20,19 @@ Move completed Quick Ingest parent/planning/review Backlog records out of active
 - [x] #1 Completed Quick Ingest planning, parent, and PR-review records are moved out of active tasks by exact file path.
 - [x] #2 Unrelated duplicate-ID active records remain untouched.
 - [x] #3 Verification records that active TASK-392 through TASK-395 IDs now resolve to the unrelated active records only.
+- [x] #4 Completed Quick Ingest TASK-403 and TASK-407 records are moved out of active tasks by exact file path.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Moved the completed Quick Ingest records for TASK-392, TASK-393, TASK-394, and TASK-395 from `backlog/tasks` to `backlog/completed` with exact path-based `git mv` commands because Backlog ID-based completion was unsafe while duplicate active IDs existed. Left the unrelated active duplicate-ID records in place.
+Moved the completed Quick Ingest records for TASK-392, TASK-393, TASK-394, and TASK-395 from `backlog/tasks` to `backlog/completed` with exact path-based `git mv` commands because Backlog ID-based completion was unsafe while duplicate active IDs existed. Follow-up on 2026-05-19 moved the already-completed Quick Ingest TASK-403 batch conference metadata record and TASK-407 extension playlist handoff record by exact path for the same reason. Left the unrelated active duplicate-ID records in place.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed the remaining Quick Ingest Backlog closeout by moving the completed design, implementation-plan, parent implementation, and PR #1751 review records to completed storage. This resolves the active duplicate-ID ambiguity for TASK-392 through TASK-395 without renumbering or modifying unrelated active tasks. Verification was metadata-only: exact file moves, active/completed path checks, `git diff --check`, and status review.
+Completed the remaining Quick Ingest Backlog closeout by moving the completed design, implementation-plan, parent implementation, PR #1751 review, batch metadata, and extension playlist handoff records to completed storage. This resolves the Quick Ingest active-task ambiguity for TASK-392 through TASK-395, TASK-403, and TASK-407 without renumbering or modifying unrelated duplicate-ID tasks. Verification was metadata-only: exact file moves, active/completed path checks, `git diff --check`, and status review.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/completed/task-407 - Add-extension-playlist-quick-ingest-handoff.md
+++ b/backlog/completed/task-407 - Add-extension-playlist-quick-ingest-handoff.md
@@ -31,6 +31,7 @@ Implement Task 7 from the bulk conference ingest plan: typed Quick Ingest open d
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented typed Quick Ingest open detail and active-tab YouTube playlist detection in the sidepanel quick action. The shared Quick Ingest event/session path now persists the detail, hydrates it into wizard state, and seeds the existing playlist preflight path. background.ts was reviewed but left unchanged because active-tab resolution happens in ControlRow at click time and existing background runtime metadata handling already covers queued batch processing. Verification: focused quick-ingest-open, sidepanel form contract, QuickIngestWizardModal integration, and sidepanel route registry Vitest suites pass; git diff --check passes; TypeScript still fails only on unrelated baseline files.
+Backlog hygiene follow-up on 2026-05-19: moved this already-completed Quick Ingest record from `backlog/tasks` to `backlog/completed` by exact path so active-board checks do not mistake it for remaining sprint work. ID-based completion was intentionally avoided because unrelated `TASK-407` records also exist.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Move the completed Quick Ingest TASK-403 and TASK-407 records from backlog/tasks to backlog/completed by exact path.
- Update the duplicate-ID closeout record so future checks know these completed Quick Ingest records were intentionally relocated.
- Add hygiene notes to the moved records explaining why ID-based completion was avoided.

## Verification
- git diff --check HEAD~1 HEAD
- Confirmed the old active task paths no longer exist.
- Confirmed the completed task paths exist.
- Backlog task_search for 'TASK-403 Quick Ingest' and 'TASK-407 Quick Ingest' returned no active matches.

## Change summary
Pending human-authored summary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved completed Quick Ingest `TASK-403` and `TASK-407` from `backlog/tasks` to `backlog/completed` by exact path to avoid duplicate-ID collisions and false active matches. Updated the duplicate-ID closeout record to include these moves and added hygiene notes explaining why ID-based completion was not used.

<sup>Written for commit 899b92853cc14871d47f2ba4f60e45b72874e82a. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1876?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

