### PR TITLE
Migrate TemplatesTab load-error alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -363,17 +363,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/TemplatesTab.tsx:Alert",
-    "path": "src/components/Flashcards/tabs/TemplatesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/TemplatesTab.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Admin/ApiKeyManagementPage.tsx:Alert#antd-alert-apikeymanagementpage-type-error-access-denied-1uep3es",
     "path": "src/components/Option/Admin/ApiKeyManagementPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/tabs/TemplatesTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/TemplatesTab.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Alert, Button, Empty, Input, Spin, Tag, Typography } from "antd"
+import { Button, Empty, Input, Spin, Tag, Typography } from "antd"
 import { Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import type {
   FlashcardTemplate,
@@ -256,18 +257,19 @@ export const TemplatesTab: React.FC = () => {
   if (templatesQuery.error) {
     return (
       <Alert
-        type="error"
-        message={t("option:flashcards.templatesLoadError", {
+        variant="error"
+        title={t("option:flashcards.templatesLoadError", {
           defaultValue: "Could not load templates."
         })}
-        description={
+      >
+        {
           templatesQuery.error instanceof Error
             ? templatesQuery.error.message
             : t("option:flashcards.templatesLoadErrorFallback", {
                 defaultValue: "Try refreshing the page."
               })
         }
-      />
+      </Alert>
     )
   }
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/TemplatesTab.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/TemplatesTab.test.tsx
@@ -143,6 +143,21 @@ describe("TemplatesTab", () => {
     expect(screen.getByRole("button", { name: "Create template" })).toBeInTheDocument()
   })
 
+  it("renders template load errors with the design-system alert", () => {
+    vi.mocked(useFlashcardTemplatesQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Network offline")
+    } as any)
+
+    render(<TemplatesTab />)
+
+    const banner = screen.getByText("Could not load templates.").closest("[role='alert']")
+    expect(banner).toHaveAttribute("data-ds-component", "Alert")
+    expect(banner).toHaveTextContent("Could not load templates.")
+    expect(banner).toHaveTextContent("Network offline")
+  })
+
   it("lists existing templates and opens the selected template in the editor", () => {
     vi.mocked(useFlashcardTemplatesQuery).mockReturnValue({
       data: {

--- a/backlog/tasks/task-45.44.9.3 - Migrate-TemplatesTab-load-error-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.3 - Migrate-TemplatesTab-load-error-alert-to-design-system-Alert.md
@@ -1,0 +1,64 @@
+---
+id: TASK-45.44.9.3
+title: Migrate TemplatesTab load-error alert to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.9
+references:
+- https://github.com/rmusser01/tldw_server/issues/1666
+- apps/packages/ui/src/components/Flashcards/tabs/TemplatesTab.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1932
+modified_files:
+- apps/packages/ui/src/components/Flashcards/tabs/TemplatesTab.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/TemplatesTab.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the Flashcards TemplatesTab load-error UI off AntD Alert and onto the canonical design-system Alert, with focused coverage and baseline evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 TemplatesTab load-error UI renders the design-system Alert primitive instead of AntD Alert.
+- [ ] #2 Design-system product-state verifier passes with the TemplatesTab Alert exception removed from the baseline.
+- [ ] #3 Focused TemplatesTab coverage verifies the load-error banner still renders and exposes the design-system Alert marker.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing TemplatesTab test for the load-error state requiring the design-system Alert marker and preserved copy.
+2. Replace the AntD Alert import/JSX with the canonical design-system Alert primitive.
+3. Remove the stale product-state baseline entry and run focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed a narrow Flashcards product-state migration slice and opened PR #1932. Verification: red test first failed on missing data-ds-component marker; `bunx vitest run src/components/Flashcards/tabs/__tests__/TemplatesTab.test.tsx` passes 15 tests; `bun run verify:design-system-state` reports 320 baseline exceptions with no stale TemplatesTab entry; `git diff --check` passes. Bandit skipped because this slice only changes frontend TSX/test/baseline JSON.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the Flashcards `TemplatesTab` load-error banner from AntD `Alert` to the canonical design-system `Alert` primitive.
- Adds focused coverage proving the load-error state renders the design-system Alert marker while preserving the current title/body copy.
- Removes the stale `TemplatesTab` Alert exception from the product-state baseline.

## Verification
- Red check: `bunx vitest run src/components/Flashcards/tabs/__tests__/TemplatesTab.test.tsx` failed first on missing `data-ds-component="Alert"`.
- `bunx vitest run src/components/Flashcards/tabs/__tests__/TemplatesTab.test.tsx` (15 tests passed)
- `bun run verify:design-system-state` (320 baseline exceptions, no stale `TemplatesTab` entry)
- `git diff --check`
- Bandit skipped: frontend-only TSX/test/JSON slice.

## Backlog
- TASK-45.44.9.3

## Change summary
TODO: Human maintainer must add a short explanation of what changed and why these implementation choices were made before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Flashcards `TemplatesTab` load-error banner from `antd` `Alert` to the design-system `Alert` for a consistent UI while keeping the same title and body copy. Satisfies TASK-45.44.9.3.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` in `TemplatesTab`.
  - Mapped props: `type` → `variant="error"`, `message` → `title`; moved description to children.
  - Added a focused test that asserts `data-ds-component="Alert"` and checks error text.
  - Removed the stale `TemplatesTab` entry from `design-system-product-state-baseline.json`.

<sup>Written for commit 2e388776cc15e748524bd5c0c0e825e61e3f6e15. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1932?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

