### PR TITLE
Add Persona Visual sectioned workspace

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -3788,6 +3788,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         data-testid="persona-visual-section-reuse-portability"
         aria-label="Reuse and portability"
       >
+        <VisualWorkspaceSectionHeading
+          title="Reuse and portability"
+          description="Create drafts from existing packs or manage portability actions."
+        />
         <VisualPackReusePanel
           selectedPersonaName={selectedPersonaName || selectedPersonaId}
           hasSelectedPack={Boolean(selectedPack)}
@@ -3815,16 +3819,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
       {!showGuidedBuilder && !selectedPack ? firstRunImportPanel : null}
 
-      <div
+      <section
         ref={libraryPanelRef}
-        data-testid="persona-visual-library-panel"
+        data-testid="persona-visual-section-library"
         tabIndex={-1}
         className="rounded-lg border border-border bg-surface p-3"
+        aria-label="Personal library"
       >
-        <VisualWorkspaceSectionHeading
-          title="Personal library"
-          description="Manage reusable user-owned Persona Visual pack references."
-        />
+        <VisualWorkspaceSectionHeading title="Personal library" />
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
             <div className="mt-1 text-xs text-text-muted">
@@ -3850,7 +3852,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </section>
 
       {selectedPack ? (
         <>

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -360,6 +360,20 @@ const VisualManagementHeader: React.FC<{
   )
 }
 
+const VisualWorkspaceSectionHeading: React.FC<{
+  title: string
+  description?: string
+}> = ({ title, description }) => (
+  <div className="mb-3">
+    <h3 className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+      {title}
+    </h3>
+    {description ? (
+      <div className="mt-1 text-xs text-text-muted">{description}</div>
+    ) : null}
+  </div>
+)
+
 const getGenerationReadinessCopy = (
   view: PersonaVisualGenerationReadinessView,
   t: VisualPackTranslate
@@ -3605,7 +3619,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         </div>
       </Modal>
 
-      <div className="rounded-lg border border-border bg-surface p-3">
+      <section
+        data-testid="persona-visual-section-pack-basics"
+        className="rounded-lg border border-border bg-surface p-3"
+        aria-label="Pack basics and active status"
+      >
         {showManagementHeader ? (
           <VisualManagementHeader
             personaName={selectedPersonaName || selectedPersonaId}
@@ -3764,20 +3782,25 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
             <div>{packHealthDiagnostic.message}</div>
           </div>
         ) : null}
-      </div>
+      </section>
 
-      <VisualPackReusePanel
-        selectedPersonaName={selectedPersonaName || selectedPersonaId}
-        hasSelectedPack={Boolean(selectedPack)}
-        canImport
-        libraryItemCount={libraryItems.length}
-        hasDuplicateTargets={availableDuplicateTargets.length > 0}
-        duplicateTargetsLoading={duplicateTargetsLoading}
-        onCreateDraft={focusDraftTitleInput}
-        onOpenLibrary={focusLibraryPanel}
-        onOpenImport={openImportArchivePicker}
-        onOpenDuplicate={focusDuplicateControls}
-      />
+      <section
+        data-testid="persona-visual-section-reuse-portability"
+        aria-label="Reuse and portability"
+      >
+        <VisualPackReusePanel
+          selectedPersonaName={selectedPersonaName || selectedPersonaId}
+          hasSelectedPack={Boolean(selectedPack)}
+          canImport
+          libraryItemCount={libraryItems.length}
+          hasDuplicateTargets={availableDuplicateTargets.length > 0}
+          duplicateTargetsLoading={duplicateTargetsLoading}
+          onCreateDraft={focusDraftTitleInput}
+          onOpenLibrary={focusLibraryPanel}
+          onOpenImport={openImportArchivePicker}
+          onOpenDuplicate={focusDuplicateControls}
+        />
+      </section>
 
       {error ? (
         <div className="rounded-md border border-danger/30 bg-danger/10 p-2 text-xs text-danger">
@@ -3798,13 +3821,14 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
         tabIndex={-1}
         className="rounded-lg border border-border bg-surface p-3"
       >
+        <VisualWorkspaceSectionHeading
+          title="Personal library"
+          description="Manage reusable user-owned Persona Visual pack references."
+        />
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
-              Personal library
-            </div>
             <div className="mt-1 text-xs text-text-muted">
-              Save reusable Persona Buddy visual packs as user-owned references.
+              Save reusable Persona Visual packs as user-owned references.
               Using one creates a draft on the target persona.
             </div>
           </div>
@@ -3830,7 +3854,15 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
       {selectedPack ? (
         <>
-          <div className="rounded-lg border border-border bg-surface p-3">
+          <section
+            data-testid="persona-visual-section-assets"
+            className="rounded-lg border border-border bg-surface p-3"
+            aria-label="Assets"
+          >
+            <VisualWorkspaceSectionHeading
+              title="Assets"
+              description="Upload and review the image assets referenced by this pack."
+            />
             <div className="flex flex-wrap items-end gap-2">
               <label className="text-xs text-text-muted">
                 <span className="mb-1 block">Asset role</span>
@@ -3886,12 +3918,17 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 </div>
               ))}
             </div>
-          </div>
+          </section>
 
-          <div className="rounded-lg border border-border bg-surface p-3">
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
-              Portability
-            </div>
+          <section
+            data-testid="persona-visual-section-portable-actions"
+            className="rounded-lg border border-border bg-surface p-3"
+            aria-label="Portable archive and duplicate actions"
+          >
+            <VisualWorkspaceSectionHeading
+              title="Portable archive and duplicate actions"
+              description="Export, import, or duplicate this pack as a draft for review."
+            />
             <div
               data-testid="persona-visual-portability-copy"
               className="mt-2 rounded-md border border-border bg-bg px-3 py-2 text-xs leading-5 text-text-muted"
@@ -4039,12 +4076,17 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
 
               {!showGuidedBuilder ? importPreviewPanel : null}
             </div>
-          </div>
+          </section>
 
-          <div className="rounded-lg border border-border bg-surface p-3">
-            <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
-              State Mapping
-            </div>
+          <section
+            data-testid="persona-visual-section-state-mapping"
+            className="rounded-lg border border-border bg-surface p-3"
+            aria-label="State mappings and fallbacks"
+          >
+            <VisualWorkspaceSectionHeading
+              title="State mappings and fallbacks"
+              description="Map runtime Persona Visual states to animations and define fallback chains."
+            />
             <div className="grid gap-2 md:grid-cols-2">
               {[...REQUIRED_VISUAL_STATES, ...OPTIONAL_VISUAL_STATES].map((state) => (
                 <label key={state} className="text-xs text-text-muted">
@@ -4109,9 +4151,17 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 </label>
               ))}
             </div>
-          </div>
+          </section>
 
-          <div className="rounded-lg border border-border bg-surface p-3">
+          <section
+            data-testid="persona-visual-section-animations"
+            className="rounded-lg border border-border bg-surface p-3"
+            aria-label="Animations"
+          >
+            <VisualWorkspaceSectionHeading
+              title="Animations"
+              description="Edit animation timing, frame order, sprite regions, and looping behavior."
+            />
             <div className="mb-2 flex flex-wrap items-end gap-2">
               <label className="min-w-[180px] text-xs text-text-muted">
                 <span className="mb-1 block">Animation</span>
@@ -4340,12 +4390,17 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 No animations in this pack.
               </div>
             )}
-          </div>
+          </section>
 
-          <div className="rounded-lg border border-border bg-surface p-3">
-            <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
-              Authored Triggers
-            </div>
+          <section
+            data-testid="persona-visual-section-authored-triggers"
+            className="rounded-lg border border-border bg-surface p-3"
+            aria-label="Authored triggers"
+          >
+            <VisualWorkspaceSectionHeading
+              title="Authored triggers"
+              description="Bind explicit trigger matches to visual states without changing runtime defaults."
+            />
             <div className="grid gap-2 md:grid-cols-[130px_minmax(160px,1fr)_130px_100px_90px_auto]">
               <select
                 data-testid="persona-visual-trigger-source-select"
@@ -4435,12 +4490,19 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 ))}
               </div>
             ) : null}
