### PR TITLE
Migrate FlashcardDocumentView truncation alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -209,17 +209,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardDocumentView.tsx:Alert",
-    "path": "src/components/Flashcards/components/FlashcardDocumentView.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/components/FlashcardDocumentView.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx:Alert",
     "path": "src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentView.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentView.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Alert, Button, Empty, Spin } from "antd"
+import { Button, Empty, Spin } from "antd"
 
+import { Alert } from "@/components/ui/primitives"
 import type { Deck, Flashcard, FlashcardBulkUpdateItem, FlashcardBulkUpdateResponse } from "@/services/flashcards"
 import { FlashcardDocumentRow } from "./FlashcardDocumentRow"
 import type { DocumentQueryFilterContext } from "../utils/document-cache-policy"
@@ -82,13 +83,13 @@ export const FlashcardDocumentView: React.FC<FlashcardDocumentViewProps> = ({
     >
       {isTruncated && (
         <Alert
-          showIcon
-          type="warning"
+          variant="warning"
           className="m-3"
           title="Document results are truncated to the current scan limit."
-          description="Refine filters or reduce tags to enable selecting across the full result set."
           data-testid="flashcards-document-truncation-banner"
-        />
+        >
+          Refine filters or reduce tags to enable selecting across the full result set.
+        </Alert>
       )}
 
       <div className="divide-y divide-border">

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.document-mode.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.document-mode.test.tsx
@@ -318,7 +318,11 @@ describe("ManageTab document mode", () => {
     fireEvent.click(screen.getByTestId("flashcards-density-toggle-document"))
     fireEvent.click(screen.getByTestId(`flashcards-document-row-select-${sampleCard.uuid}`))
 
-    expect(screen.getByTestId("flashcards-document-truncation-banner")).toBeInTheDocument()
+    const banner = screen.getByTestId("flashcards-document-truncation-banner")
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveAttribute("data-ds-component", "Alert")
+    expect(banner).toHaveTextContent("Document results are truncated to the current scan limit.")
+    expect(banner).toHaveTextContent("Refine filters or reduce tags to enable selecting across the full result set.")
     expect(screen.getByTestId("flashcards-select-all-across")).toBeDisabled()
   })
 

--- a/backlog/tasks/task-45.44.9.2 - Migrate-FlashcardDocumentView-truncation-banner-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.2 - Migrate-FlashcardDocumentView-truncation-banner-to-design-system-Alert.md
@@ -1,0 +1,61 @@
+---
+id: TASK-45.44.9.2
+title: Migrate FlashcardDocumentView truncation banner to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.9
+references:
+- https://github.com/rmusser01/tldw_server/issues/1666
+- apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentView.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1930
+modified_files:
+- apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentView.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.document-mode.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the FlashcardDocumentView truncated-results warning banner off AntD Alert and onto the canonical design-system Alert, with focused coverage and verifier evidence for the baseline reduction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the AntD Alert import and JSX in FlashcardDocumentView with the canonical design-system Alert primitive.
+2. Extend the existing document-mode truncation test to assert the rendered design-system Alert marker and preserved copy.
+3. Remove the stale product-state baseline entry and run the focused verifier/test commands.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed a narrow Flashcards product-state migration slice and opened PR #1930. Verification: `bun run verify:design-system-state` reports 321 baseline exceptions with no stale FlashcardDocumentView entry; `bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.document-mode.test.tsx` passes 3 tests; `git diff --check` passes. Bandit skipped because this slice only changes frontend TSX/test/baseline JSON.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the FlashcardDocumentView truncated-results warning from AntD `Alert` to the canonical design-system `Alert` primitive.
- Extends document-mode coverage to verify the rendered design-system Alert marker and preserved warning copy.
- Removes the stale FlashcardDocumentView Alert exception from the product-state baseline.

## Verification
- `bun run verify:design-system-state` (321 baseline exceptions, no stale FlashcardDocumentView entry)
- `bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.document-mode.test.tsx` (3 tests passed)
- `git diff --check`
- Bandit skipped: frontend-only TSX/test/JSON slice.

## Backlog
- TASK-45.44.9.2

## Change summary
TODO: Human maintainer must add a short explanation of what changed and why these implementation choices were made before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the truncation warning in `FlashcardDocumentView` from `antd` `Alert` to the design-system `Alert` for consistent UI and to retire the legacy product-state exception. Tests now assert the design-system marker and preserved copy.

- **Migration**
  - Swapped `Alert` to `@/components/ui/primitives` with `variant="warning"` and `title`; kept the same test id and moved the description into children.
  - Extended the document-mode test to verify `data-ds-component="Alert"` and both title and body text.
  - Removed the stale exception from `design-system-product-state-baseline.json`.

<sup>Written for commit b2b69de6030102085c1c9f470a58764ddf17561b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1930?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

