### PR TITLE
Clarify STT route readiness

### DIFF
--- a/apps/packages/ui/src/components/Option/STT/HistoryPanel.tsx
+++ b/apps/packages/ui/src/components/Option/STT/HistoryPanel.tsx
@@ -172,7 +172,7 @@ export const HistoryPanel: React.FC<HistoryPanelProps> = ({
           <Text type="secondary">
             {t(
               "stt.history.empty",
-              "Start a recording to see transcripts here."
+              "Completed transcriptions will appear here after you run a comparison."
             )}
           </Text>
         ) : (

--- a/apps/packages/ui/src/components/Option/STT/RecordingStrip.tsx
+++ b/apps/packages/ui/src/components/Option/STT/RecordingStrip.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react"
-import { Button, Card, Tooltip, Upload } from "antd"
+import { Button, Card, Tooltip, Typography, Upload } from "antd"
 import { Mic, Settings, Square, Trash2, Upload as UploadIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useAudioRecorder } from "@/hooks/useAudioRecorder"
@@ -9,7 +9,11 @@ import { classifyAudioError } from "@/components/Option/Audio/audio-error-classi
 export interface RecordingStripProps {
   onBlobReady: (blob: Blob, durationMs: number) => void
   onSettingsToggle?: () => void
+  disabled?: boolean
+  disabledReason?: string
 }
+
+const { Text } = Typography
 
 /** Convert milliseconds to `mm:ss` display string. */
 export function formatDuration(ms: number): string {
@@ -21,7 +25,9 @@ export function formatDuration(ms: number): string {
 
 export const RecordingStrip: React.FC<RecordingStripProps> = ({
   onBlobReady,
-  onSettingsToggle
+  onSettingsToggle,
+  disabled = false,
+  disabledReason
 }) => {
   const { t } = useTranslation(["playground"])
   const notification = useAntdNotification()
@@ -30,6 +36,22 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
 
   const isRecording = recorder.status === "recording"
   const hasBlob = recorder.blob != null && !isRecording
+  const blocksNewCapture = disabled && !isRecording
+  const recordingUnavailableText =
+    disabledReason ||
+    t("playground:stt.recordingUnavailable", "Recording is unavailable.")
+  const sourceStatus = blocksNewCapture
+    ? recordingUnavailableText
+    : isRecording
+      ? t("playground:stt.sourceRecording", "Audio source: microphone recording")
+      : hasBlob
+        ? t("playground:stt.sourceSelected", "Audio source: audio selected")
+        : t("playground:stt.sourceEmpty", "Audio source: no audio selected")
+  const recordTooltip = blocksNewCapture
+    ? recordingUnavailableText
+    : isRecording
+      ? t("playground:stt.stopTooltip", "Stop recording")
+      : t("playground:stt.startTooltip", "Start recording")
 
   // Notify parent when blob changes
   useEffect(() => {
@@ -65,6 +87,7 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
   // Listen for stt-toggle-record custom event (Space shortcut from parent)
   useEffect(() => {
     const handler = () => {
+      if (blocksNewCapture) return
       if (isRecording) {
         recorder.stopRecording()
       } else {
@@ -82,9 +105,10 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
     return () => {
       window.removeEventListener("stt-toggle-record", handler)
     }
-  }, [isRecording, recorder, notification, t])
+  }, [blocksNewCapture, isRecording, recorder, notification, t])
 
   const handleRecordClick = useCallback(() => {
+    if (blocksNewCapture) return
     if (isRecording) {
       recorder.stopRecording()
     } else {
@@ -97,27 +121,22 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
         })
       })
     }
-  }, [isRecording, recorder, notification, t])
+  }, [blocksNewCapture, isRecording, recorder, notification, t])
 
   const handleUpload = useCallback(
     (file: File) => {
+      if (blocksNewCapture) return false
       recorder.loadBlob(file, 0)
       return false // prevent auto-upload
     },
-    [recorder]
+    [blocksNewCapture, recorder]
   )
 
   return (
     <Card size="small">
       <div className="flex flex-wrap items-center gap-3">
         {/* Record / Stop button */}
-        <Tooltip
-          title={
-            isRecording
-              ? t("playground:stt.stopTooltip", "Stop recording")
-              : t("playground:stt.startTooltip", "Start recording")
-          }
-        >
+        <Tooltip title={recordTooltip}>
           <Button
             type={isRecording ? "default" : "primary"}
             danger={isRecording}
@@ -126,6 +145,7 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
                 ? t("playground:stt.stopRecording", "Stop recording (Space)")
                 : t("playground:stt.startRecording", "Start recording (Space)")
             }
+            disabled={blocksNewCapture}
             icon={
               isRecording ? (
                 <Square className="h-4 w-4" />
@@ -144,6 +164,15 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
         >
           {formatDuration(recorder.durationMs)}
         </span>
+
+        <Text
+          type={blocksNewCapture ? "danger" : "secondary"}
+          className="text-xs"
+          role="status"
+          aria-label="Recording source"
+        >
+          {sourceStatus}
+        </Text>
 
         {/* Audio level indicator — visible only while recording */}
         {isRecording && (
@@ -189,6 +218,7 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
         <Upload
           accept="audio/*"
           showUploadList={false}
+          disabled={blocksNewCapture}
           beforeUpload={handleUpload}
         >
           <Tooltip title={t("playground:stt.uploadAudio", "Upload audio file")}>
@@ -196,6 +226,7 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
               type="text"
               icon={<UploadIcon className="h-4 w-4" />}
               aria-label={t("playground:stt.uploadAudio", "Upload audio file")}
+              disabled={blocksNewCapture}
             />
           </Tooltip>
         </Upload>

--- a/apps/packages/ui/src/components/Option/STT/RecordingStrip.tsx
+++ b/apps/packages/ui/src/components/Option/STT/RecordingStrip.tsx
@@ -11,6 +11,7 @@ export interface RecordingStripProps {
   onSettingsToggle?: () => void
   disabled?: boolean
   disabledReason?: string
+  disabledStatusType?: "secondary" | "warning" | "danger"
 }
 
 const { Text } = Typography
@@ -27,7 +28,8 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
   onBlobReady,
   onSettingsToggle,
   disabled = false,
-  disabledReason
+  disabledReason,
+  disabledStatusType = "danger"
 }) => {
   const { t } = useTranslation(["playground"])
   const notification = useAntdNotification()
@@ -86,8 +88,9 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
 
   // Listen for stt-toggle-record custom event (Space shortcut from parent)
   useEffect(() => {
-    const handler = () => {
+    const handler = (event: Event) => {
       if (blocksNewCapture) return
+      event.preventDefault()
       if (isRecording) {
         recorder.stopRecording()
       } else {
@@ -166,10 +169,9 @@ export const RecordingStrip: React.FC<RecordingStripProps> = ({
         </span>
 
         <Text
-          type={blocksNewCapture ? "danger" : "secondary"}
+          type={blocksNewCapture ? disabledStatusType : "secondary"}
           className="text-xs"
           role="status"
-          aria-label="Recording source"
         >
           {sourceStatus}
         </Text>

--- a/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
@@ -208,6 +208,27 @@ export const SttPlaygroundPage: React.FC = () => {
       }),
     [modelOptions, serverModelsError, serverModelsLoading]
   )
+  const recordingDisabledReason = useMemo(() => {
+    if (serverModelsLoading) {
+      return t(
+        "playground:stt.recordingDisabledLoading",
+        "Loading transcription model catalog."
+      )
+    }
+    if (serverModelsError) {
+      return t(
+        "playground:stt.recordingDisabledModelError",
+        "Unable to load transcription models. Retry before recording."
+      )
+    }
+    if (serverModels.length === 0) {
+      return t(
+        "playground:stt.recordingDisabledNoModels",
+        "No transcription models are available. Configure STT models before recording."
+      )
+    }
+    return undefined
+  }, [serverModels.length, serverModelsError, serverModelsLoading, t])
 
   // ── History (persisted via Plasmo storage) ────────────────────────
   const [history, setHistory] = useStorage<SttHistoryEntry[]>(
@@ -465,6 +486,8 @@ export const SttPlaygroundPage: React.FC = () => {
           <RecordingStrip
             onBlobReady={handleBlobReady}
             onSettingsToggle={toggleSettings}
+            disabled={Boolean(recordingDisabledReason)}
+            disabledReason={recordingDisabledReason}
           />
         </div>
         <p className="text-[11px] text-text-subtle text-center mt-1">

--- a/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
@@ -208,24 +208,36 @@ export const SttPlaygroundPage: React.FC = () => {
       }),
     [modelOptions, serverModelsError, serverModelsLoading]
   )
-  const recordingDisabledReason = useMemo(() => {
+  const recordingDisabledState = useMemo<{
+    reason: string
+    statusType: "secondary" | "warning" | "danger"
+  } | undefined>(() => {
     if (serverModelsLoading) {
-      return t(
-        "playground:stt.recordingDisabledLoading",
-        "Loading transcription model catalog."
-      )
+      return {
+        reason: t(
+          "playground:stt.recordingDisabledLoading",
+          "Loading transcription model catalog."
+        ),
+        statusType: "secondary"
+      }
     }
     if (serverModelsError) {
-      return t(
-        "playground:stt.recordingDisabledModelError",
-        "Unable to load transcription models. Retry before recording."
-      )
+      return {
+        reason: t(
+          "playground:stt.recordingDisabledModelError",
+          "Unable to load transcription models. Retry before recording."
+        ),
+        statusType: "warning"
+      }
     }
     if (serverModels.length === 0) {
-      return t(
-        "playground:stt.recordingDisabledNoModels",
-        "No transcription models are available. Configure STT models before recording."
-      )
+      return {
+        reason: t(
+          "playground:stt.recordingDisabledNoModels",
+          "No transcription models are available. Configure STT models before recording."
+        ),
+        statusType: "danger"
+      }
     }
     return undefined
   }, [serverModels.length, serverModelsError, serverModelsLoading, t])
@@ -401,8 +413,13 @@ export const SttPlaygroundPage: React.FC = () => {
       ) {
         return
       }
-      e.preventDefault()
-      window.dispatchEvent(new CustomEvent("stt-toggle-record"))
+      const toggleEvent = new CustomEvent("stt-toggle-record", {
+        cancelable: true
+      })
+      window.dispatchEvent(toggleEvent)
+      if (toggleEvent.defaultPrevented) {
+        e.preventDefault()
+      }
     }
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
@@ -486,8 +503,9 @@ export const SttPlaygroundPage: React.FC = () => {
           <RecordingStrip
             onBlobReady={handleBlobReady}
             onSettingsToggle={toggleSettings}
-            disabled={Boolean(recordingDisabledReason)}
-            disabledReason={recordingDisabledReason}
+            disabled={Boolean(recordingDisabledState)}
+            disabledReason={recordingDisabledState?.reason}
+            disabledStatusType={recordingDisabledState?.statusType}
           />
         </div>
         <p className="text-[11px] text-text-subtle text-center mt-1">

--- a/apps/packages/ui/src/components/Option/STT/__tests__/ComparisonPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/ComparisonPanel.test.tsx
@@ -162,6 +162,42 @@ describe("ComparisonPanel", () => {
     )
   })
 
+  it("keeps successful transcripts visible when another selected model fails", () => {
+    hookReturnRef.current = {
+      ...hookReturnRef.current,
+      results: [
+        {
+          id: "result-success",
+          model: "whisper-1",
+          text: "Successful transcript remains available",
+          status: "done"
+        },
+        {
+          id: "result-error",
+          model: "distil-v3",
+          text: "",
+          status: "error",
+          error: "Model unavailable",
+          errorRecovery: "Choose a different model and retry."
+        }
+      ]
+    }
+
+    render(
+      <ComparisonPanel
+        blob={new Blob(["audio"], { type: "audio/webm" })}
+        availableModels={["whisper-1", "distil-v3"]}
+        sttOptions={{}}
+        onSaveToNotes={vi.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText("Transcript from whisper-1"))
+      .toHaveValue("Successful transcript remains available")
+    expect(screen.getByText("Model unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Choose a different model and retry.")).toBeInTheDocument()
+  })
+
   it("shows STT provenance metadata and repeat controls", () => {
     hookReturnRef.current = {
       ...hookReturnRef.current,

--- a/apps/packages/ui/src/components/Option/STT/__tests__/HistoryPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/HistoryPanel.test.tsx
@@ -77,7 +77,9 @@ describe("HistoryPanel", () => {
     render(<HistoryPanel {...defaultProps} />)
 
     expect(
-      screen.getByText("Start a recording to see transcripts here.")
+      screen.getByText(
+        "Completed transcriptions will appear here after you run a comparison."
+      )
     ).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Option/STT/__tests__/RecordingStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/RecordingStrip.test.tsx
@@ -65,8 +65,12 @@ describe("RecordingStrip", () => {
   it("shows the current audio source state before recording starts", () => {
     render(<RecordingStrip onBlobReady={mockOnBlobReady} />)
 
-    expect(screen.getByRole("status", { name: "Recording source" }))
-      .toHaveTextContent("Audio source: no audio selected")
+    const status = screen
+      .getByText("Audio source: no audio selected")
+      .closest('[role="status"]')
+
+    expect(status).toBeInTheDocument()
+    expect(status).not.toHaveAttribute("aria-label")
   })
 
   it("disables recording and upload when route readiness blocks transcription", () => {
@@ -80,8 +84,54 @@ describe("RecordingStrip", () => {
 
     expect(screen.getByRole("button", { name: /start recording/i })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Upload audio file" })).toBeDisabled()
-    expect(screen.getByRole("status", { name: "Recording source" }))
-      .toHaveTextContent("No transcription models are available.")
+    expect(screen.getByText("No transcription models are available."))
+      .toHaveAttribute("role", "status")
+  })
+
+  it("uses non-danger styling for temporary disabled recording states", () => {
+    render(
+      <RecordingStrip
+        onBlobReady={mockOnBlobReady}
+        disabled
+        disabledReason="Loading transcription model catalog."
+        disabledStatusType="secondary"
+      />
+    )
+
+    const status = screen.getByText("Loading transcription model catalog.")
+
+    expect(status).toHaveClass("ant-typography-secondary")
+    expect(status).not.toHaveClass("ant-typography-danger")
+  })
+
+  it("only cancels the Space shortcut event when it handles recording", () => {
+    render(<RecordingStrip onBlobReady={mockOnBlobReady} />)
+
+    const toggleEvent = new CustomEvent("stt-toggle-record", {
+      cancelable: true
+    })
+    window.dispatchEvent(toggleEvent)
+
+    expect(toggleEvent.defaultPrevented).toBe(true)
+    expect(mockStartRecording).toHaveBeenCalledOnce()
+  })
+
+  it("does not cancel the Space shortcut event while recording is disabled", () => {
+    render(
+      <RecordingStrip
+        onBlobReady={mockOnBlobReady}
+        disabled
+        disabledReason="No transcription models are available."
+      />
+    )
+
+    const toggleEvent = new CustomEvent("stt-toggle-record", {
+      cancelable: true
+    })
+    window.dispatchEvent(toggleEvent)
+
+    expect(toggleEvent.defaultPrevented).toBe(false)
+    expect(mockStartRecording).not.toHaveBeenCalled()
   })
 
   it("shows settings toggle button when prop provided", () => {

--- a/apps/packages/ui/src/components/Option/STT/__tests__/RecordingStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/RecordingStrip.test.tsx
@@ -62,6 +62,28 @@ describe("RecordingStrip", () => {
     expect(uploadBtn).toBeInTheDocument()
   })
 
+  it("shows the current audio source state before recording starts", () => {
+    render(<RecordingStrip onBlobReady={mockOnBlobReady} />)
+
+    expect(screen.getByRole("status", { name: "Recording source" }))
+      .toHaveTextContent("Audio source: no audio selected")
+  })
+
+  it("disables recording and upload when route readiness blocks transcription", () => {
+    render(
+      <RecordingStrip
+        onBlobReady={mockOnBlobReady}
+        disabled
+        disabledReason="No transcription models are available."
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /start recording/i })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Upload audio file" })).toBeDisabled()
+    expect(screen.getByRole("status", { name: "Recording source" }))
+      .toHaveTextContent("No transcription models are available.")
+  })
+
   it("shows settings toggle button when prop provided", () => {
     render(
       <RecordingStrip

--- a/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
@@ -21,6 +21,7 @@ const storageValues: Record<string, unknown> = {
 }
 
 let comparisonPanelProps: Record<string, unknown> | null = null
+let recordingStripProps: Record<string, unknown> | null = null
 const {
   getTranscriptionModelsMock,
   getTranscriptionModelHealthMock,
@@ -95,9 +96,10 @@ vi.mock("@/utils/request-timeout", () => ({
 
 // Mock the sub-components to keep tests focused
 vi.mock("../RecordingStrip", () => ({
-  RecordingStrip: (_props: Record<string, unknown>) => (
-    <div data-testid="recording-strip" />
-  )
+  RecordingStrip: (props: Record<string, unknown>) => {
+    recordingStripProps = props
+    return <div data-testid="recording-strip" />
+  }
 }))
 
 vi.mock("../InlineSettingsPanel", () => ({
@@ -164,6 +166,7 @@ describe("SttPlaygroundPage", () => {
 
   beforeEach(() => {
     comparisonPanelProps = null
+    recordingStripProps = null
     getTranscriptionModelsMock.mockReset()
     getTranscriptionModelsMock.mockResolvedValue({
       categories: {
@@ -235,6 +238,28 @@ describe("SttPlaygroundPage", () => {
         availability: "ready"
       })
     ])
+  })
+
+  it("keeps the route landmark visible while the model catalog is loading", () => {
+    getTranscriptionModelsMock.mockImplementationOnce(
+      () => new Promise(() => {})
+    )
+
+    render(<SttPlaygroundPage />)
+
+    expect(screen.getByTestId("page-shell")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Speech to Text" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("status", { name: "STT readiness" })
+    ).toHaveTextContent("STT models: Unknown")
+    expect(recordingStripProps).toEqual(
+      expect.objectContaining({
+        disabled: true,
+        disabledReason: "Loading transcription model catalog."
+      })
+    )
   })
 
   it("renders all 3 zones (recording-strip, comparison-panel, history-panel)", () => {
@@ -351,5 +376,50 @@ describe("SttPlaygroundPage", () => {
 
     const noModelsAlert = await screen.findByText("No transcription models available")
     expect(noModelsAlert.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Configure STT models in your server settings. Check the Audio Setup Guide for instructions."
+      )
+    ).toBeInTheDocument()
+    expect(recordingStripProps).toEqual(
+      expect.objectContaining({
+        disabled: true,
+        disabledReason: "No transcription models are available. Configure STT models before recording."
+      })
+    )
+  })
+
+  it("preserves transcript text when saving to notes fails", async () => {
+    createNoteMock.mockRejectedValueOnce(new Error("Notes database unavailable"))
+    render(<SttPlaygroundPage />)
+
+    await waitFor(() => expect(comparisonPanelProps).not.toBeNull())
+    await act(async () => {
+      await (
+        comparisonPanelProps?.onSaveToNotes as (
+          text: string,
+          model: string
+        ) => Promise<void>
+      )(
+        "Transcript text to preserve",
+        "whisper-1"
+      )
+    })
+
+    expect(createNoteMock).toHaveBeenCalledWith(
+      "Transcript text to preserve",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          origin: "stt-playground",
+          stt_model: "whisper-1"
+        })
+      })
+    )
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Error",
+        description: "Notes database unavailable"
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
@@ -257,7 +257,8 @@ describe("SttPlaygroundPage", () => {
     expect(recordingStripProps).toEqual(
       expect.objectContaining({
         disabled: true,
-        disabledReason: "Loading transcription model catalog."
+        disabledReason: "Loading transcription model catalog.",
+        disabledStatusType: "secondary"
       })
     )
   })
@@ -384,9 +385,35 @@ describe("SttPlaygroundPage", () => {
     expect(recordingStripProps).toEqual(
       expect.objectContaining({
         disabled: true,
-        disabledReason: "No transcription models are available. Configure STT models before recording."
+        disabledReason: "No transcription models are available. Configure STT models before recording.",
+        disabledStatusType: "danger"
       })
     )
+  })
+
+  it("only prevents Space scrolling when the recording strip handles the shortcut", () => {
+    render(<SttPlaygroundPage />)
+
+    const unhandledSpace = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      code: "Space"
+    })
+    window.dispatchEvent(unhandledSpace)
+
+    expect(unhandledSpace.defaultPrevented).toBe(false)
+
+    const handleToggle = (event: Event) => event.preventDefault()
+    window.addEventListener("stt-toggle-record", handleToggle, { once: true })
+
+    const handledSpace = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      code: "Space"
+    })
+    window.dispatchEvent(handledSpace)
+
+    expect(handledSpace.defaultPrevented).toBe(true)
   })
 
   it("preserves transcript text when saving to notes fails", async () => {

--- a/apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
@@ -84,7 +84,12 @@ describe("audio option routes", () => {
 
   it("renders dedicated STT playground on /stt route component", async () => {
     render(<OptionStt />)
+
+    const boundary = screen.getByTestId("route-boundary")
+
     expect(screen.getByTestId("option-layout")).toBeVisible()
+    expect(boundary).toHaveAttribute("data-route-id", "stt")
+    expect(boundary).toHaveAttribute("data-route-label", "STT Playground")
     expect(await screen.findByTestId("stt-playground")).toBeVisible()
     expect(screen.queryByTestId("speech-playground")).not.toBeInTheDocument()
   })

--- a/apps/packages/ui/src/routes/option-stt.tsx
+++ b/apps/packages/ui/src/routes/option-stt.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react"
 import OptionLayout from "~/components/Layouts/Layout"
+import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
 import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
 import { useTranslation } from "react-i18next"
 import { HostedAudioFeatureMessage } from "./HostedAudioFeatureMessage"
@@ -12,23 +13,25 @@ const OptionStt = () => {
   const { t } = useTranslation("option")
 
   return (
-    <OptionLayout>
-      {isHostedTldwDeployment() ? (
-        <HostedAudioFeatureMessage
-          featureName={t("header.modeStt", "STT Playground")}
-        />
-      ) : (
-        <Suspense
-          fallback={
-            <div className="sr-only" role="status">
-              {t("hostedAudio.loadingStt", "Loading STT playground.")}
-            </div>
-          }
-        >
-          <SttPlaygroundPage />
-        </Suspense>
-      )}
-    </OptionLayout>
+    <RouteErrorBoundary routeId="stt" routeLabel="STT Playground">
+      <OptionLayout>
+        {isHostedTldwDeployment() ? (
+          <HostedAudioFeatureMessage
+            featureName={t("header.modeStt", "STT Playground")}
+          />
+        ) : (
+          <Suspense
+            fallback={
+              <div className="sr-only" role="status">
+                {t("hostedAudio.loadingStt", "Loading STT playground.")}
+              </div>
+            }
+          >
+            <SttPlaygroundPage />
+          </Suspense>
+        )}
+      </OptionLayout>
+    </RouteErrorBoundary>
   )
 }
 

--- a/apps/tldw-frontend/e2e/utils/page-objects/STTPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/STTPage.ts
@@ -6,7 +6,7 @@
  * - Comparison panel (model selection, transcription results)
  * - History panel (past comparison entries)
  */
-import { type Page, type Locator, expect } from "@playwright/test"
+import { type Page, type Locator } from "@playwright/test"
 import { BasePage, type InteractiveElement } from "./BasePage"
 import { waitForAppShell, waitForConnection } from "../helpers"
 
@@ -25,14 +25,14 @@ export class STTPage extends BasePage {
   async assertPageReady(): Promise<void> {
     await waitForAppShell(this.page, 30_000)
     // Wait for the page heading to appear
-    const heading = this.page.getByText("STT Playground")
+    const heading = this.page.getByText("Speech to Text")
     await heading.first().waitFor({ state: "visible", timeout: 20_000 }).catch(() => {})
   }
 
   // -- Locators: Page-level ---------------------------------------------------
 
   get heading(): Locator {
-    return this.page.getByRole("heading", { name: /stt playground/i })
+    return this.page.getByRole("heading", { name: /speech to text/i })
   }
 
   get subtitle(): Locator {

--- a/apps/tldw-frontend/extension/__tests__/audio-route-parity.guard.test.ts
+++ b/apps/tldw-frontend/extension/__tests__/audio-route-parity.guard.test.ts
@@ -15,6 +15,9 @@ describe("audio route parity", () => {
 
     expect(webRoute).toContain("SttPlaygroundPage")
     expect(extRoute).toContain("SttPlaygroundPage")
+    expect(extRoute).toContain("RouteErrorBoundary")
+    expect(extRoute).toContain('routeId="stt"')
+    expect(extRoute).toContain('routeLabel="STT Playground"')
     expect(extRoute).not.toContain("SpeechPlaygroundPage")
     expect(extRoute).not.toContain('initialMode="speak"')
   })

--- a/apps/tldw-frontend/extension/routes/option-stt.tsx
+++ b/apps/tldw-frontend/extension/routes/option-stt.tsx
@@ -1,11 +1,14 @@
 import OptionLayout from "@web/components/layout/WebLayout"
 import SttPlaygroundPage from "@/components/Option/STT/SttPlaygroundPage"
+import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
 
 const OptionStt = () => {
   return (
-    <OptionLayout>
-      <SttPlaygroundPage />
-    </OptionLayout>
+    <RouteErrorBoundary routeId="stt" routeLabel="STT Playground">
+      <OptionLayout>
+        <SttPlaygroundPage />
+      </OptionLayout>
+    </RouteErrorBoundary>
   )
 }
 

--- a/backlog/tasks/task-418.8.2 - Make-WebUI-STT-route-recoverable-and-route-owned.md
+++ b/backlog/tasks/task-418.8.2 - Make-WebUI-STT-route-recoverable-and-route-owned.md
@@ -1,0 +1,80 @@
+---
+id: TASK-418.8.2
+title: Make WebUI STT route recoverable and route-owned
+status: Done
+labels:
+- webui
+- ux-audit
+- audio
+- wp11a
+- stt
+priority: medium
+parent_task_id: TASK-418.8
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-audio-routes-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/routes/option-stt.tsx
+- apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
+- apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
+- apps/packages/ui/src/components/Option/STT/RecordingStrip.tsx
+- apps/packages/ui/src/components/Option/STT/HistoryPanel.tsx
+- apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
+- apps/packages/ui/src/components/Option/STT/__tests__/RecordingStrip.test.tsx
+- apps/packages/ui/src/components/Option/STT/__tests__/ComparisonPanel.test.tsx
+- apps/packages/ui/src/components/Option/STT/__tests__/HistoryPanel.test.tsx
+- apps/tldw-frontend/extension/routes/option-stt.tsx
+- apps/tldw-frontend/extension/__tests__/audio-route-parity.guard.test.ts
+- apps/tldw-frontend/e2e/utils/page-objects/STTPage.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP11A Task 3 from the WebUI audio routes implementation plan. Make /stt a recoverable dedicated transcription route by adding route-boundary coverage, preserving hosted behavior, verifying extension route parity, and improving STT readiness/empty/error states using existing STT components and APIs only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /stt route-boundary coverage exists and verifies routeId=stt and routeLabel=STT Playground around the dedicated SttPlaygroundPage.
+- [x] #2 Hosted behavior remains intact through HostedAudioFeatureMessage.
+- [x] #3 Extension /stt ownership/parity is verified before any ownership change; any exception is documented in route metadata/tests.
+- [x] #4 STT readiness coverage includes catalog loading/failure retry, no-model setup language, recording source state, comparison partial failure preservation, save-to-notes failure preservation, and history empty state.
+- [x] #5 Focused STT component and E2E verification is recorded; no backend APIs or unrelated routes are changed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented WP11A Task 3 for the dedicated `/stt` route.
+
+- Added shared route-boundary coverage and wrapped shared `/stt` in `RouteErrorBoundary routeId="stt" routeLabel="STT Playground"` while preserving the hosted `HostedAudioFeatureMessage` path.
+- Aligned extension `/stt` to the dedicated `SttPlaygroundPage` owner under the same route boundary and extended parity coverage.
+- Added STT readiness/recovery tests for catalog loading, no-model blocking, recording source status, partial comparison failure, save-to-notes failure, and history empty state.
+- Added readiness-driven recording/upload disabling and a visible recording source status to `RecordingStrip`.
+- Updated the STT E2E page object to the route-owned `Speech to Text` heading.
+
+Verification:
+- `bunx vitest run ../packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx extension/__tests__/audio-route-parity.guard.test.ts` passed: 2 files, 5 tests.
+- `bunx vitest run ../packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx ../packages/ui/src/components/Option/STT/__tests__/RecordingStrip.test.tsx ../packages/ui/src/components/Option/STT/__tests__/InlineSettingsPanel.test.tsx ../packages/ui/src/components/Option/STT/__tests__/ComparisonPanel.test.tsx ../packages/ui/src/components/Option/STT/__tests__/HistoryPanel.test.tsx ../packages/ui/src/components/Option/STT/__tests__/keyboard-shortcuts.test.tsx` passed: 6 files, 36 tests.
+- `bunx playwright test e2e/workflows/tier-2-features/stt-transcription.spec.ts --reporter=line` passed: 2 tests.
+- Browser DOM QA at `http://localhost:8080/stt` observed `Speech to Text`, `STT readiness`, `Recording source: Audio source: no audio selected`, disabled `Transcribe All`, and the updated history empty state.
+- `bunx eslint extension/routes/option-stt.tsx extension/__tests__/audio-route-parity.guard.test.ts e2e/utils/page-objects/STTPage.ts` passed.
+- `bunx tsc --noEmit --pretty false -p ../packages/ui/tsconfig.json` failed on inherited repo-wide TypeScript debt outside the touched STT/route files; no reported errors referenced touched files.
+- Bandit on touched frontend paths completed with 0 findings and 0 Python LOC scanned.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the /stt recoverability slice with route ownership parity, readiness-driven recording blocking, visible recording source status, stronger transcript/history recovery tests, and focused Vitest/Playwright verification. No backend APIs were changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.8.2 - Make-WebUI-STT-route-recoverable-and-route-owned.md
+++ b/backlog/tasks/task-418.8.2 - Make-WebUI-STT-route-recoverable-and-route-owned.md
@@ -60,7 +60,7 @@ Verification:
 - Browser DOM QA at `http://localhost:8080/stt` observed `Speech to Text`, `STT readiness`, `Recording source: Audio source: no audio selected`, disabled `Transcribe All`, and the updated history empty state.
 - `bunx eslint extension/routes/option-stt.tsx extension/__tests__/audio-route-parity.guard.test.ts e2e/utils/page-objects/STTPage.ts` passed.
 - `bunx tsc --noEmit --pretty false -p ../packages/ui/tsconfig.json` failed on inherited repo-wide TypeScript debt outside the touched STT/route files; no reported errors referenced touched files.
-- Bandit on touched frontend paths completed with 0 findings and 0 Python LOC scanned.
+- Bandit: skipped (no Python code touched).
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- wrap the shared and extension `/stt` routes in the STT route boundary while keeping shared hosted behavior intact
- make STT recording/upload respect model-catalog readiness and expose visible recording source state
- expand STT readiness, partial-failure, save-to-notes, history, route identity, and extension parity coverage
- update the STT E2E page object to the actual route-owned heading

## Verification
- `bunx vitest run ../packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx extension/__tests__/audio-route-parity.guard.test.ts`
- `bunx vitest run ../packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx ../packages/ui/src/components/Option/STT/__tests__/RecordingStrip.test.tsx ../packages/ui/src/components/Option/STT/__tests__/InlineSettingsPanel.test.tsx ../packages/ui/src/components/Option/STT/__tests__/ComparisonPanel.test.tsx ../packages/ui/src/components/Option/STT/__tests__/HistoryPanel.test.tsx ../packages/ui/src/components/Option/STT/__tests__/keyboard-shortcuts.test.tsx`
- `bunx playwright test e2e/workflows/tier-2-features/stt-transcription.spec.ts --reporter=line`
- browser DOM QA at `http://localhost:8080/stt` observed route heading, readiness, recording source status, disabled Transcribe All, and updated history empty state
- `bunx eslint extension/routes/option-stt.tsx extension/__tests__/audio-route-parity.guard.test.ts e2e/utils/page-objects/STTPage.ts`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/Option/STT apps/packages/ui/src/routes apps/tldw-frontend/extension/routes apps/tldw-frontend/e2e/utils/page-objects -f json -o /tmp/bandit_wp11a_stt.json`

## Known checks
- `bunx tsc --noEmit --pretty false -p ../packages/ui/tsconfig.json` fails on inherited repo-wide TypeScript debt outside the touched STT/route files.
- Shared package lint from the frontend ESLint config reports the shared package files as outside the base path; extension/E2E touched files lint clean.

## Change summary
Human-authored change summary required before merge: TODO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the /stt route recoverable and clearly gated by model readiness. Adds a route boundary, blocks recording/upload when models aren’t ready, and shows the current audio source state.

- New Features
  - Wrapped shared and extension `/stt` in `RouteErrorBoundary` with `routeId="stt"` and `routeLabel="STT Playground"`; hosted deployments still show `HostedAudioFeatureMessage`.
  - `RecordingStrip`: added `disabled`, `disabledReason`, and `disabledStatusType`; blocks record/upload and Space shortcut when readiness fails; shows “Recording source” status; tooltips reflect state; only cancels the Space event when it handles the toggle.
  - `SttPlaygroundPage`: derives disabled reasons from the model catalog (loading, error, no models), passes them to `RecordingStrip`, and keeps the route landmark visible during loading; only prevents Space scrolling when the recording strip handles the shortcut.
  - Comparison/history: preserves successful transcripts when another model fails; shows error and recovery messages; updated history empty copy text.
  - Tests and E2E: added route identity and extension parity checks; coverage for readiness, partial-failure, and save-to-notes failure; added `RecordingStrip` status/event tests; updated E2E page object to the “Speech to Text” heading.

<sup>Written for commit 967192df9a826a7c1a9724d2084d178aa6c2ddb6. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1881?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