-          </div>
+          </section>
 
-          <div className="rounded-lg border border-border bg-surface p-3">
+          <section
+            data-testid="persona-visual-section-validation-activation"
+            className="rounded-lg border border-border bg-surface p-3"
+            aria-label="Validation and activation"
+          >
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <Typography.Text strong>Validation</Typography.Text>
+                <VisualWorkspaceSectionHeading
+                  title="Validation and activation"
+                  description="Save manifest changes and explicitly activate only valid packs."
+                />
                 {validationErrors.length ? (
                   <div
                     data-testid="persona-visual-validation-errors"
@@ -4487,13 +4549,18 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 </Button>
               </div>
             </div>
-          </div>
+          </section>
 
-          <div className="rounded-lg border border-border bg-surface p-3">
+          <section
+            data-testid="persona-visual-section-jobs-review"
+            className="rounded-lg border border-border bg-surface p-3"
+            aria-label="Jobs and review"
+          >
             <div className="flex flex-wrap items-start justify-between gap-2">
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
-                Generated Candidates
-              </div>
+              <VisualWorkspaceSectionHeading
+                title="Jobs and review"
+                description="Queue generation jobs and review generated candidates before applying them."
+              />
               <Button
                 data-testid="persona-visual-candidates-refresh-button"
                 size="small"
@@ -4651,7 +4718,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                 </div>
               )}
             </div>
