### PR TITLE
Add Persona Visual attention navigation

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -301,7 +301,8 @@ const VisualManagementHeader: React.FC<{
   personaName: string
   model: PersonaVisualManagementModel
   t: VisualPackTranslate
-}> = ({ personaName, model, t }) => {
+  onOpenAttention?: (row: PersonaVisualManagementAttentionRow) => void
+}> = ({ personaName, model, t, onOpenAttention }) => {
   const topAttention = model.attentionRows[0]
   const attentionCopy = getManagementAttentionCopy(topAttention, t)
   const counts = model.summary.packCounts
@@ -352,9 +353,23 @@ const VisualManagementHeader: React.FC<{
           )}
         </div>
       </div>
-      <div className="mt-3 rounded-md border border-border bg-surface px-3 py-2 text-xs">
-        <div className="font-medium text-text">{attentionCopy.title}</div>
-        <div className="mt-1 text-text-muted">{attentionCopy.message}</div>
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2 text-xs">
+        <div>
+          <div className="font-medium text-text">{attentionCopy.title}</div>
+          <div className="mt-1 text-text-muted">{attentionCopy.message}</div>
+        </div>
+        {topAttention && onOpenAttention ? (
+          <Button
+            data-testid="persona-visual-management-attention-action"
+            size="small"
+            icon={<FileSearch className="h-3.5 w-3.5" />}
+            onClick={() => onOpenAttention(topAttention)}
+          >
+            {t("sidepanel:personaGarden.visuals.management.openAttention", {
+              defaultValue: "Open"
+            })}
+          </Button>
+        ) : null}
       </div>
     </section>
   )
@@ -373,6 +388,12 @@ const VisualWorkspaceSectionHeading: React.FC<{
     ) : null}
   </div>
 )
+
+const focusPersonaVisualSection = (element: HTMLElement | null): void => {
+  if (!element) return
+  element.scrollIntoView?.({ block: "start", behavior: "smooth" })
+  element.focus()
+}
 
 const getGenerationReadinessCopy = (
   view: PersonaVisualGenerationReadinessView,
@@ -1226,7 +1247,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   const importPreviewInputRef = React.useRef<HTMLInputElement | null>(null)
   const draftTitleInputRef = React.useRef<HTMLInputElement | null>(null)
   const duplicateTargetSelectRef = React.useRef<HTMLSelectElement | null>(null)
-  const libraryPanelRef = React.useRef<HTMLDivElement | null>(null)
+  const packBasicsSectionRef = React.useRef<HTMLElement | null>(null)
+  const portableActionsSectionRef = React.useRef<HTMLElement | null>(null)
+  const libraryPanelRef = React.useRef<HTMLElement | null>(null)
+  const jobsReviewSectionRef = React.useRef<HTMLElement | null>(null)
+  const generationReadinessRef = React.useRef<HTMLDivElement | null>(null)
   const activationControlsRef = React.useRef<HTMLDivElement | null>(null)
   const generationReadinessRequestIdRef = React.useRef(0)
   const duplicateTargetsRequestIdRef = React.useRef(0)
@@ -1813,8 +1838,42 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
     const activateButton = activationControlsRef.current?.querySelector<
       HTMLButtonElement
     >('[data-testid="persona-visual-activate-button"]')
-    activateButton?.focus()
+    if (activateButton && !activateButton.disabled) {
+      activateButton.focus()
+      return
+    }
+    activationControlsRef.current?.focus()
   }, [])
