### PR TITLE
Docs: Workspace Persona Defaults PRD

### DIFF
--- a/Docs/Product/Workspace_Persona_Defaults_PRD.md
+++ b/Docs/Product/Workspace_Persona_Defaults_PRD.md
@@ -1,0 +1,240 @@
+# Workspace Persona Defaults PRD
+
+Status: Draft
+
+Owner: Persona module / Workspaces integration
+
+Tracking: #1911, split from #1902
+
+Backlog: TASK-468
+
+## Summary
+
+Define Workspace-scoped Persona defaults as a thin composition layer over existing Workspaces, Persona profiles, and Workspace-scoped chat sessions. This PRD replaces the original Persona PRD's old `project_id` language with current Workspace terminology and keeps the work separate from Persona-backed ordinary chat startup, scheduled work, Buddy animation, and broad personalization memory.
+
+The goal is not to make Workspaces own Persona profiles. The goal is to let a Workspace recommend a default assistant identity and related defaults for Workspace-bound surfaces, while preserving explicit user choices and session-level metadata.
+
+## Problem
+
+Persona Garden now owns Persona profile creation, configuration, and live-session testing. Persona-backed Chat Startup now owns ordinary chat startup as a Persona. Workspaces still need a separate contract for cases where a research workspace should carry a preferred assistant shape: for example a "literature review" Workspace might default to a careful research Persona, a specific voice for audio overview workflows, and a limited tool policy appropriate for that workspace.
+
+The current code has the pieces but not the product contract:
+
+- Workspace API schemas persist workspace metadata, study-materials policy, banner fields, and audio defaults.
+- Workspace chat uses `scope: { type: "workspace", workspaceId }`.
+- Chat session schemas already support `scope_type: "workspace"`, `workspace_id`, `assistant_kind`, `assistant_id`, and `persona_memory_mode`.
+- Chat Workspace UI already reports a runtime `selectedPersonaLabel`, but there is no documented Workspace default source of truth or precedence model.
+
+Without a PRD, Workspace defaults risk becoming implicit global state that silently overrides chat choices or Persona profile settings.
+
+## Goals
+
+- Define a Workspace-level defaults object for Persona-related behavior.
+- Preserve explicit chat/session Persona selection over Workspace defaults.
+- Keep Persona profiles user-owned and configured in Persona Garden.
+- Let Workspace-bound chat and later Workspace surfaces read a Workspace default without duplicating Persona profile data.
+- Document precedence between global user settings, Workspace defaults, Persona profile defaults, and per-session choices.
+- Replace `project_id` phrasing with `workspace_id` and current Workspace terminology.
+
+## Non-goals
+
+- No implementation in this PRD slice.
+- No Buddy animation or expressive avatar runtime.
+- No design-system backlog work.
+- No scheduled Persona work or recurring jobs.
+- No ordinary `/chat` Persona startup changes; that is covered by #1908.
+- No cross-app semantic personalization memory layer.
+- No marketplace-style tool administration.
+- No multi-agent or multi-Persona collaboration.
+
+## Current Contract Evidence
+
+- `Docs/Product/Persona_Agent_Design.md` moves Workspace Persona Defaults out of current Persona Garden completion scope and says old `project_id` language maps to Workspaces.
+- `Docs/Product/Persona_Backed_Chat_Startup_PRD.md` keeps Workspace-scoped Persona selection out of ordinary chat startup scope.
+- `apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx` creates chat scope as `{ type: "workspace", workspaceId }`.
+- `apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx` tracks Workspace runtime state including `selectedPersonaLabel`.
+- `apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx` displays `Model / Persona` status and falls back to `No persona selected`.
+- `apps/packages/ui/src/types/workspace.ts` defines `SavedWorkspace` without Persona defaults today.
+- `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py` defines Workspace create/update/response fields and already includes audio defaults.
+- `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py` supports Workspace-scoped chat session creation and Persona assistant metadata.
+- `tldw_Server_API/app/core/DB_Management/chacha/conversation_store.py` validates Workspace scope and Persona assistant identity separately.
+
+## Product Shape
+
+Workspace Persona Defaults V1 should add an explicit optional defaults object to a Workspace:
+
+```json
+{
+  "persona_defaults": {
+    "default_persona_id": "persona-id",
+    "persona_memory_mode": "read_only",
+    "style_preset_id": null,
+    "voice": {
+      "provider": "kokoro",
+      "model": "default",
+      "voice": "af_heart",
+      "speed": 1.0
+    },
+    "tool_policy_profile_id": null
+  }
+}
+```
+
+The object should be reference-backed where possible:
+
+- `default_persona_id` references a Persona profile owned by the user.
+- `persona_memory_mode` defaults to `read_only`.
+- voice defaults can reuse existing Workspace audio fields in V1 or be mirrored into a structured response shape if the existing fields remain the storage source.
+- tool policy defaults should be a future reference to Persona policy/scopes, not an embedded copy of tool permissions.
+
+## Precedence Rules
+
+V1 should use deterministic precedence:
+
+1. Per-chat/session explicit assistant selection.
+2. Workspace Persona default.
+3. User/global chat default.
+4. System fallback assistant.
+
+For other Persona-adjacent defaults:
+
+1. Per-session explicit value.
+2. Workspace default.
+3. Persona profile default.
+4. Global user setting.
+5. Server fallback.
+
+Workspace defaults should apply only when the active surface has Workspace scope. They must not silently affect ordinary global `/chat` unless that chat is explicitly started from or bound to a Workspace.
+
+## UX Requirements
+
+- Workspace settings should show the default Persona as a reference to an existing Persona profile, not as copied Persona content.
+- Chat Workspace should surface whether a Persona is inherited from Workspace defaults or explicitly selected for the chat.
+- Users must be able to clear a Workspace Persona default.
+- If the referenced Persona is deleted or unavailable, the Workspace should show a degraded state and continue to open.
+- Applying a Workspace default should not overwrite an active chat session's existing Persona metadata.
+- Any `read_write` memory mode default must be explicit and visible before use.
+
+## Backend Requirements
+
+- Workspace read/update APIs should expose an optional Persona defaults contract.
+- The persisted contract should avoid snapshots of Persona name, prompt, avatar, policy, or tool permissions.
+- Workspace update should validate references where practical:
+  - Persona exists and belongs to the current user.
+  - memory mode is one of `read_only` or `read_write`.
+  - voice fields follow existing Workspace audio validation once that validation exists.
+- Chat session creation should continue to store concrete assistant metadata on the conversation; Workspace defaults are startup hints, not hidden mutable session state.
+- If a Workspace default changes, existing conversations should not silently change assistant identity.
+
+## Data Model Direction
+
+Preferred V1 storage is an explicit JSON/object field or companion table on Workspace records rather than overloading existing banner/audio fields.
+
+Required fields:
+
+- `default_persona_id: string | null`
+- `persona_memory_mode: "read_only" | "read_write" | null`
+
+Allowed V1-adjacent fields:
+
+- `voice_provider`
+- `voice_model`
+- `voice_id`
+- `voice_speed`
+
+Deferred fields:
+
+- style preset references until a stable style preset catalog exists.
+- tool policy profile references until Persona Tool Administration PRD defines install/config lifecycle.
+- personalization memory tuning until the Personalization Memory Layer PRD.
+
+## Staged Delivery
+
+### Stage 1: Contract Audit And Schema Design
+
+Goal: define the smallest Workspace defaults contract without writing runtime behavior first.
+
+Deliverables:
+
+- Backend schema proposal for Workspace Persona defaults.
+- DB migration design for storing references and memory mode.
+- Validation rules for missing/deleted Persona references.
+- API response examples for no default, valid default, and degraded default.
+
+### Stage 2: Workspace Settings And Read Path
+
+Goal: make defaults visible and editable without changing chat behavior yet.
+
+Deliverables:
+
+- Workspace settings UI for selecting/clearing a default Persona.
+- Read-only degraded state for deleted/unavailable Persona.
+- Tests for optimistic locking and reference validation.
+
+### Stage 3: Chat Workspace Startup Application
+
+Goal: apply Workspace defaults only when starting a new Workspace-scoped chat without explicit assistant metadata.
+
+Deliverables:
+
+- Workspace chat startup reads Workspace default Persona.
+- Explicit chat/session selection overrides Workspace default.
+- Existing conversations are unaffected by later Workspace default edits.
+- Inspector labels distinguish inherited vs explicit Persona where feasible.
+
+### Stage 4: Voice And Tool Defaults
+
+Goal: integrate adjacent defaults only after Persona identity behavior is stable.
+
+Deliverables:
+
+- Reconcile existing Workspace audio fields with Persona voice defaults.
+- Add tool policy reference display only if the referenced policy contract already exists.
+- Keep broad tool installation/admin flows out of this PRD.
+
+## Risks
+
+- Workspace defaults could silently override explicit user choices if precedence is not enforced.
+- Storing Persona snapshots would drift from Persona Garden profile updates and create privacy risk.
+- Reusing existing Workspace audio fields without a structured contract may confuse voice defaults with audio overview generation settings.
+- `read_write` memory mode could create unexpected durable memory if it is inherited invisibly.
+- Workspace sharing may expose default Persona references in ways that require permission-aware redaction.
+
+## Open Questions For Implementation Planning
+
+- Should V1 store voice defaults in existing Workspace audio fields or introduce a nested Persona defaults object immediately?
+- Should shared Workspace viewers see the owner's default Persona label, a redacted label, or only "Persona default unavailable"?
+- Should Workspace defaults apply to Prompt Studio and writing surfaces in V1, or only Chat Workspace?
+- Should changing the Workspace default offer to apply to new chats only, or also prompt the user to update open unsent chat state?
+
+## Acceptance Criteria
+
+- Workspace Persona defaults are documented as Workspace-scoped startup hints, not hidden global assistant state.
+- Explicit per-session Persona choices override Workspace defaults.
+- Existing conversations do not silently change when Workspace defaults change.
+- Persona references remain reference-backed with no Persona content snapshots.
+- Missing/deleted Persona references degrade visibly and do not block opening the Workspace.
+- `read_write` memory mode is never inherited invisibly.
+- Old `project_id` terminology is replaced by current Workspace terminology in this feature's contract.
+
+## Verification Plan
+
+- Schema tests for valid, empty, invalid, and deleted Persona default references.
+- Migration tests for adding Workspace Persona defaults without altering existing Workspace records.
+- API tests for Workspace read/update optimistic locking and reference validation.
+- Component tests for selecting, clearing, and degraded display of Workspace Persona defaults.
+- Integration tests proving Workspace chat startup applies defaults only for new Workspace-scoped chats with no explicit assistant.
+- Regression tests proving global chat and existing conversations are unaffected.
+
+## References
+
+- `Docs/Product/Persona_Agent_Design.md`
+- `Docs/Product/Persona_Backed_Chat_Startup_PRD.md`
+- `Docs/superpowers/specs/2026-05-21-persona-prd-reconciliation-design.md`
+- `apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx`
+- `apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx`
+- `apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx`
+- `apps/packages/ui/src/types/workspace.ts`
+- `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`
+- `tldw_Server_API/app/core/DB_Management/chacha/conversation_store.py`

