### PR TITLE
Migrate QuickSaveWorkflow product-state alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -33,17 +33,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Common/Workflow/steps/QuickSaveWorkflow.tsx:Alert",
-    "path": "src/components/Common/Workflow/steps/QuickSaveWorkflow.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/Workflow/steps/QuickSaveWorkflow.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Common/Workflow/steps/SummarizePageWorkflow.tsx:Alert",
     "path": "src/components/Common/Workflow/steps/SummarizePageWorkflow.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx
@@ -1,0 +1,110 @@
+import React from "react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useWorkflowsStore } from "@/store/workflows"
+import { QuickSaveWorkflow } from "../steps/QuickSaveWorkflow"
+
+const mocks = vi.hoisted(() => ({
+  t: vi.fn(
+    (
+      _key: string,
+      fallbackOrOptions?: string | { defaultValue?: string },
+      values?: Record<string, string | number | undefined>
+    ) => {
+      const template =
+        typeof fallbackOrOptions === "string"
+          ? fallbackOrOptions
+          : fallbackOrOptions?.defaultValue || _key
+      if (!values) return template
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, token: string) => {
+        const value = values[token]
+        return value === undefined ? `{{${token}}}` : String(value)
+      })
+    }
+  ),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: mocks.t,
+  }),
+}))
+
+describe("QuickSaveWorkflow product-state UI", () => {
+  beforeEach(() => {
+    vi.stubGlobal("chrome", {
+      tabs: {
+        query: vi.fn().mockResolvedValue([
+          {
+            id: 42,
+            title: "Example Article",
+            url: "https://example.test/article",
+          },
+        ]),
+      },
+      scripting: {
+        executeScript: vi.fn().mockResolvedValue([
+          {
+            result: {
+              type: "selection",
+              content:
+                "Selected article text that is long enough to be captured by quick save.",
+            },
+          },
+        ]),
+      },
+      runtime: {
+        getURL: vi.fn((path: string) => `chrome-extension://tldw/${path}`),
+      },
+    })
+
+    useWorkflowsStore.setState({
+      activeWorkflow: {
+        id: "wf-quick-save-test",
+        workflowId: "quick-save",
+        status: "active",
+        currentStepIndex: 0,
+        startedAt: 1,
+        data: {},
+      },
+      isWizardOpen: true,
+      isProcessing: false,
+      processingProgress: 0,
+      processingMessage: "",
+      error: null,
+    })
+    mocks.t.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    useWorkflowsStore.setState({
+      activeWorkflow: null,
+      isWizardOpen: false,
+      isProcessing: false,
+      processingProgress: 0,
+      processingMessage: "",
+      error: null,
+    })
+    vi.clearAllMocks()
+  })
+
+  it("renders captured content success through the canonical design-system Alert", async () => {
+    const { container } = render(<QuickSaveWorkflow />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Selection captured")).toBeInTheDocument()
+    })
+
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+    expect(
+      screen.getByText("Example Article").closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(screen.getByText("https://example.test/article")).toBeInTheDocument()
+    expect(
+      screen.getByText(/Selected article text that is long enough/)
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx
@@ -33,6 +33,16 @@ vi.mock("react-i18next", () => ({
 
 describe("QuickSaveWorkflow product-state UI", () => {
   beforeEach(() => {
+    const realSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      (...args: Parameters<typeof setTimeout>) => {
+        if (args[1] === 500) {
+          return 0 as unknown as ReturnType<typeof setTimeout>
+        }
+        return realSetTimeout(...args)
+      }
+    )
+
     vi.stubGlobal("chrome", {
       tabs: {
         query: vi.fn().mockResolvedValue([
@@ -80,6 +90,7 @@ describe("QuickSaveWorkflow product-state UI", () => {
   afterEach(() => {
     cleanup()
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
     useWorkflowsStore.setState({
       activeWorkflow: null,
       isWizardOpen: false,

--- a/apps/packages/ui/src/components/Common/Workflow/steps/QuickSaveWorkflow.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/steps/QuickSaveWorkflow.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect, useRef } from "react"
-import { Input, Button, Select, Tag, Alert, Spin, message } from "antd"
+import { Input, Button, Select, Tag, Spin, message } from "antd"
 import { Save, CheckCircle, FolderOpen, Tag as TagIcon, Globe } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useWorkflowsStore } from "@/store/workflows"
 import { WizardShell } from "../WizardShell"
 import { QUICK_SAVE_WORKFLOW } from "../workflow-definitions"
@@ -191,24 +192,21 @@ const CaptureStep: React.FC = () => {
     return (
       <div className="space-y-4">
         <Alert
-          type="success"
-          showIcon
-          icon={<CheckCircle className="h-4 w-4" />}
+          variant="success"
           title={
             capturedContent.type === "selection"
               ? t("workflows:quickSave.selectionCaptured", "Selection captured")
               : t("workflows:quickSave.pageCaptured", "Page captured")
           }
-          description={
-            <div className="mt-2">
-              <p className="font-medium">{capturedContent.title}</p>
-              <p className="text-xs text-text-muted flex items-center gap-1 mt-1">
-                <Globe className="h-3 w-3" />
-                {capturedContent.url}
-              </p>
-            </div>
-          }
-        />
+        >
+          <div className="mt-2">
+            <p className="font-medium">{capturedContent.title}</p>
+            <p className="text-xs text-text-muted flex items-center gap-1 mt-1">
+              <Globe className="h-3 w-3" />
+              {capturedContent.url}
+            </p>
+          </div>
+        </Alert>
         <div className="bg-surface rounded-lg p-3">
           <p className="text-sm text-text-muted line-clamp-4">
             {capturedContent.content.slice(0, 300)}

--- a/backlog/tasks/task-454 - Migrate-QuickSaveWorkflow-capture-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-454 - Migrate-QuickSaveWorkflow-capture-alert-to-design-system-Alert.md
@@ -4,7 +4,7 @@ title: Migrate QuickSaveWorkflow capture alert to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-20 06:43'
+updated_date: '2026-05-20 14:46'
 labels:
   - design-system
   - product-state
@@ -46,6 +46,20 @@ Verification recorded for this slice:
 - git diff --check passed.
 - Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for QuickSaveWorkflow/task-454/baseline matched 0 lines.
 - Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+
+Review follow-up for PR #1889:
+- Removed the duplicate final-summary end marker reported by Gemini, CodeRabbit, and cubic; marker-count verification now reports exactly one closing marker.
+- Stabilized the QuickSaveWorkflow product-state test by intercepting only the 500ms auto-advance timeout, leaving other timers available for React Testing Library polling.
+
+Review-fix verification:
+- bunx vitest run src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot passed: 1 test.
+- bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot passed: 2 files, 2 tests.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions remain 327.
+- git diff --check passed.
+- Final-summary marker-count check passed with exactly one closing marker.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for QuickSaveWorkflow/task-454/baseline matched 0 lines.
+- Bandit skipped because the review fixes touch TypeScript test code and Backlog metadata only; no Python code touched.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -62,8 +76,6 @@ Verification:
 - git diff --check passed.
 - Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for QuickSaveWorkflow/task-454/baseline matched 0 lines.
 - Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-454 - Migrate-QuickSaveWorkflow-capture-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-454 - Migrate-QuickSaveWorkflow-capture-alert-to-design-system-Alert.md
@@ -1,0 +1,77 @@
+---
+id: TASK-454
+title: Migrate QuickSaveWorkflow capture alert to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-20 06:43'
+labels:
+  - design-system
+  - product-state
+  - ui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1889'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the QuickSaveWorkflow captured-content success notice from AntD Alert to the canonical design-system Alert while preserving title, captured page metadata, and preview behavior. Remove the matching baseline exception and verify the guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 QuickSaveWorkflow renders the capture success notice through the canonical design-system Alert primitive.
+- [x] #2 The captured selection/page title, URL, and success title content remain visible after migration.
+- [x] #3 The QuickSaveWorkflow Alert baseline exception is removed without introducing new blocked product-state findings.
+- [x] #4 Focused tests and design-system product-state verification pass, with known TypeScript/Bandit skips recorded if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented test-first: the QuickSaveWorkflow regression drives the mocked Chrome capture path and failed on the missing canonical Alert marker before replacing the AntD Alert.
+
+Verification recorded for this slice:
+- RED: bunx vitest run src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot failed on zero data-ds-component="Alert" markers before the implementation.
+- GREEN: bunx vitest run src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot passed: 1 test.
+- bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot passed: 2 files, 2 tests.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 327.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for QuickSaveWorkflow/task-454/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated QuickSaveWorkflow captured-content success notice from AntD Alert to the canonical design-system Alert. Added focused coverage for the mocked Chrome capture path and removed the QuickSaveWorkflow baseline entry, reducing product-state baseline exceptions from 328 to 327.
+
+Verification:
+- RED: bunx vitest run src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot failed on zero data-ds-component="Alert" markers.
+- GREEN: bunx vitest run src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot passed: 1 test.
+- bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot passed: 2 files, 2 tests.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 327.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for QuickSaveWorkflow/task-454/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates QuickSaveWorkflow captured-content success notice from AntD Alert to the canonical design-system Alert.
- Adds focused coverage for the mocked Chrome capture path and preserved title/URL/preview content.
- Removes the QuickSaveWorkflow product-state baseline exception, reducing baseline exceptions from 328 to 327.

## Verification
- RED: `bunx vitest run src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot` failed on zero `data-ds-component="Alert"` markers.
- GREEN: `bunx vitest run src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot` passed: 1 test.
- `bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx src/components/Common/Workflow/__tests__/QuickSaveWorkflow.product-state.test.tsx --reporter=dot` passed: 2 files, 2 tests.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 52 tests.
- `bun run verify:design-system-state` passed; baseline exceptions are now 327.
- `git diff --check` passed.
- Full `bunx tsc --noEmit --pretty false` still exits 2 from inherited baseline debt; filtered touched-file diagnostics for QuickSaveWorkflow/task-454/baseline matched 0 lines.
- Bandit skipped: TypeScript UI/test, JSON baseline, and task metadata only; no Python touched.

## Change summary
TODO (human-authored before merge): summarize what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated QuickSaveWorkflow captured-content success notice from `antd` Alert to the design-system `Alert` to standardize product-state UI and preserve title, URL, and preview. Addresses Linear TASK-454 and stabilizes the product-state test for the mocked Chrome capture path.

- **Refactors**
  - Set `variant="success"` with title; render details as children in the design-system `Alert`.
  - Removed the QuickSaveWorkflow product-state baseline exception (328 -> 327) and limited timer mocking to the 500ms auto-advance to prevent test flakiness.

<sup>Written for commit 1254f4c5e5fc5406940aaa5b932afe45eb2ef92c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1889?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

