### PR TITLE
Fix Watchlists review follow-up issues

### DIFF
--- a/Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
+++ b/Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
@@ -21,3 +21,14 @@
 **Success Criteria**: TASK metadata parses consistently; verification results are recorded in TASK-468.
 **Tests**: Targeted Vitest, targeted pytest, Bandit on touched backend files.
 **Status**: Complete
+
+## Stage 5: PR Review Follow-Up
+**Goal**: Address PR #1915 review comments and failing check evidence after the first draft review.
+**Success Criteria**: Valid review findings are fixed or documented as not applicable; targeted tests cover the fixes.
+**Tests**: Targeted Vitest, targeted pytest, Bandit on touched backend files, relevant CI log inspection.
+**Status**: Complete
+
+Review follow-up notes:
+- Mixed-case audio status normalization, numeric filter counter coercion, quoted/JSON/bearer secret redaction, and non-empty TASK acceptance criteria were patched.
+- The Watchlists Accessibility Gate failure was traced to `RunDetailDrawer.stream-lifecycle.test.tsx` expecting `Pending` while the current UI contract shows queued audio tasks as `Queued`; the test now matches the product-facing status.
+- Full Suite jobs on the pre-fix commit were cancelled around the AuthNZ slice before Watchlists tests ran; they need to be rechecked after the follow-up commit pushes.

--- a/Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
+++ b/Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
@@ -1,0 +1,23 @@
+## Stage 1: Verify Review Findings
+**Goal**: Separate still-valid PR #1907 review findings from findings already fixed by merged PR #1906.
+**Success Criteria**: Each actionable item is mapped to current `dev` evidence.
+**Tests**: Source inspection against current branch.
+**Status**: Complete
+
+## Stage 2: Patch Watchlists Status Truth
+**Goal**: Preserve audio-specific status fields, count status-only failed audio outputs, and keep health fixtures typed.
+**Success Criteria**: Audio status UI and overview attention counts cannot be masked by generic report status or missing request flags.
+**Tests**: Watchlists output metadata and overview service tests.
+**Status**: Complete
+
+## Stage 3: Patch Backend Detail And Redaction Safety
+**Goal**: Preserve legacy flat filter counters and redact JSON-style source secrets before source errors are stored.
+**Success Criteria**: Run details retain real filter counts; source error sanitizer removes JSON key/value secrets.
+**Tests**: Watchlists run detail and operator recovery tests.
+**Status**: Complete
+
+## Stage 4: Metadata Cleanup And Verification
+**Goal**: Normalize Backlog metadata and run targeted frontend/backend/security checks.
+**Success Criteria**: TASK metadata parses consistently; verification results are recorded in TASK-468.
+**Tests**: Targeted Vitest, targeted pytest, Bandit on touched backend files.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
@@ -201,6 +201,23 @@ describe("outputMetadata helpers", () => {
     expect(summary.scriptArtifact?.uri).toBeUndefined()
   })
 