--- a/backlog/tasks/task-468 - Draft-Workspace-Persona-Defaults-PRD.md
+++ b/backlog/tasks/task-468 - Draft-Workspace-Persona-Defaults-PRD.md
@@ -1,0 +1,59 @@
+---
+id: TASK-468
+title: Draft Workspace Persona Defaults PRD
+status: Done
+labels:
+- persona
+- workspace
+- prd
+- docs
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1911
+- https://github.com/rmusser01/tldw_server/issues/1902
+modified_files:
+- Docs/Product/Workspace_Persona_Defaults_PRD.md
+- backlog/tasks/task-468 - Draft-Workspace-Persona-Defaults-PRD.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Draft a repo-grounded PRD for Workspace-scoped Persona defaults, replacing old project_id terminology with current Workspace-level persona/style/voice/tool default semantics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PRD is grounded in current Workspace, chat, and Persona contracts.
+- [x] #2 Scope, non-goals, precedence rules, risks, staged implementation, and validation plan are documented.
+- [x] #3 Issue #1911 and tracker #1902 are referenced.
+- [x] #4 Docs-only verification is recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create the dedicated GitHub tracker issue for Workspace Persona Defaults. 2. Inspect current Workspace, chat, and Persona contracts to ground the PRD. 3. Draft the PRD with scope, non-goals, precedence, degraded-state behavior, staged implementation, risks, and validation. 4. Run docs-only verification and update the task status.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Workspace Persona Defaults PRD and grounded it in existing Workspace CRUD schemas, Chat Workspace scope/runtime state, Workspace-scoped chat session metadata, and Persona profile references. Documented reference-backed defaults, precedence, non-goals, staged delivery, risks, and validation. Verification: git diff --check passed. Bandit skipped because this is docs/backlog only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- adds a focused PRD for Workspace-scoped Persona defaults
- grounds the scope in existing Workspace CRUD schemas, Chat Workspace runtime state, Workspace-scoped chat sessions, and Persona references
- defines reference-backed defaults, precedence rules, degraded-state handling, and non-goals

## Tracking
- Closes #1911
- Split from #1902
- Backlog: TASK-468

## Verification
- git diff --check
- git diff --cached --check
- Bandit skipped: docs/backlog only

## Change summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PRD defining Workspace-scoped Persona defaults with clear precedence rules, degraded-state handling, and a staged delivery plan tied to current Workspace, Chat, and Persona contracts. Replaces `project_id` with `workspace_id` and satisfies #1911 / TASK-468 by specifying reference-backed defaults and validation.

<sup>Written for commit bad527242ec3fd102e5ebe86b3a57f77d3df4a99. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1912?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

