### PR TITLE
Remove duplicate TASK-456 final summary marker

### DIFF
--- a/backlog/tasks/task-456 - Migrate-VoiceTranscriptComposer-unsupported-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-456 - Migrate-VoiceTranscriptComposer-unsupported-alert-to-design-system-Alert.md
@@ -53,8 +53,6 @@ Verification:
 Migrated VoiceTranscriptComposer's unsupported-browser voice transcript notice from AntD Alert to the canonical design-system Alert, added focused product-state coverage, removed the VoiceTranscriptComposer baseline exception, and addressed PR review feedback by mapping the unavailable state to the design-system Alert error variant. Product-state baseline exceptions remain 325.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed


### PR DESCRIPTION
## Summary
- Removes the duplicate `<!-- SECTION:FINAL_SUMMARY:END -->` marker from TASK-456 that CodeRabbit flagged after PR #1897 merged.

## Verification
- `rg -n "SECTION:FINAL_SUMMARY:END" backlog/tasks/task-456\ -\ Migrate-VoiceTranscriptComposer-unsupported-alert-to-design-system-Alert.md` shows one marker.
- `git diff --check` passed.

## Change summary
TODO (human-authored before merge): summarize what changed and why this cleanup is appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a duplicate `<!-- SECTION:FINAL_SUMMARY:END -->` marker in the TASK-456 task markdown to prevent lint warnings and ensure parsers read a single final-summary terminator. No content changes; this is a formatting fix to keep the task doc well-formed.

<sup>Written for commit 70e323eccf3270c5cbcc8994c00986aeb88699e2. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1904?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

