### PR TITLE
Reconcile Persona Garden completion scope

### DIFF
--- a/Docs/Product/Persona_Agent_Design.md
+++ b/Docs/Product/Persona_Agent_Design.md
@@ -1,6 +1,6 @@
 # Persona Interaction / Persona Garden PRD
 
-Status: Active - current completion scope reconciled
+Status: Current Persona Garden/live-session completion scope implemented
 
 Owner: Core (Persona, LLM, Audio, MCP, AuthNZ, WebUI)
 
@@ -10,17 +10,19 @@ Future scope tracker: https://github.com/rmusser01/tldw_server/issues/1902
 
 Last reconciled: 2026-05-21
 
+Implementation closeout: 2026-05-21
+
 ## Summary
 
 Persona is the advanced assistant profile system for tldw_server. A Persona is derived from a Character, keeps provenance, and then evolves independently with its own live sessions, state, memory, scopes, policies, tools, voice settings, and static visual/media context.
 
 The current Persona module completion target is the Persona Garden and live-session foundation. It is not the whole assistant platform. Ordinary chat startup, Workspace-level assistant defaults, scheduled autonomous work, expressive avatars, global personalization, full tool administration, and multi-agent collaboration are valid future directions, but they are not blockers for declaring the current Persona module complete.
 
-## Current Status
+## Current Completion Status
 
 The original scaffold-era status from 2026-02-09 is stale. Current code evidence shows the module has moved beyond the initial catalog/session/websocket scaffold.
 
-Shipped or substantially implemented:
+Implemented:
 
 - Authenticated Persona endpoints and websocket interactions.
 - Persona Garden route framing, shared WebUI/extension route behavior, and tabs for `Live Session`, `Profiles`, `State Docs`, `Scopes`, and `Policies`.
@@ -31,14 +33,22 @@ Shipped or substantially implemented:
 - Persona session preference persistence, memory retrieval toggles, memory top-k handling, and Persona memory storage.
 - Persona scope and policy tables, API endpoints, runtime policy loading, and policy-denial behavior for Persona tool execution.
 - Static/state Persona visual-pack support as a Persona-owned media context.
+- Selected live-session transcript export for Persona Garden, including authenticated selected-session export, privacy/redaction constraints, UI download, and export confirmation.
+- Scopes and Policies editing surfaces in Persona Garden, including load/save flows, validation/error recovery, MCP tool picker support, and catalog/default-tool context.
+- Persona-local MCP/tool discovery through already-authorized catalog/tool-picker surfaces, without adding marketplace or global administration behavior.
+- Persona live memory status and Persona state-history archive controls where backend support already exists.
+- Acceptance tests and Backlog evidence for the reconciled completion boundary.
 
-Current completion gaps:
+Closeout evidence:
 
-- Minimal live-session transcript export for the selected Persona Garden session.
-- Non-placeholder Scopes and Policies editing surfaces in Persona Garden.
-- Minimal Persona-local MCP/tool discovery and default selection from already-authorized tools.
-- Persona memory visibility controls only where backend support already exists.
-- Updated acceptance tests and docs that capture the reconciled current boundary.
+- `TASK-442` and `TASK-443` reconciled and patched this PRD's current/future scope split.
+- `TASK-444` and `TASK-445` implemented selected-session transcript export backend and UI.
+- `TASK-449` added selected-session export confirmation.
+- `TASK-446` implemented Scope and Policy rule editors.
+- `TASK-447` exposed Persona-local MCP/tool discovery in the policy editor.
+- `TASK-448` exposed live memory mode, retrieval state, top-k, and state-context applicability.
+- `TASK-450` added state-history archive control for active state-doc history entries.
+- `TASK-451` closes the PRD evidence snapshot after these implementation slices.
 
 Not current completion blockers:
 
@@ -430,6 +440,8 @@ Future scope:
 
 ## Acceptance Criteria For Current Completion
 
+Closeout status: the reconciled current Persona Garden/live-session completion scope is implemented. The checklist below remains the durable acceptance contract for regression and future maintenance.
+
 - Persona Garden clearly separates `My Chat Identity`, `Characters`, and `Persona`.
 - Personas can be created from Characters and remain independent afterward.
 - Live text/voice sessions can connect, resume, degrade safely, and expose understandable recovery states.
@@ -445,11 +457,19 @@ Future scope:
 
 ## Verification Plan
 
-- Review this PRD against `Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md`.
-- Confirm each moved-out feature appears in #1902.
-- If a moved-out feature is missing from #1902, update #1902 before marking this PRD complete.
-- Confirm this PRD does not describe future PRDs as current completion blockers.
-- Confirm no design-system backlog tasks or files are modified.
+Completed closeout checks:
+
+- Reviewed this PRD against `Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md`.
+- Confirmed moved-out feature buckets are tracked by #1902.
+- Confirmed this PRD does not describe future PRDs as current completion blockers.
+- Confirmed no design-system backlog tasks or files are modified by the closeout.
+- Recorded implementation evidence in `TASK-442` through `TASK-451`.
+
+Maintenance checks for future changes:
+
+- Keep ordinary `/chat` Persona startup, Workspace Persona defaults, scheduled work, expressive avatar runtime, broad personalization memory, Persona tool administration, and multi-agent workflows out of the current completion contract unless their future PRDs are explicitly accepted back into scope.
+- Keep destructive/write/export actions confirmed and owner-scoped.
+- Keep MCP/tool discovery bounded to already-authorized tools and avoid leaking hidden/admin-only capabilities.
 
 ## Evidence Snapshot
 
@@ -461,3 +481,7 @@ Evidence used for this reconciliation included current code and tests for:
 - Persona profile provenance tests in `tldw_Server_API/tests/Persona/test_persona_profiles_api.py` and `tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py`.
 - Persona Garden route tabs and shared route tests in `apps/packages/ui/src/routes/sidepanel-persona.tsx` and `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`.
 - Character-to-Persona actions in `apps/packages/ui/src/components/Option/Characters/`.
+- Selected-session transcript export and confirmation coverage in `tldw_Server_API/tests/Persona/test_persona_profiles_api.py` and `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`.
+- Scope and policy editor coverage in `apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx`.
+- MCP tool picker and Persona-local capability context coverage in `apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx` and `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`.
+- Live memory status and state-history archive coverage in `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx` and `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`.

--- a/Docs/Product/Persona_Agent_Design.md
+++ b/Docs/Product/Persona_Agent_Design.md
@@ -1,247 +1,463 @@
-# Persona Interaction/Collaborator (Agent with Voice & Tools)
+# Persona Interaction / Persona Garden PRD
 
-Status: Active (MVP scaffold implemented)
+Status: Active - current completion scope reconciled
 
-Owner: Core (LLM, Audio, MCP, AuthNZ, WebUI)
+Owner: Core (Persona, LLM, Audio, MCP, AuthNZ, WebUI)
 
-Target Version: v0.2.x (Stage 1), v0.3.x (Stage 2-3)
+Current scope: Persona Garden and live Persona sessions
 
-https://github.com/VectorSpaceLab/general-agentic-memory
+Future scope tracker: https://github.com/rmusser01/tldw_server/issues/1902
 
+Last reconciled: 2026-05-21
 
 ## Summary
 
-Introduce a first-class Persona agent (text + optional voice + avatar) that chats naturally, remembers context, and uses server tools (via MCP Unified) to help with ingestion, search, analysis, and exports. Actions are transparent, previewed, and require confirmation for impactful operations.
+Persona is the advanced assistant profile system for tldw_server. A Persona is derived from a Character, keeps provenance, and then evolves independently with its own live sessions, state, memory, scopes, policies, tools, voice settings, and static visual/media context.
 
-## Current Status (v0.2.x dev, verified 2026-02-09)
+The current Persona module completion target is the Persona Garden and live-session foundation. It is not the whole assistant platform. Ordinary chat startup, Workspace-level assistant defaults, scheduled autonomous work, expressive avatars, global personalization, full tool administration, and multi-agent collaboration are valid future directions, but they are not blockers for declaring the current Persona module complete.
 
-- Implemented (backend scaffold):
-  - Feature-flag plumbing (`PERSONA_ENABLED`, persona RBAC config) and docs-info capability exposure.
-  - Persona endpoints scaffolded: `GET /api/v1/persona/catalog`, `POST /api/v1/persona/session`, `WS /api/v1/persona/stream`.
-  - Basic WS flow: `user_message -> tool_plan`, `confirm_plan -> tool_call/tool_result`.
-  - Basic tests exist for catalog, WS smoke flow, and WS metrics.
-- Partially implemented:
-  - MCP tool execution integration exists with server-stored plan validation keyed by `plan_id`.
-  - RBAC-style export/delete string checks exist in persona WS, but full policy/scoping behavior depends on MCP user identity.
-  - WebUI/extension persona surface is wired (`/persona`), capability-gated, and supports basic stream flow (connect/session/message/plan confirm-cancel) with route parity checks, component stream-flow tests, and Playwright route/workflow checks (including a live backend WS workflow test that runs when persona capability is enabled); deep backend tool-execution scenarios remain limited.
-- Not yet implemented:
-  - Full voice protocol (`audio_chunk`, `partial_transcript`, `tts_audio` binary stream).
-  - Persistent session/persona memory integration with personalization store.
-  - Per-tool policy scopes and explicit policy objects beyond string-based export/delete checks.
-- Important caveat:
-  - Persona endpoints now require authentication; anonymous interaction is not allowed.
+## Current Status
 
-## Changelog
+The original scaffold-era status from 2026-02-09 is stale. Current code evidence shows the module has moved beyond the initial catalog/session/websocket scaffold.
 
-- v0.2.x dev
-  - Added feature flag and capability exposure via `/api/v1/config/docs-info`.
-  - Added scaffold persona endpoints (catalog, session) and WS stream with a naive plan → confirm → act loop.
-  - Integrated scaffold MCP Unified tool execution path and basic RBAC-style export/delete checks.
-  - Added minimal WS smoke and metrics tests for the scaffold flow.
-  - Hardened auth contract: persona HTTP endpoints require auth; WS stream rejects unauthenticated clients.
-  - Normalized disabled behavior: persona catalog/session return `404` when persona is disabled.
-  - Standardized WS tool result payload on `output` (with temporary `result` compatibility alias).
-- v0.1.0
-  - Initial draft design with goals, architecture, and API outline.
+Shipped or substantially implemented:
 
-## `tool_result.result` Deprecation Plan (set 2026-02-09)
+- Authenticated Persona endpoints and websocket interactions.
+- Persona Garden route framing, shared WebUI/extension route behavior, and tabs for `Live Session`, `Profiles`, `State Docs`, `Scopes`, and `Policies`.
+- `My Chat Identity`, `Characters`, and `Persona Garden` separation in the chat/persona UI.
+- Character-to-Persona creation with provenance fields and independence after source Character deletion.
+- Live websocket text flow with `user_message`, `tool_plan`, `confirm_plan`, `tool_call`, `tool_result`, notices, and session turn persistence.
+- Live voice protocol paths including `audio_chunk`, `partial_transcript`, `voice_commit`, wake activation, and `tts_audio` events.
+- Persona session preference persistence, memory retrieval toggles, memory top-k handling, and Persona memory storage.
+- Persona scope and policy tables, API endpoints, runtime policy loading, and policy-denial behavior for Persona tool execution.
+- Static/state Persona visual-pack support as a Persona-owned media context.
 
-- Canonical contract now: `tool_result.output`.
-- Compatibility window: through `2026-06-30`, server continues emitting both `output` and legacy `result`.
-- Client behavior during window:
-  - Read `output` first.
-  - Fall back to `result` only for older server compatibility.
-- Planned removal window: starting `2026-07-01` (or next compatible minor/major release after that date), stop emitting `result` once WebUI/extension compatibility checks are green in CI for output-only payloads.
+Current completion gaps:
+
+- Minimal live-session transcript export for the selected Persona Garden session.
+- Non-placeholder Scopes and Policies editing surfaces in Persona Garden.
+- Minimal Persona-local MCP/tool discovery and default selection from already-authorized tools.
+- Persona memory visibility controls only where backend support already exists.
+- Updated acceptance tests and docs that capture the reconciled current boundary.
+
+Not current completion blockers:
+
+- Ordinary `/chat` startup with Persona profiles.
+- Workspace-scoped Persona defaults. The original `project_id` language maps to the old name for Workspaces and is moved to a future PRD.
+- Persona scheduled work and daily briefs.
+- Rich avatar animation, visemes, lip-sync, 3D rendering, and high-frequency visual runtimes.
+- Cross-app personalization and automatic semantic memory curation.
+- Marketplace-style MCP/tool installation, configuration, administration, and global permission lifecycle.
+- Multi-agent or multi-Persona collaboration.
+
+## Design References
+
+- Reconciliation spec: `Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md`
+- Persona Garden design: `Docs/Plans/2026-03-08-persona-garden-design.md`
+- Future PRD tracker: https://github.com/rmusser01/tldw_server/issues/1902
+
+## Product Model
+
+### My Chat Identity
+
+Represents the user in standard chat.
+
+Owns:
+
+- user display name
+- user avatar/image
+- user-side prompt templates
+
+Does not own:
+
+- Character definitions
+- Persona profiles
+- Persona memory, state, scope, policy, or tool settings
+
+### Character
+
+Represents the base assistant definition used in standard Character chat.
+
+Owns:
+
+- reusable assistant identity
+- greeting, personality, scenario, and system prompt
+- base images and related Character metadata
+
+### Persona
+
+Represents an advanced assistant artifact derived from a Character snapshot and then evolved independently.
+
+Owns:
+
+- Persona profile fields
+- Character provenance metadata
+- Persona-specific system and state overlays
+- Persona state docs
+- Persona policy rules
+- Persona scope rules
+- Persona-owned long-term and session memory
+- Persona-specific voice settings
+- Persona-specific static visual/media context
+- Persona live sessions
+
+### Persona Lifecycle
+
+1. User creates or selects a Character.
+2. User creates a Persona from that Character.
+3. Source Character fields are copied or snapshotted into the Persona seed.
+4. Persona Garden opens the newly created Persona.
+5. The Persona evolves independently afterward.
+
+Implications:
+
+- Editing the source Character does not automatically mutate existing Personas.
+- Editing a Persona does not mutate the source Character.
+- Persona memory belongs to the Persona.
+- If a source Character is deleted, the derived Persona remains valid.
+- Any future `Refresh from source Character` behavior must be explicit, manual, diff-based, and confirmed.
 
 ## Goals
 
-- Provide a persistent chat persona with configurable style, voice, and capabilities.
-- Enable tool use via MCP with a visible plan/confirm/act loop.
-- Support live voice input/output using existing STT/TTS APIs.
-- Integrate session and persona memory with personalization store (opt-in).
-- Ensure RBAC and confirmations for any write/delete/export actions.
+- Provide a persistent Persona profile with configurable behavior, voice defaults, memory preferences, scopes, policies, tools, and static visual/media context.
+- Preserve Persona Garden as the advanced workspace for Persona setup, configuration, and live testing.
+- Support live text and voice Persona sessions using the existing websocket, STT, and TTS stack.
+- Enable tool use via MCP with a visible plan, confirmation, execution, and result-review loop.
+- Make session history, transcript events, and tool outcomes auditable.
+- Keep Persona memory opt-in and bounded by visible controls.
+- Ensure RBAC, ownership, policy checks, rate limits, and explicit confirmations for write/delete/export actions.
 
-## Non-Goals (Initial)
+## Non-Goals For Current Completion
 
-- Desktop automation outside the browser (future via MCP OS tools).
-- Multi-agent collaboration (future); start with a single persona.
-- Rich 3D avatars/visemes (future); begin with static avatar states.
+- Ordinary `/chat` Persona startup.
+- Workspace-scoped Persona defaults.
+- Autonomous scheduled Persona jobs.
+- Desktop automation outside browser/server tools.
+- Multi-agent collaboration.
+- Rich 3D avatars, visemes, lip-sync, or high-frequency animation.
+- Marketplace-style MCP/tool administration.
+- Cross-app automatic memory curation.
 
-## User Stories
+Each of these is tracked as a future PRD bucket in #1902 and is not a current completion blocker.
 
-- As a user, I open the Persona dock, speak or type, and get streaming responses.
-- As a user, the persona proposes a plan to ingest a URL and summarize; I confirm steps.
-- As a user, I see transcripts and tool call results in the chat timeline for auditability.
-- As a user, I choose a different persona style/voice per project.
+## Current Completion Scope
 
-## Architecture Overview
+### Persona Garden IA And Lifecycle
 
-- Persona config stored per persona; session-scoped chat with tool execution over MCP.
-- WebSocket stream multiplexes chat text, interim transcripts, tool call previews, and TTS audio.
-- Memory integration pulls in top-k user memories (if personalization is enabled) and saves persona-specific notes.
+The current module must clearly distinguish `My Chat Identity`, `Characters`, and `Persona Garden`.
 
-## Key Components
+Persona Garden remains the advanced workspace for Persona profiles and live Persona sessions. It should preserve:
 
-- Persona Catalog & Config
-  - Location: `tldw_Server_API/app/core/Persona/`
-  - Model: name, description, system_prompt, voice, avatar_url, capabilities, default_tools.
+- Persona selection
+- profile creation and editing
+- character-derived provenance display
+- live session connect and disconnect
+- session resume
+- state-doc editing and history restore
+- memory and state-context controls
+- tool-plan review and confirmation
 
-- Session Manager
-  - Location: `tldw_Server_API/app/core/Persona/session_manager.py`
-  - Tracks `session_id`, user_id, persona_id, last N turns, tool outcomes, and scopes.
+### Live Persona Session Runtime
 
-- Tool Adapter (MCP)
-  - Use existing MCP Unified endpoints under `tldw_Server_API/app/core/MCP_unified/`.
-  - Provide a thin wrapper to list tools, propose plans, execute with confirmation, and stream results.
+The current module includes live text and voice sessions.
 
-- Voice I/O
-  - STT: reuse `/api/v1/audio/stream/transcribe` for live captions.
-  - TTS: reuse `/api/v1/audio/speech` to stream audio chunks with timing hints.
+The live session runtime should support:
 
-## API Design
+- websocket connection lifecycle
+- `user_message`
+- `audio_chunk`
+- `voice_commit`
+- `wake_activation`
+- `partial_transcript`
+- `tool_plan`
+- `confirm_plan`
+- `tool_call`
+- `tool_result`
+- `tts_audio`
+- `notice`
+- safe text-only degradation when voice/TTS paths fail
+- persisted session turns and tool outcomes
+
+### Transcript And Audit Timeline
+
+Persona Garden should expose an auditable live-session timeline containing:
+
+- user messages
+- assistant messages
+- voice transcript events where relevant
+- tool plans
+- tool calls
+- tool results
+- recovery notices and degraded-mode notices
+
+Current completion requires minimal export for the selected live Persona session in deterministic JSON, readable Markdown, or both.
+
+Export hardening requirements:
+
+- Export only sessions owned by the authenticated user.
+- Export only the selected session, not all Persona history.
+- Omit or redact secrets, auth material, raw binary audio, and large tool payloads.
+- Omit or redact hidden system/developer prompts, hidden policy metadata, hidden tool configuration, and tool metadata that was not visible in the live session UI.
+- Omit non-selected-session memory records and retrieved source payloads that were not shown to the user during the session.
+- Include enough audit metadata to understand the export, such as Persona id, session id, timestamps, event types, and redaction markers.
+
+This export is not a scheduled report system and does not imply daily brief or workflow delivery support.
+
+### Persona Memory Controls
+
+Current completion keeps memory controls bounded to Persona-owned and session-owned behavior.
+
+The module should expose:
+
+- active memory mode
+- retrieval enabled/disabled state
+- memory top-k
+- whether memory was requested and applied for a live turn
+- session/persona memory visibility where backend support already exists
+- archive or clear controls only where Persona backend support already exists
+
+Missing archive or clear controls are non-blocking follow-up unless they are already supported by the Persona backend.
+
+Move cross-app personalization, semantic memory tuning, automatic memory merge/prune, and broad long-term curation to the future Personalization Memory Layer PRD.
+
+### Scopes And Policies Editing
+
+Current completion keeps Scopes and Policies editing in scope because Persona Garden already exposes these tabs and the backend already has Persona scope/policy storage and runtime enforcement.
+
+Persona Garden should allow users to:
+
+- view scope rules
+- edit and save scope rules
+- recover from scope validation errors
+- view policy rules
+- edit and save policy rules
+- recover from policy validation errors
+- understand when a live tool plan is blocked by policy
+
+Hardening requirements:
+
+- Editing Persona rules must not grant capabilities the authenticated user, server config, or deployment policy does not already allow.
+- Destructive changes should use confirmation or a clear review step.
+- Validation errors should identify the invalid rule, field, and reason without leaking hidden tool details.
+- Saves should preserve rule ownership and avoid cross-Persona writes.
+- Concurrent edits should fail predictably or use the existing versioning pattern where available.
+
+### Minimal MCP And Tool Capability Discovery
+
+Current completion includes minimal Persona-local tool discovery and default selection, not full tool administration.
+
+Persona Garden should show:
+
+- available tools or tool categories visible to the authenticated user and deployment
+- Persona-local default or allowed tools selected only from already-authorized tools
+- blocked or unavailable reason text
+- confirmation requirements for impactful tools
+
+Hardening requirements:
+
+- Show only tools visible to the authenticated user and current deployment.
+- Avoid exposing hidden/admin-only tool names through blocked reason text.
+- Distinguish `not installed`, `disabled by server`, `not allowed for this Persona`, and `requires confirmation` where the backend can truthfully report that distinction.
+- Constrain any default-tool save path by Persona policy, server capability checks, and already-authorized user permissions.
+
+Do not expand current completion into marketplace-style tool installation, global tool configuration, admin-level tool lifecycle management, or global permission changes.
+
+### Static Visual And Persona Media Context
+
+Current completion acknowledges already-integrated static/state visual pack support as Persona-owned media context.
+
+The current module may document visual packs, state mappings, and static Persona visual feedback where they already exist. It creates no new animation, viseme, lip-sync, renderer, 3D, or high-frequency visual-runtime requirements.
+
+Rich avatar work belongs to the future Persona Expressive Avatar Runtime PRD.
+
+### Security And Reliability
+
+Current completion requires:
+
+- authenticated Persona HTTP endpoints
+- authenticated websocket interaction
+- no anonymous Persona sessions
+- capability gating when Persona is disabled or unsupported
+- session ownership checks
+- rate limits and payload bounds
+- confirmation for destructive, write, delete, and export actions
+- policy enforcement for MCP/tool execution
+- useful validation and recovery errors
+- tests covering the current completion surface
+
+## API Contract
 
 Base path: `/api/v1/persona`
 
+### Existing Core Endpoints
+
 - `GET /catalog`
-  - Auth: required (Bearer token or `X-API-KEY`)
-  - Disabled behavior: `404 { "detail": "Persona disabled" }`
-  - Res: `[ { id, name, description, voice, avatar_url, capabilities, default_tools } ]`
-
 - `POST /session`
-  - Auth: required (Bearer token or `X-API-KEY`)
-  - Disabled behavior: `404 { "detail": "Persona disabled" }`
-  - Req: `{ persona_id, project_id?, resume_session_id? }`
-  - Res: `{ session_id, persona: {...}, scopes: [...] }`
-
 - `GET /sessions`
-  - Auth: required
-  - Disabled behavior: `404 { "detail": "Persona disabled" }`
-  - Query: `persona_id?`, `limit?`
-  - Res: `[ { session_id, persona_id, created_at, updated_at, turn_count, pending_plan_count, preferences } ]`
-
 - `GET /sessions/{session_id}`
-  - Auth: required
-  - Disabled behavior: `404 { "detail": "Persona disabled" }`
-  - Query: `limit_turns?`
-  - Res: `{ session_id, persona_id, created_at, updated_at, turn_count, pending_plan_count, preferences, turns: [...] }`
+- `WS /stream`
 
-- `WS /stream` (bi-directional)
-  - Auth: required before interaction (`Authorization: Bearer ...`, `X-API-KEY`, or `token`/`api_key` query params)
-  - Missing/invalid auth: connection is closed (`1008` policy violation)
-  - Client → Server messages (JSON):
-    - `user_message`: `{ session_id, text, use_memory_context?, memory_top_k? }`
-    - `audio_chunk`: `{ session_id, audio_format, bytes_base64 }`
-    - `confirm_plan`: `{ session_id, plan_id, approved_steps: [idx...] }`
-    - `cancel`: `{ session_id, reason? }`
-  - Server → Client events (JSON frames; audio in separate binary frames if supported):
-    - `assistant_delta`: `{ session_id, text_delta }`
-    - `partial_transcript`: `{ session_id, text_delta }`
-    - `tool_plan`: `{ session_id, plan_id, steps: [ { idx, tool, args, description, policy } ], memory?: { enabled, requested_top_k, applied_count } }`
-    - `tool_call`: `{ session_id, step_idx, tool, args }`
-    - `tool_result`: `{ session_id, step_idx, ok, output, error? }`
-      - Compatibility: `result` may also be present temporarily as an alias for `output`.
-    - `tts_audio`: `{ session_id, audio_format, chunk_id }` (binary follows)
-    - `notice`: `{ session_id, level, message }`
+### Session Creation
 
