### PR TITLE
Add Character Chat session recents

### DIFF
--- a/Docs/superpowers/plans/2026-05-20-character-chat-phase4-sessions-continuity-plan.md
+++ b/Docs/superpowers/plans/2026-05-20-character-chat-phase4-sessions-continuity-plan.md
@@ -1,0 +1,125 @@
+# Character Chat Phase 4 Sessions Continuity Implementation Plan
+
+> **For agentic workers:** Follow this plan task-by-task with TDD. Keep the slice scoped to `/chat` Character Chat session continuity and reuse existing server chat history/loading paths.
+
+**Goal:** Make returning Character Chat users able to find and resume recent character conversations from the `/chat` Character Chat workflow without confusing conversations with saved role-play setups.
+
+**Architecture:** Add a compact Character Chat sessions panel inside the existing Playground cockpit context rail when Character Chat mode is active. Back it with the existing `useServerChatHistory(filterMode: "character")` and `useSelectServerChat` hooks. Keep generic `ChatSidebar` behavior intact; this is a mode-local continuity affordance, not a replacement for the global server chat sidebar.
+
+**Tech Stack:** React, TypeScript, Testing Library, Vitest, existing Playground cockpit rail components, existing tldw server chat history APIs.
+
+---
+
+## Source Context
+
+- PRD: `Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md`
+- Backlog: `TASK-449`
+- Existing history hook: `apps/packages/ui/src/hooks/useServerChatHistory.ts`
+- Existing resume hook: `apps/packages/ui/src/hooks/chat/useSelectServerChat.ts`
+- Existing cockpit rail: `apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx`
+- Existing generic history list: `apps/packages/ui/src/components/Common/ChatSidebar/ServerChatList.tsx`
+
+## Scope
+
+- In scope:
+  - Character Chat mode-local recent sessions panel on `/chat`.
+  - Server-backed character-scope history query.
+  - Resume buttons and active-chat state.
+  - Current-character prioritization when the active character id is known.
+  - Focused tests for history query contract, rendering states, and resume behavior.
+  - Backlog closeout notes and browser/real-backend verification attempt.
+- Out of scope:
+  - Extension sidepanel parity.
+  - Command palette shortcuts.
+  - Full session archive/restore/delete redesign.
+  - Backend endpoint changes.
+  - Replacing the global ChatSidebar.
+  - Saved role-play setup storage changes.
+
+## Stage 1: Character Session Panel Contract
+
+**Goal:** Define and test the component contract for a Character Chat sessions panel.
+
+**Success Criteria:**
+- Panel fetches only character-scoped server chats.
+- Empty/loading/error states are local and do not mention saved setups.
+- Recent sessions render with title, state/topic/update context, and active state.
+- Resume action calls the existing server chat selection hook with the selected chat.
+
+**Tests:**
+- `apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx`
+
+**Status:** Complete
+
+## Stage 2: Current-Character Prioritization And Safe Resume
+
+**Goal:** Make the panel useful for returning role-play users by prioritizing sessions for the currently selected character and preventing no-op active-chat reloads.
+
+**Success Criteria:**
+- Sessions whose `character_id` matches the selected character appear first under a clear current-character label.
+- Other character chats remain visible under a separate label.
+- The active server chat is labelled `Current` and its resume button is disabled.
+- Selecting another character chat clears stale next-send context through `useSelectServerChat`.
+
+**Tests:**
+- Extend `CharacterChatSessionsPanel.test.tsx`.
+- Extend `apps/packages/ui/src/hooks/chat/__tests__/useSelectServerChat.context-reset.test.tsx` only if a new stale-state reset is required.
+
+**Status:** Complete
+
+## Stage 3: Wire Into Playground Character Chat Mode
+
+**Goal:** Show the panel in `/chat` only when Character Chat mode is active.
+
+**Success Criteria:**
+- `Playground` passes the active selected character id/name and active server chat id into the panel.
+- `PlaygroundContextRail` accepts an optional Character Chat sessions panel node and renders it near the conversation session section.
+- Standard chat mode does not render the Character Chat sessions panel.
+- Existing cockpit and readiness tests continue to pass.
+
+**Tests:**
+- Extend `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx`.
+- Run the new panel tests.
+
+**Status:** Complete
+
+## Stage 4: Verification And Closeout
+
+**Goal:** Verify focused behavior, attempt browser/real-backend evidence, and close the Backlog task.
+
+**Success Criteria:**
+- Focused Vitest suite passes.
+- `git diff --check` passes.
+- TypeScript is run or documented with existing baseline failures separated from touched-file errors.
+- Real backend/browser verification is attempted against the running WebUI if feasible.
+- Bandit is skipped only if no Python files are touched.
+- `TASK-449` records touched files, verification, skips, and final summary.
+
+**Tests:**
+```bash
+cd apps/tldw-frontend
+bunx vitest run \
+  ../packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx \
+  ../packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx \
+  ../packages/ui/src/hooks/chat/__tests__/useSelectServerChat.context-reset.test.tsx \
+  --reporter=verbose
+```
+
+**Status:** Complete
+
+## Implementation Notes
+
+- Use `useServerChatHistory("", { mode: "overview", filterMode: "character", limit: 5 })`; do not client-side filter generic chats as the primary contract.
+- Use `useSelectServerChat()` for resume so server chat metadata restoration and selected assistant synchronization stay centralized.
+- Do not render saved role-play setup bundles in this panel. Those belong in `RolePlaySetupDrawer` / `SavedRolePlaySetupsPanel`.
+- Keep copy concise and cockpit-density appropriate; this is an operational rail, not a marketing section.
+- Preserve the global `ChatSidebar` server-history filter. The new panel is an in-context shortcut for Character Chat mode.
+
+## Verification Notes
+
+- `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx ../packages/ui/src/hooks/chat/__tests__/useSelectServerChat.context-reset.test.tsx --reporter=verbose` passed: 4 files, 49 tests.
+- `git diff --check` passed.
+- `bunx tsc --noEmit --pretty false` still fails on inherited frontend baseline errors outside the touched files: `MediaReadAlongPopover.tsx`, `EmbeddingsModelSelectionConfig.tsx`, `StudioPane/index.tsx`, `useShortcutConfig.ts`, and `e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts`.
+- Targeted ESLint from `apps/tldw-frontend` only reports shared UI files as outside the frontend base path; repo-root ESLint has no config at the root, so no useful ESLint signal was available for this touched shared package slice.
+- Real backend/browser verification used FastAPI on `127.0.0.1:8000` and Next on `localhost:3000`. Browser inspection confirmed `Character chat sessions` appears on `/chat?mode=character`, and `/chat?mode=character&characterId=2` shows `Recent sessions for Helpful AI Assistant` with `Resume` and disabled `Current` actions.
+- Bandit skipped: frontend-only TypeScript/React scope.

--- a/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
@@ -41,19 +41,19 @@ const getSessionUpdatedAt = (chat: ServerChatHistoryItem): string | null => {
     typeof chat.updated_at === "string" &&
     chat.updated_at.trim().length > 0
   ) {
-    return chat.updated_at;
+    return chat.updated_at.trim();
   }
   if (
     typeof chat.last_active === "string" &&
     chat.last_active.trim().length > 0
   ) {
-    return chat.last_active;
+    return chat.last_active.trim();
   }
   if (
     typeof chat.created_at === "string" &&
     chat.created_at.trim().length > 0
   ) {
-    return chat.created_at;
+    return chat.created_at.trim();
   }
   return null;
 };
