### PR TITLE
Gate Persona Buddy voice controls

### DIFF
--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -19,6 +19,7 @@ import {
 import { usePersonaVisualRuntimeStore } from "@/store/persona-visual-runtime"
 import type {
   PersonaBuddyPositionBucket,
+  PersonaBuddyLiveControlView,
   PersonaBuddyRenderContext,
   PersonaBuddySummary
 } from "@/types/persona-buddy"
@@ -557,6 +558,13 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
       visualState
     ]
   )
+  const liveControlView: PersonaBuddyLiveControlView | null =
+    liveControlEnabled
+      ? {
+          ...liveControl,
+          voiceState: renderContext.live_voice_state ?? null
+        }
+      : null
 
   React.useEffect(() => {
     const activePersonaId = String(resolvedPersona.activePersonaId || "").trim()
@@ -621,7 +629,7 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
       visualPack={visualPack}
       visualState={visualState}
       visualDiagnostic={visualDiagnostic}
-      liveControl={liveControlEnabled ? liveControl : null}
+      liveControl={liveControlView}
       onVisualRenderError={handleVisualRenderError}
       position={position}
       onToggle={() => setOpen(!isOpen)}

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellHost.tsx
@@ -562,6 +562,7 @@ const BuddyShellHostInner: React.FC<BuddyShellHostInnerProps> = ({
     liveControlEnabled
       ? {
           ...liveControl,
+          voiceIsListening: renderContext.live_voice_is_listening ?? undefined,
           voiceState: renderContext.live_voice_state ?? null
         }
       : null

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
@@ -63,7 +63,11 @@ export const BuddyShellPopover: React.FC<BuddyShellPopoverProps> = ({
       (liveControl?.voiceAvailable || focusedSession.capabilities?.voice)
   )
   const voiceState = String(liveControl?.voiceState ?? "").trim().toLowerCase()
-  const isListening = voiceState === "listening"
+  const isListening =
+    liveControl?.voiceIsListening === true || voiceState === "listening"
+  const voiceActionLabel = isListening
+    ? t("personaBuddy.voiceStop", "Stop listening")
+    : t("personaBuddy.voiceListen", "Listen")
 
   const handleDraftChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>
@@ -190,7 +194,7 @@ export const BuddyShellPopover: React.FC<BuddyShellPopoverProps> = ({
               ) : (
                 <Mic aria-hidden="true" className="h-3.5 w-3.5" />
               )}
-              {isListening ? "Stop listening" : "Listen"}
+              {voiceActionLabel}
             </Link>
           ) : null}
 

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellPopover.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Palette, Send, Square, Sparkles } from "lucide-react"
+import { Mic, MicOff, Palette, Send, Square, Sparkles } from "lucide-react"
 import { Link } from "react-router-dom"
 
 import type {
@@ -58,6 +58,12 @@ export const BuddyShellPopover: React.FC<BuddyShellPopoverProps> = ({
   const focusedSession = liveControl?.focusedSession ?? null
   const needsApproval = (focusedSession?.pendingApprovalCount ?? 0) > 0
   const sessionOptions = liveControl?.sessions ?? []
+  const voiceCapable = Boolean(
+    focusedSession &&
+      (liveControl?.voiceAvailable || focusedSession.capabilities?.voice)
+  )
+  const voiceState = String(liveControl?.voiceState ?? "").trim().toLowerCase()
+  const isListening = voiceState === "listening"
 
   const handleDraftChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>
@@ -173,6 +179,20 @@ export const BuddyShellPopover: React.FC<BuddyShellPopoverProps> = ({
               Stop
             </button>
           </div>
+          {voiceCapable ? (
+            <Link
+              data-testid="persona-buddy-voice-link"
+              to={liveRoute}
+              className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1.5 text-xs font-medium text-text hover:bg-surface2"
+            >
+              {isListening ? (
+                <MicOff aria-hidden="true" className="h-3.5 w-3.5" />
+              ) : (
+                <Mic aria-hidden="true" className="h-3.5 w-3.5" />
+              )}
+              {isListening ? "Stop listening" : "Listen"}
+            </Link>
+          ) : null}
 
           <textarea
             data-testid="persona-buddy-text-input"

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellRenderContext.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/BuddyShellRenderContext.tsx
@@ -49,6 +49,7 @@ const areRenderContextsEqual = (
     areBuddySummariesEqual(left.buddy_summary, right.buddy_summary) &&
     left.live_session_id === right.live_session_id &&
     left.live_voice_state === right.live_voice_state &&
+    left.live_voice_is_listening === right.live_voice_is_listening &&
     left.active_tool_name === right.active_tool_name &&
     left.active_tool_status === right.active_tool_status &&
     left.wake_armed === right.wake_armed &&

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -992,7 +992,8 @@ describe("BuddyShellHost", () => {
         position_bucket: "sidepanel-desktop",
         persona_source: "route-local",
         buddy_summary: buildBuddySummary("persona-1"),
-        live_voice_state: "listening"
+        live_voice_state: "idle",
+        live_voice_is_listening: true
       },
       root: "sidepanel"
     })

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx
@@ -938,11 +938,6 @@ describe("BuddyShellHost", () => {
       streamState: "open",
       canSendText: true
     }
-    usePersonaBuddyShellStore.setState((state) => ({
-      ...state,
-      isOpen: true
-    }))
-
     renderHost({
       context: {
         surface_id: "persona-garden",
@@ -955,10 +950,61 @@ describe("BuddyShellHost", () => {
       root: "sidepanel"
     })
 
+    fireEvent.click(
+      screen.getByRole("button", { name: "Toggle buddy for Persona persona-1" })
+    )
+
     expect(screen.queryByRole("button", { name: "Start" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument()
     expect(screen.queryByTestId("persona-buddy-text-input")).not.toBeInTheDocument()
     expect(liveControlMocks.calls.at(-1)).toMatchObject({ autoLoad: false })
+  })
+
+  it("passes route voice state into the Buddy live controls", () => {
+    liveControlMocks.state = {
+      ...liveControlMocks.state,
+      focusedSessionId: "live-session-1",
+      focusedSession: buildLiveSession({
+        capabilities: {
+          text: true,
+          voice: true,
+          browserMicrophoneRequired: true
+        }
+      }),
+      sessions: [
+        buildLiveSession({
+          capabilities: {
+            text: true,
+            voice: true,
+            browserMicrophoneRequired: true
+          }
+        })
+      ],
+      streamState: "open",
+      canSendText: true,
+      voiceAvailable: true
+    }
+    renderHost({
+      context: {
+        surface_id: "persona-garden",
+        surface_active: true,
+        active_persona_id: "persona-1",
+        position_bucket: "sidepanel-desktop",
+        persona_source: "route-local",
+        buddy_summary: buildBuddySummary("persona-1"),
+        live_voice_state: "listening"
+      },
+      root: "sidepanel"
+    })
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Toggle buddy for Persona persona-1" })
+    )
+
+    expect(screen.getByRole("link", { name: "Stop listening" })).toHaveAttribute(
+      "href",
+      "/persona?persona_id=persona-1&tab=live"
+    )
   })
 
   it("keeps urgent badge visible while drag movement override is active", async () => {

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx
@@ -180,4 +180,104 @@ describe("BuddyShellPopover", () => {
     expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /reject/i })).not.toBeInTheDocument()
   })
+
+  it("routes voice-capable sessions to the full Live listening surface", () => {
+    renderPopover({
+      liveControl: {
+        sessions: [
+          buildLiveSession({
+            capabilities: {
+              text: true,
+              voice: true,
+              browserMicrophoneRequired: true
+            }
+          })
+        ],
+        focusedSession: buildLiveSession({
+          capabilities: {
+            text: true,
+            voice: true,
+            browserMicrophoneRequired: true
+          }
+        }),
+        focusedSessionId: "live-session-1",
+        streamState: "open",
+        canSendText: true,
+        voiceAvailable: true,
+        voiceState: "idle",
+        pendingFocusSessionId: null,
+        startTextSession: vi.fn(),
+        stopSession: vi.fn(),
+        focusSession: vi.fn(),
+        sendText: vi.fn()
+      }
+    })
+
+    expect(screen.getByRole("link", { name: "Listen" })).toHaveAttribute(
+      "href",
+      "/persona?persona_id=persona-1&tab=live"
+    )
+    expect(screen.queryByRole("link", { name: "Stop listening" })).not.toBeInTheDocument()
+  })
+
+  it("routes active voice sessions to the full Live stop-listening surface", () => {
+    renderPopover({
+      liveControl: {
+        sessions: [
+          buildLiveSession({
+            capabilities: {
+              text: true,
+              voice: true,
+              browserMicrophoneRequired: true
+            }
+          })
+        ],
+        focusedSession: buildLiveSession({
+          capabilities: {
+            text: true,
+            voice: true,
+            browserMicrophoneRequired: true
+          }
+        }),
+        focusedSessionId: "live-session-1",
+        streamState: "open",
+        canSendText: true,
+        voiceAvailable: true,
+        voiceState: "listening",
+        pendingFocusSessionId: null,
+        startTextSession: vi.fn(),
+        stopSession: vi.fn(),
+        focusSession: vi.fn(),
+        sendText: vi.fn()
+      }
+    })
+
+    expect(screen.getByRole("link", { name: "Stop listening" })).toHaveAttribute(
+      "href",
+      "/persona?persona_id=persona-1&tab=live"
+    )
+    expect(screen.queryByRole("link", { name: "Listen" })).not.toBeInTheDocument()
+  })
+
+  it("hides voice controls when the focused session is not voice-capable", () => {
+    renderPopover({
+      liveControl: {
+        sessions: [buildLiveSession()],
+        focusedSession: buildLiveSession(),
+        focusedSessionId: "live-session-1",
+        streamState: "open",
+        canSendText: true,
+        voiceAvailable: false,
+        voiceState: "idle",
+        pendingFocusSessionId: null,
+        startTextSession: vi.fn(),
+        stopSession: vi.fn(),
+        focusSession: vi.fn(),
+        sendText: vi.fn()
+      }
+    })
+
+    expect(screen.queryByRole("link", { name: "Listen" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Stop listening" })).not.toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx
+++ b/apps/packages/ui/src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx
@@ -259,6 +259,46 @@ describe("BuddyShellPopover", () => {
     expect(screen.queryByRole("link", { name: "Listen" })).not.toBeInTheDocument()
   })
 
+  it("treats pending voice starts as listening before route state changes", () => {
+    renderPopover({
+      liveControl: {
+        sessions: [
+          buildLiveSession({
+            capabilities: {
+              text: true,
+              voice: true,
+              browserMicrophoneRequired: true
+            }
+          })
+        ],
+        focusedSession: buildLiveSession({
+          capabilities: {
+            text: true,
+            voice: true,
+            browserMicrophoneRequired: true
+          }
+        }),
+        focusedSessionId: "live-session-1",
+        streamState: "open",
+        canSendText: true,
+        voiceAvailable: true,
+        voiceIsListening: true,
+        voiceState: "idle",
+        pendingFocusSessionId: null,
+        startTextSession: vi.fn(),
+        stopSession: vi.fn(),
+        focusSession: vi.fn(),
+        sendText: vi.fn()
+      }
+    })
+
+    expect(screen.getByRole("link", { name: "Stop listening" })).toHaveAttribute(
+      "href",
+      "/persona?persona_id=persona-1&tab=live"
+    )
+    expect(screen.queryByRole("link", { name: "Listen" })).not.toBeInTheDocument()
+  })
+
   it("hides voice controls when the focused session is not voice-capable", () => {
     renderPopover({
       liveControl: {

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -235,6 +235,7 @@ const SidepanelPersona = ({
   )
   const [buddyShellLiveContext, setBuddyShellLiveContext] = React.useState({
     live_voice_state: "idle",
+    live_voice_is_listening: false,
     active_tool_name: "",
     active_tool_status: "",
     wake_armed: false,
@@ -277,6 +278,8 @@ const SidepanelPersona = ({
           null,
         live_session_id: sessionId,
         live_voice_state: buddyShellLiveContext.live_voice_state,
+        live_voice_is_listening:
+          buddyShellLiveContext.live_voice_is_listening,
         active_tool_name: buddyShellLiveContext.active_tool_name,
         active_tool_status: buddyShellLiveContext.active_tool_status,
         wake_armed: buddyShellLiveContext.wake_armed,
@@ -602,6 +605,7 @@ const SidepanelPersona = ({
   React.useEffect(() => {
     setBuddyShellLiveContext({
       live_voice_state: liveVoiceController.state,
+      live_voice_is_listening: liveVoiceController.isListening,
       active_tool_name: liveVoiceController.activeToolName,
       active_tool_status: liveVoiceController.activeToolStatus,
       wake_armed: liveVoiceController.wakeArmed,
@@ -610,6 +614,7 @@ const SidepanelPersona = ({
   }, [
     liveVoiceController.activeToolName,
     liveVoiceController.activeToolStatus,
+    liveVoiceController.isListening,
     liveVoiceController.recoveryMode,
     liveVoiceController.state,
     liveVoiceController.wakeArmed

--- a/apps/packages/ui/src/types/persona-buddy.ts
+++ b/apps/packages/ui/src/types/persona-buddy.ts
@@ -27,6 +27,11 @@ export interface PersonaBuddyLiveSessionSummary {
   personaName: string
   lifecycle: string
   pendingApprovalCount: number
+  capabilities?: {
+    text?: boolean
+    voice?: boolean
+    browserMicrophoneRequired?: boolean
+  } | null
   suggestedVisualState?: string | null
 }
 
@@ -36,6 +41,8 @@ export interface PersonaBuddyLiveControlView {
   focusedSession: PersonaBuddyLiveSessionSummary | null
   streamState: string
   canSendText: boolean
+  voiceAvailable?: boolean
+  voiceState?: string | null
   pendingFocusSessionId: string | null
   startTextSession: (personaId?: string | null) => Promise<unknown>
   stopSession: (sessionId?: string | null) => Promise<unknown>

--- a/apps/packages/ui/src/types/persona-buddy.ts
+++ b/apps/packages/ui/src/types/persona-buddy.ts
@@ -42,6 +42,7 @@ export interface PersonaBuddyLiveControlView {
   streamState: string
   canSendText: boolean
   voiceAvailable?: boolean
+  voiceIsListening?: boolean
   voiceState?: string | null
   pendingFocusSessionId: string | null
   startTextSession: (personaId?: string | null) => Promise<unknown>
@@ -61,6 +62,7 @@ export interface PersonaBuddyRenderContext {
   buddy_summary?: PersonaBuddySummary | null
   live_session_id?: string | null
   live_voice_state?: string | null
+  live_voice_is_listening?: boolean | null
   active_tool_name?: string | null
   active_tool_status?: string | null
   wake_armed?: boolean

--- a/backlog/tasks/task-464 - Implement-Persona-Buddy-voice-control-UI-gating.md
+++ b/backlog/tasks/task-464 - Implement-Persona-Buddy-voice-control-UI-gating.md
@@ -1,0 +1,58 @@
+---
+id: TASK-464
+title: Implement Persona Buddy voice control UI gating
+status: Done
+labels:
+- persona
+- buddy
+- frontend
+- implementation
+references:
+- TASK-457
+- TASK-460
+- TASK-461
+- TASK-462
+- 'issue #1510'
+- 'PR #1901'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next Persona Buddy interaction slice after PR #1901: expose conservative Listen/Stop Listening controls in the Buddy popover only when the live-control capability reports voice support, route unavailable/advanced setup cases to the full Persona Live view, and keep microphone startup user-initiated. Scope is frontend shared UI/hook behavior and focused tests; no backend turn-delivery or visual-pack changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Buddy popover renders Listen/Stop Listening controls only for voice-capable focused live sessions.
+- [x] #2 Voice controls do not render or call missing behavior when backend capabilities report voice=false or live control is unavailable.
+- [x] #3 Unavailable/advanced voice setup cases route to the full Persona Live view rather than starting microphone implicitly.
+- [x] #4 Focused hook/popover/host tests cover voice-capable, voice-unavailable, and capability-gated cases.
+- [x] #5 Verification and known skips are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added failing coverage first for Buddy popover voice-capable Listen routing, active listening Stop listening routing, voice-unavailable hiding, and host propagation of route live_voice_state.
+
+Implemented a frontend-only gate: BuddyShellHost passes route voice state into the live-control view, BuddyShellPopover renders a full-Live route link only for voice-capable focused sessions, and no Buddy-shell microphone start/stop behavior was added.
+
+Bandit was not run because the touched scope is TypeScript/frontend tests only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Persona Buddy voice control UI gating for the shared Buddy shell. Voice-capable focused live sessions now show Listen or Stop listening links that route to the full Persona Live tab, while voice=false sessions and disabled live-control capability do not expose voice controls. Verification: bunx vitest run src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx src/hooks/__tests__/usePersonaLiveControl.test.tsx (48 tests passed); git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-464 - Implement-Persona-Buddy-voice-control-UI-gating.md
+++ b/backlog/tasks/task-464 - Implement-Persona-Buddy-voice-control-UI-gating.md
@@ -14,6 +14,7 @@ references:
 - TASK-462
 - 'issue #1510'
 - 'PR #1901'
+- 'PR #1903'
 ---
 
 ## Description

--- a/backlog/tasks/task-464 - Implement-Persona-Buddy-voice-control-UI-gating.md
+++ b/backlog/tasks/task-464 - Implement-Persona-Buddy-voice-control-UI-gating.md
@@ -38,13 +38,15 @@ Added failing coverage first for Buddy popover voice-capable Listen routing, act
 
 Implemented a frontend-only gate: BuddyShellHost passes route voice state into the live-control view, BuddyShellPopover renders a full-Live route link only for voice-capable focused sessions, and no Buddy-shell microphone start/stop behavior was added.
 
+Review fix: threaded `live_voice_is_listening` from the route-owned voice controller through Buddy render context and host live-control view so pending microphone starts render as Stop listening even while `live_voice_state` remains idle. Also moved the new Listen/Stop listening labels through the existing i18n hook.
+
 Bandit was not run because the touched scope is TypeScript/frontend tests only.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented Persona Buddy voice control UI gating for the shared Buddy shell. Voice-capable focused live sessions now show Listen or Stop listening links that route to the full Persona Live tab, while voice=false sessions and disabled live-control capability do not expose voice controls. Verification: bunx vitest run src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx src/hooks/__tests__/usePersonaLiveControl.test.tsx (48 tests passed); git diff --check passed.
+Implemented Persona Buddy voice control UI gating for the shared Buddy shell. Voice-capable focused live sessions now show Listen or Stop listening links that route to the full Persona Live tab, while voice=false sessions and disabled live-control capability do not expose voice controls. Review fixes ensure pending voice starts use the Stop listening label and the new labels are localizable. Verification: bunx vitest run src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx src/hooks/__tests__/usePersonaLiveControl.test.tsx (49 tests passed); bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx (77 tests passed); git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Adds capability-gated Listen / Stop listening links to the Persona Buddy popover for voice-capable focused live sessions.
- Routes Buddy voice actions to the full Persona Live tab instead of starting or stopping the microphone from the Buddy shell.
- Threads route live voice state into the Buddy live-control view and adds focused host/popover coverage.

## Test Plan
- [x] `bunx vitest run src/components/Common/PersonaBuddy/__tests__/BuddyShellHost.test.tsx src/components/Common/PersonaBuddy/__tests__/BuddyShellPopover.test.tsx src/hooks/__tests__/usePersonaLiveControl.test.tsx`
- [x] `git diff --check`

## Change summary
Human-authored change summary required before merge: TODO

## Notes
- Bandit not run: touched scope is TypeScript/frontend only.
- Backlog: TASK-464

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds capability-gated voice controls to the Persona Buddy popover for voice-capable live sessions, routing Listen/Stop listening to the full Persona Live tab. Reflects live voice state and treats pending mic starts as listening, addressing TASK-464 / issue #1510.

- **New Features**
  - Show Listen/Stop only when the focused live session supports voice (`capabilities.voice` or `voiceAvailable`).
  - Link navigates to `/persona?persona_id=...&tab=live`; no mic control in the popover.
  - Thread `live_voice_state` and `live_voice_is_listening` from the route into `PersonaBuddyLiveControlView` so pending starts render “Stop listening”.
  - Extend types: session `capabilities`; live control `voiceAvailable`, `voiceIsListening`, `voiceState`; render context `live_voice_is_listening`.

<sup>Written for commit 8e966c1febc256ba87e8c145f617d78895770d11. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1903?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

