### PR TITLE
Harden setup connection route-state QA

### DIFF
--- a/apps/packages/ui/src/store/__tests__/connection.test.ts
+++ b/apps/packages/ui/src/store/__tests__/connection.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   ConnectionPhase,
   deriveConnectionUxState,
-  type ConnectionState
+  type ConnectionState,
+  type ConnectionUxState
 } from "@/types/connection"
 
 vi.mock("@/services/tldw-server", () => ({
@@ -46,6 +47,128 @@ const ageLastCheck = () => {
     isChecking: false
   })
 }
+
+const createBaseConnectionState = (): ConnectionState => ({
+  phase: ConnectionPhase.UNCONFIGURED,
+  serverUrl: null,
+  lastCheckedAt: null,
+  lastError: null,
+  lastStatusCode: null,
+  isConnected: false,
+  isChecking: false,
+  consecutiveFailures: 0,
+  offlineBypass: false,
+  knowledgeStatus: "unknown",
+  knowledgeLastCheckedAt: null,
+  knowledgeError: null,
+  mode: "normal",
+  configStep: "none",
+  errorKind: "none",
+  hasCompletedFirstRun: false,
+  userPersona: null,
+  lastConfigUpdatedAt: null,
+  checksSinceConfigChange: 0
+})
+
+type ConnectionUxMatrixCase = {
+  name: string
+  overrides: Partial<ConnectionState>
+  expected: ConnectionUxState
+}
+
+const connectionUxMatrix: ConnectionUxMatrixCase[] = [
+  {
+    name: "unconfigured first run",
+    overrides: {},
+    expected: "unconfigured"
+  },
+  {
+    name: "URL configuration step",
+    overrides: { configStep: "url" },
+    expected: "configuring_url"
+  },
+  {
+    name: "auth configuration step",
+    overrides: { configStep: "auth" },
+    expected: "configuring_auth"
+  },
+  {
+    name: "active health check from setup",
+    overrides: { configStep: "health", isChecking: true },
+    expected: "testing"
+  },
+  {
+    name: "searching health check",
+    overrides: {
+      phase: ConnectionPhase.SEARCHING,
+      configStep: "health",
+      isChecking: true
+    },
+    expected: "testing"
+  },
+  {
+    name: "connected ready backend",
+    overrides: {
+      phase: ConnectionPhase.CONNECTED,
+      isConnected: true,
+      serverUrl: "http://127.0.0.1:8000",
+      knowledgeStatus: "ready",
+      hasCompletedFirstRun: true
+    },
+    expected: "connected_ok"
+  },
+  {
+    name: "connected partial error",
+    overrides: {
+      phase: ConnectionPhase.CONNECTED,
+      isConnected: true,
+      serverUrl: "http://127.0.0.1:8000",
+      errorKind: "partial",
+      knowledgeStatus: "ready",
+      hasCompletedFirstRun: true
+    },
+    expected: "connected_degraded"
+  },
+  {
+    name: "connected with offline knowledge",
+    overrides: {
+      phase: ConnectionPhase.CONNECTED,
+      isConnected: true,
+      serverUrl: "http://127.0.0.1:8000",
+      knowledgeStatus: "offline",
+      hasCompletedFirstRun: true
+    },
+    expected: "connected_degraded"
+  },
+  {
+    name: "auth error",
+    overrides: {
+      phase: ConnectionPhase.ERROR,
+      errorKind: "auth",
+      serverUrl: "http://127.0.0.1:8000"
+    },
+    expected: "error_auth"
+  },
+  {
+    name: "unreachable error",
+    overrides: {
+      phase: ConnectionPhase.ERROR,
+      errorKind: "unreachable",
+      serverUrl: "http://127.0.0.1:8000"
+    },
+    expected: "error_unreachable"
+  },
+  {
+    name: "demo mode",
+    overrides: {
+      mode: "demo",
+      phase: ConnectionPhase.CONNECTED,
+      isConnected: true,
+      offlineBypass: true
+    },
+    expected: "demo_mode"
+  }
+]
 
 describe("connection store stability", () => {
   const originalChrome = (
@@ -101,96 +224,17 @@ describe("connection store stability", () => {
     })
   })
 
-  it("maps the setup connection UX state matrix to stable route states", () => {
-    const baseState: ConnectionState = {
-      phase: ConnectionPhase.UNCONFIGURED,
-      serverUrl: null,
-      lastCheckedAt: null,
-      lastError: null,
-      lastStatusCode: null,
-      isConnected: false,
-      isChecking: false,
-      consecutiveFailures: 0,
-      offlineBypass: false,
-      knowledgeStatus: "unknown",
-      knowledgeLastCheckedAt: null,
-      knowledgeError: null,
-      mode: "normal",
-      configStep: "none",
-      errorKind: "none",
-      hasCompletedFirstRun: false,
-      userPersona: null,
-      lastConfigUpdatedAt: null,
-      checksSinceConfigChange: 0
+  it.each(connectionUxMatrix)(
+    "maps $name to $expected in the setup connection UX state matrix",
+    ({ overrides, expected }) => {
+      expect(
+        deriveConnectionUxState({
+          ...createBaseConnectionState(),
+          ...overrides
+        })
+      ).toBe(expected)
     }
-    const derive = (overrides: Partial<ConnectionState>) =>
-      deriveConnectionUxState({
-        ...baseState,
-        ...overrides
-      })
-
-    expect(derive({})).toBe("unconfigured")
-    expect(derive({ configStep: "url" })).toBe("configuring_url")
-    expect(derive({ configStep: "auth" })).toBe("configuring_auth")
-    expect(derive({ configStep: "health", isChecking: true })).toBe("testing")
-    expect(
-      derive({
-        phase: ConnectionPhase.SEARCHING,
-        configStep: "health",
-        isChecking: true
-      })
-    ).toBe("testing")
-    expect(
-      derive({
-        phase: ConnectionPhase.CONNECTED,
-        isConnected: true,
-        serverUrl: "http://127.0.0.1:8000",
-        knowledgeStatus: "ready",
-        hasCompletedFirstRun: true
-      })
-    ).toBe("connected_ok")
-    expect(
-      derive({
-        phase: ConnectionPhase.CONNECTED,
-        isConnected: true,
-        serverUrl: "http://127.0.0.1:8000",
-        errorKind: "partial",
-        knowledgeStatus: "ready",
-        hasCompletedFirstRun: true
-      })
-    ).toBe("connected_degraded")
-    expect(
-      derive({
-        phase: ConnectionPhase.CONNECTED,
-        isConnected: true,
-        serverUrl: "http://127.0.0.1:8000",
-        knowledgeStatus: "offline",
-        hasCompletedFirstRun: true
-      })
-    ).toBe("connected_degraded")
-    expect(
-      derive({
-        phase: ConnectionPhase.ERROR,
-        errorKind: "auth",
-        serverUrl: "http://127.0.0.1:8000"
-      })
-    ).toBe("error_auth")
-    expect(
-      derive({
-        phase: ConnectionPhase.ERROR,
-        errorKind: "unreachable",
-        serverUrl: "http://127.0.0.1:8000"
-      })
-    ).toBe("error_unreachable")
-    expect(
-      derive({
-        mode: "demo",
-        phase: ConnectionPhase.CONNECTED,
-        isConnected: true,
-        offlineBypass: true
-      })
-    ).toBe("demo_mode")
-  })
+  )
 
   it("keeps connected state through transient unreachable checks before threshold", async () => {
     mockedApiSend.mockResolvedValue({

--- a/apps/packages/ui/src/store/__tests__/connection.test.ts
+++ b/apps/packages/ui/src/store/__tests__/connection.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { ConnectionPhase } from "@/types/connection"
+import {
+  ConnectionPhase,
+  deriveConnectionUxState,
+  type ConnectionState
+} from "@/types/connection"
 
 vi.mock("@/services/tldw-server", () => ({
   getStoredTldwServerURL: vi.fn(async () => null)
@@ -95,6 +99,97 @@ describe("connection store stability", () => {
       value: originalChrome,
       configurable: true
     })
+  })
+
+  it("maps the setup connection UX state matrix to stable route states", () => {
+    const baseState: ConnectionState = {
+      phase: ConnectionPhase.UNCONFIGURED,
+      serverUrl: null,
+      lastCheckedAt: null,
+      lastError: null,
+      lastStatusCode: null,
+      isConnected: false,
+      isChecking: false,
+      consecutiveFailures: 0,
+      offlineBypass: false,
+      knowledgeStatus: "unknown",
+      knowledgeLastCheckedAt: null,
+      knowledgeError: null,
+      mode: "normal",
+      configStep: "none",
+      errorKind: "none",
+      hasCompletedFirstRun: false,
+      userPersona: null,
+      lastConfigUpdatedAt: null,
+      checksSinceConfigChange: 0
+    }
+    const derive = (overrides: Partial<ConnectionState>) =>
+      deriveConnectionUxState({
+        ...baseState,
+        ...overrides
+      })
+
+    expect(derive({})).toBe("unconfigured")
+    expect(derive({ configStep: "url" })).toBe("configuring_url")
+    expect(derive({ configStep: "auth" })).toBe("configuring_auth")
+    expect(derive({ configStep: "health", isChecking: true })).toBe("testing")
+    expect(
+      derive({
+        phase: ConnectionPhase.SEARCHING,
+        configStep: "health",
+        isChecking: true
+      })
+    ).toBe("testing")
+    expect(
+      derive({
+        phase: ConnectionPhase.CONNECTED,
+        isConnected: true,
+        serverUrl: "http://127.0.0.1:8000",
+        knowledgeStatus: "ready",
+        hasCompletedFirstRun: true
+      })
+    ).toBe("connected_ok")
+    expect(
+      derive({
+        phase: ConnectionPhase.CONNECTED,
+        isConnected: true,
+        serverUrl: "http://127.0.0.1:8000",
+        errorKind: "partial",
+        knowledgeStatus: "ready",
+        hasCompletedFirstRun: true
+      })
+    ).toBe("connected_degraded")
+    expect(
+      derive({
+        phase: ConnectionPhase.CONNECTED,
+        isConnected: true,
+        serverUrl: "http://127.0.0.1:8000",
+        knowledgeStatus: "offline",
+        hasCompletedFirstRun: true
+      })
+    ).toBe("connected_degraded")
+    expect(
+      derive({
+        phase: ConnectionPhase.ERROR,
+        errorKind: "auth",
+        serverUrl: "http://127.0.0.1:8000"
+      })
+    ).toBe("error_auth")
+    expect(
+      derive({
+        phase: ConnectionPhase.ERROR,
+        errorKind: "unreachable",
+        serverUrl: "http://127.0.0.1:8000"
+      })
+    ).toBe("error_unreachable")
+    expect(
+      derive({
+        mode: "demo",
+        phase: ConnectionPhase.CONNECTED,
+        isConnected: true,
+        offlineBypass: true
+      })
+    ).toBe("demo_mode")
   })
 
   it("keeps connected state through transient unreachable checks before threshold", async () => {

--- a/apps/packages/ui/src/types/connection.ts
+++ b/apps/packages/ui/src/types/connection.ts
@@ -72,18 +72,6 @@ export const deriveConnectionUxState = (
     return "demo_mode"
   }
 
-  // Explicit onboarding steps when unconfigured.
-  if (phase === ConnectionPhase.UNCONFIGURED) {
-    if (configStep === "url") {
-      return "configuring_url"
-    }
-    if (configStep === "auth") {
-      return "configuring_auth"
-    }
-    return "unconfigured"
-  }
-
-  // Any active check maps to a testing state.
   // Treat offline bypass the same as a healthy connection for UX.
   if (offlineBypass && isConnected) {
     return "connected_ok"
@@ -99,6 +87,17 @@ export const deriveConnectionUxState = (
   // Any active check maps to a testing state.
   if (phase === ConnectionPhase.SEARCHING || isChecking) {
     return "testing"
+  }
+
+  // Explicit onboarding steps when unconfigured.
+  if (phase === ConnectionPhase.UNCONFIGURED) {
+    if (configStep === "url") {
+      return "configuring_url"
+    }
+    if (configStep === "auth") {
+      return "configuring_auth"
+    }
+    return "unconfigured"
   }
 
   if (phase === ConnectionPhase.CONNECTED) {

--- a/apps/tldw-frontend/e2e/workflows/setup-connection-flow.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/setup-connection-flow.spec.ts
@@ -71,7 +71,9 @@ test.describe('Setup and recovery route QA', () => {
       await expectNoHorizontalOverflow(page, `${viewport.label} / first-run`);
 
       await page.goto('/setup', { waitUntil: 'domcontentloaded' });
-      await expect(page.getByRole('heading', { level: 1, name: 'Setup Wizard' })).toBeVisible({
+      await expect(
+        page.getByRole('heading', { level: 1, name: /Setup (Wizard|readiness)/i })
+      ).toBeVisible({
         timeout: 15_000,
       });
       await expectOnePageHeading(page, `${viewport.label} /setup`);

--- a/backlog/tasks/task-418.12.1 - Address-setup-connection-flow-post-merge-QA-gaps.md
+++ b/backlog/tasks/task-418.12.1 - Address-setup-connection-flow-post-merge-QA-gaps.md
@@ -1,0 +1,67 @@
+---
+id: TASK-418.12.1
+title: Address setup connection flow post-merge QA gaps
+status: Done
+labels:
+- ux
+- webui
+- extension
+- setup
+- follow-up
+priority: High
+parent_task_id: TASK-418.12
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up to the completed WebUI setup/connection-flow remediation after post-merge continuation. Scope: lock the connection UX route-state matrix around active health checks, keep setup/recovery browser QA aligned with the configured-server readiness branch, and verify the setup-adjacent route suite without backend/API changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Connection UX state matrix covers active health-check/testing states and connected/degraded/error/demo states.
+- [x] #2 Production connection state derivation is changed only for the proved active-check gap.
+- [x] #3 Setup/recovery Playwright QA passes for desktop and mobile, including the configured-server setup readiness branch.
+- [x] #4 Focused package UI and frontend Vitest gates pass.
+- [x] #5 Focused Playwright login, onboarding, hosted-placeholder, and setup-connection-flow gates pass or documented skips are recorded.
+- [x] #6 No backend APIs, route renames, or broad visual redesign are included.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation notes:
+- Added focused connection-store matrix coverage for deriveConnectionUxState, including health-check testing, SEARCHING, connected_ok, connected_degraded, auth/unreachable errors, and demo mode.
+- Verified the red failure first: UNCONFIGURED + configStep health + isChecking mapped to unconfigured instead of testing.
+- Reordered deriveConnectionUxState so demo and stable connected states remain first, then active SEARCHING/isChecking states map to testing before unconfigured fallback handling.
+- Updated setup-connection-flow Playwright QA to accept both unconfigured Setup Wizard and configured-server Setup readiness branches while still requiring exactly one h1, no normal navigation chrome, and no horizontal overflow.
+- No backend APIs, route renames, broad visual redesign, or unrelated cleanup were included.
+
+Verification:
+- bunx vitest run src/store/__tests__/connection.test.ts -> 16 tests passed after the red failure was fixed.
+- bunx vitest run src/routes/__tests__/option-index.setup-flow.test.tsx -> 6 tests passed.
+- bunx vitest run src/components/Option/Onboarding/__tests__/OnboardingConnectForm.design-system.test.tsx -> 4 tests passed; existing react-i18next no-instance warning remains in this test path.
+- bunx vitest run __tests__/navigation/route-placeholder-component.test.tsx __tests__/navigation/route-redirect-component.test.tsx __tests__/navigation/not-found-page.test.tsx -> 16 tests passed.
+- bunx vitest run src/store/__tests__/connection.test.ts src/routes/__tests__/option-index.setup-flow.test.tsx src/components/Option/Onboarding/__tests__/OnboardingConnectForm.design-system.test.tsx -> 26 tests passed.
+- bunx playwright test e2e/workflows/setup-connection-flow.spec.ts --reporter=line -> first sandbox run failed with EPERM binding port 8080; escalated rerun exposed stale Setup Wizard-only browser expectation; after test patch, 4 tests passed.
+- bunx playwright test e2e/login.spec.ts e2e/workflows/onboarding-ingestion-first.spec.ts e2e/workflows/hosted-placeholder-routes.spec.ts --reporter=line -> 12 tests passed.
+- git diff --check -> passed.
+- Bandit not applicable: touched scope is frontend TypeScript/TSX and Backlog markdown only; no Python files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the post-merge setup/connection-flow QA follow-up. The connection UX state matrix now locks active health checks as the testing route state, production derivation handles that proved gap without destabilizing demo or connected refresh states, and setup/recovery browser QA now matches both configured-server readiness and unconfigured setup branches. Focused package UI, frontend navigation, Playwright route, login, onboarding, and hosted-placeholder gates passed. No backend/API changes, route renames, or broad visual redesign were made.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.12.1.1 - Address-PR-1896-review-comments.md
+++ b/backlog/tasks/task-418.12.1.1 - Address-PR-1896-review-comments.md
@@ -41,7 +41,8 @@ Verification:
 - At inspection time, Gemini and cubic reported no issues; CodeRabbit had completed, and most CI checks were pending with no failure requiring code changes yet.
 
 Known remaining PR status:
-- Push/review-thread resolution pending until this review-fix commit is pushed.
+- Review-fix commit was pushed to PR #1896 and the Qodo inline review thread was replied to and resolved.
+- CI re-ran after the push and was pending at closeout; `gh pr checks` did not report a failing job at that time.
 - Bandit is not applicable because the touched scope is frontend TypeScript tests and Backlog markdown only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 

--- a/backlog/tasks/task-418.12.1.1 - Address-PR-1896-review-comments.md
+++ b/backlog/tasks/task-418.12.1.1 - Address-PR-1896-review-comments.md
@@ -1,0 +1,62 @@
+---
+id: TASK-418.12.1.1
+title: Address PR 1896 review comments
+status: Done
+labels:
+- review
+- webui
+- setup
+- tests
+priority: High
+parent_task_id: TASK-418.12.1
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address live PR #1896 review feedback on the setup connection route-state QA branch. Scope is limited to still-actionable review comments and check failures for this PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Review threads/comments on PR #1896 are inspected before editing.
+- [x] #2 Connection UX matrix test is split into focused scenarios with clearer failure output.
+- [x] #3 Focused affected Vitest tests pass.
+- [x] #4 PR branch is pushed with review-fix commit.
+- [x] #5 Backlog task records verification and known remaining PR status.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation notes:
+- Inspected PR #1896 live review surfaces with gh pr view, gh pr checks, and GraphQL reviewThreads.
+- Found one actionable unresolved inline Qodo thread on apps/packages/ui/src/store/__tests__/connection.test.ts: the matrix test had many expect assertions in one it block.
+- Refactored the connection UX state matrix into a typed table plus it.each, producing one generated Vitest case and one primary assertion per state scenario.
+- No production code changed for this review fix.
+
+Verification:
+- bunx vitest run src/store/__tests__/connection.test.ts -> 1 file / 26 tests passed.
+- git diff --check -> passed.
+- At inspection time, Gemini and cubic reported no issues; CodeRabbit had completed, and most CI checks were pending with no failure requiring code changes yet.
+
+Known remaining PR status:
+- Push/review-thread resolution pending until this review-fix commit is pushed.
+- Bandit is not applicable because the touched scope is frontend TypeScript tests and Backlog markdown only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the actionable PR #1896 review comment by splitting the multi-assertion connection UX matrix test into parameterized focused scenarios. The affected Vitest test passes and no production code was changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Lock the setup connection UX route-state matrix around active health checks, degraded connected states, auth/unreachable errors, and demo mode.
- Fix the proved derivation gap so active health checks surface as `testing` without destabilizing demo mode or already-connected background refresh states.
- Align setup/recovery Playwright QA with both `/setup` branches: unconfigured `Setup Wizard` and configured-server `Setup readiness`.
- Add Backlog follow-up record `TASK-418.12.1`.

## Verification

- `bunx vitest run src/store/__tests__/connection.test.ts`
- `bunx vitest run src/routes/__tests__/option-index.setup-flow.test.tsx`
- `bunx vitest run src/components/Option/Onboarding/__tests__/OnboardingConnectForm.design-system.test.tsx`
- `bunx vitest run __tests__/navigation/route-placeholder-component.test.tsx __tests__/navigation/route-redirect-component.test.tsx __tests__/navigation/not-found-page.test.tsx`
- `bunx vitest run src/store/__tests__/connection.test.ts src/routes/__tests__/option-index.setup-flow.test.tsx src/components/Option/Onboarding/__tests__/OnboardingConnectForm.design-system.test.tsx`
- `bunx playwright test e2e/workflows/setup-connection-flow.spec.ts --reporter=line`
- `bunx playwright test e2e/login.spec.ts e2e/workflows/onboarding-ingestion-first.spec.ts e2e/workflows/hosted-placeholder-routes.spec.ts --reporter=line`
- `git diff --check`

## Change Summary

TODO: Human-authored change summary required before merge. Explain what changed and why these implementation choices were made.

## Notes

- No backend APIs, route renames, or broad visual redesign.
- Bandit is not applicable because this is a frontend TypeScript/TSX and Backlog markdown-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the setup connection route-state and QA: active health checks now always show as testing, and E2E accepts both "Setup Wizard" and "Setup readiness" branches. Follow-up to TASK-418.12.1; recorded review follow-up in Backlog as TASK-418.12.1.1.

- **Bug Fixes**
  - Reordered `deriveConnectionUxState` so active checks map to `testing` before unconfigured fallback; preserves demo and connected refresh states.
  - Updated Playwright to accept both "Setup Wizard" and "Setup readiness" headings in `/setup`.

- **Refactors**
  - Split the connection UX matrix test into parameterized cases (`it.each`) for clearer failures, adding coverage for `SEARCHING` and onboarding steps.

<sup>Written for commit 75a498996d3a7838c27235ca6ef7d80fcdd3f053. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1896?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

