### PR TITLE
Explain Watchlists source validation failures

### DIFF
--- a/Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
@@ -1328,7 +1328,7 @@ git commit -m "feat: clarify watchlists digest output contract"
 - Test: `tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py`
 - Test: `tldw_Server_API/tests/Watchlists/test_preview_endpoint.py`
 
-- [ ] **Step 1: Write source settings helper tests**
+- [x] **Step 1: Write source settings helper tests**
 
 Create tests proving unknown keys survive:
 
@@ -1341,7 +1341,7 @@ expect(merged.vendor_specific).toBe(true)
 expect(merged.scrape.selector).toBe(".article")
 ```
 
-- [ ] **Step 2: Write source test UI assertions**
+- [x] **Step 2: Write source test UI assertions**
 
 In `SourceFormModal.test-source.test.tsx`, assert a failed source test shows:
 
@@ -1350,7 +1350,7 @@ In `SourceFormModal.test-source.test.tsx`, assert a failed source test shows:
 - sample item count
 - dedupe identity preview
 
-- [ ] **Step 3: Run frontend tests and confirm failure**
+- [x] **Step 3: Run frontend tests and confirm failure**
 
 Run:
 
@@ -1364,7 +1364,7 @@ bunx vitest run \
 
 Expected: FAIL until helpers/UI are added.
 
-- [ ] **Step 4: Implement source settings helpers**
+- [x] **Step 4: Implement source settings helpers**
 
 Create `source-settings.ts` with pure helpers:
 
@@ -1383,11 +1383,11 @@ export const mergeSourceSettings = (
 
 Add typed parse/serialize helpers for scrape selectors, extraction mode, dedupe key, and advanced JSON. Invalid advanced JSON should block save with an inline error.
 
-- [ ] **Step 5: Pass draft settings to source test**
+- [x] **Step 5: Pass draft settings to source test**
 
 In `SourceFormModal.tsx`, include normalized draft `settings` in source-test calls so test results reflect what the user is saving.
 
-- [ ] **Step 6: Surface diagnostics**
+- [x] **Step 6: Surface diagnostics**
 
 Render:
 
@@ -1397,11 +1397,11 @@ Render:
 - dedupe identity preview such as "URL + canonical URL" or the configured custom identity
 - warning when no items are found
 
-- [ ] **Step 7: Extend backend diagnostics only where missing**
+- [x] **Step 7: Extend backend diagnostics only where missing**
 
 In `fetchers.py`/`watchlists.py`, expose `validate_selector_rules` diagnostics from source test responses. Do not change the stored source contract unless the UI needs a new persisted setting.
 
-- [ ] **Step 8: Run backend source tests**
+- [x] **Step 8: Run backend source tests**
 
 Run:
 
@@ -1415,7 +1415,7 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 9: Run frontend source tests**
+- [x] **Step 9: Run frontend source tests**
 
 Run:
 
@@ -1429,7 +1429,7 @@ bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 Run:
 

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
@@ -111,6 +111,26 @@ const buildDiagnosticsLines = (
       )
     )
   }
+  if (typeof diagnostics.fetch_status === "number") {
+    lines.push(
+      toText(
+        t("watchlists:sources.form.fetchStatusLine", "Fetch status: HTTP {{value}}", {
+          value: diagnostics.fetch_status
+        }),
+        `Fetch status: HTTP ${diagnostics.fetch_status}`
+      )
+    )
+  }
+  if (diagnostics.fetch_error) {
+    lines.push(
+      toText(
+        t("watchlists:sources.form.fetchErrorLine", "Fetch issue: {{value}}", {
+          value: diagnostics.fetch_error
+        }),
+        `Fetch issue: ${diagnostics.fetch_error}`
+      )
+    )
+  }
   lines.push(...toDiagnosticList(diagnostics.selector_errors))
   lines.push(...toDiagnosticList(diagnostics.selector_warnings))
   lines.push(...toDiagnosticList(diagnostics.no_match_warnings))

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
@@ -287,6 +287,8 @@ describe("SourceFormModal test-source preflight", () => {
       filtered: 0,
       diagnostics: {
         fetch_mode: "scrape_rules",
+        fetch_status: 503,
+        fetch_error: "HTTP 503 from list page",
         selector_warnings: ["title selector matched 0 nodes"],
         dedupe_preview_key: "guid_xpath"
       }
@@ -306,6 +308,8 @@ describe("SourceFormModal test-source preflight", () => {
     await waitFor(() => {
       expect(screen.getByText("Validation diagnostics")).toBeInTheDocument()
       expect(screen.getByText("Fetch mode: scrape_rules")).toBeInTheDocument()
+      expect(screen.getByText("Fetch status: HTTP 503")).toBeInTheDocument()
+      expect(screen.getByText("Fetch issue: HTTP 503 from list page")).toBeInTheDocument()
       expect(screen.getByText("title selector matched 0 nodes")).toBeInTheDocument()
       expect(screen.getByText("Dedupe preview key: guid_xpath")).toBeInTheDocument()
     })

--- a/apps/packages/ui/src/types/watchlists.ts
+++ b/apps/packages/ui/src/types/watchlists.ts
@@ -1026,6 +1026,8 @@ export interface JobPreviewResult {
 
 export interface SourcePreviewDiagnostics {
   fetch_mode?: string | null
+  fetch_status?: number | null
+  fetch_error?: string | null
   selector_errors?: string[]
   selector_warnings?: string[]
   no_match_warnings?: string[]

--- a/backlog/tasks/task-474 - Implement-Watchlists-source-validation-and-dedupe-confidence.md
+++ b/backlog/tasks/task-474 - Implement-Watchlists-source-validation-and-dedupe-confidence.md
@@ -53,15 +53,15 @@ Follow Task 8 in Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-i
 - PR review follow-up aligned scrape-rule HTTP failures with RSS diagnostics: non-2xx status events now carry an error string, the reducer keeps the first failure status/error pair instead of drifting to the last failure, and 304 remains non-error.
 - Verification:
   - `./node_modules/.bin/vitest run src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx --maxWorkers=1 --no-file-parallelism` (12 passed)
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q` (15 passed, 5 warnings)
+  - `python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q` (16 passed, 5 warnings)
   - `git diff --check` (passed)
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/Watchlists/fetchers.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_source_validation.json` (0 findings)
+  - `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/Watchlists/fetchers.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_source_validation.json` (0 findings)
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the remaining Task 8 source validation gap by surfacing fetch status/error diagnostics through source preview responses and rendering them in the /watchlists source test modal alongside existing selector, sample-count, and dedupe diagnostics. Added regression coverage for UI rendering, fetcher HTTP-status observation, endpoint fetch-error propagation, endpoint fetch-status propagation, first-failure diagnostic selection, and 304 non-error handling. Verification: focused Watchlists source Vitest suites passed (12 tests), focused backend source preview pytest suites passed (15 tests), git diff --check passed, and Bandit reported zero findings for touched backend files.
+Implemented the remaining Task 8 source validation gap by surfacing fetch status/error diagnostics through source preview responses and rendering them in the /watchlists source test modal alongside existing selector, sample-count, and dedupe diagnostics. Added regression coverage for UI rendering, fetcher HTTP-status observation, endpoint fetch-error propagation, endpoint fetch-status propagation, first-failure diagnostic selection, fetch-status preservation after raised fetcher errors, and 304 non-error handling. Verification: focused Watchlists source Vitest suites passed (12 tests), focused backend source preview pytest suites passed (16 tests), git diff --check passed, and Bandit reported zero findings for touched backend files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-474 - Implement-Watchlists-source-validation-and-dedupe-confidence.md
+++ b/backlog/tasks/task-474 - Implement-Watchlists-source-validation-and-dedupe-confidence.md
@@ -1,0 +1,74 @@
+---
+id: TASK-474
+title: Implement Watchlists source validation and dedupe confidence
+status: Done
+labels:
+- watchlists
+- webui
+- backend
+- ux
+- pr-c
+priority: high
+references:
+- Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+- https://github.com/rmusser01/tldw_server/pull/1925
+modified_files:
+- Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
+- apps/packages/ui/src/types/watchlists.ts
+- tldw_Server_API/app/api/v1/endpoints/watchlists.py
+- tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+- tldw_Server_API/app/core/Watchlists/fetchers.py
+- tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py
+- tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 8 from the Watchlists demo remediation implementation plan: preserve source settings while editing, pass draft scrape/extraction/dedupe settings into source tests, and surface fetch/selector/sample/dedupe diagnostics in /watchlists source validation flows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Source settings helper tests prove unknown existing settings survive typed scrape/extraction/dedupe patches.
+- [x] #2 Source test UI shows fetch/status diagnostics, selector diagnostics when available, sample item count, and dedupe identity preview.
+- [x] #3 Source test calls include normalized draft settings so diagnostics reflect what the user is about to save.
+- [x] #4 Backend source-test/preview diagnostics expose selector-rule diagnostics where missing without changing persisted source contracts unnecessarily.
+- [x] #5 Focused backend and frontend Watchlists source validation tests pass, with verification recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Task 8 in Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md: inspect current source form/test/preview behavior, add failing helper and UI assertions first, implement source settings helpers and draft-settings source test payloads, extend backend diagnostics only if missing, run focused frontend/backend verification, update plan/task, commit, push, and prepare PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Existing dev already had source settings preservation, draft source-test settings, selector diagnostics, sample-count summary, and dedupe preview coverage.
+- This slice filled the remaining fetch observability gap by adding fetch status/error fields to source preview diagnostics and wiring scrape-rule HTTP observations through a non-persisted fetcher callback.
+- Verification:
+  - `./node_modules/.bin/vitest run src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx --maxWorkers=1 --no-file-parallelism` (12 passed)
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q` (13 passed, 5 warnings)
+  - `git diff --check` (passed)
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/Watchlists/fetchers.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_source_validation.json` (0 findings)
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the remaining Task 8 source validation gap by surfacing fetch status/error diagnostics through source preview responses and rendering them in the /watchlists source test modal alongside existing selector, sample-count, and dedupe diagnostics. Added regression coverage for UI rendering, fetcher HTTP-status observation, endpoint fetch-error propagation, and endpoint fetch-status propagation. Verification: focused Watchlists source Vitest suites passed (12 tests), focused backend source preview pytest suites passed (13 tests), git diff --check passed, and Bandit reported zero findings for touched backend files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-474 - Implement-Watchlists-source-validation-and-dedupe-confidence.md
+++ b/backlog/tasks/task-474 - Implement-Watchlists-source-validation-and-dedupe-confidence.md
@@ -50,9 +50,10 @@ Follow Task 8 in Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-i
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Existing dev already had source settings preservation, draft source-test settings, selector diagnostics, sample-count summary, and dedupe preview coverage.
 - This slice filled the remaining fetch observability gap by adding fetch status/error fields to source preview diagnostics and wiring scrape-rule HTTP observations through a non-persisted fetcher callback.
+- PR review follow-up aligned scrape-rule HTTP failures with RSS diagnostics: non-2xx status events now carry an error string, the reducer keeps the first failure status/error pair instead of drifting to the last failure, and 304 remains non-error.
 - Verification:
   - `./node_modules/.bin/vitest run src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx --maxWorkers=1 --no-file-parallelism` (12 passed)
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q` (13 passed, 5 warnings)
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q` (15 passed, 5 warnings)
   - `git diff --check` (passed)
   - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/Watchlists/fetchers.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_source_validation.json` (0 findings)
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
@@ -60,7 +61,7 @@ Follow Task 8 in Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-i
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the remaining Task 8 source validation gap by surfacing fetch status/error diagnostics through source preview responses and rendering them in the /watchlists source test modal alongside existing selector, sample-count, and dedupe diagnostics. Added regression coverage for UI rendering, fetcher HTTP-status observation, endpoint fetch-error propagation, and endpoint fetch-status propagation. Verification: focused Watchlists source Vitest suites passed (12 tests), focused backend source preview pytest suites passed (13 tests), git diff --check passed, and Bandit reported zero findings for touched backend files.
+Implemented the remaining Task 8 source validation gap by surfacing fetch status/error diagnostics through source preview responses and rendering them in the /watchlists source test modal alongside existing selector, sample-count, and dedupe diagnostics. Added regression coverage for UI rendering, fetcher HTTP-status observation, endpoint fetch-error propagation, endpoint fetch-status propagation, first-failure diagnostic selection, and 304 non-error handling. Verification: focused Watchlists source Vitest suites passed (12 tests), focused backend source preview pytest suites passed (15 tests), git diff --check passed, and Bandit reported zero findings for touched backend files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -2384,6 +2384,35 @@ def _format_selector_diagnostic(issue: Any) -> str:
     return summary
 
 