+  it("prioritizes audio-specific status over generic report status", () => {
+    expect(
+      getAudioStatusSummary({
+        status: "completed",
+        audio_status: "failed"
+      }).status
+    ).toBe("failed")
+
+    expect(
+      getAudioStatusSummary({
+        status: "unknown",
+        audio_briefing_status: "pending",
+        audio_briefing_task_id: "task-123"
+      }).status
+    ).toBe("queued")
+  })
+
   it("returns artifact labels and tag colors by output kind", () => {
     expect(getOutputArtifactLabel({ format: "mp3", type: "tts_audio" })).toBe("Audio briefing")
     expect(getOutputArtifactTagColor({ format: "mp3", type: "tts_audio" })).toBe("purple")

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
@@ -212,7 +212,7 @@ describe("outputMetadata helpers", () => {
     expect(
       getAudioStatusSummary({
         status: "unknown",
-        audio_briefing_status: "pending",
+        audio_briefing_status: "Pending",
         audio_briefing_task_id: "task-123"
       }).status
     ).toBe("queued")

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
@@ -166,8 +166,9 @@ const asNonEmptyString = (value: unknown): string | undefined => {
 
 const asKnownAudioStatus = (value: unknown): string | undefined => {
   const status = asNonEmptyString(value)
-  if (!status || status.toLowerCase() === "unknown") return undefined
-  return status
+  const normalized = status?.toLowerCase()
+  if (!normalized || normalized === "unknown") return undefined
+  return normalized
 }
 
 const asSafeDownloadUrl = (value: unknown): string | undefined => {

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
@@ -164,6 +164,12 @@ const asNonEmptyString = (value: unknown): string | undefined => {
   return trimmed.length > 0 ? trimmed : undefined
 }
 
+const asKnownAudioStatus = (value: unknown): string | undefined => {
+  const status = asNonEmptyString(value)
+  if (!status || status.toLowerCase() === "unknown") return undefined
+  return status
+}
+
 const asSafeDownloadUrl = (value: unknown): string | undefined => {
   const url = asNonEmptyString(value)
   if (!url) return undefined
@@ -590,7 +596,11 @@ export const getAudioStatusSummary = (
     asNonEmptyString(record?.task_id) ||
     asNonEmptyString(record?.taskId) ||
     asNonEmptyString(record?.audio_briefing_task_id)
-  const rawStatus = asNonEmptyString(record?.status) || "unknown"
+  const rawStatus =
+    asKnownAudioStatus(record?.audio_briefing_status) ||
+    asKnownAudioStatus(record?.audio_status) ||
+    asKnownAudioStatus(record?.status) ||
+    "unknown"
   const status = rawStatus === "pending" && taskId ? "queued" : rawStatus
   const scriptArtifact = normalizeAudioArtifact(
     record?.script_artifact,

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
@@ -421,7 +421,7 @@ describe("RunDetailDrawer stream lifecycle", () => {
     })
     expect(screen.getByText("Audio briefing")).toBeInTheDocument()
     await waitFor(() => {
-      expect(screen.getByText("Pending")).toBeInTheDocument()
+      expect(screen.getByText("Queued")).toBeInTheDocument()
     })
   })
 

--- a/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.health.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.health.test.tsx
@@ -154,6 +154,9 @@ const buildOverviewData = (): WatchlistsOverviewData => ({
   items: {
     unread: 0
   },
+  alerts: {
+    unread: 0
+  },
   runs: {
     running: 0,
     pending: 0,

--- a/apps/packages/ui/src/services/__tests__/watchlists-overview.test.ts
+++ b/apps/packages/ui/src/services/__tests__/watchlists-overview.test.ts
@@ -438,9 +438,22 @@ describe("watchlists overview service", () => {
           version: 1,
           expired: false,
           created_at: "2026-02-18T10:06:00Z"
+        },
+        {
+          id: 703,
+          run_id: 101,
+          job_id: 10,
+          type: "briefing_markdown",
+          format: "md",
+          metadata: {
+            audio_status: "failed"
+          },
+          version: 1,
+          expired: false,
+          created_at: "2026-02-18T10:07:00Z"
         }
       ],
-      total: 2,
+      total: 3,
       has_more: false
     })
 
@@ -450,16 +463,16 @@ describe("watchlists overview service", () => {
     expect(result.runs.failed).toBe(0)
     expect(result.runs.sourceErrors).toBe(1)
     expect(result.runs.zeroItemSourceErrors).toBe(1)
-    expect(result.outputs.audioIssues).toBe(2)
+    expect(result.outputs.audioIssues).toBe(3)
     expect(result.health.statuses.sources).toBe("attention")
     expect(result.health.statuses.runs).toBe("attention")
     expect(result.health.statuses.outputs).toBe("attention")
     expect(result.health.attention).toEqual({
-      total: 4,
+      total: 5,
       sources: 1,
       jobs: 0,
       runs: 1,
-      outputs: 2
+      outputs: 3
     })
     expect(result.systemHealth).toBe("degraded")
   })

--- a/apps/packages/ui/src/services/watchlists-overview.ts
+++ b/apps/packages/ui/src/services/watchlists-overview.ts
@@ -188,18 +188,19 @@ const hasAudioOutputIssue = (metadata: unknown): boolean => {
     record.generate_audio === true ||
     audio?.requested === true ||
     audio?.enabled === true
-  if (!requested) return false
   const normalized = normalizeStatus(
     (record.audio_briefing_status as string | null | undefined) ||
       (record.audio_status as string | null | undefined) ||
       (audio?.status as string | null | undefined)
   )
-  return (
+  if (
     normalized === "enqueue failed" ||
-    normalized === "skipped" ||
     normalized === "failed" ||
     normalized === "error"
-  )
+  ) {
+    return true
+  }
+  return requested && normalized === "skipped"
 }
 
 const getSourceErrorCount = (run: Pick<WatchlistRun, "stats">): number => {

--- a/backlog/tasks/task-440 - Design-staged-remediation-plans-for-Watchlists-demo-readiness-issues.md
+++ b/backlog/tasks/task-440 - Design-staged-remediation-plans-for-Watchlists-demo-readiness-issues.md
@@ -2,10 +2,14 @@
 id: TASK-440
 title: Design staged remediation plans for Watchlists demo-readiness issues
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-05-21 00:01'
 labels:
 - watchlists
 - design
 - demo-readiness
+dependencies: []
 priority: High
 modified_files:
 - Docs/superpowers/specs/2026-05-20-watchlists-demo-remediation-staged-plans-design.md

--- a/backlog/tasks/task-442 - Implement-Watchlists-demo-rescue-slice.md
+++ b/backlog/tasks/task-442 - Implement-Watchlists-demo-rescue-slice.md
@@ -4,7 +4,7 @@ title: Implement Watchlists demo rescue slice
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-05-21 04:06
+updated_date: '2026-05-21 04:06'
 labels:
 - watchlists
 - demo-readiness

--- a/backlog/tasks/task-468 - Address-Watchlists-PR-1907-follow-up-review-findings.md
+++ b/backlog/tasks/task-468 - Address-Watchlists-PR-1907-follow-up-review-findings.md
@@ -11,6 +11,7 @@ modified_files:
 - Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
 - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
 - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunDetailDrawer.stream-lifecycle.test.tsx
 - apps/packages/ui/src/services/watchlists-overview.ts
 - apps/packages/ui/src/services/__tests__/watchlists-overview.test.ts
 - apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.health.test.tsx
@@ -24,6 +25,7 @@ modified_files:
 references:
 - https://github.com/rmusser01/tldw_server/pull/1907
 - https://github.com/rmusser01/tldw_server/pull/1906
+- https://github.com/rmusser01/tldw_server/pull/1915
 ---
 
 ## Description
@@ -34,6 +36,11 @@ Fix still-valid Watchlists demo rescue review findings after PR #1906 landed: au
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Audio status summaries prefer audio-specific fields and normalize mixed-case statuses before display.
+- [x] #2 Watchlists overview counts failed audio outputs even when legacy metadata lacks explicit request flags.
+- [x] #3 Run detail stats preserve and coerce valid filter counters while hiding filter_tallies unless requested.
+- [x] #4 Source error redaction removes common quoted, JSON-style, and bearer-token secrets before storage/logging.
+- [x] #5 Targeted frontend, backend, diff, and Bandit verification is recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -45,7 +52,7 @@ Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Verified against current origin/dev. Still-valid findings fixed: audio-specific status precedence, status-only failed audio outputs, run detail flat filter counter preservation, JSON-style secret redaction, missing health fixture alerts field, TASK-440 metadata, TASK-442 quoted updated_date. Findings already fixed in dev and intentionally left unchanged: Scheduler max_retries=1 and raw exception debug logging. Verification: targeted Vitest 27 passed; targeted pytest 4 passed; git diff --check passed; Bandit on touched backend files returned zero findings.
+PR #1915 review fixes applied locally: normalized mixed-case audio statuses, coerced run-detail filter action counts from ints/floats/numeric strings while skipping bools, strengthened quoted/JSON/bearer secret redaction, populated acceptance criteria, and aligned the RunDetailDrawer stream lifecycle expectation with the normalized queued audio-task label. Local verification passed for Watchlists a11y gate, focused Vitest, focused pytest, git diff --check, and Bandit on touched backend files.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-468 - Address-Watchlists-PR-1907-follow-up-review-findings.md
+++ b/backlog/tasks/task-468 - Address-Watchlists-PR-1907-follow-up-review-findings.md
@@ -1,0 +1,65 @@
+---
+id: TASK-468
+title: Address Watchlists PR 1907 follow-up review findings
+status: Done
+labels:
+- watchlists
+- review-fix
+- demo-readiness
+priority: high
+modified_files:
+- Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/outputMetadata.ts
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts
+- apps/packages/ui/src/services/watchlists-overview.ts
+- apps/packages/ui/src/services/__tests__/watchlists-overview.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.health.test.tsx
+- tldw_Server_API/app/api/v1/endpoints/watchlists.py
+- tldw_Server_API/app/core/Watchlists/pipeline.py
+- tldw_Server_API/tests/Watchlists/test_run_detail_filters_totals.py
+- tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+- backlog/tasks/task-440 - Design-staged-remediation-plans-for-Watchlists-demo-readiness-issues.md
+- backlog/tasks/task-442 - Implement-Watchlists-demo-rescue-slice.md
+- backlog/tasks/task-468 - Address-Watchlists-PR-1907-follow-up-review-findings.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/1907
+- https://github.com/rmusser01/tldw_server/pull/1906
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix still-valid Watchlists demo rescue review findings after PR #1906 landed: audio status precedence, status-only audio failure detection, run detail filter counter preservation, JSON-style secret redaction, health test fixture typing, and Backlog metadata formatting. Leave already-fixed retry/raw-exception findings unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-21-watchlists-pr1907-followup-review-fixes.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verified against current origin/dev. Still-valid findings fixed: audio-specific status precedence, status-only failed audio outputs, run detail flat filter counter preservation, JSON-style secret redaction, missing health fixture alerts field, TASK-440 metadata, TASK-442 quoted updated_date. Findings already fixed in dev and intentionally left unchanged: Scheduler max_retries=1 and raw exception debug logging. Verification: targeted Vitest 27 passed; targeted pytest 4 passed; git diff --check passed; Bandit on touched backend files returned zero findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the still-valid Watchlists PR #1907 follow-up findings on a clean dev-based branch. The patch keeps audio status truthful, preserves legacy filter counters in run detail stats, expands source-error redaction for JSON-style secrets, repairs the typed health fixture and Backlog metadata, and records targeted verification.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -4501,19 +4501,31 @@ def _build_run_detail_stats(
         "items_ingested": items_ingested,
     })
     for key in ("filters_include", "filters_exclude", "filters_flag"):
-        detail_stats.setdefault(key, 0)
+        detail_stats[key] = _coerce_run_detail_filter_count(detail_stats.get(key)) or 0
     try:
         if isinstance(stats.get("filters_matched"), int):
             detail_stats["filters_matched"] = int(stats.get("filters_matched") or 0)
         fa = stats.get("filters_actions")
         if isinstance(fa, dict):
             for k in ("include", "exclude", "flag"):
-                v = fa.get(k)
-                if isinstance(v, int):
-                    detail_stats[f"filters_{k}"] = int(v)
+                count = _coerce_run_detail_filter_count(fa.get(k))
+                if count is not None:
+                    detail_stats[f"filters_{k}"] = count
     except _WATCHLISTS_NONCRITICAL_EXCEPTIONS:
         pass
     return detail_stats
+
+
+def _coerce_run_detail_filter_count(value: Any) -> int | None:
+    """Coerce JSON numeric filter counters while rejecting booleans and invalid values."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
 
 
 @router.get("/runs/{run_id}/details", response_model=RunDetail, summary="Get run details with stats and logs")

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -4484,6 +4484,38 @@ async def cancel_run(
     )
 
 
+def _build_run_detail_stats(
+    stats: dict[str, Any],
+    *,
+    items_found: int,
+    items_ingested: int,
+) -> dict[str, Any]:
+    """Build run-detail stats without dropping legacy flat filter counters."""
+    detail_stats: dict[str, Any] = {
+        key: value
+        for key, value in stats.items()
+        if key != "filter_tallies"
+    }
+    detail_stats.update({
+        "items_found": items_found,
+        "items_ingested": items_ingested,
+    })
+    for key in ("filters_include", "filters_exclude", "filters_flag"):
+        detail_stats.setdefault(key, 0)
+    try:
+        if isinstance(stats.get("filters_matched"), int):
+            detail_stats["filters_matched"] = int(stats.get("filters_matched") or 0)
+        fa = stats.get("filters_actions")
+        if isinstance(fa, dict):
+            for k in ("include", "exclude", "flag"):
+                v = fa.get(k)
+                if isinstance(v, int):
+                    detail_stats[f"filters_{k}"] = int(v)
+    except _WATCHLISTS_NONCRITICAL_EXCEPTIONS:
+        pass
+    return detail_stats
+
+
 @router.get("/runs/{run_id}/details", response_model=RunDetail, summary="Get run details with stats and logs")
 async def get_run_details(
     run_id: int = Path(..., ge=1),
@@ -4544,29 +4576,11 @@ async def get_run_details(
             log_text = None
             truncated = False
     # Build stats for detail view, preserving raw stats while keeping opt-in tallies gated.
-    detail_stats: dict[str, Any] = {
-        key: value
-        for key, value in stats.items()
-        if key not in {"filter_tallies", "filters_include", "filters_exclude", "filters_flag"}
-    }
-    detail_stats.update({
-        "items_found": items_found,
-        "items_ingested": items_ingested,
-        "filters_include": 0,
-        "filters_exclude": 0,
-        "filters_flag": 0,
-    })
-    try:
-        if isinstance(stats.get("filters_matched"), int):
-            detail_stats["filters_matched"] = int(stats.get("filters_matched") or 0)
-        fa = stats.get("filters_actions")
-        if isinstance(fa, dict):
-            for k in ("include", "exclude", "flag"):
-                v = fa.get(k)
-                if isinstance(v, int):
-                    detail_stats[f"filters_{k}"] = int(v)
-    except _WATCHLISTS_NONCRITICAL_EXCEPTIONS:
-        pass
+    detail_stats = _build_run_detail_stats(
+        stats,
+        items_found=items_found,
+        items_ingested=items_ingested,
+    )
     # Optional tallies
     tallies_out = None
     if include_tallies:

--- a/tldw_Server_API/app/core/Watchlists/pipeline.py
+++ b/tldw_Server_API/app/core/Watchlists/pipeline.py
@@ -146,14 +146,18 @@ async def _maybe_await(value):
 
 
 _SENSITIVE_ERROR_TOKEN_RE = re.compile(
-    r"(?i)(?:^|[?&\s,;])(?:api[_-]?key|auth[_-]?token|access[_-]?token|"
-    r"refresh[_-]?token|token|secret|password|credential)\s*[:=]\s*[A-Za-z0-9._~+/=%-]+"
+    r"(?i)(?:"
+    r"['\"](?:api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|"
+    r"token|secret|password|credential)['\"]\s*:\s*['\"][^'\"]+['\"]"
+    r"|(?:^|[?&\s,;])(?:api[_-]?key|auth[_-]?token|access[_-]?token|"
+    r"refresh[_-]?token|token|secret|password|credential)\s*[:=]\s*['\"]?[^'\"\s,;&]+['\"]?"
+    r")"
 )
 _AUTHORIZATION_BEARER_RE = re.compile(
-    r"(?i)\bauthorization\s*:\s*bearer\s+[A-Za-z0-9._~+/=-]+"
+    r"(?i)\bauthorization\s*:\s*bearer\s+[^'\"\s,;&]+"
 )
 _BEARER_SECRET_RE = re.compile(
-    r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"
+    r"(?i)\bbearer\s+[^'\"\s,;&]+"
 )
 _STANDALONE_HTTP_URL_RE = re.compile(r"(?i)^https?://\S+$")
 

--- a/tldw_Server_API/app/core/Watchlists/pipeline.py
+++ b/tldw_Server_API/app/core/Watchlists/pipeline.py
@@ -150,14 +150,17 @@ _SENSITIVE_ERROR_TOKEN_RE = re.compile(
     r"['\"](?:api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|"
     r"token|secret|password|credential)['\"]\s*:\s*['\"][^'\"]+['\"]"
     r"|(?:^|[?&\s,;])(?:api[_-]?key|auth[_-]?token|access[_-]?token|"
-    r"refresh[_-]?token|token|secret|password|credential)\s*[:=]\s*['\"]?[^'\"\s,;&]+['\"]?"
+    r"refresh[_-]?token|token|secret|password|credential)\s*[:=]\s*"
+    r"(?:['\"][^'\"]*['\"]|[^'\"\s,;&]+)"
     r")"
 )
 _AUTHORIZATION_BEARER_RE = re.compile(
-    r"(?i)\bauthorization\s*:\s*bearer\s+[^'\"\s,;&]+"
+    r"(?i)(?:['\"]authorization['\"]\s*:\s*['\"]bearer\s+[^'\"]+['\"]|"
+    r"\bauthorization\s*:\s*bearer\s+(?:['\"][^'\"]+['\"]|[^'\"\s,;&]+))"
 )
 _BEARER_SECRET_RE = re.compile(
-    r"(?i)\bbearer\s+[^'\"\s,;&]+"
+    r"(?i)(?:['\"]bearer['\"]\s*:\s*['\"]bearer\s+[^'\"]+['\"]|"
+    r"\bbearer\s+(?:['\"][^'\"]+['\"]|[^'\"\s,;&]+))"
 )
 _STANDALONE_HTTP_URL_RE = re.compile(r"(?i)^https?://\S+$")
 

--- a/tldw_Server_API/tests/Watchlists/test_run_detail_filters_totals.py
+++ b/tldw_Server_API/tests/Watchlists/test_run_detail_filters_totals.py
@@ -111,8 +111,8 @@ def test_run_detail_stats_preserve_existing_flat_filter_counters():
         {
             "items_found": 4,
             "items_ingested": 2,
-            "filters_include": 3,
-            "filters_exclude": 1,
+            "filters_include": "3",
+            "filters_exclude": 1.0,
             "filters_flag": 2,
             "filter_tallies": {"keyword:foo": 6},
         },
@@ -124,6 +124,31 @@ def test_run_detail_stats_preserve_existing_flat_filter_counters():
     assert detail_stats["filters_exclude"] == 1
     assert detail_stats["filters_flag"] == 2
     assert "filter_tallies" not in detail_stats
+
+
+def test_run_detail_stats_coerce_filter_action_counts():
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import _build_run_detail_stats
+
+    detail_stats = _build_run_detail_stats(
+        {
+            "items_found": 4,
+            "items_ingested": 2,
+            "filters_include": None,
+            "filters_exclude": False,
+            "filters_flag": "not-a-number",
+            "filters_actions": {
+                "include": "5",
+                "exclude": 2.0,
+                "flag": True,
+            },
+        },
+        items_found=4,
+        items_ingested=2,
+    )
+
+    assert detail_stats["filters_include"] == 5
+    assert detail_stats["filters_exclude"] == 2
+    assert detail_stats["filters_flag"] == 0
 
 
 def test_run_detail_includes_include_and_exclude_totals(client_with_user):

--- a/tldw_Server_API/tests/Watchlists/test_run_detail_filters_totals.py
+++ b/tldw_Server_API/tests/Watchlists/test_run_detail_filters_totals.py
@@ -104,6 +104,28 @@ def test_run_detail_includes_filter_totals(client_with_user):
     assert "filter_tallies" not in (detail_with_tallies.get("stats") or {})
 
 
+def test_run_detail_stats_preserve_existing_flat_filter_counters():
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import _build_run_detail_stats
+
+    detail_stats = _build_run_detail_stats(
+        {
+            "items_found": 4,
+            "items_ingested": 2,
+            "filters_include": 3,
+            "filters_exclude": 1,
+            "filters_flag": 2,
+            "filter_tallies": {"keyword:foo": 6},
+        },
+        items_found=4,
+        items_ingested=2,
+    )
+
+    assert detail_stats["filters_include"] == 3
+    assert detail_stats["filters_exclude"] == 1
+    assert detail_stats["filters_flag"] == 2
+    assert "filter_tallies" not in detail_stats
+
+
 def test_run_detail_includes_include_and_exclude_totals(client_with_user):
 
 

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
@@ -530,14 +530,25 @@ def test_safe_source_error_text_redacts_common_secret_formats():
 
 def test_safe_source_error_text_redacts_json_style_secret_formats():
     text = _safe_source_error_text(
-        "fetch failed {\"token\":\"json_token_value\", \"api_key\": \"json_api_value\", "
-        "'password': 'json_password_value'} token=\"quoted_token_value\""
+        "fetch failed {\"token\":\"json token value;still\", \"api_key\": \"json,api&value\", "
+        "'password': 'json password value'} token=\"quoted token value;still\" "
+        "Authorization: Bearer \"auth bearer value;still\" "
+        "{\"Authorization\": \"Bearer json bearer value\", \"bearer\": \"Bearer nested bearer value\"}"
     )
 
-    assert "json_token_value" not in text
-    assert "json_api_value" not in text
-    assert "json_password_value" not in text
-    assert "quoted_token_value" not in text
+    for leaked in (
+        "json token",
+        "token value",
+        "json,api",
+        "api&value",
+        "json password",
+        "quoted token",
+        "auth bearer",
+        "json bearer",
+        "nested bearer",
+    ):
+        assert leaked not in text
+    assert text.count("[redacted]") >= 6
     assert "api_key" not in text.lower()
     assert "password" not in text.lower()
     assert "token=" not in text.lower()

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
@@ -528,6 +528,21 @@ def test_safe_source_error_text_redacts_common_secret_formats():
     assert "Bearer [redacted]" in text
 
 
+def test_safe_source_error_text_redacts_json_style_secret_formats():
+    text = _safe_source_error_text(
+        "fetch failed {\"token\":\"json_token_value\", \"api_key\": \"json_api_value\", "
+        "'password': 'json_password_value'} token=\"quoted_token_value\""
+    )
+
+    assert "json_token_value" not in text
+    assert "json_api_value" not in text
+    assert "json_password_value" not in text
+    assert "quoted_token_value" not in text
+    assert "api_key" not in text.lower()
+    assert "password" not in text.lower()
+    assert "token=" not in text.lower()
+
+
 def test_safe_source_error_text_removes_url_basic_auth():
     text = _safe_source_error_text(
         "https://demo_user:value_to_redact@example.test/feed?api_key=query_value_to_redact"


### PR DESCRIPTION
## Change summary
TODO (human-authored): Explain what changed and why these implementation choices are correct.

## What changed
- Prioritizes audio-specific status fields over generic report status and counts status-only failed audio outputs in overview health.
- Preserves existing flat filter counters in run detail stats while still hiding filter_tallies unless requested.
- Expands source-error redaction to JSON-style secret key/value pairs.
- Repairs Watchlists health fixture typing and normalizes Backlog metadata from the demo rescue slice.

## Verification
- `./node_modules/.bin/vitest run src/components/Option/Watchlists/OutputsTab/__tests__/outputMetadata.test.ts src/services/__tests__/watchlists-overview.test.ts src/components/Option/Watchlists/__tests__/WatchlistsPlaygroundPage.health.test.tsx src/components/Option/Watchlists/__tests__/watchlists-static-guard.typecheck.test.ts --maxWorkers=1 --no-file-parallelism`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py::test_safe_source_error_text_redacts_common_secret_formats tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py::test_safe_source_error_text_redacts_json_style_secret_formats tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py::test_safe_source_error_text_removes_url_basic_auth tldw_Server_API/tests/Watchlists/test_run_detail_filters_totals.py::test_run_detail_stats_preserve_existing_flat_filter_counters -q`
- `git diff --check`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/Watchlists/pipeline.py -f json -o /tmp/bandit_watchlists_pr1907.json`

## Context
PR #1906 is merged. PR #1907 is stale against current dev and includes unrelated churn after later merges; this clean follow-up branch carries the still-valid review fixes only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Watchlists status truth and health counts by prioritizing audio-specific statuses, normalizing mixed-case values, and counting status-only audio failures. Also preserves and coerces run-detail filter counters and expands source error redaction.

- **Bug Fixes**
  - UI: Prefer audio-specific fields, normalize case, and map pending+task to queued; tests updated.
  - Overview: Count failed/error audio outputs even without request flags; only count skipped when requested; health fixtures add alerts.unread.
  - API: Preserve flat filter counters; coerce numeric strings/floats and ignore bools; keep filter_tallies opt-in; helper + tests.
  - Pipeline: Redact quoted/JSON-style secrets and Authorization Bearer tokens (including nested); tests added.
  - Meta: Backlog metadata normalization.

<sup>Written for commit a143510fdd9e7c42ce0f7c0aa42b848ce6c78490. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1915?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

