### PR TITLE
Migrate VoiceTranscriptComposer product-state alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -264,17 +264,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/components/VoiceTranscriptComposer.tsx:Alert",
-    "path": "src/components/Flashcards/components/VoiceTranscriptComposer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/components/VoiceTranscriptComposer.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/tabs/ImageOcclusionPanel.tsx:Alert#antd-alert-imageocclusionpanel-type-info-line-230-fgog2f",
     "path": "src/components/Flashcards/tabs/ImageOcclusionPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/components/VoiceTranscriptComposer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/VoiceTranscriptComposer.tsx
@@ -49,7 +49,7 @@ export const VoiceTranscriptComposer: React.FC<VoiceTranscriptComposerProps> = (
         </div>
         {!supported && (
           <Alert
-            variant="info"
+            variant="error"
             title={t("option:flashcards.studyAssistantVoiceUnavailable", {
               defaultValue: "Voice transcript is unavailable in this browser."
             })}

--- a/apps/packages/ui/src/components/Flashcards/components/VoiceTranscriptComposer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/VoiceTranscriptComposer.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Alert, Button, Input, Space, Typography } from "antd"
+import { Button, Input, Space, Typography } from "antd"
 import { Mic, Square } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 
 const { Text } = Typography
 
@@ -48,9 +49,8 @@ export const VoiceTranscriptComposer: React.FC<VoiceTranscriptComposerProps> = (
         </div>
         {!supported && (
           <Alert
-            type="info"
-            showIcon
-            message={t("option:flashcards.studyAssistantVoiceUnavailable", {
+            variant="info"
+            title={t("option:flashcards.studyAssistantVoiceUnavailable", {
               defaultValue: "Voice transcript is unavailable in this browser."
             })}
           />

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { VoiceTranscriptComposer } from "../VoiceTranscriptComposer"
+
+const mocks = vi.hoisted(() => ({
+  t: vi.fn(
+    (
+      _key: string,
+      options?: { defaultValue?: string } | string
+    ) => {
+      if (typeof options === "string") return options
+      return options?.defaultValue ?? _key
+    }
+  ),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: mocks.t,
+  }),
+}))
+
+describe("VoiceTranscriptComposer product-state UI", () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it("renders unsupported voice state through the canonical design-system Alert", () => {
+    render(
+      <VoiceTranscriptComposer
+        transcript=""
+        isListening={false}
+        supported={false}
+        isSubmitting={false}
+        onTranscriptChange={vi.fn()}
+        onStartListening={vi.fn()}
+        onStopListening={vi.fn()}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const unavailableMessage = screen.getByText(
+      "Voice transcript is unavailable in this browser."
+    )
+
+    expect(unavailableMessage).toBeInTheDocument()
+    expect(
+      unavailableMessage.closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx
@@ -51,5 +51,6 @@ describe("VoiceTranscriptComposer product-state UI", () => {
     expect(
       unavailableMessage.closest('[data-ds-component="Alert"]')
     ).toBeInTheDocument()
+    expect(screen.getByRole("alert")).toContainElement(unavailableMessage)
   })
 })

--- a/backlog/tasks/task-456 - Migrate-VoiceTranscriptComposer-unsupported-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-456 - Migrate-VoiceTranscriptComposer-unsupported-alert-to-design-system-Alert.md
@@ -4,14 +4,14 @@ title: Migrate VoiceTranscriptComposer unsupported alert to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-21 00:34'
+updated_date: 2026-05-21 00:34
 labels:
-  - design-system
-  - product-state
-  - ui
+- design-system
+- product-state
+- ui
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/pull/1897'
+- https://github.com/rmusser01/tldw_server/pull/1897
 ---
 
 ## Description
@@ -50,7 +50,7 @@ Verification:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated VoiceTranscriptComposer's unsupported-browser voice transcript notice from AntD Alert to the canonical design-system Alert, added focused product-state coverage, and removed the VoiceTranscriptComposer baseline exception. Product-state baseline exceptions reduced from 326 to 325.
+Migrated VoiceTranscriptComposer's unsupported-browser voice transcript notice from AntD Alert to the canonical design-system Alert, added focused product-state coverage, removed the VoiceTranscriptComposer baseline exception, and addressed PR review feedback by mapping the unavailable state to the design-system Alert error variant. Product-state baseline exceptions remain 325.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-456 - Migrate-VoiceTranscriptComposer-unsupported-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-456 - Migrate-VoiceTranscriptComposer-unsupported-alert-to-design-system-Alert.md
@@ -1,0 +1,66 @@
+---
+id: TASK-456
+title: Migrate VoiceTranscriptComposer unsupported alert to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-21 00:34'
+labels:
+  - design-system
+  - product-state
+  - ui
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1897'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Flashcards VoiceTranscriptComposer unsupported-browser voice notice from AntD Alert to the canonical design-system Alert while preserving the visible message and keeping the product-state baseline clean.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VoiceTranscriptComposer renders the unsupported-browser notice through the canonical design-system Alert primitive.
+- [x] #2 The visible unsupported voice transcript message remains unchanged.
+- [x] #3 The VoiceTranscriptComposer Alert baseline exception is removed without introducing new blocked product-state findings.
+- [x] #4 Focused tests and design-system product-state verification pass, with known skips documented if applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented test-first: added VoiceTranscriptComposer product-state coverage for the unsupported browser notice and confirmed RED failure because the visible message was not inside a canonical data-ds-component="Alert" wrapper. Migrated the unsupported notice from AntD Alert to the design-system Alert while leaving the surrounding AntD form controls unchanged. Removed the matching VoiceTranscriptComposer Alert baseline exception.
+
+Verification:
+- RED: bunx vitest run src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx --reporter=dot failed on missing data-ds-component="Alert" wrapper.
+- GREEN: bunx vitest run src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx --reporter=dot passed: 1 test.
+- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 52 tests.
+- bun run verify:design-system-state passed; baseline exceptions are now 325.
+- git diff --check passed.
+- Full bunx tsc --noEmit --pretty false still exits 2 from inherited repo-wide TypeScript debt; /tmp/tsc_design_system_next_slice_18.log has 252 lines and touched-file filter for VoiceTranscriptComposer/baseline/task-456 matched 0 lines.
+- Bandit skipped because this slice changes TypeScript UI/test, JSON baseline, and task metadata only; no Python code touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated VoiceTranscriptComposer's unsupported-browser voice transcript notice from AntD Alert to the canonical design-system Alert, added focused product-state coverage, and removed the VoiceTranscriptComposer baseline exception. Product-state baseline exceptions reduced from 326 to 325.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates VoiceTranscriptComposer unsupported-browser voice notice from AntD Alert to the canonical design-system Alert.
- Adds focused product-state coverage for the unsupported voice transcript state.
- Removes the VoiceTranscriptComposer product-state baseline exception, reducing baseline exceptions from 326 to 325.

## Verification
- RED: `bunx vitest run src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx --reporter=dot` failed on missing `data-ds-component="Alert"` wrapper.
- GREEN: `bunx vitest run src/components/Flashcards/components/__tests__/VoiceTranscriptComposer.product-state.test.tsx --reporter=dot` passed: 1 test.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 52 tests.
- `bun run verify:design-system-state` passed; baseline exceptions are now 325.
- `git diff --check` passed.
- Full `bunx tsc --noEmit --pretty false` still exits 2 from inherited repo-wide TypeScript debt; `/tmp/tsc_design_system_next_slice_18.log` has 252 lines and touched-file filter for VoiceTranscriptComposer/baseline/task-456 matched 0 lines.
- Bandit skipped: TypeScript UI/test, JSON baseline, and task metadata only; no Python touched.

## Change summary
TODO (human-authored before merge): summarize what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated VoiceTranscriptComposer’s unsupported-browser notice to the design-system `Alert` for consistent product-state UI, aligning it to the `error` variant.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` from `@/components/ui/primitives`; mapped `type="info"/showIcon` to `variant="error"` and `title`, message unchanged.
  - Added a product-state test asserting the message is inside `[data-ds-component="Alert"]` and exposed via `role="alert"`.
  - Removed the VoiceTranscriptComposer Alert exception from the product-state baseline (326 → 325).

<sup>Written for commit bde16c6f6dd35bcc8332be91a244a96d7ace2133. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1897?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

