### PR TITLE
Harden Character Chat Phase 6 signoff

### DIFF
--- a/Docs/superpowers/plans/2026-05-20-character-chat-phase6-accessibility-mobile-backend-signoff-plan.md
+++ b/Docs/superpowers/plans/2026-05-20-character-chat-phase6-accessibility-mobile-backend-signoff-plan.md
@@ -1,0 +1,41 @@
+# Character Chat Phase 6 Accessibility, Mobile, And Backend Signoff Plan
+
+## Stage 1: Current-State Gate And Targeted Contracts
+**Goal**: Freeze the current Phase 6 release gates against the latest `origin/dev` after PR #1888.
+**Success Criteria**: `TASK-454` links this plan, the Character Chat DB health release dependency is recorded as resolved through `TASK-429`, and current focused tests identify any missing accessibility/mobile signoff contracts before production edits.
+**Tests**:
+- `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx --config vitest.config.ts`
+**Status**: Complete
+
+## Stage 2: Accessibility Contract Hardening
+**Goal**: Make the primary Character Chat mode surfaces easier to verify and operate by keyboard and screen reader.
+**Success Criteria**: Character Chat sessions, setup, saved setups, readiness/status, and composer role-play controls expose stable region labels, alert/status semantics, focus return behavior, and accessible names for destructive or state-changing actions.
+**Tests**:
+- Add or extend focused React Testing Library tests for `CharacterChatSessionsPanel`, `RolePlaySetupDrawer`, `SavedRolePlaySetupsPanel`, and the Character Chat mode shell.
+- Verify no broad component rewrites or parallel state systems are introduced.
+**Status**: Complete
+
+## Stage 3: Responsive And Mobile Signoff
+**Goal**: Prove `/chat` Character Chat mode remains usable at narrow, tablet, and desktop widths.
+**Success Criteria**: A Playwright signoff spec visits `/chat?mode=character` at 390px, 768px, and desktop, verifies no horizontal overflow, and checks that Character Chat setup, sessions, and composer recovery actions remain reachable.
+**Tests**:
+- Add `apps/tldw-frontend/e2e/workflows/journeys/character-chat-phase6.spec.ts`.
+- Reuse the existing route-overflow helper pattern from `setup-connection-flow.spec.ts`.
+**Status**: Complete
+
+## Stage 4: Real Backend Character Chat Signoff
+**Goal**: Ensure Phase 6 signoff uses the real FastAPI backend and real frontend path instead of frontend-only simulation.
+**Success Criteria**: The existing `character-chat.spec.ts` or a new companion spec verifies character mode entry, selected character restoration, backend `POST /api/v1/chats/` creation, `POST /api/v1/chats/{id}/complete-v2` with `include_character_context: true`, and character-session resume readiness. Provider-unconfigured environments must assert the visible recovery path rather than pretending streaming succeeded.
+**Tests**:
+- `bunx playwright test e2e/workflows/journeys/character-chat.spec.ts --reporter=line`
+- New Phase 6 signoff spec list/load check.
+**Status**: Complete
+
+## Stage 5: Browser Verification And Closeout
+**Goal**: Record real browser evidence and finish the Phase 6 task as a reviewable PR slice.
+**Success Criteria**: Real backend and WebUI are started locally, `/chat?mode=character` is inspected at desktop and narrow widths, focused tests pass, `git diff --check` passes, TypeScript baseline is classified, and Bandit is run only if Python/backend files are touched.
+**Tests**:
+- Focused Vitest suite from Stages 1-2.
+- Playwright Phase 6 spec list or live run depending on backend/provider availability.
+- Real backend browser smoke using `AUTH_MODE=single_user` and the project test API key.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
@@ -307,10 +307,6 @@ export const CharacterChatSessionsPanel = ({
           <div
             role="status"
             aria-live="polite"
-            aria-label={t(
-              "characterChatSessions.loadingStatusLabel",
-              "Loading character sessions",
-            )}
             className={cn("mt-3", cockpitRailStyles.emptyInset)}
           >
             {t(
@@ -345,10 +341,6 @@ export const CharacterChatSessionsPanel = ({
               <p
                 role="status"
                 aria-live="polite"
-                aria-label={t(
-                  "characterChatSessions.refreshStatusLabel",
-                  "Character session refresh",
-                )}
                 className="mt-2 rounded border border-warning/30 bg-warning/10 px-2 py-1 text-xs text-text-subtle"
               >
                 {t(

--- a/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
@@ -304,14 +304,22 @@ export const CharacterChatSessionsPanel = ({
         </div>
 
         {isLoading && !hasUsableData ? (
-          <div className={cn("mt-3", cockpitRailStyles.emptyInset)}>
+          <div
+            role="status"
+            aria-live="polite"
+            aria-label={t(
+              "characterChatSessions.loadingStatusLabel",
+              "Loading character sessions",
+            )}
+            className={cn("mt-3", cockpitRailStyles.emptyInset)}
+          >
             {t(
               "characterChatSessions.loading",
               "Loading character sessions...",
             )}
           </div>
         ) : sidebarRefreshState === "recoverable-error" && !hasUsableData ? (
-          <div className={cn("mt-3", cockpitRailStyles.emptyInset)}>
+          <div role="alert" className={cn("mt-3", cockpitRailStyles.emptyInset)}>
             {t(
               "characterChatSessions.refreshFailed",
               "Unable to refresh character sessions right now.",
@@ -319,6 +327,7 @@ export const CharacterChatSessionsPanel = ({
           </div>
         ) : hardErrorWithoutData ? (
           <div
+            role="alert"
             className={cn(
               "mt-3",
               cockpitRailStyles.emptyInset,
@@ -333,7 +342,15 @@ export const CharacterChatSessionsPanel = ({
         ) : hasSessions ? (
           <>
             {isShowingStaleData ? (
-              <p className="mt-2 rounded border border-warning/30 bg-warning/10 px-2 py-1 text-xs text-text-subtle">
+              <p
+                role="status"
+                aria-live="polite"
+                aria-label={t(
+                  "characterChatSessions.refreshStatusLabel",
+                  "Character session refresh",
+                )}
+                className="mt-2 rounded border border-warning/30 bg-warning/10 px-2 py-1 text-xs text-text-subtle"
+              >
                 {t(
                   "characterChatSessions.stale",
                   "Showing character sessions from the last successful refresh.",

--- a/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
@@ -909,11 +909,11 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
       className="flex flex-col gap-2">
       <div
         data-playground-toolbar-row="actions"
-        className="flex flex-nowrap items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        className="flex flex-wrap items-center gap-2 lg:flex-nowrap lg:overflow-x-auto lg:[scrollbar-width:none] lg:[&::-webkit-scrollbar]:hidden">
         <div
           role="group"
           aria-label={casualModeContextGroupLabel}
-          className="flex flex-nowrap items-center gap-2 text-text-muted">
+          className="flex min-w-0 flex-wrap items-center gap-2 text-text-muted lg:flex-nowrap">
           {modeLauncherButton}
           {mcpControl}
           {searchContextButton}
@@ -924,7 +924,7 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
         <div
           role="group"
           aria-label={runInputGroupLabel}
-          className="ml-auto flex flex-nowrap items-center gap-2">
+          className="flex min-w-0 flex-wrap items-center gap-2 lg:ml-auto lg:flex-nowrap">
           {compareControl}
           {dictationButton}
           {researchLaunchButton}

--- a/apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
@@ -467,7 +467,23 @@ export const RolePlaySetupDrawer: React.FC<RolePlaySetupDrawerProps> = ({
       onClose={closeAndReturnFocus}
       title={t("playground:composer.rolePlaySetup", "Role-play setup")}>
       <div className="space-y-4" data-testid="role-play-setup-drawer">
-        {loading && !sceneDraft ? <Skeleton active /> : null}
+        {loading && !sceneDraft ? (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-label={t(
+              "playground:composer.sceneLoadingStatus",
+              "Loading scene settings"
+            )}>
+            <Skeleton active />
+            <span className="sr-only">
+              {t(
+                "playground:composer.sceneLoading",
+                "Loading scene settings..."
+              )}
+            </span>
+          </div>
+        ) : null}
         {sceneLoadError ? (
           <p role="alert" className="rounded-md border border-warn/40 bg-warn/10 p-2 text-xs text-warn">
             {sceneLoadError}

--- a/apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
@@ -468,13 +468,7 @@ export const RolePlaySetupDrawer: React.FC<RolePlaySetupDrawerProps> = ({
       title={t("playground:composer.rolePlaySetup", "Role-play setup")}>
       <div className="space-y-4" data-testid="role-play-setup-drawer">
         {loading && !sceneDraft ? (
-          <div
-            role="status"
-            aria-live="polite"
-            aria-label={t(
-              "playground:composer.sceneLoadingStatus",
-              "Loading scene settings"
-            )}>
+          <div role="status" aria-live="polite">
             <Skeleton active />
             <span className="sr-only">
               {t(

--- a/apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
@@ -117,14 +117,24 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
           )}
         </p>
       ) : (
-        <div className="space-y-2">
+        <ul
+          aria-label={t(
+            "playground:composer.savedRolePlaySetupList",
+            "Saved role-play setup list"
+          )}
+          className="space-y-2">
           {rolePlaySetups.map((setup) => {
             const preview = describeRolePlaySetupPreview(setup)
             const renameDraft = getRenameDraft(setup)
             const deletePending = pendingDeleteId === setup.id
             return (
-              <div
+              <li
                 key={setup.id}
+                aria-label={t(
+                  "playground:composer.savedRolePlaySetupListItem",
+                  "{{name}} role-play setup",
+                  { name: setup.name }
+                )}
                 className="space-y-2 rounded-md border border-border bg-surface2 p-2">
                 <div className="flex flex-wrap items-start justify-between gap-2">
                   <div className="min-w-0">
@@ -239,10 +249,10 @@ export const SavedRolePlaySetupsPanel: React.FC<SavedRolePlaySetupsPanelProps> =
                     {t("common:rename", "Rename")}
                   </Button>
                 </div>
-              </div>
+              </li>
             )
           })}
-        </div>
+        </ul>
       )}
     </section>
   )

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
@@ -213,6 +213,9 @@ describe("CharacterChatSessionsPanel", () => {
     expect(
       screen.getByText("Loading character sessions..."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Loading character sessions" }),
+    ).toHaveTextContent("Loading character sessions...");
 
     historyHookMock.mockReturnValueOnce({
       data: [],
@@ -256,6 +259,56 @@ describe("CharacterChatSessionsPanel", () => {
     expect(
       screen.getByText("Unable to refresh character sessions right now."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Unable to refresh character sessions right now.",
+    );
+  });
+
+  it("announces stale and hard-failure session states", () => {
+    const staleChat = makeChat("chat-stale", {
+      title: "Stale Mira",
+      character_id: "mira",
+    });
+    historyHookMock.mockReturnValueOnce({
+      data: [staleChat],
+      total: 1,
+      isLoading: false,
+      sidebarRefreshState: "ready",
+      hasUsableData: true,
+      isShowingStaleData: true,
+    });
+    const { rerender } = render(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+
+    expect(screen.getByRole("status", { name: "Character session refresh" }))
+      .toHaveTextContent(
+        "Showing character sessions from the last successful refresh.",
+      );
+
+    historyHookMock.mockReturnValueOnce({
+      data: [],
+      total: 0,
+      isLoading: false,
+      sidebarRefreshState: "hard-error",
+      hasUsableData: false,
+      isShowingStaleData: false,
+    });
+    rerender(
+      <CharacterChatSessionsPanel
+        activeCharacterId="mira"
+        activeCharacterName="Mira"
+        activeServerChatId={null}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Character sessions could not be loaded.",
+    );
   });
 
   it("normalizes timestamps before rendering relative session age", () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
@@ -213,9 +213,9 @@ describe("CharacterChatSessionsPanel", () => {
     expect(
       screen.getByText("Loading character sessions..."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("status", { name: "Loading character sessions" }),
-    ).toHaveTextContent("Loading character sessions...");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Loading character sessions...",
+    );
 
     historyHookMock.mockReturnValueOnce({
       data: [],
@@ -285,10 +285,9 @@ describe("CharacterChatSessionsPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("status", { name: "Character session refresh" }))
-      .toHaveTextContent(
-        "Showing character sessions from the last successful refresh.",
-      );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Showing character sessions from the last successful refresh.",
+    );
 
     historyHookMock.mockReturnValueOnce({
       data: [],

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
@@ -440,16 +440,16 @@ describe("ComposerToolbar web search", () => {
     ).toBeNull()
   })
 
-  it("keeps casual controls in a single non-wrapping horizontal row", () => {
+  it("wraps casual controls below desktop while keeping the dense desktop row", () => {
     render(<ComposerToolbar {...createProps()} />)
 
     const actionsRow = document.querySelector<HTMLElement>(
       '[data-playground-toolbar-row="actions"]'
     )
     expect(actionsRow).not.toBeNull()
-    expect(actionsRow?.className).toContain("flex-nowrap")
-    expect(actionsRow?.className).toContain("overflow-x-auto")
-    expect(actionsRow?.className).not.toContain("flex-wrap")
+    expect(actionsRow?.className).toContain("flex-wrap")
+    expect(actionsRow?.className).toContain("lg:flex-nowrap")
+    expect(actionsRow?.className).toContain("lg:overflow-x-auto")
   })
 
   it("keeps MCP in the casual actions row when advanced controls are expanded", () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
@@ -290,6 +290,24 @@ describe("RolePlaySetupDrawer", () => {
     expect(screen.getByText(/2 pinned/)).toBeInTheDocument()
   })
 
+  it("announces scene setting loading as a status", async () => {
+    let resolveActor: (settings: ActorSettings) => void = () => {}
+    actorSettingsMocks.getActorSettingsForChatWithCharacterFallback.mockReturnValueOnce(
+      new Promise<ActorSettings>((resolve) => {
+        resolveActor = resolve
+      })
+    )
+
+    renderDrawer()
+
+    expect(
+      screen.getByRole("status", { name: "Loading scene settings" })
+    ).toHaveTextContent("Loading scene settings...")
+
+    resolveActor(activeScene())
+    await screen.findByText(/1 detail/)
+  })
+
   it("does not crash when stored actor settings omit aspects", async () => {
     actorSettingsMocks.getActorSettingsForChatWithCharacterFallback.mockResolvedValueOnce(
       {
@@ -478,6 +496,12 @@ describe("RolePlaySetupDrawer", () => {
 
     await screen.findByText(/1 detail/)
     expect(screen.getByText("Saved role-play setups")).toBeInTheDocument()
+    expect(
+      screen.getByRole("list", { name: "Saved role-play setup list" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("listitem", { name: "Mira detective scene role-play setup" })
+    ).toBeInTheDocument()
     expect(screen.getByText("Mira detective scene")).toBeInTheDocument()
     expect(screen.queryByText("Generic writing template")).not.toBeInTheDocument()
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
@@ -300,9 +300,9 @@ describe("RolePlaySetupDrawer", () => {
 
     renderDrawer()
 
-    expect(
-      screen.getByRole("status", { name: "Loading scene settings" })
-    ).toHaveTextContent("Loading scene settings...")
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Loading scene settings..."
+    )
 
     resolveActor(activeScene())
     await screen.findByText(/1 detail/)

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.character-persist.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.character-persist.test.ts
@@ -55,6 +55,31 @@ describe("TldwApiClient character persist cache invalidation", () => {
     expect(invalidateSpy).toHaveBeenCalledWith("chat-1")
   })
 
+  it("adds chat scope query params when persisting character completions", async () => {
+    mocks.bgRequest.mockResolvedValue({
+      assistant_message_id: "assistant-server-1",
+      version: 2
+    })
+
+    const client = new TldwApiClient()
+
+    await client.persistCharacterCompletion(
+      "chat-1",
+      {
+        assistant_content: "scoped reply"
+      },
+      {
+        scope: { type: "workspace", workspaceId: "workspace-7" }
+      }
+    )
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/chats/chat-1/completions/persist?scope_type=workspace&workspace_id=workspace-7"
+      })
+    )
+  })
+
   it("invalidates cached chat messages when persist reports saved degraded state via top-level detail", async () => {
     const error = Object.assign(new Error("degraded"), {
       status: 503,

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.chat-debug.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.chat-debug.test.ts
@@ -56,6 +56,32 @@ describe("TldwApiClient chat request debug snapshot", () => {
     expect((snapshot?.body as any)?.stream).toBe(true)
   })
 
+  it("adds chat scope query params to streamed character completions", async () => {
+    mocks.bgStream.mockImplementation(async function* () {
+      yield JSON.stringify({ delta: "scoped" })
+    })
+
+    const client = new TldwApiClient()
+    const scope = { type: "workspace", workspaceId: "workspace-7" } as const
+
+    for await (const _ of client.streamCharacterChatCompletion(
+      "42",
+      { include_character_context: true },
+      { scope }
+    )) {
+      break
+    }
+
+    expect(mocks.bgStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/chats/42/complete-v2?scope_type=workspace&workspace_id=workspace-7"
+      })
+    )
+    expect(getLastChatRequestDebugSnapshot()?.endpoint).toBe(
+      "/api/v1/chats/42/complete-v2?scope_type=workspace&workspace_id=workspace-7"
+    )
+  })
+
   it("captures complete endpoint payloads for non-stream character completion", async () => {
     mocks.bgRequest.mockResolvedValue({ ok: true })
 

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -5193,12 +5193,14 @@ export class TldwApiClientBase {
 
   async persistCharacterCompletion(
     chat_id: string | number,
-    payload: Record<string, any>
+    payload: Record<string, any>,
+    options?: { scope?: ChatScope }
   ): Promise<any> {
     const cid = String(chat_id)
+    const query = this.buildQuery(toChatScopeParams(options?.scope))
     try {
       const res = await bgRequest<any>({
-        path: `/api/v1/chats/${cid}/completions/persist`,
+        path: appendPathQuery(`/api/v1/chats/${cid}/completions/persist`, query),
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: payload
@@ -5216,18 +5218,19 @@ export class TldwApiClientBase {
   async *streamCharacterChatCompletion(
     chat_id: string | number,
     payload?: Record<string, any>,
-    options?: { signal?: AbortSignal; streamIdleTimeoutMs?: number }
+    options?: { signal?: AbortSignal; streamIdleTimeoutMs?: number; scope?: ChatScope }
   ): AsyncGenerator<any> {
     const cid = String(chat_id)
     const body = { ...(payload || {}), stream: true }
+    const query = this.buildQuery(toChatScopeParams(options?.scope))
     captureChatRequestDebugSnapshot({
-      endpoint: `/api/v1/chats/${cid}/complete-v2`,
+      endpoint: appendPathQuery(`/api/v1/chats/${cid}/complete-v2`, query),
       method: "POST",
       mode: "stream",
       body
     })
     for await (const line of bgStream({
-      path: `/api/v1/chats/${cid}/complete-v2`,
+      path: appendPathQuery(`/api/v1/chats/${cid}/complete-v2`, query),
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body,

--- a/apps/tldw-frontend/e2e/utils/helpers.ts
+++ b/apps/tldw-frontend/e2e/utils/helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Common test helpers for E2E tests
  */
-import { type Locator, type Page, type Route } from '@playwright/test';
+import { expect, type Locator, type Page, type Route } from '@playwright/test';
 
 /**
  * Environment configuration for tests
@@ -574,6 +574,46 @@ export async function waitForElement(
   const { timeout = 10000, state = 'visible' } = options;
   const element = page.locator(selector);
   await element.waitFor({ state, timeout });
+}
+
+/**
+ * Assert that the document and visible elements fit within the current viewport.
+ */
+export async function expectNoHorizontalOverflow(page: Page, label: string): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const scrollWidth = Math.max(
+      document.documentElement.scrollWidth,
+      document.body?.scrollWidth ?? 0
+    );
+    const offenders = Array.from(document.body.querySelectorAll<HTMLElement>('*'))
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName.toLowerCase(),
+          testId: element.getAttribute('data-testid'),
+          role: element.getAttribute('role'),
+          ariaLabel: element.getAttribute('aria-label'),
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+        };
+      })
+      .filter((entry) => entry.width > 0 && (entry.left < -1 || entry.right > viewportWidth + 1))
+      .slice(0, 5);
+
+    return {
+      viewportWidth,
+      scrollWidth,
+      offenders,
+    };
+  });
+
+  expect(
+    overflow.scrollWidth,
+    `${label} overflowed viewport: ${JSON.stringify(overflow)}`
+  ).toBeLessThanOrEqual(overflow.viewportWidth + 1);
+  expect(overflow.offenders, `${label} overflow offenders`).toEqual([]);
 }
 
 /**

--- a/apps/tldw-frontend/e2e/workflows/journeys/character-chat-phase6.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/journeys/character-chat-phase6.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Phase 6 Character Chat signoff.
+ *
+ * This suite intentionally uses the real WebUI route and backend fixture. It
+ * does not mock Character Chat APIs; provider-unconfigured environments should
+ * still expose the setup/recovery surfaces without layout overflow.
+ */
+import { type Page } from "@playwright/test"
+import {
+  assertNoCriticalErrors,
+  expect,
+  skipIfServerUnavailable,
+  test,
+} from "../../utils/fixtures"
+import { waitForConnection, waitForVisualSettle } from "../../utils/helpers"
+
+type ViewportTarget = {
+  label: "desktop" | "tablet" | "mobile"
+  width: number
+  height: number
+}
+
+const VIEWPORTS: ViewportTarget[] = [
+  { label: "desktop", width: 1440, height: 900 },
+  { label: "tablet", width: 768, height: 1024 },
+  { label: "mobile", width: 390, height: 844 },
+]
+
+async function expectNoHorizontalOverflow(
+  page: Page,
+  label: string,
+): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth
+    const scrollWidth = Math.max(
+      document.documentElement.scrollWidth,
+      document.body?.scrollWidth ?? 0,
+    )
+    const offenders = Array.from(
+      document.body.querySelectorAll<HTMLElement>("*"),
+    )
+      .map((element) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          tag: element.tagName.toLowerCase(),
+          testId: element.getAttribute("data-testid"),
+          role: element.getAttribute("role"),
+          label: element.getAttribute("aria-label"),
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+        }
+      })
+      .filter(
+        (entry) =>
+          entry.width > 0 &&
+          (entry.left < -1 || entry.right > viewportWidth + 1),
+      )
+      .slice(0, 5)
+
+    return {
+      viewportWidth,
+      scrollWidth,
+      offenders,
+    }
+  })
+
+  expect(
+    overflow.scrollWidth,
+    `${label} overflowed viewport: ${JSON.stringify(overflow)}`,
+  ).toBeLessThanOrEqual(overflow.viewportWidth + 1)
+  expect(overflow.offenders, `${label} overflow offenders`).toEqual([])
+}
+
+async function openRolePlaySetup(page: Page): Promise<void> {
+  const directSetup = page.getByTestId("composer-role-play-setup").first()
+  if (await directSetup.isVisible().catch(() => false)) {
+    await directSetup.click()
+  } else {
+    await page.getByRole("button", { name: "More options" }).first().click()
+    await page
+      .getByRole("button", { name: "Role-play setup", exact: true })
+      .click()
+  }
+
+  const dialog = page.getByRole("dialog", { name: "Role-play setup" })
+  await expect(dialog).toBeVisible({
+    timeout: 15_000,
+  })
+  await expect
+    .poll(
+      async () => {
+        const box = await dialog.boundingBox()
+        const viewportWidth = await page.evaluate(
+          () => document.documentElement.clientWidth,
+        )
+        if (!box) return false
+        return box.x >= -1 && box.x + box.width <= viewportWidth + 1
+      },
+      {
+        timeout: 5_000,
+        message: "Role-play setup drawer should settle inside the viewport",
+      },
+    )
+    .toBe(true)
+}
+
+async function expectCharacterSessionsReachable(page: Page): Promise<void> {
+  const sessions = page.getByRole("region", {
+    name: "Character chat sessions",
+  })
+  if (await sessions.isVisible().catch(() => false)) {
+    return
+  }
+
+  const showPanels = page.getByRole("button", {
+    name: "Show cockpit panels",
+  })
+  if (await showPanels.isVisible().catch(() => false)) {
+    await showPanels.click()
+  }
+
+  const contextTab = page.getByRole("tab", { name: "Context" })
+  if (await contextTab.isVisible().catch(() => false)) {
+    await contextTab.click()
+  }
+
+  await expect(sessions).toBeVisible({ timeout: 30_000 })
+}
+
+test.describe("Character Chat Phase 6 signoff", () => {
+  for (const viewport of VIEWPORTS) {
+    test(`character mode setup and recovery surfaces fit ${viewport.label}`, async ({
+      authedPage: page,
+      diagnostics,
+      serverInfo,
+    }) => {
+      skipIfServerUnavailable(serverInfo)
+
+      await page.setViewportSize({
+        width: viewport.width,
+        height: viewport.height,
+      })
+      await page.goto("/chat?mode=character", {
+        waitUntil: "domcontentloaded",
+      })
+      await waitForConnection(page)
+
+      await expect(
+        page.getByTestId("playground-active-chat-mode"),
+      ).toContainText("Character Chat", { timeout: 30_000 })
+      await expectCharacterSessionsReachable(page)
+      await expect(
+        page.getByTestId("character-chat-readiness-panel"),
+      ).toBeVisible({ timeout: 30_000 })
+      await expect(page.getByPlaceholder(/type a message/i)).toBeVisible({
+        timeout: 30_000,
+      })
+      await expectNoHorizontalOverflow(page, `${viewport.label} character chat`)
+
+      await openRolePlaySetup(page)
+      await waitForVisualSettle(page)
+      await expectNoHorizontalOverflow(
+        page,
+        `${viewport.label} role-play setup drawer`,
+      )
+
+      await assertNoCriticalErrors(diagnostics)
+    })
+  }
+})

--- a/apps/tldw-frontend/e2e/workflows/journeys/character-chat-phase6.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/journeys/character-chat-phase6.spec.ts
@@ -12,7 +12,11 @@ import {
   skipIfServerUnavailable,
   test,
 } from "../../utils/fixtures"
-import { waitForConnection, waitForVisualSettle } from "../../utils/helpers"
+import {
+  expectNoHorizontalOverflow,
+  waitForConnection,
+  waitForVisualSettle,
+} from "../../utils/helpers"
 
 type ViewportTarget = {
   label: "desktop" | "tablet" | "mobile"
@@ -26,57 +30,20 @@ const VIEWPORTS: ViewportTarget[] = [
   { label: "mobile", width: 390, height: 844 },
 ]
 
-async function expectNoHorizontalOverflow(
-  page: Page,
-  label: string,
-): Promise<void> {
-  const overflow = await page.evaluate(() => {
-    const viewportWidth = document.documentElement.clientWidth
-    const scrollWidth = Math.max(
-      document.documentElement.scrollWidth,
-      document.body?.scrollWidth ?? 0,
-    )
-    const offenders = Array.from(
-      document.body.querySelectorAll<HTMLElement>("*"),
-    )
-      .map((element) => {
-        const rect = element.getBoundingClientRect()
-        return {
-          tag: element.tagName.toLowerCase(),
-          testId: element.getAttribute("data-testid"),
-          role: element.getAttribute("role"),
-          label: element.getAttribute("aria-label"),
-          left: rect.left,
-          right: rect.right,
-          width: rect.width,
-        }
-      })
-      .filter(
-        (entry) =>
-          entry.width > 0 &&
-          (entry.left < -1 || entry.right > viewportWidth + 1),
-      )
-      .slice(0, 5)
-
-    return {
-      viewportWidth,
-      scrollWidth,
-      offenders,
-    }
-  })
-
-  expect(
-    overflow.scrollWidth,
-    `${label} overflowed viewport: ${JSON.stringify(overflow)}`,
-  ).toBeLessThanOrEqual(overflow.viewportWidth + 1)
-  expect(overflow.offenders, `${label} overflow offenders`).toEqual([])
-}
-
 async function openRolePlaySetup(page: Page): Promise<void> {
-  const directSetup = page.getByTestId("composer-role-play-setup").first()
-  if (await directSetup.isVisible().catch(() => false)) {
-    await directSetup.click()
-  } else {
+  const directSetupButtons = page.getByTestId("composer-role-play-setup")
+  const directSetupCount = await directSetupButtons.count()
+  let openedDirectly = false
+  for (let index = 0; index < directSetupCount; index += 1) {
+    const button = directSetupButtons.nth(index)
+    if (await button.isVisible().catch(() => false)) {
+      await button.click()
+      openedDirectly = true
+      break
+    }
+  }
+
+  if (!openedDirectly) {
     await page.getByRole("button", { name: "More options" }).first().click()
     await page
       .getByRole("button", { name: "Role-play setup", exact: true })

--- a/apps/tldw-frontend/e2e/workflows/setup-connection-flow.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/setup-connection-flow.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 import { test, expect, assertNoCriticalErrors } from '../utils/fixtures';
-import { seedAuth } from '../utils/helpers';
+import { expectNoHorizontalOverflow, seedAuth } from '../utils/helpers';
 
 type ViewportTarget = {
   label: 'desktop' | 'mobile';
@@ -45,43 +45,6 @@ async function expectOnePageHeading(page: Page, label: string): Promise<void> {
     timeout: 15_000,
   });
   await expect(headings, `${label} should expose exactly one h1`).toHaveCount(1);
-}
-
-async function expectNoHorizontalOverflow(page: Page, label: string): Promise<void> {
-  const overflow = await page.evaluate(() => {
-    const viewportWidth = document.documentElement.clientWidth;
-    const scrollWidth = Math.max(
-      document.documentElement.scrollWidth,
-      document.body?.scrollWidth ?? 0
-    );
-    const offenders = Array.from(document.body.querySelectorAll<HTMLElement>('*'))
-      .map((element) => {
-        const rect = element.getBoundingClientRect();
-        const tag = element.tagName.toLowerCase();
-        const testId = element.getAttribute('data-testid');
-        return {
-          tag,
-          testId,
-          left: rect.left,
-          right: rect.right,
-          width: rect.width,
-        };
-      })
-      .filter((entry) => entry.width > 0 && (entry.left < -1 || entry.right > viewportWidth + 1))
-      .slice(0, 5);
-
-    return {
-      viewportWidth,
-      scrollWidth,
-      offenders,
-    };
-  });
-
-  expect(
-    overflow.scrollWidth,
-    `${label} overflowed viewport: ${JSON.stringify(overflow)}`
-  ).toBeLessThanOrEqual(overflow.viewportWidth + 1);
-  expect(overflow.offenders, `${label} overflow offenders`).toEqual([]);
 }
 
 test.describe('Setup and recovery route QA', () => {

--- a/backlog/tasks/task-454 - Implement-Character-Chat-Phase-6-accessibility-mobile-and-real-backend-signoff.md
+++ b/backlog/tasks/task-454 - Implement-Character-Chat-Phase-6-accessibility-mobile-and-real-backend-signoff.md
@@ -1,0 +1,79 @@
+---
+id: TASK-454
+title: Implement Character Chat Phase 6 accessibility mobile and real-backend signoff
+status: Done
+labels:
+- chat
+- characters
+- role-play
+- phase-6
+- frontend
+- e2e
+- accessibility
+priority: high
+references:
+- TASK-426
+- TASK-428
+- TASK-431
+- TASK-438
+- TASK-447
+- TASK-449
+- TASK-452
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+documentation:
+- Docs/Product/WebUI/Character_Chat_Roleplay_First_Class_PRD_2026_05_18.md
+- Docs/superpowers/plans/2026-05-20-character-chat-phase6-accessibility-mobile-backend-signoff-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-05-20-character-chat-phase6-accessibility-mobile-backend-signoff-plan.md
+- apps/packages/ui/src/components/Option/Playground/CharacterChatSessionsPanel.tsx
+- apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
+- apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
+- apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
+- apps/packages/ui/src/services/tldw/TldwApiClient.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.character-persist.test.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.chat-debug.test.ts
+- apps/tldw-frontend/e2e/workflows/journeys/character-chat-phase6.spec.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Phase 6 from the first-class Character Chat PRD: close the release-quality accessibility, mobile, and real-backend signoff gates for the /chat Character Chat workflow after Phase 5 sidepanel parity merged. Scope should focus on keyboard/focus semantics, screen-reader labels/live regions, narrow viewport behavior, and real backend E2E verification for create/select/send/resume without introducing a parallel character chat runtime.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Keyboard-only users can complete primary Character Chat setup and send/resume paths on /chat with logical focus order and no trapped focus.
+- [x] #2 Screen-reader labels/live regions for mode switch, setup surface, sessions rail, selectors, composer, and destructive confirmations are covered by focused tests or browser accessibility snapshots.
+- [x] #3 Desktop, tablet, and narrow/mobile viewports pass without horizontal overflow or hidden primary recovery actions for Character Chat mode, setup, sessions, and composer.
+- [x] #4 Real backend E2E or documented real-backend browser verification covers character mode entry, character selection/restoration, send path readiness, and session resume using the actual backend API path rather than frontend-only mocks.
+- [x] #5 Chat/character DB health release dependency is explicitly resolved, verified, or documented as a remaining release blocker with owner.
+- [x] #6 Focused tests, real-browser evidence, diff hygiene, and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created Phase 6 implementation plan after verifying latest origin/dev includes PR #1888 and existing PRD phases 0-5. Current focus is release-quality accessibility, responsive/mobile signoff, and real-backend evidence rather than redoing already completed role-play remediation stages.
+
+Implemented Phase 6 by adding screen-reader status/alert semantics to Character Chat sessions and setup loading/error states, adding saved setup list/listitem semantics, allowing the dense composer toolbar to wrap on non-desktop widths, adding desktop/tablet/mobile real-backend Playwright signoff for `/chat?mode=character`, and aligning monolithic `TldwApiClient` character stream/persist methods with the scoped domain client for real backend workspace-scoped calls.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verification recorded: focused Vitest suite passed 62 tests across Character Chat panels, composer toolbar, character mode contract, and TldwApiClient stream/persist regression coverage; real-backend Playwright passed 4/4 across character-chat-phase6.spec.ts and character-chat.spec.ts against http://127.0.0.1:8000; git diff --check passed. TypeScript checks were run for apps/packages/ui and apps/tldw-frontend and still fail on inherited baseline files, but the touched files and the previously in-scope useCharacterChatMode errors are absent from the fresh logs. Bandit was not run because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-454 - Implement-Character-Chat-Phase-6-accessibility-mobile-and-real-backend-signoff.md
+++ b/backlog/tasks/task-454 - Implement-Character-Chat-Phase-6-accessibility-mobile-and-real-backend-signoff.md
@@ -30,12 +30,15 @@ modified_files:
 - apps/packages/ui/src/components/Option/Playground/RolePlaySetupDrawer.tsx
 - apps/packages/ui/src/components/Option/Playground/SavedRolePlaySetupsPanel.tsx
 - apps/packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.role-play-mobile.test.tsx
 - apps/packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx
 - apps/packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx
 - apps/packages/ui/src/services/tldw/TldwApiClient.ts
 - apps/packages/ui/src/services/__tests__/tldw-api-client.character-persist.test.ts
 - apps/packages/ui/src/services/__tests__/tldw-api-client.chat-debug.test.ts
+- apps/tldw-frontend/e2e/utils/helpers.ts
 - apps/tldw-frontend/e2e/workflows/journeys/character-chat-phase6.spec.ts
+- apps/tldw-frontend/e2e/workflows/setup-connection-flow.spec.ts
 ---
 
 ## Description
@@ -60,12 +63,14 @@ Implement Phase 6 from the first-class Character Chat PRD: close the release-qua
 Created Phase 6 implementation plan after verifying latest origin/dev includes PR #1888 and existing PRD phases 0-5. Current focus is release-quality accessibility, responsive/mobile signoff, and real-backend evidence rather than redoing already completed role-play remediation stages.
 
 Implemented Phase 6 by adding screen-reader status/alert semantics to Character Chat sessions and setup loading/error states, adding saved setup list/listitem semantics, allowing the dense composer toolbar to wrap on non-desktop widths, adding desktop/tablet/mobile real-backend Playwright signoff for `/chat?mode=character`, and aligning monolithic `TldwApiClient` character stream/persist methods with the scoped domain client for real backend workspace-scoped calls.
+
+Review follow-up addressed PR #1892 comments by removing live-region `aria-label` overrides that hid visible or sr-only status text from assistive tech, moving the duplicated Playwright `expectNoHorizontalOverflow` helper into `e2e/utils/helpers.ts`, importing it from both the Phase 6 and setup recovery specs, and making the role-play setup opener choose the first visible duplicate toolbar control before falling back to the overflow menu.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Verification recorded: focused Vitest suite passed 62 tests across Character Chat panels, composer toolbar, character mode contract, and TldwApiClient stream/persist regression coverage; real-backend Playwright passed 4/4 across character-chat-phase6.spec.ts and character-chat.spec.ts against http://127.0.0.1:8000; git diff --check passed. TypeScript checks were run for apps/packages/ui and apps/tldw-frontend and still fail on inherited baseline files, but the touched files and the previously in-scope useCharacterChatMode errors are absent from the fresh logs. Bandit was not run because no Python files were touched.
+Verification recorded: focused Vitest suite passed 62 tests across Character Chat panels, composer toolbar, character mode contract, and TldwApiClient stream/persist regression coverage; real-backend Playwright passed 6/6 across character-chat-phase6.spec.ts, character-chat.spec.ts, and the setup-adjacent recovery overflow helper path against http://127.0.0.1:8000; git diff --check passed. TypeScript checks were run for apps/packages/ui and apps/tldw-frontend and still fail on inherited baseline files, but the touched files and the previously in-scope useCharacterChatMode errors are absent from the fresh logs. Bandit was not run because no Python files were touched.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Harden Character Chat role-play setup/session surfaces with screen-reader status and alert semantics.
- Add narrow/mobile responsive signoff for the Character Chat composer/setup workflow.
- Add real-backend Playwright coverage for `/chat?mode=character` and align scoped character stream/persist client paths.

## Test Plan
- [x] `bunx vitest run ../packages/ui/src/components/Option/Playground/__tests__/CharacterChatSessionsPanel.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/RolePlaySetupDrawer.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/ComposerToolbar.role-play-mobile.test.tsx ../packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts ../packages/ui/src/services/__tests__/tldw-api-client.chat-debug.test.ts ../packages/ui/src/services/__tests__/tldw-api-client.character-persist.test.ts --config vitest.config.ts`
- [x] `TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx playwright test e2e/workflows/journeys/character-chat-phase6.spec.ts e2e/workflows/journeys/character-chat.spec.ts --reporter=line`
- [x] `git diff --check`
- [x] `bunx tsc --noEmit --pretty false` in `apps/packages/ui` and `apps/tldw-frontend` was run; both still fail on inherited baseline files, with no fresh errors in touched files or `useCharacterChatMode`.
- [x] Bandit not run: no Python files touched.

## Change summary
Human-owned summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Character Chat Phase 6 for `/chat?mode=character` with stronger accessibility, mobile behavior, and real-backend scope support. Adds ARIA status/alert coverage, wraps the composer toolbar below desktop, and aligns `TldwApiClient` character completion endpoints with scoped query params, covered by focused tests and Playwright signoff.

- New Features
  - Accessibility: added status/alert roles with polite live regions for session loading/error and stale states; setup loading announces as status; saved setups now use list/listitem semantics with accessible names.
  - Responsive: toolbar wraps below desktop while keeping dense desktop layout; new Playwright signoff checks no horizontal overflow at desktop/tablet/mobile and keeps setup, sessions, and composer reachable; overflow helper centralized in `e2e/utils/helpers.ts` and reused.
  - Backend: `streamCharacterChatCompletion` and `persistCharacterCompletion` now accept `scope` and append query params; debug snapshot records scoped endpoints; unit tests verify scoped paths.
  - Linear: Satisfies `TASK-454` Phase 6 requirements for keyboard/screen-reader signoff, narrow viewport usability, and real-backend verification of create/select/send/resume.

<sup>Written for commit 3e0310f16bbbe6a46adf0b6c5fd2cbfdc34c72a1. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1892?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