-- Optional: `POST /tools/execute` for non-WS flows; prefer WS for streaming.
+`POST /session` remains Persona/session scoped.
 
-Schemas live under: `tldw_Server_API/app/api/v1/schemas/persona.py`
+Any legacy `project_id` field should not be treated as current Workspace-level Persona defaults. Workspace-scoped Persona defaults are moved to a future PRD.
 
-Implementation notes:
-- WS accepts auth via headers and query params, and requires successful auth before stream interaction.
-- For compatibility with HTTP auth behavior, single-user/non-JWT bearer values are treated as API keys.
-- Tool name → module mapping is minimal; error messages returned for unknown/forbidden tools.
-- Client is responsible for rendering plan steps and sending back approvals.
+### Websocket Messages
 
-## Tool Use Loop (Plan → Confirm → Act → Review)
+Client to server:
 
-1. Persona drafts a short plan (1-3 steps max by default) with tools and inputs.
-2. UI shows the plan for user confirmation (per step approvals allowed).
-3. On confirmation, server calls MCP tools with scoped tokens; streams results.
-4. Persona summarizes outcomes and proposes next steps.
+- `user_message`: `{ session_id, text, use_memory_context?, memory_top_k? }`
+- `audio_chunk`: `{ session_id, audio_format, bytes_base64 }`
+- `voice_commit`: `{ session_id, transcript? }`
+- `wake_activation`: `{ session_id, phrase?, source? }`
+- `confirm_plan`: `{ session_id, plan_id, approved_steps: [idx...] }`
+- `cancel`: `{ session_id, reason? }`
 
-Guardrails:
+Server to client:
 
-- Never call write/delete/export tools without explicit confirmation.
-- Enforce `max_tool_steps` per session/persona from config.
-- Attach `why`/audit metadata to each tool invocation.
+- `assistant_delta`: `{ session_id, text_delta }`
+- `partial_transcript`: `{ session_id, text_delta }`
+- `tool_plan`: `{ session_id, plan_id, steps: [...] }`
+- `tool_call`: `{ session_id, step_idx, tool, args }`
+- `tool_result`: `{ session_id, step_idx, ok, output, error? }`
+- `tts_audio`: `{ session_id, audio_format, chunk_id }`
+- `notice`: `{ session_id, level, message, reason_code? }`
 
-## Memory & Personalization Integration
+### `tool_result.result` Deprecation Plan
 
-- Session Memory: last N turns + tool outcomes (persisted with `session_id`).
-- Persona Memory (per user/persona): saved as semantic memories via personalization store.
-- Retrieval: before responding, fetch top-k relevant user memories for grounding if enabled.
+Canonical contract: `tool_result.output`.
 
-## WebUI Additions
+Compatibility window: through 2026-06-30, the server may continue emitting both `output` and legacy `result`.
 
-- Persona Dock: mic button (push-to-talk), live captions, avatar with speaking/listening states.
-- Action Preview: shows tool plan steps with toggles; confirm/cancel buttons.
-- Transcript Panel: interleaves messages with tool calls/results; downloadable.
-- Persona Selector: choose persona/voice within session.
-- Visibility controlled by capability map from `GET /api/v1/config/docs-info` (`capabilities.persona`).
+Client behavior during the window:
 
-## Configuration
+- Read `output` first.
+- Fall back to `result` only for older server compatibility.
 
-`tldw_Server_API/Config_Files/config.txt`
+Planned removal window: starting 2026-07-01, or the next compatible minor/major release after that date, stop emitting `result` once WebUI/extension compatibility checks are green for output-only payloads.
 
-```
-[persona]
-enabled = true
-default_persona = "Research Assistant"
-voice = "default"
-stt = "faster_whisper"
-max_tool_steps = 3
+This is a dated maintenance item, not a current feature gap before the planned removal window.
 
-[persona.rbac]
-allow_export = false
-allow_delete = false
-```
+## Future PRDs
 
-Runtime capability surface:
-- `GET /api/v1/config/docs-info` → includes `capabilities` and `supported_features` maps (for backward compatibility).
+The following product directions are moved out of current completion scope. Each item should get its own PRD before implementation. Each item is not a current completion blocker.
 
-## Security & Permissions
+Tracker: https://github.com/rmusser01/tldw_server/issues/1902
 
-- AuthNZ: Sessions tied to `user_id`; RBAC governs tool access and scope.
-- WS persona interactions require authentication; anonymous sessions are not permitted.
-- Confirmations required for destructive actions; audit log entries for all tool calls.
-- Rate limiting on WS messages and tool executions; backpressure handling on TTS.
+### Persona-backed Chat Startup
 
-## Testing Strategy
+Not a current completion blocker.
 
-- Unit
-  - Session manager state transitions; plan merging/approvals; step caps.
-  - Tool adapter request/response normalization.
+Future scope:
 
-- Integration
-  - WS flow: connect → chat → plan → confirm → execute → stream TTS.
-  - Permissions: attempts to call restricted tools are denied/logged.
-  - Voice pipeline: STT partials drive interim captions; TTS emits playable chunks.
-  - WS smoke tests for plan/confirm path.
+- Make ordinary `/chat` use Persona profiles as first-class assistants.
+- Preserve current Character chat behavior.
+- Resolve migration from deprecated `persona_id` alias semantics.
+- Define chat startup state, persistence, and UI selection.
 
-- Mocks/Fixtures
-  - Mock MCP tools with deterministic outputs.
-  - Fake TTS generator for byte chunks; STT stub emitting partials.
+### Workspace Persona Defaults
 
-## Milestones
+Not a current completion blocker.
 
-- Stage 1 (MVP)
-  - Persona catalog + session; WS chat; tool plan/confirm loop (text only).
+Future scope:
 
-- Stage 2
-  - Voice I/O (STT/TTS) and avatar states; transcript timeline with tool logs.
+- Replace old `project_id` terminology with Workspace terminology.
+- Define Workspace-level Persona defaults.
+- Define Workspace-level style, voice, tool, and memory defaults.
+- Handle conflicts between local session choice and Workspace default.
+- Integrate with chat, Prompt Studio, writing, and workspace surfaces.
 
-- Stage 3
-  - Multi-persona selection per project; scheduled jobs (e.g., daily brief); per-tool RBAC policies.
+### Persona Scheduled Work
 
-## Open Questions
+Not a current completion blocker.
 
-- Default toolset priority for MVP (ingest_url, rag_search, summarize, notes)?
-- Policy: any hard “never-do” actions beyond delete/export without confirmation?
-- Do we require visemes/lip-sync at v1, or ship later?
+Future scope:
 
-## Risks & Mitigations
+- recurring Persona jobs
+- daily briefs
+- review and approval gates
+- delivery channels
+- Jobs versus Scheduler integration
+- failure, retry, and notification behavior
 
-- Tool misuse → strict confirmations, RBAC scopes, and audit logs.
-- Latency in voice mode → stream partials early; bound TTS chunk sizes.
-- Context bloat → limit session turns and injected memories; prune aggressively.
+### Persona Expressive Avatar Runtime
+
+Not a current completion blocker.
+
+Future scope:
+
+- high-frequency animation
+- visemes and lip-sync
+- expressive 2D or 3D rendering
+- advanced runtime synchronization with voice and text
+
+### Personalization Memory Layer
+
+Not a current completion blocker.
+
+Future scope:
+
+- cross-app semantic memory
+- memory creation and curation
+- merge and prune behavior
+- personalization tuning
+- user controls for global personalization
+
+### Persona Tool Administration
+
+Not a current completion blocker.
+
+Future scope:
+
+- marketplace-style tool install and configuration
+- admin-level tool lifecycle
+- broad permissions management
+- integration-level setup and health checks
+
+Current completion keeps only minimal discovery, Persona-local defaults from already-authorized tools, and blocked reason text.
+
+### Persona Collaboration And Multi-agent Workflows
+
+Not a current completion blocker.
+
+Future scope:
+
+- multiple Personas acting concurrently
+- Persona-to-Persona coordination
+- shared plans and arbitration
+- concurrent tool use and conflict resolution
+
+## Acceptance Criteria For Current Completion
+
+- Persona Garden clearly separates `My Chat Identity`, `Characters`, and `Persona`.
+- Personas can be created from Characters and remain independent afterward.
+- Live text/voice sessions can connect, resume, degrade safely, and expose understandable recovery states.
+- Transcript timeline includes user/assistant messages, voice transcript events where relevant, tool plans, tool calls/results, and notices.
+- Selected-session transcript export is available and follows the privacy/redaction constraints in this PRD.
+- Persona memory controls expose mode, retrieval toggle, top-k, and existing backend-supported visibility/archive/clear operations.
+- Scopes and Policies tabs are not placeholders; users can view, edit, save, and recover from validation errors for Persona scope and policy rules.
+- Scopes and Policies editing cannot grant capabilities the authenticated user/server/deployment does not already allow.
+- Persona Garden shows available MCP/tool capabilities, Persona-local defaults from already-authorized tools, and blocked/unavailable reasons without leaking hidden/admin-only tools.
+- Static/state visual pack support is documented as current context only, with expressive avatar runtime clearly future scoped.
+- Auth, ownership, capability gating, rate limits, destructive-action confirmations, and useful error states are covered by tests.
+- Future PRD buckets are linked to #1902 and explicitly labeled as not current completion blockers.
+
+## Verification Plan
+
+- Review this PRD against `Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md`.
+- Confirm each moved-out feature appears in #1902.
+- If a moved-out feature is missing from #1902, update #1902 before marking this PRD complete.
+- Confirm this PRD does not describe future PRDs as current completion blockers.
+- Confirm no design-system backlog tasks or files are modified.
+
+## Evidence Snapshot
+
+Evidence used for this reconciliation included current code and tests for:
+
+- Persona websocket voice and tool events in `tldw_Server_API/app/api/v1/endpoints/persona.py`.
+- Persona websocket coverage in `tldw_Server_API/tests/Persona/test_persona_ws.py`.
+- Persona session and memory persistence in `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py` and `tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py`.
+- Persona profile provenance tests in `tldw_Server_API/tests/Persona/test_persona_profiles_api.py` and `tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py`.
+- Persona Garden route tabs and shared route tests in `apps/packages/ui/src/routes/sidepanel-persona.tsx` and `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`.
+- Character-to-Persona actions in `apps/packages/ui/src/components/Option/Characters/`.

--- a/Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
+++ b/Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
@@ -1,0 +1,245 @@
+# Persona PRD Reconciliation Design
+
+Date: 2026-05-21
+
+Status: Draft
+
+Tracker: https://github.com/rmusser01/tldw_server/issues/1902
+
+Backlog: TASK-442
+
+## Summary
+
+Reconcile the original Persona module PRD into a current completion contract for Persona Garden and live Persona sessions, while preserving the broader assistant vision as separate future PRDs.
+
+The current Persona PRD should stop acting as a catch-all roadmap. It should define what must be true before the current Persona module is considered coherent and complete. Broader platform work remains valid, but should move into explicit follow-up PRDs tracked by issue #1902.
+
+## Source Documents
+
+- `Docs/Product/Persona_Agent_Design.md`
+- `Docs/Plans/2026-03-08-persona-garden-design.md`
+- `Docs/Plans/2026-03-08-persona-garden-implementation-plan.md`
+
+## Product Boundary
+
+The current Persona module is the Persona Garden and live Persona session foundation.
+
+It owns:
+
+- Persona profiles derived from Characters and independent afterward.
+- Persona Garden as the advanced persona workspace.
+- Live text and voice sessions.
+- Persona-owned state, memory, scope, policy, tool, and static visual/media context.
+- Auditable transcript and tool timelines.
+
+It does not own ordinary chat startup, Workspace-level assistant defaults, scheduled autonomous work, rich avatar rendering, global personalization, full tool marketplace administration, or multi-agent collaboration.
+
+## Keep In Current Persona Completion Scope
+
+### Persona Garden IA And Lifecycle
+
+Keep the separation between `My Chat Identity`, `Characters`, and `Persona Garden`.
+
+Personas remain advanced assistant artifacts created from Characters, with provenance retained for audit and display. After creation, personas evolve independently. Editing the source Character must not silently mutate an existing Persona, and editing a Persona must not mutate the source Character.
+
+### Live Persona Session Runtime
+
+Keep live text and voice sessions as part of current completion. This includes:
+
+- connect and disconnect
+- session resume
+- websocket user messages
+- audio chunks
+- partial transcripts
+- TTS audio events
+- tool plans
+- plan confirmation and cancellation
+- notices and safe degradation states
+
+The current PRD should mark the stale "full voice protocol not implemented" status as obsolete when reconciling against current code.
+
+### Transcript And Audit Timeline
+
+Keep transcript auditability in current scope.
+
+The Persona Garden live session should show user and assistant turns, voice transcript events where relevant, tool plans, tool calls, tool results, and recovery notices. It should support a minimal downloadable export for a live Persona session in JSON or Markdown.
+
+This export is not a scheduled report system and should not imply daily brief or workflow delivery support.
+
+### Persona Memory Controls
+
+Keep persona-owned memory controls in current scope, but bound them narrowly.
+
+The current module should expose:
+
+- active memory mode
+- retrieval toggle
+- top-k retrieval setting
+- session/persona memory visibility where supported
+- archive or clear controls where backend support already exists or is directly adjacent
+
+Move cross-app personalization, semantic memory tuning, automatic memory merge/prune, and broad long-term curation into a separate future PRD.
+
+### Scopes And Policies Editing
+
+Keep Scopes and Policies editing in current scope.
+
+The backend already has persona scope and policy rule storage plus runtime enforcement paths, and Persona Garden already exposes `Scopes` and `Policies` tabs. Those tabs should not remain placeholders in the completion contract.
+
+Current completion should require users to:
+
+- view scope rules
+- edit and save scope rules
+- recover from scope validation errors
+- view policy rules
+- edit and save policy rules
+- recover from policy validation errors
+- understand when a live tool plan is blocked by policy
+
+### Minimal MCP And Tool Capability Discovery
+
+Keep minimal tool discovery and default toolset management in current scope.
+
+Persona Garden should show enough tool information for a user to understand what a persona can use and why a tool may be unavailable. This includes:
+
+- visible available tools or tool categories
+- persona default or allowed tools
+- blocked or unavailable reason text
+- confirmation requirements for impactful tools
+
+Do not expand this into marketplace-style tool installation or admin-level tool lifecycle management in the current PRD.
+
+### Static Visual And Persona Media Context
+
+Keep existing static/state visual pack support as persona-owned media context.
+
+The current PRD should acknowledge visual packs, state mappings, and static persona visual feedback where already integrated. It should explicitly avoid making rich avatar animation, visemes, lip-sync, or 3D rendering blockers for current completion.
+
+### Security And Reliability Completion
+
+Keep security and reliability as acceptance criteria:
+
+- authenticated Persona endpoints and websocket interactions
+- capability gating
+- session ownership checks
+- rate limits and payload bounds
+- confirmation for destructive, write, delete, and export actions
+- useful validation and recovery errors
+- no anonymous Persona interaction
+- tests covering the current completion surface
+
+## Move Out To Future PRDs
+
+Each item below should become its own PRD and should not block current Persona module completion. The tracking issue is #1902.
+
+### Persona-backed Chat Startup
+
+Move ordinary `/chat` integration into a future PRD.
+
+Scope:
+
+- selecting Persona profiles as first-class chat assistants
+- preserving current Character chat behavior
+- migration from deprecated `persona_id` alias semantics
+- chat startup state, persistence, and UI selection
+
+### Workspace Persona Defaults
+
+Move workspace-scoped persona selection into a future PRD.
+
+The original PRD's `project_id` language should be updated to current Workspace terminology.
+
+Scope:
+
+- Workspace-level persona defaults
+- Workspace-level style, voice, tool, and memory defaults
+- interaction with chat, Prompt Studio, writing, and workspace surfaces
+- conflict handling between local session choice and Workspace default
+
+### Persona Scheduled Work
+
+Move scheduled jobs and daily briefs into a future PRD.
+
+Scope:
+
+- recurring persona jobs
+- daily briefs
+- review and approval gates
+- delivery channels
+- Jobs versus Scheduler integration
+- failure/retry/notification behavior
+
+### Persona Expressive Avatar Runtime
+
+Move rich avatar work into a future PRD.
+
+Scope:
+
+- high-frequency animation
+- visemes and lip-sync
+- expressive 2D or 3D rendering
+- advanced runtime synchronization with voice and text
+
+### Personalization Memory Layer
+
+Move broader memory and personalization into a future PRD.
+
+Scope:
+
+- cross-app semantic memory
+- memory creation and curation
+- merge and prune behavior
+- personalization tuning
+- user controls for global personalization
+
+### Persona Tool Administration
+
+Move full tool administration into a future PRD.
+
+Scope:
+
+- marketplace-style tool install and configuration
+- admin-level tool lifecycle
+- broad permissions management
+- integration-level setup and health checks
+
+The current PRD keeps only minimal discovery, allowed/default tool visibility, and blocked reason text.
+
+### Persona Collaboration And Multi-agent Workflows
+
+Move multi-agent and multi-persona collaboration into a future PRD.
+
+Scope:
+
+- multiple personas acting concurrently
+- persona-to-persona coordination
+- shared plans and arbitration
+- concurrent tool use and conflict resolution
+
+## Reconciliation Updates For The Current PRD
+
+When updating `Docs/Product/Persona_Agent_Design.md`, apply these changes:
+
+1. Replace stale implementation status with a current status section.
+2. Mark voice protocol, persona/session memory, and policy object support as shipped or partially shipped according to current code evidence.
+3. Clarify that Persona Garden/live Persona sessions are the current module boundary.
+4. Add the current completion scope from this design.
+5. Add a future PRD section linking #1902.
+6. Replace old `project_id` phrasing with a note that Workspace-scoped persona defaults moved to a future PRD.
+7. Keep the original long-term vision visible, but do not let future tracks block current completion.
+
+## Acceptance Criteria
+
+- Current Persona PRD distinguishes current completion scope from future platform scope.
+- Current Persona PRD keeps Persona Garden and live Persona sessions as the module boundary.
+- Current Persona PRD keeps Scopes and Policies editing, transcript export, minimal tool discovery, memory controls, and reliability/security closeout in scope.
+- Current Persona PRD moves ordinary chat integration, Workspace persona defaults, scheduled work, expressive avatars, broad personalization, tool administration, and multi-agent collaboration out to future PRDs.
+- Future scope links to GitHub issue #1902.
+- No design-system backlog tasks are touched.
+
+## Verification Plan
+
+- Review the updated PRD against this spec.
+- Confirm every moved-out feature appears in #1902.
+- Confirm the PRD does not describe future PRDs as current completion blockers.
+- Confirm no design-system backlog tasks or files are modified.

--- a/Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
+++ b/Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
@@ -82,6 +82,8 @@ Export hardening:
 - allow export only for sessions owned by the authenticated user
 - export only the selected session, not all persona history
 - omit or redact secrets, auth material, raw binary audio, and large tool payloads
+- omit or redact hidden system/developer prompts, hidden policy metadata, hidden tool configuration, and tool metadata that was not visible in the live session UI
+- omit non-selected-session memory records and retrieved source payloads that were not shown to the user during the session
 - include enough metadata for audit, such as persona id, session id, timestamps, event types, and redaction markers
 - provide deterministic JSON for machine use and Markdown as a readable convenience, if both are implemented
 
@@ -95,9 +97,9 @@ The current module should expose:
 - retrieval toggle
 - top-k retrieval setting
 - session/persona memory visibility where supported
-- archive or clear controls where backend support already exists or is directly adjacent
+- archive or clear controls only where backend support already exists
 
-Move cross-app personalization, semantic memory tuning, automatic memory merge/prune, and broad long-term curation into a separate future PRD.
+Missing archive or clear controls should be marked as non-blocking follow-up unless they are already supported by the Persona backend. Move cross-app personalization, semantic memory tuning, automatic memory merge/prune, and broad long-term curation into a separate future PRD.
 
 ### Scopes And Policies Editing
 
@@ -125,29 +127,31 @@ Scopes and Policies hardening:
 
 ### Minimal MCP And Tool Capability Discovery
 
-Keep minimal tool discovery and default toolset management in current scope.
+Keep minimal tool discovery and persona-local default selection in current scope.
 
 Persona Garden should show enough tool information for a user to understand what a persona can use and why a tool may be unavailable. This includes:
 
 - visible available tools or tool categories
-- persona default or allowed tools
+- persona-local default or allowed tools selected only from already-authorized tools
 - blocked or unavailable reason text
 - confirmation requirements for impactful tools
 
-Do not expand this into marketplace-style tool installation or admin-level tool lifecycle management in the current PRD.
+Do not expand this into marketplace-style tool installation, global tool configuration, admin-level tool lifecycle management, or global permission changes in the current PRD.
 
 Tool discovery hardening:
 
 - show only tools visible to the authenticated user and current deployment
 - avoid exposing hidden/admin-only tool names through blocked reason text
 - distinguish "not installed", "disabled by server", "not allowed for this persona", and "requires confirmation" where the backend can truthfully report that distinction
-- keep any default-tool save path constrained by persona policy and server capability checks
+- keep any default-tool save path constrained by persona policy, server capability checks, and already-authorized user permissions
 
 ### Static Visual And Persona Media Context
 
 Keep existing static/state visual pack support as persona-owned media context.
 
 The current PRD should acknowledge visual packs, state mappings, and static persona visual feedback where already integrated. It should explicitly avoid making rich avatar animation, visemes, lip-sync, or 3D rendering blockers for current completion.
+
+Current completion creates no new animation, viseme, lip-sync, renderer, or high-frequency visual-runtime requirements. It only acknowledges already-integrated visual pack and static state support.
 
 ### Security And Reliability Completion
 
@@ -165,6 +169,8 @@ Keep security and reliability as acceptance criteria:
 ## Move Out To Future PRDs
 
 Each item below should become its own PRD and should not block current Persona module completion. The tracking issue is #1902.
+
+The patched PRD should label every item in this section as "not a current completion blocker."
 
 ### Persona-backed Chat Startup
 
@@ -279,6 +285,8 @@ When updating `Docs/Product/Persona_Agent_Design.md`, apply these changes:
 - Current Persona PRD keeps Scopes and Policies editing, transcript export, minimal tool discovery, memory controls, and reliability/security closeout in scope.
 - Current Persona PRD moves ordinary chat integration, Workspace persona defaults, scheduled work, expressive avatars, broad personalization, tool administration, and multi-agent collaboration out to future PRDs.
 - Future scope links to GitHub issue #1902.
+- Every future-scope bucket is labeled as not a current completion blocker in the patched PRD.
+- If a future-scope bucket is missing from #1902, update #1902 before considering the PRD patch complete.
 - Transcript export, Scopes/Policies editing, and tool discovery include the hardening constraints from this design.
 - Shipped or partially shipped claims are backed by current code evidence during the PRD patch.
 - No design-system backlog tasks are touched.
@@ -287,5 +295,6 @@ When updating `Docs/Product/Persona_Agent_Design.md`, apply these changes:
 
 - Review the updated PRD against this spec.
 - Confirm every moved-out feature appears in #1902.
+- If any moved-out feature is missing from #1902, update #1902 before marking the PRD patch complete.
 - Confirm the PRD does not describe future PRDs as current completion blockers.
 - Confirm no design-system backlog tasks or files are modified.

--- a/Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
+++ b/Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
@@ -14,6 +14,17 @@ Reconcile the original Persona module PRD into a current completion contract for
 
 The current Persona PRD should stop acting as a catch-all roadmap. It should define what must be true before the current Persona module is considered coherent and complete. Broader platform work remains valid, but should move into explicit follow-up PRDs tracked by issue #1902.
 
+## Design Review Notes
+
+This reconciliation intentionally narrows the current Persona PRD, but the first draft left four risks underspecified:
+
+- transcript export could expose more session/tool data than intended
+- scope and policy editing could be mistaken for a privilege-granting admin surface
+- tool discovery could reveal tools the current user or deployment should not see
+- PRD status updates could mark stale goals as shipped without current code evidence
+
+The hardening rules below address those risks and should be carried into the PRD patch.
+
 ## Source Documents
 
 - `Docs/Product/Persona_Agent_Design.md`
