### PR TITLE
Clarify Watchlists digest output contract

### DIFF
--- a/Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
@@ -1172,7 +1172,9 @@ Committed in PR #1921.
 - Test: `tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py`
 - Test: `tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py`
 
-- [ ] **Step 1: Write scheduled output contract tests**
+Implementation note: completed in TASK-472. `OutputsTab.tsx` was already metadata-driven, so the implementation added/kept regression coverage there without changing the component source.
+
+- [x] **Step 1: Write scheduled output contract tests**
 
 In `pipeline-contract.test.ts`, add two cases:
 
@@ -1198,7 +1200,7 @@ expect(toPipelineJobCreatePayload({
 
 If the draft model does not yet have `createScheduledOutput`, add it in the same test as the explicit user choice.
 
-- [ ] **Step 2: Write job form summary tests**
+- [x] **Step 2: Write job form summary tests**
 
 In `JobFormModal.live-summary.test.tsx`, assert the save review distinguishes:
 
@@ -1207,7 +1209,7 @@ In `JobFormModal.live-summary.test.tsx`, assert the save review distinguishes:
 - delivery enabled versus in-app Reports only
 - audio enabled versus text digest only
 
-- [ ] **Step 3: Write Reports discoverability test**
+- [x] **Step 3: Write Reports discoverability test**
 
 In `OutputsTab.regenerate-modal.test.tsx`, assert regenerated digest/newsletter output shows:
 
@@ -1217,7 +1219,7 @@ In `OutputsTab.regenerate-modal.test.tsx`, assert regenerated digest/newsletter 
 - delivery status
 - audio status if audio requested
 
-- [ ] **Step 4: Run frontend tests and confirm failure**
+- [x] **Step 4: Run frontend tests and confirm failure**
 
 Run:
 
@@ -1233,7 +1235,7 @@ bunx vitest run \
 
 Expected: FAIL where scheduled output intent and report state are implicit or mislabeled.
 
-- [ ] **Step 5: Implement explicit scheduled output preference**
+- [x] **Step 5: Implement explicit scheduled output preference**
 
 In `pipeline-contract.ts`, set scheduled output only when requested:
 
@@ -1249,7 +1251,7 @@ if (draft.createScheduledOutput) {
 
 Keep one-off test output creation in `toPipelineOutputCreatePayload`; do not conflate it with scheduled `auto_output`.
 
-- [ ] **Step 6: Update job form copy and summaries**
+- [x] **Step 6: Update job form copy and summaries**
 
 In `JobFormModal.tsx` and `job-summaries.ts`, render explicit phrases:
 
@@ -1262,11 +1264,11 @@ In `JobFormModal.tsx` and `job-summaries.ts`, render explicit phrases:
 
 Keep raw cron, template selector, and existing advanced controls reachable.
 
-- [ ] **Step 7: Keep Reports state grounded in backend artifacts**
+- [x] **Step 7: Keep Reports state grounded in backend artifacts**
 
 In `OutputsTab.tsx`, show output state from actual output records and metadata. Do not show "newsletter sent" or "audio ready" unless the output metadata says delivery/audio succeeded.
 
-- [ ] **Step 8: Run backend output contract tests**
+- [x] **Step 8: Run backend output contract tests**
 
 Run:
 
@@ -1280,7 +1282,7 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 9: Run frontend output contract tests**
+- [x] **Step 9: Run frontend output contract tests**
 
 Run:
 
@@ -1296,7 +1298,7 @@ bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 Run:
 

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
@@ -578,8 +578,8 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
       hasRecurringSchedule &&
       createScheduledOutput
     )
+    existingAutoOutput.enabled = shouldAutoOutput
     if (shouldAutoOutput) {
-      existingAutoOutput.enabled = true
       existingAutoOutput.type =
         typeof existingAutoOutput.type === "string" && existingAutoOutput.type.trim().length > 0
           ? existingAutoOutput.type.trim()
@@ -599,6 +599,8 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
       } else {
         delete existingAutoOutput.template_version
       }
+      basePrefs.auto_output = existingAutoOutput
+    } else if (isEditing && isRecord(basePrefs.auto_output)) {
       basePrefs.auto_output = existingAutoOutput
     } else {
       delete basePrefs.auto_output

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
@@ -219,6 +219,7 @@ const OUTPUT_PRESETS: Record<
     format: OutputFormat
     emailEnabled: boolean
     emailBodyFormat: EmailBodyFormat
+    createScheduledOutput: boolean
   }
 > = {
   briefing_md: {
@@ -226,18 +227,21 @@ const OUTPUT_PRESETS: Record<
     format: "md",
     emailEnabled: false,
     emailBodyFormat: "auto",
+    createScheduledOutput: true,
   },
   newsletter_html: {
     templateName: "newsletter_html",
     format: "html",
     emailEnabled: true,
     emailBodyFormat: "html",
+    createScheduledOutput: true,
   },
   mece_md: {
     templateName: "mece_markdown",
     format: "md",
     emailEnabled: false,
     emailBodyFormat: "auto",
+    createScheduledOutput: true,
   },
 }
 
@@ -288,6 +292,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
   const [outputTemplateName, setOutputTemplateName] = useState<string | undefined>(undefined)
   const [outputTemplateVersion, setOutputTemplateVersion] = useState<number | null>(null)
   const [outputTemplateFormat, setOutputTemplateFormat] = useState<OutputFormat | undefined>(undefined)
+  const [createScheduledOutput, setCreateScheduledOutput] = useState(false)
   const [retentionDefaultDuration, setRetentionDefaultDuration] = useState<DurationInputValue>({
     value: null,
     unit: "days"
@@ -331,6 +336,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
     const deliveriesRecord = isRecord(prefsRecord.deliveries) ? prefsRecord.deliveries : {}
     const emailRecord = isRecord(deliveriesRecord.email) ? deliveriesRecord.email : null
     const chatbookRecord = isRecord(deliveriesRecord.chatbook) ? deliveriesRecord.chatbook : null
+    const autoOutputRecord = isRecord(prefsRecord.auto_output) ? prefsRecord.auto_output : null
 
     setOutputTemplateName(
       typeof templateRecord.default_name === "string" && templateRecord.default_name.trim().length > 0
@@ -347,6 +353,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
     setOutputTemplateFormat(
       isOutputFormat(templateRecord.default_format) ? templateRecord.default_format : undefined
     )
+    setCreateScheduledOutput(Boolean(autoOutputRecord) && autoOutputRecord.enabled === true)
     const parsedDefaultRetention = Number(retentionRecord.default_seconds)
     setRetentionDefaultDuration(
       secondsToDurationInput(
@@ -569,12 +576,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
       : {}
     const shouldAutoOutput = (
       hasRecurringSchedule &&
-      (
-        deliveryEmailEnabled ||
-        deliveryChatbookEnabled ||
-        audioBriefingEnabled ||
-        existingAutoOutput.enabled === true
-      )
+      createScheduledOutput
     )
     if (shouldAutoOutput) {
       existingAutoOutput.enabled = true
@@ -620,6 +622,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
     setOutputTemplateFormat(preset.format)
     setDeliveryEmailEnabled(preset.emailEnabled)
     setDeliveryEmailBodyFormat(preset.emailBodyFormat)
+    setCreateScheduledOutput(preset.createScheduledOutput)
     setOutputPreset(presetId)
     message.success(t("watchlists:jobs.form.presetApplied", "Preset applied"))
   }
@@ -1051,7 +1054,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
       }
 
       const confirmationItems: string[] = []
-      if (deliveryEmailEnabled) {
+      if (createScheduledOutput && deliveryEmailEnabled) {
         confirmationItems.push(
           t(
             "watchlists:jobs.form.confirmationEmail",
@@ -1063,7 +1066,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
           )
         )
       }
-      if (deliveryChatbookEnabled) {
+      if (createScheduledOutput && deliveryChatbookEnabled) {
         confirmationItems.push(
           t(
             "watchlists:jobs.form.confirmationChatbook",
@@ -1211,6 +1214,7 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
     filters.length > 0 ||
     retentionDefaultDuration.value !== null ||
     retentionTemporaryDuration.value !== null ||
+    createScheduledOutput ||
     deliveryEmailEnabled ||
     deliveryEmailRecipients.length > 0 ||
     deliveryEmailSubject.trim().length > 0 ||
@@ -1308,12 +1312,26 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
     ? t("watchlists:jobs.form.confidenceNeedsAttention", "Needs attention")
     : t("watchlists:jobs.form.confidenceReady", "Ready to save")
   const confidenceStatusColor = confidenceHasBlockingRisk ? "orange" : "green"
+  const outputScheduleSummaryText = createScheduledOutput
+    ? hasScheduleSelection
+      ? t(
+        "watchlists:jobs.form.liveSummary.scheduledOutput",
+        "Create a report after each scheduled run"
+      )
+      : t(
+        "watchlists:jobs.form.liveSummary.scheduledOutputNeedsSchedule",
+        "Add a schedule to create reports automatically"
+      )
+    : t(
+      "watchlists:jobs.form.liveSummary.manualOutput",
+      "Manual/test reports only"
+    )
   const deliverySummaryParts: string[] = []
   if (deliveryEmailEnabled) {
     deliverySummaryParts.push(
       t(
         "watchlists:jobs.form.liveSummary.deliveryEmail",
-        "Email ({{count}} recipient{{plural}})",
+        "Deliver by email ({{count}} recipient{{plural}})",
         {
           count: deliveryEmailRecipients.length,
           plural: deliveryEmailRecipients.length === 1 ? "" : "s"
@@ -1323,23 +1341,23 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
   }
   if (deliveryChatbookEnabled) {
     deliverySummaryParts.push(
-      t("watchlists:jobs.form.liveSummary.deliveryChatbook", "Chatbook export enabled")
+      t("watchlists:jobs.form.liveSummary.deliveryChatbook", "Save to Chatbook")
     )
   }
   const deliverySummaryText =
     deliverySummaryParts.length > 0
       ? deliverySummaryParts.join(" + ")
-      : t("watchlists:jobs.form.liveSummary.deliveryNone", "No automatic delivery")
+      : t("watchlists:jobs.form.liveSummary.deliveryReportsOnly", "Reports tab only")
   const audioSummaryText = audioBriefingEnabled
     ? t(
       "watchlists:jobs.form.liveSummary.audioEnabled",
-      "Enabled ({{voice}}, {{minutes}} min target)",
+      "Audio briefing requested ({{voice}}, {{minutes}} min target)",
       {
         voice: audioVoice,
         minutes: audioTargetMinutes
       }
     )
-    : t("watchlists:jobs.form.liveSummary.audioDisabled", "Disabled")
+    : t("watchlists:jobs.form.liveSummary.audioDisabled", "Text report only")
   const hasHiddenAdvancedInBasic = authoringMode === "basic" && hasAdvancedConfiguration
 
   const handleAuthoringModeChange = (nextMode: AuthoringMode) => {
@@ -1561,6 +1579,35 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
                 "Presets prefill template and delivery defaults. Structured review groups content into non-overlapping sections for easier scanning."
               )}
             </div>
+          </div>
+
+          <div className="rounded-lg border border-border p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium">
+                  {t("watchlists:jobs.form.createScheduledOutput", "Scheduled reports")}
+                </div>
+                <div className="text-xs text-text-muted">
+                  {t(
+                    "watchlists:jobs.form.createScheduledOutputHint",
+                    "Create a report after each scheduled run. Leave off for manual/test reports only."
+                  )}
+                </div>
+              </div>
+              <Switch
+                checked={createScheduledOutput}
+                onChange={setCreateScheduledOutput}
+                data-testid="job-form-create-scheduled-output-switch"
+              />
+            </div>
+            {createScheduledOutput && !hasScheduleSelection && (
+              <div className="mt-2 text-xs text-text-muted">
+                {t(
+                  "watchlists:jobs.form.createScheduledOutputNeedsSchedule",
+                  "Add a schedule before saving if this monitor should generate recurring reports."
+                )}
+              </div>
+            )}
           </div>
 
           <div className="rounded-lg border border-border p-3">
@@ -2171,7 +2218,10 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
           {filterPreviewSummaryText}
         </div>
         <div className="text-xs text-text-muted" data-testid="job-form-summary-output">
-          {t("watchlists:jobs.form.liveSummary.output", "Output template")}:{" "}
+          {t("watchlists:jobs.form.liveSummary.output", "Output")}:{" "}
+          {outputScheduleSummaryText}
+          {" • "}
+          {t("watchlists:jobs.form.liveSummary.outputTemplate", "Template")}:{" "}
           {outputTemplateName || t("watchlists:jobs.form.defaultTemplateVersionAuto", "Latest")}
         </div>
         <div className="text-xs text-text-muted" data-testid="job-form-summary-delivery">
@@ -2281,7 +2331,9 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
                 )}
               </div>
               <div>
-                {t("watchlists:jobs.form.steps.reviewOutput", "Output template")}:{" "}
+                {t("watchlists:jobs.form.steps.reviewOutput", "Output")}:{" "}
+                {outputScheduleSummaryText}
+                {" • "}
                 {outputTemplateName || t("watchlists:jobs.form.defaultTemplatePlaceholder", "Select a template")}
               </div>
               <div>

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
@@ -404,7 +404,7 @@ describe("JobFormModal live summary", () => {
     )
   }, 15_000)
 
-  it("enables scheduled auto-output when recurring delivery or audio is configured", async () => {
+  it("keeps recurring reports opt-in separately from delivery and audio settings", async () => {
     render(<JobFormModal open onClose={vi.fn()} onSuccess={vi.fn()} />)
 
     await waitFor(() => {
@@ -422,6 +422,56 @@ describe("JobFormModal live summary", () => {
     fireEvent.click(screen.getByTestId("schedule-setter"))
     fireEvent.click(screen.getByText("Output & Delivery"))
     fireEvent.click(screen.getByTestId("job-form-audio-enabled-switch"))
+
+    expect(screen.getByTestId("job-form-summary-output")).toHaveTextContent(
+      "Manual/test reports only"
+    )
+    expect(screen.getByTestId("job-form-summary-delivery")).toHaveTextContent(
+      "Reports tab only"
+    )
+    expect(screen.getByTestId("job-form-summary-audio")).toHaveTextContent(
+      "Audio briefing requested"
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(servicesMock.createWatchlistJob).toHaveBeenCalledTimes(1)
+    })
+
+    const payload = servicesMock.createWatchlistJob.mock.calls[0][0]
+    expect(payload.output_prefs).toEqual(
+      expect.objectContaining({
+        generate_audio: true
+      })
+    )
+    expect(payload.output_prefs).not.toHaveProperty("auto_output")
+  }, 15_000)
+
+  it("enables scheduled report generation only when the recurring report switch is on", async () => {
+    render(<JobFormModal open onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(servicesMock.fetchWatchlistSources).toHaveBeenCalled()
+      expect(servicesMock.fetchWatchlistGroups).toHaveBeenCalled()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("e.g., Daily Tech News"), {
+      target: { value: "Scheduled Audio Brief" }
+    })
+    fireEvent.click(screen.getByTestId("scope-setter"))
+    fireEvent.click(screen.getByTestId("job-form-mode-advanced"))
+    const collapseHeaders = Array.from(document.querySelectorAll(".ant-collapse-header"))
+    fireEvent.click(collapseHeaders[1] as Element)
+    fireEvent.click(screen.getByTestId("schedule-setter"))
+    fireEvent.click(screen.getByText("Output & Delivery"))
+    fireEvent.click(screen.getByTestId("job-form-create-scheduled-output-switch"))
+    fireEvent.click(screen.getByTestId("job-form-audio-enabled-switch"))
+
+    expect(screen.getByTestId("job-form-summary-output")).toHaveTextContent(
+      "Create a report after each scheduled run"
+    )
+
     fireEvent.click(screen.getByRole("button", { name: "Create" }))
 
     await waitFor(() => {
@@ -992,8 +1042,8 @@ describe("JobFormModal live summary", () => {
       expect(servicesMock.fetchWatchlistGroups).toHaveBeenCalled()
     })
 
-    expect(screen.getByTestId("job-form-summary-delivery")).toHaveTextContent("No automatic delivery")
-    expect(screen.getByTestId("job-form-summary-audio")).toHaveTextContent("Disabled")
+    expect(screen.getByTestId("job-form-summary-delivery")).toHaveTextContent("Reports tab only")
+    expect(screen.getByTestId("job-form-summary-audio")).toHaveTextContent("Text report only")
 
     fireEvent.click(screen.getByTestId("job-form-mode-advanced"))
     fireEvent.click(screen.getByText("Output & Delivery"))
@@ -1003,7 +1053,7 @@ describe("JobFormModal live summary", () => {
     })
 
     expect(screen.getByTestId("job-form-summary-audio")).toHaveTextContent(
-      "Enabled (alloy, 8 min target)"
+      "Audio briefing requested (alloy, 8 min target)"
     )
     fireEvent.click(screen.getByTestId("job-form-mode-basic"))
 

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
@@ -491,6 +491,64 @@ describe("JobFormModal live summary", () => {
     )
   }, 15_000)
 
+  it("sends an explicit disabled auto_output record when scheduled reports are turned off during edit", async () => {
+    servicesMock.updateWatchlistJob.mockResolvedValueOnce({ id: 78 })
+
+    render(
+      <JobFormModal
+        open
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        initialValues={{
+          id: 78,
+          name: "Existing scheduled reports monitor",
+          description: "existing",
+          scope: { sources: [1] },
+          schedule_expr: "0 9 * * *",
+          timezone: "UTC",
+          active: true,
+          output_prefs: {
+            template: { default_name: "briefing_markdown" },
+            auto_output: {
+              enabled: true,
+              type: "briefing_markdown",
+              template_name: "briefing_markdown"
+            }
+          },
+          job_filters: null,
+          created_at: "2026-01-15T00:00:00Z"
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(servicesMock.fetchWatchlistSources).toHaveBeenCalled()
+      expect(servicesMock.fetchWatchlistGroups).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByText("Output & Delivery"))
+    const scheduledReportsSwitch = screen.getByTestId("job-form-create-scheduled-output-switch")
+    expect(scheduledReportsSwitch).toHaveAttribute("aria-checked", "true")
+    fireEvent.click(scheduledReportsSwitch)
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(servicesMock.updateWatchlistJob).toHaveBeenCalledTimes(1)
+    })
+
+    const [, payload] = servicesMock.updateWatchlistJob.mock.calls[0]
+    expect(payload.output_prefs).toEqual(
+      expect.objectContaining({
+        auto_output: expect.objectContaining({
+          enabled: false,
+          type: "briefing_markdown",
+          template_name: "briefing_markdown"
+        })
+      })
+    )
+  }, 15_000)
+
   it("shows practical audio setup guidance in monitor form", async () => {
     render(<JobFormModal open onClose={vi.fn()} onSuccess={vi.fn()} />)
 

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.scope-filter-summary.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.scope-filter-summary.test.tsx
@@ -171,8 +171,13 @@ describe("JobsTab scope/filter summaries", () => {
       schedule_expr: "0 9 * * *",
       timezone: "UTC",
       output_prefs: {
+        auto_output: { enabled: true, type: "briefing_markdown" },
         template: { default_name: "briefing_markdown" },
-        generate_audio: true
+        generate_audio: true,
+        deliveries: {
+          email: { enabled: true, recipients: ["digest@example.com"] },
+          chatbook: { enabled: true, title: "Daily Digest" }
+        }
       },
       created_at: "2026-02-18T00:00:00Z",
       updated_at: "2026-02-18T00:00:00Z",
@@ -229,7 +234,7 @@ describe("JobsTab scope/filter summaries", () => {
       expect(screen.getByText("Tags: tech")).toBeInTheDocument()
       expect(screen.getByText("Exclude author: spam-bot")).toBeInTheDocument()
       expect(screen.getByTestId("job-output-linkage-77")).toHaveTextContent(
-        "Output linkage: Template: briefing_markdown • Audio: enabled"
+        "Output linkage: Create a report after each scheduled run • Template: briefing_markdown • Deliver by email • Save to Chatbook • Audio briefing requested"
       )
     })
   })

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/job-summaries.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/job-summaries.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import type { WatchlistFilter } from "@/types/watchlists"
 import {
   buildScopeTooltipLines,
+  summarizeOutputLinkage,
   summarizeFilters,
   summarizeOverflowList,
   summarizeScopeCounts
@@ -77,5 +78,33 @@ describe("job summary helpers", () => {
       "Include keyword: ai, safety +1",
       "Exclude author: spam-bot"
     ])
+  })
+
+  it("only summarizes delivery channels with explicit enabled flags", () => {
+    expect(
+      summarizeOutputLinkage(
+        {
+          auto_output: { enabled: true },
+          deliveries: {
+            email: { recipients: ["digest@example.com"] },
+            chatbook: { title: "Daily Digest" }
+          }
+        },
+        t
+      )
+    ).toBe("Create a report after each scheduled run • Template: default • Reports tab only • Text report only")
+
+    expect(
+      summarizeOutputLinkage(
+        {
+          auto_output: { enabled: true },
+          deliveries: {
+            email: { enabled: true, recipients: ["digest@example.com"] },
+            chatbook: { enabled: true, title: "Daily Digest" }
+          }
+        },
+        t
+      )
+    ).toBe("Create a report after each scheduled run • Template: default • Deliver by email • Save to Chatbook • Text report only")
   })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/job-summaries.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/job-summaries.ts
@@ -218,7 +218,7 @@ const isEnabledRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" &&
   value !== null &&
   !Array.isArray(value) &&
-  (value as Record<string, unknown>).enabled !== false
+  (value as Record<string, unknown>).enabled === true
 
 export const summarizeOutputLinkage = (
   outputPrefs: JobOutputPrefs | null | undefined,

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/job-summaries.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/job-summaries.ts
@@ -214,10 +214,29 @@ const resolveTemplateName = (outputPrefs: JobOutputPrefs | null | undefined): st
   return null
 }
 
+const isEnabledRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  (value as Record<string, unknown>).enabled !== false
+
 export const summarizeOutputLinkage = (
   outputPrefs: JobOutputPrefs | null | undefined,
   t: Translator
 ): string => {
+  const autoOutputSummary = outputPrefs?.auto_output?.enabled
+    ? toText(
+        t(
+          "watchlists:jobs.outputLinkage.scheduledReport",
+          "Create a report after each scheduled run"
+        )
+      )
+    : toText(
+        t(
+          "watchlists:jobs.outputLinkage.manualReports",
+          "Manual/test reports only"
+        )
+      )
   const templateName = resolveTemplateName(outputPrefs)
   const templateSummary = templateName
     ? toText(
@@ -229,9 +248,28 @@ export const summarizeOutputLinkage = (
         t("watchlists:jobs.outputLinkage.templateDefault", "Template: default")
       )
 
-  const audioSummary = outputPrefs?.generate_audio
-    ? toText(t("watchlists:jobs.outputLinkage.audioEnabled", "Audio: enabled"))
-    : toText(t("watchlists:jobs.outputLinkage.audioDisabled", "Audio: text only"))
+  const deliveryParts: string[] = []
+  if (isEnabledRecord(outputPrefs?.deliveries?.email)) {
+    deliveryParts.push(
+      toText(t("watchlists:jobs.outputLinkage.email", "Deliver by email"))
+    )
+  }
+  if (isEnabledRecord(outputPrefs?.deliveries?.chatbook)) {
+    deliveryParts.push(
+      toText(t("watchlists:jobs.outputLinkage.chatbook", "Save to Chatbook"))
+    )
+  }
+  if (deliveryParts.length === 0) {
+    deliveryParts.push(
+      toText(t("watchlists:jobs.outputLinkage.reportsTabOnly", "Reports tab only"))
+    )
+  }
 
-  return `${templateSummary} • ${audioSummary}`
+  const audioSummary = outputPrefs?.generate_audio
+    ? toText(
+        t("watchlists:jobs.outputLinkage.audioRequested", "Audio briefing requested")
+      )
+    : toText(t("watchlists:jobs.outputLinkage.audioTextOnly", "Text report only"))
+
+  return [autoOutputSummary, templateSummary, ...deliveryParts, audioSummary].join(" • ")
 }

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.regenerate-modal.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.regenerate-modal.test.tsx
@@ -331,4 +331,30 @@ describe("OutputsTab regenerate modal", () => {
     expect(setActiveTab).toHaveBeenCalledWith("runs")
     expect(openRunDetail).toHaveBeenCalledWith(91)
   })
+
+  it("renders delivery state only when output metadata contains delivery statuses", async () => {
+    mocks.storeStateRef.current = baseState({
+      outputs: [
+        buildOutput({
+          id: 18,
+          metadata: {
+            deliveries: {
+              email: { channel: "email", status: "sent" }
+            }
+          }
+        }),
+        buildOutput({
+          id: 19,
+          title: "Manual Brief",
+          metadata: {}
+        })
+      ],
+      outputsTotal: 2
+    })
+
+    render(<OutputsTab />)
+
+    expect(screen.getByTestId("outputs-row-18")).toHaveTextContent("email Sent")
+    expect(screen.getByTestId("outputs-row-19")).toHaveTextContent("-")
+  })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
@@ -361,6 +361,7 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
     draft.scheduleIntervalUnit === "minutes" ? INTERVAL_MINUTES_MIN : INTERVAL_HOURS_MIN
   const intervalMax =
     draft.scheduleIntervalUnit === "minutes" ? INTERVAL_MINUTES_MAX : INTERVAL_HOURS_MAX
+  const hasScheduledCadence = draft.scheduleMode !== "manual"
 
   return (
     <Modal
@@ -510,7 +511,11 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                 aria-label={t("watchlists:overview.pipelineSetup.fields.schedule", "Schedule")}
                 value={draft.scheduleMode}
                 options={scheduleOptions}
-                onChange={(value) => updateDraft({ scheduleMode: value as PipelineWizardScheduleMode })}
+                onChange={(value) => updateDraft({
+                  scheduleMode: value as PipelineWizardScheduleMode,
+                  createScheduledOutput:
+                    value === "manual" ? false : draft.createScheduledOutput
+                })}
               />
             </Form.Item>
             {draft.scheduleMode === "interval" && (
@@ -620,6 +625,27 @@ export const PipelineWizard: React.FC<PipelineWizardProps> = ({
                 value={draft.templateName}
                 onChange={(event) => updateDraft({ templateName: event.target.value })}
               />
+            </Form.Item>
+            <Form.Item label={t("watchlists:overview.pipelineSetup.fields.createScheduledOutput", "Scheduled reports")}>
+              <div className="space-y-1">
+                <Switch
+                  aria-label={t("watchlists:overview.pipelineSetup.fields.createScheduledOutput", "Scheduled reports")}
+                  checked={draft.createScheduledOutput}
+                  disabled={!hasScheduledCadence}
+                  onChange={(checked) => updateDraft({ createScheduledOutput: checked })}
+                />
+                <p className="text-xs text-text-muted">
+                  {hasScheduledCadence
+                    ? t(
+                      "watchlists:overview.pipelineSetup.fields.createScheduledOutputHelp",
+                      "Create a digest after each scheduled monitor run."
+                    )
+                    : t(
+                      "watchlists:overview.pipelineSetup.fields.createScheduledOutputNeedsSchedule",
+                      "Choose a schedule before enabling scheduled reports."
+                    )}
+                </p>
+              </div>
             </Form.Item>
             <Form.Item label={t("watchlists:overview.pipelineSetup.fields.emailDelivery", "Email delivery")}>
               <Switch

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
@@ -1111,7 +1111,7 @@ describe("OverviewTab quick setup flow", () => {
     expect(mockState.setActiveTabMock).not.toHaveBeenLastCalledWith("outputs")
     expect(mockState.openOutputPreviewMock).not.toHaveBeenCalled()
     consoleErrorSpy.mockRestore()
-  })
+  }, 20_000)
 
   it("restores focus to guided setup trigger after quick setup modal closes", async () => {
     mockState.fetchOverviewMock.mockResolvedValue(createOverviewPayload())

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
@@ -135,12 +135,62 @@ describe("PipelineWizard", () => {
           monitorName: "Five Hour Brief",
           scheduleMode: "interval",
           scheduleIntervalValue: 5,
+          createScheduledOutput: false,
           templateName: "newsletter_markdown",
           audioEnabled: true,
           audioSpeakers: expect.arrayContaining([
             expect.objectContaining({ label: "Host" }),
             expect.objectContaining({ label: "Analyst" })
           ])
+        }),
+        { mode: "create" }
+      )
+    })
+  })
+
+  it("lets scheduled pipeline creation opt in to scheduled reports explicitly", async () => {
+    const { onSubmit } = renderWizard()
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("AI Feed")).toBeInTheDocument()
+    })
+
+    fireEvent.click(getDialogQueries().getByLabelText("AI Feed"))
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Monitor name")).toBeInTheDocument()
+    })
+    fireEvent.change(getDialogQueries().getByLabelText("Monitor name"), {
+      target: { value: "Scheduled Report Brief" }
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Template")).toBeInTheDocument()
+    })
+    const scheduledReportsSwitch = getDialogQueries().getByLabelText("Scheduled reports")
+    expect(scheduledReportsSwitch).toHaveAttribute("aria-checked", "false")
+    fireEvent.click(scheduledReportsSwitch)
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(getDialogQueries().getByLabelText("Audio briefing")).toBeInTheDocument()
+    })
+    fireEvent.click(getDialogQueries().getByLabelText("Audio briefing"))
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlists-pipeline-review-summary")).toHaveTextContent("AI Feed")
+    })
+    fireEvent.click(getDialogQueries().getByRole("button", { name: "Create pipeline" }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          monitorName: "Scheduled Report Brief",
+          createScheduledOutput: true,
+          audioEnabled: false
         }),
         { mode: "create" }
       )

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
@@ -68,13 +68,6 @@ describe("watchlists pipeline contract", () => {
         schedule_expr: "0 8 * * *",
         timezone: "UTC",
         output_prefs: expect.objectContaining({
-          auto_output: {
-            enabled: true,
-            type: "briefing_markdown",
-            format: "md",
-            template_name: "briefing_markdown",
-            template_version: 2
-          },
           template_name: "briefing_markdown",
           template: expect.objectContaining({
             default_name: "briefing_markdown"
@@ -122,11 +115,33 @@ describe("watchlists pipeline contract", () => {
     timezoneSpy.mockRestore()
   })
 
+  it("does not auto-generate scheduled output unless requested", () => {
+    expect(toPipelineJobCreatePayload(baseDraft).output_prefs).not.toHaveProperty("auto_output")
+  })
+
+  it("enables scheduled output when a pipeline draft explicitly requests scheduled reports", () => {
+    expect(
+      toPipelineJobCreatePayload({
+        ...baseDraft,
+        createScheduledOutput: true
+      }).output_prefs
+    ).toMatchObject({
+      auto_output: {
+        enabled: true,
+        type: "briefing_markdown",
+        format: "md",
+        template_name: "briefing_markdown",
+        template_version: 2
+      }
+    })
+  })
+
   it("does not auto-generate scheduled output for manual-only monitor drafts", () => {
     expect(
       toPipelineJobCreatePayload({
         ...baseDraft,
         schedulePreset: "none",
+        createScheduledOutput: true,
         includeAudio: false,
         emailRecipients: [],
         createChatbook: false

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
@@ -130,6 +130,7 @@ describe("watchlists pipeline wizard state", () => {
         scheduleExpr: "15 */5 * * *",
         timezone: "UTC",
         templateName: "newsletter_markdown",
+        createScheduledOutput: true,
         includeAudio: true,
         audioCast: {
           speaker_count: 2,
@@ -340,6 +341,23 @@ describe("watchlists pipeline wizard state", () => {
         sources: "AI Feed",
         cadence: "Manual only",
         audio: "Audio disabled"
+      })
+    )
+
+    expect(
+      toBriefingPipelineDraft({
+        ...createDefaultPipelineWizardDraft(),
+        sourceMode: "existing",
+        sourceIds: [7],
+        monitorName: "Manual Brief",
+        scheduleMode: "manual",
+        templateName: "briefing_md",
+        audioEnabled: false,
+        audioSpeakers: []
+      })
+    ).toEqual(
+      expect.objectContaining({
+        createScheduledOutput: false
       })
     )
   })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
@@ -7,6 +7,7 @@ import {
   validatePipelineWizardCron,
   validatePipelineWizardDraft
 } from "../pipeline-wizard-state"
+import { toPipelineJobCreatePayload } from "../pipeline-contract"
 
 describe("watchlists pipeline wizard state", () => {
   it("validates source, monitor, digest, delivery, and optional audio requirements", () => {
@@ -130,7 +131,7 @@ describe("watchlists pipeline wizard state", () => {
         scheduleExpr: "15 */5 * * *",
         timezone: "UTC",
         templateName: "newsletter_markdown",
-        createScheduledOutput: true,
+        createScheduledOutput: false,
         includeAudio: true,
         audioCast: {
           speaker_count: 2,
@@ -145,6 +146,45 @@ describe("watchlists pipeline wizard state", () => {
         }
       })
     )
+
+    timezoneSpy.mockRestore()
+  })
+
+  it("keeps scheduled wizard monitors manual/test-only until scheduled reports are selected", () => {
+    const timezoneSpy = vi
+      .spyOn(Intl, "DateTimeFormat")
+      .mockImplementation(
+        () =>
+          ({
+            resolvedOptions: () => ({ timeZone: "UTC" })
+          }) as Intl.DateTimeFormat
+      )
+
+    const scheduledDraft = {
+      ...createDefaultPipelineWizardDraft(),
+      sourceMode: "existing" as const,
+      sourceIds: [10],
+      monitorName: "Daily Brief",
+      scheduleMode: "daily" as const,
+      templateName: "briefing_md",
+      audioEnabled: false,
+      audioSpeakers: []
+    }
+
+    expect(toPipelineJobCreatePayload(toBriefingPipelineDraft(scheduledDraft)).output_prefs).not.toHaveProperty("auto_output")
+    expect(
+      toPipelineJobCreatePayload(
+        toBriefingPipelineDraft({
+          ...scheduledDraft,
+          createScheduledOutput: true
+        })
+      ).output_prefs
+    ).toMatchObject({
+      auto_output: {
+        enabled: true,
+        type: "briefing_markdown"
+      }
+    })
 
     timezoneSpy.mockRestore()
   })

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
@@ -23,6 +23,7 @@ export interface BriefingPipelineDraft {
   scheduleCadence?: WatchlistCadenceDraft
   scheduleExpr?: string | null
   timezone?: string
+  createScheduledOutput?: boolean
   templateName: string
   templateFormat?: "md" | "html"
   templateVersion?: number
@@ -191,7 +192,7 @@ export const toPipelineJobCreatePayload = (
     draft.templateFormat === "html" || draft.templateFormat === "md"
       ? draft.templateFormat
       : undefined
-  const shouldAutoOutput = Boolean(schedule.schedule_expr)
+  const shouldAutoOutput = Boolean(draft.createScheduledOutput && schedule.schedule_expr)
   const normalizedAudioVoice = String(draft.audioVoice || "").trim() || undefined
   const templateName = normalizeWatchlistTemplateName(draft.templateName)
 

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
@@ -359,6 +359,7 @@ export const toBriefingPipelineDraft = (
     schedulePreset: schedule.schedule_expr ? "daily" : "none",
     scheduleExpr: schedule.schedule_expr,
     timezone: schedule.timezone,
+    createScheduledOutput: Boolean(schedule.schedule_expr),
     templateName: trim(draft.templateName),
     ...(draft.templateFormat ? { templateFormat: draft.templateFormat } : {}),
     includeAudio: Boolean(draft.audioEnabled),

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
@@ -51,6 +51,7 @@ export interface PipelineWizardDraft {
   scheduleMinute: number
   scheduleWeekday: WeekdayToken
   scheduleAdvancedCron: string
+  createScheduledOutput: boolean
   templateName: string
   templateFormat?: "md" | "html"
   emailDeliveryEnabled: boolean
@@ -128,6 +129,7 @@ export const createDefaultPipelineWizardDraft = (): PipelineWizardDraft => ({
   scheduleMinute: 0,
   scheduleWeekday: "MON",
   scheduleAdvancedCron: "",
+  createScheduledOutput: false,
   templateName: "",
   emailDeliveryEnabled: false,
   emailRecipients: [],
@@ -359,7 +361,7 @@ export const toBriefingPipelineDraft = (
     schedulePreset: schedule.schedule_expr ? "daily" : "none",
     scheduleExpr: schedule.schedule_expr,
     timezone: schedule.timezone,
-    createScheduledOutput: Boolean(schedule.schedule_expr),
+    createScheduledOutput: Boolean(schedule.schedule_expr && draft.createScheduledOutput),
     templateName: trim(draft.templateName),
     ...(draft.templateFormat ? { templateFormat: draft.templateFormat } : {}),
     includeAudio: Boolean(draft.audioEnabled),

--- a/backlog/tasks/task-472 - Implement-Watchlists-digest-and-newsletter-output-contract.md
+++ b/backlog/tasks/task-472 - Implement-Watchlists-digest-and-newsletter-output-contract.md
@@ -1,0 +1,66 @@
+---
+id: TASK-472
+title: Implement Watchlists digest and newsletter output contract
+status: Done
+labels:
+- watchlists
+- webui
+- ux
+- pr-b
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/1921
+modified_files:
+- Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-contract.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/job-summaries.ts
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.scope-filter-summary.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.regenerate-modal.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 7 from the Watchlists demo remediation implementation plan: make scheduled digest/newsletter output intent explicit, keep manual/test output separate from scheduled auto-output, and ensure Jobs/Reports UI describes delivery/audio status truthfully inside /watchlists.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pipeline job payloads only enable scheduled auto-output when explicitly requested and preserve backend template naming.
+- [x] #2 Job form summaries distinguish scheduled reports, manual/test reports, delivery targets, and audio briefing request state.
+- [x] #3 Reports/Outputs surface digest/newsletter artifacts from actual output records and metadata without claiming delivery or audio success prematurely.
+- [x] #4 Focused frontend/backend Watchlists output-contract tests pass, with verification recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Task 7 implementation completed locally: explicit scheduled output contract, monitor form scheduled reports switch, expanded job output linkage summary, Reports metadata regression coverage, and plan status update. Next: final static checks, Bandit skip note because no Python source changed, commit, and PR preparation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification so far: focused vitest suite 49 passed; watchlists static guard 3 passed; backend pytest for test_job_output_prefs_roundtrip.py and test_newsletter_briefing_gaps.py 47 passed; bun run test:watchlists:a11y 90 passed; git diff --check passed. No Python source was changed, so Bandit touched-scope scan is not applicable for this slice.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Watchlists digest/newsletter output contract slice: scheduled auto-output is now an explicit user choice, pipeline wizard drafts preserve that explicit intent, monitor summaries distinguish scheduled reports from manual/test reports, output linkage includes delivery/audio state, and Reports has regression coverage for metadata-driven delivery visibility. Verified after rebasing onto origin/dev with focused Watchlists frontend tests (49 passed), Watchlists static guard (3 passed), backend Watchlists output/newsletter tests (47 passed), the broader Watchlists a11y suite (90 passed), and git diff --check. Bandit is not applicable because this slice changed frontend/planning files and tests only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-473 - Address-PR-1925-Watchlists-digest-output-review-comments.md
+++ b/backlog/tasks/task-473 - Address-PR-1925-Watchlists-digest-output-review-comments.md
@@ -1,0 +1,64 @@
+---
+id: TASK-473
+title: Address PR 1925 Watchlists digest output review comments
+status: Done
+labels:
+- watchlists
+- webui
+- review-fix
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/1925
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/pipeline-wizard-state.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/PipelineWizard.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/PipelineWizard.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OverviewTab/__tests__/OverviewTab.quick-setup.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/job-summaries.ts
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/job-summaries.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve actionable review comments on PR #1925: add explicit scheduled-output intent to PipelineWizard, prevent stale auto_output.enabled from surviving monitor edits, and require enabled === true when summarizing delivery channels.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pipeline Wizard exposes and persists an explicit Scheduled reports choice instead of deriving auto-output from schedule presence.
+- [x] #2 Job form output prefs clear auto_output.enabled when scheduled reports are toggled off.
+- [x] #3 Job summaries only report email/chatbook delivery when the delivery record explicitly has enabled === true.
+- [x] #4 Focused Watchlists tests are updated and pass after the review fixes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify current PipelineWizard state model and render controls. 2. Add explicit createScheduledOutput wizard state and UI switch. 3. Fix stale auto_output.enabled and strict delivery summary checks. 4. Update focused tests for red/green review cases. 5. Run focused Watchlists verification, update task, commit, push, and reply/resolve PR comments.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1925 review comments: Pipeline Wizard now has an explicit Scheduled reports switch/default false state, scheduled wizard monitors remain manual/test-only until opted in, JobForm edit payloads send auto_output.enabled=false when disabling previously scheduled reports, and job summaries require delivery.enabled === true before reporting email/chatbook delivery. Also stabilized the existing missing-template pipeline error test by giving it the same 20s timeout as adjacent long-running pipeline tests after the rebased a11y suite exposed a default-timeout flake. Verification on the rebased branch: focused Watchlists suite 64 passed, static guard 3 passed, bun run test:watchlists:a11y 91 passed, backend Watchlists output/newsletter pytest 47 passed, git diff --check passed. Bandit is not applicable because no Python source changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds an explicit scheduled reports switch so recurring monitors do not imply auto-output unless requested.
- Keeps pipeline wizard output intent explicit while preserving backend template naming.
- Expands monitor/report summaries and regression coverage for delivery/audio metadata visibility.

## Test Plan
- [x] `./node_modules/.bin/vitest run src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-contract.test.ts src/components/Option/Watchlists/OverviewTab/__tests__/pipeline-wizard-state.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx src/components/Option/Watchlists/JobsTab/__tests__/JobsTab.scope-filter-summary.test.tsx src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.regenerate-modal.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `./node_modules/.bin/vitest run src/components/Option/Watchlists/__tests__/watchlists-static-guard.typecheck.test.ts --maxWorkers=1 --no-file-parallelism`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_job_output_prefs_roundtrip.py tldw_Server_API/tests/Watchlists/test_newsletter_briefing_gaps.py`
- [x] `bun run test:watchlists:a11y`
- [x] `git diff --check`

Bandit: not applicable for this slice because no Python source files changed.

## Change summary
Human-authored summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes scheduled digest/newsletter generation explicit and opt‑in across Watchlists. Adds a “Scheduled reports” switch, only sets `output_prefs.auto_output` when requested, and updates summaries to reflect scheduled vs manual, delivery, audio, and actual metadata (implements TASK-472; addresses TASK-473).

- **New Features**
  - Adds a “Scheduled reports” switch in the Job form and Pipeline Wizard; payloads set `output_prefs.auto_output` only when `createScheduledOutput` is true.
  - Job/list summaries now show scheduled vs manual, template, delivery channels, and audio request; delivery is shown only when `enabled === true`.

- **Bug Fixes**
  - Editing a monitor now sends `auto_output.enabled: false` when scheduled reports are turned off.
  - Reports/Outputs render delivery state only when output metadata includes delivery statuses.

<sup>Written for commit 9abd8a1a0f28e01cf8b10374a5cd91325a51ff90. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1925?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