+
+  const focusManagementAttentionTarget = React.useCallback(
+    (row: PersonaVisualManagementAttentionRow) => {
+      switch (row.target) {
+        case "packs":
+          focusPersonaVisualSection(packBasicsSectionRef.current)
+          break
+        case "validation":
+          focusActivationControls()
+          break
+        case "candidates":
+        case "jobs":
+          focusPersonaVisualSection(jobsReviewSectionRef.current)
+          break
+        case "import":
+        case "export":
+          focusPersonaVisualSection(portableActionsSectionRef.current)
+          break
+        case "library":
+          focusLibraryPanel()
+          break
+        case "generation":
+          focusPersonaVisualSection(generationReadinessRef.current)
+          break
+        default:
+          break
+      }
+    },
+    [focusActivationControls, focusLibraryPanel]
+  )
 
   const handleCreateDraft = async () => {
     const title = draftTitle.trim()
@@ -3620,15 +3679,18 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       </Modal>
 
       <section
+        ref={packBasicsSectionRef}
         data-testid="persona-visual-section-pack-basics"
         className="rounded-lg border border-border bg-surface p-3"
         aria-label="Pack basics and active status"
+        tabIndex={-1}
       >
         {showManagementHeader ? (
           <VisualManagementHeader
             personaName={selectedPersonaName || selectedPersonaId}
             model={managementModel}
             t={t}
+            onOpenAttention={focusManagementAttentionTarget}
           />
         ) : null}
         <div
@@ -3923,9 +3985,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           </section>
 
           <section
+            ref={portableActionsSectionRef}
             data-testid="persona-visual-section-portable-actions"
             className="rounded-lg border border-border bg-surface p-3"
             aria-label="Portable archive and duplicate actions"
+            tabIndex={-1}
           >
             <VisualWorkspaceSectionHeading
               title="Portable archive and duplicate actions"
@@ -4518,7 +4582,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
                   </div>
                 )}
               </div>
-              <div ref={activationControlsRef} className="flex flex-wrap gap-2">
+              <div
+                ref={activationControlsRef}
+                className="flex flex-wrap gap-2"
+                tabIndex={-1}
+              >
                 <Button
                   data-testid="persona-visual-save-manifest"
                   size="small"
@@ -4554,9 +4622,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           </section>
 
           <section
+            ref={jobsReviewSectionRef}
             data-testid="persona-visual-section-jobs-review"
             className="rounded-lg border border-border bg-surface p-3"
             aria-label="Jobs and review"
+            tabIndex={-1}
           >
             <div className="flex flex-wrap items-start justify-between gap-2">
               <VisualWorkspaceSectionHeading
@@ -4637,7 +4707,9 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
               </Button>
             </div>
             <div
+              ref={generationReadinessRef}
               data-testid="persona-visual-generation-readiness"
+              tabIndex={-1}
               className={`mt-3 rounded border px-3 py-2 text-xs ${generationReadinessCopy.toneClassName}`}
             >
               <div className="font-medium">{generationReadinessCopy.title}</div>

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -391,8 +391,8 @@ const VisualWorkspaceSectionHeading: React.FC<{
 
 const focusPersonaVisualSection = (element: HTMLElement | null): void => {
   if (!element) return
+  element.focus({ preventScroll: true })
   element.scrollIntoView?.({ block: "start", behavior: "smooth" })
-  element.focus()
 }
 
 const getGenerationReadinessCopy = (
@@ -1839,10 +1839,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       HTMLButtonElement
     >('[data-testid="persona-visual-activate-button"]')
     if (activateButton && !activateButton.disabled) {
-      activateButton.focus()
+      focusPersonaVisualSection(activateButton)
       return
     }
-    activationControlsRef.current?.focus()
+    focusPersonaVisualSection(activationControlsRef.current)
   }, [])
 
   const focusManagementAttentionTarget = React.useCallback(

--- a/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/VisualPackEditor.tsx
@@ -389,10 +389,13 @@ const VisualWorkspaceSectionHeading: React.FC<{
   </div>
 )
 
-const focusPersonaVisualSection = (element: HTMLElement | null): void => {
+const focusPersonaVisualSection = (
+  element: HTMLElement | null,
+  block: ScrollLogicalPosition = "start"
+): void => {
   if (!element) return
   element.focus({ preventScroll: true })
-  element.scrollIntoView?.({ block: "start", behavior: "smooth" })
+  element.scrollIntoView?.({ block, behavior: "smooth" })
 }
 
 const getGenerationReadinessCopy = (
@@ -1810,14 +1813,11 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
   }, [])
 
   const focusLibraryPanel = React.useCallback(() => {
-    libraryPanelRef.current?.scrollIntoView?.({ block: "start" })
-    libraryPanelRef.current?.focus()
+    focusPersonaVisualSection(libraryPanelRef.current)
   }, [])
 
   const focusImportPreviewInput = React.useCallback(() => {
-    importPreviewInputRef.current?.scrollIntoView?.({ block: "center" })
-    importPreviewInputRef.current?.click()
-    importPreviewInputRef.current?.focus()
+    focusPersonaVisualSection(importPreviewInputRef.current, "center")
   }, [])
 
   const openImportArchivePicker = React.useCallback(() => {
@@ -1825,7 +1825,10 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
       source: "native_import",
       requestId: (current?.requestId ?? 0) + 1
     }))