+def _format_fetch_diagnostic_error(error: Any) -> str | None:
+    """Format a fetch failure for user-visible source-test diagnostics."""
+    if error is None:
+        return None
+    raw = str(error).strip() or error.__class__.__name__
+    normalized = re.sub(r"\s+", " ", raw).strip()
+    if not normalized:
+        return None
+    return normalized[:240]
+
+
+def _apply_fetch_diagnostic_events(
+    diagnostics: SourcePreviewDiagnostics,
+    events: list[dict[str, Any]],
+) -> None:
+    """Copy fetch status/error observations onto source preview diagnostics."""
+    selected_status: int | None = None
+    selected_error: str | None = None
+    for event in events:
+        status = event.get("status")
+        if isinstance(status, int):
+            if selected_status is None or status // 100 != 2:
+                selected_status = status
+        if selected_error is None:
+            selected_error = _format_fetch_diagnostic_error(event.get("error"))
+    diagnostics.fetch_status = selected_status
+    diagnostics.fetch_error = selected_error
+
+
 def _first_present_rule_key(rules: dict[str, Any], keys: tuple[str, ...]) -> str | None:
     """Return the first configured scrape-rule key from a preferred key list."""
     for key in keys:
@@ -2434,9 +2463,13 @@ def _build_source_preview_diagnostics(
     *,
     fetch_mode: str,
     scrape_rules: dict[str, Any] | None = None,
+    fetch_status: int | None = None,
+    fetch_error: Any = None,
 ) -> SourcePreviewDiagnostics:
     """Build optional source-test diagnostics without changing preview item behavior."""
     diagnostics = SourcePreviewDiagnostics(fetch_mode=fetch_mode)
