### PR TITLE
docs: finalize watchlists remediation verification gate

### DIFF
--- a/Docs/Runbooks/watchlists_demo_readiness_2026_05_20.md
+++ b/Docs/Runbooks/watchlists_demo_readiness_2026_05_20.md
@@ -89,3 +89,24 @@ Do not describe audio as playable, produced, or complete when only the Scheduler
 - Some remote sources may block scraping or return no usable items. Replace the source or show the diagnostic rather than retrying silently.
 - Extension verification depends on a current extension build and seeded server configuration.
 - Current verification on 2026-05-21: the Chrome MV3 extension build completed and `tests/e2e/watchlists.spec.ts` passed 14 Watchlists smoke tests. Existing WXT/Rollup font, chunk-size, duplicate-import, and circular chunk warnings remain noisy but did not block the route smoke.
+
+## Verification Snapshot - 2026-05-21
+
+Branch: `codex/watchlists-final-verification`
+Base: `origin/dev` at `668ee4929dd2b27a786a1ca519cd22ed936486e4`
+
+Passed gates:
+
+- `bun run test:watchlists:typecheck` from `apps/packages/ui`: 1 file, 3 tests passed.
+- `bun run test:watchlists:scale` from `apps/packages/ui`: 7 files, 53 tests passed.
+- `bun run test:watchlists:a11y` from `apps/packages/ui`: 12 files, 91 tests passed. Expected mocked error-state stderr appeared in load-error/remediation tests.
+- `python -m pytest tldw_Server_API/tests/Watchlists -q`: 498 passed, 9 skipped, 1 xpassed, 147 warnings. The skipped tests are environment-gated integration/E2E cases in the Watchlists suite.
+- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py tldw_Server_API/app/core/Watchlists -f json -o /tmp/bandit_watchlists_remediation_final.json`: `results: []`, `errors: []`.
+- WebUI Playwright smoke: `playwright test e2e/workflows/watchlists-demo-readiness.spec.ts --reporter=line` from `apps/tldw-frontend`: 3 passed. The first sandboxed attempt failed to bind `0.0.0.0:8080`; the escalated rerun passed.
+- Extension Playwright smoke: `PLAYWRIGHT_JSON_OUTPUT_NAME=.watchlists-e2e-report.json TLDW_E2E_EXTENSION_HEADLESS=0 playwright test tests/e2e/watchlists.spec.ts --reporter=json` from `apps/extension`: 14 passed. `node scripts/assert-playwright-no-skips.mjs .watchlists-e2e-report.json` reported `passed=14 skipped=0 unexpected=0 flaky=0`. A headless CI-mode attempt skipped all 14 tests because Chromium could not keep the MV3 extension context alive in this environment; the escalated headed rerun is the valid result.
+
+Manual live demo dry run:
+
+- Not completed in this verification pass. It still requires the actual demo API environment, reachable real source URLs, configured LLM/TTS providers, and chosen voices.
+- The automated WebUI and extension gates verify the route, guided setup, monitor payloads, output error recovery, truthful audio status display, and Reports/Activity surfaces with controlled API responses.
+- Before a public demo claims final playable audio, rerun the Provider And Voice Preflight and Final playback gate above against the actual demo environment.

--- a/Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
@@ -1829,9 +1829,10 @@ git commit -m "feat: improve watchlists power-user throughput"
 
 **Files:**
 - Modify: `Docs/Runbooks/watchlists_demo_readiness_2026_05_20.md`
-- Modify: `backlog/tasks/task-441 - Create-implementation-plan-for-Watchlists-demo-remediation-tracks.md`
+- Modify: `Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md`
+- Modify: `backlog/tasks/task-475 - Run-Watchlists-remediation-final-verification-gate.md`
 
-- [ ] **Step 1: Run full frontend watchlists gates**
+- [x] **Step 1: Run full frontend watchlists gates**
 
 Run:
 
@@ -1844,7 +1845,10 @@ bun run test:watchlists:a11y
 
 Expected: PASS.
 
-- [ ] **Step 2: Run full backend watchlists gate**
+Result on 2026-05-21 from `codex/watchlists-final-verification`: PASS.
+`test:watchlists:typecheck` passed 3 tests, `test:watchlists:scale` passed 53 tests, and `test:watchlists:a11y` passed 91 tests.
+
+- [x] **Step 2: Run full backend watchlists gate**
 
 Run:
 
@@ -1855,7 +1859,9 @@ python -m pytest tldw_Server_API/tests/Watchlists -q
 
 Expected: PASS. Existing expected xfail/xpass behavior must be explained if present.
 
-- [ ] **Step 3: Run WebUI browser smoke**
+Result on 2026-05-21: PASS. `python -m pytest tldw_Server_API/tests/Watchlists -q` reported 498 passed, 9 skipped, 1 xpassed, and 147 warnings. The skipped tests are environment-gated integration/E2E cases in the Watchlists suite.
+
+- [x] **Step 3: Run WebUI browser smoke**
 
 Start backend and WebUI in the same-origin mode chosen in the runbook, then run:
 
@@ -1866,7 +1872,9 @@ npx playwright test e2e/workflows/watchlists-demo-readiness.spec.ts --reporter=l
 
 Expected: PASS.
 
-- [ ] **Step 4: Run extension strict watchlists gate**
+Result on 2026-05-21: PASS after rerunning outside the sandbox port-bind restriction. The sandboxed attempt failed with `listen EPERM: operation not permitted 0.0.0.0:8080`; the escalated Playwright rerun passed 3 tests.
+
+- [x] **Step 4: Run extension strict watchlists gate**
 
 Run:
 
@@ -1877,7 +1885,9 @@ npx playwright test tests/e2e/watchlists.spec.ts --reporter=line
 
 Expected: PASS with no skipped watchlists tests. If sandbox blocks Chrome launch, rerun with the already approved escalated Playwright path and record that in the runbook.
 
-- [ ] **Step 5: Run Bandit on touched Python scope**
+Result on 2026-05-21: PASS with no skips after rerunning escalated with `TLDW_E2E_EXTENSION_HEADLESS=0`. The valid run passed 14 tests and `node scripts/assert-playwright-no-skips.mjs .watchlists-e2e-report.json` reported `passed=14 skipped=0 unexpected=0 flaky=0`. The first headless CI-mode attempt skipped all tests because Chromium could not keep the MV3 extension context alive in this environment.
+
+- [x] **Step 5: Run Bandit on touched Python scope**
 
 Run:
 
@@ -1891,6 +1901,8 @@ python -m bandit -r \
 ```
 
 Expected: no new findings in touched code.