@@ -66,6 +77,14 @@ The Persona Garden live session should show user and assistant turns, voice tran
 
 This export is not a scheduled report system and should not imply daily brief or workflow delivery support.
 
+Export hardening:
+
+- allow export only for sessions owned by the authenticated user
+- export only the selected session, not all persona history
+- omit or redact secrets, auth material, raw binary audio, and large tool payloads
+- include enough metadata for audit, such as persona id, session id, timestamps, event types, and redaction markers
+- provide deterministic JSON for machine use and Markdown as a readable convenience, if both are implemented
+
 ### Persona Memory Controls
 
 Keep persona-owned memory controls in current scope, but bound them narrowly.
@@ -96,6 +115,14 @@ Current completion should require users to:
 - recover from policy validation errors
 - understand when a live tool plan is blocked by policy
 
+Scopes and Policies hardening:
+
+- editing persona rules must not grant capabilities the authenticated user, server config, or deployment policy does not already allow
+- destructive changes should use confirmation or a clear review step
+- validation errors should identify the invalid rule, field, and reason without leaking hidden tool details
+- saves should preserve rule ownership and avoid cross-persona writes
+- concurrent edits should fail predictably or use the existing versioning pattern where available
+
 ### Minimal MCP And Tool Capability Discovery
 
 Keep minimal tool discovery and default toolset management in current scope.
@@ -108,6 +135,13 @@ Persona Garden should show enough tool information for a user to understand what
 - confirmation requirements for impactful tools
 
 Do not expand this into marketplace-style tool installation or admin-level tool lifecycle management in the current PRD.
+
+Tool discovery hardening:
+
+- show only tools visible to the authenticated user and current deployment
+- avoid exposing hidden/admin-only tool names through blocked reason text
+- distinguish "not installed", "disabled by server", "not allowed for this persona", and "requires confirmation" where the backend can truthfully report that distinction
+- keep any default-tool save path constrained by persona policy and server capability checks
 
 ### Static Visual And Persona Media Context
 
@@ -221,12 +255,22 @@ Scope:
 When updating `Docs/Product/Persona_Agent_Design.md`, apply these changes:
 
 1. Replace stale implementation status with a current status section.
-2. Mark voice protocol, persona/session memory, and policy object support as shipped or partially shipped according to current code evidence.
+2. Mark voice protocol, persona/session memory, and policy object support as shipped or partially shipped only when current code evidence supports it.
 3. Clarify that Persona Garden/live Persona sessions are the current module boundary.
 4. Add the current completion scope from this design.
 5. Add a future PRD section linking #1902.
 6. Replace old `project_id` phrasing with a note that Workspace-scoped persona defaults moved to a future PRD.
 7. Keep the original long-term vision visible, but do not let future tracks block current completion.
+8. Preserve the `tool_result.result` compatibility-removal timeline as a dated maintenance item rather than treating it as a current feature gap before its planned removal window.
+
+## Suggested PRD Patch Sequence
+
+1. Update the status and summary so the PRD no longer reads as a 2026-02-09 scaffold snapshot.
+2. Add a "Current Completion Scope" section using the keep-list above.
+3. Add "Moved To Future PRDs" and link #1902.
+4. Replace or annotate old `project_id` language with Workspace terminology and future-PRD ownership.
+5. Add acceptance criteria for transcript export, Scopes/Policies editing, tool discovery, memory controls, and security/reliability.
+6. Keep the historical milestone section only if it is relabeled as history; otherwise replace it with current completion milestones.
 
 ## Acceptance Criteria
 
@@ -235,6 +279,8 @@ When updating `Docs/Product/Persona_Agent_Design.md`, apply these changes:
 - Current Persona PRD keeps Scopes and Policies editing, transcript export, minimal tool discovery, memory controls, and reliability/security closeout in scope.
 - Current Persona PRD moves ordinary chat integration, Workspace persona defaults, scheduled work, expressive avatars, broad personalization, tool administration, and multi-agent collaboration out to future PRDs.
 - Future scope links to GitHub issue #1902.
+- Transcript export, Scopes/Policies editing, and tool discovery include the hardening constraints from this design.
+- Shipped or partially shipped claims are backed by current code evidence during the PRD patch.
 - No design-system backlog tasks are touched.
 
 ## Verification Plan

--- a/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
@@ -5,6 +5,8 @@ import { Button, Checkbox, Input, Select, Tag, Typography } from "antd"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { toAllowedPath } from "@/services/tldw/path-utils"
 
+import { McpToolPicker } from "./McpToolPicker"
+
 type PersonaPolicyRuleKind = "mcp_tool" | "skill"
 
 type PersonaPolicyRule = {
@@ -17,6 +19,8 @@ type PersonaPolicyRule = {
 
 type PoliciesPanelProps = {
   selectedPersonaId?: string
+  personaCapabilities?: string[]
+  personaDefaultTools?: string[]
   hasPendingPlan: boolean
 }
 
@@ -38,6 +42,8 @@ const emptyPolicyRule = (): PersonaPolicyRule => ({
 
 export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
   selectedPersonaId = "",
+  personaCapabilities = [],
+  personaDefaultTools = [],
   hasPendingPlan
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
@@ -192,6 +198,44 @@ export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
             })}
       </div>
 
+      {personaCapabilities.length > 0 || personaDefaultTools.length > 0 ? (
+        <div
+          data-testid="persona-policy-catalog-context"
+          className="mt-3 rounded-md border border-border bg-background px-3 py-2"
+        >
+          {personaDefaultTools.length > 0 ? (
+            <div className="space-y-1">
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+                {t("sidepanel:personaGarden.policies.defaultTools", {
+                  defaultValue: "Persona defaults"
+                })}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {personaDefaultTools.map((toolName) => (
+                  <Tag key={toolName} color="blue">
+                    {toolName}
+                  </Tag>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          {personaCapabilities.length > 0 ? (
+            <div className={personaDefaultTools.length > 0 ? "mt-2 space-y-1" : "space-y-1"}>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+                {t("sidepanel:personaGarden.policies.capabilities", {
+                  defaultValue: "Capabilities"
+                })}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {personaCapabilities.map((capability) => (
+                  <Tag key={capability}>{capability}</Tag>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       {!normalizedPersonaId ? (
         <Typography.Text type="secondary" className="text-xs">
           {t("sidepanel:personaGarden.policies.noneSelected", {
@@ -234,17 +278,24 @@ export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
                   updateRule(index, { rule_kind: value as PersonaPolicyRuleKind })
                 }
               />
-              <Input
-                data-testid={`persona-policy-rule-name-${index}`}
-                size="small"
-                value={rule.rule_name}
-                placeholder={t("sidepanel:personaGarden.policies.namePlaceholder", {
-                  defaultValue: "Tool or skill name"
-                })}
-                onChange={(event) =>
-                  updateRule(index, { rule_name: event.target.value })
-                }
-              />
+              {rule.rule_kind === "mcp_tool" ? (
+                <McpToolPicker
+                  value={rule.rule_name}
+                  onChange={(value) => updateRule(index, { rule_name: value })}
+                />
+              ) : (
+                <Input
+                  data-testid={`persona-policy-rule-name-${index}`}
+                  size="small"
+                  value={rule.rule_name}
+                  placeholder={t("sidepanel:personaGarden.policies.namePlaceholder", {
+                    defaultValue: "Tool or skill name"
+                  })}
+                  onChange={(event) =>
+                    updateRule(index, { rule_name: event.target.value })
+                  }
+                />
+              )}
               <Checkbox
                 data-testid={`persona-policy-rule-allowed-${index}`}
                 checked={rule.allowed}

--- a/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
@@ -60,7 +60,10 @@ export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
     setRules([])
     setError(null)
     setNotice(null)
-    if (!normalizedPersonaId) return
+    if (!normalizedPersonaId) {
+      setLoading(false)
+      return
+    }
 
     const loadRules = async () => {
       setLoading(true)
@@ -111,6 +114,7 @@ export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
   const saveRules = async () => {
     setError(null)
     setNotice(null)
+    if (loading || saving) return
     if (!normalizedPersonaId) {
       setError("Select a persona before editing policy rules.")
       return
@@ -173,7 +177,7 @@ export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
           size="small"
           type="primary"
           loading={saving}
-          disabled={!normalizedPersonaId}
+          disabled={!normalizedPersonaId || loading || saving}
           onClick={() => {
             void saveRules()
           }}

--- a/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
@@ -1,39 +1,306 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { Button, Checkbox, Input, Select, Tag, Typography } from "antd"
+
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { toAllowedPath } from "@/services/tldw/path-utils"
+
+type PersonaPolicyRuleKind = "mcp_tool" | "skill"
+
+type PersonaPolicyRule = {
+  rule_kind: PersonaPolicyRuleKind
+  rule_name: string
+  allowed: boolean
+  require_confirmation: boolean
+  max_calls_per_turn: number | null
+}
 
 type PoliciesPanelProps = {
+  selectedPersonaId?: string
   hasPendingPlan: boolean
 }
 
+const POLICY_RULE_KIND_OPTIONS: Array<{
+  value: PersonaPolicyRuleKind
+  label: string
+}> = [
+  { value: "mcp_tool", label: "MCP tool" },
+  { value: "skill", label: "Skill" }
+]
+
+const emptyPolicyRule = (): PersonaPolicyRule => ({
+  rule_kind: "mcp_tool",
+  rule_name: "",
+  allowed: true,
+  require_confirmation: true,
+  max_calls_per_turn: null
+})
+
 export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
+  selectedPersonaId = "",
   hasPendingPlan
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
+  const [rules, setRules] = React.useState<PersonaPolicyRule[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [notice, setNotice] = React.useState<string | null>(null)
+
+  const normalizedPersonaId = String(selectedPersonaId || "").trim()
+
+  React.useEffect(() => {
+    let cancelled = false
+    setRules([])
+    setError(null)
+    setNotice(null)
+    if (!normalizedPersonaId) return
+
+    const loadRules = async () => {
+      setLoading(true)
+      try {
+        const response = await tldwClient.fetchWithAuth(
+          toAllowedPath(
+            `/api/v1/persona/profiles/${encodeURIComponent(
+              normalizedPersonaId
+            )}/policy-rules`
+          )
+        )
+        if (!response.ok) {
+          throw new Error(response.error || "Failed to load policy rules")
+        }
+        const payload = await response.json()
+        if (!cancelled) {
+          setRules(Array.isArray(payload?.rules) ? payload.rules : [])
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(String(err?.message || "Failed to load policy rules"))
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadRules()
+    return () => {
+      cancelled = true
+    }
+  }, [normalizedPersonaId])
+
+  const updateRule = (index: number, patch: Partial<PersonaPolicyRule>) => {
+    setRules((current) =>
+      current.map((rule, ruleIndex) =>
+        ruleIndex === index ? { ...rule, ...patch } : rule
+      )
+    )
+  }
+
+  const removeRule = (index: number) => {
+    setRules((current) => current.filter((_, ruleIndex) => ruleIndex !== index))
+  }
+
+  const saveRules = async () => {
+    setError(null)
+    setNotice(null)
+    if (!normalizedPersonaId) {
+      setError("Select a persona before editing policy rules.")
+      return
+    }
+
+    const normalizedRules = rules.map((rule) => {
+      const parsedMaxCalls = Number(rule.max_calls_per_turn || 0)
+      return {
+        rule_kind: rule.rule_kind,
+        rule_name: String(rule.rule_name || "").trim(),
+        allowed: Boolean(rule.allowed),
+        require_confirmation: Boolean(rule.require_confirmation),
+        max_calls_per_turn:
+          Number.isFinite(parsedMaxCalls) && parsedMaxCalls > 0
+            ? parsedMaxCalls
+            : null
+      }
+    })
+    if (normalizedRules.some((rule) => !rule.rule_name)) {
+      setError("Rule name is required.")
+      return
+    }
+
+    setSaving(true)
+    try {
+      const response = await tldwClient.fetchWithAuth(
+        toAllowedPath(
+          `/api/v1/persona/profiles/${encodeURIComponent(
+            normalizedPersonaId
+          )}/policy-rules`
+        ),
+        {
+          method: "PUT",
+          body: { rules: normalizedRules }
+        }
+      )
+      if (!response.ok) {
+        throw new Error(response.error || "Failed to save policy rules")
+      }
+      const payload = await response.json()
+      setRules(Array.isArray(payload?.rules) ? payload.rules : normalizedRules)
+      setNotice("Policy rules saved.")
+    } catch (err: any) {
+      setError(String(err?.message || "Failed to save policy rules"))
+    } finally {
+      setSaving(false)
+    }
+  }
 
   return (
     <div className="rounded-lg border border-border bg-surface p-3">
-      <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
-        {t("sidepanel:personaGarden.policies.heading", {
-          defaultValue: "Tool Policies"
-        })}
-      </div>
-      <div className="mt-2 space-y-2 text-sm text-text">
-        <p className="text-xs text-text-muted">
-          {t("sidepanel:personaGarden.policies.description", {
-            defaultValue:
-              "Policy enforcement remains active through pending tool plans and live-session confirmations. This tab reserves the dedicated policy surface without changing the current approval contract."
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+          {t("sidepanel:personaGarden.policies.heading", {
+            defaultValue: "Tool Policies"
           })}
-        </p>
-        <div className="text-xs text-text-muted">
-          {hasPendingPlan
-            ? t("sidepanel:personaGarden.policies.pendingPlan", {
-                defaultValue: "A pending tool plan is available on the Live Session tab."
-              })
-            : t("sidepanel:personaGarden.policies.noPendingPlan", {
-                defaultValue: "No pending tool plan right now."
-              })}
         </div>
+        <Button
+          data-testid="persona-policy-save-button"
+          size="small"
+          type="primary"
+          loading={saving}
+          disabled={!normalizedPersonaId}
+          onClick={() => {
+            void saveRules()
+          }}
+        >
+          {t("common:save", { defaultValue: "Save" })}
+        </Button>
       </div>
+
+      <p className="mt-2 text-xs text-text-muted">
+        {t("sidepanel:personaGarden.policies.description", {
+          defaultValue:
+            "Choose which already-authorized tools or skills this persona may use, and whether a live turn must ask before executing them."
+        })}
+      </p>
+      <div className="text-xs text-text-muted">
+        {hasPendingPlan
+          ? t("sidepanel:personaGarden.policies.pendingPlan", {
+              defaultValue: "A pending tool plan is available on the Live Session tab."
+            })
+          : t("sidepanel:personaGarden.policies.noPendingPlan", {
+              defaultValue: "No pending tool plan right now."
+            })}
+      </div>
+
+      {!normalizedPersonaId ? (
+        <Typography.Text type="secondary" className="text-xs">
+          {t("sidepanel:personaGarden.policies.noneSelected", {
+            defaultValue: "Select a persona to edit policy rules."
+          })}
+        </Typography.Text>
+      ) : null}
+
+      {error ? (
+        <div className="mt-2 text-xs text-danger" role="alert">
+          {error}
+        </div>
+      ) : null}
+      {notice ? <div className="mt-2 text-xs text-success">{notice}</div> : null}
+
+      <div className="mt-3 space-y-2">
+        {loading ? (
+          <Typography.Text type="secondary" className="text-xs">
+            {t("common:loading", { defaultValue: "Loading..." })}
+          </Typography.Text>
+        ) : null}
+        {!loading && normalizedPersonaId && rules.length === 0 ? (
+          <Typography.Text type="secondary" className="text-xs">
+            {t("sidepanel:personaGarden.policies.empty", {
+              defaultValue: "No policy rules yet."
+            })}
+          </Typography.Text>
+        ) : null}
+        {rules.map((rule, index) => (
+          <div
+            key={`${rule.rule_kind}-${index}`}
+            className="rounded-md border border-border bg-background p-2"
+          >
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-[130px_1fr_120px_150px_110px_auto]">
+              <Select
+                size="small"
+                value={rule.rule_kind}
+                options={POLICY_RULE_KIND_OPTIONS}
+                onChange={(value) =>
+                  updateRule(index, { rule_kind: value as PersonaPolicyRuleKind })
+                }
+              />
+              <Input
+                data-testid={`persona-policy-rule-name-${index}`}
+                size="small"
+                value={rule.rule_name}
+                placeholder={t("sidepanel:personaGarden.policies.namePlaceholder", {
+                  defaultValue: "Tool or skill name"
+                })}
+                onChange={(event) =>
+                  updateRule(index, { rule_name: event.target.value })
+                }
+              />
+              <Checkbox
+                data-testid={`persona-policy-rule-allowed-${index}`}
+                checked={rule.allowed}
+                onChange={(event) =>
+                  updateRule(index, { allowed: event.target.checked })
+                }
+              >
+                {rule.allowed ? <Tag color="green">allow</Tag> : <Tag color="red">deny</Tag>}
+              </Checkbox>
+              <Checkbox
+                data-testid={`persona-policy-rule-confirm-${index}`}
+                checked={rule.require_confirmation}
+                onChange={(event) =>
+                  updateRule(index, { require_confirmation: event.target.checked })
+                }
+              >
+                {t("sidepanel:personaGarden.policies.confirm", {
+                  defaultValue: "Confirm"
+                })}
+              </Checkbox>
+              <Input
+                data-testid={`persona-policy-rule-max-calls-${index}`}
+                size="small"
+                type="number"
+                min={1}
+                value={rule.max_calls_per_turn ?? ""}
+                placeholder={t("sidepanel:personaGarden.policies.maxCalls", {
+                  defaultValue: "Max calls"
+                })}
+                onChange={(event) =>
+                  updateRule(index, {
+                    max_calls_per_turn: event.target.value
+                      ? Number(event.target.value)
+                      : null
+                  })
+                }
+              />
+              <Button size="small" onClick={() => removeRule(index)}>
+                {t("common:remove", { defaultValue: "Remove" })}
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        data-testid="persona-policy-add-rule"
+        className="mt-3"
+        size="small"
+        disabled={!normalizedPersonaId}
+        onClick={() => setRules((current) => [...current, emptyPolicyRule()])}
+      >
+        {t("sidepanel:personaGarden.policies.addRule", {
+          defaultValue: "Add policy rule"
+        })}
+      </Button>
     </div>
   )
 }

--- a/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
@@ -57,10 +57,10 @@ export const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
 
   React.useEffect(() => {
     let cancelled = false
-    setRules([])
     setError(null)
     setNotice(null)
     if (!normalizedPersonaId) {
+      setRules([])
       setLoading(false)
       return
     }

--- a/apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx
@@ -1,36 +1,272 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { Button, Checkbox, Input, Select, Tag, Typography } from "antd"
+
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { toAllowedPath } from "@/services/tldw/path-utils"
+
+type PersonaScopeRuleType =
+  | "conversation_id"
+  | "character_id"
+  | "media_id"
+  | "media_tag"
+  | "note_id"
+
+type PersonaScopeRule = {
+  rule_type: PersonaScopeRuleType
+  rule_value: string
+  include: boolean
+}
 
 type ScopesPanelProps = {
+  selectedPersonaId?: string
   selectedPersonaName: string
 }
 
+const SCOPE_RULE_TYPE_OPTIONS: Array<{
+  value: PersonaScopeRuleType
+  label: string
+}> = [
+  { value: "conversation_id", label: "Conversation" },
+  { value: "character_id", label: "Character" },
+  { value: "media_id", label: "Media ID" },
+  { value: "media_tag", label: "Media tag" },
+  { value: "note_id", label: "Note" }
+]
+
+const emptyScopeRule = (): PersonaScopeRule => ({
+  rule_type: "media_tag",
+  rule_value: "",
+  include: true
+})
+
 export const ScopesPanel: React.FC<ScopesPanelProps> = ({
+  selectedPersonaId = "",
   selectedPersonaName
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
+  const [rules, setRules] = React.useState<PersonaScopeRule[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [notice, setNotice] = React.useState<string | null>(null)
+
+  const normalizedPersonaId = String(selectedPersonaId || "").trim()
+
+  React.useEffect(() => {
+    let cancelled = false
+    setRules([])
+    setError(null)
+    setNotice(null)
+    if (!normalizedPersonaId) return
+
+    const loadRules = async () => {
+      setLoading(true)
+      try {
+        const response = await tldwClient.fetchWithAuth(
+          toAllowedPath(
+            `/api/v1/persona/profiles/${encodeURIComponent(
+              normalizedPersonaId
+            )}/scope-rules`
+          )
+        )
+        if (!response.ok) {
+          throw new Error(response.error || "Failed to load scope rules")
+        }
+        const payload = await response.json()
+        if (!cancelled) {
+          setRules(Array.isArray(payload?.rules) ? payload.rules : [])
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(String(err?.message || "Failed to load scope rules"))
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadRules()
+    return () => {
+      cancelled = true
+    }
+  }, [normalizedPersonaId])
+
+  const updateRule = (index: number, patch: Partial<PersonaScopeRule>) => {
+    setRules((current) =>
+      current.map((rule, ruleIndex) =>
+        ruleIndex === index ? { ...rule, ...patch } : rule
+      )
+    )
+  }
+
+  const removeRule = (index: number) => {
+    setRules((current) => current.filter((_, ruleIndex) => ruleIndex !== index))
+  }
+
+  const saveRules = async () => {
+    setError(null)
+    setNotice(null)
+    if (!normalizedPersonaId) {
+      setError("Select a persona before editing scope rules.")
+      return
+    }
+    const normalizedRules = rules.map((rule) => ({
+      rule_type: rule.rule_type,
+      rule_value: String(rule.rule_value || "").trim(),
+      include: Boolean(rule.include)
+    }))
+    if (normalizedRules.some((rule) => !rule.rule_value)) {
+      setError("Rule value is required.")
+      return
+    }
+
+    setSaving(true)
+    try {
+      const response = await tldwClient.fetchWithAuth(
+        toAllowedPath(
+          `/api/v1/persona/profiles/${encodeURIComponent(
+            normalizedPersonaId
+          )}/scope-rules`
+        ),
+        {
+          method: "PUT",
+          body: { rules: normalizedRules }
+        }
+      )
+      if (!response.ok) {
+        throw new Error(response.error || "Failed to save scope rules")
+      }
+      const payload = await response.json()
+      setRules(Array.isArray(payload?.rules) ? payload.rules : normalizedRules)
+      setNotice("Scope rules saved.")
+    } catch (err: any) {
+      setError(String(err?.message || "Failed to save scope rules"))
+    } finally {
+      setSaving(false)
+    }
+  }
 
   return (
     <div className="rounded-lg border border-border bg-surface p-3">
-      <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
-        {t("sidepanel:personaGarden.scopes.heading", {
-          defaultValue: "Scoped Access"
-        })}
-      </div>
-      <div className="mt-2 space-y-2 text-sm text-text">
-        <div className="font-medium">
-          {selectedPersonaName ||
-            t("sidepanel:personaGarden.scopes.selectedPersonaFallback", {
-              defaultValue: "Selected persona"
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+            {t("sidepanel:personaGarden.scopes.heading", {
+              defaultValue: "Scoped Access"
             })}
+          </div>
+          <div className="mt-1 text-sm font-medium text-text">
+            {selectedPersonaName ||
+              t("sidepanel:personaGarden.scopes.selectedPersonaFallback", {
+                defaultValue: "Selected persona"
+              })}
+          </div>
         </div>
-        <p className="text-xs text-text-muted">
-          {t("sidepanel:personaGarden.scopes.description", {
-            defaultValue:
-              "Scope-aware behavior is still enforced through the current persona session workflow. Dedicated scope editing will attach here without moving the route-owned session logic."
-          })}
-        </p>
+        <Button
+          data-testid="persona-scope-save-button"
+          size="small"
+          type="primary"
+          loading={saving}
+          disabled={!normalizedPersonaId}
+          onClick={() => {
+            void saveRules()
+          }}
+        >
+          {t("common:save", { defaultValue: "Save" })}
+        </Button>
       </div>
+
+      <p className="mt-2 text-xs text-text-muted">
+        {t("sidepanel:personaGarden.scopes.description", {
+          defaultValue:
+            "Limit persona retrieval and session context to explicitly allowed IDs or tags. These rules narrow scope; they do not grant new server permissions."
+        })}
+      </p>
+
+      {!normalizedPersonaId ? (
+        <Typography.Text type="secondary" className="text-xs">
+          {t("sidepanel:personaGarden.scopes.noneSelected", {
+            defaultValue: "Select a persona to edit scope rules."
+          })}
+        </Typography.Text>
+      ) : null}
+
+      {error ? (
+        <div className="mt-2 text-xs text-danger" role="alert">
+          {error}
+        </div>
+      ) : null}
+      {notice ? <div className="mt-2 text-xs text-success">{notice}</div> : null}
+
+      <div className="mt-3 space-y-2">
+        {loading ? (
+          <Typography.Text type="secondary" className="text-xs">
+            {t("common:loading", { defaultValue: "Loading..." })}
+          </Typography.Text>
+        ) : null}
+        {!loading && normalizedPersonaId && rules.length === 0 ? (
+          <Typography.Text type="secondary" className="text-xs">
+            {t("sidepanel:personaGarden.scopes.empty", {
+              defaultValue: "No scope rules yet."
+            })}
+          </Typography.Text>
+        ) : null}
+        {rules.map((rule, index) => (
+          <div
+            key={`${rule.rule_type}-${index}`}
+            className="rounded-md border border-border bg-background p-2"
+          >
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-[150px_1fr_auto_auto]">
+              <Select
+                size="small"
+                value={rule.rule_type}
+                options={SCOPE_RULE_TYPE_OPTIONS}
+                onChange={(value) =>
+                  updateRule(index, { rule_type: value as PersonaScopeRuleType })
+                }
+              />
+              <Input
+                data-testid={`persona-scope-rule-value-${index}`}
+                size="small"
+                value={rule.rule_value}
+                placeholder={t("sidepanel:personaGarden.scopes.valuePlaceholder", {
+                  defaultValue: "ID or tag"
+                })}
+                onChange={(event) =>
+                  updateRule(index, { rule_value: event.target.value })
+                }
+              />
+              <Checkbox
+                data-testid={`persona-scope-rule-include-${index}`}
+                checked={rule.include}
+                onChange={(event) =>
+                  updateRule(index, { include: event.target.checked })
+                }
+              >
+                {rule.include ? <Tag color="green">include</Tag> : <Tag>exclude</Tag>}
+              </Checkbox>
+              <Button size="small" onClick={() => removeRule(index)}>
+                {t("common:remove", { defaultValue: "Remove" })}
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        data-testid="persona-scope-add-rule"
+        className="mt-3"
+        size="small"
+        disabled={!normalizedPersonaId}
+        onClick={() => setRules((current) => [...current, emptyScopeRule()])}
+      >
+        {t("sidepanel:personaGarden.scopes.addRule", {
+          defaultValue: "Add scope rule"
+        })}
+      </Button>
     </div>
   )
 }

--- a/apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx
@@ -55,10 +55,10 @@ export const ScopesPanel: React.FC<ScopesPanelProps> = ({
 
   React.useEffect(() => {
     let cancelled = false
-    setRules([])
     setError(null)
     setNotice(null)
     if (!normalizedPersonaId) {
+      setRules([])
       setLoading(false)
       return
     }

--- a/apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx
@@ -58,7 +58,10 @@ export const ScopesPanel: React.FC<ScopesPanelProps> = ({
     setRules([])
     setError(null)
     setNotice(null)
-    if (!normalizedPersonaId) return
+    if (!normalizedPersonaId) {
+      setLoading(false)
+      return
+    }
 
     const loadRules = async () => {
       setLoading(true)
@@ -109,6 +112,7 @@ export const ScopesPanel: React.FC<ScopesPanelProps> = ({
   const saveRules = async () => {
     setError(null)
     setNotice(null)
+    if (loading || saving) return
     if (!normalizedPersonaId) {
       setError("Select a persona before editing scope rules.")
       return
@@ -170,7 +174,7 @@ export const ScopesPanel: React.FC<ScopesPanelProps> = ({
           size="small"
           type="primary"
           loading={saving}
-          disabled={!normalizedPersonaId}
+          disabled={!normalizedPersonaId || loading || saving}
           onClick={() => {
             void saveRules()
           }}

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
@@ -19,6 +19,26 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   }
 }))
 
+vi.mock("../McpToolPicker", () => ({
+  McpToolPicker: ({
+    value,
+    onChange
+  }: {
+    value: string
+    onChange: (value: string) => void
+  }) => (
+    <select
+      data-testid="mock-mcp-tool-picker"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">Select a tool</option>
+      <option value="knowledge.search">knowledge.search</option>
+      <option value="notes.search">notes.search</option>
+    </select>
+  )
+}))
+
 import { PoliciesPanel } from "../PoliciesPanel"
 import { ScopesPanel } from "../ScopesPanel"
 
@@ -149,8 +169,8 @@ describe("Persona Garden scope and policy editors", () => {
 
     render(<PoliciesPanel selectedPersonaId="persona-1" hasPendingPlan={false} />)
 
-    const nameInput = await screen.findByTestId("persona-policy-rule-name-0")
-    fireEvent.change(nameInput, { target: { value: "notes.search" } })
+    const picker = await screen.findByTestId("mock-mcp-tool-picker")
+    fireEvent.change(picker, { target: { value: "notes.search" } })
     fireEvent.click(screen.getByTestId("persona-policy-rule-confirm-0"))
     fireEvent.change(screen.getByTestId("persona-policy-rule-max-calls-0"), {
       target: { value: "3" }
@@ -213,5 +233,87 @@ describe("Persona Garden scope and policy editors", () => {
     expect(await screen.findByText("policy validation failed")).toBeInTheDocument()
     expect(screen.getByDisplayValue("summarize")).toBeInTheDocument()
     expect(screen.getByText("A pending tool plan is available on the Live Session tab.")).toBeInTheDocument()
+  })
+
+  it("uses MCP picker selections for mcp_tool policy rule names", async () => {
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: unknown }) => {
+      if (path === "/api/v1/persona/profiles/persona-1/policy-rules" && !init) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "persona-1",
+            rules: [
+              {
+                rule_kind: "mcp_tool",
+                rule_name: "knowledge.search",
+                allowed: true,
+                require_confirmation: false,
+                max_calls_per_turn: null
+              }
+            ]
+          })
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/policy-rules" &&
+        init?.method === "PUT"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "persona-1",
+            replaced_count: 1,
+            rules: (init.body as any).rules
+          })
+        })
+      }
+      return Promise.resolve({ ok: false, error: `unhandled ${path}`, json: async () => ({}) })
+    })
+
+    render(<PoliciesPanel selectedPersonaId="persona-1" hasPendingPlan={false} />)
+
+    const picker = await screen.findByTestId("mock-mcp-tool-picker")
+    fireEvent.change(picker, { target: { value: "notes.search" } })
+    fireEvent.click(screen.getByTestId("persona-policy-save-button"))
+
+    await waitFor(() => {
+      expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+        "/api/v1/persona/profiles/persona-1/policy-rules",
+        expect.objectContaining({
+          method: "PUT",
+          body: {
+            rules: [
+              expect.objectContaining({
+                rule_kind: "mcp_tool",
+                rule_name: "notes.search"
+              })
+            ]
+          }
+        })
+      )
+    })
+  })
+
+  it("shows persona catalog default tool and capability context when available", async () => {
+    mocks.fetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        persona_id: "persona-1",
+        rules: []
+      })
+    })
+
+    render(
+      <PoliciesPanel
+        selectedPersonaId="persona-1"
+        hasPendingPlan={false}
+        personaCapabilities={["agentic", "mcp_tools_configured"]}
+        personaDefaultTools={["knowledge.search", "notes.search"]}
+      />
+    )
+
+    expect(await screen.findByText("knowledge.search")).toBeInTheDocument()
+    expect(screen.getByText("notes.search")).toBeInTheDocument()
+    expect(screen.getByText("mcp_tools_configured")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
@@ -1,0 +1,217 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  fetchWithAuth: vi.fn()
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue || _key
+  })
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    fetchWithAuth: mocks.fetchWithAuth
+  }
+}))
+
+import { PoliciesPanel } from "../PoliciesPanel"
+import { ScopesPanel } from "../ScopesPanel"
+
+describe("Persona Garden scope and policy editors", () => {
+  beforeEach(() => {
+    mocks.fetchWithAuth.mockReset()
+  })
+
+  it("loads and saves selected persona scope rules through the authenticated endpoint", async () => {
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: unknown }) => {
+      if (path === "/api/v1/persona/profiles/persona-1/scope-rules" && !init) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "persona-1",
+            rules: [
+              {
+                rule_type: "media_tag",
+                rule_value: "research",
+                include: true
+              }
+            ]
+          })
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/scope-rules" &&
+        init?.method === "PUT"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "persona-1",
+            replaced_count: 1,
+            rules: (init.body as any).rules
+          })
+        })
+      }
+      return Promise.resolve({ ok: false, error: `unhandled ${path}`, json: async () => ({}) })
+    })
+
+    render(
+      <ScopesPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Research Persona"
+      />
+    )
+
+    const valueInput = await screen.findByTestId("persona-scope-rule-value-0")
+    fireEvent.change(valueInput, { target: { value: "science" } })
+    fireEvent.click(screen.getByTestId("persona-scope-rule-include-0"))
+    fireEvent.click(screen.getByTestId("persona-scope-save-button"))
+
+    await waitFor(() => {
+      expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+        "/api/v1/persona/profiles/persona-1/scope-rules",
+        {
+          method: "PUT",
+          body: {
+            rules: [
+              {
+                rule_type: "media_tag",
+                rule_value: "science",
+                include: false
+              }
+            ]
+          }
+        }
+      )
+    })
+    expect(await screen.findByText("Scope rules saved.")).toBeInTheDocument()
+  })
+
+  it("blocks saving a blank added scope rule and keeps the editor open", async () => {
+    mocks.fetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({ persona_id: "persona-1", rules: [] })
+    })
+
+    render(
+      <ScopesPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Research Persona"
+      />
+    )
+
+    fireEvent.click(await screen.findByTestId("persona-scope-add-rule"))
+    fireEvent.click(screen.getByTestId("persona-scope-save-button"))
+
+    expect(await screen.findByText("Rule value is required.")).toBeInTheDocument()
+    expect(mocks.fetchWithAuth).toHaveBeenCalledTimes(1)
+  })
+
+  it("loads and saves selected persona policy rules through the authenticated endpoint", async () => {
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: unknown }) => {
+      if (path === "/api/v1/persona/profiles/persona-1/policy-rules" && !init) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "persona-1",
+            rules: [
+              {
+                rule_kind: "mcp_tool",
+                rule_name: "knowledge.search",
+                allowed: true,
+                require_confirmation: false,
+                max_calls_per_turn: 2
+              }
+            ]
+          })
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/policy-rules" &&
+        init?.method === "PUT"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "persona-1",
+            replaced_count: 1,
+            rules: (init.body as any).rules
+          })
+        })
+      }
+      return Promise.resolve({ ok: false, error: `unhandled ${path}`, json: async () => ({}) })
+    })
+
+    render(<PoliciesPanel selectedPersonaId="persona-1" hasPendingPlan={false} />)
+
+    const nameInput = await screen.findByTestId("persona-policy-rule-name-0")
+    fireEvent.change(nameInput, { target: { value: "notes.search" } })
+    fireEvent.click(screen.getByTestId("persona-policy-rule-confirm-0"))
+    fireEvent.change(screen.getByTestId("persona-policy-rule-max-calls-0"), {
+      target: { value: "3" }
+    })
+    fireEvent.click(screen.getByTestId("persona-policy-save-button"))
+
+    await waitFor(() => {
+      expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+        "/api/v1/persona/profiles/persona-1/policy-rules",
+        {
+          method: "PUT",
+          body: {
+            rules: [
+              {
+                rule_kind: "mcp_tool",
+                rule_name: "notes.search",
+                allowed: true,
+                require_confirmation: true,
+                max_calls_per_turn: 3
+              }
+            ]
+          }
+        }
+      )
+    })
+    expect(await screen.findByText("Policy rules saved.")).toBeInTheDocument()
+  })
+
+  it("reports policy save failures without dropping the current rules", async () => {
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      if (path === "/api/v1/persona/profiles/persona-1/policy-rules" && !init) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "persona-1",
+            rules: [
+              {
+                rule_kind: "skill",
+                rule_name: "summarize",
+                allowed: true,
+                require_confirmation: true,
+                max_calls_per_turn: null
+              }
+            ]
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: "policy validation failed",
+        json: async () => ({})
+      })
+    })
+
+    render(<PoliciesPanel selectedPersonaId="persona-1" hasPendingPlan />)
+
+    expect(await screen.findByDisplayValue("summarize")).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId("persona-policy-save-button"))
+
+    expect(await screen.findByText("policy validation failed")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("summarize")).toBeInTheDocument()
+    expect(screen.getByText("A pending tool plan is available on the Live Session tab.")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
@@ -161,6 +161,56 @@ describe("Persona Garden scope and policy editors", () => {
     await screen.findByText("No scope rules yet.")
   })
 
+  it("keeps existing scope rules visible while a new persona load is in flight", async () => {
+    let resolveSecondLoad:
+      | ((value: { ok: boolean; json: () => Promise<{ rules: unknown[] }> }) => void)
+      | undefined
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path === "/api/v1/persona/profiles/persona-1/scope-rules") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            rules: [{ rule_type: "media_tag", rule_value: "research", include: true }]
+          })
+        })
+      }
+      if (path === "/api/v1/persona/profiles/persona-2/scope-rules") {
+        return new Promise((resolve) => {
+          resolveSecondLoad = resolve
+        })
+      }
+      return Promise.resolve({ ok: false, error: `unhandled ${path}`, json: async () => ({}) })
+    })
+
+    const { rerender } = render(
+      <ScopesPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Research Persona"
+      />
+    )
+
+    expect(await screen.findByDisplayValue("research")).toBeInTheDocument()
+
+    rerender(
+      <ScopesPanel
+        selectedPersonaId="persona-2"
+        selectedPersonaName="Ops Persona"
+      />
+    )
+
+    expect(await screen.findByText("Loading...")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("research")).toBeInTheDocument()
+    expect(screen.getByTestId("persona-scope-save-button")).toBeDisabled()
+
+    resolveSecondLoad?.({
+      ok: true,
+      json: async () => ({
+        rules: [{ rule_type: "media_tag", rule_value: "operations", include: true }]
+      })
+    })
+    expect(await screen.findByDisplayValue("operations")).toBeInTheDocument()
+  })
+
   it("loads and saves selected persona policy rules through the authenticated endpoint", async () => {
     mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: unknown }) => {
       if (path === "/api/v1/persona/profiles/persona-1/policy-rules" && !init) {
@@ -262,6 +312,64 @@ describe("Persona Garden scope and policy editors", () => {
     expect(await screen.findByText("policy validation failed")).toBeInTheDocument()
     expect(screen.getByDisplayValue("summarize")).toBeInTheDocument()
     expect(screen.getByText("A pending tool plan is available on the Live Session tab.")).toBeInTheDocument()
+  })
+
+  it("keeps existing policy rules visible while a new persona load is in flight", async () => {
+    let resolveSecondLoad:
+      | ((value: { ok: boolean; json: () => Promise<{ rules: unknown[] }> }) => void)
+      | undefined
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path === "/api/v1/persona/profiles/persona-1/policy-rules") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            rules: [
+              {
+                rule_kind: "skill",
+                rule_name: "summarize",
+                allowed: true,
+                require_confirmation: false
+              }
+            ]
+          })
+        })
+      }
+      if (path === "/api/v1/persona/profiles/persona-2/policy-rules") {
+        return new Promise((resolve) => {
+          resolveSecondLoad = resolve
+        })
+      }
+      return Promise.resolve({ ok: false, error: `unhandled ${path}`, json: async () => ({}) })
+    })
+
+    const { rerender } = render(
+      <PoliciesPanel selectedPersonaId="persona-1" selectedPersonaName="Research Persona" />
+    )
+
+    expect(await screen.findByDisplayValue("summarize")).toBeInTheDocument()
+
+    rerender(
+      <PoliciesPanel selectedPersonaId="persona-2" selectedPersonaName="Ops Persona" />
+    )
+
+    expect(await screen.findByText("Loading...")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("summarize")).toBeInTheDocument()
+    expect(screen.getByTestId("persona-policy-save-button")).toBeDisabled()
+
+    resolveSecondLoad?.({
+      ok: true,
+      json: async () => ({
+        rules: [
+          {
+            rule_kind: "skill",
+            rule_name: "draft_report",
+            allowed: true,
+            require_confirmation: true
+          }
+        ]
+      })
+    })
+    expect(await screen.findByDisplayValue("draft_report")).toBeInTheDocument()
   })
 
   it("uses MCP picker selections for mcp_tool policy rule names", async () => {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx
@@ -132,6 +132,35 @@ describe("Persona Garden scope and policy editors", () => {
     expect(mocks.fetchWithAuth).toHaveBeenCalledTimes(1)
   })
 
+  it("disables scope saves while rules are loading", async () => {
+    let resolveLoad:
+      | ((value: { ok: boolean; json: () => Promise<{ rules: unknown[] }> }) => void)
+      | undefined
+    mocks.fetchWithAuth.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve
+      })
+    )
+
+    render(
+      <ScopesPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Research Persona"
+      />
+    )
+
+    expect(await screen.findByText("Loading...")).toBeInTheDocument()
+    expect(screen.getByTestId("persona-scope-save-button")).toBeDisabled()
+    fireEvent.click(screen.getByTestId("persona-scope-save-button"))
+    expect(mocks.fetchWithAuth).toHaveBeenCalledTimes(1)
+
+    resolveLoad?.({
+      ok: true,
+      json: async () => ({ rules: [] })
+    })
+    await screen.findByText("No scope rules yet.")
+  })
+
   it("loads and saves selected persona policy rules through the authenticated endpoint", async () => {
     mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: unknown }) => {
       if (path === "/api/v1/persona/profiles/persona-1/policy-rules" && !init) {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -756,6 +756,10 @@ describe("SidepanelPersona", () => {
 
       await waitForLiveSessionPanel()
       fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+      await waitFor(() => {
+        expect(MockWebSocket.instances).toHaveLength(1)
+      })
+      MockWebSocket.instances[0].emitOpen()
 
       const exportButton = await screen.findByTestId("persona-transcript-export-button")
       fireEvent.click(exportButton)
@@ -768,10 +772,19 @@ describe("SidepanelPersona", () => {
         "/api/v1/persona/sessions/sess-export/export",
         { method: "GET" }
       )
+      fireEvent.click(screen.getByRole("button", { name: /Disconnect/i }))
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("persona-transcript-export-confirmation")
+        ).not.toBeInTheDocument()
+      })
+      await screen.findByTestId("persona-transcript-export-button")
+
+      fireEvent.click(screen.getByTestId("persona-transcript-export-button"))
       fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
       expect(createObjectURLSpy).not.toHaveBeenCalled()
 
-      fireEvent.click(exportButton)
+      fireEvent.click(screen.getByTestId("persona-transcript-export-button"))
       fireEvent.click(await screen.findByRole("button", { name: "Confirm export" }))
 
       await waitFor(() => {
@@ -7314,8 +7327,26 @@ describe("SidepanelPersona", () => {
                   content: "history soul version",
                   is_active: false,
                   version: 1
+                },
+                {
+                  entry_id: "archive-guard-entry",
+                  field: "identity_md",
+                  content: "active identity version",
+                  is_active: true,
+                  version: 2
                 }
               ]
+            })
+          })
+        }
+        if (path.includes("/persona/profiles/research_assistant/state/archive")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              persona_id: "research_assistant",
+              soul_md: "initial soul",
+              identity_md: null,
+              heartbeat_md: "initial heartbeat"
             })
           })
         }
