### PR TITLE
Migrate LlamaCpp controls product-state alerts

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1,27 +1,5 @@
 [
   {
-    "id": "antd-product-state-import:src/components/Common/Settings/LlamaCppAdvancedControls.tsx:Alert#antd-alert-llamacppadvancedcontrols-type-info-line-225-1ac43xr",
-    "path": "src/components/Common/Settings/LlamaCppAdvancedControls.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/Settings/LlamaCppAdvancedControls.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Common/Settings/LlamaCppAdvancedControls.tsx:Alert#antd-alert-llamacppadvancedcontrols-type-warning-line-23-1eql100",
-    "path": "src/components/Common/Settings/LlamaCppAdvancedControls.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/Settings/LlamaCppAdvancedControls.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Common/Workflow/steps/AnalyzeBookWorkflow.tsx:Alert#antd-alert-chunkingstep-type-warning-line-479-3p9wfj",
     "path": "src/components/Common/Workflow/steps/AnalyzeBookWorkflow.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Alert, Button, Input, InputNumber, Select, Typography } from "antd"
+import { Button, Input, InputNumber, Select, Typography } from "antd"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useStoreChatModelSettings } from "@/store/model"
 import { resolveApiProviderForModel } from "@/utils/resolve-api-provider"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
@@ -223,22 +224,21 @@ export function LlamaCppAdvancedControls({
 
         {!grammarSupported && controls?.grammar?.effective_reason ? (
           <Alert
-            type="info"
-            showIcon
+            variant="info"
             title={controls.grammar.effective_reason}
           />
         ) : null}
 
         {conflictingExtraBodyKeys.length > 0 ? (
           <Alert
-            type="warning"
-            showIcon
+            variant="warning"
             title={t(
               "sidepanel:llamaControls.extraBodyConflictTitle",
               "First-class llama.cpp controls override reserved raw extra body keys."
             )}
-            description={conflictingExtraBodyKeys.join(", ")}
-          />
+          >
+            {conflictingExtraBodyKeys.join(", ")}
+          </Alert>
         ) : null}
 
         <div className="space-y-1">

--- a/apps/packages/ui/src/components/Common/Settings/__tests__/LlamaCppAdvancedControls.test.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/__tests__/LlamaCppAdvancedControls.test.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { LlamaCppAdvancedControls } from "../LlamaCppAdvancedControls"
+
+const mocks = vi.hoisted(() => ({
+  getLlmProviders: vi.fn(),
+  listGrammars: vi.fn(),
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    getLlmProviders: mocks.getLlmProviders,
+  },
+}))
+
+vi.mock("@/services/tldw/TldwLlamaGrammars", () => ({
+  tldwLlamaGrammars: {
+    list: mocks.listGrammars,
+  },
+}))
+
+vi.mock("../LlamaGrammarLibraryModal", () => ({
+  LlamaGrammarLibraryModal: () => null,
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue || _key,
+  }),
+}))
+
+const renderControls = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LlamaCppAdvancedControls
+        resolvedProvider="llama.cpp"
+        grammarMode="none"
+        extraBody='{"grammar":"root ::= \"ok\""}'
+        onChange={vi.fn()}
+      />
+    </QueryClientProvider>
+  )
+}
+
+describe("LlamaCppAdvancedControls", () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it("renders llama.cpp notices through the canonical design-system Alert", async () => {
+    mocks.getLlmProviders.mockResolvedValue({
+      providers: {
+        "llama.cpp": {
+          llama_cpp_controls: {
+            grammar: {
+              supported: false,
+              effective_reason: "Grammar support is disabled on this server.",
+            },
+            thinking_budget: {
+              supported: true,
+            },
+            reserved_extra_body_keys: ["grammar", "grammar_file"],
+          },
+        },
+      },
+    })
+    mocks.listGrammars.mockResolvedValue({ items: [] })
+
+    const { container } = renderControls()
+
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('[data-ds-component="Alert"]')
+      ).toHaveLength(2)
+    })
+
+    expect(
+      screen.getByText("Grammar support is disabled on this server.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "First-class llama.cpp controls override reserved raw extra body keys."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText("grammar")).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-453 - Migrate-LlamaCppAdvancedControls-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-453 - Migrate-LlamaCppAdvancedControls-alerts-to-design-system-Alert.md
@@ -1,0 +1,68 @@
+---
+id: TASK-453
+title: Migrate LlamaCppAdvancedControls alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-20 04:55
+labels:
+- design-system
+- product-state
+- ui
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/pull/1886
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the llama.cpp advanced controls grammar-support and extra-body-conflict notices from AntD Alert to the canonical design-system Alert while preserving message content and removing the matching baseline exceptions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 LlamaCppAdvancedControls renders grammar support and extra body conflict notices through the canonical design-system Alert primitive.
+- [x] #2 Existing notice title/message content is preserved for grammar unsupported and reserved extra body key conflict states.
+- [x] #3 The two LlamaCppAdvancedControls Alert baseline exceptions are removed without introducing new blocked product-state findings.
+- [x] #4 Focused tests and design-system product-state verification pass, with known TypeScript/Bandit skips recorded if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented test-first: the LlamaCppAdvancedControls regression renders mocked llama.cpp provider metadata and failed on zero canonical Alert markers before replacing the AntD Alerts.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated LlamaCppAdvancedControls grammar-support and raw extra-body conflict notices from AntD Alert to the canonical design-system Alert. Added focused coverage for both notices and removed the two matching baseline entries, reducing product-state baseline exceptions from 330 to 328.
+
+PR review follow-up:
+- Removed the no-longer-needed DesignSystemAlert alias after AntD Alert was removed from the file and rendered the canonical primitive as Alert directly.
+
+Verification:
+- RED: bunx vitest run src/components/Common/Settings/__tests__/LlamaCppAdvancedControls.test.tsx --reporter=dot failed on zero data-ds-component="Alert" markers.
+- GREEN: bunx vitest run src/components/Common/Settings/__tests__/LlamaCppAdvancedControls.test.tsx --reporter=dot passed.
+- REVIEW FIX: bunx vitest run src/components/Common/Settings/__tests__/LlamaCppAdvancedControls.test.tsx --reporter=dot passed after the alias cleanup.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 328.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for LlamaCppAdvancedControls/task-453/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates LlamaCppAdvancedControls grammar-support and extra-body conflict notices from AntD Alert to the canonical design-system Alert.
- Adds focused coverage for both notice paths using mocked llama.cpp provider metadata.
- Removes the two LlamaCppAdvancedControls product-state baseline exceptions, reducing baseline exceptions from 330 to 328.

## Verification
- RED: `bunx vitest run src/components/Common/Settings/__tests__/LlamaCppAdvancedControls.test.tsx --reporter=dot` failed on zero `data-ds-component="Alert"` markers.
- GREEN: `bunx vitest run src/components/Common/Settings/__tests__/LlamaCppAdvancedControls.test.tsx --reporter=dot` passed: 1 test.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 52 tests.
- `bun run verify:design-system-state` passed; baseline exceptions are now 328.
- `git diff --check` passed.
- Full `bunx tsc --noEmit --pretty false` still exits 2 from inherited baseline debt; filtered touched-file diagnostics for LlamaCppAdvancedControls/task-453/baseline matched 0 lines.
- Bandit skipped: TypeScript UI/test, JSON baseline, and task metadata only; no Python touched.

## Change summary
TODO (human-authored before merge): summarize what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated llama.cpp advanced controls notices from `antd` `Alert` to the design-system `Alert`, added focused tests, and removed two product-state baseline exceptions (330 → 328). This unifies the UI and cleans up legacy state.

- **Refactors**
  - Replaced `antd` `Alert` with `Alert` from `@/components/ui/primitives` for grammar unsupported and extra-body conflict notices.
  - Preserved titles; moved conflict keys to children; mapped `type` → `variant` (`info`, `warning`).
  - Added tests checking `[data-ds-component="Alert"]` markers and notice content with mocked provider metadata.
  - Removed two LlamaCppAdvancedControls baseline exceptions; baseline now 328.

<sup>Written for commit 481750072ebdb5adae95b4a1b5812fe888097dcf. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1886?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