+
+Result on 2026-05-21: PASS. `/tmp/bandit_watchlists_remediation_final.json` reported `results: []` and `errors: []`.
 
 - [ ] **Step 6: Do manual live demo dry run**
 
@@ -1907,25 +1919,30 @@ Using the runbook, verify:
 - active source failure blocks `System healthy`
 - extension claim matches what was tested
 
-- [ ] **Step 7: Update task final summary**
+Result on 2026-05-21: not completed as a live manual dry run. The automated WebUI and extension gates passed with controlled API responses; live source/provider/audio proof still requires the actual demo environment and must pass the runbook's Provider And Voice Preflight before claiming final playable audio.
 
-Update `TASK-441` with:
+- [x] **Step 7: Update task final summary**
+
+Update the active closeout task with:
 
 - plan path
 - review status
-- verification commands run for plan-only work
-- note that Bandit is not applicable to this plan-only task unless code tasks have also been executed
+- verification commands run for the final gate
+- any manual live-demo blocker
 
-- [ ] **Step 8: Commit final docs/task update**
+- [x] **Step 8: Commit final docs/task update**
 
 Run:
 
 ```bash
 git add \
   Docs/Runbooks/watchlists_demo_readiness_2026_05_20.md \
-  'backlog/tasks/task-441 - Create-implementation-plan-for-Watchlists-demo-remediation-tracks.md'
+  Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md \
+  'backlog/tasks/task-475 - Run-Watchlists-remediation-final-verification-gate.md'
 git commit -m "docs: finalize watchlists remediation verification gate"
 ```
+
+Result on 2026-05-21: prepared as the closeout branch commit for Task 12.
 
 ## Execution Notes
 

