### PR TITLE
Migrate SummarizePageWorkflow product-state alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -33,17 +33,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Common/Workflow/steps/SummarizePageWorkflow.tsx:Alert",
-    "path": "src/components/Common/Workflow/steps/SummarizePageWorkflow.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Common/Workflow/steps/SummarizePageWorkflow.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentPickerModal.tsx:Alert#antd-alert-documentpickermodal-type-error-line-573-1sibda5",
     "path": "src/components/DocumentWorkspace/DocumentPickerModal.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { cleanup, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useWorkflowsStore } from "@/store/workflows"
@@ -25,6 +25,9 @@ const mocks = vi.hoisted(() => ({
   ),
 }))
 
+const MOCKED_PAGE_CONTENT =
+  "Page content selected for summarization and long enough to show a length preview."
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: mocks.t,
@@ -33,15 +36,7 @@ vi.mock("react-i18next", () => ({
 
 describe("SummarizePageWorkflow product-state UI", () => {
   beforeEach(() => {
-    const realSetTimeout = globalThis.setTimeout
-    vi.spyOn(globalThis, "setTimeout").mockImplementation(
-      (...args: Parameters<typeof setTimeout>) => {
-        if (args[1] === 500) {
-          return 0 as unknown as ReturnType<typeof setTimeout>
-        }
-        return realSetTimeout(...args)
-      }
-    )
+    vi.useFakeTimers()
 
     vi.stubGlobal("chrome", {
       tabs: {
@@ -58,8 +53,7 @@ describe("SummarizePageWorkflow product-state UI", () => {
           {
             result: {
               title: "Captured Article",
-              content:
-                "Page content selected for summarization and long enough to show a length preview.",
+              content: MOCKED_PAGE_CONTENT,
             },
           },
         ]),
@@ -86,6 +80,7 @@ describe("SummarizePageWorkflow product-state UI", () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     useWorkflowsStore.setState({
@@ -102,7 +97,7 @@ describe("SummarizePageWorkflow product-state UI", () => {
   it("renders captured page success through the canonical design-system Alert", async () => {
     const { container } = render(<SummarizePageWorkflow />)
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(screen.getByText("Page captured")).toBeInTheDocument()
     })
 
@@ -111,6 +106,10 @@ describe("SummarizePageWorkflow product-state UI", () => {
       screen.getByText("Captured Article").closest('[data-ds-component="Alert"]')
     ).toBeInTheDocument()
     expect(screen.getByText("https://example.test/page")).toBeInTheDocument()
-    expect(screen.getByText(/^Content length: \d+ characters$/)).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        `Content length: ${MOCKED_PAGE_CONTENT.length.toLocaleString()} characters`
+      )
+    ).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx
@@ -1,0 +1,116 @@
+import React from "react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useWorkflowsStore } from "@/store/workflows"
+import { SummarizePageWorkflow } from "../steps/SummarizePageWorkflow"
+
+const mocks = vi.hoisted(() => ({
+  t: vi.fn(
+    (
+      _key: string,
+      fallbackOrOptions?: string | { defaultValue?: string },
+      values?: Record<string, string | number | undefined>
+    ) => {
+      const template =
+        typeof fallbackOrOptions === "string"
+          ? fallbackOrOptions
+          : fallbackOrOptions?.defaultValue || _key
+      if (!values) return template
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, token: string) => {
+        const value = values[token]
+        return value === undefined ? `{{${token}}}` : String(value)
+      })
+    }
+  ),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: mocks.t,
+  }),
+}))
+
+describe("SummarizePageWorkflow product-state UI", () => {
+  beforeEach(() => {
+    const realSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      (...args: Parameters<typeof setTimeout>) => {
+        if (args[1] === 500) {
+          return 0 as unknown as ReturnType<typeof setTimeout>
+        }
+        return realSetTimeout(...args)
+      }
+    )
+
+    vi.stubGlobal("chrome", {
+      tabs: {
+        query: vi.fn().mockResolvedValue([
+          {
+            id: 42,
+            title: "Example Page",
+            url: "https://example.test/page",
+          },
+        ]),
+      },
+      scripting: {
+        executeScript: vi.fn().mockResolvedValue([
+          {
+            result: {
+              title: "Captured Article",
+              content:
+                "Page content selected for summarization and long enough to show a length preview.",
+            },
+          },
+        ]),
+      },
+    })
+
+    useWorkflowsStore.setState({
+      activeWorkflow: {
+        id: "wf-summarize-page-test",
+        workflowId: "summarize-page",
+        status: "active",
+        currentStepIndex: 0,
+        startedAt: 1,
+        data: {},
+      },
+      isWizardOpen: true,
+      isProcessing: false,
+      processingProgress: 0,
+      processingMessage: "",
+      error: null,
+    })
+    mocks.t.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    useWorkflowsStore.setState({
+      activeWorkflow: null,
+      isWizardOpen: false,
+      isProcessing: false,
+      processingProgress: 0,
+      processingMessage: "",
+      error: null,
+    })
+    vi.clearAllMocks()
+  })
+
+  it("renders captured page success through the canonical design-system Alert", async () => {
+    const { container } = render(<SummarizePageWorkflow />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Page captured")).toBeInTheDocument()
+    })
+
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+    expect(
+      screen.getByText("Captured Article").closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(screen.getByText("https://example.test/page")).toBeInTheDocument()
+    expect(screen.getByText(/^Content length: \d+ characters$/)).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Common/Workflow/steps/SummarizePageWorkflow.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/steps/SummarizePageWorkflow.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect, useRef } from "react"
-import { Input, Radio, Button, Space, Alert, Spin, message } from "antd"
-import { Copy, Download, MessageSquare, CheckCircle, Globe } from "lucide-react"
+import { Input, Radio, Button, Space, Spin, message } from "antd"
+import { Copy, Download, MessageSquare, Globe } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useWorkflowsStore } from "@/store/workflows"
 import { WizardShell } from "../WizardShell"
 import { SUMMARIZE_PAGE_WORKFLOW } from "../workflow-definitions"
@@ -177,20 +178,17 @@ const CaptureStep: React.FC = () => {
     return (
       <div className="space-y-4">
         <Alert
-          type="success"
-          showIcon
-          icon={<CheckCircle className="h-4 w-4" />}
+          variant="success"
           title={t("workflows:summarizePage.captured", "Page captured")}
-          description={
-            <div className="mt-2">
-              <p className="font-medium">{pageInfo.title}</p>
-              <p className="text-xs text-text-muted flex items-center gap-1 mt-1">
-                <Globe className="h-3 w-3" />
-                {pageInfo.url}
-              </p>
-            </div>
-          }
-        />
+        >
+          <div className="mt-2">
+            <p className="font-medium">{pageInfo.title}</p>
+            <p className="text-xs text-text-muted flex items-center gap-1 mt-1">
+              <Globe className="h-3 w-3" />
+              {pageInfo.url}
+            </p>
+          </div>
+        </Alert>
         <p className="text-sm text-text-muted">
           {t(
             "workflows:summarizePage.contentPreview",

--- a/backlog/tasks/task-455 - Migrate-SummarizePageWorkflow-capture-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-455 - Migrate-SummarizePageWorkflow-capture-alert-to-design-system-Alert.md
@@ -1,0 +1,77 @@
+---
+id: TASK-455
+title: Migrate SummarizePageWorkflow capture alert to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-20 19:01'
+labels:
+  - design-system
+  - product-state
+  - ui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1893'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the SummarizePageWorkflow captured-page success notice from AntD Alert to the canonical design-system Alert while preserving title, URL, and content-length preview behavior. Remove the matching baseline exception and verify the guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SummarizePageWorkflow renders the capture success notice through the canonical design-system Alert primitive.
+- [x] #2 The captured page title, URL, success title, and content-length preview remain visible after migration.
+- [x] #3 The SummarizePageWorkflow Alert baseline exception is removed without introducing new blocked product-state findings.
+- [x] #4 Focused tests and design-system product-state verification pass, with known TypeScript/Bandit skips recorded if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented test-first: the SummarizePageWorkflow regression drives the mocked Chrome page-capture path and failed on the missing canonical Alert marker before replacing the AntD Alert.
+
+Verification recorded for this slice:
+- RED: bunx vitest run src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot failed on zero data-ds-component="Alert" markers before the implementation.
+- GREEN: bunx vitest run src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot passed: 1 test.
+- bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot passed: 2 files, 2 tests.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 326.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for SummarizePageWorkflow/task-455/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated SummarizePageWorkflow captured-page success notice from AntD Alert to the canonical design-system Alert. Added focused coverage for the mocked Chrome page-capture path and removed the SummarizePageWorkflow baseline entry, reducing product-state baseline exceptions from 327 to 326.
+
+Verification:
+- RED: bunx vitest run src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot failed on zero data-ds-component="Alert" markers.
+- GREEN: bunx vitest run src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot passed: 1 test.
+- bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot passed: 2 files, 2 tests.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 326.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for SummarizePageWorkflow/task-455/baseline matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-455 - Migrate-SummarizePageWorkflow-capture-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-455 - Migrate-SummarizePageWorkflow-capture-alert-to-design-system-Alert.md
@@ -4,7 +4,7 @@ title: Migrate SummarizePageWorkflow capture alert to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-20 19:01'
+updated_date: '2026-05-20 20:04'
 labels:
   - design-system
   - product-state
@@ -46,6 +46,8 @@ Verification recorded for this slice:
 - git diff --check passed.
 - Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for SummarizePageWorkflow/task-455/baseline matched 0 lines.
 - Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+
+PR review follow-up: replaced the SummarizePageWorkflow test's manual setTimeout spy with Vitest fake timers plus vi.waitFor, and changed the content-length assertion to compute the exact localized length from the mocked captured content. Focused regression test remained green after the fix.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -62,6 +64,8 @@ Verification:
 - git diff --check passed.
 - Full bunx tsc --noEmit --pretty false still exits 2 from inherited baseline debt; filtered touched-file diagnostics for SummarizePageWorkflow/task-455/baseline matched 0 lines.
 - Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+
+PR review follow-up addressed the timer and locale-fragility comments in the SummarizePageWorkflow product-state test.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- Migrates SummarizePageWorkflow captured-page success notice from AntD Alert to the canonical design-system Alert.
- Adds focused coverage for the mocked Chrome page-capture path and preserved title/URL/content-length preview content.
- Removes the SummarizePageWorkflow product-state baseline exception, reducing baseline exceptions from 327 to 326.

## Verification
- RED: `bunx vitest run src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot` failed on zero `data-ds-component="Alert"` markers.
- GREEN: `bunx vitest run src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot` passed: 1 test.
- `bunx vitest run src/components/Common/Workflow/__tests__/WizardShell.test.tsx src/components/Common/Workflow/__tests__/SummarizePageWorkflow.product-state.test.tsx --reporter=dot` passed: 2 files, 2 tests.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 52 tests.
- `bun run verify:design-system-state` passed; baseline exceptions are now 326.
- `git diff --check` passed.
- Full `bunx tsc --noEmit --pretty false` still exits 2 from inherited baseline debt; filtered touched-file diagnostics for SummarizePageWorkflow/task-455/baseline matched 0 lines.
- Bandit skipped: TypeScript UI/test, JSON baseline, and task metadata only; no Python touched.

## Change summary
TODO (human-authored before merge): summarize what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the captured-page success notice in `SummarizePageWorkflow` from `antd` to the design-system `Alert`, removed the related baseline exception, and verified the product‑state guard; reduces baseline exceptions from 327 to 326 and completes TASK‑455.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` (`variant="success"`), preserving title, URL, and content-length preview.
  - Removed the `SummarizePageWorkflow` product-state baseline exception entry.

- **Tests**
  - Added a focused unit test for the mocked Chrome capture path that asserts the `data-ds-component="Alert"` marker; switched to fake timers with `vi.waitFor` and made the content-length assertion locale-safe.

<sup>Written for commit f94d649f5a59386ee7ab95de4d08e84b5946f6ee. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1893?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