@@ -7400,6 +7431,24 @@ describe("SidepanelPersona", () => {
     fireEvent.change(soulInput, {
       target: { value: "unsaved local draft before restore" }
     })
+
+    confirmSpy.mockClear()
+    confirmSpy.mockReturnValueOnce(false)
+    fireEvent.click(screen.getByTestId("persona-state-archive-archive-guard-entry"))
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalled()
+    })
+    expect(String(confirmSpy.mock.calls[0]?.[0] || "")).toContain(
+      "Archive this state version and discard local drafts"
+    )
+    const declinedArchiveCall = mocks.fetchWithAuth.mock.calls.find(
+      ([calledPath, calledInit]) =>
+        String(calledPath).includes("/persona/profiles/research_assistant/state/archive") &&
+        String((calledInit as { method?: string } | undefined)?.method || "").toUpperCase() ===
+          "POST"
+    )
+    expect(declinedArchiveCall).toBeFalsy()
+    expect(soulInput.value).toBe("unsaved local draft before restore")
 
     confirmSpy.mockClear()
     confirmSpy.mockReturnValueOnce(false)

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -670,7 +670,7 @@ describe("SidepanelPersona", () => {
     )
   })
 
-  it("exports the selected live session transcript through the authenticated endpoint", async () => {
+  it("confirms before exporting the selected live session transcript", async () => {
     const createObjectURLSpy = vi
       .spyOn(URL, "createObjectURL")
       .mockReturnValue("blob:persona-session-export")
@@ -759,6 +759,20 @@ describe("SidepanelPersona", () => {
 
       const exportButton = await screen.findByTestId("persona-transcript-export-button")
       fireEvent.click(exportButton)
+
+      expect(await screen.findByText("Export selected Persona session?")).toBeInTheDocument()
+      expect(screen.getByText("Session: sess-export")).toBeInTheDocument()
+      expect(
+        mocks.fetchWithAuth
+      ).not.toHaveBeenCalledWith(
+        "/api/v1/persona/sessions/sess-export/export",
+        { method: "GET" }
+      )
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+      expect(createObjectURLSpy).not.toHaveBeenCalled()
+
+      fireEvent.click(exportButton)
+      fireEvent.click(await screen.findByRole("button", { name: "Confirm export" }))
 
       await waitFor(() => {
         expect(mocks.fetchWithAuth).toHaveBeenCalledWith(

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -6073,7 +6073,8 @@ describe("SidepanelPersona", () => {
     })
   })
 
-  it("loads, saves, and restores persona state docs from sidepanel controls", async () => {
+  it("loads, saves, restores, and archives persona state docs from sidepanel controls", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm")
     mocks.getConfig.mockResolvedValue({
       serverUrl: "http://127.0.0.1:8000",
       authMode: "single-user",
@@ -6099,6 +6100,13 @@ describe("SidepanelPersona", () => {
                 content: "archived soul version",
                 is_active: false,
                 version: 1
+              },
+              {
+                entry_id: "hist-active",
+                field: "identity_md",
+                content: "initial identity",
+                is_active: true,
+                version: 2
               }
             ]
           })
@@ -6111,6 +6119,17 @@ describe("SidepanelPersona", () => {
             persona_id: "research_assistant",
             soul_md: "restored soul version",
             identity_md: "initial identity",
+            heartbeat_md: "initial heartbeat"
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/research_assistant/state/archive")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "research_assistant",
+            soul_md: "restored soul version",
+            identity_md: null,
             heartbeat_md: "initial heartbeat"
           })
         })
@@ -6167,63 +6186,95 @@ describe("SidepanelPersona", () => {
       })
     })
 
-    render(<SidepanelPersona />)
-    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
-    await waitFor(() => {
-      expect(MockWebSocket.instances).toHaveLength(1)
-    })
-    MockWebSocket.instances[0].emitOpen()
-    await openStateDocsTab()
+    try {
+      render(<SidepanelPersona />)
+      fireEvent.click(await screen.findByRole("button", { name: "Connect" }))
+      await waitFor(() => {
+        expect(MockWebSocket.instances).toHaveLength(1)
+      })
+      MockWebSocket.instances[0].emitOpen()
+      await openStateDocsTab()
 
-    const soulInput = await waitForStateDocsEditor()
-    const identityInput = screen.getByTestId(
-      "persona-state-identity-input"
-    ) as HTMLTextAreaElement
-    const heartbeatInput = screen.getByTestId(
-      "persona-state-heartbeat-input"
-    ) as HTMLTextAreaElement
+      const soulInput = await waitForStateDocsEditor()
+      const identityInput = screen.getByTestId(
+        "persona-state-identity-input"
+      ) as HTMLTextAreaElement
+      const heartbeatInput = screen.getByTestId(
+        "persona-state-heartbeat-input"
+      ) as HTMLTextAreaElement
 
-    await waitFor(() => {
-      expect(soulInput.value).toBe("initial soul")
-      expect(identityInput.value).toBe("initial identity")
-      expect(heartbeatInput.value).toBe("initial heartbeat")
-    })
+      await waitFor(() => {
+        expect(soulInput.value).toBe("initial soul")
+        expect(identityInput.value).toBe("initial identity")
+        expect(heartbeatInput.value).toBe("initial heartbeat")
+      })
 
-    fireEvent.change(soulInput, { target: { value: "updated soul draft" } })
-    fireEvent.click(screen.getByTestId("persona-state-save-button"))
+      fireEvent.change(soulInput, { target: { value: "updated soul draft" } })
+      fireEvent.click(screen.getByTestId("persona-state-save-button"))
 
-    await waitFor(() => {
-      const putCall = mocks.fetchWithAuth.mock.calls.find(
-        ([calledPath, calledInit]) =>
-          String(calledPath).includes("/persona/profiles/research_assistant/state") &&
-          String((calledInit as { method?: string } | undefined)?.method || "").toUpperCase() ===
-            "PUT"
-      )
-      expect(putCall).toBeTruthy()
+      await waitFor(() => {
+        const putCall = mocks.fetchWithAuth.mock.calls.find(
+          ([calledPath, calledInit]) =>
+            String(calledPath).includes("/persona/profiles/research_assistant/state") &&
+            String((calledInit as { method?: string } | undefined)?.method || "").toUpperCase() ===
+              "PUT"
+        )
+        expect(putCall).toBeTruthy()
+        expect(
+          (putCall?.[1] as { body?: { soul_md?: string } } | undefined)?.body?.soul_md
+        ).toBe("updated soul draft")
+      })
+
+      fireEvent.click(screen.getByTestId("persona-state-history-button"))
+      await screen.findByText("archived soul version")
+
+      fireEvent.click(screen.getByTestId("persona-state-restore-hist-1"))
+      await waitFor(() => {
+        const restoreCall = mocks.fetchWithAuth.mock.calls.find(
+          ([calledPath, calledInit]) =>
+            String(calledPath).includes("/persona/profiles/research_assistant/state/restore") &&
+            String((calledInit as { method?: string } | undefined)?.method || "").toUpperCase() ===
+              "POST"
+        )
+        expect(restoreCall).toBeTruthy()
+        expect(
+          (
+            restoreCall?.[1] as { body?: { entry_id?: string } } | undefined
+          )?.body?.entry_id
+        ).toBe("hist-1")
+        expect(soulInput.value).toBe("restored soul version")
+      })
+
+      confirmSpy.mockReturnValueOnce(false)
+      fireEvent.click(screen.getByTestId("persona-state-archive-hist-active"))
+      expect(confirmSpy).toHaveBeenCalled()
       expect(
-        (putCall?.[1] as { body?: { soul_md?: string } } | undefined)?.body?.soul_md
-      ).toBe("updated soul draft")
-    })
-
-    fireEvent.click(screen.getByTestId("persona-state-history-button"))
-    await screen.findByText("archived soul version")
-
-    fireEvent.click(screen.getByTestId("persona-state-restore-hist-1"))
-    await waitFor(() => {
-      const restoreCall = mocks.fetchWithAuth.mock.calls.find(
-        ([calledPath, calledInit]) =>
-          String(calledPath).includes("/persona/profiles/research_assistant/state/restore") &&
-          String((calledInit as { method?: string } | undefined)?.method || "").toUpperCase() ===
-            "POST"
+        mocks.fetchWithAuth
+      ).not.toHaveBeenCalledWith(
+        "/api/v1/persona/profiles/research_assistant/state/archive",
+        expect.anything()
       )
-      expect(restoreCall).toBeTruthy()
-      expect(
-        (
-          restoreCall?.[1] as { body?: { entry_id?: string } } | undefined
-        )?.body?.entry_id
-      ).toBe("hist-1")
-      expect(soulInput.value).toBe("restored soul version")
-    })
+
+      confirmSpy.mockReturnValueOnce(true)
+      fireEvent.click(screen.getByTestId("persona-state-archive-hist-active"))
+      await waitFor(() => {
+        const archiveCall = mocks.fetchWithAuth.mock.calls.find(
+          ([calledPath, calledInit]) =>
+            String(calledPath).includes("/persona/profiles/research_assistant/state/archive") &&
+            String((calledInit as { method?: string } | undefined)?.method || "").toUpperCase() ===
+              "POST"
+        )
+        expect(archiveCall).toBeTruthy()
+        expect(
+          (
+            archiveCall?.[1] as { body?: { entry_id?: string } } | undefined
+          )?.body?.entry_id
+        ).toBe("hist-active")
+        expect(identityInput.value).toBe("")
+      })
+    } finally {
+      confirmSpy.mockRestore()
+    }
   })
 
   it("targets catalog-resolved persona for profile and state writes when connected", async () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -5947,6 +5947,12 @@ describe("SidepanelPersona", () => {
           json: async () => []
         })
       }
+      if (path.includes("/persona/session")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ session_id: "sess-memory-mode-status" })
+        })
+      }
       return Promise.resolve({
         ok: false,
         error: `unhandled path: ${path}`,

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -4354,7 +4354,7 @@ describe("SidepanelPersona", () => {
 
     render(<SidepanelPersona mode="companion" />)
 
-    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Connect" }))
     await waitFor(() => {
       expect(MockWebSocket.instances).toHaveLength(1)
     })
@@ -4459,7 +4459,7 @@ describe("SidepanelPersona", () => {
 
     render(<SidepanelPersona />)
 
-    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Connect" }))
 
     await waitFor(() => {
       expect(mocks.fetchWithAuth).toHaveBeenCalled()
@@ -4604,6 +4604,12 @@ describe("SidepanelPersona", () => {
         return Promise.resolve({
           ok: true,
           json: async () => []
+        })
+      }
+      if (path.includes("/persona/session")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ session_id: "sess-memory-status" })
         })
       }
       return Promise.resolve({
@@ -5333,7 +5339,7 @@ describe("SidepanelPersona", () => {
     })
 
     render(<SidepanelPersona />)
-    fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Connect" }))
 
     await waitFor(() => {
       expect(MockWebSocket.instances).toHaveLength(1)
@@ -5887,6 +5893,54 @@ describe("SidepanelPersona", () => {
       expect(userMessage?.use_companion_context).toBe(false)
       expect(userMessage?.memory_top_k).toBe(3)
     })
+  })
+
+  it("shows live memory mode status from the selected persona and controls", async () => {
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "persona-key"
+    })
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            {
+              id: "research_assistant",
+              name: "Research Assistant",
+              mode: "persistent_scoped"
+            }
+          ]
+        })
+      }
+      if (path.includes("/persona/sessions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+    fireEvent.click(await screen.findByRole("button", { name: "Connect" }))
+
+    const memoryStatus = await screen.findByTestId("persona-memory-status")
+    await waitFor(() => {
+      expect(memoryStatus).toHaveTextContent("Mode: persistent scoped")
+    })
+    expect(memoryStatus).toHaveTextContent("Memory: on")
+    expect(memoryStatus).toHaveTextContent("Top-k: 3")
+    expect(memoryStatus).toHaveTextContent("State context: available")
+
+    fireEvent.click(screen.getByTestId("persona-memory-toggle"))
+
+    expect(memoryStatus).toHaveTextContent("Memory: off")
   })
 
   it("updates persona state-context profile default and applies it to outgoing messages", async () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -670,6 +670,115 @@ describe("SidepanelPersona", () => {
     )
   })
 
+  it("exports the selected live session transcript through the authenticated endpoint", async () => {
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:persona-session-export")
+    const revokeObjectURLSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {})
+
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { body?: any }) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "research_assistant", name: "Research Assistant" }]
+        })
+      }
+      if (path.includes("/persona/profiles/research_assistant")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "research_assistant",
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      if (path.includes("/persona/sessions?persona_id=research_assistant")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path === "/api/v1/persona/session") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: "sess-export",
+            persona: { id: init?.body?.persona_id || "research_assistant" }
+          })
+        })
+      }
+      if (path === "/api/v1/persona/sessions/sess-export?limit_turns=0") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ preferences: {} })
+        })
+      }
+      if (path === "/api/v1/persona/sessions/sess-export/export") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: "sess-export",
+            persona_id: "research_assistant",
+            format: "json",
+            created_at: "2026-05-21T00:00:00Z",
+            updated_at: "2026-05-21T00:00:01Z",
+            turn_count: 1,
+            redaction_markers: ["metadata.auth_token"],
+            turns: [
+              {
+                turn_id: "turn-1",
+                timestamp: "2026-05-21T00:00:01Z",
+                role: "user",
+                event_type: "user_message",
+                content: "hello",
+                metadata: {}
+              }
+            ]
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    try {
+      render(<SidepanelPersona />)
+
+      await waitForLiveSessionPanel()
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+
+      const exportButton = await screen.findByTestId("persona-transcript-export-button")
+      fireEvent.click(exportButton)
+
+      await waitFor(() => {
+        expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+          "/api/v1/persona/sessions/sess-export/export",
+          { method: "GET" }
+        )
+      })
+      expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
+      const blob = createObjectURLSpy.mock.calls[0]?.[0] as Blob
+      expect(blob.type).toBe("application/json")
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:persona-session-export")
+      expect(
+        await screen.findByText("Transcript export downloaded.")
+      ).toBeInTheDocument()
+    } finally {
+      createObjectURLSpy.mockRestore()
+      revokeObjectURLSpy.mockRestore()
+    }
+  })
+
   it("publishes route-local buddy context ahead of stale persisted assistant state", async () => {
     window.localStorage.setItem(
       SELECTED_ASSISTANT_STORAGE_KEY,

--- a/apps/packages/ui/src/routes/hooks/usePersonaLiveSession.tsx
+++ b/apps/packages/ui/src/routes/hooks/usePersonaLiveSession.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/services/companion"
 import { buildPersonaWebSocketUrl } from "@/services/persona-stream"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { downloadBlob } from "@/utils/download-blob"
 
 import type { PersonaGardenTabKey } from "@/utils/persona-garden-route"
 import type { PersonaVoiceDefaults } from "@/hooks/useResolvedPersonaVoiceDefaults"
@@ -38,6 +39,17 @@ type PersonaSessionPreferences = {
 
 type PersonaSessionDetailResponse = {
   preferences?: PersonaSessionPreferences
+  turns?: Array<Record<string, unknown>>
+}
+
+type PersonaSessionExportResponse = {
+  session_id?: string
+  persona_id?: string
+  format?: "json"
+  created_at?: string
+  updated_at?: string
+  turn_count?: number
+  redaction_markers?: string[]
   turns?: Array<Record<string, unknown>>
 }
 
@@ -239,6 +251,7 @@ export function usePersonaLiveSession(deps: UsePersonaLiveSessionDeps) {
     React.useState(false)
   const [savingCompanionCheckIn, setSavingCompanionCheckIn] =
     React.useState(false)
+  const [transcriptExporting, setTranscriptExporting] = React.useState(false)
   const [companionPrompts, setCompanionPrompts] = React.useState<
     Array<{ prompt_id: string; label: string; prompt_text: string }>
   >([])
@@ -855,6 +868,39 @@ export function usePersonaLiveSession(deps: UsePersonaLiveSessionDeps) {
     setLogs(historyLogs)
   }, [sessionId, setError, setLogs])
 
+  // ── exportSelectedSessionTranscript ──
+  const exportSelectedSessionTranscript = React.useCallback(async () => {
+    const selectedSessionId = String(sessionId || "").trim()
+    if (!selectedSessionId || transcriptExporting) return
+    setTranscriptExporting(true)
+    try {
+      const resp = await tldwClient.fetchWithAuth(
+        `/api/v1/persona/sessions/${encodeURIComponent(
+          selectedSessionId
+        )}/export` as any,
+        { method: "GET" }
+      )
+      if (!resp.ok) {
+        throw new Error(resp.error || "Failed to export transcript")
+      }
+      const payload = (await resp.json()) as PersonaSessionExportResponse
+      const filename = `persona-session-${selectedSessionId}-transcript.json`
+      downloadBlob(
+        new Blob([JSON.stringify(payload, null, 2)], {
+          type: "application/json"
+        }),
+        filename
+      )
+      appendLog("notice", "Transcript export downloaded.")
+    } catch (err: any) {
+      const message = String(err?.message || "Failed to export transcript")
+      setError(message)
+      appendLog("notice", message)
+    } finally {
+      setTranscriptExporting(false)
+    }
+  }, [appendLog, sessionId, setError, transcriptExporting])
+
   // ── confirmPlan / cancelPlan ──
   const confirmPlan = React.useCallback(() => {
     if (!pendingPlan || !sessionId || !wsRef.current || !connected)
@@ -1150,6 +1196,7 @@ export function usePersonaLiveSession(deps: UsePersonaLiveSessionDeps) {
     setPersonaStateContextProfileDefault,
     updatingPersonaStateContextDefault,
     savingCompanionCheckIn,
+    transcriptExporting,
     companionPrompts,
     canSend,
     canSaveCompanionCheckIn,
@@ -1162,6 +1209,7 @@ export function usePersonaLiveSession(deps: UsePersonaLiveSessionDeps) {
     sendUserMessage,
     sendSetupLiveTestMessage,
     loadSessionHistory,
+    exportSelectedSessionTranscript,
     confirmPlanWithMap,
     cancelPlan,
     handleResumeSessionSelectionChange,

--- a/apps/packages/ui/src/routes/hooks/usePersonaStateDocs.ts
+++ b/apps/packages/ui/src/routes/hooks/usePersonaStateDocs.ts
@@ -57,6 +57,7 @@ export interface UsePersonaStateDocsReturn {
   personaStateHistoryOrder: "newest" | "oldest"
   setPersonaStateHistoryOrder: React.Dispatch<React.SetStateAction<"newest" | "oldest">>
   restoringStateEntryId: string | null
+  archivingStateEntryId: string | null
 
   // ── Editor expansion ──
   personaStateEditorExpanded: boolean
@@ -73,6 +74,7 @@ export interface UsePersonaStateDocsReturn {
   loadPersonaStateHistory: (personaIdOverride?: string) => Promise<boolean>
   savePersonaStateDocs: () => Promise<boolean | undefined>
   restorePersonaStateHistoryEntry: (entryId: string) => Promise<boolean>
+  archivePersonaStateHistoryEntry: (entryId: string) => Promise<boolean>
   revertPersonaStateDraft: () => void
   confirmDiscardUnsavedStateDrafts: (reason?: UnsavedStateDiscardReason) => boolean
 }
@@ -123,6 +125,7 @@ export function usePersonaStateDocs(
   const [personaStateHistoryOrder, setPersonaStateHistoryOrder] =
     React.useState<"newest" | "oldest">(_readHistoryOrderPreference)
   const [restoringStateEntryId, setRestoringStateEntryId] = React.useState<string | null>(null)
+  const [archivingStateEntryId, setArchivingStateEntryId] = React.useState<string | null>(null)
 
   // ── Editor expansion ──
   const [personaStateEditorExpanded, setPersonaStateEditorExpanded] =
@@ -435,6 +438,63 @@ export function usePersonaStateDocs(
     ]
   )
 
+  // ── Archive history entry ──
+
+  const archivePersonaStateHistoryEntry = React.useCallback(
+    async (entryId: string) => {
+      const personaId = getTargetPersonaId()
+      const trimmedEntryId = String(entryId || "").trim()
+      if (!personaId || !trimmedEntryId || archivingStateEntryId) return false
+      const confirmed = _confirmWithBrowserPrompt(
+        t(
+          "sidepanel:persona.stateArchiveConfirm",
+          "Archive this active state version? This removes it from current Persona state without deleting history."
+        )
+      )
+      if (!confirmed) {
+        return false
+      }
+      setArchivingStateEntryId(trimmedEntryId)
+      setError(null)
+      try {
+        const archiveResp = await tldwClient.fetchWithAuth(
+          `/api/v1/persona/profiles/${encodeURIComponent(personaId)}/state/archive` as any,
+          {
+            method: "POST",
+            body: { entry_id: trimmedEntryId },
+          }
+        )
+        if (!archiveResp.ok) {
+          throw new Error(
+            archiveResp.error || "Failed to archive persona state version"
+          )
+        }
+        const archivePayload =
+          (await archiveResp.json()) as PersonaStateDocsResponse
+        applyPersonaStatePayload(archivePayload)
+        await loadPersonaStateHistory(personaId)
+        appendLog("notice", "Archived persona state version")
+        return true
+      } catch (err: any) {
+        setError(
+          String(err?.message || "Failed to archive persona state version")
+        )
+        return false
+      } finally {
+        setArchivingStateEntryId(null)
+      }
+    },
+    [
+      appendLog,
+      applyPersonaStatePayload,
+      archivingStateEntryId,
+      getTargetPersonaId,
+      loadPersonaStateHistory,
+      setError,
+      t,
+    ]
+  )
+
   // ── Revert ──
 
   const revertPersonaStateDraft = React.useCallback(() => {
@@ -522,6 +582,7 @@ export function usePersonaStateDocs(
     personaStateHistoryOrder,
     setPersonaStateHistoryOrder,
     restoringStateEntryId,
+    archivingStateEntryId,
     personaStateEditorExpanded,
     setPersonaStateEditorExpanded,
     hasUnsavedPersonaStateChanges,
@@ -532,6 +593,7 @@ export function usePersonaStateDocs(
     loadPersonaStateHistory,
     savePersonaStateDocs,
     restorePersonaStateHistoryEntry,
+    archivePersonaStateHistoryEntry,
     revertPersonaStateDraft,
     confirmDiscardUnsavedStateDrafts,
   }

--- a/apps/packages/ui/src/routes/hooks/usePersonaStateDocs.ts
+++ b/apps/packages/ui/src/routes/hooks/usePersonaStateDocs.ts
@@ -191,6 +191,11 @@ export function usePersonaStateDocs(
             "sidepanel:persona.unsavedStateDiscardPromptRestoreState",
             "You have unsaved state-doc changes. Restore this state version and discard local drafts?"
           )
+        case "archive_state":
+          return t(
+            "sidepanel:persona.unsavedStateDiscardPromptArchiveState",
+            "You have unsaved state-doc changes. Archive this state version and discard local drafts?"
+          )
         case "route_transition":
           return t(
             "sidepanel:persona.unsavedStateDiscardPromptRouteTransition",
@@ -445,6 +450,9 @@ export function usePersonaStateDocs(
       const personaId = getTargetPersonaId()
       const trimmedEntryId = String(entryId || "").trim()
       if (!personaId || !trimmedEntryId || archivingStateEntryId) return false
+      if (!confirmDiscardUnsavedStateDrafts("archive_state")) {
+        return false
+      }
       const confirmed = _confirmWithBrowserPrompt(
         t(
           "sidepanel:persona.stateArchiveConfirm",
@@ -488,6 +496,7 @@ export function usePersonaStateDocs(
       appendLog,
       applyPersonaStatePayload,
       archivingStateEntryId,
+      confirmDiscardUnsavedStateDrafts,
       getTargetPersonaId,
       loadPersonaStateHistory,
       setError,

--- a/apps/packages/ui/src/routes/personaTypes.ts
+++ b/apps/packages/ui/src/routes/personaTypes.ts
@@ -263,6 +263,7 @@ export type UnsavedStateDiscardReason =
   | "persona_switch"
   | "session_switch"
   | "restore_state"
+  | "archive_state"
   | "route_transition"
   | "before_unload"
 

--- a/apps/packages/ui/src/routes/personaTypes.ts
+++ b/apps/packages/ui/src/routes/personaTypes.ts
@@ -14,6 +14,7 @@ import {
 export type PersonaInfo = {
   id: string
   name: string
+  mode?: "session_scoped" | "persistent_scoped"
   description?: string | null
   voice?: string | null
   avatar_url?: string | null
@@ -73,6 +74,7 @@ export type PersonaCompanionUsage = {
 export type PersonaProfileResponse = {
   id?: string
   version?: number
+  mode?: "session_scoped" | "persistent_scoped"
   buddy_summary?: PersonaBuddySummary | null
   use_persona_state_context_default?: boolean
   voice_defaults?: PersonaVoiceDefaults | null

--- a/apps/packages/ui/src/routes/personaTypes.ts
+++ b/apps/packages/ui/src/routes/personaTypes.ts
@@ -19,6 +19,8 @@ export type PersonaInfo = {
   avatar_url?: string | null
   system_prompt?: string | null
   greeting?: string | null
+  capabilities?: string[]
+  default_tools?: string[]
   extensions?: Record<string, unknown> | null
   buddy_summary?: PersonaBuddySummary | null
   metadata?: Record<string, unknown> | null

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -2054,7 +2054,10 @@ const SidepanelPersona = ({
       label: t("sidepanel:persona.tabScopes", "Scopes"),
       content: renderLazyPersonaTab(
         "scopes",
-        <LazyScopesPanel selectedPersonaName={selectedPersonaName} />,
+        <LazyScopesPanel
+          selectedPersonaId={selectedPersonaId}
+          selectedPersonaName={selectedPersonaName}
+        />,
         {
           includeSetupHandoff: false
         }
@@ -2065,7 +2068,10 @@ const SidepanelPersona = ({
       label: t("sidepanel:persona.tabPolicies", "Policies"),
       content: renderLazyPersonaTab(
         "policies",
-        <LazyPoliciesPanel hasPendingPlan={Boolean(pendingPlan)} />,
+        <LazyPoliciesPanel
+          selectedPersonaId={selectedPersonaId}
+          hasPendingPlan={Boolean(pendingPlan)}
+        />,
         {
           includeSetupHandoff: false
         }

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -2070,6 +2070,8 @@ const SidepanelPersona = ({
         "policies",
         <LazyPoliciesPanel
           selectedPersonaId={selectedPersonaId}
+          personaCapabilities={selectedCatalogPersona?.capabilities || []}
+          personaDefaultTools={selectedCatalogPersona?.default_tools || []}
           hasPendingPlan={Boolean(pendingPlan)}
         />,
         {

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -605,6 +605,11 @@ const SidepanelPersona = ({
     [savedPersonaVoiceDefaults]
   )
   const livePersonaId = connected ? activeSessionPersonaId || selectedPersonaId : selectedPersonaId
+
+  React.useEffect(() => {
+    setTranscriptExportConfirmOpen(false)
+  }, [activeSessionPersonaId, sessionId])
+
   const liveVoiceController = usePersonaLiveVoiceController({
     ws: wsRef.current,
     connected,

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -1773,6 +1773,19 @@ const SidepanelPersona = ({
                     >
                       {t("sidepanel:persona.stateRestore", "Restore")}
                     </Button>
+                    {entry.is_active ? (
+                      <Button
+                        data-testid={`persona-state-archive-${entry.entry_id}`}
+                        size="small"
+                        danger
+                        loading={stateDocs.archivingStateEntryId === entry.entry_id}
+                        onClick={() => {
+                          void stateDocs.archivePersonaStateHistoryEntry(entry.entry_id)
+                        }}
+                      >
+                        {t("sidepanel:persona.stateArchive", "Archive")}
+                      </Button>
+                    ) : null}
                   </div>
                   <div className="mt-1 whitespace-pre-wrap text-text">
                     {String(entry.content || "")}

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -152,6 +152,15 @@ const normalizeWakeTriggerPhrases = (phrases?: string[] | null): string[] => {
   return next
 }
 
+const normalizePersonaRuntimeMode = (
+  mode?: string | null
+): "session_scoped" | "persistent_scoped" =>
+  mode === "persistent_scoped" ? "persistent_scoped" : "session_scoped"
+
+const formatPersonaRuntimeMode = (
+  mode: "session_scoped" | "persistent_scoped"
+) => mode.replace(/_/g, " ")
+
 const SidepanelPersona = ({
   mode = "persona",
   shell = "sidepanel"
@@ -974,6 +983,19 @@ const SidepanelPersona = ({
     }
     openSettings()
   }
+  const selectedPersonaRuntimeMode = normalizePersonaRuntimeMode(
+    selectedCatalogPersona?.mode
+  )
+  const personaStateContextModeAvailable =
+    selectedPersonaRuntimeMode === "persistent_scoped"
+  const personaStateContextStatus = !personaStateContextEnabled
+    ? t("sidepanel:persona.memoryStatus.stateContextOff", "off")
+    : personaStateContextModeAvailable
+      ? t("sidepanel:persona.memoryStatus.stateContextAvailable", "available")
+      : t(
+          "sidepanel:persona.memoryStatus.stateContextUnavailableSession",
+          "unavailable in session scoped"
+        )
   const handlePersonaTabChange = React.useCallback(
     (key: string) => {
       const nextTab = key as PersonaGardenTabKey
@@ -987,121 +1009,150 @@ const SidepanelPersona = ({
 
   // ── JSX: live session controls ──
   const liveSessionControls = (
-    <div className="flex flex-wrap items-center gap-2">
-      {!isCompanionMode ? (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {!isCompanionMode ? (
+          <Select
+            size="small"
+            className="min-w-[180px]"
+            value={selectedPersonaId}
+            disabled={connected}
+            aria-label={t("sidepanel:persona.select", "Select persona")}
+            onChange={(value) => {
+              void liveVoiceController.stopWakeListening("persona_switch")
+              handlePersonaSelectionChange(String(value))
+            }}
+            options={catalog.map((persona) => ({
+              label: persona.name || persona.id,
+              value: persona.id
+            }))}
+            placeholder={t("sidepanel:persona.select", "Select persona")}
+          />
+        ) : null}
         <Select
+          data-testid="persona-resume-session-select"
           size="small"
           className="min-w-[180px]"
-          value={selectedPersonaId}
+          value={resumeSessionId || "__new__"}
+          aria-label={t("sidepanel:persona.resume", "Resume session")}
           disabled={connected}
-          aria-label={t("sidepanel:persona.select", "Select persona")}
           onChange={(value) => {
             void liveVoiceController.stopWakeListening("persona_switch")
-            handlePersonaSelectionChange(String(value))
+            handleResumeSessionSelectionChange(String(value))
           }}
-          options={catalog.map((persona) => ({
-            label: persona.name || persona.id,
-            value: persona.id
-          }))}
-          placeholder={t("sidepanel:persona.select", "Select persona")}
+          options={[
+            { label: t("sidepanel:persona.newSession", "New session"), value: "__new__" },
+            ...sessionHistory.map((session) => ({
+              label: session.session_id,
+              value: session.session_id
+            }))
+          ]}
+          placeholder={t("sidepanel:persona.resume", "Resume session")}
         />
-      ) : null}
-      <Select
-        data-testid="persona-resume-session-select"
-        size="small"
-        className="min-w-[180px]"
-        value={resumeSessionId || "__new__"}
-        aria-label={t("sidepanel:persona.resume", "Resume session")}
-        disabled={connected}
-        onChange={(value) => {
-          void liveVoiceController.stopWakeListening("persona_switch")
-          handleResumeSessionSelectionChange(String(value))
-        }}
-        options={[
-          { label: t("sidepanel:persona.newSession", "New session"), value: "__new__" },
-          ...sessionHistory.map((session) => ({
-            label: session.session_id,
-            value: session.session_id
-          }))
-        ]}
-        placeholder={t("sidepanel:persona.resume", "Resume session")}
-      />
-      <Checkbox
-        data-testid="persona-memory-toggle"
-        checked={memoryEnabled}
-        onChange={(event) => setMemoryEnabled(event.target.checked)}
-      >
-        {t("sidepanel:persona.memoryToggle", "Memory")}
-      </Checkbox>
-      {!isCompanionMode ? (
         <Checkbox
-          data-testid="persona-state-context-toggle"
-          checked={personaStateContextEnabled}
-          onChange={(event) => setPersonaStateContextEnabled(event.target.checked)}
+          data-testid="persona-memory-toggle"
+          checked={memoryEnabled}
+          onChange={(event) => setMemoryEnabled(event.target.checked)}
         >
-          {t("sidepanel:persona.stateContextToggle", "State context")}
+          {t("sidepanel:persona.memoryToggle", "Memory")}
         </Checkbox>
-      ) : null}
-      {!isCompanionMode ? (
-        <Checkbox
-          data-testid="persona-companion-context-toggle"
-          checked={companionContextEnabled}
-          onChange={(event) => setCompanionContextEnabled(event.target.checked)}
-        >
-          {t("sidepanel:persona.companionContextToggle", "Companion context")}
-        </Checkbox>
-      ) : null}
-      {!isCompanionMode ? (
-        <Checkbox
-          data-testid="persona-state-context-default-toggle"
-          checked={personaStateContextProfileDefault}
-          disabled={!connected || updatingPersonaStateContextDefault}
-          onChange={(event) => {
-            void updatePersonaStateContextDefault(event.target.checked)
-          }}
-        >
-          {t("sidepanel:persona.stateContextDefaultToggle", "Profile default")}
-        </Checkbox>
-      ) : null}
-      <Select
-        data-testid="persona-memory-topk-select"
-        size="small"
-        className="w-[150px]"
-        value={memoryTopK}
-        aria-label={t("sidepanel:persona.memoryTopK", "Memory results")}
-        disabled={!memoryEnabled}
-        onChange={(value) => setMemoryTopK(Number(value))}
-        options={MEMORY_TOP_K_OPTIONS.map((k) => ({
-          label: formatMemoryResultsLabel(k),
-          value: k
-        }))}
-        placeholder={t("sidepanel:persona.memoryTopK", "Memory results")}
-      />
-      {!connected ? (
-        <Button
+        {!isCompanionMode ? (
+          <Checkbox
+            data-testid="persona-state-context-toggle"
+            checked={personaStateContextEnabled}
+            onChange={(event) => setPersonaStateContextEnabled(event.target.checked)}
+          >
+            {t("sidepanel:persona.stateContextToggle", "State context")}
+          </Checkbox>
+        ) : null}
+        {!isCompanionMode ? (
+          <Checkbox
+            data-testid="persona-companion-context-toggle"
+            checked={companionContextEnabled}
+            onChange={(event) => setCompanionContextEnabled(event.target.checked)}
+          >
+            {t("sidepanel:persona.companionContextToggle", "Companion context")}
+          </Checkbox>
+        ) : null}
+        {!isCompanionMode ? (
+          <Checkbox
+            data-testid="persona-state-context-default-toggle"
+            checked={personaStateContextProfileDefault}
+            disabled={!connected || updatingPersonaStateContextDefault}
+            onChange={(event) => {
+              void updatePersonaStateContextDefault(event.target.checked)
+            }}
+          >
+            {t("sidepanel:persona.stateContextDefaultToggle", "Profile default")}
+          </Checkbox>
+        ) : null}
+        <Select
+          data-testid="persona-memory-topk-select"
           size="small"
-          type="primary"
-          loading={connecting}
-          onClick={() => {
-            void liveVoiceController.stopWakeListening("persona_switch")
-            void connect()
-          }}
+          className="w-[150px]"
+          value={memoryTopK}
+          aria-label={t("sidepanel:persona.memoryTopK", "Memory results")}
+          disabled={!memoryEnabled}
+          onChange={(value) => setMemoryTopK(Number(value))}
+          options={MEMORY_TOP_K_OPTIONS.map((k) => ({
+            label: formatMemoryResultsLabel(k),
+            value: k
+          }))}
+          placeholder={t("sidepanel:persona.memoryTopK", "Memory results")}
+        />
+        {!connected ? (
+          <Button
+            size="small"
+            type="primary"
+            loading={connecting}
+            onClick={() => {
+              void liveVoiceController.stopWakeListening("persona_switch")
+              void connect()
+            }}
+          >
+            {t("sidepanel:persona.connect", "Connect")}
+          </Button>
+        ) : (
+          <Button size="small" onClick={() => {
+            void liveVoiceController.stopWakeListening("stop_live_voice")
+            disconnect()
+          }}>
+            {t("sidepanel:persona.disconnect", "Disconnect")}
+          </Button>
+        )}
+        {sessionId ? <Tag color="blue">{`session: ${sessionId.slice(0, 8)}`}</Tag> : null}
+        {sessionId ? (
+          <Button size="small" onClick={() => void loadSessionHistory()}>
+            {t("sidepanel:persona.loadHistory", "Load history")}
+          </Button>
+        ) : null}
+      </div>
+      {!isCompanionMode ? (
+        <div
+          data-testid="persona-memory-status"
+          className="flex flex-wrap items-center gap-1 text-xs text-text-muted"
         >
-          {t("sidepanel:persona.connect", "Connect")}
-        </Button>
-      ) : (
-        <Button size="small" onClick={() => {
-          void liveVoiceController.stopWakeListening("stop_live_voice")
-          disconnect()
-        }}>
-          {t("sidepanel:persona.disconnect", "Disconnect")}
-        </Button>
-      )}
-      {sessionId ? <Tag color="blue">{`session: ${sessionId.slice(0, 8)}`}</Tag> : null}
-      {sessionId ? (
-        <Button size="small" onClick={() => void loadSessionHistory()}>
-          {t("sidepanel:persona.loadHistory", "Load history")}
-        </Button>
+          <Tag color={personaStateContextModeAvailable ? "green" : "default"}>
+            {`${t("sidepanel:persona.memoryStatus.mode", "Mode")}: ${formatPersonaRuntimeMode(selectedPersonaRuntimeMode)}`}
+          </Tag>
+          <Tag color={memoryEnabled ? "green" : "default"}>
+            {`${t("sidepanel:persona.memoryStatus.memory", "Memory")}: ${
+              memoryEnabled ? t("common:on", "on") : t("common:off", "off")
+            }`}
+          </Tag>
+          <Tag color="blue">
+            {`${t("sidepanel:persona.memoryStatus.topK", "Top-k")}: ${memoryTopK}`}
+          </Tag>
+          <Tag
+            color={
+              personaStateContextEnabled && personaStateContextModeAvailable
+                ? "green"
+                : "default"
+            }
+          >
+            {`${t("sidepanel:persona.memoryStatus.stateContext", "State context")}: ${personaStateContextStatus}`}
+          </Tag>
+        </div>
       ) : null}
     </div>
   )

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Button, Checkbox, Input, Select, Tag, Typography } from "antd"
-import { CheckCircle2, Send, XCircle } from "lucide-react"
+import { CheckCircle2, Download, Send, XCircle } from "lucide-react"
 import {
   useLocation,
   useNavigate
@@ -549,6 +549,7 @@ const SidepanelPersona = ({
     personaStateContextProfileDefault,
     updatingPersonaStateContextDefault,
     savingCompanionCheckIn,
+    transcriptExporting,
     companionPrompts,
     canSend,
     canSaveCompanionCheckIn,
@@ -559,6 +560,7 @@ const SidepanelPersona = ({
     sendUserMessage,
     sendSetupLiveTestMessage,
     loadSessionHistory,
+    exportSelectedSessionTranscript,
     confirmPlanWithMap,
     cancelPlan,
     handleResumeSessionSelectionChange,
@@ -1758,6 +1760,24 @@ const SidepanelPersona = ({
 
   const transcriptPanel = (
     <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-border bg-surface p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <Typography.Text className="text-xs font-medium text-text">
+          {t("sidepanel:persona.transcript", "Transcript")}
+        </Typography.Text>
+        {sessionId ? (
+          <Button
+            data-testid="persona-transcript-export-button"
+            size="small"
+            icon={<Download size={14} />}
+            loading={transcriptExporting}
+            onClick={() => {
+              void exportSelectedSessionTranscript()
+            }}
+          >
+            {t("sidepanel:persona.exportTranscript", "Export transcript")}
+          </Button>
+        ) : null}
+      </div>
       <div className="space-y-2">
         {logs.length === 0 ? (
           <Typography.Text type="secondary" className="text-xs">

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -229,6 +229,8 @@ const SidepanelPersona = ({
   const [input, setInput] = React.useState("")
   const [logs, setLogs] = React.useState<PersonaLogEntry[]>([])
   const [pendingPlan, setPendingPlan] = React.useState<PendingPlan | null>(null)
+  const [transcriptExportConfirmOpen, setTranscriptExportConfirmOpen] =
+    React.useState(false)
   const [activeSessionPersonaId, setActiveSessionPersonaId] = React.useState<string | null>(
     null
   )
@@ -586,6 +588,10 @@ const SidepanelPersona = ({
   const confirmPlan = React.useCallback(() => {
     confirmPlanWithMap(approvedStepMap)
   }, [approvedStepMap, confirmPlanWithMap])
+  const confirmTranscriptExport = React.useCallback(() => {
+    setTranscriptExportConfirmOpen(false)
+    void exportSelectedSessionTranscript()
+  }, [exportSelectedSessionTranscript])
 
   // ── Voice controller ──
   const resolvedLivePersonaVoiceDefaults = useResolvedPersonaVoiceDefaults(
@@ -1822,13 +1828,50 @@ const SidepanelPersona = ({
             icon={<Download size={14} />}
             loading={transcriptExporting}
             onClick={() => {
-              void exportSelectedSessionTranscript()
+              setTranscriptExportConfirmOpen(true)
             }}
           >
             {t("sidepanel:persona.exportTranscript", "Export transcript")}
           </Button>
         ) : null}
       </div>
+      {sessionId && transcriptExportConfirmOpen ? (
+        <div
+          data-testid="persona-transcript-export-confirmation"
+          className="mb-3 rounded-md border border-warning/40 bg-warning/5 p-2 text-xs text-text"
+        >
+          <div className="font-medium">
+            {t(
+              "sidepanel:persona.exportTranscriptConfirmTitle",
+              "Export selected Persona session?"
+            )}
+          </div>
+          <div className="mt-1 text-text-muted">
+            {t(
+              "sidepanel:persona.exportTranscriptConfirmDescription",
+              "This downloads a redacted transcript for the selected live session only."
+            )}
+          </div>
+          <div className="mt-1 text-text-muted">{`Session: ${sessionId}`}</div>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Button
+              size="small"
+              type="primary"
+              loading={transcriptExporting}
+              onClick={confirmTranscriptExport}
+            >
+              {t("sidepanel:persona.confirmExportTranscript", "Confirm export")}
+            </Button>
+            <Button
+              size="small"
+              disabled={transcriptExporting}
+              onClick={() => setTranscriptExportConfirmOpen(false)}
+            >
+              {t("common:cancel", "Cancel")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
       <div className="space-y-2">
         {logs.length === 0 ? (
           <Typography.Text type="secondary" className="text-xs">

--- a/backlog/tasks/task-442 - Document-Persona-PRD-reconciliation-scope-split.md
+++ b/backlog/tasks/task-442 - Document-Persona-PRD-reconciliation-scope-split.md
@@ -1,0 +1,49 @@
+---
+id: TASK-442
+title: Document Persona PRD reconciliation scope split
+status: Done
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1902
+- Docs/Product/Persona_Agent_Design.md
+- Docs/Plans/2026-03-08-persona-garden-design.md
+modified_files:
+- Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
+- backlog/tasks/task-442 - Document-Persona-PRD-reconciliation-scope-split.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write a design/spec artifact that reconciles the original Persona module PRD into current completion scope and future PRD tracks, linking the future work tracker issue.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec documents current Persona module completion scope.
+- [x] #2 Spec lists moved-out future PRD tracks and links GitHub issue #1902.
+- [x] #3 Spec keeps ordinary chat, workspace defaults, scheduled work, rich avatar, cross-app personalization, tool administration, and multi-agent collaboration out of current completion scope.
+- [x] #4 No design-system backlog tasks are touched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Persona PRD reconciliation design spec. The spec defines the current Persona Garden/live-session completion scope, moves future platform tracks to GitHub issue #1902, and explicitly avoids design-system backlog work. Verification: git diff --check passed; targeted rg confirmed #1902 and moved-out PRD tracks are present. Bandit was skipped because this is documentation-only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-442 - Document-Persona-PRD-reconciliation-scope-split.md
+++ b/backlog/tasks/task-442 - Document-Persona-PRD-reconciliation-scope-split.md
@@ -35,7 +35,7 @@ Write a design/spec artifact that reconciles the original Persona module PRD int
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Reviewed and hardened the Persona PRD reconciliation design. Added risk notes and constraints for transcript export redaction/ownership, non-escalating Scopes/Policies editing, safe MCP/tool discovery, evidence-backed shipped-status claims, and a suggested PRD patch sequence. Verification: git diff --check passed on the updated spec. Bandit skipped because this remains documentation-only.
+Spec review iteration 2 approved. Hardened the Persona PRD reconciliation design with persona-local already-authorized tool defaults, broader transcript export redaction, existing-backend-only memory controls, #1902 completeness gate, bounded visual/static state language, and explicit future-scope non-blocker wording. Verification: git diff --check passed on the updated spec. Bandit skipped because this remains documentation-only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-442 - Document-Persona-PRD-reconciliation-scope-split.md
+++ b/backlog/tasks/task-442 - Document-Persona-PRD-reconciliation-scope-split.md
@@ -35,7 +35,7 @@ Write a design/spec artifact that reconciles the original Persona module PRD int
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created the Persona PRD reconciliation design spec. The spec defines the current Persona Garden/live-session completion scope, moves future platform tracks to GitHub issue #1902, and explicitly avoids design-system backlog work. Verification: git diff --check passed; targeted rg confirmed #1902 and moved-out PRD tracks are present. Bandit was skipped because this is documentation-only.
+Reviewed and hardened the Persona PRD reconciliation design. Added risk notes and constraints for transcript export redaction/ownership, non-escalating Scopes/Policies editing, safe MCP/tool discovery, evidence-backed shipped-status claims, and a suggested PRD patch sequence. Verification: git diff --check passed on the updated spec. Bandit skipped because this remains documentation-only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-443 - Patch-Persona-Agent-PRD-with-reconciled-completion-scope.md
+++ b/backlog/tasks/task-443 - Patch-Persona-Agent-PRD-with-reconciled-completion-scope.md
@@ -1,0 +1,52 @@
+---
+id: TASK-443
+title: Patch Persona Agent PRD with reconciled completion scope
+status: Done
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md
+- https://github.com/rmusser01/tldw_server/issues/1902
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the original Persona Agent PRD so it reflects current implementation status, current Persona Garden/live-session completion scope, and future PRD tracks moved to #1902.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Original Persona PRD distinguishes current completion scope from future PRD tracks.
+- [x] #2 Stale shipped-status claims are updated using current code evidence.
+- [x] #3 Future-scope buckets are explicitly labeled as not current completion blockers and linked to #1902.
+- [x] #4 Transcript export, Scopes/Policies editing, tool discovery, memory controls, visual scope, and security/reliability hardening are captured.
+- [x] #5 No design-system backlog tasks are touched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Replaced the stale original Persona PRD with the reconciled Persona Garden/live Persona completion contract from `Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md`.
+- Verified issue #1902 still tracks all moved-out future PRD buckets: Persona-backed Chat Startup, Workspace Persona Defaults, Persona Scheduled Work, Persona Expressive Avatar Runtime, Personalization Memory Layer, Persona Tool Administration, and Persona Collaboration / Multi-agent Workflows.
+- Kept this slice docs-only and did not touch design-system backlog tasks.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Patched `Docs/Product/Persona_Agent_Design.md` so the original Persona PRD now distinguishes current Persona Garden/live-session completion scope from future PRD tracks.
+- Updated the current-status section from stale scaffold-era claims to code-evidence-backed shipped/gap language.
+- Linked future scope to #1902 and labeled each moved-out bucket as not a current completion blocker.
+- Recorded verification with `git diff --check` and live `gh issue view 1902`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-444 - Implement-Persona-selected-session-transcript-export.md
+++ b/backlog/tasks/task-444 - Implement-Persona-selected-session-transcript-export.md
@@ -1,0 +1,54 @@
+---
+id: TASK-444
+title: Implement Persona selected-session transcript export
+status: Done
+labels:
+- persona
+- backend
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- https://github.com/rmusser01/tldw_server/issues/1902
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the current-scope Persona Garden backend foundation for exporting only the selected live Persona session transcript with deterministic, redacted payloads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected Persona session export endpoint returns deterministic JSON for the authenticated user's selected session only.
+- [x] #2 Export payload includes session/persona metadata, timestamps, event types, and redaction markers where fields are omitted.
+- [x] #3 Export does not expose raw binary audio, hidden prompts/policy/tool configuration, or non-selected-session memory/source payloads.
+- [x] #4 Export is user-scoped and returns 404 for another user's session.
+- [x] #5 Focused tests validate success and ownership behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `GET /api/v1/persona/sessions/{session_id}/export` with user ownership checks matching the existing session detail path.
+- Added a JSON export response schema with session/persona metadata, turn event types, timestamps, sanitized metadata, and sorted redaction markers.
+- Added recursive metadata redaction for raw audio/binary fields, auth/secrets, hidden prompts, policy metadata, and tool configuration style keys.
+- Export currently uses the selected session's existing runtime turn snapshot, matching the existing session detail behavior and avoiding non-selected-session memory/source payloads.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Implemented the selected-session Persona transcript export backend endpoint and focused tests for redaction and user scoping.
+- Verification: focused export RED failed with missing endpoint; full `test_persona_sessions.py` passed with 10 tests; `git diff --check` passed; Bandit on production touched files reported zero findings.
+- Bandit on the touched pytest file reports only the existing B101 pytest-assert baseline and no non-B101 findings after removing the new hardcoded-secret-style literal.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-445 - Wire-Persona-Garden-selected-session-transcript-export-UI.md
+++ b/backlog/tasks/task-445 - Wire-Persona-Garden-selected-session-transcript-export-UI.md
@@ -1,0 +1,59 @@
+---
+id: TASK-445
+title: Wire Persona Garden selected-session transcript export UI
+status: Done
+labels:
+- persona
+- frontend
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- TASK-444
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the Persona Garden live-session UI action for exporting the selected session transcript through the backend session export endpoint.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Live Session transcript panel exposes an export action only when a selected session exists.
+- [x] #2 Export action calls GET /api/v1/persona/sessions/{session_id}/export through the authenticated client.
+- [x] #3 Export action downloads deterministic JSON for the selected session and reports success in the live transcript timeline.
+- [x] #4 Failed export reports an actionable error without clearing the current transcript.
+- [x] #5 Focused frontend test covers the export action and authenticated endpoint path.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added the selected-session transcript export button to the Persona Garden Live Session transcript panel.
+- Added `exportSelectedSessionTranscript` to `usePersonaLiveSession`; it calls the authenticated backend export endpoint, downloads formatted JSON via `downloadBlob`, and records transcript notices for success or failure.
+- Kept the action hidden until a live session id exists and preserved existing transcript logs on failures.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Persona Garden selected-session transcript export UI.
+
+Verification:
+- RED: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "exports the selected live session transcript"` failed before implementation because `persona-transcript-export-button` was missing.
+- GREEN: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "exports the selected live session transcript"` passed after implementation.
+- `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx` passed 74 tests.
+- `git diff --check` passed before task finalization.
+- `bunx tsc --noEmit --pretty false` still exits 2 on unrelated repo-wide baseline errors; no changed files were present in the visible error output.
+- Bandit is not applicable to this frontend-only slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-446 - Wire-Persona-Garden-scope-and-policy-rule-editors.md
+++ b/backlog/tasks/task-446 - Wire-Persona-Garden-scope-and-policy-rule-editors.md
@@ -1,0 +1,60 @@
+---
+id: TASK-446
+title: Wire Persona Garden scope and policy rule editors
+status: Done
+labels:
+- persona
+- frontend
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- TASK-445
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the Persona Garden Scopes and Policies placeholder panels with focused editors backed by existing Persona scope-rules and policy-rules endpoints.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Scopes panel loads GET /api/v1/persona/profiles/{persona_id}/scope-rules for the selected persona and shows empty/error states.
+- [x] #2 Scopes panel allows add/edit/remove of allowed rule types and saves with PUT /api/v1/persona/profiles/{persona_id}/scope-rules.
+- [x] #3 Policies panel loads GET /api/v1/persona/profiles/{persona_id}/policy-rules for the selected persona and shows empty/error/pending-plan context.
+- [x] #4 Policies panel allows add/edit/remove of mcp_tool/skill rules, allowed/confirmation/max-calls settings, and saves with PUT /api/v1/persona/profiles/{persona_id}/policy-rules.
+- [x] #5 Focused frontend tests cover load, save payloads, and validation/error recovery for both panels.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Replaced the Scopes placeholder with a compact rule editor that loads/saves through the existing `scope-rules` endpoint and validates non-empty rule values locally.
+- Replaced the Policies placeholder with a compact rule editor that loads/saves through the existing `policy-rules` endpoint and preserves current rules on save failures.
+- Passed `selectedPersonaId` from the Persona Garden route into both panels; no backend behavior or permission scope was added.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Persona Garden scope and policy rule editors for the current Persona PRD completion scope.
+
+Verification:
+- RED: `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx` failed before implementation because the placeholder panels had no editor controls.
+- GREEN: `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx` passed 4 tests.
+- Regression: `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx` passed 6 tests.
+- Regression: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx` passed 74 tests.
+- `git diff --check` passed.
+- `bunx tsc --noEmit --pretty false` still exits 2 on unrelated repo-wide baseline errors; visible output did not include the changed Persona Garden files.
+- Bandit is not applicable to this frontend-only slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-447 - Expose-Persona-local-MCP-tool-discovery-in-policy-editor.md
+++ b/backlog/tasks/task-447 - Expose-Persona-local-MCP-tool-discovery-in-policy-editor.md
@@ -1,0 +1,58 @@
+---
+id: TASK-447
+title: Expose Persona-local MCP tool discovery in policy editor
+status: Done
+labels:
+- persona
+- frontend
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- TASK-446
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wire existing MCP executable-tool discovery into the Persona Garden Policies editor so Persona-local MCP allow rules can be selected from already-authorized tools, while still preserving manual/error fallback behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Policy editor uses the existing MCP tool picker for mcp_tool rules instead of plain text only.
+- [x] #2 Policy editor still supports manual/unavailable MCP fallback through the existing picker behavior and does not introduce new backend permissions.
+- [x] #3 Policy editor shows selected Persona capability/default-tool context from the catalog when available.
+- [x] #4 Focused frontend tests cover picker-driven rule-name updates and catalog default-tool/capability context.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Integrated `McpToolPicker` into `mcp_tool` policy rows while keeping `skill` rules on the existing text input path.
+- Added read-only catalog context for selected Persona default tools and capabilities, passed from the selected catalog Persona into the Policies panel.
+- Reused the existing MCP picker/manual fallback behavior and existing policy endpoints; no backend permission or discovery surface changes were introduced.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Implemented Persona-local MCP discovery/default context in the Persona Garden Policies editor.
+- RED verification: focused `ScopePolicyEditors` tests failed before implementation because picker and catalog context were missing.
+- GREEN verification: `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx` passed 6 tests.
+- Adjacent verification: `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx src/components/PersonaGarden/__tests__/McpToolPicker.test.tsx` passed 14 tests.
+- Route regression verification: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx` passed 74 tests.
+- Static checks: `git diff --check` passed before final staging. `bunx tsc --noEmit --pretty false` still exits 2 on unrelated repo-wide baseline errors; visible output did not include changed Persona files.
+- Bandit not applicable: frontend-only TypeScript/React changes.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-448 - Expose-Persona-live-memory-status-in-Persona-Garden.md
+++ b/backlog/tasks/task-448 - Expose-Persona-live-memory-status-in-Persona-Garden.md
@@ -1,0 +1,56 @@
+---
+id: TASK-448
+title: Expose Persona live memory status in Persona Garden
+status: Done
+labels:
+- persona
+- frontend
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- TASK-447
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a bounded Live Session memory status surface that makes the selected Persona runtime mode, retrieval toggle/top-k, and Persona state-context mode availability visible without adding new backend behavior or broad memory curation controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Live Session shows the selected Persona runtime mode from the profile/catalog response when available.
+- [x] #2 Live Session shows memory retrieval on/off and selected top-k alongside the existing controls.
+- [x] #3 Live Session distinguishes whether Persona state context can apply in the current runtime mode, matching existing backend persistent_scoped gating.
+- [x] #4 Focused frontend coverage proves the memory status is rendered from catalog/profile state and updates when controls change.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `mode` to the Persona catalog/profile UI contract so Persona Garden can render the selected runtime mode without adding a new endpoint or memory behavior.
+- Projected catalog profile modes through the existing backend runtime-mode allowlist, defaulting invalid or missing values to `session_scoped`.
+- Added a compact Live Session memory status row for Persona mode, memory on/off, selected top-k, and state-context availability. The status is hidden in companion mode and does not add mutation, archive, or broad memory-curation controls.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- RED: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "shows live memory mode status"` initially failed because the memory status row did not exist.
+- GREEN: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "shows live memory mode status"` passed.
+- GREEN: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx` passed, 75 tests.
+- GREEN: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_catalog.py -q` passed, 5 tests.
+- GREEN: `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_memory_status.json` passed with no findings.
+- GREEN: `git diff --check` passed.
+- KNOWN BASELINE: `bunx tsc --noEmit --pretty false` still fails on existing broad WebUI TypeScript debt outside this slice, including unrelated audio, chat composer, flashcards, workspace, route registry, and service test typing issues.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-449 - Add-Persona-transcript-export-confirmation.md
+++ b/backlog/tasks/task-449 - Add-Persona-transcript-export-confirmation.md
@@ -1,0 +1,56 @@
+---
+id: TASK-449
+title: Add Persona transcript export confirmation
+status: Done
+labels:
+- persona
+- frontend
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- TASK-445
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a confirmation/review step before exporting the selected Persona live-session transcript, satisfying the current Persona PRD security requirement for explicit confirmation on export actions without changing backend export behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Transcript export does not call the export endpoint until the user confirms.
+- [x] #2 The confirmation copy makes clear the export is for the selected Persona session.
+- [x] #3 Cancelling the confirmation leaves the session connected and performs no download.
+- [x] #4 Focused route coverage proves confirm/cancel behavior without changing backend export behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added a route-local confirmation panel for the selected Persona live-session transcript export.
+- The first export click opens review copy with the selected session id and does not call the export endpoint.
+- Confirming runs the existing authenticated export path; cancelling closes the prompt without downloading or disconnecting.
+- No backend export behavior, redaction logic, permissions, or route contracts were changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- RED: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "confirms before exporting"` failed before implementation because no confirmation prompt existed and export ran immediately.
+- GREEN: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "confirms before exporting"` passed.
+- GREEN: `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx` passed, 75 tests.
+- GREEN: `git diff --check` passed.
+- KNOWN BASELINE: `bunx tsc --noEmit --pretty false` still exits 2 on existing broad WebUI TypeScript debt outside this slice; visible output did not include the touched Persona route files.
+- Bandit skipped because this is a frontend-only TypeScript/Backlog markdown change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-450 - Add-Persona-state-history-archive-control.md
+++ b/backlog/tasks/task-450 - Add-Persona-state-history-archive-control.md
@@ -39,7 +39,7 @@ Expose existing Persona state-memory archive support for visible Persona Garden 
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 - Implemented Persona state-history archive control across backend API, Persona Garden UI, and focused regression tests.
-- Verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -k "state_history" -q`; `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "loads, saves, restores, and archives"`; `python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q`; `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx`; `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_state_archive.json`; `git diff --check`.
+- Verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -k "state_history" -q`; `bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "loads, saves, restores, and archives"`; `python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q`; `bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`; `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_state_archive.json`; `git diff --check`.
 - Known skips/blockers: none.
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-450 - Add-Persona-state-history-archive-control.md
+++ b/backlog/tasks/task-450 - Add-Persona-state-history-archive-control.md
@@ -1,0 +1,54 @@
+---
+id: TASK-450
+title: Add Persona state-history archive control
+status: Done
+labels:
+- persona
+- frontend
+- backend
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- TASK-448
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose existing Persona state-memory archive support for visible Persona Garden state-history entries. Keep scope limited to state docs history, require ownership checks and a user confirmation, and avoid broad memory curation or generic memory management.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend exposes an authenticated owner-scoped archive action for Persona state-history entries only.
+- [x] #2 Archiving an active state-history entry removes that field from current Persona state without deleting the history row.
+- [x] #3 Persona Garden shows an archive control for active state-history entries and confirms before calling the archive action.
+- [x] #4 Focused backend and frontend tests cover archive success, scoping, and cancel-before-call behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added authenticated `POST /api/v1/persona/profiles/{persona_id}/state/archive` for Persona state-history entries, scoped by current user and persona.
+- Reused existing Persona memory archive storage behavior so active state fields are removed from current state without deleting the history row.
+- Kept the UI scope to Persona Garden state-history rows: active rows show an Archive control, archived rows remain restore-only.
+- Added a browser confirmation before the frontend calls the archive endpoint.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Implemented Persona state-history archive control across backend API, Persona Garden UI, and focused regression tests.
+- Verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -k "state_history" -q`; `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "loads, saves, restores, and archives"`; `python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q`; `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx`; `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_state_archive.json`; `git diff --check`.
+- Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-451 - Close-Persona-PRD-current-completion-evidence.md
+++ b/backlog/tasks/task-451 - Close-Persona-PRD-current-completion-evidence.md
@@ -1,0 +1,61 @@
+---
+id: TASK-451
+title: Close Persona PRD current completion evidence
+status: Done
+labels:
+- persona
+- docs
+priority: Medium
+references:
+- Docs/Product/Persona_Agent_Design.md
+- TASK-442
+- TASK-443
+- TASK-444
+- TASK-445
+- TASK-446
+- TASK-447
+- TASK-448
+- TASK-449
+- TASK-450
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the current Persona module PRD after the reconciliation implementation slices have landed. Convert stale current-gap language into an evidence-backed completion snapshot for Persona Garden/live Persona sessions, preserve future PRD boundaries, and avoid design-system or Buddy-system backlog work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona PRD no longer lists the completed 442-450 slices as current gaps.
+- [x] #2 Persona PRD records evidence for transcript export, scope/policy editing, MCP discovery, memory visibility/archive controls, and export/archive confirmations.
+- [x] #3 Future-scope buckets remain explicitly not current completion blockers and linked to issue #1902.
+- [x] #4 Verification is recorded and no design-system or Buddy-system backlog tasks/files are touched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Updated `Docs/Product/Persona_Agent_Design.md` from reconciled-active status to implemented current Persona Garden/live-session completion scope.
+- Replaced stale current-gap language with an implemented evidence snapshot for TASK-442 through TASK-451.
+- Preserved the future PRD buckets and #1902 boundary language without adding Buddy-system or design-system work.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Closed the current Persona module PRD evidence snapshot after the transcript export, confirmations, scope/policy editors, MCP discovery, memory status, and state-history archive slices landed.
+- Verification: `rg -n "Current completion gaps|completion gaps|current gaps|not current completion blockers|TASK-451|Implementation closeout|Closeout status|design-system|Buddy" Docs/Product/Persona_Agent_Design.md "backlog/tasks/task-451 - Close-Persona-PRD-current-completion-evidence.md"`; `git diff --check`.
+- Bandit skipped because this slice only changes documentation and Backlog task metadata.
+- Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-464 - Address-PR-1905-Persona-export-null-redaction-review.md
+++ b/backlog/tasks/task-464 - Address-PR-1905-Persona-export-null-redaction-review.md
@@ -1,0 +1,52 @@
+---
+id: TASK-464
+title: Address PR 1905 Persona export null-redaction review
+status: Done
+labels:
+- persona
+- review-fix
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/1905
+- tldw_Server_API/app/api/v1/endpoints/persona.py
+- tldw_Server_API/tests/Persona/test_persona_sessions.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve PR #1905 review feedback for Persona transcript export metadata redaction. Preserve valid JSON null values in exported metadata dictionaries and lists while continuing to drop redacted/unsupported values, and add focused regression coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona transcript export metadata preserves original null values in dictionaries.
+- [x] #2 Persona transcript export metadata preserves original null values in lists without shifting list indices.
+- [x] #3 Redacted secret-like keys and unsupported values remain omitted from export metadata.
+- [x] #4 Focused backend tests and security/whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Replaced the Persona export redaction helper's overloaded `None` drop sentinel with a private object sentinel so valid JSON null values survive recursive metadata sanitization.
+- Extended the Persona session export regression test to assert null preservation in dictionaries and lists while existing secret-like metadata redaction still applies.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Addressed the two PR #1905 review comments on Persona transcript export metadata redaction by preserving JSON null values in exported dict/list metadata.
+- Verification: `python -m pytest tldw_Server_API/tests/Persona/test_persona_sessions.py -k "export" -q`; `python -m pytest tldw_Server_API/tests/Persona/test_persona_sessions.py -q`; `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_pr1905_review_fix.json`; `git diff --check`.
+- Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-465 - Address-PR-1905-Persona-follow-up-review-findings.md
+++ b/backlog/tasks/task-465 - Address-PR-1905-Persona-follow-up-review-findings.md
@@ -1,0 +1,61 @@
+---
+id: TASK-465
+title: Address PR 1905 Persona follow-up review findings
+status: Done
+labels:
+- persona
+- review-fix
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/1905
+- tldw_Server_API/app/api/v1/endpoints/persona.py
+- tldw_Server_API/app/api/v1/schemas/persona.py
+- tldw_Server_API/tests/Persona/test_persona_sessions.py
+- tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+- apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx
+- apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx
+- apps/packages/ui/src/routes/hooks/usePersonaStateDocs.ts
+- apps/packages/ui/src/routes/sidepanel-persona.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the remaining PR #1905 Cubic and Qodo review findings across Persona export, state archive, scope/policy editor loading states, transcript export confirmation lifecycle, metrics, and docstrings. Fix only still-valid issues and keep scope limited to Persona.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Scope and policy editors avoid stale loading/save races called out by review.
+- [x] #2 State-history archive preserves unsaved-draft confirmation behavior before applying returned payloads.
+- [x] #3 Transcript export confirmation cannot carry over across selected session context changes.
+- [x] #4 Archive metrics classify archive actions correctly and archive request validation uses schema validation for blank IDs.
+- [x] #5 Persona export/archive helpers and endpoint behavior are documented and empty transcript exports fail loudly.
+- [x] #6 Focused backend/frontend tests plus Bandit and whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Disabled scope/policy saves while rules are loading or saving and reset loading when no persona is selected.
+- Added an archive-state unsaved-draft guard before archive confirmation and payload application.
+- Reset transcript export confirmation when live Persona session/persona context changes.
+- Classified persona state archive metrics as archive, moved blank archive entry validation into the Pydantic request schema, documented touched helper/endpoint behavior, and made transcript export return 409 when no live snapshot exists.
+- Added/updated focused backend and frontend regression tests for the review findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved the remaining PR #1905 Persona review findings with focused UI/backend changes and regression coverage. Verification passed: `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "scope|export|restore|archives"`; `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx`; `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_sessions.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q`; `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_pr1905_followup_fix.json`; `git diff --check`. No known skips or blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-466 - Address-PR-1905-CodeRabbit-follow-up-review-findings.md
+++ b/backlog/tasks/task-466 - Address-PR-1905-CodeRabbit-follow-up-review-findings.md
@@ -1,0 +1,53 @@
+---
+id: TASK-466
+title: Address PR 1905 CodeRabbit follow-up review findings
+status: Done
+labels:
+- persona
+- review-fix
+priority: Medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the remaining PR #1905 CodeRabbit follow-up findings after the first review-fix commit. Verify each item against current code, fix only still-valid issues, and keep scope limited to Persona.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Scope and policy editors do not clear existing rule state before async reload completes and still block save while loading.
+- [x] #2 Sidepanel Persona tests do not issue unhandled connect-session requests.
+- [x] #3 Persona mode values in API responses are consistently normalized through the bounded runtime-mode helper.
+- [x] #4 Transcript export metadata drops non-dict top-level metadata instead of leaking scalar/list payloads.
+- [x] #5 Persona transcript export honors the existing export RBAC toggle/permission behavior.
+- [x] #6 Relevant task verification paths are corrected and focused tests/security checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Preserved existing scope/policy rule editor state while replacement persona rules are loading and kept save controls disabled during reload.
+- Added regression coverage for preserving scope/policy rules during async persona switches.
+- Added the missing sidepanel memory-mode connect-session mock to avoid unhandled request paths.
+- Centralized Persona runtime-mode normalization for profile, catalog/session projection, and session summary/detail builders.
+- Made transcript export reject direct calls when Persona export policy is disabled and added regression coverage.
+- Redacted non-object top-level transcript metadata to an empty object with a redaction marker instead of exporting scalar/list payloads.
+- Corrected the Persona state-archive Backlog verification path noted by review.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved the still-valid CodeRabbit follow-up findings for PR #1905. Verification passed: `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx --testNamePattern "scope|policy|memory mode|export|restore|archives"`; `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_sessions.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py -k "export or mode or state_history" -q`; `bunx vitest run src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx`; `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_sessions.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q`; `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_pr1905_coderabbit_fix.json`; `git diff --check`. No known skips or blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -75,6 +75,7 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaSetupEventWriteResponse,
     PersonaSetupState,
     PersonaStateHistoryResponse,
+    PersonaStateArchiveRequest,
     PersonaStateResponse,
     PersonaStateRestoreRequest,
     PersonaStateUpdateRequest,
@@ -6393,6 +6394,73 @@ async def restore_persona_profile_state_entry(
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         _increment_persona_state_metric(action="restore", result="error")
         raise _to_http_exception(exc, action="restore persona profile state entry") from exc
+
+
+@router.post(
+    "/profiles/{persona_id}/state/archive",
+    response_model=PersonaStateResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+)
+async def archive_persona_profile_state_entry(
+    persona_id: str,
+    payload: PersonaStateArchiveRequest = Body(...),
+    _current_user: User = Depends(get_request_user),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaStateResponse:
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    target_entry_id = str(payload.entry_id or "").strip()
+    if not target_entry_id:
+        raise HTTPException(status_code=400, detail="entry_id is required")
+
+    try:
+        profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+        if profile is None:
+            _increment_persona_state_metric(action="archive", result="not_found")
+            raise HTTPException(status_code=404, detail="Persona profile not found")
+
+        rows = db.list_persona_memory_entries(
+            user_id=user_id,
+            persona_id=persona_id,
+            include_archived=True,
+            include_deleted=False,
+            limit=_get_persona_state_history_max_entries(),
+            offset=0,
+        )
+        target_row: dict[str, Any] | None = None
+        for row in rows:
+            row_id = str(row.get("id") or "").strip()
+            if row_id != target_entry_id:
+                continue
+            if str(row.get("memory_type") or "").strip() not in _PERSONA_STATE_MEMORY_TYPES:
+                continue
+            target_row = row
+            break
+        if target_row is None:
+            _increment_persona_state_metric(action="archive", result="entry_not_found")
+            raise HTTPException(status_code=404, detail="State history entry not found")
+
+        if not _coerce_bool(target_row.get("archived"), default=False):
+            archived = db.set_persona_memory_archived(
+                entry_id=target_entry_id,
+                user_id=user_id,
+                persona_id=persona_id,
+                archived=True,
+            )
+            if not archived:
+                _increment_persona_state_metric(action="archive", result="entry_not_found")
+                raise HTTPException(status_code=404, detail="State history entry not found")
+
+        current_rows = _get_persona_state_rows(db, user_id=user_id, persona_id=persona_id)
+        _increment_persona_state_metric(action="archive", result="success")
+        return _persona_state_response_from_rows(persona_id=persona_id, rows=current_rows)
+    except HTTPException:
+        raise
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        _increment_persona_state_metric(action="archive", result="error")
+        raise _to_http_exception(exc, action="archive persona profile state entry") from exc
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2928,7 +2928,7 @@ def _replace_persona_state_docs(
 
 
 def _increment_persona_state_metric(*, action: str, result: str) -> None:
-    action_value = _bounded_label(action, allowed={"read", "write", "history", "restore"}, fallback="read")
+    action_value = _bounded_label(action, allowed={"read", "write", "history", "restore", "archive"}, fallback="read")
     result_value = _bounded_label(
         result,
         allowed={
@@ -3208,6 +3208,12 @@ def _redacted_persona_export_metadata(
     path: str = "metadata",
     markers: set[str],
 ) -> Any:
+    """Return transcript-export-safe metadata while recording omitted paths.
+
+    JSON primitives, including null values represented by ``None``, are preserved.
+    Values under secret-like keys and values that cannot be safely serialized into
+    the export payload are omitted and recorded in ``markers``.
+    """
     if isinstance(value, dict):
         redacted: dict[str, Any] = {}
         for raw_key in sorted(value):
@@ -3238,6 +3244,12 @@ def _persona_session_export_from_db(
     *,
     manager_snapshot: dict[str, Any] | None = None,
 ) -> PersonaSessionExportResponse:
+    """Build the deterministic redacted export payload for one live session.
+
+    The caller is responsible for proving session ownership and providing the
+    in-memory session snapshot. This helper only shapes DB metadata, visible
+    transcript turns, and redaction markers into the response schema.
+    """
     turns = list((manager_snapshot or {}).get("turns") or [])
     redaction_markers: set[str] = set()
     exported_turns: list[dict[str, Any]] = []
@@ -6323,12 +6335,16 @@ async def restore_persona_profile_state_entry(
     _current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> PersonaStateResponse:
+    """Restore a user-owned Persona state-history entry as the active state.
+
+    Only state-doc memory entries for the selected Persona can be restored. The
+    restored entry becomes active for its state field, sibling active entries
+    for that field are archived, and the updated state-doc view is returned.
+    """
     if not is_persona_enabled():
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)
     target_entry_id = str(payload.entry_id or "").strip()
-    if not target_entry_id:
-        raise HTTPException(status_code=400, detail="entry_id is required")
 
     try:
         profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
@@ -6409,12 +6425,17 @@ async def archive_persona_profile_state_entry(
     _current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> PersonaStateResponse:
+    """Archive a user-owned Persona state-history entry without deleting it.
+
+    Only state-doc memory entries for the selected Persona can be archived. The
+    action removes the entry from current state by marking it archived and
+    returns the updated state-doc view; missing Persona or entry ownership
+    failures return 404.
+    """
     if not is_persona_enabled():
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)
     target_entry_id = str(payload.entry_id or "").strip()
-    if not target_entry_id:
-        raise HTTPException(status_code=400, detail="entry_id is required")
 
     try:
         profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
@@ -7860,6 +7881,11 @@ async def persona_session_export(
             user_id=user_id,
             limit_turns=None if limit_turns <= 0 else limit_turns,
         )
+        if snapshot is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Persona transcript is only available for active live sessions",
+            )
         return _persona_session_export_from_db(row, manager_snapshot=snapshot)
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -3199,6 +3199,7 @@ _PERSONA_SESSION_EXPORT_REDACT_KEY_RE = re.compile(
     r"password|policy|secret|system[_-]?prompt|token|tool[_-]?config)",
     re.IGNORECASE,
 )
+_PERSONA_SESSION_EXPORT_DROP = object()
 
 
 def _redacted_persona_export_metadata(
@@ -3216,20 +3217,20 @@ def _redacted_persona_export_metadata(
                 markers.add(marker_path)
                 continue
             sanitized = _redacted_persona_export_metadata(value[raw_key], path=marker_path, markers=markers)
-            if sanitized is not None:
+            if sanitized is not _PERSONA_SESSION_EXPORT_DROP:
                 redacted[key] = sanitized
         return redacted
     if isinstance(value, list):
         sanitized_items: list[Any] = []
         for idx, item in enumerate(value):
             sanitized = _redacted_persona_export_metadata(item, path=f"{path}.{idx}", markers=markers)
-            if sanitized is not None:
+            if sanitized is not _PERSONA_SESSION_EXPORT_DROP:
                 sanitized_items.append(sanitized)
         return sanitized_items
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
     markers.add(path)
-    return None
+    return _PERSONA_SESSION_EXPORT_DROP
 
 
 def _persona_session_export_from_db(

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -64,6 +64,7 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaScopeRulesReplaceRequest,
     PersonaScopeRulesResponse,
     PersonaSessionDetail,
+    PersonaSessionExportResponse,
     PersonaSessionRequest,
     PersonaSessionResponse,
     PersonaSessionSummary,
@@ -3183,6 +3184,79 @@ def _persona_session_detail_from_db(
         scope_snapshot_id=_scope_snapshot_id_from_snapshot(scope_snapshot),
         scope_audit=_scope_audit_from_snapshot(scope_snapshot),
         turns=turns,
+    )
+
+
+_PERSONA_SESSION_EXPORT_REDACT_KEY_RE = re.compile(
+    r"(api[_-]?key|auth|authorization|binary|bytes|bytes_base64|developer[_-]?prompt|hidden|"
+    r"password|policy|secret|system[_-]?prompt|token|tool[_-]?config)",
+    re.IGNORECASE,
+)
+
+
+def _redacted_persona_export_metadata(
+    value: Any,
+    *,
+    path: str = "metadata",
+    markers: set[str],
+) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for raw_key in sorted(value):
+            key = str(raw_key)
+            marker_path = f"{path}.{key}"
+            if _PERSONA_SESSION_EXPORT_REDACT_KEY_RE.search(key):
+                markers.add(marker_path)
+                continue
+            sanitized = _redacted_persona_export_metadata(value[raw_key], path=marker_path, markers=markers)
+            if sanitized is not None:
+                redacted[key] = sanitized
+        return redacted
+    if isinstance(value, list):
+        sanitized_items: list[Any] = []
+        for idx, item in enumerate(value):
+            sanitized = _redacted_persona_export_metadata(item, path=f"{path}.{idx}", markers=markers)
+            if sanitized is not None:
+                sanitized_items.append(sanitized)
+        return sanitized_items
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    markers.add(path)
+    return None
+
+
+def _persona_session_export_from_db(
+    row: dict[str, Any],
+    *,
+    manager_snapshot: dict[str, Any] | None = None,
+) -> PersonaSessionExportResponse:
+    turns = list((manager_snapshot or {}).get("turns") or [])
+    redaction_markers: set[str] = set()
+    exported_turns: list[dict[str, Any]] = []
+    for turn in turns:
+        turn_type = str(turn.get("type") or "text")
+        exported_turns.append(
+            {
+                "turn_id": str(turn.get("turn_id") or "") or None,
+                "timestamp": str(turn.get("timestamp") or "") or None,
+                "role": str(turn.get("role") or "unknown"),
+                "event_type": turn_type,
+                "content": str(turn.get("content") or ""),
+                "metadata": _redacted_persona_export_metadata(
+                    turn.get("metadata") or {},
+                    markers=redaction_markers,
+                )
+                or {},
+            }
+        )
+    return PersonaSessionExportResponse(
+        session_id=str(row.get("id") or ""),
+        persona_id=str(row.get("persona_id") or ""),
+        created_at=str(row.get("created_at") or _utc_now_iso()),
+        updated_at=str(row.get("last_modified") or row.get("created_at") or _utc_now_iso()),
+        turn_count=len(exported_turns),
+        redaction_markers=sorted(redaction_markers),
+        turns=exported_turns,
     )
 
 
@@ -7683,6 +7757,39 @@ async def persona_session_detail(
         raise
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         raise _to_http_exception(exc, action="get persona session detail") from exc
+
+
+@router.get(
+    "/sessions/{session_id}/export",
+    response_model=PersonaSessionExportResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+)
+async def persona_session_export(
+    session_id: str,
+    limit_turns: int = Query(default=1000, ge=0, le=1000),
+    _current_user: User = Depends(get_request_user),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaSessionExportResponse:
+    """Export a redacted transcript for one selected Persona session owned by the user."""
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    manager = get_session_manager()
+    try:
+        row = db.get_persona_session(session_id, user_id=user_id, include_deleted=False)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Persona session not found")
+        snapshot = manager.get_session_snapshot(
+            session_id=session_id,
+            user_id=user_id,
+            limit_turns=None if limit_turns <= 0 else limit_turns,
+        )
+        return _persona_session_export_from_db(row, manager_snapshot=snapshot)
+    except HTTPException:
+        raise
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="export persona session") from exc
 
 
 @router.websocket("/stream")

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2982,6 +2982,11 @@ def _persona_info_from_profile(
     return PersonaInfo(
         id=str(profile.get("id") or _DEFAULT_PERSONA_ID),
         name=str(profile.get("name") or _DEFAULT_PERSONA_NAME),
+        mode=_bounded_label(
+            profile.get("mode"),
+            allowed=_PERSONA_RUNTIME_MODES,
+            fallback="session_scoped",
+        ),
         description=description[:300] if description else None,
         voice="default",
         avatar_url=None,
@@ -3123,6 +3128,7 @@ def _persona_catalog_items() -> list[PersonaInfo]:
         PersonaInfo(
             id=_DEFAULT_PERSONA_ID,
             name=_DEFAULT_PERSONA_NAME,
+            mode="session_scoped",
             description=_DEFAULT_PERSONA_DESCRIPTION,
             voice="default",
             avatar_url=None,

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -355,6 +355,11 @@ def _bounded_label(value: Any, *, allowed: set[str], fallback: str) -> str:
     return fallback
 
 
+def _persona_runtime_mode_value(value: Any) -> str:
+    """Normalize stored Persona runtime mode values for public responses."""
+    return _bounded_label(value, allowed=_PERSONA_RUNTIME_MODES, fallback="session_scoped")
+
+
 def _redacted_id_for_logs(raw_id: Any) -> str:
     text = str(raw_id or "").strip()
     if not text:
@@ -590,6 +595,16 @@ def _get_persona_rbac_flags() -> tuple[bool, bool]:
         allow_export = False
         allow_delete = False
     return allow_export, allow_delete
+
+
+def _require_persona_export_allowed() -> None:
+    """Reject direct Persona export requests when export scope is disabled."""
+    allow_export, _allow_delete = _get_persona_rbac_flags()
+    if not allow_export:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Persona export is disabled by policy",
+        )
 
 
 def _get_persona_runtime_explorer_config() -> RuntimeExplorerConfig:
@@ -1389,9 +1404,7 @@ def _load_persona_policy_rules_for_session(
         if not session_row:
             return dict(default_payload)
         persona_id = str(session_row.get("persona_id") or _DEFAULT_PERSONA_ID).strip() or _DEFAULT_PERSONA_ID
-        runtime_mode = str(session_row.get("mode") or "session_scoped").strip().lower()
-        if runtime_mode not in _PERSONA_RUNTIME_MODES:
-            runtime_mode = "session_scoped"
+        runtime_mode = _persona_runtime_mode_value(session_row.get("mode"))
         persona_profile = db.get_persona_profile(persona_id, user_id=uid, include_deleted=False)
         persona_state_context_default = True
         if isinstance(persona_profile, dict):
@@ -1922,7 +1935,7 @@ def _persona_profile_to_response(
         origin_character_id=profile.get("origin_character_id"),
         origin_character_name=profile.get("origin_character_name"),
         origin_character_snapshot_at=profile.get("origin_character_snapshot_at"),
-        mode=str(profile.get("mode") or "session_scoped"),
+        mode=_persona_runtime_mode_value(profile.get("mode")),
         system_prompt=profile.get("system_prompt"),
         is_active=bool(profile.get("is_active", True)),
         use_persona_state_context_default=_coerce_bool(
@@ -2983,11 +2996,7 @@ def _persona_info_from_profile(
     return PersonaInfo(
         id=str(profile.get("id") or _DEFAULT_PERSONA_ID),
         name=str(profile.get("name") or _DEFAULT_PERSONA_NAME),
-        mode=_bounded_label(
-            profile.get("mode"),
-            allowed=_PERSONA_RUNTIME_MODES,
-            fallback="session_scoped",
-        ),
+        mode=_persona_runtime_mode_value(profile.get("mode")),
         description=description[:300] if description else None,
         voice="default",
         avatar_url=None,
@@ -3157,7 +3166,7 @@ def _persona_session_summary_from_db(
         turn_count=int((manager_row or {}).get("turn_count") or 0),
         pending_plan_count=int((manager_row or {}).get("pending_plan_count") or 0),
         preferences=preferences,
-        runtime_mode=str(row.get("mode") or "session_scoped"),
+        runtime_mode=_persona_runtime_mode_value(row.get("mode")),
         status=str(row.get("status") or "active"),
         reuse_allowed=bool(row.get("reuse_allowed", False)),
         scope_snapshot_id=_scope_snapshot_id_from_snapshot(scope_snapshot),
@@ -3185,7 +3194,7 @@ def _persona_session_detail_from_db(
         turn_count=turn_count,
         pending_plan_count=int((manager_snapshot or {}).get("pending_plan_count") or 0),
         preferences=preferences,
-        runtime_mode=str(row.get("mode") or "session_scoped"),
+        runtime_mode=_persona_runtime_mode_value(row.get("mode")),
         status=str(row.get("status") or "active"),
         reuse_allowed=bool(row.get("reuse_allowed", False)),
         scope_snapshot_id=_scope_snapshot_id_from_snapshot(scope_snapshot),
@@ -3214,6 +3223,9 @@ def _redacted_persona_export_metadata(
     Values under secret-like keys and values that cannot be safely serialized into
     the export payload are omitted and recorded in ``markers``.
     """
+    if path == "metadata" and not isinstance(value, dict):
+        markers.add(path)
+        return {}
     if isinstance(value, dict):
         redacted: dict[str, Any] = {}
         for raw_key in sorted(value):
@@ -7629,7 +7641,7 @@ async def persona_session(
             session_id=materialized.session_id,
             persona=persona,
             scopes=scopes,
-            runtime_mode=str(session_row.get("mode") or profile.get("mode") or "session_scoped"),
+            runtime_mode=_persona_runtime_mode_value(session_row.get("mode") or profile.get("mode")),
             scope_snapshot_id=scope_snapshot_id_from_snapshot(scope_snapshot),
             scope_audit=materialized.scope_audit,
         )
@@ -7871,6 +7883,7 @@ async def persona_session_export(
     if not is_persona_enabled():
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)
+    _require_persona_export_allowed()
     manager = get_session_manager()
     try:
         row = db.get_persona_session(session_id, user_id=user_id, include_deleted=False)

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -1093,6 +1093,10 @@ class PersonaStateRestoreRequest(BaseModel):
     entry_id: str = Field(..., min_length=1, max_length=200)
 
 
+class PersonaStateArchiveRequest(BaseModel):
+    entry_id: str = Field(..., min_length=1, max_length=200)
+
+
 class PersonaConnectionCreate(BaseModel):
     id: str | None = Field(default=None, min_length=1, max_length=200)
     name: str = Field(..., min_length=1, max_length=200)

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -664,6 +664,26 @@ class PersonaSessionDetail(PersonaSessionSummary):
     turns: list[dict[str, object]] = Field(default_factory=list)
 
 
+class PersonaSessionExportTurn(BaseModel):
+    turn_id: str | None = None
+    timestamp: str | None = None
+    role: str
+    event_type: str
+    content: str
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+
+class PersonaSessionExportResponse(BaseModel):
+    session_id: str
+    persona_id: str
+    format: Literal["json"] = "json"
+    created_at: str
+    updated_at: str
+    turn_count: int = 0
+    redaction_markers: list[str] = Field(default_factory=list)
+    turns: list[PersonaSessionExportTurn] = Field(default_factory=list)
+
+
 class PersonaLiveSessionCreateRequest(BaseModel):
     persona_id: str = Field(min_length=1, max_length=128)
     reuse_policy: PersonaLiveReusePolicy = "resume_compatible"

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -593,6 +593,7 @@ class PersonaVisualDeactivateResponse(BaseModel):
 class PersonaInfo(BaseModel):
     id: str
     name: str
+    mode: PersonaMode = "session_scoped"
     description: str | None = None
     voice: str | None = None
     avatar_url: str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -1096,6 +1096,16 @@ class PersonaStateRestoreRequest(BaseModel):
 class PersonaStateArchiveRequest(BaseModel):
     entry_id: str = Field(..., min_length=1, max_length=200)
 
+    @field_validator("entry_id", mode="before")
+    @classmethod
+    def _strip_required_entry_id(cls, value: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("entry_id is required")
+        return stripped
+
 
 class PersonaConnectionCreate(BaseModel):
     id: str | None = Field(default=None, min_length=1, max_length=200)

--- a/tldw_Server_API/tests/Persona/test_persona_catalog.py
+++ b/tldw_Server_API/tests/Persona/test_persona_catalog.py
@@ -48,6 +48,7 @@ def test_persona_catalog_smoke(client_with_persona_user: TestClient):
     assert isinstance(payload, list)
     assert payload
     assert payload[0]["id"] == "research_assistant"
+    assert payload[0]["mode"] == "session_scoped"
 
 
 def test_persona_catalog_returns_404_when_disabled(client_with_persona_user: TestClient, monkeypatch):

--- a/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
@@ -882,6 +882,20 @@ def test_persona_profile_state_history_and_restore(persona_db: CharactersRAGDB):
         assert len(active_entries) == 1
         assert active_entries[0]["is_active"] is True
         assert active_entries[0]["content"] == v1
+        active_entry_id = active_entries[0]["entry_id"]
+
+        archive = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/state/archive",
+            json={"entry_id": active_entry_id},
+        )
+        assert archive.status_code == 200, archive.text
+        assert archive.json()["soul_md"] is None
+
+        history_after_archive = client.get(
+            f"/api/v1/persona/profiles/{persona_id}/state/history?field=soul_md&include_archived=false&limit=20"
+        )
+        assert history_after_archive.status_code == 200, history_after_archive.text
+        assert history_after_archive.json()["entries"] == []
 
     fastapi_app.dependency_overrides.clear()
 
@@ -916,6 +930,11 @@ def test_persona_profile_state_history_scoping_and_validation(persona_db: Charac
             json={"entry_id": "forged-entry"},
         )
         assert restore.status_code == 404
+        archive = user_two_client.post(
+            f"/api/v1/persona/profiles/{persona_id}/state/archive",
+            json={"entry_id": "forged-entry"},
+        )
+        assert archive.status_code == 404
 
     fastapi_app.dependency_overrides.clear()
 

--- a/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
@@ -130,6 +130,19 @@ def test_persona_profile_scope_policy_crud(persona_db: CharactersRAGDB):
     fastapi_app.dependency_overrides.clear()
 
 
+def test_persona_profile_response_normalizes_invalid_mode():
+    response = persona_ep._persona_profile_to_response(
+        {
+            "id": "persona-invalid-mode",
+            "name": "Invalid Mode Persona",
+            "mode": "unexpected_mode",
+            "system_prompt": "Helper",
+        }
+    )
+
+    assert response.mode == "session_scoped"
+
+
 def test_persona_profile_projection_fails_open_when_buddy_lookup_breaks(
     persona_db: CharactersRAGDB,
     monkeypatch,

--- a/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
@@ -919,6 +919,11 @@ def test_persona_profile_state_history_scoping_and_validation(persona_db: Charac
             f"/api/v1/persona/profiles/{persona_id}/state/history?field=unknown_field"
         )
         assert invalid_filter.status_code == 400
+        invalid_archive = user_one_client.post(
+            f"/api/v1/persona/profiles/{persona_id}/state/archive",
+            json={"entry_id": "   "},
+        )
+        assert invalid_archive.status_code == 422
 
     fastapi_app.dependency_overrides.clear()
 

--- a/tldw_Server_API/tests/Persona/test_persona_sessions.py
+++ b/tldw_Server_API/tests/Persona/test_persona_sessions.py
@@ -188,6 +188,39 @@ def test_persona_session_export_is_user_scoped(monkeypatch, persona_db: Characte
     fastapi_app.dependency_overrides.clear()
 
 
+def test_persona_session_export_requires_live_snapshot(monkeypatch, persona_db: CharactersRAGDB):
+    manager = SessionManager()
+    monkeypatch.setattr(persona_ep, "get_session_manager", lambda: manager)
+    persona_id = persona_db.create_persona_profile(
+        {
+            "id": "research_assistant",
+            "user_id": "1",
+            "name": "Research Assistant",
+            "mode": "session_scoped",
+            "system_prompt": "Helper",
+            "is_active": True,
+        }
+    )
+    _ = persona_db.create_persona_session(
+        {
+            "id": "sess_export_not_live",
+            "persona_id": persona_id,
+            "user_id": "1",
+            "mode": "session_scoped",
+            "reuse_allowed": False,
+            "status": "active",
+            "scope_snapshot_json": {},
+        }
+    )
+
+    with _client_for_user(1, persona_db) as client:
+        resp = client.get("/api/v1/persona/sessions/sess_export_not_live/export")
+        assert resp.status_code == 409
+        assert "active live sessions" in resp.json()["detail"]
+
+    fastapi_app.dependency_overrides.clear()
+
+
 def test_persona_sessions_list_and_detail_fall_back_to_persisted_preferences(
     monkeypatch,
     persona_db: CharactersRAGDB,

--- a/tldw_Server_API/tests/Persona/test_persona_sessions.py
+++ b/tldw_Server_API/tests/Persona/test_persona_sessions.py
@@ -96,6 +96,7 @@ def test_materialized_session_reads_memory_top_k_from_settings_attributes(monkey
 def test_persona_session_export_returns_selected_session_transcript(monkeypatch, persona_db: CharactersRAGDB):
     manager = SessionManager()
     monkeypatch.setattr(persona_ep, "get_session_manager", lambda: manager)
+    monkeypatch.setattr(persona_ep, "_get_persona_rbac_flags", lambda: (True, False))
 
     with _client_for_user(1, persona_db) as client:
         created = client.post("/api/v1/persona/session", json={"persona_id": "research_assistant"})
@@ -156,9 +157,47 @@ def test_persona_session_export_returns_selected_session_transcript(monkeypatch,
     fastapi_app.dependency_overrides.clear()
 
 
+def test_persona_session_export_rejects_when_export_disabled(monkeypatch, persona_db: CharactersRAGDB):
+    monkeypatch.setattr(persona_ep, "_get_persona_rbac_flags", lambda: (False, False))
+
+    with _client_for_user(1, persona_db) as client:
+        resp = client.get("/api/v1/persona/sessions/sess_export_disabled/export")
+        assert resp.status_code == 403
+        assert "export is disabled" in resp.json()["detail"]
+
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_persona_session_export_redacts_non_object_top_level_metadata():
+    markers: set[str] = set()
+
+    redacted = persona_ep._redacted_persona_export_metadata(
+        ["unexpected", {"auth_token": "hidden"}],
+        markers=markers,
+    )
+
+    assert redacted == {}
+    assert markers == {"metadata"}
+
+
+def test_persona_session_response_helpers_normalize_invalid_runtime_mode():
+    row = {
+        "id": "sess_invalid_mode",
+        "persona_id": "research_assistant",
+        "mode": "unexpected_mode",
+        "status": "active",
+        "reuse_allowed": False,
+        "scope_snapshot": {},
+    }
+
+    assert persona_ep._persona_session_summary_from_db(row).runtime_mode == "session_scoped"
+    assert persona_ep._persona_session_detail_from_db(row).runtime_mode == "session_scoped"
+
+
 def test_persona_session_export_is_user_scoped(monkeypatch, persona_db: CharactersRAGDB):
     manager = SessionManager()
     monkeypatch.setattr(persona_ep, "get_session_manager", lambda: manager)
+    monkeypatch.setattr(persona_ep, "_get_persona_rbac_flags", lambda: (True, False))
     persona_id = persona_db.create_persona_profile(
         {
             "id": "research_assistant",
@@ -191,6 +230,7 @@ def test_persona_session_export_is_user_scoped(monkeypatch, persona_db: Characte
 def test_persona_session_export_requires_live_snapshot(monkeypatch, persona_db: CharactersRAGDB):
     manager = SessionManager()
     monkeypatch.setattr(persona_ep, "get_session_manager", lambda: manager)
+    monkeypatch.setattr(persona_ep, "_get_persona_rbac_flags", lambda: (True, False))
     persona_id = persona_db.create_persona_profile(
         {
             "id": "research_assistant",

--- a/tldw_Server_API/tests/Persona/test_persona_sessions.py
+++ b/tldw_Server_API/tests/Persona/test_persona_sessions.py
@@ -112,6 +112,9 @@ def test_persona_session_export_returns_selected_session_transcript(monkeypatch,
             turn_type="user_message",
             metadata={
                 "visible": "kept",
+                "optional_value": None,
+                "list_with_null": ["first", None, "last"],
+                "nested": {"kept_null": None},
                 "bytes_base64": "raw-audio",
                 "system_prompt": "hidden prompt",
                 "auth_token": sensitive_value,
@@ -140,7 +143,12 @@ def test_persona_session_export_returns_selected_session_transcript(monkeypatch,
         ]
         assert [turn["event_type"] for turn in payload["turns"]] == ["user_message", "assistant_message"]
         assert payload["turns"][0]["content"] == "hello"
-        assert payload["turns"][0]["metadata"] == {"visible": "kept"}
+        assert payload["turns"][0]["metadata"] == {
+            "list_with_null": ["first", None, "last"],
+            "nested": {"kept_null": None},
+            "optional_value": None,
+            "visible": "kept",
+        }
         assert sensitive_value not in str(payload)
         assert "hidden prompt" not in str(payload)
         assert "raw-audio" not in str(payload)

--- a/tldw_Server_API/tests/Persona/test_persona_sessions.py
+++ b/tldw_Server_API/tests/Persona/test_persona_sessions.py
@@ -93,6 +93,93 @@ def test_materialized_session_reads_memory_top_k_from_settings_attributes(monkey
     assert row["preferences"]["memory_top_k"] == 6
 
 
+def test_persona_session_export_returns_selected_session_transcript(monkeypatch, persona_db: CharactersRAGDB):
+    manager = SessionManager()
+    monkeypatch.setattr(persona_ep, "get_session_manager", lambda: manager)
+
+    with _client_for_user(1, persona_db) as client:
+        created = client.post("/api/v1/persona/session", json={"persona_id": "research_assistant"})
+        assert created.status_code == 200
+        session_id = created.json()["session_id"]
+        sensitive_value = "sensitive" + "-value"
+
+        manager.append_turn(
+            session_id=session_id,
+            user_id="1",
+            persona_id="research_assistant",
+            role="user",
+            content="hello",
+            turn_type="user_message",
+            metadata={
+                "visible": "kept",
+                "bytes_base64": "raw-audio",
+                "system_prompt": "hidden prompt",
+                "auth_token": sensitive_value,
+            },
+        )
+        manager.append_turn(
+            session_id=session_id,
+            user_id="1",
+            persona_id="research_assistant",
+            role="assistant",
+            content="Hi there.",
+            turn_type="assistant_message",
+        )
+
+        exported = client.get(f"/api/v1/persona/sessions/{session_id}/export")
+        assert exported.status_code == 200
+        payload = exported.json()
+        assert payload["session_id"] == session_id
+        assert payload["persona_id"] == "research_assistant"
+        assert payload["format"] == "json"
+        assert payload["turn_count"] == 2
+        assert payload["redaction_markers"] == [
+            "metadata.auth_token",
+            "metadata.bytes_base64",
+            "metadata.system_prompt",
+        ]
+        assert [turn["event_type"] for turn in payload["turns"]] == ["user_message", "assistant_message"]
+        assert payload["turns"][0]["content"] == "hello"
+        assert payload["turns"][0]["metadata"] == {"visible": "kept"}
+        assert sensitive_value not in str(payload)
+        assert "hidden prompt" not in str(payload)
+        assert "raw-audio" not in str(payload)
+
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_persona_session_export_is_user_scoped(monkeypatch, persona_db: CharactersRAGDB):
+    manager = SessionManager()
+    monkeypatch.setattr(persona_ep, "get_session_manager", lambda: manager)
+    persona_id = persona_db.create_persona_profile(
+        {
+            "id": "research_assistant",
+            "user_id": "1",
+            "name": "Research Assistant",
+            "mode": "session_scoped",
+            "system_prompt": "Helper",
+            "is_active": True,
+        }
+    )
+    _ = persona_db.create_persona_session(
+        {
+            "id": "sess_export_scoped",
+            "persona_id": persona_id,
+            "user_id": "1",
+            "mode": "session_scoped",
+            "reuse_allowed": False,
+            "status": "active",
+            "scope_snapshot_json": {},
+        }
+    )
+
+    with _client_for_user(2, persona_db) as client:
+        resp = client.get("/api/v1/persona/sessions/sess_export_scoped/export")
+        assert resp.status_code == 404
+
+    fastapi_app.dependency_overrides.clear()
+
+
 def test_persona_sessions_list_and_detail_fall_back_to_persisted_preferences(
     monkeypatch,
     persona_db: CharactersRAGDB,


### PR DESCRIPTION
## Summary

- Reconciles the current Persona Garden/live-session PRD scope and moves broader assistant directions to future PRD buckets.
- Adds selected Persona session transcript export with redaction, authenticated ownership checks, UI download, and confirmation.
- Wires Persona Garden scope/policy editors, Persona-local MCP tool discovery context, live memory status, and state-history archive controls.
- Closes the PRD evidence snapshot with TASK-442 through TASK-451.

## Change summary

Human-authored summary required before merge.

## Verification

- `python -m pytest tldw_Server_API/tests/Persona/test_persona_sessions.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q`
- `bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/components/PersonaGarden/__tests__/ScopePolicyEditors.test.tsx`
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_prd_reconciliation_clean.json`
- `git diff --check`

## Scope notes

- Persona system only.
- Does not touch Buddy-system implementation work.
- Does not touch design-system backlog tasks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the Persona PRD to the current Persona Garden/live-session scope and ships focused features: selected‑session redacted export, scope/policy editors with MCP tool discovery, live memory status, and state‑history archive. Aligns backend, UI, and docs to close the completion scope and addresses follow‑up review fixes.

- New Features
  - Selected session transcript export: deterministic redacted JSON, ownership checks, and download with confirmation.
  - Scope and policy editors: add/edit/remove rules backed by profile scope/policy endpoints; policy editor supports MCP tool selection.
  - Live memory status: shows persona runtime mode, retrieval on/off and top‑k, and when state context applies.
  - State history archive: owner‑scoped archive action for active state entries with confirm and refreshed history; PRD/docs updated.

- Bug Fixes
  - Transcript export robustness: preserves nulls in metadata, drops non‑dict top‑level metadata, and honors existing export gating; adds focused tests.
  - Editor/UI stability: scope/policy editors keep existing rules during async reload and block save while loading; hardened export confirmation flow.
  - Runtime mode consistency: normalized mode across API responses and catalog/schema with tests; sidepanel tests avoid unhandled session connections.

<sup>Written for commit a3285927d65cc4873648bc4fe3d8986e85feee9c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1905?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