--- a/backlog/tasks/task-475 - Run-Watchlists-remediation-final-verification-gate.md
+++ b/backlog/tasks/task-475 - Run-Watchlists-remediation-final-verification-gate.md
@@ -1,0 +1,65 @@
+---
+id: TASK-475
+title: Run Watchlists remediation final verification gate
+status: Done
+labels:
+- watchlists
+- demo-readiness
+- verification
+priority: high
+references:
+- Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+- Docs/Runbooks/watchlists_demo_readiness_2026_05_20.md
+modified_files:
+- Docs/Runbooks/watchlists_demo_readiness_2026_05_20.md
+- Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+- backlog/tasks/task-475 - Run-Watchlists-remediation-final-verification-gate.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run the final Watchlists remediation verification gate on current `origin/dev`, record exact automated evidence, and document any demo-environment proof that still cannot be claimed from the repo-only verification pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Run or explicitly document blockers for the full Watchlists frontend gates.
+- [x] #2 Run or explicitly document blockers for the full Watchlists backend gate and Bandit touched-scope gate.
+- [x] #3 Run or explicitly document blockers for WebUI and extension Watchlists smoke gates.
+- [x] #4 Reconcile the remediation plan/runbook/backlog closeout state with current origin/dev evidence without removing existing Watchlists workflows.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Task 12 from Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md on a clean origin/dev worktree. Refresh current code evidence first, run the listed frontend/backend/browser/extension/security gates where available, record exact pass/fail/blocker evidence in the runbook and task, update stale plan checkboxes only when verified, and prepare a narrow docs/task PR if edits are needed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verification ran from clean worktree `codex/watchlists-final-verification`, based on `origin/dev` at `668ee4929dd2b27a786a1ca519cd22ed936486e4`.
+- Frontend Watchlists gates passed from `apps/packages/ui`: `bun run test:watchlists:typecheck` reported 1 file and 3 tests passed; `bun run test:watchlists:scale` reported 7 files and 53 tests passed; `bun run test:watchlists:a11y` reported 12 files and 91 tests passed with expected mocked error-state stderr.
+- Backend Watchlists gate passed: `.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists -q` reported 498 passed, 9 skipped, 1 xpassed, and 147 warnings. Skips are environment-gated Watchlists integration/E2E cases.
+- Bandit touched-scope gate passed: `.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py tldw_Server_API/app/core/Watchlists -f json -o /tmp/bandit_watchlists_remediation_final.json` produced `results: []` and `errors: []`.
+- WebUI Playwright smoke passed from `apps/tldw-frontend`: the first sandboxed attempt could not bind `0.0.0.0:8080` (`EPERM`), and the escalated rerun of `playwright test e2e/workflows/watchlists-demo-readiness.spec.ts --reporter=line` passed 3 tests.
+- Extension Playwright smoke passed from `apps/extension`: the first headless CI-mode run skipped all 14 tests because Chromium could not keep the MV3 extension context alive in this environment; the escalated headed rerun with `TLDW_E2E_EXTENSION_HEADLESS=0` passed 14 tests, and `node scripts/assert-playwright-no-skips.mjs .watchlists-e2e-report.json` reported `passed=14 skipped=0 unexpected=0 flaky=0`.
+- Manual live demo dry run was not completed in this repo-only pass. It still requires the actual demo API environment, reachable real source URLs, configured LLM/TTS providers, and chosen voices. Final playable podcast/audio claims remain gated by the runbook's Provider And Voice Preflight and Final playback gate.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Ran the Watchlists remediation final verification gate on current origin/dev and recorded the results in the runbook and implementation plan. All automated frontend, backend, Bandit, WebUI, and extension gates passed after using the required escalated runs for local server bind and headed MV3 extension launch. The only remaining demo-dependent item is the manual live dry run with real sources and provider/voice configuration before claiming final playable audio.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
Human author must complete before merge:
- What changed:
- Why these implementation choices:

## Scope
- Adds the final Watchlists verification snapshot to the demo readiness runbook.
- Adds Backlog task TASK-475 for the final remediation verification gate.
- Reconciles Task 12 in the staged remediation implementation plan with the verified gate results.

## Verification
- `bun run test:watchlists:typecheck`: 3 tests passed.
- `bun run test:watchlists:scale`: 53 tests passed.
- `bun run test:watchlists:a11y`: 91 tests passed.
- `python -m pytest tldw_Server_API/tests/Watchlists -q`: 498 passed, 9 skipped, 1 xpassed.
- Bandit touched-scope scan: `results: []`, `errors: []`.
- WebUI Playwright smoke: 3 passed after escalated local port-bind rerun.
- Extension Playwright smoke: 14 passed with no skips after escalated headed MV3 rerun.
- `git diff --cached --check`: clean before commit.

## Known gap
Manual live demo dry run was not completed in this repo-only verification pass. Final playable audio claims still require the actual demo API environment, reachable real source URLs, configured LLM/TTS providers, selected voices, and the Provider/Voice preflight plus final playback gate documented in the runbook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalized the Watchlists remediation verification gate by adding the final verification snapshot to the demo readiness runbook, reconciling Task 12 in the remediation plan, and adding `TASK-475` to record acceptance criteria and results. All automated gates passed (frontend typecheck/scale/a11y, backend `pytest`, WebUI and extension `playwright`, and `bandit`); the runbook documents that the manual live demo dry run remains required before claiming final playable audio.

<sup>Written for commit 30f738b831c686bc62cfef9585a358102974e1b3. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1934?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