@@ -182,7 +182,7 @@ const CharacterSessionList = ({
                 type="button"
                 disabled={isActive}
                 onClick={() => {
-                  if (!isActive) onSelectSession(session);
+                  onSelectSession(session);
                 }}
                 aria-label={
                   isActive
@@ -290,27 +290,28 @@ export const CharacterChatSessionsPanel = ({
             </p>
           </div>
           <span
-            className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${cockpitRailToneClass(
-              sessionBadgeTone,
-            )}`}
+            className={cn(
+              "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold",
+              cockpitRailToneClass(sessionBadgeTone),
+            )}
           >
             {hasSessions
               ? t("characterChatSessions.available", "Available")
               : hardErrorWithoutData
                 ? t("characterChatSessions.errorBadge", "Error")
-              : t("characterChatSessions.emptyBadge", "None")}
+                : t("characterChatSessions.emptyBadge", "None")}
           </span>
         </div>
 
         {isLoading && !hasUsableData ? (
-          <div className={`mt-3 ${cockpitRailStyles.emptyInset}`}>
+          <div className={cn("mt-3", cockpitRailStyles.emptyInset)}>
             {t(
               "characterChatSessions.loading",
               "Loading character sessions...",
             )}
           </div>
         ) : sidebarRefreshState === "recoverable-error" && !hasUsableData ? (
-          <div className={`mt-3 ${cockpitRailStyles.emptyInset}`}>
+          <div className={cn("mt-3", cockpitRailStyles.emptyInset)}>
             {t(
               "characterChatSessions.refreshFailed",
               "Unable to refresh character sessions right now.",
@@ -356,7 +357,7 @@ export const CharacterChatSessionsPanel = ({
             />
           </>
         ) : (
-          <div className={`mt-3 ${cockpitRailStyles.emptyInset}`}>
+          <div className={cn("mt-3", cockpitRailStyles.emptyInset)}>
             {t(
               "characterChatSessions.empty",
               "No character conversations yet.",

--- a/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
@@ -1,0 +1,340 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Clock, MessageSquareText } from "lucide-react";
+
+import {
+  useServerChatHistory,
+  type ServerChatHistoryItem,
+} from "@/hooks/useServerChatHistory";
+import { useSelectServerChat } from "@/hooks/chat/useSelectServerChat";
+import { formatRelativeTime } from "@/utils/dateFormatters";
+import { cn } from "@/libs/utils";
+import {
+  cockpitRailStyles,
+  cockpitRailToneClass,
+} from "./playground-cockpit-rail-styles";
+import { PlaygroundRailSection } from "./PlaygroundRailSection";
+
+type CharacterChatSessionsPanelProps = {
+  activeCharacterId?: string | number | null;
+  activeCharacterName?: string | null;
+  activeServerChatId?: string | null;
+  enabled?: boolean;
+  limit?: number;
+};
+
+const DEFAULT_SESSION_LIMIT = 5;
+
+const normalizeId = (value: unknown): string | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+};
+
+const getSessionUpdatedAt = (chat: ServerChatHistoryItem): string | null => {
+  if (
+    typeof chat.updated_at === "string" &&
+    chat.updated_at.trim().length > 0
+  ) {
+    return chat.updated_at;
+  }
+  if (
+    typeof chat.last_active === "string" &&
+    chat.last_active.trim().length > 0
+  ) {
+    return chat.last_active;
+  }
+  if (
+    typeof chat.created_at === "string" &&
+    chat.created_at.trim().length > 0
+  ) {
+    return chat.created_at;
+  }
+  return null;
+};
+
+const partitionCharacterSessions = (
+  sessions: ServerChatHistoryItem[],
+  activeCharacterId: string | number | null | undefined,
+): {
+  currentCharacterSessions: ServerChatHistoryItem[];
+  otherCharacterSessions: ServerChatHistoryItem[];
+} => {
+  const normalizedActiveId = normalizeId(activeCharacterId);
+  if (!normalizedActiveId) {
+    return {
+      currentCharacterSessions: sessions,
+      otherCharacterSessions: [],
+    };
+  }
+
+  const currentCharacterSessions: ServerChatHistoryItem[] = [];
+  const otherCharacterSessions: ServerChatHistoryItem[] = [];
+
+  for (const session of sessions) {
+    const sessionCharacterId = normalizeId(session.character_id);
+    if (sessionCharacterId === normalizedActiveId) {
+      currentCharacterSessions.push(session);
+    } else {
+      otherCharacterSessions.push(session);
+    }
+  }
+
+  return {
+    currentCharacterSessions,
+    otherCharacterSessions,
+  };
+};
+
+type SessionListProps = {
+  label: string;
+  sessions: ServerChatHistoryItem[];
+  activeServerChatId?: string | null;
+  onSelectSession: (chat: ServerChatHistoryItem) => void;
+};
+
+const CharacterSessionList = ({
+  label,
+  sessions,
+  activeServerChatId,
+  onSelectSession,
+}: SessionListProps) => {
+  const { t } = useTranslation(["playground", "common"]);
+
+  if (sessions.length === 0) return null;
+
+  return (
+    <ul aria-label={label} className="mt-2 space-y-2">
+      {sessions.map((session) => {
+        const isActive = activeServerChatId === session.id;
+        const updatedAt = getSessionUpdatedAt(session);
+        const updatedLabel = updatedAt
+          ? formatRelativeTime(updatedAt, t, { compact: true })
+          : null;
+        const title =
+          typeof session.title === "string" && session.title.trim().length > 0
+            ? session.title.trim()
+            : t("characterChatSessions.untitled", "Untitled character chat");
+        const topic =
+          typeof session.topic_label === "string" &&
+          session.topic_label.trim().length > 0
+            ? session.topic_label.trim()
+            : null;
+        const messageCount =
+          typeof session.message_count === "number" &&
+          Number.isFinite(session.message_count)
+            ? Math.max(0, Math.trunc(session.message_count))
+            : null;
+
+        return (
+          <li
+            key={session.id}
+            className={cn(
+              cockpitRailStyles.inset,
+              isActive && "border-primary/40 bg-primary/5",
+            )}
+          >
+            <div className="flex items-start gap-2">
+              <span className="mt-0.5 rounded border border-border bg-surface2 p-1 text-text-muted">
+                <MessageSquareText className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p
+                  className="truncate text-sm font-medium text-text"
+                  title={title}
+                >
+                  {title}
+                </p>
+                <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-text-muted">
+                  {updatedLabel ? (
+                    <span className="inline-flex items-center gap-1">
+                      <Clock className="h-3 w-3" aria-hidden="true" />
+                      {updatedLabel}
+                    </span>
+                  ) : null}
+                  {topic ? <span className="truncate">{topic}</span> : null}
+                  {messageCount != null ? (
+                    <span>
+                      {t(
+                        "characterChatSessions.messageCount",
+                        "{{count}} messages",
+                        { count: messageCount },
+                      )}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <button
+                type="button"
+                disabled={isActive}
+                onClick={() => {
+                  if (!isActive) onSelectSession(session);
+                }}
+                aria-label={
+                  isActive
+                    ? t(
+                        "characterChatSessions.currentSessionAction",
+                        "Current {{title}}",
+                        {
+                          title,
+                        },
+                      )
+                    : t(
+                        "characterChatSessions.resumeSessionAction",
+                        "Resume {{title}}",
+                        {
+                          title,
+                        },
+                      )
+                }
+                className={cn(
+                  cockpitRailStyles.action,
+                  "shrink-0 px-2 py-1 text-[11px]",
+                  isActive && "cursor-default opacity-70",
+                )}
+              >
+                {isActive
+                  ? t("characterChatSessions.current", "Current")
+                  : t("characterChatSessions.resume", "Resume")}
+              </button>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export const CharacterChatSessionsPanel = ({
+  activeCharacterId,
+  activeCharacterName,
+  activeServerChatId,
+  enabled = true,
+  limit = DEFAULT_SESSION_LIMIT,
+}: CharacterChatSessionsPanelProps) => {
+  const { t } = useTranslation(["playground", "common"]);
+  const selectServerChat = useSelectServerChat();
+  const {
+    data = [],
+    isLoading,
+    sidebarRefreshState,
+    hasUsableData,
+    isShowingStaleData,
+  } = useServerChatHistory("", {
+    enabled,
+    mode: "overview",
+    page: 1,
+    limit,
+    filterMode: "character",
+  });
+  const sessions = Array.isArray(data) ? data.slice(0, limit) : [];
+  const { currentCharacterSessions, otherCharacterSessions } = React.useMemo(
+    () => partitionCharacterSessions(sessions, activeCharacterId),
+    [activeCharacterId, sessions],
+  );
+  const currentCharacterLabel = activeCharacterName
+    ? t(
+        "characterChatSessions.currentCharacterListLabel",
+        "Recent sessions for {{name}}",
+        { name: activeCharacterName },
+      )
+    : t(
+        "characterChatSessions.currentCharacterFallbackLabel",
+        "Recent character sessions",
+      );
+  const hasSessions = sessions.length > 0;
+
+  return (
+    <section
+      role="region"
+      aria-label={t(
+        "characterChatSessions.regionLabel",
+        "Character chat sessions",
+      )}
+    >
+      <PlaygroundRailSection
+        label={t("characterChatSessions.label", "Character sessions")}
+        title={t("characterChatSessions.title", "Recent character chats")}
+      >
+        <div className="mt-1 flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className={cockpitRailStyles.value}>
+              {t("characterChatSessions.resumeTitle", "Resume role-play")}
+            </p>
+            <p className={cockpitRailStyles.muted}>
+              {t(
+                "characterChatSessions.resumeDetail",
+                "Recent character conversations stay separate from saved role-play setups.",
+              )}
+            </p>
+          </div>
+          <span
+            className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${cockpitRailToneClass(
+              hasSessions ? "success" : "muted",
+            )}`}
+          >
+            {hasSessions
+              ? t("characterChatSessions.available", "Available")
+              : t("characterChatSessions.emptyBadge", "None")}
+          </span>
+        </div>
+
+        {isLoading && !hasUsableData ? (
+          <div className={`mt-3 ${cockpitRailStyles.emptyInset}`}>
+            {t(
+              "characterChatSessions.loading",
+              "Loading character sessions...",
+            )}
+          </div>
+        ) : sidebarRefreshState === "recoverable-error" && !hasUsableData ? (
+          <div className={`mt-3 ${cockpitRailStyles.emptyInset}`}>
+            {t(
+              "characterChatSessions.refreshFailed",
+              "Unable to refresh character sessions right now.",
+            )}
+          </div>
+        ) : hasSessions ? (
+          <>
+            {isShowingStaleData ? (
+              <p className="mt-2 rounded border border-warning/30 bg-warning/10 px-2 py-1 text-xs text-text-subtle">
+                {t(
+                  "characterChatSessions.stale",
+                  "Showing character sessions from the last successful refresh.",
+                )}
+              </p>
+            ) : null}
+            <CharacterSessionList
+              label={currentCharacterLabel}
+              sessions={currentCharacterSessions}
+              activeServerChatId={activeServerChatId}
+              onSelectSession={selectServerChat}
+            />
+            <CharacterSessionList
+              label={t(
+                "characterChatSessions.otherCharactersListLabel",
+                "Other character sessions",
+              )}
+              sessions={otherCharacterSessions}
+              activeServerChatId={activeServerChatId}
+              onSelectSession={selectServerChat}
+            />
+          </>
+        ) : (
+          <div className={`mt-3 ${cockpitRailStyles.emptyInset}`}>
+            {t(
+              "characterChatSessions.empty",
+              "No character conversations yet.",
+            )}
+          </div>
+        )}
+      </PlaygroundRailSection>
+    </section>
+  );
+};
+
+export default CharacterChatSessionsPanel;

--- a/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
@@ -58,6 +58,15 @@ const getSessionUpdatedAt = (chat: ServerChatHistoryItem): string | null => {
   return null;
 };
 
+const getSessionCharacterIdentity = (
+  session: ServerChatHistoryItem,
+): string | null => {
+  const characterId = normalizeId(session.character_id);
+  if (characterId) return characterId;
+  if (session.assistant_kind !== "character") return null;
+  return normalizeId(session.assistant_id);
+};
+
 const partitionCharacterSessions = (
   sessions: ServerChatHistoryItem[],
   activeCharacterId: string | number | null | undefined,
@@ -77,7 +86,7 @@ const partitionCharacterSessions = (
   const otherCharacterSessions: ServerChatHistoryItem[] = [];
 
   for (const session of sessions) {
-    const sessionCharacterId = normalizeId(session.character_id);
+    const sessionCharacterId = getSessionCharacterIdentity(session);
     if (sessionCharacterId === normalizedActiveId) {
       currentCharacterSessions.push(session);
     } else {
@@ -248,6 +257,13 @@ export const CharacterChatSessionsPanel = ({
         "Recent character sessions",
       );
   const hasSessions = sessions.length > 0;
+  const hardErrorWithoutData =
+    sidebarRefreshState === "hard-error" && !hasUsableData;
+  const sessionBadgeTone = hasSessions
+    ? "success"
+    : hardErrorWithoutData
+      ? "danger"
+      : "muted";
 
   return (
     <section
@@ -275,11 +291,13 @@ export const CharacterChatSessionsPanel = ({
           </div>
           <span
             className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${cockpitRailToneClass(
-              hasSessions ? "success" : "muted",
+              sessionBadgeTone,
             )}`}
           >
             {hasSessions
               ? t("characterChatSessions.available", "Available")
+              : hardErrorWithoutData
+                ? t("characterChatSessions.errorBadge", "Error")
               : t("characterChatSessions.emptyBadge", "None")}
           </span>
         </div>
@@ -296,6 +314,19 @@ export const CharacterChatSessionsPanel = ({
             {t(
               "characterChatSessions.refreshFailed",
               "Unable to refresh character sessions right now.",
+            )}
+          </div>
+        ) : hardErrorWithoutData ? (
+          <div
+            className={cn(
+              "mt-3",
+              cockpitRailStyles.emptyInset,
+              "border-danger/30 bg-danger/10 text-danger",
+            )}
+          >
+            {t(
+              "characterChatSessions.loadFailed",
+              "Character sessions could not be loaded.",
             )}
           </div>
         ) : hasSessions ? (

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -134,6 +134,10 @@ type ChatModelCatalog = Awaited<ReturnType<typeof fetchChatModels>>;
 const toText = (value: unknown): string =>
   typeof value === "string" ? value : String(value);
 
+const isPlaygroundContextSource = (
+  item: PlaygroundContextSource | null,
+): item is PlaygroundContextSource => Boolean(item);
+
 const UNAVAILABLE_DESIGN_STATE_LABEL =
   getDesignSystemState("unavailable").label;
 
@@ -2293,7 +2297,7 @@ export const Playground = () => {
         ),
       })),
     ] satisfies Array<PlaygroundContextSource | null>
-  ).filter(Boolean) as PlaygroundContextSource[];
+  ).filter(isPlaygroundContextSource);
   const activeScopedModelSettings =
     activeSettingsScope && scopedSettingsByModelKey
       ? scopedSettingsByModelKey[activeSettingsScope]

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -20,6 +20,7 @@ import {
   CharacterChatReadinessPanel,
   type MissingCharacterRecovery,
 } from "./CharacterChatReadinessPanel";
+import { CharacterChatSessionsPanel } from "./CharacterChatSessionsPanel";
 import {
   buildCockpitAssistantSummary,
   buildCockpitMcpSummary,
@@ -170,10 +171,7 @@ const COCKPIT_MCP_SETTINGS_TRIGGER_SELECTOR =
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value);
 
-const getRecordString = (
-  value: unknown,
-  keys: string[],
-): string | null => {
+const getRecordString = (value: unknown, keys: string[]): string | null => {
   if (!isRecord(value)) return null;
   for (const key of keys) {
     const fieldValue = value[key];
@@ -266,11 +264,10 @@ export const Playground = () => {
   }, []);
   const [characterModeIntentActive, setCharacterModeIntentActive] =
     React.useState(false);
-  const [chatLayoutMode, setChatLayoutMode] =
-    useStorage<PlaygroundCockpitMode>(
-      "playgroundChatLayoutMode",
-      defaultChatLayoutMode,
-    );
+  const [chatLayoutMode, setChatLayoutMode] = useStorage<PlaygroundCockpitMode>(
+    "playgroundChatLayoutMode",
+    defaultChatLayoutMode,
+  );
   const [cockpitContextRailVisible, setCockpitContextRailVisible] =
     useStorage<boolean>("playgroundChatContextRailVisible", true);
   const [cockpitRuntimeRailVisible, setCockpitRuntimeRailVisible] =
@@ -471,7 +468,7 @@ export const Playground = () => {
       ? selectedAssistant.name
       : selectedAssistant
         ? null
-        : selectedCharacter?.name ?? null;
+        : (selectedCharacter?.name ?? null);
   const setRouteContext = useChatSurfaceCoordinatorStore(
     (state) => state.setRouteContext,
   );
@@ -520,7 +517,9 @@ export const Playground = () => {
     };
     const handleStarterSelected = (event: Event) => {
       const detail = (event as CustomEvent<{ mode?: unknown }>).detail;
-      const mode = String(detail?.mode || "").trim().toLowerCase();
+      const mode = String(detail?.mode || "")
+        .trim()
+        .toLowerCase();
       if (mode === "character") {
         setCharacterModeIntentActive(true);
         void setChatWorkflowMode("character");
@@ -613,11 +612,7 @@ export const Playground = () => {
         routeCharacterIntentRequestRef.current += 1;
       }
     };
-  }, [
-    routeCharacterIntentId,
-    routeCharacterRetryToken,
-    setSelectedCharacter,
-  ]);
+  }, [routeCharacterIntentId, routeCharacterRetryToken, setSelectedCharacter]);
 
   React.useEffect(() => {
     if (!routeCharacterIntentId) {
@@ -639,10 +634,12 @@ export const Playground = () => {
 
   React.useEffect(() => {
     const handleReadinessState = (event: Event) => {
-      const detail = (event as CustomEvent<{
-        state?: string;
-        degradedChecks?: unknown;
-      }>).detail;
+      const detail = (
+        event as CustomEvent<{
+          state?: string;
+          degradedChecks?: unknown;
+        }>
+      ).detail;
       const nextState =
         detail?.state === "ready" ||
         detail?.state === "degraded" ||
@@ -1807,12 +1804,12 @@ export const Playground = () => {
     : selectedKnowledge
       ? 1
       : 0;
-  const ragMediaIdCount = Array.isArray(ragMediaIds)
-    ? ragMediaIds.length
-    : 0;
+  const ragMediaIdCount = Array.isArray(ragMediaIds) ? ragMediaIds.length : 0;
   const trimmedSystemPrompt = String(systemPrompt || "").trim();
   const hasPromptContext = Boolean(
-    selectedSystemPrompt || selectedQuickPrompt || trimmedSystemPrompt.length > 0,
+    selectedSystemPrompt ||
+    selectedQuickPrompt ||
+    trimmedSystemPrompt.length > 0,
   );
   const promptSummary: PlaygroundPromptSummary = buildCockpitPromptSummary({
     selectedSystemPrompt,
@@ -1964,25 +1961,25 @@ export const Playground = () => {
           ),
         )
       : serverReadinessState === "degraded"
-      ? serverDegradedChecks.length > 0
-        ? `${toText(
-            t("playground:cockpit.degraded", DEGRADED_STATE_LABEL),
-          )}: ${serverDegradedChecks.join(", ")}`
-        : toText(
-            t(
-              "playground:cockpit.degradedServerHealth",
-              "Server health is degraded",
-            ),
-          )
-      : null;
+        ? serverDegradedChecks.length > 0
+          ? `${toText(
+              t("playground:cockpit.degraded", DEGRADED_STATE_LABEL),
+            )}: ${serverDegradedChecks.join(", ")}`
+          : toText(
+              t(
+                "playground:cockpit.degradedServerHealth",
+                "Server health is degraded",
+              ),
+            )
+        : null;
   const hasChatContext = Boolean(
     attachedResearchContext ||
-      webSearch ||
-      contextFileCount > 0 ||
-      selectedKnowledgeCount > 0 ||
-      ragMediaIdCount > 0 ||
-      hasPromptContext ||
-      cockpitAssistantSummary.mode !== "none",
+    webSearch ||
+    contextFileCount > 0 ||
+    selectedKnowledgeCount > 0 ||
+    ragMediaIdCount > 0 ||
+    hasPromptContext ||
+    cockpitAssistantSummary.mode !== "none",
   );
   const sessionSummary = buildCockpitSessionSummary({
     temporaryChat,
@@ -2014,7 +2011,9 @@ export const Playground = () => {
       loadingStatusLabel: toText(
         t("playground:cockpit.sessionLoading", "Loading conversation"),
       ),
-      localChatLabel: toText(t("playground:cockpit.sessionLocal", "Local chat")),
+      localChatLabel: toText(
+        t("playground:cockpit.sessionLocal", "Local chat"),
+      ),
       localHistoryStatusLabel: toText(
         t("playground:cockpit.localHistory", "Local history"),
       ),
@@ -2077,12 +2076,7 @@ export const Playground = () => {
             characterName: activeCharacterModeLabel,
           })
         : null,
-    [
-      activeCharacterModeLabel,
-      characterChatBlocked,
-      characterChatReadiness,
-      t,
-    ],
+    [activeCharacterModeLabel, characterChatBlocked, characterChatReadiness, t],
   );
   React.useEffect(() => {
     if (typeof setActiveSettingsScope === "function") {
@@ -2098,13 +2092,17 @@ export const Playground = () => {
   const ragMediaItems = Array.isArray(ragMediaIds) ? ragMediaIds : [];
   const removeContextFileAt = React.useCallback(
     (index: number) => {
-      setContextFiles(contextFileItems.filter((_, itemIndex) => itemIndex !== index));
+      setContextFiles(
+        contextFileItems.filter((_, itemIndex) => itemIndex !== index),
+      );
     },
     [contextFileItems, setContextFiles],
   );
   const removeRagMediaAt = React.useCallback(
     (index: number) => {
-      const nextIds = ragMediaItems.filter((_, itemIndex) => itemIndex !== index);
+      const nextIds = ragMediaItems.filter(
+        (_, itemIndex) => itemIndex !== index,
+      );
       setRagMediaIds(nextIds.length > 0 ? nextIds : null);
     },
     [ragMediaItems, setRagMediaIds],
@@ -2123,166 +2121,179 @@ export const Playground = () => {
     },
     [selectedKnowledge, selectedKnowledgeItems, setSelectedKnowledge],
   );
-  const contextSources = ([
-    webSearch
-      ? {
-          id: "web-search",
-          kind: "web" as const,
-          label: toText(t("playground:cockpit.web", "Web")),
-          title: toText(t("playground:cockpit.webSearch", "Web search")),
+  const contextSources = (
+    [
+      webSearch
+        ? {
+            id: "web-search",
+            kind: "web" as const,
+            label: toText(t("playground:cockpit.web", "Web")),
+            title: toText(t("playground:cockpit.webSearch", "Web search")),
+            detail: toText(
+              t(
+                "playground:cockpit.webSearchDetail",
+                "Enabled for the next reply.",
+              ),
+            ),
+            state: "active" as const,
+            onRemove: toggleWebSearchFromCockpit,
+            removeLabel: toText(
+              t("playground:cockpit.disableWebSearch", "Disable web search"),
+            ),
+          }
+        : null,
+      hasPromptContext
+        ? {
+            id: `prompt-${promptSummary.state}`,
+            kind: "prompt" as const,
+            label: toText(t("playground:cockpit.prompt", "Prompt")),
+            title: promptSummary.label,
+            detail: promptSummary.detail,
+            state: "active" as const,
+            onOpen: openPromptSelectorFromCockpit,
+            onRemove: clearPromptContextFromCockpit,
+            openLabel: toText(
+              t("playground:cockpit.selectPrompt", "Select a prompt"),
+            ),
+            removeLabel: toText(
+              t(
+                "playground:cockpit.clearPromptContext",
+                "Clear prompt context",
+              ),
+            ),
+          }
+        : null,
+      cockpitAssistantSummary.mode !== "none" && cockpitAssistantSummary.name
+        ? {
+            id: `assistant-${cockpitAssistantSummary.mode}-${cockpitAssistantSummary.name}`,
+            kind: "assistant" as const,
+            label:
+              cockpitAssistantSummary.mode === "persona"
+                ? toText(t("playground:cockpit.persona", "Persona"))
+                : toText(t("playground:cockpit.character", "Character")),
+            title: cockpitAssistantSummary.name,
+            detail: cockpitAssistantSummary.detail,
+            state: "active" as const,
+            onOpen: openAssistantSelectorFromCockpit,
+            onRemove: clearAssistantFromCockpit,
+            openLabel: toText(
+              t(
+                "playground:cockpit.selectCharacterPersona",
+                "Select character or persona",
+              ),
+            ),
+            removeLabel: toText(
+              t("playground:cockpit.clearAssistant", "Clear assistant"),
+            ),
+          }
+        : null,
+      attachedResearchContext
+        ? {
+            id: `research-${attachedResearchContext.run_id || "active"}`,
+            kind: "research" as const,
+            label: toText(t("playground:cockpit.research", "Research")),
+            title:
+              attachedResearchContext.query ||
+              attachedResearchContext.question ||
+              toText(
+                t("playground:cockpit.researchContext", "Research context"),
+              ),
+            detail: attachedResearchContext.run_id
+              ? toText(
+                  t("playground:cockpit.researchRun", "Run {{runId}}", {
+                    runId: attachedResearchContext.run_id,
+                  }),
+                )
+              : null,
+            state: "active" as const,
+            onOpen: () => openSearchAndContext({ tab: "context" }),
+            onRemove: handleRemoveAttachedResearchContext,
+            removeLabel: toText(
+              t(
+                "playground:cockpit.clearResearchContext",
+                "Clear research context",
+              ),
+            ),
+          }
+        : null,
+      ...contextFileItems.map((file, index) => {
+        const title =
+          getRecordString(file, ["name", "filename", "title", "id"]) ||
+          toText(
+            t("playground:cockpit.fileFallback", "File {{index}}", {
+              index: index + 1,
+            }),
+          );
+        return {
+          id: `file-${getRecordString(file, ["id"]) || index}`,
+          kind: "file" as const,
+          label: toText(t("playground:cockpit.file", "File")),
+          title,
           detail: toText(
-            t(
-              "playground:cockpit.webSearchDetail",
-              "Enabled for the next reply.",
-            ),
+            t("playground:cockpit.nextReply", "Used on next reply"),
           ),
           state: "active" as const,
-          onRemove: toggleWebSearchFromCockpit,
+          onRemove: () => removeContextFileAt(index),
           removeLabel: toText(
-            t("playground:cockpit.disableWebSearch", "Disable web search"),
+            t("playground:cockpit.removeFileSource", `Remove ${title}`, {
+              title,
+            }),
           ),
-        }
-      : null,
-    hasPromptContext
-      ? {
-          id: `prompt-${promptSummary.state}`,
-          kind: "prompt" as const,
-          label: toText(t("playground:cockpit.prompt", "Prompt")),
-          title: promptSummary.label,
-          detail: promptSummary.detail,
-          state: "active" as const,
-          onOpen: openPromptSelectorFromCockpit,
-          onRemove: clearPromptContextFromCockpit,
-          openLabel: toText(
-            t("playground:cockpit.selectPrompt", "Select a prompt"),
+        };
+      }),
+      ...selectedKnowledgeItems.map((knowledge, index) => {
+        const title =
+          getRecordString(knowledge, ["title", "name", "id"]) ||
+          toText(
+            t("playground:cockpit.knowledgeFallback", "Knowledge {{index}}", {
+              index: index + 1,
+            }),
+          );
+        return {
+          id: `knowledge-${getRecordString(knowledge, ["id"]) || index}`,
+          kind: "knowledge" as const,
+          label: toText(t("playground:cockpit.knowledge", "Knowledge")),
+          title,
+          detail: toText(
+            t("playground:cockpit.nextReply", "Used on next reply"),
           ),
-          removeLabel: toText(
-            t("playground:cockpit.clearPromptContext", "Clear prompt context"),
-          ),
-        }
-      : null,
-    cockpitAssistantSummary.mode !== "none" && cockpitAssistantSummary.name
-      ? {
-          id: `assistant-${cockpitAssistantSummary.mode}-${cockpitAssistantSummary.name}`,
-          kind: "assistant" as const,
-          label:
-            cockpitAssistantSummary.mode === "persona"
-              ? toText(t("playground:cockpit.persona", "Persona"))
-              : toText(t("playground:cockpit.character", "Character")),
-          title: cockpitAssistantSummary.name,
-          detail: cockpitAssistantSummary.detail,
-          state: "active" as const,
-          onOpen: openAssistantSelectorFromCockpit,
-          onRemove: clearAssistantFromCockpit,
-          openLabel: toText(
-            t(
-              "playground:cockpit.selectCharacterPersona",
-              "Select character or persona",
-            ),
-          ),
-          removeLabel: toText(
-            t("playground:cockpit.clearAssistant", "Clear assistant"),
-          ),
-        }
-      : null,
-    attachedResearchContext
-      ? {
-          id: `research-${attachedResearchContext.run_id || "active"}`,
-          kind: "research" as const,
-          label: toText(t("playground:cockpit.research", "Research")),
-          title:
-            attachedResearchContext.query ||
-            attachedResearchContext.question ||
-            toText(t("playground:cockpit.researchContext", "Research context")),
-          detail: attachedResearchContext.run_id
-            ? toText(
-                t("playground:cockpit.researchRun", "Run {{runId}}", {
-                  runId: attachedResearchContext.run_id,
-                }),
-              )
-            : null,
           state: "active" as const,
           onOpen: () => openSearchAndContext({ tab: "context" }),
-          onRemove: handleRemoveAttachedResearchContext,
-          removeLabel: toText(
-            t(
-              "playground:cockpit.clearResearchContext",
-              "Clear research context",
-            ),
+          onRemove: () => removeSelectedKnowledgeAt(index),
+          openLabel: toText(
+            t("playground:cockpit.openKnowledgeSource", `Open ${title}`, {
+              title,
+            }),
           ),
-        }
-      : null,
-    ...contextFileItems.map((file, index) => {
-      const title =
-        getRecordString(file, ["name", "filename", "title", "id"]) ||
-        toText(
-          t("playground:cockpit.fileFallback", "File {{index}}", {
-            index: index + 1,
+          removeLabel: toText(
+            t("playground:cockpit.removeKnowledgeSource", `Remove ${title}`, {
+              title,
+            }),
+          ),
+        };
+      }),
+      ...ragMediaItems.map((mediaId, index) => ({
+        id: `media-${mediaId}`,
+        kind: "media" as const,
+        label: toText(t("playground:cockpit.media", "Media")),
+        title: toText(
+          t("playground:cockpit.mediaScopeLabel", "Media scope {{id}}", {
+            id: mediaId,
           }),
-        );
-      return {
-        id: `file-${getRecordString(file, ["id"]) || index}`,
-        kind: "file" as const,
-        label: toText(t("playground:cockpit.file", "File")),
-        title,
-        detail: toText(t("playground:cockpit.nextReply", "Used on next reply")),
-        state: "active" as const,
-        onRemove: () => removeContextFileAt(index),
-        removeLabel: toText(
-          t("playground:cockpit.removeFileSource", `Remove ${title}`, { title }),
         ),
-      };
-    }),
-    ...selectedKnowledgeItems.map((knowledge, index) => {
-      const title =
-        getRecordString(knowledge, ["title", "name", "id"]) ||
-        toText(
-          t("playground:cockpit.knowledgeFallback", "Knowledge {{index}}", {
-            index: index + 1,
-          }),
-        );
-      return {
-        id: `knowledge-${getRecordString(knowledge, ["id"]) || index}`,
-        kind: "knowledge" as const,
-        label: toText(t("playground:cockpit.knowledge", "Knowledge")),
-        title,
         detail: toText(t("playground:cockpit.nextReply", "Used on next reply")),
         state: "active" as const,
         onOpen: () => openSearchAndContext({ tab: "context" }),
-        onRemove: () => removeSelectedKnowledgeAt(index),
+        onRemove: () => removeRagMediaAt(index),
         openLabel: toText(
-          t("playground:cockpit.openKnowledgeSource", `Open ${title}`, { title }),
+          t("playground:cockpit.openMediaSource", "Open media scope"),
         ),
         removeLabel: toText(
-          t("playground:cockpit.removeKnowledgeSource", `Remove ${title}`, {
-            title,
-          }),
+          t("playground:cockpit.removeMediaSource", "Remove media scope"),
         ),
-      };
-    }),
-    ...ragMediaItems.map((mediaId, index) => ({
-      id: `media-${mediaId}`,
-      kind: "media" as const,
-      label: toText(t("playground:cockpit.media", "Media")),
-      title: toText(
-        t("playground:cockpit.mediaScopeLabel", "Media scope {{id}}", {
-          id: mediaId,
-        }),
-      ),
-      detail: toText(t("playground:cockpit.nextReply", "Used on next reply")),
-      state: "active" as const,
-      onOpen: () => openSearchAndContext({ tab: "context" }),
-      onRemove: () => removeRagMediaAt(index),
-      openLabel: toText(
-        t("playground:cockpit.openMediaSource", "Open media scope"),
-      ),
-      removeLabel: toText(
-        t("playground:cockpit.removeMediaSource", "Remove media scope"),
-      ),
-    })),
-  ] satisfies Array<PlaygroundContextSource | null>).filter(
-    Boolean,
-  ) as PlaygroundContextSource[];
+      })),
+    ] satisfies Array<PlaygroundContextSource | null>
+  ).filter(Boolean) as PlaygroundContextSource[];
   const activeScopedModelSettings =
     activeSettingsScope && scopedSettingsByModelKey
       ? scopedSettingsByModelKey[activeSettingsScope]
@@ -2291,7 +2302,10 @@ export const Playground = () => {
     key: keyof ChatModelSettings,
   ): RuntimeSettingSummary["source"] =>
     activeSettingsScope
-      ? Object.prototype.hasOwnProperty.call(activeScopedModelSettings || {}, key)
+      ? Object.prototype.hasOwnProperty.call(
+          activeScopedModelSettings || {},
+          key,
+        )
         ? "override"
         : "default"
       : undefined;
@@ -2340,8 +2354,8 @@ export const Playground = () => {
       : null,
   ];
   const runtimeSettingSummaries: RuntimeSettingSummary[] =
-    runtimeSettingSummaryItems.filter(
-      (item): item is RuntimeSettingSummary => Boolean(item),
+    runtimeSettingSummaryItems.filter((item): item is RuntimeSettingSummary =>
+      Boolean(item),
     );
   const cockpitToolSummary = buildCockpitMcpSummary({
     hasMcp: mcpHealthState !== "unavailable",
@@ -2400,10 +2414,7 @@ export const Playground = () => {
       ),
       toolsLabel: toText(t("playground:cockpit.mcpTools", "MCP tools")),
       unavailableDetail: toText(
-        t(
-          "playground:composer.mcpToolsUnavailable",
-          "MCP tools unavailable",
-        ),
+        t("playground:composer.mcpToolsUnavailable", "MCP tools unavailable"),
       ),
       unavailableLabel: toText(
         t("playground:composer.mcpUnavailable", "MCP unavailable"),
@@ -2490,7 +2501,9 @@ export const Playground = () => {
   }, []);
   const statusContextSummary = [
     hasPromptContext ? promptSummary.label : null,
-    webSearch ? toText(t("playground:cockpit.webSearchOn", "Web search on")) : null,
+    webSearch
+      ? toText(t("playground:cockpit.webSearchOn", "Web search on"))
+      : null,
     contextFileCount > 0
       ? contextFileCount === 1
         ? toText(t("playground:cockpit.contextFilesCountOne", "1 file"))
@@ -2505,7 +2518,10 @@ export const Playground = () => {
     selectedKnowledgeCount > 0
       ? selectedKnowledgeCount === 1
         ? toText(
-            t("playground:cockpit.contextKnowledgeCountOne", "1 knowledge item"),
+            t(
+              "playground:cockpit.contextKnowledgeCountOne",
+              "1 knowledge item",
+            ),
           )
         : toText(
             t(
@@ -2528,6 +2544,17 @@ export const Playground = () => {
       : null,
   ].filter((item): item is string => Boolean(item));
   const cockpitMessageCount = getCockpitMessageCount(messages, history);
+  const activeCharacterSessionId =
+    selectedAssistant?.kind === "character"
+      ? selectedAssistant.id
+      : selectedCharacter?.id;
+  const characterSessionsPanel = characterWorkflowActive ? (
+    <CharacterChatSessionsPanel
+      activeCharacterId={activeCharacterSessionId ?? null}
+      activeCharacterName={activeCharacterModeLabel}
+      activeServerChatId={serverChatId}
+    />
+  ) : null;
   const cockpitLeftRail = (
     <PlaygroundContextRail
       hasContext={hasChatContext}
@@ -2556,12 +2583,15 @@ export const Playground = () => {
           type="button"
           className="inline-flex min-h-[30px] items-center rounded-md border border-border bg-surface2 px-2.5 py-1 text-xs font-medium text-text hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
           data-cockpit-prompt-select-trigger
-          aria-label={toText(t("playground:cockpit.selectPrompt", "Select a prompt"))}
+          aria-label={toText(
+            t("playground:cockpit.selectPrompt", "Select a prompt"),
+          )}
           onClick={openPromptSelectorFromCockpit}
         >
           {toText(t("playground:cockpit.selectPrompt", "Select prompt"))}
         </button>
       }
+      characterSessionsPanel={characterSessionsPanel}
       onClearPrompt={clearPromptContextFromCockpit}
       onOpenSearchContext={() => openSearchAndContext({ tab: "search" })}
       onClearFiles={() => setContextFiles([])}
@@ -2581,12 +2611,14 @@ export const Playground = () => {
         characterChatModelUnavailable || serverReadinessState === "blocked"
           ? "error"
           : streaming
-          ? "streaming"
-          : serverReadinessState === "degraded"
-            ? "degraded"
-            : "ready"
+            ? "streaming"
+            : serverReadinessState === "degraded"
+              ? "degraded"
+              : "ready"
       }
-      runtimeStatusDetail={characterChatReadinessCopy?.title ?? runtimeStatusDetail}
+      runtimeStatusDetail={
+        characterChatReadinessCopy?.title ?? runtimeStatusDetail
+      }
       messageCount={cockpitMessageCount}
       threadSearchOpen={threadSearchOpen}
       assistantSummary={cockpitAssistantSummary}
@@ -2705,469 +2737,482 @@ export const Playground = () => {
           statusStrip={cockpitStatusStrip}
         >
           <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
-          {parentMeta?.parentHistoryId && (
-            <div className="flex w-full justify-center px-5 pt-2">
-              <div className="inline-flex flex-wrap items-center justify-center gap-2">
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-2 rounded-full border border-primary bg-surface2 px-3 py-1 text-[11px] font-medium text-primaryStrong hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
-                  title={t(
-                    "playground:composer.compareBreadcrumb",
-                    "Back to comparison chat",
-                  )}
-                  onClick={() => {
-                    window.dispatchEvent(
-                      new CustomEvent("tldw:open-history", {
-                        detail: { historyId: parentMeta.parentHistoryId },
-                      }),
-                    );
-                  }}
-                >
-                  <span aria-hidden="true">←</span>
-                  <span>
-                    {t(
+            {parentMeta?.parentHistoryId && (
+              <div className="flex w-full justify-center px-5 pt-2">
+                <div className="inline-flex flex-wrap items-center justify-center gap-2">
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-2 rounded-full border border-primary bg-surface2 px-3 py-1 text-[11px] font-medium text-primaryStrong hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                    title={t(
                       "playground:composer.compareBreadcrumb",
                       "Back to comparison chat",
                     )}
-                  </span>
-                </button>
-                {branchForkPointLabel && (
-                  <span
-                    data-testid="playground-branch-fork-point"
-                    className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5 text-[10px] text-text-muted"
+                    onClick={() => {
+                      window.dispatchEvent(
+                        new CustomEvent("tldw:open-history", {
+                          detail: { historyId: parentMeta.parentHistoryId },
+                        }),
+                      );
+                    }}
                   >
-                    {branchForkPointLabel}
-                  </span>
-                )}
-                {branchDepthLabel && (
+                    <span aria-hidden="true">←</span>
+                    <span>
+                      {t(
+                        "playground:composer.compareBreadcrumb",
+                        "Back to comparison chat",
+                      )}
+                    </span>
+                  </button>
+                  {branchForkPointLabel && (
+                    <span
+                      data-testid="playground-branch-fork-point"
+                      className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5 text-[10px] text-text-muted"
+                    >
+                      {branchForkPointLabel}
+                    </span>
+                  )}
+                  {branchDepthLabel && (
+                    <span
+                      data-testid="playground-branch-depth"
+                      className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5 text-[10px] text-text-muted"
+                    >
+                      {branchDepthLabel}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="px-4 pt-2">
+              <div className="mx-auto flex w-full max-w-[64rem] items-center justify-between text-[11px] text-text-muted">
+                <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                   <span
-                    data-testid="playground-branch-depth"
-                    className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5 text-[10px] text-text-muted"
+                    data-testid="playground-active-chat-mode"
+                    className={`inline-flex max-w-full items-center rounded-full border px-2 py-0.5 font-medium ${
+                      characterWorkflowActive
+                        ? "border-primary/40 bg-primary/10 text-primaryStrong"
+                        : "border-border bg-surface2 text-text-muted"
+                    }`}
                   >
-                    {branchDepthLabel}
+                    {characterWorkflowActive
+                      ? toText(
+                          t(
+                            "playground:characterChat.modeLabel",
+                            "Character Chat",
+                          ),
+                        )
+                      : toText(
+                          t("playground:regions.standardChat", "Standard chat"),
+                        )}
+                    {characterWorkflowActive && activeCharacterModeLabel ? (
+                      <span className="ml-1 max-w-[14rem] truncate text-text">
+                        {activeCharacterModeLabel}
+                      </span>
+                    ) : null}
                   </span>
-                )}
-              </div>
-            </div>
-          )}
-          <div className="px-4 pt-2">
-            <div className="mx-auto flex w-full max-w-[64rem] items-center justify-between text-[11px] text-text-muted">
-              <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                <span
-                  data-testid="playground-active-chat-mode"
-                  className={`inline-flex max-w-full items-center rounded-full border px-2 py-0.5 font-medium ${
-                    characterWorkflowActive
-                      ? "border-primary/40 bg-primary/10 text-primaryStrong"
-                      : "border-border bg-surface2 text-text-muted"
-                  }`}
-                >
-                  {characterWorkflowActive
-                    ? toText(
-                        t(
-                          "playground:characterChat.modeLabel",
-                          "Character Chat",
-                        ),
-                      )
-                    : toText(t("playground:regions.standardChat", "Standard chat"))}
-                  {characterWorkflowActive && activeCharacterModeLabel ? (
-                    <span className="ml-1 max-w-[14rem] truncate text-text">
-                      {activeCharacterModeLabel}
-                    </span>
-                  ) : null}
-                </span>
-                <span className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5">
-                  {t("playground:regions.timeline", "Conversation timeline")}
-                </span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <button
-                  ref={shortcutsTriggerRef}
-                  type="button"
-                  data-testid="playground-shortcuts-help-trigger"
-                  onClick={() => setShortcutsHelpOpen((previous) => !previous)}
-                  title={
-                    t(
-                      "playground:shortcuts.openHelp",
-                      "Open keyboard shortcuts (Shift+/)",
-                    ) as string
-                  }
-                  className="inline-flex items-center gap-1 rounded-full border border-border bg-surface2 px-2 py-0.5 text-text hover:bg-surface"
-                >
-                  <Keyboard className="h-3 w-3" aria-hidden="true" />
-                  {t("playground:shortcuts.title", "Shortcuts")}
-                </button>
-                <button
-                  ref={artifactsTriggerRef}
-                  type="button"
-                  data-testid="playground-artifacts-trigger"
-                  disabled={!activeArtifact && !artifactsOpen}
-                  onClick={() => {
-                    if (artifactsOpen) {
-                      closeArtifacts();
-                      return;
+                  <span className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5">
+                    {t("playground:regions.timeline", "Conversation timeline")}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <button
+                    ref={shortcutsTriggerRef}
+                    type="button"
+                    data-testid="playground-shortcuts-help-trigger"
+                    onClick={() =>
+                      setShortcutsHelpOpen((previous) => !previous)
                     }
-                    if (!activeArtifact) {
-                      return;
+                    title={
+                      t(
+                        "playground:shortcuts.openHelp",
+                        "Open keyboard shortcuts (Shift+/)",
+                      ) as string
                     }
-                    setArtifactsOpen(true);
-                    markArtifactsRead();
-                  }}
-                  title={artifactBadgeLabel as string}
-                  className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 transition ${
-                    !activeArtifact && !artifactsOpen
-                      ? "cursor-not-allowed border-border bg-surface text-text-subtle opacity-70"
-                      : "border-border bg-surface2 text-text hover:bg-surface"
-                  }`}
-                >
-                  <span>{artifactBadgeLabel}</span>
-                  {artifactUnreadCount > 0 && (
-                    <span
-                      data-testid="playground-artifacts-unread"
-                      className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-white"
-                    >
-                      {toText(
-                        t("playground:regions.artifactsNew", "New {{count}}", {
-                          count: artifactUnreadCount,
-                        } as any),
-                      )}
-                    </span>
-                  )}
-                  {artifactPinnedCount > 0 && (
-                    <span
-                      data-testid="playground-artifacts-pinned"
-                      className="rounded-full border border-border bg-surface px-1.5 py-0.5 text-[10px] font-medium text-text-subtle"
-                    >
-                      {toText(
-                        t(
-                          "playground:regions.artifactsPinned",
-                          "Pinned {{count}}",
-                          {
-                            count: artifactPinnedCount,
-                          } as any,
-                        ),
-                      )}
-                    </span>
-                  )}
-                  {artifactHistoryCount > 0 && (
-                    <span
-                      data-testid="playground-artifacts-count"
-                      className="rounded-full border border-border bg-surface px-1.5 py-0.5 text-[10px] text-text-subtle"
-                    >
-                      {toText(
-                        t(
-                          "playground:regions.artifactsCount",
-                          "{{count}} total",
-                          {
-                            count: artifactHistoryCount,
-                          } as any,
-                        ),
-                      )}
-                    </span>
-                  )}
-                </button>
-              </div>
-            </div>
-            {shortcutsHelpOpen && (
-              <div
-                data-testid="playground-shortcuts-help-panel"
-                role="dialog"
-                aria-modal="false"
-                aria-label={t("playground:shortcuts.title", "Shortcuts")}
-                className="mx-auto mt-1 w-full max-w-[64rem] rounded-md border border-border bg-surface2 px-2 py-1.5 text-[11px] text-text"
-              >
-                <div className="mb-1 flex items-center justify-between gap-2">
-                  <span className="font-semibold">
+                    className="inline-flex items-center gap-1 rounded-full border border-border bg-surface2 px-2 py-0.5 text-text hover:bg-surface"
+                  >
+                    <Keyboard className="h-3 w-3" aria-hidden="true" />
                     {t("playground:shortcuts.title", "Shortcuts")}
+                  </button>
+                  <button
+                    ref={artifactsTriggerRef}
+                    type="button"
+                    data-testid="playground-artifacts-trigger"
+                    disabled={!activeArtifact && !artifactsOpen}
+                    onClick={() => {
+                      if (artifactsOpen) {
+                        closeArtifacts();
+                        return;
+                      }
+                      if (!activeArtifact) {
+                        return;
+                      }
+                      setArtifactsOpen(true);
+                      markArtifactsRead();
+                    }}
+                    title={artifactBadgeLabel as string}
+                    className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 transition ${
+                      !activeArtifact && !artifactsOpen
+                        ? "cursor-not-allowed border-border bg-surface text-text-subtle opacity-70"
+                        : "border-border bg-surface2 text-text hover:bg-surface"
+                    }`}
+                  >
+                    <span>{artifactBadgeLabel}</span>
+                    {artifactUnreadCount > 0 && (
+                      <span
+                        data-testid="playground-artifacts-unread"
+                        className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-white"
+                      >
+                        {toText(
+                          t(
+                            "playground:regions.artifactsNew",
+                            "New {{count}}",
+                            {
+                              count: artifactUnreadCount,
+                            } as any,
+                          ),
+                        )}
+                      </span>
+                    )}
+                    {artifactPinnedCount > 0 && (
+                      <span
+                        data-testid="playground-artifacts-pinned"
+                        className="rounded-full border border-border bg-surface px-1.5 py-0.5 text-[10px] font-medium text-text-subtle"
+                      >
+                        {toText(
+                          t(
+                            "playground:regions.artifactsPinned",
+                            "Pinned {{count}}",
+                            {
+                              count: artifactPinnedCount,
+                            } as any,
+                          ),
+                        )}
+                      </span>
+                    )}
+                    {artifactHistoryCount > 0 && (
+                      <span
+                        data-testid="playground-artifacts-count"
+                        className="rounded-full border border-border bg-surface px-1.5 py-0.5 text-[10px] text-text-subtle"
+                      >
+                        {toText(
+                          t(
+                            "playground:regions.artifactsCount",
+                            "{{count}} total",
+                            {
+                              count: artifactHistoryCount,
+                            } as any,
+                          ),
+                        )}
+                      </span>
+                    )}
+                  </button>
+                </div>
+              </div>
+              {shortcutsHelpOpen && (
+                <div
+                  data-testid="playground-shortcuts-help-panel"
+                  role="dialog"
+                  aria-modal="false"
+                  aria-label={t("playground:shortcuts.title", "Shortcuts")}
+                  className="mx-auto mt-1 w-full max-w-[64rem] rounded-md border border-border bg-surface2 px-2 py-1.5 text-[11px] text-text"
+                >
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <span className="font-semibold">
+                      {t("playground:shortcuts.title", "Shortcuts")}
+                    </span>
+                    <button
+                      ref={shortcutsCloseRef}
+                      type="button"
+                      data-testid="playground-shortcuts-help-close"
+                      onClick={() => {
+                        setShortcutsHelpOpen(false);
+                        requestAnimationFrame(() => {
+                          shortcutsTriggerRef.current?.focus();
+                        });
+                      }}
+                      className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] font-medium text-text hover:bg-surface2"
+                    >
+                      {t("common:close", "Close")}
+                    </button>
+                  </div>
+                  <div className="grid gap-1 sm:grid-cols-2">
+                    <p>
+                      <span className="font-medium">Shift+Esc</span>{" "}
+                      {t(
+                        "playground:shortcuts.focusComposer",
+                        "Focus composer",
+                      )}
+                    </p>
+                    <p>
+                      <span className="font-medium">
+                        {t("playground:shortcuts.findCombo", "Cmd/Ctrl+F")}
+                      </span>{" "}
+                      {t(
+                        "playground:shortcuts.searchThread",
+                        "Search this thread",
+                      )}
+                    </p>
+                    <p>
+                      <span className="font-medium">
+                        {t("playground:shortcuts.helpCombo", "Shift+/")}
+                      </span>{" "}
+                      {t(
+                        "playground:shortcuts.openHelp",
+                        "Open keyboard shortcuts (Shift+/)",
+                      )}
+                    </p>
+                    <p>
+                      <span className="font-medium">Alt+Shift+A</span>{" "}
+                      {t(
+                        "playground:shortcuts.toggleArtifacts",
+                        "Toggle artifacts panel",
+                      )}
+                    </p>
+                    <p>
+                      <span className="font-medium">Alt+Shift+C</span>{" "}
+                      {t(
+                        "playground:shortcuts.toggleCompare",
+                        "Toggle compare mode",
+                      )}
+                    </p>
+                    <p>
+                      <span className="font-medium">Alt+Shift+M</span>{" "}
+                      {t(
+                        "playground:shortcuts.toggleModes",
+                        "Open mode launcher",
+                      )}
+                    </p>
+                    <p>
+                      <span className="font-medium">Alt+Shift+← / →</span>{" "}
+                      {t(
+                        "playground:shortcuts.variantSwitch",
+                        "Switch response variant",
+                      )}
+                    </p>
+                    <p>
+                      <span className="font-medium">Alt+Shift+B / R</span>{" "}
+                      {t(
+                        "playground:shortcuts.branchRegenerate",
+                        "Fork branch / regenerate",
+                      )}
+                    </p>
+                  </div>
+                </div>
+              )}
+              {threadSearchOpen && (
+                <div className="mx-auto mt-1 flex w-full max-w-[64rem] flex-wrap items-center gap-2 rounded-md border border-border bg-surface2 px-2 py-1">
+                  <div className="relative min-w-[200px] flex-1">
+                    <Search
+                      className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-subtle"
+                      aria-hidden="true"
+                    />
+                    <input
+                      ref={threadSearchInputRef}
+                      value={threadSearchQuery}
+                      onChange={(event) => {
+                        setThreadSearchQuery(event.target.value);
+                        setThreadSearchActiveIndex(0);
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          stepThreadSearchMatch(event.shiftKey ? -1 : 1);
+                        }
+                      }}
+                      placeholder={t(
+                        "playground:search.placeholder",
+                        "Search messages in this conversation",
+                      )}
+                      className="h-7 w-full rounded border border-border bg-surface pl-7 pr-2 text-xs text-text placeholder:text-text-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                    />
+                  </div>
+                  <span
+                    className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-text-subtle"
+                    aria-live="polite"
+                  >
+                    {threadSearchMatches.length > 0
+                      ? toText(
+                          t(
+                            "playground:search.matchCount",
+                            "{{current}} / {{total}}",
+                            {
+                              current: Math.min(
+                                threadSearchActiveIndex + 1,
+                                threadSearchMatches.length,
+                              ),
+                              total: threadSearchMatches.length,
+                            } as any,
+                          ),
+                        )
+                      : toText(t("playground:search.noMatches", "No matches"))}
                   </span>
                   <button
-                    ref={shortcutsCloseRef}
                     type="button"
-                    data-testid="playground-shortcuts-help-close"
-                    onClick={() => {
-                      setShortcutsHelpOpen(false);
-                      requestAnimationFrame(() => {
-                        shortcutsTriggerRef.current?.focus();
-                      });
-                    }}
-                    className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] font-medium text-text hover:bg-surface2"
+                    onClick={() => stepThreadSearchMatch(-1)}
+                    disabled={threadSearchMatches.length === 0}
+                    className={`rounded border px-2 py-0.5 text-[10px] font-medium ${
+                      threadSearchMatches.length === 0
+                        ? "cursor-not-allowed border-border bg-surface text-text-subtle opacity-60"
+                        : "border-border bg-surface text-text hover:bg-surface2"
+                    }`}
                   >
+                    {t("common:previous", "Previous")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => stepThreadSearchMatch(1)}
+                    disabled={threadSearchMatches.length === 0}
+                    className={`rounded border px-2 py-0.5 text-[10px] font-medium ${
+                      threadSearchMatches.length === 0
+                        ? "cursor-not-allowed border-border bg-surface text-text-subtle opacity-60"
+                        : "border-border bg-surface text-text hover:bg-surface2"
+                    }`}
+                  >
+                    {t("common:next", "Next")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setThreadSearchOpen(false)}
+                    title={t("common:close", "Close") as string}
+                    className="inline-flex items-center rounded border border-border bg-surface px-2 py-0.5 text-[10px] font-medium text-text hover:bg-surface2"
+                  >
+                    <X className="mr-1 h-3 w-3" aria-hidden="true" />
                     {t("common:close", "Close")}
                   </button>
                 </div>
-                <div className="grid gap-1 sm:grid-cols-2">
-                  <p>
-                    <span className="font-medium">Shift+Esc</span>{" "}
-                    {t("playground:shortcuts.focusComposer", "Focus composer")}
-                  </p>
-                  <p>
-                    <span className="font-medium">
-                      {t("playground:shortcuts.findCombo", "Cmd/Ctrl+F")}
-                    </span>{" "}
-                    {t(
-                      "playground:shortcuts.searchThread",
-                      "Search this thread",
-                    )}
-                  </p>
-                  <p>
-                    <span className="font-medium">
-                      {t("playground:shortcuts.helpCombo", "Shift+/")}
-                    </span>{" "}
-                    {t(
-                      "playground:shortcuts.openHelp",
-                      "Open keyboard shortcuts (Shift+/)",
-                    )}
-                  </p>
-                  <p>
-                    <span className="font-medium">Alt+Shift+A</span>{" "}
-                    {t(
-                      "playground:shortcuts.toggleArtifacts",
-                      "Toggle artifacts panel",
-                    )}
-                  </p>
-                  <p>
-                    <span className="font-medium">Alt+Shift+C</span>{" "}
-                    {t(
-                      "playground:shortcuts.toggleCompare",
-                      "Toggle compare mode",
-                    )}
-                  </p>
-                  <p>
-                    <span className="font-medium">Alt+Shift+M</span>{" "}
-                    {t(
-                      "playground:shortcuts.toggleModes",
-                      "Open mode launcher",
-                    )}
-                  </p>
-                  <p>
-                    <span className="font-medium">Alt+Shift+← / →</span>{" "}
-                    {t(
-                      "playground:shortcuts.variantSwitch",
-                      "Switch response variant",
-                    )}
-                  </p>
-                  <p>
-                    <span className="font-medium">Alt+Shift+B / R</span>{" "}
-                    {t(
-                      "playground:shortcuts.branchRegenerate",
-                      "Fork branch / regenerate",
-                    )}
-                  </p>
-                </div>
-              </div>
-            )}
-            {threadSearchOpen && (
-              <div className="mx-auto mt-1 flex w-full max-w-[64rem] flex-wrap items-center gap-2 rounded-md border border-border bg-surface2 px-2 py-1">
-                <div className="relative min-w-[200px] flex-1">
-                  <Search
-                    className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-subtle"
-                    aria-hidden="true"
-                  />
-                  <input
-                    ref={threadSearchInputRef}
-                    value={threadSearchQuery}
-                    onChange={(event) => {
-                      setThreadSearchQuery(event.target.value);
-                      setThreadSearchActiveIndex(0);
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter") {
-                        event.preventDefault();
-                        stepThreadSearchMatch(event.shiftKey ? -1 : 1);
-                      }
-                    }}
-                    placeholder={t(
-                      "playground:search.placeholder",
-                      "Search messages in this conversation",
-                    )}
-                    className="h-7 w-full rounded border border-border bg-surface pl-7 pr-2 text-xs text-text placeholder:text-text-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
-                  />
-                </div>
-                <span
-                  className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-text-subtle"
-                  aria-live="polite"
+              )}
+              {compactFeatureNoticeVisible && (
+                <div
+                  data-testid="playground-mobile-parity-notice"
+                  className="mx-auto mt-1 w-full max-w-[64rem] rounded-md border border-warn/30 bg-warn/10 px-2 py-1 text-[10px] text-warn"
                 >
-                  {threadSearchMatches.length > 0
-                    ? toText(
-                        t(
-                          "playground:search.matchCount",
-                          "{{current}} / {{total}}",
-                          {
-                            current: Math.min(
-                              threadSearchActiveIndex + 1,
-                              threadSearchMatches.length,
-                            ),
-                            total: threadSearchMatches.length,
-                          } as any,
-                        ),
-                      )
-                    : toText(t("playground:search.noMatches", "No matches"))}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => stepThreadSearchMatch(-1)}
-                  disabled={threadSearchMatches.length === 0}
-                  className={`rounded border px-2 py-0.5 text-[10px] font-medium ${
-                    threadSearchMatches.length === 0
-                      ? "cursor-not-allowed border-border bg-surface text-text-subtle opacity-60"
-                      : "border-border bg-surface text-text hover:bg-surface2"
-                  }`}
-                >
-                  {t("common:previous", "Previous")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => stepThreadSearchMatch(1)}
-                  disabled={threadSearchMatches.length === 0}
-                  className={`rounded border px-2 py-0.5 text-[10px] font-medium ${
-                    threadSearchMatches.length === 0
-                      ? "cursor-not-allowed border-border bg-surface text-text-subtle opacity-60"
-                      : "border-border bg-surface text-text hover:bg-surface2"
-                  }`}
-                >
-                  {t("common:next", "Next")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setThreadSearchOpen(false)}
-                  title={t("common:close", "Close") as string}
-                  className="inline-flex items-center rounded border border-border bg-surface px-2 py-0.5 text-[10px] font-medium text-text hover:bg-surface2"
-                >
-                  <X className="mr-1 h-3 w-3" aria-hidden="true" />
-                  {t("common:close", "Close")}
-                </button>
-              </div>
-            )}
-            {compactFeatureNoticeVisible && (
-              <div
-                data-testid="playground-mobile-parity-notice"
-                className="mx-auto mt-1 w-full max-w-[64rem] rounded-md border border-warn/30 bg-warn/10 px-2 py-1 text-[10px] text-warn"
-              >
-                {t(
-                  "playground:regions.compactFeatureNotice",
-                  "Limited on this device: compare and branch workflows use compact controls. Use full-chat opens from model cards for detailed review.",
-                )}
-              </div>
-            )}
-            {characterWorkflowActive ? (
-              <CharacterChatReadinessPanel
-                readiness={characterChatReadiness}
-                characterName={activeCharacterModeLabel}
-                missingCharacter={routeCharacterRecovery}
-                onAction={handleCharacterChatReadinessAction}
-                onChooseCharacter={openCharacterSelectorFromReadiness}
-                onRetryMissingCharacter={retryRouteCharacterRecovery}
-              />
-            ) : null}
-          </div>
-          <div
-            ref={containerRef}
-            data-testid={
-              stickyChatInput ? "playground-chat-transcript" : undefined
-            }
-            role="log"
-            aria-live="polite"
-            aria-relevant="additions"
-            aria-label={t("playground:aria.chatTranscript", "Chat messages")}
-            className="custom-scrollbar flex-1 min-h-0 w-full overflow-x-hidden overflow-y-auto px-4"
-          >
-            <div className="mx-auto w-full max-w-[64rem] pb-6">
-              <ChatErrorBoundary>
-                <PlaygroundChat
-                  showStarterDeck={showStarterDeck}
-                  searchQuery={threadSearchQuery.trim()}
-                  matchedMessageIndices={threadSearchMatchSet}
-                  activeSearchMessageIndex={threadSearchActiveMessageIndex}
-                  onAttachResearchContext={handleAttachResearchContext}
-                  onPrepareResearchFollowUp={handlePrepareResearchFollowUp}
-                  returnedResearchRunId={pendingReturnedResearchRunId}
-                  onDismissReturnedResearchRun={() => {
-                    if (!pendingReturnedResearchRunId) {
-                      return;
-                    }
-                    setDismissedReturnedResearchRunId(
-                      pendingReturnedResearchRunId,
-                    );
-                    setPendingReturnedResearchRunId(null);
-                  }}
-                />
-              </ChatErrorBoundary>
-            </div>
-          </div>
-          <div
-            ref={composerDockRef}
-            data-testid={
-              stickyChatInput ? "playground-chat-composer-dock" : undefined
-            }
-            className={`relative w-full shrink-0 ${
-              stickyChatInput
-                ? "sticky bottom-0 z-20 border-t border-border bg-surface/95 backdrop-blur"
-                : ""
-            }`}
-          >
-            <div className="mx-auto w-full max-w-[64rem] px-4 pt-2 text-[11px] text-text-muted">
-              <span className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5">
-                {t("playground:regions.composer", "Composer")}
-              </span>
-            </div>
-            {!isAutoScrollToBottom && (
-              <div className="pointer-events-none absolute -top-12 left-0 right-0 flex justify-center">
-                <button
-                  onClick={() => autoScrollToBottom()}
-                  aria-label={t(
-                    "playground:composer.scrollToLatest",
-                    "Scroll to latest messages",
+                  {t(
+                    "playground:regions.compactFeatureNotice",
+                    "Limited on this device: compare and branch workflows use compact controls. Use full-chat opens from model cards for detailed review.",
                   )}
-                  title={
-                    t(
+                </div>
+              )}
+              {characterWorkflowActive ? (
+                <CharacterChatReadinessPanel
+                  readiness={characterChatReadiness}
+                  characterName={activeCharacterModeLabel}
+                  missingCharacter={routeCharacterRecovery}
+                  onAction={handleCharacterChatReadinessAction}
+                  onChooseCharacter={openCharacterSelectorFromReadiness}
+                  onRetryMissingCharacter={retryRouteCharacterRecovery}
+                />
+              ) : null}
+            </div>
+            <div
+              ref={containerRef}
+              data-testid={
+                stickyChatInput ? "playground-chat-transcript" : undefined
+              }
+              role="log"
+              aria-live="polite"
+              aria-relevant="additions"
+              aria-label={t("playground:aria.chatTranscript", "Chat messages")}
+              className="custom-scrollbar flex-1 min-h-0 w-full overflow-x-hidden overflow-y-auto px-4"
+            >
+              <div className="mx-auto w-full max-w-[64rem] pb-6">
+                <ChatErrorBoundary>
+                  <PlaygroundChat
+                    showStarterDeck={showStarterDeck}
+                    searchQuery={threadSearchQuery.trim()}
+                    matchedMessageIndices={threadSearchMatchSet}
+                    activeSearchMessageIndex={threadSearchActiveMessageIndex}
+                    onAttachResearchContext={handleAttachResearchContext}
+                    onPrepareResearchFollowUp={handlePrepareResearchFollowUp}
+                    returnedResearchRunId={pendingReturnedResearchRunId}
+                    onDismissReturnedResearchRun={() => {
+                      if (!pendingReturnedResearchRunId) {
+                        return;
+                      }
+                      setDismissedReturnedResearchRunId(
+                        pendingReturnedResearchRunId,
+                      );
+                      setPendingReturnedResearchRunId(null);
+                    }}
+                  />
+                </ChatErrorBoundary>
+              </div>
+            </div>
+            <div
+              ref={composerDockRef}
+              data-testid={
+                stickyChatInput ? "playground-chat-composer-dock" : undefined
+              }
+              className={`relative w-full shrink-0 ${
+                stickyChatInput
+                  ? "sticky bottom-0 z-20 border-t border-border bg-surface/95 backdrop-blur"
+                  : ""
+              }`}
+            >
+              <div className="mx-auto w-full max-w-[64rem] px-4 pt-2 text-[11px] text-text-muted">
+                <span className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5">
+                  {t("playground:regions.composer", "Composer")}
+                </span>
+              </div>
+              {!isAutoScrollToBottom && (
+                <div className="pointer-events-none absolute -top-12 left-0 right-0 flex justify-center">
+                  <button
+                    onClick={() => autoScrollToBottom()}
+                    aria-label={t(
                       "playground:composer.scrollToLatest",
                       "Scroll to latest messages",
-                    ) as string
-                  }
-                  className="pointer-events-auto rounded-full border border-border bg-surface p-2.5 text-text-subtle shadow-md transition-all duration-200 animate-in fade-in zoom-in-95 hover:bg-surface2 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
-                >
-                  <ChevronDown
-                    className="size-4 text-text-subtle"
-                    aria-hidden="true"
-                  />
-                </button>
-              </div>
-            )}
-            <PlaygroundForm
-              droppedFiles={droppedFiles}
-              stickyDockEnabled={stickyChatInput}
-              onComposerLayoutChange={
-                stickyChatInput ? handleComposerLayoutChange : undefined
-              }
-              attachedResearchContext={attachedResearchContext}
-              attachedResearchContextBaseline={attachedResearchContextBaseline}
-              attachedResearchContextPinned={attachedResearchContextPinned}
-              attachedResearchContextHistory={attachedResearchContextHistory}
-              onApplyAttachedResearchContext={
-                handleApplyAttachedResearchContext
-              }
-              onResetAttachedResearchContext={
-                handleResetAttachedResearchContext
-              }
-              onRemoveAttachedResearchContext={
-                handleRemoveAttachedResearchContext
-              }
-              onPinAttachedResearchContext={handlePinAttachedResearchContext}
-              onPinAttachedResearchContextHistory={
-                handlePinAttachedResearchContextHistory
-              }
-              onUnpinAttachedResearchContext={
-                handleUnpinAttachedResearchContext
-              }
-              onRestorePinnedResearchContext={
-                handleRestorePinnedResearchContext
-              }
-              onPrepareResearchFollowUp={handlePrepareResearchFollowUp}
-              onSelectAttachedResearchContextHistory={
-                handleSelectAttachedResearchContextHistory
-              }
-              onDraftPresenceChange={handleComposerDraftPresenceChange}
-            />
-          </div>
+                    )}
+                    title={
+                      t(
+                        "playground:composer.scrollToLatest",
+                        "Scroll to latest messages",
+                      ) as string
+                    }
+                    className="pointer-events-auto rounded-full border border-border bg-surface p-2.5 text-text-subtle shadow-md transition-all duration-200 animate-in fade-in zoom-in-95 hover:bg-surface2 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                  >
+                    <ChevronDown
+                      className="size-4 text-text-subtle"
+                      aria-hidden="true"
+                    />
+                  </button>
+                </div>
+              )}
+              <PlaygroundForm
+                droppedFiles={droppedFiles}
+                stickyDockEnabled={stickyChatInput}
+                onComposerLayoutChange={
+                  stickyChatInput ? handleComposerLayoutChange : undefined
+                }
+                attachedResearchContext={attachedResearchContext}
+                attachedResearchContextBaseline={
+                  attachedResearchContextBaseline
+                }
+                attachedResearchContextPinned={attachedResearchContextPinned}
+                attachedResearchContextHistory={attachedResearchContextHistory}
+                onApplyAttachedResearchContext={
+                  handleApplyAttachedResearchContext
+                }
+                onResetAttachedResearchContext={
+                  handleResetAttachedResearchContext
+                }
+                onRemoveAttachedResearchContext={
+                  handleRemoveAttachedResearchContext
+                }
+                onPinAttachedResearchContext={handlePinAttachedResearchContext}
+                onPinAttachedResearchContextHistory={
+                  handlePinAttachedResearchContextHistory
+                }
+                onUnpinAttachedResearchContext={
+                  handleUnpinAttachedResearchContext
+                }
+                onRestorePinnedResearchContext={
+                  handleRestorePinnedResearchContext
+                }
+                onPrepareResearchFollowUp={handlePrepareResearchFollowUp}
+                onSelectAttachedResearchContextHistory={
+                  handleSelectAttachedResearchContextHistory
+                }
+                onDraftPresenceChange={handleComposerDraftPresenceChange}
+              />
+            </div>
           </div>
         </PlaygroundCockpitShell>
         {artifactsOpen && (

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
@@ -28,7 +28,11 @@ type ContextCountItem = {
   onClear: (() => void) | undefined;
 };
 
-export type PlaygroundPromptContextState = "none" | "system" | "quick" | "custom";
+export type PlaygroundPromptContextState =
+  | "none"
+  | "system"
+  | "quick"
+  | "custom";
 
 export type PlaygroundPromptSummary = {
   state: PlaygroundPromptContextState;
@@ -85,6 +89,7 @@ export type PlaygroundContextRailProps = {
   };
   promptSummary?: PlaygroundPromptSummary;
   promptSelectControl?: React.ReactNode;
+  characterSessionsPanel?: React.ReactNode;
   onClearPrompt?: () => void;
   onOpenSearchContext: () => void;
   onClearFiles?: () => void;
@@ -96,11 +101,16 @@ export type PlaygroundContextRailProps = {
 
 const sourceIcon = (kind: PlaygroundContextSource["kind"]) => {
   const className = "h-3.5 w-3.5";
-  if (kind === "web") return <Globe2 className={className} aria-hidden="true" />;
-  if (kind === "file") return <FileText className={className} aria-hidden="true" />;
-  if (kind === "knowledge") return <BookOpen className={className} aria-hidden="true" />;
-  if (kind === "media") return <Database className={className} aria-hidden="true" />;
-  if (kind === "assistant") return <UserRound className={className} aria-hidden="true" />;
+  if (kind === "web")
+    return <Globe2 className={className} aria-hidden="true" />;
+  if (kind === "file")
+    return <FileText className={className} aria-hidden="true" />;
+  if (kind === "knowledge")
+    return <BookOpen className={className} aria-hidden="true" />;
+  if (kind === "media")
+    return <Database className={className} aria-hidden="true" />;
+  if (kind === "assistant")
+    return <UserRound className={className} aria-hidden="true" />;
   return <Layers3 className={className} aria-hidden="true" />;
 };
 
@@ -138,6 +148,7 @@ export const PlaygroundContextRail = ({
   contextCounts,
   promptSummary,
   promptSelectControl,
+  characterSessionsPanel,
   onClearPrompt,
   onOpenSearchContext,
   onClearFiles,
@@ -157,15 +168,11 @@ export const PlaygroundContextRail = ({
   const activeSourceCount = contextSources.filter(
     (source) => source.state !== "disabled",
   ).length;
-  const effectivePromptSummary =
-    promptSummary || {
-      state: "none" as const,
-      label: t("cockpit.noPromptSelected", "No prompt selected"),
-      detail: t(
-        "cockpit.noPromptContext",
-        "No system prompt will be added.",
-      ),
-    };
+  const effectivePromptSummary = promptSummary || {
+    state: "none" as const,
+    label: t("cockpit.noPromptSelected", "No prompt selected"),
+    detail: t("cockpit.noPromptContext", "No system prompt will be added."),
+  };
   const promptActive = effectivePromptSummary.state !== "none";
   const showActionablePromptEmptyState =
     !promptActive && Boolean(compositionPreviewSummary);
@@ -193,87 +200,87 @@ export const PlaygroundContextRail = ({
       : t("cockpit.activeSourceCountMany", "{{count}} active sources", {
           count: activeSourceCount,
         });
-  const countLabels = ([
-    contextCounts.research > 0
-      ? contextCounts.research === 1
-        ? {
-            label: t(
-              "cockpit.contextResearchCountOne",
-              "1 research attachment",
-            ),
-            clearLabel: t(
-              "cockpit.clearResearchContext",
-              "Clear research context",
-            ),
-            onClear: onClearResearch,
-          }
-        : {
-            label: t(
-              "cockpit.contextResearchCountMany",
-              `${contextCounts.research} research attachments`,
-              { count: contextCounts.research },
-            ),
-            clearLabel: t(
-              "cockpit.clearResearchContext",
-              "Clear research context",
-            ),
-            onClear: onClearResearch,
-          }
-      : null,
-    contextCounts.files > 0
-      ? contextCounts.files === 1
-        ? {
-            label: t("cockpit.contextFilesCountOne", "1 file"),
-            clearLabel: t("cockpit.clearFiles", "Clear files"),
-            onClear: onClearFiles,
-          }
-        : {
-            label: t(
-              "cockpit.contextFilesCountMany",
-              `${contextCounts.files} files`,
-              { count: contextCounts.files },
-            ),
-            clearLabel: t("cockpit.clearFiles", "Clear files"),
-            onClear: onClearFiles,
-          }
-      : null,
-    contextCounts.knowledge > 0
-      ? contextCounts.knowledge === 1
-        ? {
-            label: t("cockpit.contextKnowledgeCountOne", "1 knowledge item"),
-            clearLabel: t("cockpit.clearKnowledge", "Clear knowledge"),
-            onClear: onClearKnowledge,
-          }
-        : {
-            label: t(
-              "cockpit.contextKnowledgeCountMany",
-              `${contextCounts.knowledge} knowledge items`,
-              { count: contextCounts.knowledge },
-            ),
-            clearLabel: t("cockpit.clearKnowledge", "Clear knowledge"),
-            onClear: onClearKnowledge,
-          }
-      : null,
-    contextCounts.media > 0
-      ? contextCounts.media === 1
-        ? {
-            label: t("cockpit.contextMediaCountOne", "1 media scope"),
-            clearLabel: t("cockpit.clearMediaScopes", "Clear media scopes"),
-            onClear: onClearMedia,
-          }
-        : {
-            label: t(
-              "cockpit.contextMediaCountMany",
-              `${contextCounts.media} media scopes`,
-              { count: contextCounts.media },
-            ),
-            clearLabel: t("cockpit.clearMediaScopes", "Clear media scopes"),
-            onClear: onClearMedia,
-          }
-      : null,
-  ] satisfies Array<ContextCountItem | null>).filter(
-    (item): item is ContextCountItem => Boolean(item),
-  );
+  const countLabels = (
+    [
+      contextCounts.research > 0
+        ? contextCounts.research === 1
+          ? {
+              label: t(
+                "cockpit.contextResearchCountOne",
+                "1 research attachment",
+              ),
+              clearLabel: t(
+                "cockpit.clearResearchContext",
+                "Clear research context",
+              ),
+              onClear: onClearResearch,
+            }
+          : {
+              label: t(
+                "cockpit.contextResearchCountMany",
+                `${contextCounts.research} research attachments`,
+                { count: contextCounts.research },
+              ),
+              clearLabel: t(
+                "cockpit.clearResearchContext",
+                "Clear research context",
+              ),
+              onClear: onClearResearch,
+            }
+        : null,
+      contextCounts.files > 0
+        ? contextCounts.files === 1
+          ? {
+              label: t("cockpit.contextFilesCountOne", "1 file"),
+              clearLabel: t("cockpit.clearFiles", "Clear files"),
+              onClear: onClearFiles,
+            }
+          : {
+              label: t(
+                "cockpit.contextFilesCountMany",
+                `${contextCounts.files} files`,
+                { count: contextCounts.files },
+              ),
+              clearLabel: t("cockpit.clearFiles", "Clear files"),
+              onClear: onClearFiles,
+            }
+        : null,
+      contextCounts.knowledge > 0
+        ? contextCounts.knowledge === 1
+          ? {
+              label: t("cockpit.contextKnowledgeCountOne", "1 knowledge item"),
+              clearLabel: t("cockpit.clearKnowledge", "Clear knowledge"),
+              onClear: onClearKnowledge,
+            }
+          : {
+              label: t(
+                "cockpit.contextKnowledgeCountMany",
+                `${contextCounts.knowledge} knowledge items`,
+                { count: contextCounts.knowledge },
+              ),
+              clearLabel: t("cockpit.clearKnowledge", "Clear knowledge"),
+              onClear: onClearKnowledge,
+            }
+        : null,
+      contextCounts.media > 0
+        ? contextCounts.media === 1
+          ? {
+              label: t("cockpit.contextMediaCountOne", "1 media scope"),
+              clearLabel: t("cockpit.clearMediaScopes", "Clear media scopes"),
+              onClear: onClearMedia,
+            }
+          : {
+              label: t(
+                "cockpit.contextMediaCountMany",
+                `${contextCounts.media} media scopes`,
+                { count: contextCounts.media },
+              ),
+              clearLabel: t("cockpit.clearMediaScopes", "Clear media scopes"),
+              onClear: onClearMedia,
+            }
+        : null,
+    ] satisfies Array<ContextCountItem | null>
+  ).filter((item): item is ContextCountItem => Boolean(item));
 
   return (
     <div
@@ -349,10 +356,7 @@ export const PlaygroundContextRail = ({
                   title: source.title,
                 });
               return (
-                <li
-                  key={source.id}
-                  className={cockpitRailStyles.inset}
-                >
+                <li key={source.id} className={cockpitRailStyles.inset}>
                   <div className="flex items-start gap-2">
                     <span className="mt-0.5 rounded border border-border bg-surface2 p-1 text-text-muted">
                       {sourceIcon(source.kind)}
@@ -432,7 +436,9 @@ export const PlaygroundContextRail = ({
           <div className="min-w-0">
             <p className={cockpitRailStyles.value}>{promptManagementLabel}</p>
             {promptManagementDetail ? (
-              <p className={cockpitRailStyles.muted}>{promptManagementDetail}</p>
+              <p className={cockpitRailStyles.muted}>
+                {promptManagementDetail}
+              </p>
             ) : null}
           </div>
           <span
@@ -525,6 +531,8 @@ export const PlaygroundContextRail = ({
           </button>
         </div>
       </PlaygroundRailSection>
+
+      {characterSessionsPanel}
 
       <PlaygroundRailSection
         label={t("cockpit.conversationSession", "Conversation session")}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ServerChatHistoryItem } from "@/hooks/useServerChatHistory";
+import { CharacterChatSessionsPanel } from "../CharacterChatSessionsPanel";
+
+const historyHookMock = vi.hoisted(() => vi.fn());
+const selectServerChatMock = vi.hoisted(() => vi.fn());
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      defaultValueOrOptions?: string | { defaultValue?: string },
+      interpolationOptions?: Record<string, unknown>,
+    ) => {
+      const defaultValue =
+        typeof defaultValueOrOptions === "string"
+          ? defaultValueOrOptions
+          : defaultValueOrOptions?.defaultValue || _key;
+      const values =
+        typeof defaultValueOrOptions === "object" && defaultValueOrOptions
+          ? defaultValueOrOptions
+          : interpolationOptions;
+
+      return defaultValue.replace(/\{\{(\w+)\}\}/g, (_match, key) =>
+        values?.[key] == null ? `{{${key}}}` : String(values[key]),
+      );
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useServerChatHistory", () => ({
+  SERVER_CHAT_HISTORY_OVERVIEW_PAGE_SIZE: 25,
+  useServerChatHistory: (...args: unknown[]) => historyHookMock(...args),
+}));
+
+vi.mock("@/hooks/chat/useSelectServerChat", () => ({
+  useSelectServerChat: () => selectServerChatMock,
+}));
+
+const makeChat = (
+  id: string,
+  overrides: Partial<ServerChatHistoryItem> = {},
+): ServerChatHistoryItem =>
+  ({
+    id,
+    title: `Chat ${id}`,
+    created_at: "2026-05-20T00:00:00.000Z",
+    updated_at: "2026-05-20T00:10:00.000Z",
+    createdAtMs: Date.parse("2026-05-20T00:00:00.000Z"),
+    updatedAtMs: Date.parse("2026-05-20T00:10:00.000Z"),
+    state: "in-progress",
+    ...overrides,
+  }) as ServerChatHistoryItem;
+
+describe("CharacterChatSessionsPanel", () => {
+  beforeEach(() => {
+    historyHookMock.mockReset();
+    selectServerChatMock.mockReset();
+    historyHookMock.mockReturnValue({
+      data: [],
+      total: 0,
+      isLoading: false,
+      sidebarRefreshState: "ready",
+      hasUsableData: false,
+      isShowingStaleData: false,
+    });
+  });
+
+  it("fetches character-scoped recent sessions and prioritizes the active character", () => {
+    const currentCharacterChat = makeChat("chat-current", {
+      title: "Mira Act I",
+      character_id: "mira",
+    });
+    const nextMiraChat = makeChat("chat-next", {
+      title: "Mira Act II",
+      character_id: "mira",
+    });
+    const otherCharacterChat = makeChat("chat-other", {
+      title: "Rook Side Quest",
+      character_id: "rook",
+    });
+    historyHookMock.mockReturnValue({
+      data: [otherCharacterChat, nextMiraChat, currentCharacterChat],
+      total: 3,
+      isLoading: false,
+      sidebarRefreshState: "ready",
+      hasUsableData: true,
+      isShowingStaleData: false,
+    });
+
+    render(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId="chat-current"
+      />,
+    );
+
+    expect(historyHookMock).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({
+        enabled: true,
+        filterMode: "character",
+        limit: 5,
+        mode: "overview",
+        page: 1,
+      }),
+    );
+
+    const currentCharacterList = screen.getByRole("list", {
+      name: "Recent sessions for Mira",
+    });
+    expect(
+      within(currentCharacterList).getByText("Mira Act I"),
+    ).toBeInTheDocument();
+    expect(
+      within(currentCharacterList).getByText("Mira Act II"),
+    ).toBeInTheDocument();
+    expect(
+      within(currentCharacterList).queryByText("Rook Side Quest"),
+    ).not.toBeInTheDocument();
+
+    const otherCharactersList = screen.getByRole("list", {
+      name: "Other character sessions",
+    });
+    expect(
+      within(otherCharactersList).getByText("Rook Side Quest"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: "Current Mira Act I" }),
+    ).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Resume Mira Act II" }));
+    expect(selectServerChatMock).toHaveBeenCalledWith(nextMiraChat);
+  });
+
+  it("shows local loading, empty, and refresh-error states distinct from saved setups", () => {
+    historyHookMock.mockReturnValueOnce({
+      data: [],
+      total: 0,
+      isLoading: true,
+      sidebarRefreshState: "idle",
+      hasUsableData: false,
+      isShowingStaleData: false,
+    });
+    const { rerender } = render(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+    expect(
+      screen.getByText("Loading character sessions..."),
+    ).toBeInTheDocument();
+
+    historyHookMock.mockReturnValueOnce({
+      data: [],
+      total: 0,
+      isLoading: false,
+      sidebarRefreshState: "ready",
+      hasUsableData: false,
+      isShowingStaleData: false,
+    });
+    rerender(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+    expect(
+      screen.getByText("No character conversations yet."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Recent character conversations stay separate from saved role-play setups.",
+      ),
+    ).toBeInTheDocument();
+
+    historyHookMock.mockReturnValueOnce({
+      data: [],
+      total: 0,
+      isLoading: false,
+      sidebarRefreshState: "recoverable-error",
+      hasUsableData: false,
+      isShowingStaleData: false,
+    });
+    rerender(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+    expect(
+      screen.getByText("Unable to refresh character sessions right now."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
@@ -138,6 +138,53 @@ describe("CharacterChatSessionsPanel", () => {
     expect(selectServerChatMock).toHaveBeenCalledWith(nextMiraChat);
   });
 
+  it("uses character assistant identity when character_id is missing", () => {
+    const assistantBackedChat = makeChat("chat-assistant-backed", {
+      title: "Mira Assistant Identity",
+      character_id: null,
+      assistant_kind: "character",
+      assistant_id: "mira",
+    });
+    const personaBackedChat = makeChat("chat-persona", {
+      title: "Garden Helper",
+      character_id: null,
+      assistant_kind: "persona",
+      assistant_id: "mira",
+    });
+    historyHookMock.mockReturnValue({
+      data: [personaBackedChat, assistantBackedChat],
+      total: 2,
+      isLoading: false,
+      sidebarRefreshState: "ready",
+      hasUsableData: true,
+      isShowingStaleData: false,
+    });
+
+    render(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+
+    const currentCharacterList = screen.getByRole("list", {
+      name: "Recent sessions for Mira",
+    });
+    expect(
+      within(currentCharacterList).getByText("Mira Assistant Identity"),
+    ).toBeInTheDocument();
+    expect(
+      within(currentCharacterList).queryByText("Garden Helper"),
+    ).not.toBeInTheDocument();
+
+    expect(
+      within(
+        screen.getByRole("list", { name: "Other character sessions" }),
+      ).getByText("Garden Helper"),
+    ).toBeInTheDocument();
+  });
+
   it("shows local loading, empty, and refresh-error states distinct from saved setups", () => {
     historyHookMock.mockReturnValueOnce({
       data: [],
@@ -200,5 +247,31 @@ describe("CharacterChatSessionsPanel", () => {
     expect(
       screen.getByText("Unable to refresh character sessions right now."),
     ).toBeInTheDocument();
+  });
+
+  it("shows hard history load failures as an error instead of an empty state", () => {
+    historyHookMock.mockReturnValue({
+      data: [],
+      total: 0,
+      isLoading: false,
+      sidebarRefreshState: "hard-error",
+      hasUsableData: false,
+      isShowingStaleData: false,
+    });
+
+    render(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+
+    expect(
+      screen.getByText("Character sessions could not be loaded."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No character conversations yet."),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
@@ -8,6 +8,9 @@ import { CharacterChatSessionsPanel } from "../CharacterChatSessionsPanel";
 
 const historyHookMock = vi.hoisted(() => vi.fn());
 const selectServerChatMock = vi.hoisted(() => vi.fn());
+const formatRelativeTimeMock = vi.hoisted(() =>
+  vi.fn((value: string) => `relative:${value}`),
+);
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -41,6 +44,11 @@ vi.mock("@/hooks/chat/useSelectServerChat", () => ({
   useSelectServerChat: () => selectServerChatMock,
 }));
 
+vi.mock("@/utils/dateFormatters", () => ({
+  formatRelativeTime: (...args: Parameters<typeof formatRelativeTimeMock>) =>
+    formatRelativeTimeMock(...args),
+}));
+
 const makeChat = (
   id: string,
   overrides: Partial<ServerChatHistoryItem> = {},
@@ -60,6 +68,7 @@ describe("CharacterChatSessionsPanel", () => {
   beforeEach(() => {
     historyHookMock.mockReset();
     selectServerChatMock.mockReset();
+    formatRelativeTimeMock.mockClear();
     historyHookMock.mockReturnValue({
       data: [],
       total: 0,
@@ -246,6 +255,39 @@ describe("CharacterChatSessionsPanel", () => {
     );
     expect(
       screen.getByText("Unable to refresh character sessions right now."),
+    ).toBeInTheDocument();
+  });
+
+  it("normalizes timestamps before rendering relative session age", () => {
+    const chatWithPaddedTimestamp = makeChat("chat-padded", {
+      title: "Padded Timestamp",
+      character_id: "mira",
+      updated_at: "  2026-05-20T00:10:00.000Z  ",
+    });
+    historyHookMock.mockReturnValue({
+      data: [chatWithPaddedTimestamp],
+      total: 1,
+      isLoading: false,
+      sidebarRefreshState: "ready",
+      hasUsableData: true,
+      isShowingStaleData: false,
+    });
+
+    render(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+
+    expect(formatRelativeTimeMock).toHaveBeenCalledWith(
+      "2026-05-20T00:10:00.000Z",
+      expect.any(Function),
+      { compact: true },
+    );
+    expect(
+      screen.getByText("relative:2026-05-20T00:10:00.000Z"),
     ).toBeInTheDocument();
   });
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -93,11 +93,17 @@ const tldwServerState = vi.hoisted(() => ({
   ]),
 }));
 
+const characterSessionsPanelState = vi.hoisted(() => ({
+  props: [] as Array<Record<string, unknown>>,
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (
       key: string,
-      fallbackOrOptions?: string | { defaultValue?: string; [key: string]: unknown },
+      fallbackOrOptions?:
+        | string
+        | { defaultValue?: string; [key: string]: unknown },
     ) => {
       if (typeof fallbackOrOptions === "string") return fallbackOrOptions;
       const template = fallbackOrOptions?.defaultValue || key;
@@ -128,11 +134,7 @@ vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
 }));
 
 vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
-  PlaygroundChat: ({
-    showStarterDeck,
-  }: {
-    showStarterDeck?: boolean;
-  }) => {
+  PlaygroundChat: ({ showStarterDeck }: { showStarterDeck?: boolean }) => {
     cockpitChatRenderState.starterDeckSignals.push(showStarterDeck);
     const legacyWouldShowStarterDeck =
       messageOptionState.value.messages.length === 0;
@@ -178,6 +180,13 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
 
 vi.mock("@/services/tldw-server", () => ({
   fetchChatModels: tldwServerState.fetchChatModels,
+}));
+
+vi.mock("@/components/Option/Playground/CharacterChatSessionsPanel", () => ({
+  CharacterChatSessionsPanel: (props: Record<string, unknown>) => {
+    characterSessionsPanelState.props.push(props);
+    return <section data-testid="character-chat-sessions-panel" />;
+  },
 }));
 
 vi.mock("@/db/dexie/helpers", () => ({
@@ -330,10 +339,13 @@ describe("Playground cockpit shell", () => {
         provider_is_configured: true,
       },
     ]);
-    tldwClientState.getCharacter.mockImplementation(async (id: string | number) => ({
-      id,
-      name: "Route Character",
-    }));
+    tldwClientState.getCharacter.mockImplementation(
+      async (id: string | number) => ({
+        id,
+        name: "Route Character",
+      }),
+    );
+    characterSessionsPanelState.props = [];
   });
 
   it("renders the cockpit rails, main chat surface, and status strip by default", async () => {
@@ -356,11 +368,36 @@ describe("Playground cockpit shell", () => {
     ).toHaveTextContent("Context and runtime rails visible.");
     expect(screen.getByTestId("playground-chat")).toBeInTheDocument();
     expect(screen.getByTestId("playground-form")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("character-chat-sessions-panel"),
+    ).not.toBeInTheDocument();
     await waitFor(() => {
       expect(tldwServerState.fetchChatModels).toHaveBeenCalledWith({
         returnEmpty: true,
         forceRefresh: true,
       });
+    });
+  });
+
+  it("renders Character Chat recent sessions only for the active character workflow", async () => {
+    storageState.values.set("playgroundChatWorkflowMode", "character");
+    messageOptionState.value.selectedCharacter = {
+      id: "char-1",
+      name: "Ariadne",
+    };
+    messageOptionState.value.serverChatId = "server-chat-1";
+
+    render(<Playground />);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("character-chat-sessions-panel").length,
+      ).toBeGreaterThan(0);
+    });
+    expect(characterSessionsPanelState.props.at(-1)).toMatchObject({
+      activeCharacterId: "char-1",
+      activeCharacterName: "Ariadne",
+      activeServerChatId: "server-chat-1",
     });
   });
 
@@ -382,9 +419,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("playground-active-chat-mode")).toHaveTextContent(
-        "Character Chat",
-      );
+      expect(
+        screen.getByTestId("playground-active-chat-mode"),
+      ).toHaveTextContent("Character Chat");
     });
     await waitFor(() => {
       expect(tldwClientState.getCharacter).toHaveBeenCalledWith("char-route");
@@ -410,7 +447,9 @@ describe("Playground cockpit shell", () => {
       expect(tldwClientState.getCharacter).toHaveBeenCalledTimes(1);
     });
     await waitFor(() => {
-      expect(messageOptionState.value.setSelectedCharacter).toHaveBeenCalledWith(
+      expect(
+        messageOptionState.value.setSelectedCharacter,
+      ).toHaveBeenCalledWith(
         expect.objectContaining({
           id: "char-route",
           name: "Route Character",
@@ -428,12 +467,14 @@ describe("Playground cockpit shell", () => {
     rerender(<Playground />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("playground-active-chat-mode")).toHaveTextContent(
-        "Manual Character",
-      );
+      expect(
+        screen.getByTestId("playground-active-chat-mode"),
+      ).toHaveTextContent("Manual Character");
     });
     expect(tldwClientState.getCharacter).not.toHaveBeenCalled();
-    expect(messageOptionState.value.setSelectedCharacter).not.toHaveBeenCalled();
+    expect(
+      messageOptionState.value.setSelectedCharacter,
+    ).not.toHaveBeenCalled();
   });
 
   it("uses a typed fallback when route character hydration returns no character", async () => {
@@ -447,7 +488,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     await waitFor(() => {
-      expect(messageOptionState.value.setSelectedCharacter).toHaveBeenCalledWith({
+      expect(
+        messageOptionState.value.setSelectedCharacter,
+      ).toHaveBeenCalledWith({
         id: "missing-character",
         name: "Character missing-character",
       });
@@ -462,13 +505,18 @@ describe("Playground cockpit shell", () => {
     );
     tldwClientState.getCharacter.mockResolvedValueOnce(null);
     const assistantSelectListener = vi.fn();
-    window.addEventListener("tldw:open-assistant-select", assistantSelectListener);
+    window.addEventListener(
+      "tldw:open-assistant-select",
+      assistantSelectListener,
+    );
 
     try {
       render(<Playground />);
 
       expect(
-        await screen.findByText("Character missing-character could not be loaded"),
+        await screen.findByText(
+          "Character missing-character could not be loaded",
+        ),
       ).toBeInTheDocument();
 
       fireEvent.click(screen.getByRole("button", { name: "Choose character" }));
@@ -500,7 +548,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     expect(
-      await screen.findByText("Character missing-character could not be loaded"),
+      await screen.findByText(
+        "Character missing-character could not be loaded",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.queryByText("Choose a character to start character chat"),
@@ -522,7 +572,9 @@ describe("Playground cockpit shell", () => {
     );
 
     expect(
-      await screen.findByText("Character missing-character could not be loaded"),
+      await screen.findByText(
+        "Character missing-character could not be loaded",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -540,9 +592,9 @@ describe("Playground cockpit shell", () => {
       render(<Playground />);
 
       expect(
-        within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
-          "Choose a chat model before chatting as Ariadne",
-        ),
+        within(
+          await screen.findByTestId("character-chat-readiness-panel"),
+        ).getByText("Choose a chat model before chatting as Ariadne"),
       ).toBeInTheDocument();
 
       fireEvent.click(
@@ -553,12 +605,13 @@ describe("Playground cockpit shell", () => {
       );
 
       expect(modelSettingsListener).toHaveBeenCalledTimes(1);
-      expect(messageOptionState.value.setSelectedCharacter).not.toHaveBeenCalled();
+      expect(
+        messageOptionState.value.setSelectedCharacter,
+      ).not.toHaveBeenCalled();
       expect(messageOptionState.value.selectedCharacter).toEqual({
         id: "char-1",
         name: "Ariadne",
       });
-
     } finally {
       window.removeEventListener(
         "tldw:open-model-settings",
@@ -586,9 +639,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     expect(
-      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
-        "Choose a chat model before chatting as Ariadne",
-      ),
+      within(
+        await screen.findByTestId("character-chat-readiness-panel"),
+      ).getByText("Choose a chat model before chatting as Ariadne"),
     ).toBeInTheDocument();
     const chatStatus = screen.getByRole("status", { name: "Chat status" });
     expect(chatStatus).toHaveTextContent("Model unavailable");
@@ -606,9 +659,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     expect(
-      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
-        "Choose a chat model before chatting as Ariadne",
-      ),
+      within(
+        await screen.findByTestId("character-chat-readiness-panel"),
+      ).getByText("Choose a chat model before chatting as Ariadne"),
     ).toBeInTheDocument();
     const chatStatus = screen.getByRole("status", { name: "Chat status" });
     expect(chatStatus).toHaveTextContent("No model selected");
@@ -643,9 +696,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     expect(
-      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
-        "Choose a chat model before chatting as Ariadne",
-      ),
+      within(
+        await screen.findByTestId("character-chat-readiness-panel"),
+      ).getByText("Choose a chat model before chatting as Ariadne"),
     ).toBeInTheDocument();
   });
 
@@ -661,9 +714,9 @@ describe("Playground cockpit shell", () => {
     render(<Playground />);
 
     expect(
-      within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
-        "Character chat is preparing",
-      ),
+      within(
+        await screen.findByTestId("character-chat-readiness-panel"),
+      ).getByText("Character chat is preparing"),
     ).toBeInTheDocument();
     const runtimeRail = screen.getByTestId("playground-cockpit-right-rail");
     expect(within(runtimeRail).getByText("Streaming")).toBeInTheDocument();
@@ -690,12 +743,14 @@ describe("Playground cockpit shell", () => {
       );
 
       expect(
-        within(await screen.findByTestId("character-chat-readiness-panel")).getByText(
-          "Connect to tldw_server before starting character chat",
-        ),
+        within(
+          await screen.findByTestId("character-chat-readiness-panel"),
+        ).getByText("Connect to tldw_server before starting character chat"),
       ).toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole("button", { name: "Open server settings" }));
+      fireEvent.click(
+        screen.getByRole("button", { name: "Open server settings" }),
+      );
 
       const event = modelSettingsListener.mock.calls[0]?.[0] as CustomEvent;
       expect(event.detail).toMatchObject({
@@ -721,11 +776,13 @@ describe("Playground cockpit shell", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("playground-active-chat-mode")).toHaveTextContent(
-        "Character Chat",
-      );
+      expect(
+        screen.getByTestId("playground-active-chat-mode"),
+      ).toHaveTextContent("Character Chat");
     });
-    expect(messageOptionState.value.setSelectedCharacter).not.toHaveBeenCalled();
+    expect(
+      messageOptionState.value.setSelectedCharacter,
+    ).not.toHaveBeenCalled();
   });
 
   it("resets character workflow for non-character starter modes", async () => {
@@ -745,9 +802,9 @@ describe("Playground cockpit shell", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("playground-active-chat-mode")).toHaveTextContent(
-        "Standard chat",
-      );
+      expect(
+        screen.getByTestId("playground-active-chat-mode"),
+      ).toHaveTextContent("Standard chat");
     });
     expect(storageState.values.get("playgroundChatWorkflowMode")).toBe(
       "standard",

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx
@@ -166,12 +166,39 @@ describe("PlaygroundContextRail first-slice controls", () => {
     });
 
     expect(
-      screen.getAllByRole("heading", { level: 2 }).map((heading) => heading.textContent),
+      screen
+        .getAllByRole("heading", { level: 2 })
+        .map((heading) => heading.textContent),
     ).toEqual([
       "Composition",
       "Context stack",
       "Prompt",
       "Search & sources",
+      "Session",
+    ]);
+  });
+
+  it("places the optional character sessions panel before the generic session controls", () => {
+    renderRail({
+      compositionPreviewSummary: compositionSummary(),
+      characterSessionsPanel: (
+        <section>
+          <h2>Character sessions</h2>
+          <p>Recent character chats</p>
+        </section>
+      ),
+    });
+
+    expect(
+      screen
+        .getAllByRole("heading", { level: 2 })
+        .map((heading) => heading.textContent),
+    ).toEqual([
+      "Composition",
+      "Context stack",
+      "Prompt",
+      "Search & sources",
+      "Character sessions",
       "Session",
     ]);
   });
@@ -197,15 +224,21 @@ describe("PlaygroundContextRail first-slice controls", () => {
       screen.getByRole("region", { name: "Next message composition" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Prompt" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Select a prompt" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Select a prompt" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Search & sources" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Open Search & Context" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Web search" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Session" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Web search" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Session" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Use temporary chat" }),
     ).toBeInTheDocument();
@@ -262,13 +295,19 @@ describe("PlaygroundContextRail first-slice controls", () => {
       within(rail).getByRole("button", { name: "Collapse Session" }),
     );
 
-    expect(screen.getByRole("heading", { name: "Composition" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Context stack" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Composition" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Context stack" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Prompt" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Search & sources" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Session" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Session" }),
+    ).toBeInTheDocument();
   });
 
   it("preserves existing left rail actions after regrouping", () => {
@@ -296,11 +335,15 @@ describe("PlaygroundContextRail first-slice controls", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Clear prompt" }));
     fireEvent.click(screen.getByRole("button", { name: "Web search" }));
-    fireEvent.click(screen.getByRole("button", { name: "Open Search & Context" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Search & Context" }),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Clear files" }));
     fireEvent.click(screen.getByRole("button", { name: "Clear knowledge" }));
     fireEvent.click(screen.getByRole("button", { name: "Clear media scopes" }));
-    fireEvent.click(screen.getByRole("button", { name: "Clear research context" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear research context" }),
+    );
 
     expect(props.onClearPrompt).toHaveBeenCalledTimes(1);
     expect(props.onToggleWebSearch).toHaveBeenCalledTimes(1);
@@ -347,10 +390,16 @@ describe("PlaygroundContextRail first-slice controls", () => {
     const promptManagement = screen.getByRole("region", {
       name: "Prompt management",
     });
-    expect(within(promptManagement).queryByText("No prompt selected")).toBeNull();
-    expect(within(promptManagement).getByText("Ready to add prompt")).toBeInTheDocument();
     expect(
-      within(promptManagement).getByText("Select a prompt to add system instructions."),
+      within(promptManagement).queryByText("No prompt selected"),
+    ).toBeNull();
+    expect(
+      within(promptManagement).getByText("Ready to add prompt"),
+    ).toBeInTheDocument();
+    expect(
+      within(promptManagement).getByText(
+        "Select a prompt to add system instructions.",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -452,7 +501,9 @@ describe("PlaygroundContextRail first-slice controls", () => {
 
     expect(screen.getByText("Server chat")).toBeInTheDocument();
     expect(screen.getByText("Research follow-up")).toBeInTheDocument();
-    expect(screen.getAllByText("Loading conversation").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Loading conversation").length).toBeGreaterThan(
+      0,
+    );
     expect(screen.getByText("History linked")).toBeInTheDocument();
   });
 
@@ -469,7 +520,9 @@ describe("PlaygroundContextRail first-slice controls", () => {
     expect(screen.getByText("Load failed")).toBeInTheDocument();
     expect(screen.getByText("Archived investigation")).toBeInTheDocument();
     expect(screen.getByText("Failed to load conversation")).toBeInTheDocument();
-    expect(screen.getByText("Conversation no longer exists")).toBeInTheDocument();
+    expect(
+      screen.getByText("Conversation no longer exists"),
+    ).toBeInTheDocument();
     expect(screen.getByText("No saved history yet")).toBeInTheDocument();
   });
 
@@ -504,7 +557,9 @@ describe("PlaygroundContextRail first-slice controls", () => {
     fireEvent.click(screen.getByRole("button", { name: "Clear files" }));
     fireEvent.click(screen.getByRole("button", { name: "Clear knowledge" }));
     fireEvent.click(screen.getByRole("button", { name: "Clear media scopes" }));
-    fireEvent.click(screen.getByRole("button", { name: "Clear research context" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear research context" }),
+    );
 
     expect(props.onClearFiles).toHaveBeenCalledTimes(1);
     expect(props.onClearKnowledge).toHaveBeenCalledTimes(1);

--- a/backlog/tasks/task-449 - Implement-Character-Chat-Phase-4-sessions-recents-and-continuity.md
+++ b/backlog/tasks/task-449 - Implement-Character-Chat-Phase-4-sessions-recents-and-continuity.md
@@ -69,13 +69,21 @@ PR #1882 review follow-up:
 - Added regression coverage for both cases. Focused Vitest now passes: 4 files, 51 tests.
 - `git diff --check` passes. Full frontend TypeScript remains blocked by existing baseline errors outside this slice.
 - Real backend/browser smoke after review fixes used FastAPI on `127.0.0.1:8000` and Next on `localhost:3000`; `/chat?mode=character` still rendered the sessions region, and `/chat?mode=character&characterId=2` rendered `Recent sessions for Helpful AI Assistant` with `Resume` and disabled `Current` actions.
-
+Second PR #1882 review follow-up after rebasing onto latest origin/dev:
+- Addressed Gemini consistency feedback by converting the Character Chat sessions panel's remaining conditional template-literal class names to `cn(...)` composition.
+- Addressed CodeRabbit cleanup feedback by trimming timestamp strings before relative-time formatting, removing the redundant disabled-button click guard, and replacing `filter(Boolean) as PlaygroundContextSource[]` with a typed predicate.
+- Added regression coverage for padded timestamp normalization.
+- Focused Vitest passes: CharacterChatSessionsPanel.test.tsx has 5 tests, and the focused Character Chat/Playground suite passes with 4 files and 52 tests.
+Verification after second review follow-up:
+- `git diff --check` passes.
+- Focused Vitest passes: 4 files, 52 tests.
+- `bunx tsc --noEmit --pretty false` still fails only on existing baseline files outside this slice (`MediaReadAlongPopover.tsx`, `EmbeddingsModelSelectionConfig.tsx`, `StudioPane/index.tsx`, `useShortcutConfig.ts`, and `admin-llamacpp.spec.ts`); the touched `Playground.tsx` predicate issue found during verification was fixed before commit.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Phase 4 sessions continuity slice is implemented for /chat Character Chat. Verification recorded: focused Vitest passed with 4 files and 51 tests after PR review fixes, git diff --check passed, real FastAPI + Next browser inspection confirmed the panel on /chat?mode=character and /chat?mode=character&characterId=2, Bandit skipped as frontend-only, and full tsc remains blocked by existing baseline errors outside touched files.
+Phase 4 sessions continuity slice is implemented for /chat Character Chat. Verification recorded: focused Vitest passed with 4 files and 52 tests after PR review fixes, git diff --check passed, real FastAPI + Next browser inspection confirmed the panel on /chat?mode=character and /chat?mode=character&characterId=2, Bandit skipped as frontend-only, and full tsc remains blocked by existing baseline errors outside touched files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-449 - Implement-Character-Chat-Phase-4-sessions-recents-and-continuity.md
+++ b/backlog/tasks/task-449 - Implement-Character-Chat-Phase-4-sessions-recents-and-continuity.md
@@ -1,0 +1,82 @@
+---
+id: TASK-449
+title: Implement Character Chat Phase 4 sessions recents and continuity
+status: Done
+labels:
+- chat
+- characters
+- role-play
+- phase-4
+- frontend
+priority: high
+references:
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+- TASK-428
+- TASK-431
+- TASK-438
+- TASK-446
+- TASK-447
+- https://github.com/rmusser01/tldw_server/pull/1882
+documentation:
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+modified_files:
+- Docs/superpowers/plans/2026-05-20-character-chat-phase4-sessions-continuity-plan.md
+- apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
+- apps/packages/ui/src/components/Option/Playground/Playground.tsx
+- apps/packages/ui/src/components/Option/Playground/PlaygroundContextRail.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Phase 4 from the first-class Character Chat PRD: make continuing role-play sessions fast and safe from /chat by surfacing character-scoped session history, recent characters/chats, continuity restoration, and safe session actions without mixing saved role-play setups with conversations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Returning user can resume a recent character chat in two clicks or fewer from /chat.
+- [x] #2 Refreshing a character-backed server chat restores character identity and composer context before stored selected fallback.
+- [x] #3 Switching between character chats does not leak old character, prompt, or scene state.
+- [x] #4 Saved role-play setups remain visually and structurally distinct from character chat conversations.
+- [x] #5 Focused tests and real-backend or browser verification are recorded; Bandit is run or explicitly skipped for frontend-only scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-20-character-chat-phase4-sessions-continuity-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added a Character Chat sessions rail panel that uses the existing server chat history hook with `filterMode: "character"` and the existing `useSelectServerChat` resume path. The panel appears only when Character Chat mode is active, prioritizes sessions for the selected character, keeps other character chats distinct, disables the active chat's resume action as `Current`, and states that recent conversations are separate from saved role-play setups. Standard chat mode remains unchanged.
+
+Verification:
+- Focused Vitest passed: 4 files, 49 tests.
+- `git diff --check` passed.
+- Real FastAPI + Next browser inspection confirmed the panel on `/chat?mode=character` and `/chat?mode=character&characterId=2`, including `Recent sessions for Helpful AI Assistant`, `Resume`, and disabled `Current` actions.
+- `bunx tsc --noEmit --pretty false` still fails on existing baseline files outside this slice.
+- Targeted ESLint could not produce a useful signal because shared package paths are outside the frontend ESLint base path and the repo root has no ESLint config.
+- Bandit skipped because this is a frontend-only TypeScript/React change.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Phase 4 sessions continuity slice is implemented for /chat Character Chat. Verification recorded: focused Vitest passed with 4 files and 49 tests, git diff --check passed, real FastAPI + Next browser inspection confirmed the panel on /chat?mode=character and /chat?mode=character&characterId=2, Bandit skipped as frontend-only, and full tsc remains blocked by existing baseline errors outside touched files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-449 - Implement-Character-Chat-Phase-4-sessions-recents-and-continuity.md
+++ b/backlog/tasks/task-449 - Implement-Character-Chat-Phase-4-sessions-recents-and-continuity.md
@@ -63,12 +63,19 @@ Verification:
 - Targeted ESLint could not produce a useful signal because shared package paths are outside the frontend ESLint base path and the repo root has no ESLint config.
 - Bandit skipped because this is a frontend-only TypeScript/React change.
 
+PR #1882 review follow-up:
+- Addressed Qodo and cubic hard-error findings by rendering `sidebarRefreshState: "hard-error"` with no usable data as an explicit load failure instead of the empty state.
+- Addressed Qodo character grouping feedback by deriving the session character identity from `character_id`, falling back to `assistant_kind: "character"` plus `assistant_id`, matching the server-chat resume identity path.
+- Added regression coverage for both cases. Focused Vitest now passes: 4 files, 51 tests.
+- `git diff --check` passes. Full frontend TypeScript remains blocked by existing baseline errors outside this slice.
+- Real backend/browser smoke after review fixes used FastAPI on `127.0.0.1:8000` and Next on `localhost:3000`; `/chat?mode=character` still rendered the sessions region, and `/chat?mode=character&characterId=2` rendered `Recent sessions for Helpful AI Assistant` with `Resume` and disabled `Current` actions.
+
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Phase 4 sessions continuity slice is implemented for /chat Character Chat. Verification recorded: focused Vitest passed with 4 files and 49 tests, git diff --check passed, real FastAPI + Next browser inspection confirmed the panel on /chat?mode=character and /chat?mode=character&characterId=2, Bandit skipped as frontend-only, and full tsc remains blocked by existing baseline errors outside touched files.
+Phase 4 sessions continuity slice is implemented for /chat Character Chat. Verification recorded: focused Vitest passed with 4 files and 51 tests after PR review fixes, git diff --check passed, real FastAPI + Next browser inspection confirmed the panel on /chat?mode=character and /chat?mode=character&characterId=2, Bandit skipped as frontend-only, and full tsc remains blocked by existing baseline errors outside touched files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

- Adds a Character Chat sessions rail panel on `/chat` that uses server-backed character chat history and the existing server-chat resume path.
- Shows recent sessions only in Character Chat mode, prioritizes the active character, keeps other character chats separate, and marks the active chat as `Current`.
- Records the phase 4 plan and Backlog closeout for TASK-449.

## Verification

- `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/PlaygroundContextRail.first-slice.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx ../packages/ui/src/hooks/chat/__tests__/useSelectServerChat.context-reset.test.tsx --reporter=verbose` passed: 4 files, 49 tests.
- `git diff --check` passed.
- Real backend/browser check: FastAPI on `127.0.0.1:8000` and Next on `localhost:3000`; browser inspection confirmed `Character chat sessions` on `/chat?mode=character` and `Recent sessions for Helpful AI Assistant` with `Resume` and disabled `Current` actions on `/chat?mode=character&characterId=2`.
- `bunx tsc --noEmit --pretty false` still fails on existing baseline errors outside touched files: `MediaReadAlongPopover.tsx`, `EmbeddingsModelSelectionConfig.tsx`, `StudioPane/index.tsx`, `useShortcutConfig.ts`, and `e2e/workflows/tier-4-admin/admin-llamacpp.spec.ts`.
- Bandit skipped: frontend-only TypeScript/React scope.

## Change summary

_Human owner to fill before merge._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Character Chat sessions panel on `/chat` so users can see recent character conversations and quickly resume them. Implements TASK-449’s sessions recents and continuity for Character Chat.

- New Features
  - Added `CharacterChatSessionsPanel` to the Playground context rail when `mode=character`.
  - Uses `useServerChatHistory({ filterMode: "character" })` and `useSelectServerChat` to load and resume sessions.
  - Prioritizes the active character, groups other characters, and marks the current chat as “Current”.
  - Added a `characterSessionsPanel` slot to `PlaygroundContextRail`; rendered before generic session controls.
  - Supports `enabled` and `limit` props (default 5). Global chat sidebar stays unchanged.

<sup>Written for commit 44bdbfc2db14522373bf2160069ef057b4dcf3ce. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1882?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

