### PR TITLE
Migrate WorkflowRunInspector product states

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -99,28 +99,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Common/Workflow/WorkflowRunInspector.tsx:Empty",
-    "path": "src/components/Common/Workflow/WorkflowRunInspector.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/Common/Workflow/WorkflowRunInspector.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Common/Workflow/WorkflowRunInspector.tsx:Tag",
-    "path": "src/components/Common/Workflow/WorkflowRunInspector.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Tag",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Tag product-state UI in src/components/Common/Workflow/WorkflowRunInspector.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentPickerModal.tsx:Alert#antd-alert-documentpickermodal-type-error-line-573-1sibda5",
     "path": "src/components/DocumentWorkspace/DocumentPickerModal.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx
@@ -1,5 +1,6 @@
-import { Empty, Tabs, Tag } from "antd"
+import { Tabs } from "antd"
 
+import { Badge, EmptyState } from "@/components/ui"
 import type {
   WorkflowRunInvestigation,
   WorkflowStepAttempt
@@ -19,12 +20,27 @@ const formatAttemptSubtitle = (attempt: WorkflowStepAttempt) => {
   return details.join(" • ")
 }
 
+const getAttemptStatusVariant = (
+  status: WorkflowStepAttempt["status"]
+): "danger" | "success" | "warning" | "secondary" => {
+  if (status === "failed") return "danger"
+  if (status === "completed") return "success"
+  if (status === "running") return "warning"
+  return "secondary"
+}
+
 export const WorkflowRunInspector = ({
   investigation,
   className = ""
 }: WorkflowRunInspectorProps) => {
   if (!investigation) {
-    return <Empty description="No run diagnostics available" />
+    return (
+      <EmptyState
+        variant="inline"
+        size="sm"
+        title="No run diagnostics available"
+      />
+    )
   }
 
   const failure = investigation.primary_failure
@@ -51,14 +67,20 @@ export const WorkflowRunInspector = ({
                   </h4>
                   <div className="mt-2 flex flex-wrap items-center gap-2">
                     {failure?.reason_code_core && (
-                      <Tag color="error">{failure.reason_code_core}</Tag>
+                      <Badge variant="danger">{failure.reason_code_core}</Badge>
                     )}
-                    {failure?.category && <Tag>{failure.category}</Tag>}
-                    {failure?.blame_scope && <Tag>{failure.blame_scope}</Tag>}
+                    {failure?.category && (
+                      <Badge variant="secondary">{failure.category}</Badge>
+                    )}
+                    {failure?.blame_scope && (
+                      <Badge variant="secondary">{failure.blame_scope}</Badge>
+                    )}
                     {failure?.retryable !== undefined && (
-                      <Tag color={failure.retryable ? "success" : "default"}>
+                      <Badge
+                        variant={failure.retryable ? "success" : "secondary"}
+                      >
                         {failure.retryable ? "Retryable" : "Non-retryable"}
-                      </Tag>
+                      </Badge>
                     )}
                   </div>
                   {failure?.error_summary && (
@@ -83,9 +105,11 @@ export const WorkflowRunInspector = ({
                             <span className="font-medium text-sm">
                               Attempt {attempt.attempt_number}
                             </span>
-                            <Tag color={attempt.status === "failed" ? "error" : "default"}>
+                            <Badge
+                              variant={getAttemptStatusVariant(attempt.status)}
+                            >
                               {attempt.status}
-                            </Tag>
+                            </Badge>
                           </div>
                           {formatAttemptSubtitle(attempt) && (
                             <p className="mt-2 text-xs text-text-subtle">

--- a/apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx
@@ -24,7 +24,7 @@ const getAttemptStatusVariant = (
   status: WorkflowStepAttempt["status"]
 ): "danger" | "success" | "warning" | "secondary" => {
   if (status === "failed") return "danger"
-  if (status === "completed") return "success"
+  if (status === "completed" || status === "success") return "success"
   if (status === "running") return "warning"
   return "secondary"
 }

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx
@@ -67,11 +67,29 @@ const investigation: WorkflowRunInvestigation = {
 }
 
 describe("WorkflowRunInspector", () => {
+  it("uses the canonical empty state when diagnostics are unavailable", () => {
+    render(<WorkflowRunInspector investigation={null} />)
+
+    expect(
+      screen
+        .getByText("No run diagnostics available")
+        .closest('[data-ds-component="EmptyState"]')
+    ).toBeInTheDocument()
+  })
+
   it("renders failure summary and attempts", () => {
     render(<WorkflowRunInspector investigation={investigation} />)
 
     expect(screen.getByText("Failure summary")).toBeInTheDocument()
-    expect(screen.getByText("runtime_error")).toBeInTheDocument()
+    expect(
+      screen.getByText("runtime_error").closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Retryable").closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByText("failed")[0]?.closest('[data-ds-component="Badge"]')
+    ).toBeInTheDocument()
     expect(screen.getByText("Attempt 2")).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: /evidence/i })).toBeInTheDocument()
     expect(

--- a/backlog/tasks/task-449 - Migrate-WorkflowRunInspector-product-states-to-design-system.md
+++ b/backlog/tasks/task-449 - Migrate-WorkflowRunInspector-product-states-to-design-system.md
@@ -1,0 +1,53 @@
+---
+id: TASK-449
+title: Migrate WorkflowRunInspector product states to design system
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-20 02:09'
+labels:
+  - design-system
+  - product-state
+  - ui
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the WorkflowRunInspector null/empty state and status tags from AntD Empty/Tag product-state UI to canonical design-system primitives while preserving existing failure summary, attempt status, evidence, and recommended-action behavior. Remove the two matching design-system product-state baseline exceptions and verify the guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkflowRunInspector renders the canonical EmptyState primitive when run diagnostics are unavailable.
+- [x] #2 WorkflowRunInspector status markers render through the shared design-system Badge primitive while preserving status text and tone.
+- [x] #3 The WorkflowRunInspector Empty and Tag baseline exceptions are removed without introducing new blocked product-state findings.
+- [x] #4 Focused WorkflowRunInspector tests and design-system product-state verification pass, with known TypeScript/Bandit skips recorded if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated WorkflowRunInspector's no-diagnostics state from AntD Empty to the canonical EmptyState primitive and replaced workflow failure/attempt AntD Tags with shared Badge variants while preserving existing failure summary, attempts, evidence, and recommended actions. Removed the two matching WorkflowRunInspector entries from the design-system product-state baseline, reducing the current baseline from 335 to 333 allowed legacy exceptions. Verification: RED WorkflowRunInspector test failed on missing EmptyState/Badge markers before implementation; focused WorkflowRunInspector Vitest passed 2 tests; product-state guard Vitest passed 52 tests; bun run verify:design-system-state passed with 333 allowed legacy exceptions and no blocked findings; git diff --check passed; full UI TypeScript still fails on existing repo-wide debt and touched-file filtering returned no WorkflowRunInspector/baseline/task diagnostics; Bandit skipped because touched files are UI TypeScript/JSON and Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate WorkflowRunInspector no-diagnostics UI from AntD Empty to the canonical EmptyState primitive.
- Replace workflow failure and attempt status AntD Tags with shared Badge variants.
- Remove the two matching WorkflowRunInspector product-state baseline exceptions and add TASK-449 tracking.

## Verification
- RED: `bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx --reporter=dot` failed on missing EmptyState/Badge markers before implementation.
- GREEN: `bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx --reporter=dot` passed 2 tests.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 52 tests.
- `bun run verify:design-system-state` passed with 333 allowed legacy exceptions and no blocked findings.
- `git diff --check` passed.
- `bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI TypeScript debt; touched-file filtering returned no WorkflowRunInspector/baseline/task diagnostics.

## Change summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WorkflowRunInspector to design-system product states by replacing AntD `Empty`/`Tag` with `EmptyState`/`Badge`. Removed matching baseline exceptions and updated tests; aligns with TASK-449.

- **Refactors**
  - Replaced AntD `Empty` with inline `EmptyState` for the no-diagnostics view.
  - Swapped all failure/attempt AntD `Tag`s for `Badge` variants (including category, blame_scope, retryable).
  - Added status-to-variant mapping: failed→danger, completed/success→success, running→warning, default→secondary.
  - Deleted two product-state baseline exceptions and updated tests to assert `EmptyState`/`Badge` usage.

<sup>Written for commit ec6e0cb78246d5de83a216ab8425d4f4e359fb89. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1878?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

