### PR TITLE
Migrate WizardShell product-state alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -88,17 +88,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Common/Workflow/WizardShell.tsx:Alert",
-    "path": "src/components/Common/Workflow/WizardShell.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/Workflow/WizardShell.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentPickerModal.tsx:Alert#antd-alert-documentpickermodal-type-error-line-573-1sibda5",
     "path": "src/components/DocumentWorkspace/DocumentPickerModal.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/Workflow/WizardShell.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/WizardShell.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo } from "react"
-import { Steps, Card, Button, Alert, Progress } from "antd"
+import { Steps, Card, Button, Progress } from "antd"
 import { ArrowLeft, ArrowRight, X, Loader2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { useWorkflowsStore } from "@/store/workflows"
 import type { WizardShellProps } from "@/types/workflows"
 
@@ -115,15 +116,19 @@ export const WizardShell: React.FC<WizardShellProps> = ({
 
       {/* Error alert */}
       {error && (
-        <Alert
+        <DesignSystemAlert
           title={t("workflows:error", "Error")}
-          description={error}
-          type="error"
-          showIcon
-          closable
-          onClose={() => setError(null)}
+          variant="error"
+          dismissible
+          dismissLabel={t(
+            "workflows:dismissWorkflowError",
+            "Dismiss workflow error"
+          )}
+          onDismiss={() => setError(null)}
           className="mb-4"
-        />
+        >
+          {error}
+        </DesignSystemAlert>
       )}
 
       {/* Processing indicator */}

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/WizardShell.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/WizardShell.test.tsx
@@ -1,0 +1,103 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { WorkflowDefinition } from "@/types/workflows"
+
+const mocks = vi.hoisted(() => ({
+  setWorkflowStep: vi.fn(),
+  cancelWorkflow: vi.fn(),
+  completeWorkflow: vi.fn(),
+  setError: vi.fn()
+}))
+
+const workflowStoreState = {
+  activeWorkflow: {
+    id: "wf-test",
+    workflowId: "quick-save" as const,
+    status: "active" as const,
+    currentStepIndex: 0,
+    startedAt: 1,
+    data: {}
+  },
+  isProcessing: false,
+  processingProgress: 0,
+  processingMessage: "",
+  error: "The workflow failed",
+  setWorkflowStep: mocks.setWorkflowStep,
+  cancelWorkflow: mocks.cancelWorkflow,
+  completeWorkflow: mocks.completeWorkflow,
+  setError: mocks.setError
+}
+
+vi.mock("@/store/workflows", () => ({
+  useWorkflowsStore: (selector: (state: typeof workflowStoreState) => unknown) =>
+    selector(workflowStoreState)
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallbackOrOptions?: string | { defaultValue?: string }) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) return fallbackOrOptions.defaultValue
+      return _key
+    }
+  })
+}))
+
+import { WizardShell } from "../WizardShell"
+
+const workflow: WorkflowDefinition = {
+  id: "quick-save",
+  category: "content-capture",
+  labelToken: "Quick Save",
+  descriptionToken: "Save the current page",
+  icon: "save",
+  steps: [
+    {
+      id: "details",
+      labelToken: "Details",
+      component: "DetailsStep"
+    },
+    {
+      id: "review",
+      labelToken: "Review",
+      component: "ReviewStep"
+    }
+  ]
+}
+
+describe("WizardShell", () => {
+  beforeEach(() => {
+    workflowStoreState.error = "The workflow failed"
+    workflowStoreState.isProcessing = false
+    workflowStoreState.processingProgress = 0
+    workflowStoreState.processingMessage = ""
+    workflowStoreState.activeWorkflow.currentStepIndex = 0
+    mocks.setWorkflowStep.mockReset()
+    mocks.cancelWorkflow.mockReset()
+    mocks.completeWorkflow.mockReset()
+    mocks.setError.mockReset()
+  })
+
+  it("renders workflow errors with the design-system Alert and dismisses them", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <WizardShell workflow={workflow}>
+        <div>Step body</div>
+      </WizardShell>
+    )
+
+    expect(
+      screen.getByText("Error").closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(screen.getByText("The workflow failed")).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: /dismiss workflow error/i })
+    )
+
+    expect(mocks.setError).toHaveBeenCalledWith(null)
+  })
+})

