### PR TITLE
Migrate study assistant warning alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -209,17 +209,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx:Alert",
-    "path": "src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardTemplateValueModal.tsx:Alert",
     "path": "src/components/Flashcards/components/FlashcardTemplateValueModal.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
@@ -240,6 +240,9 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
       defaultValue: "Study assistant requires an LLM provider. Configure one in Settings \u2192 LLM Providers."
     })
   }, [isError, queryError, t])
+  const assistantUnavailableTitle = t("option:flashcards.studyAssistantUnavailable", {
+    defaultValue: "Study assistant unavailable"
+  })
 
   const { speak, isSpeaking } = useTTS()
   const {
@@ -259,6 +262,7 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
   const [factCheckOpen, setFactCheckOpen] = React.useState(false)
   const lastAutoSubmitTokenRef = React.useRef<number | null>(null)
   const resetTranscriptRef = React.useRef(resetTranscript)
+  const assistantWarningMessage = assistantError ?? classifiedQueryError
 
   React.useEffect(() => {
     resetTranscriptRef.current = resetTranscript
@@ -529,17 +533,13 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
       }
     >
       <Space orientation="vertical" size={12} className="w-full">
-        {(assistantError || isError) && (
+        {(assistantWarningMessage || isError) && (
           <Alert
             variant="warning"
-            title={
-              assistantError ??
-              classifiedQueryError ??
-              t("option:flashcards.studyAssistantUnavailable", {
-                defaultValue: "Study assistant unavailable"
-              })
-            }
-          />
+            title={assistantUnavailableTitle}
+          >
+            {assistantWarningMessage}
+          </Alert>
         )}
         {conflictRequest && (
           <div className="rounded border border-amber-300 bg-amber-50 p-3">

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { Alert, Button, Card, Empty, Input, Space, Tag, Typography } from "antd"
+import { Button, Card, Empty, Input, Space, Tag, Typography } from "antd"
 import { Lightbulb, MessageSquareText, Sparkles, Volume2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Link as RouterLink, useInRouterContext } from "react-router-dom"
+import { Alert } from "@/components/ui/primitives"
 import { useSpeechRecognition } from "@/hooks/useSpeechRecognition"
 import { useTTS } from "@/hooks/useTTS"
 import type {
@@ -530,8 +531,7 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
       <Space orientation="vertical" size={12} className="w-full">
         {(assistantError || isError) && (
           <Alert
-            showIcon
-            type="warning"
+            variant="warning"
             title={
               assistantError ??
               classifiedQueryError ??

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
@@ -14,6 +14,7 @@ import {
   useFlashcardShortcuts,
   useHasCardsQuery,
   useNextDueQuery,
+  useRecentFlashcardReviewSessionsQuery,
   useResetFlashcardSchedulingMutation,
   useReviewAnalyticsSummaryQuery,
   useReviewFlashcardMutation,
@@ -202,6 +203,13 @@ describe("ReviewTab study assistant panel", () => {
     } as any)
     vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
     vi.mocked(useNextDueQuery).mockReturnValue({ data: null } as any)
+    vi.mocked(useRecentFlashcardReviewSessionsQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn()
+    } as any)
     assistantQueryState = {
       data: {
         thread: {
@@ -374,6 +382,10 @@ describe("ReviewTab study assistant panel", () => {
         )
       ).toBeInTheDocument()
     })
+    const banner = screen
+      .getByText("Study assistant requires an LLM provider. Configure one in Settings → LLM Providers.")
+      .closest("[role='alert']")
+    expect(banner).toHaveAttribute("data-ds-component", "Alert")
     expect(screen.getByTestId("flashcards-review-show-answer")).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
@@ -382,6 +382,7 @@ describe("ReviewTab study assistant panel", () => {
         )
       ).toBeInTheDocument()
     })
+    expect(screen.getByText("Study assistant unavailable")).toBeInTheDocument()
     const banner = screen
       .getByText("Study assistant requires an LLM provider. Configure one in Settings → LLM Providers.")
       .closest("[role='alert']")

--- a/backlog/tasks/task-45.44.9.4 - Migrate-FlashcardStudyAssistantPanel-warning-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.4 - Migrate-FlashcardStudyAssistantPanel-warning-alert-to-design-system-Alert.md
@@ -44,13 +44,13 @@ Move the Flashcards study-assistant warning UI off AntD Alert and onto the canon
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-TDD red/green completed. The first red run exposed a stale test harness mock for recent flashcard sessions; after adding the default hook mock, the focused test failed on the intended missing data-ds-component="Alert" assertion. Production code now imports the canonical design-system Alert primitive and renders the study-assistant warning with variant="warning". Removed the now-stale baseline entry for FlashcardStudyAssistantPanel Alert.
+TDD red/green completed. The first red run exposed a stale test harness mock for recent flashcard sessions; after adding the default hook mock, the focused test failed on the intended missing data-ds-component="Alert" assertion. Production code now imports the canonical design-system Alert primitive and renders the study-assistant warning with variant="warning". PR review follow-up moved the longer assistant warning message into Alert children while keeping a short "Study assistant unavailable" title, with a focused red/green assertion. Removed the now-stale baseline entry for FlashcardStudyAssistantPanel Alert.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated FlashcardStudyAssistantPanel's study-assistant warning from AntD Alert to the design-system Alert primitive. Added focused ReviewTab assistant coverage that verifies the warning remains visible and carries the design-system Alert marker. Removed the stale product-state baseline exception and verified the guard passes with 319 remaining legacy exceptions. Verification: bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx; bun run verify:design-system-state; git diff --check. Bandit skipped: frontend-only TSX/test/JSON change.
+Migrated FlashcardStudyAssistantPanel's study-assistant warning from AntD Alert to the design-system Alert primitive. Added focused ReviewTab assistant coverage that verifies the warning remains visible, carries the design-system Alert marker, and uses a short design-system Alert title with the longer warning message in the body. Removed the stale product-state baseline exception and verified the guard passes with 319 remaining legacy exceptions. Verification: bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx; bun run verify:design-system-state; git diff --check. Bandit skipped: frontend-only TSX/test/JSON change.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.9.4 - Migrate-FlashcardStudyAssistantPanel-warning-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.4 - Migrate-FlashcardStudyAssistantPanel-warning-alert-to-design-system-Alert.md
@@ -1,0 +1,64 @@
+---
+id: TASK-45.44.9.4
+title: Migrate FlashcardStudyAssistantPanel warning alert to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+priority: medium
+parent_task_id: TASK-45.44.9
+references:
+- https://github.com/rmusser01/tldw_server/issues/1666
+- apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1933
+modified_files:
+- apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the Flashcards study-assistant warning UI off AntD Alert and onto the canonical design-system Alert, with focused coverage and baseline evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FlashcardStudyAssistantPanel warning UI renders the design-system Alert primitive instead of AntD Alert.
+- [x] #2 Design-system product-state verifier passes with the FlashcardStudyAssistantPanel Alert exception removed from the baseline.
+- [x] #3 Focused ReviewTab assistant coverage verifies the warning still renders and exposes the design-system Alert marker.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing ReviewTab assistant test assertion for the study-assistant warning state requiring the design-system Alert marker.
+2. Replace the AntD Alert import/JSX in FlashcardStudyAssistantPanel with the canonical design-system Alert primitive.
+3. Remove the stale product-state baseline entry and run focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+TDD red/green completed. The first red run exposed a stale test harness mock for recent flashcard sessions; after adding the default hook mock, the focused test failed on the intended missing data-ds-component="Alert" assertion. Production code now imports the canonical design-system Alert primitive and renders the study-assistant warning with variant="warning". Removed the now-stale baseline entry for FlashcardStudyAssistantPanel Alert.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated FlashcardStudyAssistantPanel's study-assistant warning from AntD Alert to the design-system Alert primitive. Added focused ReviewTab assistant coverage that verifies the warning remains visible and carries the design-system Alert marker. Removed the stale product-state baseline exception and verified the guard passes with 319 remaining legacy exceptions. Verification: bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx; bun run verify:design-system-state; git diff --check. Bandit skipped: frontend-only TSX/test/JSON change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates `FlashcardStudyAssistantPanel` study-assistant warning UI from AntD `Alert` to the design-system `Alert`.
- Adds focused ReviewTab assistant coverage that verifies the warning remains visible and carries `data-ds-component="Alert"`.
- Removes the now-stale FlashcardStudyAssistantPanel `Alert` exception from the design-system product-state baseline.

## Verification
- `bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx`
- `bun run verify:design-system-state`
- `git diff --check`

## Backlog
- `TASK-45.44.9.4`

## Change Summary
TODO: Human-authored summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the FlashcardStudyAssistantPanel study-assistant warning from `antd` `Alert` to the design-system `Alert` for consistent UI and product-state compliance. Updates tests to verify the DS alert renders with a short title and the expected marker.

- **Refactors**
  - Replace `antd` `Alert` with design-system `Alert` using `variant="warning"`, `title="Study assistant unavailable"`, and move the detailed message into children.
  - Update ReviewTab test to mock `useRecentFlashcardReviewSessionsQuery`, assert the title, and verify `[role="alert"]` has `data-ds-component="Alert"`.
  - Remove the FlashcardStudyAssistantPanel `Alert` legacy exception from the product-state baseline.
  - Meets TASK-45.44.9.4.

<sup>Written for commit e97e17cccbed1c9a78ab8b25da0838b66b50128b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1933?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

