### PR TITLE
Clarify TTS route readiness

### DIFF
--- a/apps/packages/ui/src/components/Option/Audio/__tests__/audio-readiness.test.ts
+++ b/apps/packages/ui/src/components/Option/Audio/__tests__/audio-readiness.test.ts
@@ -270,6 +270,34 @@ describe("audio readiness helpers", () => {
     )
   })
 
+  it("reports missing ffmpeg for ElevenLabs output processing", () => {
+    const items = buildTtsReadinessItems({
+      provider: "elevenlabs",
+      hasAudio: false,
+      providersInfo: null,
+      elevenLabsApiKey: "sk_test_key",
+      elevenLabsData: {
+        voices: [{ voice_id: "voice-1" }],
+        models: [{ model_id: "model-1" }]
+      },
+      ffmpegAvailable: false
+    })
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "elevenlabs-catalog",
+          state: "ready"
+        }),
+        expect.objectContaining({
+          id: "ffmpeg-output",
+          label: "Output processing",
+          state: "warning"
+        })
+      ])
+    )
+  })
+
   it("reports missing ffmpeg as degraded output capability", () => {
     const items = buildTtsReadinessItems({
       provider: "kitten_tts",

--- a/apps/packages/ui/src/components/Option/Audio/__tests__/audio-readiness.test.ts
+++ b/apps/packages/ui/src/components/Option/Audio/__tests__/audio-readiness.test.ts
@@ -179,7 +179,7 @@ describe("audio readiness helpers", () => {
     })
   })
 
-  it("builds TTS readiness that treats Browser preview as a no-setup fallback", () => {
+  it("builds TTS readiness that treats Browser local output as a no-setup fallback", () => {
     const items = buildTtsReadinessItems({
       provider: "browser",
       hasAudio: false,
@@ -190,7 +190,7 @@ describe("audio readiness helpers", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: "browser-preview",
-          label: "Browser preview",
+          label: "Browser local output",
           state: "ready",
           detail: "Available in this browser without server setup."
         })
@@ -240,6 +240,61 @@ describe("audio readiness helpers", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: "tts-server-audio"
+        })
+      ])
+    )
+  })
+
+  it("reports ElevenLabs catalog loading separately from saved credentials", () => {
+    const items = buildTtsReadinessItems({
+      provider: "elevenlabs",
+      hasAudio: true,
+      providersInfo: null,
+      elevenLabsApiKey: "sk_test_key",
+      elevenLabsLoading: true
+    })
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "elevenlabs-credentials",
+          state: "ready"
+        }),
+        expect.objectContaining({
+          id: "elevenlabs-catalog",
+          label: "ElevenLabs catalog",
+          state: "unknown",
+          detail: "Loading ElevenLabs voices and models."
+        })
+      ])
+    )
+  })
+
+  it("reports missing ffmpeg as degraded output capability", () => {
+    const items = buildTtsReadinessItems({
+      provider: "kitten_tts",
+      hasAudio: true,
+      providersInfo: {
+        providers: {
+          kitten_tts: {
+            provider_name: "KittenTTS",
+            formats: ["mp3"]
+          }
+        },
+        voices: {}
+      },
+      ffmpegAvailable: false
+    })
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "ffmpeg-output",
+          label: "Output processing",
+          state: "warning",
+          detail:
+            "ffmpeg is not detected. Basic speech generation can continue, but output conversion features may be degraded.",
+          source: "health"
         })
       ])
     )

--- a/apps/packages/ui/src/components/Option/Audio/audio-readiness.ts
+++ b/apps/packages/ui/src/components/Option/Audio/audio-readiness.ts
@@ -343,7 +343,7 @@ export function buildTtsReadinessItems({
       state: "blocked",
       detail: "API key required before generation."
     })