--- a/backlog/tasks/task-450 - Migrate-WizardShell-error-state-to-design-system-Alert.md
+++ b/backlog/tasks/task-450 - Migrate-WizardShell-error-state-to-design-system-Alert.md
@@ -1,0 +1,61 @@
+---
+id: TASK-450
+title: Migrate WizardShell error state to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-20 02:22
+labels:
+- design-system
+- product-state
+- ui
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/pull/1880
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the WizardShell workflow error banner from AntD Alert to the canonical design-system Alert while preserving translated title, error text, closable dismissal, and workflow navigation behavior. Remove the matching baseline exception and verify the guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WizardShell renders workflow errors through the canonical design-system Alert primitive.
+- [x] #2 The existing translated error title, error message, and close-to-clear behavior are preserved.
+- [x] #3 The WizardShell Alert baseline exception is removed without introducing new blocked product-state findings.
+- [x] #4 Focused tests and design-system product-state verification pass, with known TypeScript/Bandit skips recorded if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented test-first: the new WizardShell regression failed on the missing canonical Alert marker, then passed after replacing the AntD error banner with the design-system Alert and preserving setError(null) dismissal.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated WizardShell's workflow error banner from AntD Alert to the canonical design-system Alert and added focused coverage for the DS wrapper plus dismiss-to-clear behavior. Removed the WizardShell baseline entry, reducing product-state baseline exceptions from 333 to 332.
+
+Verification:
+- RED: bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx --reporter=dot failed on the missing data-ds-component="Alert" wrapper.
+- GREEN: bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx --reporter=dot passed.
+- bunx vitest run src/components/Common/Workflow/__tests__ --reporter=dot passed: 4 files, 9 tests; jsdom emitted existing CSS parse warnings.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 332.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for WizardShell/task-450/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test JSON task metadata only, with no Python code touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates WizardShell workflow errors from AntD Alert to the canonical design-system Alert.
- Adds focused coverage for the DS Alert wrapper and dismiss-to-clear behavior.
- Removes the WizardShell product-state baseline exception, reducing baseline exceptions from 333 to 332.

## Verification
- RED: `bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx --reporter=dot` failed on missing `data-ds-component="Alert"`.
- GREEN: `bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx --reporter=dot` passed.
- `bunx vitest run src/components/Common/Workflow/__tests__ --reporter=dot` passed: 4 files, 9 tests; jsdom emitted existing CSS parse warnings.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 52 tests.
- `bun run verify:design-system-state` passed; baseline exceptions are now 332.
- `git diff --check --cached` passed before commit.
- Full `bunx tsc --noEmit --pretty false` still exits 2 from inherited baseline debt; filtered touched-file diagnostics for WizardShell/task-450/baseline matched 0 lines.
- Bandit skipped: TypeScript UI/test and JSON/task metadata only; no Python touched.

## Change summary
TODO (human-authored before merge): summarize what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the WizardShell workflow error banner from AntD to the design-system `Alert`, aligning UI and reducing product-state baseline exceptions by 1. Fulfills TASK-450 by preserving dismiss-to-clear behavior and translations.

- **Refactors**
  - Replaced AntD `Alert` with `Alert` from `@/components/ui/primitives` in `WizardShell`; keeps translated title, error body, and dismissal via `setError(null)` with a translated dismiss label.
  - Added focused test to assert the design-system `Alert` (`[data-ds-component="Alert"]`) and dismiss flow.
  - Removed the `WizardShell` product-state baseline exception; baseline now 332 and guard checks pass.

<sup>Written for commit 88bdc88b3397963255958709e16f0813d23967d0. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1880?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