-    globalThis.setTimeout(focusImportPreviewInput, 0)
+    globalThis.setTimeout(() => {
+      focusImportPreviewInput()
+      importPreviewInputRef.current?.click()
+    }, 0)
   }, [focusImportPreviewInput])
 
   const focusDuplicateControls = React.useCallback(() => {
@@ -1859,6 +1862,8 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           focusPersonaVisualSection(jobsReviewSectionRef.current)
           break
         case "import":
+          focusImportPreviewInput()
+          break
         case "export":
           focusPersonaVisualSection(portableActionsSectionRef.current)
           break
@@ -1872,7 +1877,7 @@ export const VisualPackEditor: React.FC<VisualPackEditorProps> = ({
           break
       }
     },
-    [focusActivationControls, focusLibraryPanel]
+    [focusActivationControls, focusImportPreviewInput, focusLibraryPanel]
   )
 
   const handleCreateDraft = async () => {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -635,6 +635,174 @@ describe("VisualPackEditor", () => {
     expect(screen.getByTestId("persona-visual-generation-readiness")).toHaveFocus()
   })
 
+  it("opens import attention from the management header without a selected pack", async () => {
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse({ packs: [], active_pack: null })
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "queued",
+          stage: "queued"
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/import-previews/preview-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          preview_id: "preview-1",
+          job_id: "preview-job-1",
+          portability_job_id: "portability-preview-1",
+          operation: "import_preview",
+          target_persona_id: "persona-1",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          bundle_summary: { pack_title: "Imported Visuals", asset_count: 2 },
+          validation_warnings: [],
+          conflicts: [],
+          proposed_plan: { target_mode: "create_new" },
+          required_choices: []
+        })
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      throw new Error(`Unhandled path: ${path}`)
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const archive = new File(["portable archive"], "portable.tldw-persona-vpack", {
+      type: "application/octet-stream"
+    })
+    fireEvent.change(await selectNativeImportSource(), {
+      target: { files: [archive] }
+    })
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-import-preview-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-import-preview-refresh-button"))
+    const header = await screen.findByTestId("persona-visual-management-header")
+    await waitFor(() => expect(header).toHaveTextContent("Import preview ready"))
+    fireEvent.click(screen.getByTestId("persona-visual-management-attention-action"))
+    expect(screen.getByTestId("persona-visual-import-preview-input")).toHaveFocus()
+  })
+
+  it("opens export attention from the management header", async () => {
+    const activePack = makeVisualPack({
+      id: "active-pack",
+      title: "Rendered now",
+      status: "active"
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse({ packs: [activePack], active_pack: activePack })
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/export" &&
+        method === "POST"
+      ) {
+        return okResponse({
+          job_id: "export-job-1",
+          portability_job_id: "portability-1",
+          operation: "export",
+          persona_id: "persona-1",
+          pack_id: "active-pack",
+          status: "queued",
+          stage: "queued",
+          download_url: null
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/exports/export-job-1" &&
+        method === "GET"
+      ) {
+        return okResponse({
+          job_id: "export-job-1",
+          portability_job_id: "portability-1",
+          operation: "export",
+          persona_id: "persona-1",
+          pack_id: "active-pack",
+          status: "completed",
+          visual_status: "completed",
+          stage: "completed",
+          download_url:
+            "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/exports/export-job-1/download"
+        })
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      throw new Error(`Unhandled path: ${path}`)
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    await screen.findByTestId("persona-visual-management-header")
+    fireEvent.click(screen.getByTestId("persona-visual-export-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-visual-export-status")).toHaveTextContent(
+        "queued"
+      )
+    )
+
+    fireEvent.click(screen.getByTestId("persona-visual-export-refresh-button"))
+    const header = screen.getByTestId("persona-visual-management-header")
+    await waitFor(() => expect(header).toHaveTextContent("Export ready"))
+    fireEvent.click(screen.getByTestId("persona-visual-management-attention-action"))
+    expect(screen.getByTestId("persona-visual-section-portable-actions")).toHaveFocus()
+  })
+
   it("groups post-setup Persona Visual controls into workspace sections", async () => {
     const activePack = makeVisualPack({
       id: "active-pack",

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
@@ -216,6 +216,7 @@ const makeVisualPack = (
     title: string
     status: string
     persona_id: string
+    manifest: typeof baseManifest
   }> = {}
 ) => ({
   id: overrides.id || "pack-1",
@@ -223,7 +224,7 @@ const makeVisualPack = (
   title: overrides.title || "Animated pack",
   renderer_type: "sprite_frames",
   status: overrides.status || "draft",
-  manifest: structuredClone(baseManifest),
+  manifest: structuredClone(overrides.manifest || baseManifest),
   assets: visualAssets,
   version: 3
 })
@@ -459,7 +460,179 @@ describe("VisualPackEditor", () => {
     expect(header).toHaveTextContent("review 1")
     await waitFor(() => expect(header).toHaveTextContent("Review required"))
     expect(header).toHaveTextContent("2 generated candidates need review.")
+    fireEvent.click(screen.getByTestId("persona-visual-management-attention-action"))
+    expect(screen.getByTestId("persona-visual-section-jobs-review")).toHaveFocus()
     expect(screen.getByTestId("persona-visual-pack-select")).toBeInTheDocument()
+  })
+
+  it("opens library attention from the management header", async () => {
+    const activePack = makeVisualPack({
+      id: "active-pack",
+      title: "Rendered now",
+      status: "active"
+    })
+    const libraryItem = {
+      id: "library-stale",
+      user_id: "user-1",
+      source_persona_id: null,
+      source_pack_id: null,
+      title: "Missing source pack",
+      notes: null,
+      tags: [],
+      source_persona_name: null,
+      source_pack_title: null,
+      source_pack_version: 1,
+      source_current_version: null,
+      source_available: false,
+      source_changed: false,
+      created_at: "2026-05-08T00:00:00Z",
+      last_modified: "2026-05-08T00:00:00Z",
+      version: 1
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse({ packs: [activePack], active_pack: activePack })
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [libraryItem] })
+      }
+      throw new Error(`Unhandled path: ${path}`)
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const header = await screen.findByTestId("persona-visual-management-header")
+    await waitFor(() => expect(header).toHaveTextContent("Library source unavailable"))
+    fireEvent.click(screen.getByTestId("persona-visual-management-attention-action"))
+    expect(screen.getByTestId("persona-visual-section-library")).toHaveFocus()
+  })
+
+  it("opens validation attention from the management header", async () => {
+    const activePack = makeVisualPack({
+      id: "active-pack",
+      title: "Rendered now",
+      status: "active",
+      manifest: {
+        ...structuredClone(baseManifest),
+        states: {} as typeof baseManifest.states
+      }
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse({ packs: [activePack], active_pack: activePack })
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse(readyGenerationReadiness)
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      throw new Error(`Unhandled path: ${path}`)
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const header = await screen.findByTestId("persona-visual-management-header")
+    await waitFor(() => expect(header).toHaveTextContent("Activation is blocked"))
+    fireEvent.click(screen.getByTestId("persona-visual-management-attention-action"))
+    expect(screen.getByTestId("persona-visual-section-validation-activation")).toContainElement(
+      document.activeElement
+    )
+  })
+
+  it("opens generation attention from the management header", async () => {
+    const activePack = makeVisualPack({
+      id: "active-pack",
+      title: "Rendered now",
+      status: "active"
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      const method = init?.method || "GET"
+      if (path === "/api/v1/persona/profiles/persona-1/visual-packs" && method === "GET") {
+        return okResponse({ packs: [activePack], active_pack: activePack })
+      }
+      if (path === "/api/v1/persona/visual-starter-packs" && method === "GET") {
+        return okResponse(starterCatalogPayload)
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/visual-packs/active-pack/generated-candidates" &&
+        method === "GET"
+      ) {
+        return okResponse({ candidates: [] })
+      }
+      if (path.endsWith("/generation-readiness") && method === "GET") {
+        return okResponse({
+          ...readyGenerationReadiness,
+          available: false,
+          worker_enabled: false,
+          reasons: ["jobs_worker_unavailable"]
+        })
+      }
+      if (path === "/api/v1/persona/catalog" && method === "GET") {
+        return okResponse([{ id: "persona-1", name: "Garden Helper" }])
+      }
+      if (path === "/api/v1/persona/visual-library" && method === "GET") {
+        return okResponse({ items: [] })
+      }
+      throw new Error(`Unhandled path: ${path}`)
+    })
+
+    render(
+      <VisualPackEditor
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+      />
+    )
+
+    const header = await screen.findByTestId("persona-visual-management-header")
+    await waitFor(() => expect(header).toHaveTextContent("Generation unavailable"))
+    fireEvent.click(screen.getByTestId("persona-visual-management-attention-action"))
+    expect(screen.getByTestId("persona-visual-generation-readiness")).toHaveFocus()
   })
 
   it("groups post-setup Persona Visual controls into workspace sections", async () => {
@@ -523,6 +696,9 @@ describe("VisualPackEditor", () => {
     expect(screen.getByTestId("persona-visual-upload-button")).toBeInTheDocument()
     expect(screen.getByTestId("persona-visual-activate-button")).toBeInTheDocument()
     expect(screen.queryByText(/Unhandled path:/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId("persona-visual-management-attention-action")
+    ).not.toBeInTheDocument()
   })
 
   it("does not show setup choices before active pack state is known", async () => {

--- a/backlog/tasks/task-456 - Implement-Persona-Visual-attention-navigation-polish.md
+++ b/backlog/tasks/task-456 - Implement-Persona-Visual-attention-navigation-polish.md
@@ -1,0 +1,64 @@
+---
+id: TASK-456
+title: Implement Persona Visual attention navigation polish
+status: Done
+labels:
+- persona-visual
+- webui
+- frontend
+references:
+- https://github.com/rmusser01/tldw_server/issues/1510
+- https://github.com/rmusser01/tldw_server/issues/1899
+- https://github.com/rmusser01/tldw_server/issues/1769
+- https://github.com/rmusser01/tldw_server/pull/1771
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Management header attention rows expose an action that focuses or scrolls to relevant existing controls for candidate review, import preview/commit, export download, validation/activation, personal library, and generation readiness.
+- [x] #2 Navigation reuses existing VisualPackEditor refs/sections and does not add backend calls or change server behavior.
+- [x] #3 Review-before-activation and explicit activation semantics remain unchanged.
+- [x] #4 Focused shared UI tests cover supported attention target mappings and a no-op/no-target case.
+- [x] #5 No Buddy animation, VN/CYOA, backend schema, generation orchestration, marketplace/shared-library, renderer, MCP provider execution, or auto-activation work is included.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Slice 4 from Docs/superpowers/specs/2026-05-16-persona-visual-post-setup-management-design.md: add focus/scroll navigation from Persona Visual management attention rows to existing VisualPackEditor controls and sections while preserving backend/API behavior and explicit review/activation semantics.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Slice 4 from the Persona Visual post-setup management design. Added a management-header attention action that routes the top attention row to existing VisualPackEditor sections or controls through refs. Candidate and job attention focuses the jobs/review section, library attention focuses the personal-library section, validation attention uses the existing activation controls focus path, import/export attention targets the portable actions section, generation attention targets the readiness panel, and pack failures target the pack basics section. The change is frontend-only and does not add backend calls or alter activation semantics.
+
+Verification:
+- `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "management header|library attention|validation attention|generation attention|workspace sections"` passed with 5 focused tests.
+- `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed with 70 tests.
+- `git diff --check` passed.
+- `bunx tsc --noEmit -p tsconfig.json` was attempted from `apps/packages/ui` and failed on existing package-wide TypeScript debt outside the touched PersonaGarden files; no errors referenced the touched files in the visible output.
+- Bandit is not applicable to this frontend-only TypeScript/Backlog slice.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Persona Visual attention navigation polish. The management header now exposes an attention action that focuses the relevant existing VisualPackEditor section/control for review, library, generation, validation, import/export, jobs, or pack-state attention without changing backend behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-456 - Implement-Persona-Visual-attention-navigation-polish.md
+++ b/backlog/tasks/task-456 - Implement-Persona-Visual-attention-navigation-polish.md
@@ -45,6 +45,9 @@ Verification:
 - `git diff --check` passed.
 - `bunx tsc --noEmit -p tsconfig.json` was attempted from `apps/packages/ui` and failed on existing package-wide TypeScript debt outside the touched PersonaGarden files; no errors referenced the touched files in the visible output.
 - Bandit is not applicable to this frontend-only TypeScript/Backlog slice.
+
+Review fix:
+- Addressed Gemini inline feedback by focusing attention targets with `preventScroll: true` before smooth scrolling, and by routing validation/activation attention through the same smooth-scroll focus helper as the other Persona Visual attention targets.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-456 - Implement-Persona-Visual-attention-navigation-polish.md
+++ b/backlog/tasks/task-456 - Implement-Persona-Visual-attention-navigation-polish.md
@@ -48,6 +48,9 @@ Verification:
 
 Review fix:
 - Addressed Gemini inline feedback by focusing attention targets with `preventScroll: true` before smooth scrolling, and by routing validation/activation attention through the same smooth-scroll focus helper as the other Persona Visual attention targets.
+- Addressed Qodo inline feedback by routing import attention to the import preview input when no pack is selected, keeping export attention on portable actions, and adding import/export attention coverage.
+- `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "management header|library attention|validation attention|generation attention|import attention|export attention|workspace sections"` passed with 7 focused tests.
+- `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed with 72 tests.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- add an Open action to the Persona Visual management header when a top attention row exists
- route attention rows to the existing editor sections for review/jobs, validation/activation, library, generation readiness, import/export, and pack basics
- add focused VisualPackEditor coverage for review, library, validation, generation, and no-attention cases

## Change summary
TODO: Human-authored change summary required before merge.

## Test plan
- bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "management header|library attention|validation attention|generation attention|workspace sections"
- bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx
- git diff --check
- bunx tsc --noEmit -p tsconfig.json (fails on existing package-wide TypeScript debt outside touched PersonaGarden files)

Closes #1899

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Open action in the Persona Visual management header to jump to the right `VisualPackEditor` section for the top attention item. Focus-first + smooth-scroll behavior is consistent across sections, with no backend changes.

- **New Features**
  - Open button (shown only when attention exists) routes to: jobs/review, validation/activation, library, import (focuses preview input), export, generation readiness, or pack basics.
  - Sections and key controls are now focusable; we prefer the most relevant control when available (e.g., activate button when enabled).
  - Tests cover review, library, validation, generation, import, export, and no-attention cases. Aligns with issue #1899; activation semantics unchanged.

<sup>Written for commit cfb813463d030a6ccda9e4c15f279e28d0ed9b05. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1900?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