-    return items
+    return appendFfmpegWarning()
   }
 
   if (provider === "elevenlabs") {
@@ -362,7 +362,7 @@ export function buildTtsReadinessItems({
         detail: "Loading ElevenLabs voices and models.",
         source: "provider"
       })
-      return items
+      return appendFfmpegWarning()
     }
     if (elevenLabsError) {
       items.push({
@@ -372,7 +372,7 @@ export function buildTtsReadinessItems({
         detail: "Unable to load ElevenLabs voices or models. Retry before generation.",
         source: "provider"
       })
-      return items
+      return appendFfmpegWarning()
     }
     if (elevenLabsData) {
       const hasVoices = Array.isArray(elevenLabsData.voices) && elevenLabsData.voices.length > 0
@@ -388,7 +388,7 @@ export function buildTtsReadinessItems({
         source: "provider"
       })
     }
-    return items
+    return appendFfmpegWarning()
   }
 
   if (!hasAudio) {

--- a/apps/packages/ui/src/components/Option/Audio/audio-readiness.ts
+++ b/apps/packages/ui/src/components/Option/Audio/audio-readiness.ts
@@ -104,6 +104,13 @@ export type BuildTtsReadinessItemsArgs = {
   hasAudio: boolean
   providersInfo?: TldwTtsProvidersInfo | null
   elevenLabsApiKey?: string | null
+  elevenLabsData?: {
+    voices?: unknown[]
+    models?: unknown[]
+  } | null
+  elevenLabsLoading?: boolean
+  elevenLabsError?: unknown
+  ffmpegAvailable?: boolean | null
 }
 
 const UNKNOWN_CAPABILITIES: SttModelOption["capabilities"] = {
@@ -293,7 +300,11 @@ export function buildTtsReadinessItems({
   provider,
   hasAudio,
   providersInfo,
-  elevenLabsApiKey
+  elevenLabsApiKey,
+  elevenLabsData,
+  elevenLabsLoading = false,
+  elevenLabsError,
+  ffmpegAvailable
 }: BuildTtsReadinessItemsArgs): ReadinessItem[] {
   const hasElevenLabsApiKey =
     typeof elevenLabsApiKey === "string"
@@ -302,11 +313,24 @@ export function buildTtsReadinessItems({
   const items: ReadinessItem[] = [
     {
       id: "browser-preview",
-      label: "Browser preview",
+      label: "Browser local output",
       state: "ready",
       detail: "Available in this browser without server setup."
     }
   ]
+  const appendFfmpegWarning = () => {
+    if (provider !== "browser" && ffmpegAvailable === false) {
+      items.push({
+        id: "ffmpeg-output",
+        label: "Output processing",
+        state: "warning",
+        detail:
+          "ffmpeg is not detected. Basic speech generation can continue, but output conversion features may be degraded.",
+        source: "health"
+      })
+    }
+    return items
+  }
 
   if (provider === "browser") {
     return items
@@ -330,6 +354,40 @@ export function buildTtsReadinessItems({
       detail: "API key saved. Voices and models load directly from ElevenLabs.",
       source: "provider"
     })
+    if (elevenLabsLoading) {
+      items.push({
+        id: "elevenlabs-catalog",
+        label: "ElevenLabs catalog",
+        state: "unknown",
+        detail: "Loading ElevenLabs voices and models.",
+        source: "provider"
+      })
+      return items
+    }
+    if (elevenLabsError) {
+      items.push({
+        id: "elevenlabs-catalog",
+        label: "ElevenLabs catalog",
+        state: "warning",
+        detail: "Unable to load ElevenLabs voices or models. Retry before generation.",
+        source: "provider"
+      })
+      return items
+    }
+    if (elevenLabsData) {
+      const hasVoices = Array.isArray(elevenLabsData.voices) && elevenLabsData.voices.length > 0
+      const hasModels = Array.isArray(elevenLabsData.models) && elevenLabsData.models.length > 0
+      items.push({
+        id: "elevenlabs-catalog",
+        label: "ElevenLabs catalog",
+        state: hasVoices && hasModels ? "ready" : "blocked",
+        detail:
+          hasVoices && hasModels
+            ? "Voices and models loaded from ElevenLabs."
+            : "No ElevenLabs voices or models were returned.",
+        source: "provider"
+      })
+    }
     return items
   }
 
@@ -340,7 +398,7 @@ export function buildTtsReadinessItems({
       state: "blocked",
       detail: "tldw audio/speech API not detected."
     })
-    return items
+    return appendFfmpegWarning()
   }
 
   const providerInfo = providersInfo?.providers?.[provider]
@@ -357,5 +415,5 @@ export function buildTtsReadinessItems({
     source: providerInfo ? "provider" : "unknown"
   })
 
-  return items
+  return appendFfmpegWarning()
 }

--- a/apps/packages/ui/src/components/Option/Speech/RenderStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/RenderStrip.tsx
@@ -130,7 +130,7 @@ export const RenderStrip: React.FC<RenderStripProps> = ({
 
   const providerLabel =
     config.provider === "browser"
-      ? "Browser preview"
+      ? "Browser local output"
       : config.provider === "tldw"
         ? (config.model || "tldw")
         : config.provider

--- a/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
@@ -2120,11 +2120,8 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
     tldwVoiceOptions.length === 0
   const elevenLabsCatalogEmpty =
     provider === "elevenlabs" &&
-    Boolean(elevenLabsData) &&
-    (!Array.isArray(elevenLabsData?.voices) ||
-      elevenLabsData.voices.length === 0 ||
-      !Array.isArray(elevenLabsData?.models) ||
-      elevenLabsData.models.length === 0)
+    !!elevenLabsData &&
+    (!elevenLabsData.voices?.length || !elevenLabsData.models?.length)
 
   const playDisabledReason = (() => {
     if (isTtsDisabled) {

--- a/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
@@ -61,7 +61,7 @@ import { markdownToText } from "@/utils/markdown-to-text"
 import { isTimeoutLikeError } from "@/utils/request-timeout"
 import { withTemplateFallback } from "@/utils/template-guards"
 import { listCustomVoices, type TldwCustomVoice } from "@/services/tldw/voice-cloning"
-import { normalizeTtsProviderKey, toServerTtsProviderKey } from "@/services/tldw/tts-provider-keys"
+import { normalizeTtsProviderKey } from "@/services/tldw/tts-provider-keys"
 import { TtsJobProgress } from "@/components/Common/TtsJobProgress"
 import { LongformDraftEditor } from "@/components/Common/LongformDraftEditor"
 import { CharacterProgressBar } from "@/components/Common/CharacterProgressBar"
@@ -870,6 +870,7 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
   }, [isTldw, tldwModel, ttsSettings?.tldwTtsModel])
   const {
     hasAudio,
+    ffmpegAvailable,
     providersInfo,
     tldwTtsModels,
     tldwVoiceCatalog,
@@ -957,15 +958,29 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
     tldwVoice,
     ttsSettings
   ])
+  const readinessProvider = isTldw && inferredProviderKey ? inferredProviderKey : provider
   const ttsReadinessItems = React.useMemo(
     () =>
       buildTtsReadinessItems({
-        provider,
+        provider: readinessProvider,
         hasAudio,
         providersInfo,
-        elevenLabsApiKey: ttsSettings?.elevenLabsApiKey
+        elevenLabsApiKey: ttsSettings?.elevenLabsApiKey,
+        elevenLabsData,
+        elevenLabsLoading,
+        elevenLabsError,
+        ffmpegAvailable
       }),
-    [hasAudio, provider, providersInfo, ttsSettings?.elevenLabsApiKey]
+    [
+      elevenLabsData,
+      elevenLabsError,
+      elevenLabsLoading,
+      ffmpegAvailable,
+      hasAudio,
+      providersInfo,
+      readinessProvider,
+      ttsSettings?.elevenLabsApiKey
+    ]
   )
 
   React.useEffect(() => {
@@ -2089,6 +2104,28 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
   }
   const [showSegmentsPreview, setShowSegmentsPreview] = React.useState(false)
 
+  const hasElevenLabsKey = Boolean(ttsSettings?.elevenLabsApiKey)
+  const selectedTldwProviderLabel =
+    activeProviderCaps?.caps.provider_name || inferredProviderKey || providerLabel
+  const selectedTldwProviderMissing =
+    isTldw &&
+    hasAudio &&
+    Boolean(providersInfo) &&
+    Boolean(inferredProviderKey) &&
+    !activeProviderCaps
+  const selectedTldwVoiceCatalogMissing =
+    isTldw &&
+    hasAudio &&
+    Boolean(activeProviderCaps) &&
+    tldwVoiceOptions.length === 0
+  const elevenLabsCatalogEmpty =
+    provider === "elevenlabs" &&
+    Boolean(elevenLabsData) &&
+    (!Array.isArray(elevenLabsData?.voices) ||
+      elevenLabsData.voices.length === 0 ||
+      !Array.isArray(elevenLabsData?.models) ||
+      elevenLabsData.models.length === 0)
+
   const playDisabledReason = (() => {
     if (isTtsDisabled) {
       return t(
@@ -2099,6 +2136,57 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
     if (!(useDraftEditor ? transcriptDraft : ttsText).trim()) {
       return t("playground:tts.playDisabledNoText", "Enter text to enable Play.")
     }
+    if (provider !== "browser" && provider !== "elevenlabs" && !hasAudio) {
+      return t(
+        "playground:tts.playDisabledServerAudioUnavailable",
+        "Open Settings -> Speech to connect the tldw audio/speech API before generating server TTS."
+      )
+    }
+    if (selectedTldwProviderMissing) {
+      return t(
+        "playground:tts.playDisabledProviderMissing",
+        "The selected TTS provider is not reported by the server. Open Settings -> Speech and choose a configured provider."
+      )
+    }
+    if (selectedTldwVoiceCatalogMissing) {
+      return withTemplateFallback(
+        t(
+          "playground:tts.playDisabledVoiceCatalogMissing",
+          "No voices reported for {{provider}}. Configure voices in Settings -> Speech before generating.",
+          { provider: selectedTldwProviderLabel } as any
+        ),
+        `No voices reported for ${selectedTldwProviderLabel}. Configure voices in Settings -> Speech before generating.`
+      )
+    }
+    if (provider === "elevenlabs" && !hasElevenLabsKey) {
+      return t(
+        "playground:tts.playDisabledElevenLabsKeyMissing",
+        "Enter an ElevenLabs API key before generating audio."
+      )
+    }
+    if (provider === "elevenlabs" && elevenLabsLoading) {
+      return t(
+        "playground:tts.playDisabledElevenLabsLoading",
+        "Loading ElevenLabs voices and models before generation."
+      )
+    }
+    if (provider === "elevenlabs" && elevenLabsError) {
+      return isTimeoutLikeError(elevenLabsError)
+        ? t(
+            "playground:tts.playDisabledElevenLabsTimeout",
+            "Retry ElevenLabs voice/model loading; the last request timed out."
+          )
+        : t(
+            "playground:tts.playDisabledElevenLabsError",
+            "Retry ElevenLabs voice/model loading before generating audio."
+          )
+    }
+    if (elevenLabsCatalogEmpty) {
+      return t(
+        "playground:tts.playDisabledElevenLabsCatalogEmpty",
+        "No ElevenLabs voices or models are available. Check your ElevenLabs account or API key."
+      )
+    }
     if (voiceRoleError) return voiceRoleError
     return draftErrors.outline || draftErrors.transcript || null
   })()
@@ -2108,7 +2196,6 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
   const canStop = Boolean(segments.length || audioRef.current || isStreamingActive || isTtsJobRunning)
   const stopDisabledReason =
     !canStop && t("playground:tts.stopDisabled", "Stop activates after audio starts.")
-  const hasElevenLabsKey = Boolean(ttsSettings?.elevenLabsApiKey)
   const showElevenLabsHint =
     provider === "elevenlabs" &&
     !elevenLabsData &&

--- a/apps/packages/ui/src/components/Option/Speech/TtsProviderStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/TtsProviderStrip.tsx
@@ -40,7 +40,7 @@ export function TtsProviderStrip({
 
       {isBrowser ? (
         <>
-          <Tag className="cursor-pointer">Browser preview</Tag>
+          <Tag className="cursor-pointer">Browser local output</Tag>
           {voice && (
             <Tooltip title={`Voice: ${voice}`}>
               <Tag

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/RenderStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/RenderStrip.test.tsx
@@ -50,7 +50,7 @@ describe("RenderStrip", () => {
       />
     )
 
-    expect(screen.getByText("Browser preview")).toBeInTheDocument()
+    expect(screen.getByText("Browser local output")).toBeInTheDocument()
     expect(screen.queryByText("browser")).not.toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
@@ -46,7 +46,11 @@ const {
   getElevenLabsModelsMock,
   addRenderMock,
   setTTSSettingsMock,
+  inferTldwProviderFromModelMock,
+  isTimeoutLikeErrorMock,
   ttsSettingsRef,
+  ttsProviderDataRef,
+  ttsSegmentsRef,
   audioPresetControlPropsRef,
 } =
   vi.hoisted(() => ({
@@ -59,6 +63,8 @@ const {
     getElevenLabsModelsMock: vi.fn(),
     addRenderMock: vi.fn(),
     setTTSSettingsMock: vi.fn(async () => undefined),
+    inferTldwProviderFromModelMock: vi.fn(() => null),
+    isTimeoutLikeErrorMock: vi.fn(() => false),
     ttsSettingsRef: {
       current: {
         ttsProvider: "",
@@ -67,6 +73,29 @@ const {
         tldwTtsStreaming: false,
         responseSplitting: "punctuation",
       } as any,
+    },
+    ttsProviderDataRef: {
+      current: {
+        hasAudio: true,
+        providersInfo: {
+          providers: {
+            browser: {
+              supports_streaming: false,
+            },
+          },
+          voices: {},
+        },
+        tldwTtsModels: [],
+        tldwVoiceCatalog: [],
+        elevenLabsData: null,
+        elevenLabsLoading: false,
+        elevenLabsError: null,
+        ffmpegAvailable: true,
+        refetchElevenLabs: vi.fn(),
+      } as any,
+    },
+    ttsSegmentsRef: {
+      current: [] as any[],
     },
     audioPresetControlPropsRef: {
       current: null as null | {
@@ -167,27 +196,75 @@ vi.mock("@/components/Option/Speech/TtsProviderStrip", () => ({
 }))
 
 vi.mock("@/components/Option/Speech/TtsStickyActionBar", () => ({
-  TtsStickyActionBar: ({ onAddRender }: { onAddRender?: () => void }) => (
-    <button type="button" data-testid="tts-sticky-action-bar" onClick={onAddRender}>
-      Add render
-    </button>
+  TtsStickyActionBar: ({
+    onAddRender,
+    onPlay,
+    isPlayDisabled,
+    playDisabledReason,
+    provider,
+    inspectorBadge,
+    segmentCount,
+  }: {
+    onAddRender?: () => void
+    onPlay?: () => void
+    isPlayDisabled?: boolean
+    playDisabledReason?: string | null
+    provider?: string
+    inspectorBadge?: string
+    segmentCount?: number
+  }) => (
+    <div
+      data-testid="tts-sticky-action-bar"
+      data-provider={provider}
+      data-inspector-badge={inspectorBadge}
+      data-segment-count={String(segmentCount ?? 0)}
+    >
+      <button type="button" data-testid="tts-add-render" onClick={onAddRender}>
+        Add render
+      </button>
+      <button
+        type="button"
+        data-testid="tts-play-button"
+        disabled={Boolean(isPlayDisabled)}
+        onClick={onPlay}
+      >
+        Play
+      </button>
+      {playDisabledReason && (
+        <p data-testid="tts-play-disabled-reason">{playDisabledReason}</p>
+      )}
+    </div>
   ),
 }))
 
 vi.mock("@/components/Option/Speech/TtsInspectorPanel", () => ({
-  TtsInspectorPanel: () => <div data-testid="tts-inspector-panel" />,
+  TtsInspectorPanel: ({
+    voiceTab,
+    outputTab,
+    advancedTab,
+  }: {
+    voiceTab?: React.ReactNode
+    outputTab?: React.ReactNode
+    advancedTab?: React.ReactNode
+  }) => (
+    <div data-testid="tts-inspector-panel">
+      <div data-testid="tts-inspector-voice-content">{voiceTab}</div>
+      <div data-testid="tts-inspector-output-content">{outputTab}</div>
+      <div data-testid="tts-inspector-advanced-content">{advancedTab}</div>
+    </div>
+  ),
 }))
 
 vi.mock("@/components/Option/Speech/TtsVoiceTab", () => ({
-  TtsVoiceTab: () => <div data-testid="tts-voice-tab" />,
+  TtsVoiceTab: () => <div data-testid="tts-voice-tab">tts-voice-tab</div>,
 }))
 
 vi.mock("@/components/Option/Speech/TtsOutputTab", () => ({
-  TtsOutputTab: () => <div data-testid="tts-output-tab" />,
+  TtsOutputTab: () => <div data-testid="tts-output-tab">tts-output-tab</div>,
 }))
 
 vi.mock("@/components/Option/Speech/TtsAdvancedTab", () => ({
-  TtsAdvancedTab: () => <div data-testid="tts-advanced-tab" />,
+  TtsAdvancedTab: () => <div data-testid="tts-advanced-tab">tts-advanced-tab</div>,
 }))
 
 vi.mock("@/components/Option/TTS/VoiceCloningManager", () => ({
@@ -242,7 +319,7 @@ vi.mock("@/hooks/useTtsPlayground", () => ({
     },
   },
   useTtsPlayground: () => ({
-    segments: [],
+    segments: ttsSegmentsRef.current,
     isGenerating: false,
     generateSegments: vi.fn(async () => []),
     clearSegments: vi.fn(),
@@ -266,7 +343,11 @@ vi.mock("@/hooks/useTtsProviderData", () => ({
   OPENAI_TTS_VOICES: {
     "tts-1": [{ label: "Alloy", value: "alloy" }],
   },
-  useTtsProviderData: () => ({
+  useTtsProviderData: () => ttsProviderDataRef.current,
+}))
+
+const resetTtsProviderData = () => {
+  ttsProviderDataRef.current = {
     hasAudio: true,
     providersInfo: {
       providers: {
@@ -281,9 +362,10 @@ vi.mock("@/hooks/useTtsProviderData", () => ({
     elevenLabsData: null,
     elevenLabsLoading: false,
     elevenLabsError: null,
+    ffmpegAvailable: true,
     refetchElevenLabs: vi.fn(),
-  }),
-}))
+  }
+}
 
 vi.mock("@/hooks/useMultiRenderState", () => ({
   useMultiRenderState: () => ({
@@ -305,7 +387,7 @@ vi.mock("@/hooks/useMultiRenderState", () => ({
 }))
 
 vi.mock("@/services/tts-provider", () => ({
-  inferTldwProviderFromModel: vi.fn(() => null),
+  inferTldwProviderFromModel: inferTldwProviderFromModelMock,
   resolveTtsProviderContext: vi.fn(async (text: string) => ({
     utterance: text,
   })),
@@ -365,7 +447,7 @@ vi.mock("@/utils/markdown-to-text", () => ({
 }))
 
 vi.mock("@/utils/request-timeout", () => ({
-  isTimeoutLikeError: vi.fn(() => false),
+  isTimeoutLikeError: isTimeoutLikeErrorMock,
 }))
 
 vi.mock("@/utils/template-guards", () => ({
@@ -394,6 +476,12 @@ describe("SpeechPlaygroundPage", () => {
     addRenderMock.mockReset()
     setTTSSettingsMock.mockClear()
     audioPresetControlPropsRef.current = null
+    inferTldwProviderFromModelMock.mockReset()
+    inferTldwProviderFromModelMock.mockReturnValue(null)
+    isTimeoutLikeErrorMock.mockReset()
+    isTimeoutLikeErrorMock.mockReturnValue(false)
+    resetTtsProviderData()
+    ttsSegmentsRef.current = []
     ttsSettingsRef.current = {
       ttsProvider: "",
       ttsEnabled: true,
@@ -452,7 +540,7 @@ describe("SpeechPlaygroundPage", () => {
 
     render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
 
-    fireEvent.click(screen.getByTestId("tts-sticky-action-bar"))
+    fireEvent.click(screen.getByTestId("tts-add-render"))
 
     expect(addRenderMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -477,7 +565,7 @@ describe("SpeechPlaygroundPage", () => {
       screen.getByRole("heading", { level: 1, name: "Text to Speech" })
     ).toBeInTheDocument()
     expect(screen.getByRole("status", { name: "TTS readiness" })).toHaveTextContent(
-      "Browser preview: Ready"
+      "Browser local output: Ready"
     )
     expect(
       screen.getByText("Draft text, choose a voice, and generate audio in one place.")
@@ -485,6 +573,228 @@ describe("SpeechPlaygroundPage", () => {
     expect(screen.getByText("TTS history")).toBeInTheDocument()
     expect(screen.getByText("Generate audio to see TTS history here.")).toBeInTheDocument()
     expect(screen.queryByTestId("speech-history-type-filter")).not.toBeInTheDocument()
+  })
+
+  it("disables server TTS generation when the audio API is unavailable and preserves typed text", (): void => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "tldw",
+      tldwTtsModel: "KittenML/kitten-tts-nano-0.8",
+      tldwTtsVoice: "Bella",
+    }
+    ttsProviderDataRef.current = {
+      ...ttsProviderDataRef.current,
+      hasAudio: false,
+      providersInfo: null,
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("Enter some text to hear it spoken."), {
+      target: { value: "Draft narration remains editable" },
+    })
+
+    expect(screen.getByTestId("tts-play-button")).toBeDisabled()
+    expect(screen.getByTestId("tts-play-disabled-reason")).toHaveTextContent(
+      "Open Settings -> Speech"
+    )
+    expect(screen.getByDisplayValue("Draft narration remains editable")).toBeInTheDocument()
+  })
+
+  it("disables server TTS generation when the selected provider is not reported", (): void => {
+    inferTldwProviderFromModelMock.mockReturnValue("kitten_tts")
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "tldw",
+      tldwTtsModel: "KittenML/kitten-tts-nano-0.8",
+      tldwTtsVoice: "Bella",
+    }
+    ttsProviderDataRef.current = {
+      ...ttsProviderDataRef.current,
+      providersInfo: {
+        providers: {},
+        voices: {},
+      },
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("Enter some text to hear it spoken."), {
+      target: { value: "Configured provider check" },
+    })
+
+    expect(screen.getByTestId("tts-play-button")).toBeDisabled()
+    expect(screen.getByTestId("tts-play-disabled-reason")).toHaveTextContent(
+      "choose a configured provider"
+    )
+  })
+
+  it("disables server TTS generation when the selected provider has no voice catalog", (): void => {
+    inferTldwProviderFromModelMock.mockReturnValue("kitten_tts")
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "tldw",
+      tldwTtsModel: "KittenML/kitten-tts-nano-0.8",
+      tldwTtsVoice: "Bella",
+    }
+    ttsProviderDataRef.current = {
+      ...ttsProviderDataRef.current,
+      providersInfo: {
+        providers: {
+          kitten_tts: {
+            provider_name: "KittenTTS",
+            formats: ["mp3"],
+            supports_streaming: false,
+          },
+        },
+        voices: {},
+      },
+      tldwVoiceCatalog: [],
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("Enter some text to hear it spoken."), {
+      target: { value: "Voice catalog stays in the draft" },
+    })
+
+    expect(screen.getByTestId("tts-play-button")).toBeDisabled()
+    expect(screen.getByTestId("tts-play-disabled-reason")).toHaveTextContent(
+      "No voices reported for KittenTTS"
+    )
+    expect(screen.getByDisplayValue("Voice catalog stays in the draft")).toBeInTheDocument()
+  })
+
+  it("disables ElevenLabs playback while voices and models are loading", (): void => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "sk_test_key",
+    }
+    ttsProviderDataRef.current = {
+      ...ttsProviderDataRef.current,
+      elevenLabsData: null,
+      elevenLabsLoading: true,
+      elevenLabsError: null,
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("Enter some text to hear it spoken."), {
+      target: { value: "ElevenLabs loading should keep this text" },
+    })
+
+    expect(screen.getByRole("status", { name: "TTS readiness" })).toHaveTextContent(
+      "ElevenLabs catalog: Unknown"
+    )
+    expect(screen.getByTestId("tts-play-button")).toBeDisabled()
+    expect(screen.getByTestId("tts-play-disabled-reason")).toHaveTextContent(
+      "Loading ElevenLabs voices and models"
+    )
+    expect(screen.getByDisplayValue("ElevenLabs loading should keep this text")).toBeInTheDocument()
+  })
+
+  it("disables ElevenLabs playback until an API key is present", (): void => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "",
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("Enter some text to hear it spoken."), {
+      target: { value: "ElevenLabs key required" },
+    })
+
+    expect(screen.getByTestId("tts-play-button")).toBeDisabled()
+    expect(screen.getByTestId("tts-play-disabled-reason")).toHaveTextContent(
+      "Enter an ElevenLabs API key"
+    )
+  })
+
+  it("uses timeout recovery copy when ElevenLabs voice and model loading times out", (): void => {
+    isTimeoutLikeErrorMock.mockReturnValue(true)
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "sk_test_key",
+    }
+    ttsProviderDataRef.current = {
+      ...ttsProviderDataRef.current,
+      elevenLabsData: null,
+      elevenLabsLoading: false,
+      elevenLabsError: "Request timed out",
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("Enter some text to hear it spoken."), {
+      target: { value: "ElevenLabs timeout recovery" },
+    })
+
+    expect(screen.getByRole("status", { name: "TTS readiness" })).toHaveTextContent(
+      "ElevenLabs catalog: Degraded"
+    )
+    expect(screen.getByTestId("tts-play-button")).toBeDisabled()
+    expect(screen.getByTestId("tts-play-disabled-reason")).toHaveTextContent(
+      "last request timed out"
+    )
+  })
+
+  it("surfaces ffmpeg as degraded output capability without blocking the TTS route", (): void => {
+    ttsProviderDataRef.current = {
+      ...ttsProviderDataRef.current,
+      ffmpegAvailable: false,
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    expect(screen.getByRole("status", { name: "TTS readiness" })).toHaveTextContent(
+      "Output processing: Degraded"
+    )
+    expect(screen.getByRole("heading", { level: 1, name: "Text to Speech" })).toBeInTheDocument()
+  })
+
+  it("keeps generated audio segments inspectable on the routed TTS page", (): void => {
+    ttsSegmentsRef.current = [
+      {
+        id: "segment-1",
+        text: "First generated segment",
+        url: "blob:first",
+        format: "mp3",
+      },
+      {
+        id: "segment-2",
+        text: "Second generated segment",
+        url: "blob:second",
+        format: "mp3",
+      },
+    ]
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    expect(screen.getByText("Generated audio segments")).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /First generated segment/ })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /Second generated segment/ })).toBeInTheDocument()
+    expect(screen.getByTestId("tts-sticky-action-bar")).toHaveAttribute(
+      "data-segment-count",
+      "2"
+    )
+  })
+
+  it("keeps advanced voice and model controls mounted for the routed TTS page", (): void => {
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    expect(screen.getByTestId("tts-inspector-voice-content")).toHaveTextContent(
+      "tts-voice-tab"
+    )
+    expect(screen.getByTestId("tts-inspector-output-content")).toHaveTextContent(
+      "tts-output-tab"
+    )
+    expect(screen.getByTestId("tts-inspector-advanced-content")).toHaveTextContent(
+      "tts-advanced-tab"
+    )
   })
 
   it("renders TTS preset controls and applies a saved preset without starting generation", async (): Promise<void> => {

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/TtsProviderStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/TtsProviderStrip.test.tsx
@@ -42,7 +42,7 @@ describe("TtsProviderStrip", () => {
   it("simplifies display for browser provider", () => {
     render(<TtsProviderStrip {...defaults} provider="browser" />)
 
-    expect(screen.getByText("Browser preview")).toBeInTheDocument()
+    expect(screen.getByText("Browser local output")).toBeInTheDocument()
     expect(screen.queryByText("mp3")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/hooks/useTtsProviderData.ts
+++ b/apps/packages/ui/src/hooks/useTtsProviderData.ts
@@ -115,6 +115,7 @@ export const useTtsProviderData = ({
 
   return {
     hasAudio,
+    ffmpegAvailable: capabilities?.ffmpegAvailable ?? null,
     providersInfo,
     tldwTtsModels,
     tldwVoiceCatalog,

--- a/apps/tldw-frontend/e2e/utils/page-objects/TTSPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/TTSPage.ts
@@ -1,10 +1,10 @@
 /**
- * Page Object for the TTS (Text-to-Speech) Playground
+ * Page Object for the Text to Speech route
  *
  * Wraps the /tts route which renders SpeechPlaygroundPage in locked "listen" mode.
  * Key UI elements: title, text input area, Play/Stop/Download buttons, voice provider strip.
  */
-import { type Page, type Locator, expect } from "@playwright/test"
+import { type Page, type Locator } from "@playwright/test"
 import { BasePage, type InteractiveElement } from "./BasePage"
 import { waitForAppShell, waitForConnection } from "../helpers"
 
@@ -22,16 +22,16 @@ export class TTSPage extends BasePage {
 
   async assertPageReady(): Promise<void> {
     await waitForAppShell(this.page, 30_000)
-    // Wait for the TTS Playground heading
-    const heading = this.page.getByText("TTS Playground")
+    // Wait for the canonical Text to Speech route heading.
+    const heading = this.page.getByText("Text to Speech")
     await heading.first().waitFor({ state: "visible", timeout: 20_000 }).catch(() => {})
   }
 
   // -- Locators --------------------------------------------------------------
 
-  /** Page heading ("TTS Playground") */
+  /** Page heading ("Text to Speech") */
   get heading(): Locator {
-    return this.page.getByRole("heading", { name: /tts playground/i })
+    return this.page.getByRole("heading", { name: /text to speech/i })
   }
 
   /** Subtitle text */

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/tts-synthesis.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/tts-synthesis.spec.ts
@@ -1,7 +1,7 @@
 /**
  * TTS Synthesis E2E Tests (Tier 2)
  *
- * Tests the TTS Playground page (/tts) lifecycle:
+ * Tests the Text to Speech route (/tts) lifecycle:
  * - Page loads with expected elements (heading, subtitle, text input, playback toolbar)
  * - Play button fires POST /api/v1/audio/speech when text is present
  *
@@ -30,7 +30,7 @@ test.describe("TTS Synthesis", () => {
   // =========================================================================
 
   test.describe("Page Load", () => {
-    test("should render the TTS Playground page with expected elements", async ({
+    test("should render the Text to Speech route with expected elements", async ({
       authedPage,
       diagnostics,
     }) => {

--- a/backlog/tasks/task-418.8.3 - Make-WebUI-TTS-route-recoverable-and-route-owned.md
+++ b/backlog/tasks/task-418.8.3 - Make-WebUI-TTS-route-recoverable-and-route-owned.md
@@ -1,0 +1,63 @@
+---
+id: TASK-418.8.3
+title: Make WebUI TTS route recoverable and route-owned
+status: Done
+labels:
+- webui
+- ux-audit
+- audio
+- wp11a
+- tts
+priority: medium
+parent_task_id: TASK-418.8
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-audio-routes-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/components/Option/Audio/audio-readiness.ts
+- apps/packages/ui/src/components/Option/Audio/__tests__/audio-readiness.test.ts
+- apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+- apps/packages/ui/src/components/Option/Speech/RenderStrip.tsx
+- apps/packages/ui/src/components/Option/Speech/TtsProviderStrip.tsx
+- apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+- apps/packages/ui/src/components/Option/Speech/__tests__/RenderStrip.test.tsx
+- apps/packages/ui/src/components/Option/Speech/__tests__/TtsProviderStrip.test.tsx
+- apps/packages/ui/src/hooks/useTtsProviderData.ts
+- apps/tldw-frontend/e2e/utils/page-objects/TTSPage.ts
+- apps/tldw-frontend/e2e/workflows/tier-2-features/tts-synthesis.spec.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP11A Task 4 from the WebUI audio routes implementation plan. Make /tts a single canonical synthesis route by preserving SpeechPlaygroundPage locked listen ownership, improving provider/voice/readiness/recovery states, keeping advanced synthesis controls discoverable, and preventing the legacy TtsPlaygroundPage from drifting into a second route owner.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /tts route-owner guard coverage verifies RouteErrorBoundary routeId=tts and routeLabel=TTS Playground around SpeechPlaygroundPage lockedMode=listen with hidden mode switcher.
+- [x] #2 TTS readiness coverage includes missing provider, missing voice catalog, ElevenLabs loading/timeout/missing-key states, ffmpeg degraded output warning, Browser TTS local-output labeling, generated segment inspection, and advanced voice/model control discoverability.
+- [x] #3 Implementation reuses existing Speech/TTS components and does not add a second TTS route surface or backend APIs.
+- [x] #4 Focused TTS component and E2E verification is recorded; inherited repo-wide type debt is separated from touched-scope results.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Kept /tts routed through SpeechPlaygroundPage lockedMode=listen and tightened route-level synthesis recovery. Added readiness inputs for ElevenLabs catalog state and ffmpeg availability, labeled browser synthesis as local browser output, passed inferred server provider keys into TTS readiness, and gated Play with actionable recovery reasons for missing server audio, missing provider metadata, missing voice catalogs, ElevenLabs missing credentials/loading/timeout/error/empty catalogs. Updated focused render/helper/E2E coverage around these states without adding backend APIs or a second route surface.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed WP11A Task 4 for /tts route readiness. Focused tests passed: component suite 73/73, route contract 8/8, and TTS E2E 2 passed with 1 backend-dependent speech API test skipped. ESLint reported 0 errors with existing warnings in the large Speech page/test files. Broad frontend/UI TypeScript checks still fail on inherited unrelated debt outside this slice. Bandit was not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.8.3 - Make-WebUI-TTS-route-recoverable-and-route-owned.md
+++ b/backlog/tasks/task-418.8.3 - Make-WebUI-TTS-route-recoverable-and-route-owned.md
@@ -43,13 +43,13 @@ Execute WP11A Task 4 from the WebUI audio routes implementation plan. Make /tts 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Kept /tts routed through SpeechPlaygroundPage lockedMode=listen and tightened route-level synthesis recovery. Added readiness inputs for ElevenLabs catalog state and ffmpeg availability, labeled browser synthesis as local browser output, passed inferred server provider keys into TTS readiness, and gated Play with actionable recovery reasons for missing server audio, missing provider metadata, missing voice catalogs, ElevenLabs missing credentials/loading/timeout/error/empty catalogs. Updated focused render/helper/E2E coverage around these states without adding backend APIs or a second route surface.
+Kept /tts routed through SpeechPlaygroundPage lockedMode=listen and tightened route-level synthesis recovery. Added readiness inputs for ElevenLabs catalog state and ffmpeg availability, labeled browser synthesis as local browser output, passed inferred server provider keys into TTS readiness, and gated Play with actionable recovery reasons for missing server audio, missing provider metadata, missing voice catalogs, ElevenLabs missing credentials/loading/timeout/error/empty catalogs. PR review follow-up made ffmpeg degraded output reporting consistent for ElevenLabs and simplified the ElevenLabs empty-catalog guard without adding backend APIs or a second route surface.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed WP11A Task 4 for /tts route readiness. Focused tests passed: component suite 73/73, route contract 8/8, and TTS E2E 2 passed with 1 backend-dependent speech API test skipped. ESLint reported 0 errors with existing warnings in the large Speech page/test files. Broad frontend/UI TypeScript checks still fail on inherited unrelated debt outside this slice. Bandit was not applicable because no Python files were touched.
+Completed WP11A Task 4 for /tts route readiness and addressed PR #1885 review comments. Focused tests passed: component suite 74/74, route contract 8/8, and TTS E2E 3/3. ESLint reported 0 errors with existing warnings in the large Speech page/test files. Broad frontend/UI TypeScript checks still fail on inherited unrelated debt outside this slice. Bandit was not applicable because no Python files were touched.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Keeps `/tts` as the canonical listen-mode `SpeechPlaygroundPage` route while improving TTS readiness and recovery states.
- Adds actionable play gating for missing server audio, missing provider metadata, missing voice catalogs, and ElevenLabs key/loading/timeout/error/empty-catalog states.
- Aligns Browser TTS copy to local browser output and updates focused component/E2E coverage.

## Test Plan
- [x] `bunx vitest run ../packages/ui/src/components/Option/Audio/__tests__/audio-readiness.test.ts ../packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx ../packages/ui/src/components/Option/Speech/__tests__/TtsProviderStrip.test.tsx ../packages/ui/src/components/Option/Speech/__tests__/TtsInspectorPanel.test.tsx ../packages/ui/src/components/Option/Speech/__tests__/TtsInspectorTabs.test.tsx ../packages/ui/src/components/Option/Speech/__tests__/RenderStrip.test.tsx ../packages/ui/src/components/Option/Speech/__tests__/TtsStickyActionBar.test.tsx ../packages/ui/src/components/Option/Speech/__tests__/VoicePickerModal.test.tsx ../packages/ui/src/components/Option/TTS/__tests__/TtsPlaygroundPage.defaults.test.tsx`
- [x] `bunx vitest run ../packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx ../packages/ui/src/routes/__tests__/audio-route-jobs.test.ts`
- [x] `bunx playwright test e2e/workflows/tier-2-features/tts-synthesis.spec.ts --reporter=line`
- [x] `apps/tldw-frontend/node_modules/.bin/eslint --config apps/tldw-frontend/eslint.config.mjs <touched files>` exits 0 with existing warnings
- [x] `git diff --check origin/dev..HEAD`
- [ ] `apps/tldw-frontend/node_modules/.bin/tsc --noEmit --pretty false -p apps/tldw-frontend/tsconfig.json` remains blocked by inherited unrelated TypeScript debt

## Change summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `/tts` the canonical Text to Speech route with clear readiness and recovery so users always know why Play is disabled and how to fix it. Part of WP11A to make the TTS route recoverable and route-owned.

- **New Features**
  - Keeps `/tts` owned by `SpeechPlaygroundPage` (locked listen); renames “Browser preview” to “Browser local output”; updates the route heading to “Text to Speech”.
  - Readiness and Play gating for missing server audio, provider not reported, and missing voice catalogs; infers provider from `tldw` model for accurate messages.
  - ElevenLabs: separates saved credentials from catalog loading; handles missing key, loading, timeout/error, and empty catalog states with targeted recovery text.
  - Adds non-blocking `ffmpeg` “Output processing” degraded warning across non-browser providers.
  - Preserves typed text and generated segments; keeps voice/output/advanced tabs mounted.
  - Updates focused component tests and E2E to match the new copy, gating, and route identity.

<sup>Written for commit c90aa463da1994e741b4ba4573d5671c1d84305f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