-          </div>
+          </section>
         </>
       ) : null}
     </div>

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -492,12 +492,7 @@ describe("VisualPackEditor", () => {
       if (path === "/api/v1/persona/visual-library" && method === "GET") {
         return okResponse({ items: [] })
       }
-      return Promise.resolve({
-        ok: false,
-        status: 404,
-        error: `Unhandled path: ${path}`,
-        json: async () => ({})
-      })
+      throw new Error(`Unhandled path: ${path}`)
     })
 
     render(
@@ -511,8 +506,8 @@ describe("VisualPackEditor", () => {
     await screen.findByTestId("persona-visual-management-header")
     const expectedSections = [
       ["persona-visual-section-pack-basics", "Rendered now"],
-      ["persona-visual-section-reuse-portability", "Create draft"],
-      ["persona-visual-library-panel", "Personal library"],
+      ["persona-visual-section-reuse-portability", "Reuse and portability"],
+      ["persona-visual-section-library", "Personal library"],
       ["persona-visual-section-assets", "Assets"],
       ["persona-visual-section-portable-actions", "Portable archive and duplicate actions"],
       ["persona-visual-section-state-mapping", "State mappings and fallbacks"],
@@ -527,6 +522,7 @@ describe("VisualPackEditor", () => {
     }
     expect(screen.getByTestId("persona-visual-upload-button")).toBeInTheDocument()
     expect(screen.getByTestId("persona-visual-activate-button")).toBeInTheDocument()
+    expect(screen.queryByText(/Unhandled path:/)).not.toBeInTheDocument()
   })
 
   it("does not show setup choices before active pack state is known", async () => {
@@ -2139,7 +2135,7 @@ describe("VisualPackEditor", () => {
     fireEvent.click(
       within(reusePanel).getByRole("button", { name: /use personal library/i })
     )
-    expect(screen.getByTestId("persona-visual-library-panel")).toHaveFocus()
+    expect(screen.getByTestId("persona-visual-section-library")).toHaveFocus()
 
     await waitFor(() =>
       expect(
@@ -3662,7 +3658,7 @@ describe("VisualPackEditor", () => {
       />
     )
 
-    const libraryPanel = await screen.findByTestId("persona-visual-library-panel")
+    const libraryPanel = await screen.findByTestId("persona-visual-section-library")
     expect(libraryPanel).toHaveTextContent("Personal library")
     expect(within(libraryPanel).getByText("Saved animated pack")).toBeInTheDocument()
     expect(within(libraryPanel).getByText("source changed")).toBeInTheDocument()
@@ -3750,7 +3746,7 @@ describe("VisualPackEditor", () => {
       />
     )
 
-    const libraryPanel = await screen.findByTestId("persona-visual-library-panel")
+    const libraryPanel = await screen.findByTestId("persona-visual-section-library")
     expect(libraryPanel).toHaveTextContent("Personal library")
     expect(within(libraryPanel).getByText("Reusable source pack")).toBeInTheDocument()
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -462,6 +462,73 @@ describe("VisualPackEditor", () => {
     expect(screen.getByTestId("persona-visual-pack-select")).toBeInTheDocument()
   })
 
+  it("groups post-setup Persona Visual controls into workspace sections", async () => {
+    const activePack = makeVisualPack({
+      id: "active-pack",
+      title: "Rendered now",
+      status: "active"
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse({ packs: [activePack], active_pack: activePack })
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        error: `Unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await screen.findByTestId("persona-visual-management-header")
+    const expectedSections = [
+      ["persona-visual-section-pack-basics", "Rendered now"],
+      ["persona-visual-section-reuse-portability", "Create draft"],
+      ["persona-visual-library-panel", "Personal library"],
+      ["persona-visual-section-assets", "Assets"],
+      ["persona-visual-section-portable-actions", "Portable archive and duplicate actions"],
+      ["persona-visual-section-state-mapping", "State mappings and fallbacks"],
+      ["persona-visual-section-animations", "Animations"],
+      ["persona-visual-section-authored-triggers", "Authored triggers"],
+      ["persona-visual-section-validation-activation", "Validation and activation"],
+      ["persona-visual-section-jobs-review", "Jobs and review"]
+    ]
+
+    for (const [testId, label] of expectedSections) {
+      expect(screen.getByTestId(testId)).toHaveTextContent(label)
+    }
+    expect(screen.getByTestId("persona-visual-upload-button")).toBeInTheDocument()
+    expect(screen.getByTestId("persona-visual-activate-button")).toBeInTheDocument()
+  })
+
   it("does not show setup choices before active pack state is known", async () => {
     const activePack = makeVisualPack({ status: "active" })
     const packsDeferred = deferredResponse<any>()

--- a/backlog/tasks/task-455 - Implement-Persona-Visual-sectioned-pack-workspace.md
+++ b/backlog/tasks/task-455 - Implement-Persona-Visual-sectioned-pack-workspace.md
@@ -1,0 +1,64 @@
+---
+id: TASK-455
+title: Implement Persona Visual sectioned pack workspace
+status: In Progress
+labels:
+- persona
+- persona-visual
+- webui
+- frontend
+references:
+- https://github.com/rmusser01/tldw_server/issues/1510
+- https://github.com/rmusser01/tldw_server/issues/1894
+- https://github.com/rmusser01/tldw_server/issues/1769
+- https://github.com/rmusser01/tldw_server/pull/1771
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VisualPackEditor groups existing controls into clear Persona Visual workspace sections for pack basics/status, assets, animations, state mappings/fallbacks, authored triggers, validation/activation, jobs/review, and reuse/portability without backend behavior changes.
+- [x] #2 Existing first-run setup, management header, import/export, generation, candidate review, validation, activation, library, and duplicate-to-persona controls remain available and keep current test coverage.
+- [x] #3 Focused shared UI tests cover the section headings/landmarks and preservation of existing behavior.
+- [x] #4 No Buddy animation, VN/CYOA, backend schema, generation orchestration, marketplace, shared-library, renderer, MCP provider execution, or auto-activation work is included.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Slice 3 from Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md: refactor the Persona Garden VisualPackEditor surface into clearer post-setup workspace sections while preserving existing behavior and backend/API contracts. Keep this Persona Visual only and leave attention navigation polish for the next slice.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Slice 3 from the Persona Visual post-setup management design. Added semantic section landmarks and compact headings around the existing VisualPackEditor control groups: pack basics/status, reuse and portability entry points, personal library, assets, portable archive/duplicate actions, state mappings/fallbacks, animations, authored triggers, validation/activation, and jobs/review. Existing controls remain in place and continue to use the current frontend state and backend/API contracts.
+
+Verification:
+- `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "workspace sections|management header"` passed with 2 focused tests.
+- `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed with 67 tests.
+- `git diff --check` passed.
+- `bunx tsc --noEmit -p tsconfig.json` was attempted from `apps/packages/ui` and failed on existing package-wide TypeScript debt outside the touched PersonaGarden files; no errors referenced the touched files in the visible output.
+- Bandit is not applicable to this frontend-only TypeScript/Backlog slice.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the Persona Visual sectioned pack workspace for post-setup management. VisualPackEditor now exposes testable, accessible sections for the existing lifecycle areas without changing backend behavior, generation orchestration, activation semantics, or Buddy animation functionality.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-455 - Implement-Persona-Visual-sectioned-pack-workspace.md
+++ b/backlog/tasks/task-455 - Implement-Persona-Visual-sectioned-pack-workspace.md
@@ -45,6 +45,13 @@ Verification:
 - `git diff --check` passed.
 - `bunx tsc --noEmit -p tsconfig.json` was attempted from `apps/packages/ui` and failed on existing package-wide TypeScript debt outside the touched PersonaGarden files; no errors referenced the touched files in the visible output.
 - Bandit is not applicable to this frontend-only TypeScript/Backlog slice.
+
+Review follow-up:
+- Added the missing reuse/portability section heading.
+- Converted the personal library container to a semantic section with a matching section test id and aria label.
+- Removed duplicate personal-library heading description text.
+- Hardened the new workspace-section test so unmocked API paths throw instead of rendering a silent error banner.
+- Verification after review fixes: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "workspace sections|management header"` passed with 2 focused tests; `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed with 67 tests; `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary

- Add semantic, testable sections to the Persona Garden VisualPackEditor post-setup workspace.
- Keep existing controls and backend/API behavior intact while making pack basics, assets, portability, state mappings, animations, triggers, validation, jobs/review, library, and reuse areas easier to scan.
- Track the work in Backlog TASK-455 and GitHub issue #1894 under the broader Persona/Buddy reliability epic #1510.

## Change summary

Human-authored change summary required before merge.

## Verification

- `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "workspace sections|management header"`
- `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx`
- `git diff --check`
- Attempted `bunx tsc --noEmit -p tsconfig.json`; it fails on existing package-wide TypeScript debt outside the touched PersonaGarden files, with no visible errors referencing the touched files.

## Scope boundaries

- No Buddy animation pipeline work.
- No VN/CYOA behavior.
- No backend schema/API changes.
- No generation orchestration, renderer expansion, MCP provider execution, or auto-activation behavior changes.

Closes #1894.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added semantic, accessible sections to the Persona Visual post-setup workspace in `VisualPackEditor` to make controls easier to scan and test. No backend or behavior changes; aligns with TASK-455 and closes #1894.

- **Refactors**
  - Grouped existing controls into sections: pack basics/status, reuse/portability, personal library, assets, portable archive/duplicate actions, state mappings/fallbacks, animations, authored triggers, validation/activation, and jobs/review. Added `VisualWorkspaceSectionHeading`, per-section `aria-label`s, and `data-testid`s; updated copy and test IDs (e.g., “Persona Visual”).
  - Review follow-ups: added the missing Reuse/portability heading, converted Personal library to a semantic section with a new test ID, removed duplicate text, and hardened tests to assert section landmarks and fail on unmocked API paths.

<sup>Written for commit 6eb99fade1c48a6c07a843d22410b6e668ad8daa. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1895?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

