### PR TITLE
Improve chat global chrome UX

### DIFF
--- a/apps/packages/ui/src/components/Common/CommandPalette.tsx
+++ b/apps/packages/ui/src/components/Common/CommandPalette.tsx
@@ -264,8 +264,8 @@ export function CommandPalette({
         id: "nav-mcp-hub",
         label: t("common:commandPalette.goToMcpHub", "Go to MCP Hub"),
         icon: <Settings className="size-4" />,
-        action: () => { navigate("/settings/mcp-hub"); setOpen(false) },
-        targetPath: "/settings/mcp-hub",
+        action: () => { navigate("/mcp-hub"); setOpen(false) },
+        targetPath: "/mcp-hub",
         category: "navigation",
         keywords: ["mcp", "hub", "acp", "policy", "server"],
       },
@@ -481,6 +481,11 @@ export function CommandPalette({
     return [...defaultCommands, ...additionalCommands, ...settingCommands]
   }, [defaultCommands, additionalCommands, settingCommands])
 
+  const getCanonicalCommandTargetPath = useCallback((targetPath: string) => {
+    if (targetPath === "/settings/mcp-hub") return "/mcp-hub"
+    return targetPath
+  }, [])
+
   const dedupeByTargetPath = useCallback((commands: CommandItem[]) => {
     const dedupedCommands: CommandItem[] = []
     const targetPathIndex = new Map<string, number>()
@@ -491,9 +496,10 @@ export function CommandPalette({
         continue
       }
 
-      const existingIndex = targetPathIndex.get(command.targetPath)
+      const canonicalTargetPath = getCanonicalCommandTargetPath(command.targetPath)
+      const existingIndex = targetPathIndex.get(canonicalTargetPath)
       if (existingIndex === undefined) {
-        targetPathIndex.set(command.targetPath, dedupedCommands.length)
+        targetPathIndex.set(canonicalTargetPath, dedupedCommands.length)
         dedupedCommands.push(command)
         continue
       }
@@ -510,7 +516,7 @@ export function CommandPalette({
     }
 
     return dedupedCommands
-  }, [])
+  }, [getCanonicalCommandTargetPath])
 
   // Filter commands based on query
   const filteredCommands = useMemo(() => {

--- a/apps/packages/ui/src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { describe, expect, it, vi } from "vitest"
 import { fireEvent, render, screen } from "@testing-library/react"
-import { MemoryRouter } from "react-router-dom"
+import { MemoryRouter, useLocation } from "react-router-dom"
 
 import { CommandPalette } from "../CommandPalette"
 
@@ -12,6 +12,11 @@ vi.mock("react-i18next", () => ({
 }))
 
 describe("CommandPalette MCP Hub discoverability", () => {
+  const RouteProbe = () => {
+    const location = useLocation()
+    return <div data-testid="route-probe">{location.pathname}</div>
+  }
+
   it("shows Go to MCP Hub when the palette opens with an empty query", async () => {
     render(
       <MemoryRouter>
@@ -42,6 +47,25 @@ describe("CommandPalette MCP Hub discoverability", () => {
     fireEvent.change(searchInput, { target: { value: "mcp" } })
 
     expect(screen.getAllByRole("option", { name: /MCP Hub/i })).toHaveLength(1)
+  })
+
+  it("opens MCP Hub on its canonical top-level route", async () => {
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <CommandPalette />
+        <RouteProbe />
+      </MemoryRouter>
+    )
+
+    window.dispatchEvent(new CustomEvent("tldw:open-command-palette"))
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    const goToMcpHub = screen.getByRole("option", { name: /Go to MCP Hub/i })
+
+    expect(goToMcpHub).toHaveAttribute("data-target-path", "/mcp-hub")
+    fireEvent.click(goToMcpHub)
+
+    expect(screen.getByTestId("route-probe")).toHaveTextContent("/mcp-hub")
   })
 
   it("keeps the specific Theme setting when searching a shared settings route", async () => {

--- a/apps/packages/ui/src/components/Layouts/ChatHeader.tsx
+++ b/apps/packages/ui/src/components/Layouts/ChatHeader.tsx
@@ -35,7 +35,6 @@ type ChatHeaderProps = {
   shareButtonDisabled?: boolean
   onToggleTheme?: () => void
   themeMode?: "system" | "dark" | "light"
-  onClearChat: () => void
   onStartSavedChat?: () => void
   onStartTemporaryChat?: () => void
   onStartCharacterChat?: () => void
@@ -73,7 +72,6 @@ export function ChatHeader({
   shareButtonDisabled = false,
   onToggleTheme,
   themeMode = "dark",
-  onClearChat,
   onStartSavedChat,
   onStartTemporaryChat,
   onStartCharacterChat,
@@ -103,12 +101,9 @@ export function ChatHeader({
   const themeToggleLabel = isDarkTheme
     ? toText(t("common:theme.switchToLight", "Switch to light theme"))
     : toText(t("common:theme.switchToDark", "Switch to dark theme"))
-  const startSavedChat =
-    onStartSavedChat ?? onClearChat
-  const startTemporaryChat =
-    onStartTemporaryChat ?? onClearChat
-  const startCharacterChat =
-    onStartCharacterChat ?? onClearChat
+  const showSavedChatAction = Boolean(onStartSavedChat)
+  const showTemporaryChatAction = Boolean(onStartTemporaryChat)
+  const showCharacterChatAction = Boolean(onStartCharacterChat)
   const shareButtonLabel = shareStatusLabel
     ? toText(
         t("playground:header.shareStatusAria", "Share conversation ({{status}})", {
@@ -262,40 +257,46 @@ export function ChatHeader({
               {commandKeyLabel}K
             </span>
           </button>
-          <Tooltip title={t("playground:header.newSavedChat", "New saved chat")}>
-            <button
-              type="button"
-              onClick={startSavedChat}
-              aria-label={t("playground:header.newSavedChat", "New saved chat") as string}
-              className={`inline-flex items-center justify-center rounded-md p-2 text-text-muted hover:bg-surface2 hover:text-text ${focusRingClasses}`}
-              title={t("playground:header.newSavedChat", "New saved chat")}
-              data-testid="new-chat-button"
-            >
-              <SquarePen className="size-4" aria-hidden="true" />
-            </button>
-          </Tooltip>
-          <Tooltip title={t("playground:header.newTemporaryChat", "Temporary chat (not saved)")}>
-            <button
-              type="button"
-              onClick={startTemporaryChat}
-              aria-label={t("playground:header.newTemporaryChat", "Temporary chat (not saved)") as string}
-              className={`hidden items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text sm:inline-flex ${focusRingClasses}`}
-              title={t("playground:header.newTemporaryChat", "Temporary chat (not saved)")}
-            >
-              {t("playground:header.temporaryShort", "Temp")}
-            </button>
-          </Tooltip>
-          <Tooltip title={t("playground:header.newCharacterChat", "Character chat")}>
-            <button
-              type="button"
-              onClick={startCharacterChat}
-              aria-label={t("playground:header.newCharacterChat", "Character chat") as string}
-              className={`hidden items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text sm:inline-flex ${focusRingClasses}`}
-              title={t("playground:header.newCharacterChat", "Character chat")}
-            >
-              {t("playground:header.characterShort", "Character")}
-            </button>
-          </Tooltip>
+          {showSavedChatAction ? (
+            <Tooltip title={t("playground:header.newSavedChat", "New saved chat")}>
+              <button
+                type="button"
+                onClick={onStartSavedChat}
+                aria-label={t("playground:header.newSavedChat", "New saved chat") as string}
+                className={`inline-flex items-center justify-center rounded-md p-2 text-text-muted hover:bg-surface2 hover:text-text ${focusRingClasses}`}
+                title={t("playground:header.newSavedChat", "New saved chat")}
+                data-testid="new-chat-button"
+              >
+                <SquarePen className="size-4" aria-hidden="true" />
+              </button>
+            </Tooltip>
+          ) : null}
+          {showTemporaryChatAction ? (
+            <Tooltip title={t("playground:header.newTemporaryChat", "Temporary chat (not saved)")}>
+              <button
+                type="button"
+                onClick={onStartTemporaryChat}
+                aria-label={t("playground:header.newTemporaryChat", "Temporary chat (not saved)") as string}
+                className={`hidden items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text sm:inline-flex ${focusRingClasses}`}
+                title={t("playground:header.newTemporaryChat", "Temporary chat (not saved)")}
+              >
+                {t("playground:header.temporaryShort", "Temp")}
+              </button>
+            </Tooltip>
+          ) : null}
+          {showCharacterChatAction ? (
+            <Tooltip title={t("playground:header.newCharacterChat", "Character chat")}>
+              <button
+                type="button"
+                onClick={onStartCharacterChat}
+                aria-label={t("playground:header.newCharacterChat", "Character chat") as string}
+                className={`hidden items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text sm:inline-flex ${focusRingClasses}`}
+                title={t("playground:header.newCharacterChat", "Character chat")}
+              >
+                {t("playground:header.characterShort", "Character")}
+              </button>
+            </Tooltip>
+          ) : null}
           {onOpenShareModal && (
             <Tooltip title={shareButtonLabel}>
               <button

--- a/apps/packages/ui/src/components/Layouts/Header.tsx
+++ b/apps/packages/ui/src/components/Layouts/Header.tsx
@@ -27,6 +27,7 @@ import {
   isShareLinkRevoked,
   sortShareLinksByCreatedDesc,
 } from "./chat-share-links"
+import { getHeaderActionPolicy } from "./header-action-policy"
 
 type Props = {
   onToggleSidebar?: () => void
@@ -78,7 +79,11 @@ export const Header: React.FC<Props> = ({
     location.pathname.length > 1 && location.pathname.endsWith("/")
       ? location.pathname.slice(0, -1)
       : location.pathname
-  const isChatRoute = normalizedPath === "/chat"
+  const headerActionPolicy = React.useMemo(
+    () => getHeaderActionPolicy(normalizedPath),
+    [normalizedPath]
+  )
+  const isChatRoute = headerActionPolicy.showChatSessionActions
 
   React.useEffect(() => {
     ;(async () => {
@@ -356,19 +361,32 @@ export const Header: React.FC<Props> = ({
         sidebarCollapsed={sidebarCollapsed}
         onOpenCommandPalette={openCommandPalette}
         onOpenShortcutsModal={openShortcutsModal}
-        onOpenShareModal={isChatRoute ? openShareModal : undefined}
-        shareStatusLabel={isChatRoute ? shareStatusLabel : null}
+        onOpenShareModal={
+          headerActionPolicy.showShareConversation ? openShareModal : undefined
+        }
+        shareStatusLabel={
+          headerActionPolicy.showShareConversation ? shareStatusLabel : null
+        }
         shareButtonDisabled={shareButtonDisabled}
         onOpenSettings={() => navigate(hostedMode ? "/account" : "/settings/tldw")}
         onToggleTheme={toggleDarkMode}
         themeMode={themeMode}
-        onClearChat={clearChat}
-        onStartSavedChat={startSavedChat}
-        onStartTemporaryChat={startTemporaryChat}
-        onStartCharacterChat={startCharacterChat}
+        onStartSavedChat={
+          headerActionPolicy.showChatSessionActions ? startSavedChat : undefined
+        }
+        onStartTemporaryChat={
+          headerActionPolicy.showChatSessionActions
+            ? startTemporaryChat
+            : undefined
+        }
+        onStartCharacterChat={
+          headerActionPolicy.showChatSessionActions
+            ? startCharacterChat
+            : undefined
+        }
         activeCharacterName={selectedCharacter?.name || null}
-        showChatTitle={isChatRoute}
-        showSessionModeBadge={isChatRoute}
+        showChatTitle={headerActionPolicy.showChatTitle}
+        showSessionModeBadge={headerActionPolicy.showSessionModeBadge}
         shortcutsExpanded={headerShortcutsExpanded}
         onToggleShortcuts={toggleHeaderShortcuts}
         commandKeyLabel={cmdKey}

--- a/apps/packages/ui/src/components/Layouts/Header.tsx
+++ b/apps/packages/ui/src/components/Layouts/Header.tsx
@@ -75,13 +75,9 @@ export const Header: React.FC<Props> = ({
   const [shareLabel, setShareLabel] = React.useState("")
   const [shareError, setShareError] = React.useState<string | null>(null)
   const [copiedShareId, setCopiedShareId] = React.useState<string | null>(null)
-  const normalizedPath =
-    location.pathname.length > 1 && location.pathname.endsWith("/")
-      ? location.pathname.slice(0, -1)
-      : location.pathname
   const headerActionPolicy = React.useMemo(
-    () => getHeaderActionPolicy(normalizedPath),
-    [normalizedPath]
+    () => getHeaderActionPolicy(location.pathname),
+    [location.pathname]
   )
   const isChatRoute = headerActionPolicy.showChatSessionActions
 

--- a/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
@@ -149,6 +149,28 @@ describe("ChatHeader shortcut toggle", () => {
     expect(props.onStartCharacterChat).toHaveBeenCalledTimes(1)
   })
 
+  it("hides chat session actions when callbacks are omitted", () => {
+    render(
+      <ChatHeader
+        {...createProps({
+          onStartSavedChat: undefined,
+          onStartTemporaryChat: undefined,
+          onStartCharacterChat: undefined
+        })}
+      />
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "New saved chat" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Temporary chat (not saved)" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Character chat" })
+    ).not.toBeInTheDocument()
+  })
+
   it("hides temporary and character quick actions below the small breakpoint", () => {
     const props = createProps()
     render(<ChatHeader {...props} />)

--- a/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
@@ -53,7 +53,6 @@ const createProps = (overrides: Partial<React.ComponentProps<typeof ChatHeader>>
   onOpenSettings: vi.fn(),
   onToggleTheme: vi.fn(),
   themeMode: "dark" as const,
-  onClearChat: vi.fn(),
   onStartSavedChat: vi.fn(),
   onStartTemporaryChat: vi.fn(),
   onStartCharacterChat: vi.fn(),

--- a/apps/packages/ui/src/components/Layouts/__tests__/Header.character-mode.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/Header.character-mode.test.tsx
@@ -98,15 +98,21 @@ vi.mock("../ChatHeader", () => ({
     activeCharacterName?: string | null
   }) => (
     <div>
-      <button type="button" onClick={() => onStartSavedChat?.()}>
-        New saved chat
-      </button>
-      <button type="button" onClick={() => onStartTemporaryChat?.()}>
-        Temporary chat
-      </button>
-      <button type="button" onClick={() => onStartCharacterChat?.()}>
-        Character chat
-      </button>
+      {onStartSavedChat ? (
+        <button type="button" onClick={() => onStartSavedChat()}>
+          New saved chat
+        </button>
+      ) : null}
+      {onStartTemporaryChat ? (
+        <button type="button" onClick={() => onStartTemporaryChat()}>
+          Temporary chat
+        </button>
+      ) : null}
+      {onStartCharacterChat ? (
+        <button type="button" onClick={() => onStartCharacterChat()}>
+          Character chat
+        </button>
+      ) : null}
       <div data-testid="active-character">
         {activeCharacterName || "none"}
       </div>
@@ -193,18 +199,23 @@ describe("Header character mode sequencing", () => {
     }
   })
 
-  it("routes non-chat surfaces into first-class character chat intent", () => {
+  it("omits chat session actions on non-chat surfaces", () => {
     locationPathname = "/settings/characters"
     selectedCharacter = { id: "char-1", name: "Rin" }
     render(<Header />)
 
-    fireEvent.click(screen.getByRole("button", { name: "Character chat" }))
-
-    expect(setTemporaryChatMock).toHaveBeenCalledWith(false)
+    expect(
+      screen.queryByRole("button", { name: "New saved chat" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Temporary chat" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Character chat" })
+    ).not.toBeInTheDocument()
+    expect(setTemporaryChatMock).not.toHaveBeenCalled()
     expect(clearChatMock).not.toHaveBeenCalled()
-    expect(navigateMock).toHaveBeenCalledWith(
-      "/chat?mode=character&characterId=char-1"
-    )
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 
   it("clears character state when switching back to saved or temporary chat", () => {

--- a/apps/packages/ui/src/components/Layouts/__tests__/header-action-policy.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/header-action-policy.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { getHeaderActionPolicy } from "../header-action-policy"
+
+describe("getHeaderActionPolicy", () => {
+  it("enables chat session actions on the main chat route", () => {
+    expect(getHeaderActionPolicy("/chat")).toMatchObject({
+      showChatSessionActions: true,
+      showChatTitle: true,
+      showSessionModeBadge: true,
+      showShareConversation: true,
+    })
+  })
+
+  it.each([
+    "/knowledge",
+    "/media",
+    "/sources",
+    "/settings",
+    "/mcp-hub",
+    "/stt",
+    "/tts",
+    "/quick-chat-popout",
+  ])("hides chat session actions on %s", (pathname) => {
+    expect(getHeaderActionPolicy(pathname)).toMatchObject({
+      showChatSessionActions: false,
+      showChatTitle: false,
+      showSessionModeBadge: false,
+      showShareConversation: false,
+    })
+  })
+
+  it("normalizes trailing slashes before classifying chat routes", () => {
+    expect(getHeaderActionPolicy("/chat/").showChatSessionActions).toBe(true)
+  })
+})

--- a/apps/packages/ui/src/components/Layouts/__tests__/header-action-policy.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/header-action-policy.test.ts
@@ -29,7 +29,15 @@ describe("getHeaderActionPolicy", () => {
     })
   })
 
-  it("normalizes trailing slashes before classifying chat routes", () => {
-    expect(getHeaderActionPolicy("/chat/").showChatSessionActions).toBe(true)
-  })
+  it.each(["/chat/", "/chat//"])(
+    "normalizes trailing slashes before classifying chat routes: %s",
+    (pathname) => {
+      expect(getHeaderActionPolicy(pathname)).toMatchObject({
+        showChatSessionActions: true,
+        showChatTitle: true,
+        showSessionModeBadge: true,
+        showShareConversation: true,
+      })
+    }
+  )
 })

--- a/apps/packages/ui/src/components/Layouts/header-action-policy.ts
+++ b/apps/packages/ui/src/components/Layouts/header-action-policy.ts
@@ -8,9 +8,8 @@ export type HeaderActionPolicy = {
 const normalizePathname = (pathname: string): string => {
   const trimmed = pathname.trim()
   if (!trimmed || trimmed === "/") return "/"
-  return trimmed.endsWith("/") && trimmed.length > 1
-    ? trimmed.slice(0, -1)
-    : trimmed
+  const withoutTrailingSlashes = trimmed.replace(/\/+$/, "")
+  return withoutTrailingSlashes || "/"
 }
 
 export const isMainChatRoute = (pathname: string): boolean =>

--- a/apps/packages/ui/src/components/Layouts/header-action-policy.ts
+++ b/apps/packages/ui/src/components/Layouts/header-action-policy.ts
@@ -1,0 +1,27 @@
+export type HeaderActionPolicy = {
+  showChatSessionActions: boolean
+  showChatTitle: boolean
+  showSessionModeBadge: boolean
+  showShareConversation: boolean
+}
+
+const normalizePathname = (pathname: string): string => {
+  const trimmed = pathname.trim()
+  if (!trimmed || trimmed === "/") return "/"
+  return trimmed.endsWith("/") && trimmed.length > 1
+    ? trimmed.slice(0, -1)
+    : trimmed
+}
+
+export const isMainChatRoute = (pathname: string): boolean =>
+  normalizePathname(pathname) === "/chat"
+
+export const getHeaderActionPolicy = (pathname: string): HeaderActionPolicy => {
+  const chatRoute = isMainChatRoute(pathname)
+  return {
+    showChatSessionActions: chatRoute,
+    showChatTitle: chatRoute,
+    showSessionModeBadge: chatRoute,
+    showShareConversation: chatRoute,
+  }
+}

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
@@ -26,6 +26,7 @@ export const PlaygroundEmpty = () => {
   const isConnected = useIsConnected();
   const { open: openHelpModal } = useHelpModal();
   const navigate = useNavigate();
+  const [modesExpanded, setModesExpanded] = React.useState(false);
 
   const dispatchStarter = React.useCallback(
     (mode: "general" | "compare" | "character" | "rag", prompt?: string) => {
@@ -187,48 +188,62 @@ export const PlaygroundEmpty = () => {
       >
         <div className="flex flex-col gap-6">
           <div className="border-t border-border/60 pt-5">
-            <div className="flex flex-col gap-1 text-center sm:text-left">
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
-                {t("playground:empty.modeTitle", "Choose a mode")}
-              </p>
-              <p className="text-sm text-text-muted">
-                {t(
-                  "playground:empty.modeBody",
-                  "Pick any starting point. All five stay equally available from the first screen.",
-                )}
-              </p>
+            <div className="flex flex-col gap-3 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+              <div className="flex flex-col gap-1">
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
+                  {t("playground:empty.modeTitle", "Chat modes")}
+                </p>
+                <p className="text-sm text-text-muted">
+                  {t(
+                    "playground:empty.modeBody",
+                    "Use a different starting point when the conversation needs structure.",
+                  )}
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-controls="playground-empty-mode-deck"
+                aria-expanded={modesExpanded}
+                onClick={() => setModesExpanded((expanded) => !expanded)}
+                className={`inline-flex items-center justify-center rounded-md border border-border bg-surface2 px-3 py-1.5 text-xs font-medium text-text transition hover:bg-surface ${actionButtonFocusClassName}`}
+              >
+                {t("playground:empty.exploreModes", "Explore chat modes")}
+              </button>
             </div>
 
-            <div
-              data-testid="playground-empty-mode-deck"
-              className="mt-4 grid gap-3 sm:grid-cols-2"
-            >
-              {starterCards.map((starter) => {
-                const Icon = starter.icon;
-                return (
-                  <button
-                    key={starter.key}
-                    type="button"
-                    onClick={starter.action}
-                    className={`group flex min-h-[118px] flex-col rounded-2xl border border-border/60 bg-bg/20 px-4 py-4 text-left transition hover:border-primary/40 hover:bg-surface2/60 ${actionButtonFocusClassName}`}
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="rounded-xl border border-border/50 bg-surface2/70 p-2 text-text-muted transition group-hover:text-text">
-                        <Icon className="h-4 w-4" aria-hidden="true" />
+            {modesExpanded ? (
+              <div
+                id="playground-empty-mode-deck"
+                data-testid="playground-empty-mode-deck"
+                className="mt-4 grid gap-3 sm:grid-cols-2"
+              >
+                {starterCards.map((starter) => {
+                  const Icon = starter.icon;
+                  return (
+                    <button
+                      key={starter.key}
+                      type="button"
+                      onClick={starter.action}
+                      className={`group flex min-h-[118px] flex-col rounded-2xl border border-border/60 bg-bg/20 px-4 py-4 text-left transition hover:border-primary/40 hover:bg-surface2/60 ${actionButtonFocusClassName}`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="rounded-xl border border-border/50 bg-surface2/70 p-2 text-text-muted transition group-hover:text-text">
+                          <Icon className="h-4 w-4" aria-hidden="true" />
+                        </div>
+                        <div className="space-y-1">
+                          <span className="block text-base font-semibold text-text">
+                            {starter.title}
+                          </span>
+                          <p className="text-sm leading-6 text-text-muted">
+                            {starter.description}
+                          </p>
+                        </div>
                       </div>
-                      <div className="space-y-1">
-                        <span className="block text-base font-semibold text-text">
-                          {starter.title}
-                        </span>
-                        <p className="text-sm leading-6 text-text-muted">
-                          {starter.description}
-                        </p>
-                      </div>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
           </div>
 
           <div className="border-t border-border/60 pt-4">

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx
@@ -55,10 +55,13 @@ describe("PlaygroundEmpty", () => {
       within(shell).getByRole("button", { name: "Quick Ingest" }),
     ).toBeInTheDocument();
     expect(
-      within(shell).getByRole("button", {
+      within(shell).getByRole("button", { name: "Explore chat modes" }),
+    ).toBeInTheDocument();
+    expect(
+      within(shell).queryByRole("button", {
         name: /Compare AI models side-by-side/i,
       }),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     expect(
       within(shell).getByRole("button", { name: "Take a quick tour" }),
     ).toBeInTheDocument();
@@ -75,10 +78,33 @@ describe("PlaygroundEmpty", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps starter modes behind a discoverable launcher on first render", () => {
+    render(<PlaygroundEmpty />);
+
+    const shell = screen.getByTestId("playground-empty-shell");
+
+    expect(
+      within(shell).queryByRole("button", {
+        name: /Compare AI models side-by-side/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(shell).getByRole("button", { name: "Explore chat modes" }),
+    );
+
+    expect(
+      within(shell).getByRole("button", {
+        name: /Compare AI models side-by-side/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("dispatches starter telemetry and starter action events when compare is selected", () => {
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
     render(<PlaygroundEmpty />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Explore chat modes" }));
     fireEvent.click(
       screen.getByRole("button", { name: /Compare AI models side-by-side/i }),
     );
@@ -147,6 +173,7 @@ describe("PlaygroundEmpty", () => {
   it("routes the deep research starter to the research console", () => {
     render(<PlaygroundEmpty />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Explore chat modes" }));
     fireEvent.click(screen.getByRole("button", { name: /Deep Research/i }));
 
     expect(navigate).toHaveBeenCalledWith("/research");

--- a/apps/packages/ui/src/routes/__tests__/option-quick-chat-popout.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-quick-chat-popout.test.tsx
@@ -1,0 +1,136 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { describe, expect, it, vi } from "vitest"
+
+import QuickChatPopout from "../option-quick-chat-popout"
+
+vi.mock("antd", () => ({
+  Select: ({
+    "aria-label": ariaLabel,
+    options = [],
+  }: {
+    "aria-label"?: string
+    options?: Array<{ value: string; label: string }>
+  }) => (
+    <select aria-label={ariaLabel}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+  Segmented: ({
+    options = [],
+    value,
+    onChange,
+  }: {
+    options?: Array<{ value: string; label: string }>
+    value?: string
+    onChange?: (value: string) => void
+  }) => (
+    <div role="group" aria-label="Quick chat mode">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          aria-pressed={value === option.value}
+          onClick={() => onChange?.(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ select }: { select?: (data: Array<{ model: string }>) => unknown }) => {
+    const models = [{ model: "local:test-model" }]
+    return {
+      data: select ? select(models) : models,
+      isLoading: false,
+      isError: false,
+    }
+  },
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+vi.mock("@/hooks/useQuickChat", () => ({
+  useQuickChat: () => ({
+    messages: [],
+    sendMessage: vi.fn(),
+    cancelStream: vi.fn(),
+    isStreaming: false,
+    hasModel: true,
+    activeModel: "local:test-model",
+    currentModel: "local:test-model",
+    modelOverride: null,
+    setModelOverride: vi.fn(),
+  }),
+}))
+
+vi.mock("@/store/quick-chat", () => {
+  const store = {
+    assistantMode: "chat",
+    setAssistantMode: vi.fn(),
+  }
+  const useQuickChatStore = () => store
+  useQuickChatStore.getState = () => ({
+    restoreFromState: vi.fn(),
+    clearMessages: vi.fn(),
+  })
+  return { useQuickChatStore }
+})
+
+vi.mock("@/services/tldw-server", () => ({
+  fetchChatModels: vi.fn(),
+}))
+
+vi.mock("@/hooks/useChatModelsSelect", () => ({
+  useChatModelsSelect: () => ({
+    allowClear: true,
+    modelOptions: [{ value: "local:test-model", label: "Local test model" }],
+    modelPlaceholder: "Select model",
+    handleModelChange: vi.fn(),
+  }),
+}))
+
+vi.mock("@/components/Common/QuickChatHelper/QuickChatInput", () => ({
+  QuickChatInput: () => <textarea aria-label="Quick chat input" />,
+}))
+
+vi.mock("@/components/Common/QuickChatHelper/QuickChatMessage", () => ({
+  QuickChatMessage: () => <div data-testid="quick-chat-message" />,
+}))
+
+vi.mock("@/components/Common/QuickChatHelper/QuickChatGuidesPanel", () => ({
+  QuickChatGuidesPanel: () => <div data-testid="quick-chat-guides" />,
+}))
+
+describe("QuickChatPopout route identity", () => {
+  it("presents quick chat as a helper surface", () => {
+    render(
+      <MemoryRouter initialEntries={["/quick-chat-popout"]}>
+        <QuickChatPopout />
+      </MemoryRouter>
+    )
+
+    expect(
+      screen.getByRole("heading", { name: "Quick Chat Helper" })
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText("Model")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Chat" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Docs Q&A" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Browse Guides" })).toBeInTheDocument()
+    expect(
+      screen.getByText("Start a quick side chat to keep your main thread clean.")
+    ).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-418.3.1 - Implement-WebUI-chat-composer-and-global-chrome-remediation.md
+++ b/backlog/tasks/task-418.3.1 - Implement-WebUI-chat-composer-and-global-chrome-remediation.md
@@ -43,22 +43,28 @@ Docs/superpowers/plans/2026-05-17-webui-chat-global-chrome-implementation-plan.m
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented WP6 chat composer/global chrome remediation.
+Implemented WP6 chat composer/global chrome remediation and PR #1898 review fixes.
 
-Implementation notes:
+Initial implementation notes:
 - Changed Command Palette MCP Hub navigation to canonical /mcp-hub and canonicalized /settings/mcp-hub during target dedupe.
 - Added header action policy so chat title/session/share actions render only for /chat while global chrome actions remain available elsewhere.
 - Removed ChatHeader fallback session actions when chat-specific callbacks are omitted.
 - Collapsed /chat starter modes behind an Explore chat modes launcher while leaving primary Start chatting and Quick Ingest visible.
 - Added /quick-chat-popout route identity coverage as a helper surface.
 
+Review fix notes:
+- Removed duplicate pathname normalization in Header; Header now passes raw location.pathname into getHeaderActionPolicy.
+- Updated header-action-policy normalization to strip repeated trailing slashes while preserving root.
+- Added /chat// regression coverage to header-action-policy tests.
+- Removed stale onClearChat from ChatHeader test props.
+
 Verification:
-- Focused Vitest red pass failed before implementation for the intended missing behaviors.
-- Focused Vitest green pass: 4 files / 34 tests passed for command palette, header policy, ChatHeader, and PlaygroundEmpty.
-- WP6 Vitest set: 11 files / 75 tests passed.
-- Playwright browser QA: e2e/workflows/chat.spec.ts, e2e/smoke/chat-sticky-composer.spec.ts, e2e/smoke/composer-mobile-viewport.spec.ts, e2e/smoke/stage4-responsive-landmarks.spec.ts passed with 27 passed / 9 skipped.
+- Red focused regression: header-action-policy test failed for /chat// before helper fix.
+- Focused review-fix Vitest: 3 files / 27 tests passed.
+- WP6 Vitest set: 11 files / 76 tests passed.
 - git diff --check passed.
 - bunx tsc --noEmit --pretty false still fails on repo-wide baseline TypeScript debt; captured 252 log lines and no errors mention touched WP6 files.
+- CI before review-fix push: direct frontend/build/UX/E2E required checks passed; old full-suite macOS/windows jobs failed while the workflow was still in progress and logs were unavailable until completion. Recheck after pushing the review-fix commit.
 - Bandit not applicable: this slice only touched TypeScript/React UI and Backlog markdown.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
@@ -70,6 +76,7 @@ Completed the WP6 chat composer/global chrome remediation slice:
 - Command Palette MCP Hub navigation uses canonical /mcp-hub, with /settings/mcp-hub canonicalized during target dedupe.
 - Header chat session/share/title controls are gated to /chat-owned context through a small header action policy.
 - /quick-chat-popout has route-level test coverage that keeps it framed as a helper surface.
+- PR #1898 review feedback was addressed: repeated trailing slash normalization, single policy-owned normalization source, and stale ChatHeader test props.
 - Focused Vitest and Playwright verification passed; full package TypeScript remains blocked by existing baseline debt outside the touched files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-418.3.1 - Implement-WebUI-chat-composer-and-global-chrome-remediation.md
+++ b/backlog/tasks/task-418.3.1 - Implement-WebUI-chat-composer-and-global-chrome-remediation.md
@@ -1,0 +1,84 @@
+---
+id: TASK-418.3.1
+title: Implement WebUI chat composer and global chrome remediation
+status: Done
+labels:
+- ux
+- webui
+- extension
+- chat
+- navigation
+- implementation
+priority: high
+parent_task_id: TASK-418.3
+references:
+- TASK-418.3
+- Docs/superpowers/plans/2026-05-17-webui-chat-global-chrome-implementation-plan.md
+- Docs/superpowers/plans/2026-05-17-webui-extension-ux-remediation-implementation-plan.md
+- Docs/superpowers/specs/2026-05-17-webui-extension-ux-remediation-program-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the WP6 chat composer/global chrome remediation slice. Scope: keep /chat composer-first, preserve quick-chat as a helper surface, verify canonical command/header navigation targets, and ensure chat session controls do not foreground themselves on non-chat routes. No backend API changes, route renames, or broad visual redesign.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 /chat foregrounds composer readiness over starter modes while keeping starter modes available through one obvious launcher.
+- [x] #2 Command palette and header shortcuts continue to use canonical top-level route targets for Chat and MCP Hub.
+- [x] #3 Header/global chrome exposes chat session controls only in chat-owned contexts while preserving global settings/theme/notifications/shortcuts.
+- [x] #4 /quick-chat-popout remains a clearly labeled helper surface and is not treated as the main Chat target.
+- [x] #5 Focused Vitest coverage passes for changed command palette, header, chat empty-state, and quick-chat behavior.
+- [x] #6 Focused Playwright checks pass for /chat sticky/mobile behavior and responsive landmarks, or environment blockers are documented with evidence.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-17-webui-chat-global-chrome-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented WP6 chat composer/global chrome remediation.
+
+Implementation notes:
+- Changed Command Palette MCP Hub navigation to canonical /mcp-hub and canonicalized /settings/mcp-hub during target dedupe.
+- Added header action policy so chat title/session/share actions render only for /chat while global chrome actions remain available elsewhere.
+- Removed ChatHeader fallback session actions when chat-specific callbacks are omitted.
+- Collapsed /chat starter modes behind an Explore chat modes launcher while leaving primary Start chatting and Quick Ingest visible.
+- Added /quick-chat-popout route identity coverage as a helper surface.
+
+Verification:
+- Focused Vitest red pass failed before implementation for the intended missing behaviors.
+- Focused Vitest green pass: 4 files / 34 tests passed for command palette, header policy, ChatHeader, and PlaygroundEmpty.
+- WP6 Vitest set: 11 files / 75 tests passed.
+- Playwright browser QA: e2e/workflows/chat.spec.ts, e2e/smoke/chat-sticky-composer.spec.ts, e2e/smoke/composer-mobile-viewport.spec.ts, e2e/smoke/stage4-responsive-landmarks.spec.ts passed with 27 passed / 9 skipped.
+- git diff --check passed.
+- bunx tsc --noEmit --pretty false still fails on repo-wide baseline TypeScript debt; captured 252 log lines and no errors mention touched WP6 files.
+- Bandit not applicable: this slice only touched TypeScript/React UI and Backlog markdown.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the WP6 chat composer/global chrome remediation slice:
+- /chat now keeps starter modes available behind one explicit launcher instead of foregrounding every mode on first render.
+- Command Palette MCP Hub navigation uses canonical /mcp-hub, with /settings/mcp-hub canonicalized during target dedupe.
+- Header chat session/share/title controls are gated to /chat-owned context through a small header action policy.
+- /quick-chat-popout has route-level test coverage that keeps it framed as a helper surface.
+- Focused Vitest and Playwright verification passed; full package TypeScript remains blocked by existing baseline debt outside the touched files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Gated chat-specific header title/session/share controls to the main `/chat` route while preserving global chrome actions elsewhere.
- Moved `/chat` starter modes behind one explicit launcher so composer readiness stays primary on first render.
- Made Command Palette MCP Hub navigation canonical to `/mcp-hub` and kept `/quick-chat-popout` covered as a helper surface.

## Change summary
Human requester to complete before merge per project policy.

## Verification
- `bunx vitest run src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx src/components/Layouts/__tests__/header-action-policy.test.ts src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx`
- `bunx vitest run src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx src/components/Common/__tests__/CommandPalette.shortcuts.test.tsx src/components/Layouts/__tests__/header-action-policy.test.ts src/components/Layouts/__tests__/ChatHeader.test.tsx src/components/Layouts/__tests__/Header.character-mode.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.test.tsx src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx src/components/Option/Playground/__tests__/Playground.responsive-parity.guard.test.ts src/components/Option/Playground/__tests__/mobile-composer-layout.test.ts src/routes/__tests__/option-quick-chat-popout.test.tsx`
- `bunx playwright test e2e/workflows/chat.spec.ts e2e/smoke/chat-sticky-composer.spec.ts e2e/smoke/composer-mobile-viewport.spec.ts e2e/smoke/stage4-responsive-landmarks.spec.ts --reporter=line`
- `git diff --check`

## Known Issues
- `bunx tsc --noEmit --pretty false` still fails on the existing package-wide TypeScript baseline; captured output did not include the files touched in this PR.
- Bandit not applicable: only TypeScript/React UI and Backlog markdown changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the chat/global chrome UX by gating chat-only controls to `/chat`, making the composer primary, and standardizing MCP Hub navigation to `/mcp-hub`. Aligns with TASK-418.3.1 by keeping quick chat a helper surface and reducing distractions outside chat.

- **New Features**
  - Show chat title/session/share only on `/chat`; share button follows policy and trailing slashes like `/chat//` are normalized.
  - Make MCP Hub navigation canonical to `/mcp-hub` in `CommandPalette`; dedupe treats `/settings/mcp-hub` as the same target.
  - Keep `/chat` starter modes behind a single “Explore chat modes” launcher; `/quick-chat-popout` stays a clearly labeled helper surface.

- **Refactors**
  - Add `getHeaderActionPolicy` and use it in `Header`; remove `onClearChat` fallback and hide `ChatHeader` actions when callbacks are omitted.
  - Add focused tests for MCP Hub canonical route, header policy normalization, chat header actions, playground modes toggle, and quick chat helper identity.

<sup>Written for commit beab445a5d67b6836ab4bddd72f8dbd6748355d9. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1898?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

