### PR TITLE
Migrate PromptInsertModal product-state alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1,16 +1,5 @@
 [
   {
-    "id": "antd-product-state-import:src/components/Common/PromptInsertModal.tsx:Alert",
-    "path": "src/components/Common/PromptInsertModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/PromptInsertModal.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Common/Settings/LlamaCppAdvancedControls.tsx:Alert#antd-alert-llamacppadvancedcontrols-type-info-line-225-1ac43xr",
     "path": "src/components/Common/Settings/LlamaCppAdvancedControls.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/PromptInsertModal.tsx
+++ b/apps/packages/ui/src/components/Common/PromptInsertModal.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import { useQuery } from "@tanstack/react-query"
-import { Alert, Empty, Input, List, Modal, Select, Tag } from "antd"
+import { Empty, Input, List, Modal, Select, Tag } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 export type PromptInsertItem = {
@@ -78,7 +79,8 @@ export const PromptInsertModal: React.FC<Props> = ({
     data: prompts = [],
     isLoading,
     isError,
-    error
+    error,
+    refetch
   } = useQuery({
     queryKey: ["promptInsertPrompts"],
     queryFn: async () => {
@@ -147,6 +149,7 @@ export const PromptInsertModal: React.FC<Props> = ({
   })
   const noMatches = t("option:noMatchingPrompts", "No matching prompts")
   const errorTitle = t("option:error", "Error")
+  const retryLabel = t("option:retry", "Retry")
   const errorFallback = t("option:somethingWentWrong", "Something went wrong")
   const errorDescription =
     error instanceof Error && error.message ? error.message : errorFallback
@@ -185,12 +188,18 @@ export const PromptInsertModal: React.FC<Props> = ({
         <div className="max-h-80 overflow-auto rounded-md border border-border">
           {showLoadError ? (
             <div className="p-3">
-              <Alert
-                type="error"
-                showIcon
+              <DesignSystemAlert
+                variant="error"
                 title={errorTitle}
-                description={errorDescription}
-              />
+                action={{
+                  label: retryLabel,
+                  onClick: () => {
+                    void refetch()
+                  }
+                }}
+              >
+                {errorDescription}
+              </DesignSystemAlert>
             </div>
           ) : filteredPrompts.length === 0 ? (
             <div className="py-8">

--- a/apps/packages/ui/src/components/Common/__tests__/PromptInsertModal.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/PromptInsertModal.test.tsx
@@ -1,0 +1,85 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn()
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: mocks.useQuery
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn(),
+    getPrompts: vi.fn()
+  }
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallbackOrOptions?: string | { defaultValue?: string }) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) return fallbackOrOptions.defaultValue
+      return _key
+    }
+  })
+}))
+
+import { PromptInsertModal } from "../PromptInsertModal"
+
+describe("PromptInsertModal", () => {
+  beforeEach(() => {
+    mocks.useQuery.mockReset()
+  })
+
+  it("renders prompt load errors with the design-system Alert", () => {
+    mocks.useQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+      error: new Error("Prompt service unavailable")
+    })
+
+    render(
+      <PromptInsertModal
+        open
+        onClose={vi.fn()}
+        onInsertPrompt={vi.fn()}
+      />
+    )
+
+    expect(
+      screen
+        .getByText("Prompt service unavailable")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(screen.getByText("Error")).toBeInTheDocument()
+  })
+
+  it("allows retrying prompt loading from the error alert", async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+    mocks.useQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+      error: new Error("Prompt service unavailable"),
+      refetch
+    })
+
+    render(
+      <PromptInsertModal
+        open
+        onClose={vi.fn()}
+        onInsertPrompt={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Retry" }))
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/backlog/tasks/task-451 - Migrate-PromptInsertModal-load-error-to-design-system-Alert.md
+++ b/backlog/tasks/task-451 - Migrate-PromptInsertModal-load-error-to-design-system-Alert.md
@@ -1,0 +1,61 @@
+---
+id: TASK-451
+title: Migrate PromptInsertModal load error to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-20 03:15
+labels:
+- design-system
+- product-state
+- ui
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/pull/1883
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the PromptInsertModal prompt-load error banner from AntD Alert to the canonical design-system Alert while preserving translated title and server/error fallback description. Remove the matching baseline exception and verify the guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PromptInsertModal renders prompt-load errors through the canonical design-system Alert primitive.
+- [x] #2 The existing translated error title and fallback/error message behavior are preserved.
+- [x] #3 The PromptInsertModal Alert baseline exception is removed without introducing new blocked product-state findings.
+- [x] #4 Focused tests and design-system product-state verification pass, with known TypeScript/Bandit skips recorded if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented test-first: the new PromptInsertModal regression failed on the missing canonical Alert marker, then passed after replacing the AntD prompt-load error banner with the design-system Alert and preserving the error title/description path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated PromptInsertModal's prompt-load error banner from AntD Alert to the canonical design-system Alert, added focused coverage for the DS wrapper plus translated title, and addressed PR #1883 review feedback by adding a Retry action that calls React Query refetch. Removed the PromptInsertModal baseline entry, reducing product-state baseline exceptions from 332 to 331.
+
+Verification:
+- RED: bunx vitest run src/components/Common/__tests__/PromptInsertModal.test.tsx --reporter=dot failed on the missing data-ds-component="Alert" wrapper before the migration.
+- RED review fix: bunx vitest run src/components/Common/__tests__/PromptInsertModal.test.tsx --reporter=dot failed on the missing Retry button before wiring refetch.
+- GREEN: bunx vitest run src/components/Common/__tests__/PromptInsertModal.test.tsx --reporter=dot passed: 2 tests.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 331.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for PromptInsertModal/task-451/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test JSON task metadata only, with no Python code touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates PromptInsertModal prompt-load errors from AntD Alert to the canonical design-system Alert.
- Adds focused coverage for the DS Alert wrapper and translated error title.
- Removes the PromptInsertModal product-state baseline exception, reducing baseline exceptions from 332 to 331.

## Verification
- RED: `bunx vitest run src/components/Common/__tests__/PromptInsertModal.test.tsx --reporter=dot` failed on missing `data-ds-component="Alert"`.
- GREEN: `bunx vitest run src/components/Common/__tests__/PromptInsertModal.test.tsx --reporter=dot` passed.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 52 tests.
- `bun run verify:design-system-state` passed; baseline exceptions are now 331.
- `git diff --check` passed.
- Full `bunx tsc --noEmit --pretty false` still exits 2 from inherited baseline debt; filtered touched-file diagnostics for PromptInsertModal/task-451/baseline matched 0 lines.
- Bandit skipped: TypeScript UI/test and JSON/task metadata only; no Python touched.

## Change summary
TODO (human-authored before merge): summarize what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates PromptInsertModal prompt-load error from AntD to the design-system `Alert`, adds a Retry action, and removes the related product-state baseline exception. Preserves translations and aligns with product-state rules, fulfilling TASK-451.

- **Refactors**
  - Swapped AntD `Alert` for design-system `Alert` in `PromptInsertModal`.
  - Preserved translated error title and fallback description.
  - Added tests for `[data-ds-component="Alert"]` and the retry behavior.
  - Removed the legacy product-state baseline exception (332 → 331).

- **New Features**
  - Added a Retry action on the error `Alert` that calls `refetch`.

<sup>Written for commit 7e71151e98c4efff151f51730c5cdf7c5efc1657. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1883?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

