### PR TITLE
Migrate PagesTab product-state alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -187,17 +187,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/PagesTab.tsx:Alert",
-    "path": "src/components/DocumentWorkspace/LeftSidebar/PagesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/LeftSidebar/PagesTab.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-errorstate-line-413-wx7ci2",
     "path": "src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/PagesTab.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/PagesTab.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { Document, Page } from "react-pdf"
-import { Empty, Skeleton, Alert } from "antd"
+import { Empty, Skeleton } from "antd"
 import { Image as ImageIcon } from "lucide-react"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { useDocumentWorkspaceStore } from "@/store/document-workspace"
 
 const MAX_THUMBNAILS = 24
@@ -109,13 +110,13 @@ export const PagesTab: React.FC = () => {
   return (
     <div className="h-full overflow-auto p-3">
       {loadError ? (
-        <Alert
+        <DesignSystemAlert
           className="mb-3"
-          type="error"
+          variant="error"
           title={t("option:documentWorkspace.pagesError", "Failed to load document")}
-          description={loadError || t("common:unknownError", "An unknown error occurred")}
-          showIcon
-        />
+        >
+          {loadError || t("common:unknownError", "An unknown error occurred")}
+        </DesignSystemAlert>
       ) : null}
       <Document
         file={documentUrl}

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/PagesTab.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/PagesTab.test.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useDocumentWorkspaceStore } from "@/store/document-workspace"
+import { PagesTab } from "../PagesTab"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      defaultValue?: string,
+      values?: Record<string, string | number | undefined>
+    ) => {
+      const template = defaultValue || _key
+      if (!values) return template
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, token: string) => {
+        const value = values[token]
+        return value === undefined ? `{{${token}}}` : String(value)
+      })
+    }
+  })
+}))
+
+vi.mock("react-pdf", () => ({
+  Document: ({
+    children,
+    onLoadError
+  }: {
+    children?: React.ReactNode
+    onLoadError?: (error: Error) => void
+  }) => {
+    React.useEffect(() => {
+      const timeoutId = setTimeout(() => {
+        onLoadError?.(new Error("Failed to parse PDF"))
+      }, 0)
+
+      return () => clearTimeout(timeoutId)
+    }, [onLoadError])
+
+    return <div data-testid="mock-document">{children}</div>
+  },
+  Page: ({ pageNumber }: { pageNumber: number }) => (
+    <div data-testid={`mock-page-${pageNumber}`} />
+  )
+}))
+
+describe("PagesTab", () => {
+  beforeEach(() => {
+    useDocumentWorkspaceStore.getState().reset()
+    useDocumentWorkspaceStore.setState({
+      activeDocumentId: 42,
+      activeDocumentType: "pdf",
+      openDocuments: [
+        {
+          id: 42,
+          title: "Research paper",
+          type: "pdf",
+          url: "blob://paper.pdf"
+        }
+      ],
+      totalPages: 1
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useDocumentWorkspaceStore.getState().reset()
+    vi.clearAllMocks()
+  })
+
+  it("renders PDF load errors with the design-system Alert", async () => {
+    render(<PagesTab />)
+
+    const message = await screen.findByText("Failed to parse PDF")
+
+    expect(
+      message.closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(screen.getByText("Failed to load document")).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-452 - Migrate-PagesTab-load-error-to-design-system-Alert.md
+++ b/backlog/tasks/task-452 - Migrate-PagesTab-load-error-to-design-system-Alert.md
@@ -1,0 +1,60 @@
+---
+id: TASK-452
+title: Migrate PagesTab load error to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-20 03:48
+labels:
+- design-system
+- product-state
+- ui
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/pull/1884
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the DocumentWorkspace PagesTab PDF load-error banner from AntD Alert to the canonical design-system Alert while preserving translated title and load-error message. Remove the matching baseline exception and verify the guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PagesTab renders PDF load errors through the canonical design-system Alert primitive.
+- [x] #2 The existing translated error title and load-error message fallback behavior are preserved.
+- [x] #3 The PagesTab Alert baseline exception is removed without introducing new blocked product-state findings.
+- [x] #4 Focused tests and design-system product-state verification pass, with known TypeScript/Bandit skips recorded if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented test-first: the PagesTab regression drives the mocked react-pdf load-error branch and failed on the missing canonical Alert marker before the AntD Alert was replaced with the design-system Alert.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated PagesTab's PDF load-error banner from AntD Alert to the canonical design-system Alert and added focused coverage for the DS wrapper plus translated title/message. Removed the PagesTab baseline entry, reducing product-state baseline exceptions from 331 to 330.
+
+Verification:
+- RED: bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/PagesTab.test.tsx --reporter=dot failed on the missing data-ds-component="Alert" wrapper.
+- GREEN: bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/PagesTab.test.tsx --reporter=dot passed.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 330.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for PagesTab/task-452/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test JSON task metadata only, with no Python code touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates DocumentWorkspace PagesTab PDF load errors from AntD Alert to the canonical design-system Alert.
- Adds focused coverage for the DS Alert wrapper and translated load-error title/message.
- Removes the PagesTab product-state baseline exception, reducing baseline exceptions from 331 to 330.

## Verification
- RED: `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/PagesTab.test.tsx --reporter=dot` failed on missing `data-ds-component="Alert"`.
- GREEN: `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/PagesTab.test.tsx --reporter=dot` passed: 1 test.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 52 tests.
- `bun run verify:design-system-state` passed; baseline exceptions are now 330.
- `git diff --check` passed.
- Full `bunx tsc --noEmit --pretty false` still exits 2 from inherited baseline debt; filtered touched-file diagnostics for PagesTab/task-452/baseline matched 0 lines.
- Bandit skipped: TypeScript UI/test and JSON/task metadata only; no Python touched.

## Change summary
TODO (human-authored before merge): summarize what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the PagesTab PDF load-error banner from `antd` to the design-system `Alert` for consistent UI and guard coverage. Added focused tests and removed the legacy baseline exception (TASK-452).

- **Refactors**
  - Replaced `antd` `Alert` with `Alert` from `@/components/ui/primitives` using `variant="error"` and children for the message.
  - Added a test that mocks `react-pdf` load errors and asserts `[data-ds-component="Alert"]` plus translated title/message.
  - Removed the PagesTab product-state baseline entry (exceptions: 331 → 330).

<sup>Written for commit b049353d44a022a46a538186aed016538d76b8c3. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1884?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