+    diagnostics.fetch_status = fetch_status
+    diagnostics.fetch_error = _format_fetch_diagnostic_error(fetch_error)
     if not scrape_rules:
         return diagnostics
 
@@ -2484,9 +2517,16 @@ async def _build_source_preview_response(
                 last_modified=last_modified,
                 tenant_id="default",
             )
+            if isinstance(res, dict):
+                status = res.get("status")
+                if isinstance(status, int):
+                    diagnostics.fetch_status = status
+                    if status // 100 != 2 and status != 304:
+                        diagnostics.fetch_error = f"HTTP {status}"
             items = res.get("items", []) if isinstance(res, dict) else []
         except _WATCHLISTS_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug(f"watchlists.test_source: rss fetch failed: {exc}")
+            diagnostics.fetch_error = _format_fetch_diagnostic_error(exc)
             items = []
     elif source_type.lower() in {"site", "forum"}:
         scrape_rules = (
@@ -2497,14 +2537,18 @@ async def _build_source_preview_response(
                 fetch_mode="scrape_rules",
                 scrape_rules=scrape_rules,
             )
+            fetch_events: list[dict[str, Any]] = []
             try:
                 items = await fetch_site_items_with_rules(
                     base_url=str(scrape_rules.get("list_url") or normalized_url),
                     rules=scrape_rules,
                     tenant_id="default",
+                    fetch_diagnostics=fetch_events.append,
                 )
+                _apply_fetch_diagnostic_events(diagnostics, fetch_events)
             except _WATCHLISTS_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug(f"watchlists.test_source: scrape rules fetch failed: {exc}")
+                diagnostics.fetch_error = _format_fetch_diagnostic_error(exc)
                 items = []
         elif test_mode:
             diagnostics = _build_source_preview_diagnostics(fetch_mode="test_mode")

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -2552,11 +2552,13 @@ async def _build_source_preview_response(
                     tenant_id="default",
                     fetch_diagnostics=fetch_events.append,
                 )
-                _apply_fetch_diagnostic_events(diagnostics, fetch_events)
             except _WATCHLISTS_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug(f"watchlists.test_source: scrape rules fetch failed: {exc}")
-                diagnostics.fetch_error = _format_fetch_diagnostic_error(exc)
+                _apply_fetch_diagnostic_events(diagnostics, fetch_events)
+                diagnostics.fetch_error = diagnostics.fetch_error or _format_fetch_diagnostic_error(exc)
                 items = []
+            else:
+                _apply_fetch_diagnostic_events(diagnostics, fetch_events)
         elif test_mode:
             diagnostics = _build_source_preview_diagnostics(fetch_mode="test_mode")
             items = [

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -2399,16 +2399,23 @@ def _apply_fetch_diagnostic_events(
     diagnostics: SourcePreviewDiagnostics,
     events: list[dict[str, Any]],
 ) -> None:
-    """Copy fetch status/error observations onto source preview diagnostics."""
+    """Copy the first meaningful fetch status/error observation onto diagnostics."""
     selected_status: int | None = None
     selected_error: str | None = None
     for event in events:
         status = event.get("status")
         if isinstance(status, int):
-            if selected_status is None or status // 100 != 2:
+            if selected_status is None:
                 selected_status = status
-        if selected_error is None:
-            selected_error = _format_fetch_diagnostic_error(event.get("error"))
+            status_is_failure = status // 100 != 2 and status != 304
+        else:
+            status_is_failure = False
+        formatted_error = _format_fetch_diagnostic_error(event.get("error"))
+        if selected_error is None and (formatted_error or status_is_failure):
+            if isinstance(status, int):
+                selected_status = status
+            selected_error = formatted_error or f"HTTP {status}"
+            break
     diagnostics.fetch_status = selected_status
     diagnostics.fetch_error = selected_error
 

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -642,6 +642,8 @@ class PreviewItem(BaseModel):
 
 class SourcePreviewDiagnostics(BaseModel):
     fetch_mode: str | None = None
+    fetch_status: int | None = None
+    fetch_error: str | None = None
     selector_errors: list[str] = Field(default_factory=list)
     selector_warnings: list[str] = Field(default_factory=list)
     no_match_warnings: list[str] = Field(default_factory=list)

--- a/tldw_Server_API/app/core/Watchlists/fetchers.py
+++ b/tldw_Server_API/app/core/Watchlists/fetchers.py
@@ -1633,7 +1633,10 @@ async def fetch_site_items_with_rules(
             try:
                 resp = await afetch(method="GET", url=page_url, headers=headers, timeout=timeout)
                 status_code = int(resp.status_code)
-                emit_fetch_diagnostic({"url": page_url, "status": status_code})
+                diagnostic_event: dict[str, Any] = {"url": page_url, "status": status_code}
+                if status_code // 100 != 2 and status_code != 304:
+                    diagnostic_event["error"] = f"HTTP {status_code}"
+                emit_fetch_diagnostic(diagnostic_event)
                 if status_code // 100 != 2:
                     logger.debug(f"fetch_site_items_with_rules HTTP {status_code} for {page_url}")
                     continue

--- a/tldw_Server_API/app/core/Watchlists/fetchers.py
+++ b/tldw_Server_API/app/core/Watchlists/fetchers.py
@@ -20,7 +20,7 @@ import contextlib
 import os
 import re
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
 from functools import lru_cache
 from threading import Lock
@@ -1560,6 +1560,7 @@ async def fetch_site_items_with_rules(
     *,
     tenant_id: str = "default",
     timeout: float = 10.0,
+    fetch_diagnostics: Callable[[dict[str, Any]], None] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch a list page and extract items using scrape rules."""
     list_url = str(rules.get("list_url") or base_url or "").strip()
@@ -1604,6 +1605,12 @@ async def fetch_site_items_with_rules(
     seen_items: set[str] = set()
     collected: list[dict[str, Any]] = []
 
+    def emit_fetch_diagnostic(event: dict[str, Any]) -> None:
+        if fetch_diagnostics is None:
+            return
+        with contextlib.suppress(*_WATCHLISTS_FETCHERS_NONCRITICAL_EXCEPTIONS):
+            fetch_diagnostics(event)
+
     try:
         from tldw_Server_API.app.core.http_client import afetch
         while queue and len(visited) < max_pages:
@@ -1619,17 +1626,21 @@ async def fetch_site_items_with_rules(
                 allowed = is_url_allowed(page_url)
             if not allowed:
                 logger.debug(f"Scrape rules blocked by URL policy: {page_url}")
+                emit_fetch_diagnostic({"url": page_url, "error": "blocked_by_url_policy"})
                 continue
 
             resp = None
             try:
                 resp = await afetch(method="GET", url=page_url, headers=headers, timeout=timeout)
-                if resp.status_code // 100 != 2:
-                    logger.debug(f"fetch_site_items_with_rules HTTP {resp.status_code} for {page_url}")
+                status_code = int(resp.status_code)
+                emit_fetch_diagnostic({"url": page_url, "status": status_code})
+                if status_code // 100 != 2:
+                    logger.debug(f"fetch_site_items_with_rules HTTP {status_code} for {page_url}")
                     continue
                 parsed = parse_scraped_items(resp.text or "", page_url, rules)
             except _WATCHLISTS_FETCHERS_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug(f"fetch_site_items_with_rules request failed ({page_url}): {exc}")
+                emit_fetch_diagnostic({"url": page_url, "error": str(exc) or exc.__class__.__name__})
                 continue
             finally:
                 await _close_response(resp)

--- a/tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py
+++ b/tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py
@@ -229,5 +229,6 @@ async def test_fetch_site_items_with_rules_reports_fetch_status(monkeypatch):
         {
             "url": "https://example.com/blog",
             "status": 503,
+            "error": "HTTP 503",
         }
     ]

--- a/tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py
+++ b/tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py
@@ -168,7 +168,10 @@ async def test_fetch_site_items_with_rules_pagination(monkeypatch):
         raising=True,
     )
     monkeypatch.setattr("tldw_Server_API.app.core.Watchlists.fetchers.is_url_allowed_for_tenant", lambda url, tenant_id: True)
-    monkeypatch.setattr("tldw_Server_API.app.core.Watchlists.fetchers.is_url_allowed", lambda url: True)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Watchlists.fetchers.is_url_allowed",
+        lambda url: True,
+    )
 
     rules = {
         "list_url": "https://example.com/blog",
@@ -186,3 +189,45 @@ async def test_fetch_site_items_with_rules_pagination(monkeypatch):
     assert len(items) == 3
     assert items[0]["title"] == "First"
     assert items[-1]["url"] == "https://example.com/post-3"
+
+
+@pytest.mark.asyncio
+async def test_fetch_site_items_with_rules_reports_fetch_status(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "0")
+
+    class FakeResponse:
+        status_code = 503
+        headers = {}
+        text = "Service unavailable"
+
+    async def fake_afetch(*, method: str, url: str, client=None, headers=None, timeout=None, **kwargs):
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.afetch",
+        fake_afetch,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Watchlists.fetchers.is_url_allowed_for_tenant",
+        lambda url, tenant_id: True,
+    )
+    monkeypatch.setattr("tldw_Server_API.app.core.Watchlists.fetchers.is_url_allowed", lambda url: True)
+
+    events: list[dict[str, object]] = []
+    items = await fetch_site_items_with_rules(
+        "https://example.com/blog",
+        {
+            "entry_xpath": "//article",
+            "link_xpath": ".//a/@href",
+        },
+        fetch_diagnostics=events.append,
+    )
+
+    assert items == []
+    assert events == [
+        {
+            "url": "https://example.com/blog",
+            "status": 503,
+        }
+    ]

--- a/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+++ b/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
@@ -237,6 +237,49 @@ def test_draft_source_test_returns_fetch_status_diagnostics(client_with_user: Te
     assert r.status_code == 200, r.text
     diagnostics = r.json().get("diagnostics") or {}
     assert diagnostics.get("fetch_status") == 503
+    assert diagnostics.get("fetch_error") == "HTTP 503"
+
+
+def test_source_fetch_diagnostics_keep_first_failure_status():
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import (
+        _apply_fetch_diagnostic_events,
+    )
+    from tldw_Server_API.app.api.v1.schemas.watchlists_schemas import (
+        SourcePreviewDiagnostics,
+    )
+
+    diagnostics = SourcePreviewDiagnostics(fetch_mode="scrape_rules")
+
+    _apply_fetch_diagnostic_events(
+        diagnostics,
+        [
+            {"url": "https://example.com/news", "status": 200},
+            {"url": "https://example.com/news?page=2", "status": 404},
+            {"url": "https://example.com/news?page=3", "status": 500},
+        ],
+    )
+
+    assert diagnostics.fetch_status == 404
+    assert diagnostics.fetch_error == "HTTP 404"
+
+
+def test_source_fetch_diagnostics_treat_304_as_non_error():
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import (
+        _apply_fetch_diagnostic_events,
+    )
+    from tldw_Server_API.app.api.v1.schemas.watchlists_schemas import (
+        SourcePreviewDiagnostics,
+    )
+
+    diagnostics = SourcePreviewDiagnostics(fetch_mode="scrape_rules")
+
+    _apply_fetch_diagnostic_events(
+        diagnostics,
+        [{"url": "https://example.com/news", "status": 304}],
+    )
+
+    assert diagnostics.fetch_status == 304
+    assert diagnostics.fetch_error is None
 
 
 def test_source_diagnostics_preserve_warning_detail_and_selector_identity():

--- a/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+++ b/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
@@ -240,6 +240,45 @@ def test_draft_source_test_returns_fetch_status_diagnostics(client_with_user: Te
     assert diagnostics.get("fetch_error") == "HTTP 503"
 
 
+def test_draft_source_test_preserves_fetch_status_when_fetcher_raises(
+    client_with_user: TestClient,
+    monkeypatch,
+):
+    c = client_with_user
+
+    async def status_then_fail(*args, fetch_diagnostics=None, **kwargs):
+        if fetch_diagnostics:
+            fetch_diagnostics({"url": "https://example.com/news", "status": 503})
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists.fetch_site_items_with_rules",
+        status_then_fail,
+        raising=True,
+    )
+
+    r = c.post(
+        "/api/v1/watchlists/sources/test",
+        json={
+            "name": "Draft Site",
+            "url": "https://example.com/news",
+            "source_type": "site",
+            "settings": {
+                "scrape_rules": {
+                    "list_url": "https://example.com/news",
+                    "item_selector": "css:article",
+                    "link_xpath": ".//a/@href",
+                }
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    diagnostics = r.json().get("diagnostics") or {}
+    assert diagnostics.get("fetch_status") == 503
+    assert diagnostics.get("fetch_error") == "HTTP 503"
+
+
 def test_source_fetch_diagnostics_keep_first_failure_status():
     from tldw_Server_API.app.api.v1.endpoints.watchlists import (
         _apply_fetch_diagnostic_events,

--- a/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
+++ b/tldw_Server_API/tests/Watchlists/test_preview_endpoint.py
@@ -170,6 +170,75 @@ def test_draft_source_test_returns_scrape_rule_diagnostics(client_with_user: Tes
     assert "selector_warnings" in diagnostics
 
 
+def test_draft_source_test_returns_fetch_failure_diagnostics(client_with_user: TestClient, monkeypatch):
+    c = client_with_user
+
+    async def fail_fetch(*args, **kwargs):
+        raise RuntimeError("upstream timeout")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists.fetch_site_items_with_rules",
+        fail_fetch,
+        raising=True,
+    )
+
+    r = c.post(
+        "/api/v1/watchlists/sources/test",
+        json={
+            "name": "Draft Site",
+            "url": "https://example.com/news",
+            "source_type": "site",
+            "settings": {
+                "scrape_rules": {
+                    "list_url": "https://example.com/news",
+                    "item_selector": "css:article",
+                    "link_xpath": ".//a/@href",
+                }
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    diagnostics = r.json().get("diagnostics") or {}
+    assert diagnostics.get("fetch_mode") == "scrape_rules"
+    assert diagnostics.get("fetch_error") == "upstream timeout"
+
+
+def test_draft_source_test_returns_fetch_status_diagnostics(client_with_user: TestClient, monkeypatch):
+    c = client_with_user
+
+    async def status_fetch(*args, fetch_diagnostics=None, **kwargs):
+        if fetch_diagnostics:
+            fetch_diagnostics({"url": "https://example.com/news", "status": 503})
+        return []
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.watchlists.fetch_site_items_with_rules",
+        status_fetch,
+        raising=True,
+    )
+
+    r = c.post(
+        "/api/v1/watchlists/sources/test",
+        json={
+            "name": "Draft Site",
+            "url": "https://example.com/news",
+            "source_type": "site",
+            "settings": {
+                "scrape_rules": {
+                    "list_url": "https://example.com/news",
+                    "item_selector": "css:article",
+                    "link_xpath": ".//a/@href",
+                }
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    diagnostics = r.json().get("diagnostics") or {}
+    assert diagnostics.get("fetch_status") == 503
+
+
 def test_source_diagnostics_preserve_warning_detail_and_selector_identity():
     from tldw_Server_API.app.api.v1.endpoints.watchlists import (
         _format_selector_diagnostic,


### PR DESCRIPTION
## Summary
- Add fetch status/error diagnostics to Watchlists source preview responses.
- Wire scrape-rule HTTP observations through a non-persisted fetch diagnostics callback and render those diagnostics in the `/watchlists` source test modal.
- Add regression coverage for UI diagnostics, fetcher HTTP status reporting, endpoint fetch-error propagation, and endpoint fetch-status propagation.

## Test Plan
- [x] `./node_modules/.bin/vitest run src/components/Option/Watchlists/SourcesTab/__tests__/source-settings.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_fetchers_scrape_rules.py tldw_Server_API/tests/Watchlists/test_preview_endpoint.py -q`
- [x] `git diff --check`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/Watchlists/fetchers.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_source_validation.json`

## Change summary
Human author must complete before merge:
- What changed:
- Why these implementation choices:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explain why Watchlists source validation fails by showing fetch status and errors in source previews and the Source Test modal. Align diagnostics across RSS and scrape-rule sources and capture HTTP observations without persisting.

- **New Features**
  - UI: show “Fetch status: HTTP …” and “Fetch issue: …” in the Source Test modal.
  - API: `SourcePreviewDiagnostics` now includes `fetch_status` and `fetch_error`; endpoint fills these for RSS and scrape-rule sources.
  - Fetchers: `fetch_site_items_with_rules` emits status/error events via an optional `fetch_diagnostics` callback; UI/types and focused tests updated.

- **Bug Fixes**
  - Keep the first failure status/error, treat 304 as non-error, and preserve fetch status if the fetcher raises after emitting events.
  - Normalize and truncate fetch error messages; align RSS and scrape-rule diagnostics.

<sup>Written for commit a874313511e49094daf90cdbbf572c91b079c301. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1931?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

