### PR TITLE
Make audio route browser coverage capability-aware

### DIFF
--- a/apps/packages/ui/src/components/Option/Audio/__tests__/audio-error-classification.test.ts
+++ b/apps/packages/ui/src/components/Option/Audio/__tests__/audio-error-classification.test.ts
@@ -33,6 +33,16 @@ describe("audio error classification", () => {
     expect(result.recovery).toContain("browser permission")
   })
 
+  it("preserves audio capture busy owner guidance", () => {
+    const result = classifyAudioError(
+      new Error("Audio capture is already active for live_voice")
+    )
+
+    expect(result.category).toBe("capture_busy")
+    expect(result.title).toBe("Audio capture is already active")
+    expect(result.recovery).toBe("Audio capture is already active for live_voice")
+  })
+
   it("maps network and timeout errors separately", () => {
     expect(classifyAudioError(new Error("Failed to fetch")).category).toBe("network")
     expect(classifyAudioError(new Error("request timed out")).category).toBe("timeout")

--- a/apps/packages/ui/src/components/Option/Audio/__tests__/audio-error-classification.test.ts
+++ b/apps/packages/ui/src/components/Option/Audio/__tests__/audio-error-classification.test.ts
@@ -40,7 +40,9 @@ describe("audio error classification", () => {
 
     expect(result.category).toBe("capture_busy")
     expect(result.title).toBe("Audio capture is already active")
-    expect(result.recovery).toBe("Audio capture is already active for live_voice")
+    expect(result.recovery).toBe(
+      "Stop the active capture session in live_voice and try again."
+    )
   })
 
   it("maps network and timeout errors separately", () => {

--- a/apps/packages/ui/src/components/Option/Audio/audio-error-classification.ts
+++ b/apps/packages/ui/src/components/Option/Audio/audio-error-classification.ts
@@ -4,6 +4,7 @@ export type AudioErrorCategory =
   | "engine_unavailable"
   | "unsupported_capability"
   | "microphone_blocked"
+  | "capture_busy"
   | "network"
   | "timeout"
   | "unknown"
@@ -67,6 +68,18 @@ export function classifyAudioError(error: unknown): AudioErrorClassification {
       category: "microphone_blocked",
       title: "Microphone access is blocked",
       recovery: "Allow microphone access in your browser permission settings, then try recording again.",
+      debugMessage
+    }
+  }
+
+  const captureBusyMatch = rawMessage.match(
+    /audio capture is already active for ([\w:-]+)/i
+  )
+  if (captureBusyMatch) {
+    return {
+      category: "capture_busy",
+      title: "Audio capture is already active",
+      recovery: `Audio capture is already active for ${captureBusyMatch[1]}`,
       debugMessage
     }
   }

--- a/apps/packages/ui/src/components/Option/Audio/audio-error-classification.ts
+++ b/apps/packages/ui/src/components/Option/Audio/audio-error-classification.ts
@@ -79,7 +79,7 @@ export function classifyAudioError(error: unknown): AudioErrorClassification {
     return {
       category: "capture_busy",
       title: "Audio capture is already active",
-      recovery: `Audio capture is already active for ${captureBusyMatch[1]}`,
+      recovery: `Stop the active capture session in ${captureBusyMatch[1]} and try again.`,
       debugMessage
     }
   }

--- a/apps/packages/ui/src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx
+++ b/apps/packages/ui/src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx
@@ -403,14 +403,13 @@ export const AudiobookStudioPage: React.FC = () => {
       <span
         role="status"
         aria-live="polite"
-        aria-label={t(
-          "audiobook:saveStatus.ariaLabel",
-          "Project save status"
-        )}
         className={`mb-3 block text-sm ${
           saveStatusType === "warning" ? "text-warning" : "text-text-subtle"
         }`}
       >
+        <span className="sr-only">
+          {t("audiobook:saveStatus.ariaLabel", "Project save status")}:{" "}
+        </span>
         {saveStatusLabel}
       </span>
 

--- a/apps/packages/ui/src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx
+++ b/apps/packages/ui/src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx
@@ -400,17 +400,19 @@ export const AudiobookStudioPage: React.FC = () => {
         </Space>
       </div>
 
-      <Text
+      <span
         role="status"
+        aria-live="polite"
         aria-label={t(
           "audiobook:saveStatus.ariaLabel",
           "Project save status"
         )}
-        className="mb-3 block text-sm"
-        type={saveStatusType}
+        className={`mb-3 block text-sm ${
+          saveStatusType === "warning" ? "text-warning" : "text-text-subtle"
+        }`}
       >
         {saveStatusLabel}
-      </Text>
+      </span>
 
       <DismissibleBetaAlert
         storageKey="beta-dismissed:audiobookStudio"

--- a/apps/packages/ui/src/components/Option/AudiobookStudio/__tests__/AudiobookStudioPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/AudiobookStudio/__tests__/AudiobookStudioPage.test.tsx
@@ -141,9 +141,7 @@ describe("AudiobookStudioPage", () => {
     expect(screen.getByRole("button", { name: "New" })).toBeVisible()
     expect(screen.getByDisplayValue("Untitled Audiobook")).toBeVisible()
 
-    expect(
-      screen.getByRole("status", { name: "Project save status" })
-    ).toHaveTextContent("Draft not saved")
+    expect(screen.getByRole("status")).toHaveTextContent("Draft not saved")
     expect(
       screen.getByRole("button", { name: "Save project" })
     ).toBeVisible()
@@ -204,9 +202,7 @@ describe("AudiobookStudioPage", () => {
 
     render(<AudiobookStudioPage />)
 
-    const saveStatus = screen.getByRole("status", {
-      name: "Project save status"
-    })
+    const saveStatus = screen.getByRole("status")
 
     await waitFor(() => expect(saveStatus).toHaveTextContent("Unsaved changes"))
 
@@ -226,9 +222,7 @@ describe("AudiobookStudioPage", () => {
 
     render(<AudiobookStudioPage />)
 
-    const saveStatus = screen.getByRole("status", {
-      name: "Project save status"
-    })
+    const saveStatus = screen.getByRole("status")
 
     await waitFor(() => expect(saveStatus).toHaveTextContent("Unsaved changes"))
     await user.click(screen.getByRole("button", { name: "Save project" }))
@@ -255,9 +249,7 @@ describe("AudiobookStudioPage", () => {
 
     render(<AudiobookStudioPage />)
 
-    const saveStatus = screen.getByRole("status", {
-      name: "Project save status"
-    })
+    const saveStatus = screen.getByRole("status")
 
     await waitFor(() => expect(saveStatus).toHaveTextContent("Unsaved changes"))
     await user.click(screen.getByRole("button", { name: "Save project" }))
@@ -267,7 +259,7 @@ describe("AudiobookStudioPage", () => {
       vi.advanceTimersByTime(60000)
     })
 
-    await waitFor(() => expect(saveStatus).toHaveTextContent(/^Saved$/))
+    await waitFor(() => expect(saveStatus).toHaveTextContent(/Saved$/))
   })
 })
 

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.audio-source.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.audio-source.test.tsx
@@ -492,7 +492,9 @@ describe("SpeechPlaygroundPage audio source", () => {
     expect(mockGetUserMedia).not.toHaveBeenCalled()
     await waitFor(() => {
       expect(
-        screen.getAllByText("Audio capture is already active for live_voice").length
+        screen.getAllByText(
+          "Stop the active capture session in live_voice and try again."
+        ).length
       ).toBeGreaterThanOrEqual(1)
     })
   })

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.audio-source.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.audio-source.test.tsx
@@ -176,6 +176,10 @@ vi.mock("@/components/Option/Speech/RenderStrip", () => ({
   RenderStrip: () => <div data-testid="render-strip" />
 }))
 
+vi.mock("@/components/Option/Audio/AudioPresetControls", () => ({
+  AudioPresetControls: () => <div data-testid="audio-preset-controls" />
+}))
+
 vi.mock("@/components/Option/Speech/VoicePickerModal", () => ({
   VoicePickerModal: () => <div data-testid="voice-picker-modal" />
 }))

--- a/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
@@ -55,11 +55,65 @@ const stubDocsInfo = async (page: Page) => {
 }
 
 const stubAudioSmokeBootstrapApis = async (page: Page) => {
+  await stubDocsInfo(page)
   await stubNotificationsApi(page)
+  await page.route("**/openapi.json", async (route) => {
+    await fulfillJson(route, 200, {
+      openapi: "3.0.0",
+      info: { title: "tldw e2e", version: "e2e" },
+      paths: {}
+    })
+  })
+  await page.route("**/api/v1/audio/providers**", async (route) => {
+    await fulfillJson(route, 200, {
+      providers: {
+        browser: {
+          provider_name: "browser",
+          formats: ["mp3"],
+          default_format: "mp3"
+        }
+      },
+      voices: {
+        browser: [{ id: "browser-default", name: "Browser default" }]
+      }
+    })
+  })
   await page.route("**/api/v1/audio/voices**", async (route) => {
     await fulfillJson(route, 200, {
       voices: [{ id: "af_heart", name: "AF Heart", provider: "kokoro" }]
     })
+  })
+  await page.route("**/api/v1/audio/transcriptions/capabilities**", async (route) => {
+    await fulfillJson(route, 200, {
+      formats: ["audio/webm"],
+      engines: ["whisper"],
+      limits: {}
+    })
+  })
+  await page.route("**/api/v1/audio/transcriptions/health**", async (route) => {
+    await fulfillJson(route, 200, {
+      status: "ok",
+      model: "whisper-1"
+    })
+  })
+  await page.route("**/api/v1/media/transcription-models**", async (route) => {
+    await fulfillJson(route, 200, {
+      all_models: ["whisper-1"]
+    })
+  })
+  await page.route("**/api/v1/audio/presets**", async (route) => {
+    await fulfillJson(route, 200, {
+      items: [],
+      total: 0
+    })
+  })
+  await page.route("**/api/v1/ingestion-sources/capabilities**", async (route) => {
+    await fulfillJson(route, 200, {
+      capabilities: {}
+    })
+  })
+  await page.route("**/api/v1/persona/profiles**", async (route) => {
+    await fulfillJson(route, 200, [])
   })
 }
 
@@ -239,7 +293,7 @@ test.describe("Stage 7 audio regression gate", () => {
 
     await page.goto("/tts", { waitUntil: "domcontentloaded", timeout: LOAD_TIMEOUT })
 
-    const timeoutAlert = page.locator(".ant-alert").filter({
+    const timeoutAlert = page.getByRole("alert").filter({
       hasText: /ElevenLabs voices unavailable/i
     })
     await expect(timeoutAlert).toBeVisible({ timeout: LOAD_TIMEOUT })
@@ -313,7 +367,7 @@ test.describe("Stage 7 audio regression gate", () => {
 
     await page.goto("/speech", { waitUntil: "domcontentloaded", timeout: LOAD_TIMEOUT })
 
-    const timeoutAlert = page.locator(".ant-alert").filter({
+    const timeoutAlert = page.getByRole("alert").filter({
       hasText: /ElevenLabs voices unavailable/i
     })
     await expect(timeoutAlert).toBeVisible({ timeout: LOAD_TIMEOUT })

--- a/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
@@ -61,7 +61,17 @@ const stubAudioSmokeBootstrapApis = async (page: Page) => {
     await fulfillJson(route, 200, {
       openapi: "3.0.0",
       info: { title: "tldw e2e", version: "e2e" },
-      paths: {}
+      paths: {
+        "/api/v1/audio/transcriptions": {},
+        "/api/v1/audio/transcriptions/health": {},
+        "/api/v1/audio/stream/transcribe": {},
+        "/api/v1/audio/chat/stream": {},
+        "/api/v1/audio/speech": {},
+        "/api/v1/audio/health": {},
+        "/api/v1/audio/voices/catalog": {},
+        "/api/v1/ingestion-sources": {},
+        "/api/v1/ingestion-sources/capabilities": {}
+      }
     })
   })
   await page.route("**/api/v1/audio/providers**", async (route) => {

--- a/apps/tldw-frontend/e2e/utils/page-objects/AudiobookStudioPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/AudiobookStudioPage.ts
@@ -55,7 +55,7 @@ export class AudiobookStudioPage extends BasePage {
   }
 
   get saveButton(): Locator {
-    return this.page.getByRole("button", { name: /save project/i })
+    return this.page.getByRole("button", { name: /^save(?: project)?$/i })
   }
 
   get saveStatus(): Locator {

--- a/apps/tldw-frontend/e2e/utils/page-objects/AudiobookStudioPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/AudiobookStudioPage.ts
@@ -59,7 +59,7 @@ export class AudiobookStudioPage extends BasePage {
   }
 
   get saveStatus(): Locator {
-    return this.page.getByRole("status", { name: /project save status/i })
+    return this.page.getByRole("status")
   }
 
   get projectTitleInput(): Locator {

--- a/backlog/tasks/task-418.8.5 - Verify-WebUI-audio-routes-across-browser-tests-and-responsive-states.md
+++ b/backlog/tasks/task-418.8.5 - Verify-WebUI-audio-routes-across-browser-tests-and-responsive-states.md
@@ -1,0 +1,77 @@
+---
+id: TASK-418.8.5
+title: Verify WebUI audio routes across browser tests and responsive states
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-20 06:43
+labels:
+- ux
+- webui
+- extension
+- audio
+- verification
+dependencies: []
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-audio-routes-implementation-plan.md
+parent_task_id: TASK-418.8
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/1890
+modified_files:
+- apps/packages/ui/src/components/Option/Audio/__tests__/audio-error-classification.test.ts
+- apps/packages/ui/src/components/Option/Audio/audio-error-classification.ts
+- apps/packages/ui/src/components/Option/AudiobookStudio/AudiobookStudioPage.tsx
+- apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.audio-source.test.tsx
+- apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
+- apps/tldw-frontend/e2e/utils/page-objects/AudiobookStudioPage.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP11A Task 6 from the WebUI audio routes implementation plan. Verify /audio, /speech, /stt, /tts, and /audiobook-studio across route tests, focused component tests, Playwright workflows, and responsive browser observations; add only scoped verification assertions or minimal route-local fixes needed by observed failures, without backend API changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-17-webui-audio-routes-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verified the root audio route group after PR #1887 merged. Added hermetic audio smoke stubs so browser tests cover /audio, /speech, /stt, /tts, and /audiobook-studio without background bootstrap noise; fixed the Audiobook Studio save-status live region so Playwright can observe the project save state; aligned the Audiobook Studio page object with the accessible Save button label; and added capture-busy audio error classification coverage preserving the active capture owner.
+
+Verification recorded:
+- PASS: bunx vitest run ../packages/ui/src/components/Option/Speech/__tests__ ../packages/ui/src/components/Option/STT/__tests__ ../packages/ui/src/components/Option/TTS/__tests__ ../packages/ui/src/components/Option/AudiobookStudio/__tests__ ../packages/ui/src/components/Option/Audio/__tests__/audio-error-classification.test.ts (18 files, 121 tests; rerun after rebase)
+- PASS: bunx vitest run ../packages/ui/src/routes/__tests__/audio-route-jobs.test.ts ../packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx ../packages/ui/src/routes/__tests__/option-audio-hosted-message.test.tsx ../packages/ui/src/routes/__tests__/option-route-visibility.test.ts (4 files, 13 tests; rerun after rebase)
+- PASS: git diff --check HEAD~1..HEAD
+- PASS: TLDW_WEB_URL=http://localhost:18085 TLDW_WEB_CMD='bun run dev -- -p 18085' bunx playwright test e2e/smoke/stage7-audio-regression.spec.ts --reporter=line --workers=1 (6 passed)
+- PASS: TLDW_WEB_URL=http://localhost:18087 TLDW_WEB_CMD='bun run dev -- -p 18087' bunx playwright test e2e/smoke/stage7-audio-regression.spec.ts e2e/workflows/tier-2-features/speech-playground.spec.ts e2e/workflows/tier-2-features/stt-transcription.spec.ts e2e/workflows/tier-2-features/tts-synthesis.spec.ts e2e/workflows/tier-2-features/audiobook-studio.spec.ts --reporter=line --workers=1 (17 passed, 3 skipped; rerun after rebase)
+- PARTIAL: bunx tsc --noEmit --pretty false still fails on existing unrelated TypeScript debt outside this slice: MediaReadAlongPopover, Evaluations EmbeddingsModelSelectionConfig, WorkspacePlayground StudioPane, keyboard shortcut config, and tier-4 llama.cpp admin tests.
+- SKIP: Bandit is not applicable because this slice only changes frontend TypeScript/Playwright files and a Backlog task record.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.8.5.1 - Address-PR-1890-audio-route-review-comments.md
+++ b/backlog/tasks/task-418.8.5.1 - Address-PR-1890-audio-route-review-comments.md
@@ -1,0 +1,56 @@
+---
+id: TASK-418.8.5.1
+title: Address PR 1890 audio route review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-20 15:07'
+labels:
+  - ux
+  - webui
+  - extension
+  - audio
+  - review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1890'
+  - 'https://github.com/rmusser01/tldw_server/pull/1890#discussion_r3271830587'
+  - 'https://github.com/rmusser01/tldw_server/pull/1890#discussion_r3271830591'
+  - 'https://github.com/rmusser01/tldw_server/pull/1890#discussion_r3271909500'
+parent_task_id: TASK-418.8.5
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the actionable review threads on PR #1890. Scope is limited to the Gemini accessibility/copy findings and the Qodo OpenAPI smoke-stub reliability finding, plus focused verification and PR thread resolution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all actionable review threads on PR #1890: replaced the Audiobook Studio save-status aria-label with a visually hidden prefix, made capture_busy recovery copy actionable, updated affected unit/page-object assertions, and added minimal truthy OpenAPI paths to the Stage 7 audio smoke stub so capability-gated audio bootstrap paths are exercised. Verification: focused audio component Vitest suite passed (18 files, 121 tests); audio route Vitest suite passed (4 files, 13 tests); Playwright audio smoke plus tier-2 workflow sweep passed (20 tests) after running the local Next server with elevated permissions because sandboxed server startup hit EPERM; git diff --check passed. Local package-wide `bunx tsc --noEmit --pretty false` still fails only in unrelated baseline files outside this PR's touched scope. GitHub Full Suite failures were inspected and are backend/PostgreSQL/Audit issues outside this frontend review patch.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Makes the Stage 7 audio smoke gate hermetic by stubbing the background bootstrap APIs used by /audio, /speech, /stt, /tts, and /audiobook-studio.
- Restores an observable Audiobook Studio project save status live region and aligns the page object with the accessible Save button label.
- Adds regression coverage for audio capture-busy error classification so the active capture owner remains visible.
- Adds Backlog task TASK-418.8.5 with the verification record.

## Verification
- PASS: bunx vitest run ../packages/ui/src/components/Option/Speech/__tests__ ../packages/ui/src/components/Option/STT/__tests__ ../packages/ui/src/components/Option/TTS/__tests__ ../packages/ui/src/components/Option/AudiobookStudio/__tests__ ../packages/ui/src/components/Option/Audio/__tests__/audio-error-classification.test.ts (18 files, 121 tests)
- PASS: bunx vitest run ../packages/ui/src/routes/__tests__/audio-route-jobs.test.ts ../packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx ../packages/ui/src/routes/__tests__/option-audio-hosted-message.test.tsx ../packages/ui/src/routes/__tests__/option-route-visibility.test.ts (4 files, 13 tests)
- PASS: git diff --check HEAD~1..HEAD
- PASS: TLDW_WEB_URL=http://localhost:18087 TLDW_WEB_CMD="bun run dev -- -p 18087" bunx playwright test e2e/smoke/stage7-audio-regression.spec.ts e2e/workflows/tier-2-features/speech-playground.spec.ts e2e/workflows/tier-2-features/stt-transcription.spec.ts e2e/workflows/tier-2-features/tts-synthesis.spec.ts e2e/workflows/tier-2-features/audiobook-studio.spec.ts --reporter=line --workers=1 (17 passed, 3 skipped)
- PARTIAL: bunx tsc --noEmit --pretty false still fails on inherited unrelated TypeScript debt in MediaReadAlongPopover, Evaluations EmbeddingsModelSelectionConfig, WorkspacePlayground StudioPane, keyboard shortcut config, and tier-4 llama.cpp admin tests.
- SKIP: Bandit is not applicable; this slice only changes frontend TypeScript/Playwright files plus a Backlog task record.

## Change summary
Maintainer to fill in before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hermeticates Stage 7 audio-route browser tests by stubbing bootstrap APIs and asserting by role across /audio, /speech, /stt, /tts, and /audiobook-studio. Improves Audiobook Studio save-status accessibility and preserves capture-busy guidance; supports TASK-418.8.5 and TASK-418.8.5.1.

- **New Features**
  - Expanded `playwright` stubs for `openapi.json`, audio providers/voices, transcription capabilities/health, media models, presets, ingestion sources, and persona profiles.
  - Switched e2e alerts to role-based assertions.
  - Isolated Speech tests by mocking `AudioPresetControls`.

- **Bug Fixes**
  - Audiobook Studio: replaced save-status aria-label with a visually hidden prefix while keeping role=status and aria-live=polite.
  - Page object: Save button matcher now matches “Save” or “Save project”.
  - Audio errors: added `capture_busy` classification with owner-preserving, actionable recovery text and `vitest` coverage.

<sup>Written for commit ed95ed5efd932d8bab9c5b75290b159fc7fcbd46. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1890?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

