### PR TITLE
Migrate RecentStudySessions empty states

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -242,28 +242,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/components/RecentStudySessions.tsx:Empty#antd-empty-recentstudysessions-loading-recent-study-sess-13qi672",
-    "path": "src/components/Flashcards/components/RecentStudySessions.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/Flashcards/components/RecentStudySessions.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/components/RecentStudySessions.tsx:Empty#antd-empty-recentstudysessions-retry-line-47-16icsdx",
-    "path": "src/components/Flashcards/components/RecentStudySessions.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/Flashcards/components/RecentStudySessions.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/tabs/ImageOcclusionPanel.tsx:Alert#antd-alert-imageocclusionpanel-type-info-line-230-fgog2f",
     "path": "src/components/Flashcards/tabs/ImageOcclusionPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
@@ -1,6 +1,8 @@
 import React from "react"
-import { Button, Card, Empty, List, Space, Tag, Typography } from "antd"
+import { Button, Card, List, Space, Tag, Typography } from "antd"
 
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
+import { LoadingState } from "@/components/ui/feedback/LoadingState"
 import { useRecentFlashcardReviewSessionsQuery } from "../hooks"
 
 const { Text } = Typography
@@ -21,8 +23,7 @@ export const RecentStudySessions: React.FC<RecentStudySessionsProps> = ({
   onOpenSession,
   isActive
 }) => {
-  const recentSessionsQuery =
-    useRecentFlashcardReviewSessionsQuery(
+  const recentSessionsQuery = useRecentFlashcardReviewSessionsQuery(
     {
       deckId,
       status: "completed",
@@ -31,7 +32,7 @@ export const RecentStudySessions: React.FC<RecentStudySessionsProps> = ({
     {
       enabled: isActive
     }
-    )
+  )
 
   const sessions = recentSessionsQuery.data ?? []
   const errorMessage =
@@ -42,16 +43,28 @@ export const RecentStudySessions: React.FC<RecentStudySessionsProps> = ({
   return (
     <Card size="small" title="Recent study sessions">
       {recentSessionsQuery.isLoading ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Loading recent study sessions..." />
+        <LoadingState
+          mode="spinner"
+          size="sm"
+          label="Loading recent study sessions..."
+          className="py-4"
+        />
       ) : recentSessionsQuery.isError ? (
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={errorMessage}
-        >
-          <Button onClick={() => void recentSessionsQuery.refetch()}>Retry</Button>
-        </Empty>
+        <EmptyState
+          variant="inline"
+          size="sm"
+          title={errorMessage}
+          primaryAction={{
+            label: "Retry",
+            onClick: () => void recentSessionsQuery.refetch()
+          }}
+        />
       ) : sessions.length === 0 ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No completed study sessions yet." />
+        <EmptyState
+          variant="inline"
+          size="sm"
+          title="No completed study sessions yet."
+        />
       ) : (
         <List
           dataSource={sessions}

--- a/apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
@@ -47,13 +47,13 @@ export const RecentStudySessions: React.FC<RecentStudySessionsProps> = ({
           mode="spinner"
           size="sm"
           label="Loading recent study sessions..."
-          className="py-4"
         />
       ) : recentSessionsQuery.isError ? (
         <EmptyState
           variant="inline"
           size="sm"
-          title={errorMessage}
+          title="Failed to load recent study sessions"
+          description={errorMessage}
           primaryAction={{
             label: "Retry",
             onClick: () => void recentSessionsQuery.refetch()

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
@@ -10,7 +10,28 @@ vi.mock("../../hooks", () => ({
   useRecentFlashcardReviewSessionsQuery: vi.fn()
 }))
 
+type RecentSessionsQueryResult = ReturnType<typeof useRecentFlashcardReviewSessionsQuery>
+type RecentSessionsQueryMock = Partial<RecentSessionsQueryResult>
+
 const sessionsMock = vi.fn()
+
+const mockRecentSessionsQuery = (result: RecentSessionsQueryMock) => {
+  vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue(
+    result as RecentSessionsQueryResult
+  )
+}
+
+const createRefetchMock = () => {
+  const mock = vi.fn()
+  const refetch = ((...args: Parameters<RecentSessionsQueryResult["refetch"]>) => {
+    mock(...args)
+    return Promise.resolve(
+      {} as Awaited<ReturnType<RecentSessionsQueryResult["refetch"]>>
+    )
+  }) as RecentSessionsQueryResult["refetch"]
+
+  return { mock, refetch }
+}
 
 if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   Object.defineProperty(window, "matchMedia", {
@@ -32,7 +53,7 @@ describe("RecentStudySessions", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sessionsMock.mockReset()
-    vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue({
+    mockRecentSessionsQuery({
       data: [
         {
           id: 81,
@@ -49,7 +70,7 @@ describe("RecentStudySessions", () => {
       ],
       isLoading: false,
       isFetching: false
-    } as any)
+    })
   })
 
   it("lists completed sessions and reopens the selected snapshot when clicked", () => {
@@ -76,15 +97,15 @@ describe("RecentStudySessions", () => {
   })
 
   it("shows a retryable error state when loading fails", () => {
-    const refetchMock = vi.fn()
-    vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue({
+    const refetchMock = createRefetchMock()
+    mockRecentSessionsQuery({
       data: undefined,
       isLoading: false,
       isFetching: false,
       isError: true,
       error: new Error("Session service offline"),
-      refetch: refetchMock
-    } as any)
+      refetch: refetchMock.refetch
+    })
 
     render(
       <RecentStudySessions
@@ -95,6 +116,7 @@ describe("RecentStudySessions", () => {
       />
     )
 
+    expect(screen.getByText("Failed to load recent study sessions")).toBeInTheDocument()
     expect(screen.getByText("Session service offline")).toBeInTheDocument()
     expect(
       screen
@@ -103,16 +125,16 @@ describe("RecentStudySessions", () => {
     ).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
 
-    expect(refetchMock).toHaveBeenCalled()
+    expect(refetchMock.mock).toHaveBeenCalled()
   })
 
   it("renders loading and no-session product states through canonical design-system primitives", () => {
-    vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue({
+    mockRecentSessionsQuery({
       data: undefined,
       isLoading: true,
       isFetching: false,
       isError: false
-    } as any)
+    })
 
     const { rerender } = render(
       <RecentStudySessions
@@ -130,12 +152,12 @@ describe("RecentStudySessions", () => {
         .closest('[data-ds-component="LoadingState"]')
     ).toBeInTheDocument()
 
-    vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue({
+    mockRecentSessionsQuery({
       data: [],
       isLoading: false,
       isFetching: false,
       isError: false
-    } as any)
+    })
 
     rerender(
       <RecentStudySessions

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
@@ -96,8 +96,61 @@ describe("RecentStudySessions", () => {
     )
 
     expect(screen.getByText("Session service offline")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Session service offline")
+        .closest('[data-ds-component="EmptyState"]')
+    ).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
 
     expect(refetchMock).toHaveBeenCalled()
+  })
+
+  it("renders loading and no-session product states through canonical design-system primitives", () => {
+    vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: false,
+      isError: false
+    } as any)
+
+    const { rerender } = render(
+      <RecentStudySessions
+        deckId={12}
+        selectedSessionId={null}
+        onOpenSession={sessionsMock}
+        isActive
+      />
+    )
+
+    expect(screen.getByText("Loading recent study sessions...")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Loading recent study sessions...")
+        .closest('[data-ds-component="LoadingState"]')
+    ).toBeInTheDocument()
+
+    vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isError: false
+    } as any)
+
+    rerender(
+      <RecentStudySessions
+        deckId={12}
+        selectedSessionId={null}
+        onOpenSession={sessionsMock}
+        isActive
+      />
+    )
+
+    expect(screen.getByText("No completed study sessions yet.")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("No completed study sessions yet.")
+        .closest('[data-ds-component="EmptyState"]')
+    ).toBeInTheDocument()
   })
 })

--- a/backlog/tasks/task-45.51 - Migrate-RecentStudySessions-empty-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.51 - Migrate-RecentStudySessions-empty-states-to-design-system-primitives.md
@@ -22,18 +22,25 @@ Continue the tldw_server WebUI design-system product-state migration by replacin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] RecentStudySessions uses the design-system LoadingState during recent session data fetches.
+- [x] Retryable error state renders a design-system EmptyState with a Retry action and the dynamic error message as description.
+- [x] Empty sessions state renders a design-system EmptyState with the no completed sessions message.
+- [x] Focused tests assert the canonical design-system wrappers through data-ds-component attributes.
+- [x] The two RecentStudySessions AntD Empty baseline exceptions are removed from design-system-product-state-baseline.json.
+- [x] The design-system product-state guard passes with the reduced baseline.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Verification: `bunx vitest run src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx --reporter=dot` passed (3 tests); `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed (52 tests); `bun run verify:design-system-state` passed with baseline exceptions now 323; `git diff --check` passed. `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on inherited repo-wide TypeScript debt unrelated to this slice. Bandit skipped because no Python was touched.
+- Review follow-up: documented explicit Acceptance Criteria, removed redundant LoadingState padding override, moved dynamic load failure text into EmptyState description behind a stable title, and replaced raw `as any` hook-return mocks with a typed RecentSessionsQuery helper. Reverified the focused component test, product-state guard, design-system verifier, diff whitespace, and touched-file TypeScript status.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated RecentStudySessions loading, retryable error, and no-session product states from AntD Empty to canonical design-system LoadingState/EmptyState primitives. Added focused DOM coverage that asserts those states render through data-ds-component markers, removed the two matching RecentStudySessions product-state baseline exceptions, and verified the focused component test, product-state guard unit test, design-system state verifier, and git diff whitespace. Bandit was not run because this slice touched only TypeScript/TSX UI, JSON baseline, and Backlog metadata. Full TypeScript still fails on inherited repo-wide debt unrelated to this slice; no diagnostics referenced the changed RecentStudySessions files.
+Migrated RecentStudySessions loading, retryable error, and no-session product states from AntD Empty to canonical design-system LoadingState/EmptyState primitives. Added focused DOM coverage that asserts those states render through data-ds-component markers, removed the two matching RecentStudySessions product-state baseline exceptions, and documented explicit task Acceptance Criteria. Review follow-up removed redundant LoadingState padding, split the retryable error state into a stable title plus dynamic description, and typed the hook-return mocks instead of using raw `as any`. Verified the focused component test, product-state guard unit test, design-system state verifier, and git diff whitespace. Bandit was not run because this slice touched only TypeScript/TSX UI, JSON baseline, and Backlog metadata. Full local TypeScript still fails on inherited repo-wide debt unrelated to this slice; no diagnostics referenced the changed RecentStudySessions files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.51 - Migrate-RecentStudySessions-empty-states-to-design-system-primitives.md
+++ b/backlog/tasks/task-45.51 - Migrate-RecentStudySessions-empty-states-to-design-system-primitives.md
@@ -1,0 +1,47 @@
+---
+id: TASK-45.51
+title: Migrate RecentStudySessions empty states to design-system primitives
+status: Done
+labels:
+- design-system
+- product-state
+- ui
+- flashcards
+parent_task_id: TASK-45
+references:
+- apps/packages/ui/src/components/Flashcards/components/RecentStudySessions.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system product-state migration by replacing RecentStudySessions AntD Empty product-state surfaces with canonical design-system EmptyState/LoadingState primitives while preserving the existing loading, retryable error, no-sessions, and session-list behaviors. Remove the matching product-state baseline exceptions and verify the guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verification: `bunx vitest run src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx --reporter=dot` passed (3 tests); `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed (52 tests); `bun run verify:design-system-state` passed with baseline exceptions now 323; `git diff --check` passed. `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on inherited repo-wide TypeScript debt unrelated to this slice. Bandit skipped because no Python was touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated RecentStudySessions loading, retryable error, and no-session product states from AntD Empty to canonical design-system LoadingState/EmptyState primitives. Added focused DOM coverage that asserts those states render through data-ds-component markers, removed the two matching RecentStudySessions product-state baseline exceptions, and verified the focused component test, product-state guard unit test, design-system state verifier, and git diff whitespace. Bandit was not run because this slice touched only TypeScript/TSX UI, JSON baseline, and Backlog metadata. Full TypeScript still fails on inherited repo-wide debt unrelated to this slice; no diagnostics referenced the changed RecentStudySessions files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate RecentStudySessions loading, error/retry, and empty-session states from AntD Empty to canonical design-system LoadingState/EmptyState primitives.
- Add focused DOM coverage that asserts those states render through design-system `data-ds-component` markers.
- Remove the two matching RecentStudySessions product-state baseline exceptions; baseline exceptions are now 323.
- Add and complete Backlog task `TASK-45.51`.

## Verification
- `bunx vitest run src/components/Flashcards/components/__tests__/RecentStudySessions.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`

## Known follow-up / existing debt
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on inherited repo-wide TypeScript debt unrelated to this slice. No diagnostics referenced the changed RecentStudySessions files.
- Bandit was not run because this slice touches only TypeScript/TSX UI, JSON baseline, and Backlog metadata.

## Change summary
TODO: Human-authored summary required before merge. Please describe what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved RecentStudySessions loading, error/retry, and empty states from `antd` `Empty` to design-system `LoadingState`/`EmptyState` for a consistent product-state UI (completes TASK-45.51). Error state now uses a stable title with the server error shown in the description.

- **Refactors**
  - Swapped in `LoadingState` (spinner, sm) and `EmptyState` (inline, sm) for loading, retryable error, and no-session views.
  - Expanded tests to assert `data-ds-component` markers for loading/empty/error and verify Retry via a typed refetch helper.
  - Removed the two RecentStudySessions entries from the product-state baseline.

<sup>Written for commit 70801d8459ab3599018418719365e826d78917c4. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1910?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

