### PR TITLE
Fix Persona chat startup memory isolation

### DIFF
--- a/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
@@ -131,6 +131,56 @@ describe("ensurePersonaServerChat", () => {
     )
   })
 
+  it("starts a brand new persona chat with fresh metadata even when stale state remains in the store", async () => {
+    const setters = createSetterBundle()
+    const createChat = vi.fn().mockResolvedValue({
+      id: "persona-chat-fresh",
+      title: "Fresh persona chat",
+      assistant_kind: "persona",
+      assistant_id: "garden-helper",
+      persona_memory_mode: "read_only"
+    })
+
+    await ensurePersonaServerChat({
+      assistant: {
+        kind: "persona",
+        id: "garden-helper",
+        name: "Garden Helper"
+      },
+      serverChatId: null,
+      serverChatTitle: null,
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      serverChatPersonaMemoryMode: "read_write",
+      serverChatMetaLoaded: false,
+      serverChatState: "resolved",
+      serverChatTopic: "Stale topic",
+      serverChatClusterId: "stale-cluster",
+      serverChatSource: "stale-source",
+      serverChatExternalRef: "stale-ref",
+      historyId: "history-local",
+      temporaryChat: false,
+      createChat,
+      ensureServerChatHistoryId: vi.fn().mockResolvedValue("history-fresh"),
+      invalidateServerChatHistory: vi.fn(),
+      ...setters
+    })
+
+    expect(createChat).toHaveBeenCalledWith(
+      {
+        assistant_kind: "persona",
+        assistant_id: "garden-helper",
+        persona_memory_mode: "read_only",
+        state: "in-progress",
+        topic_label: undefined,
+        cluster_id: undefined,
+        source: undefined,
+        external_ref: undefined
+      },
+      undefined
+    )
+  })
+
   it("reuses an existing matching persona chat without creating a new one", async () => {
     const setters = createSetterBundle()
     const createChat = vi.fn()

--- a/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
@@ -215,11 +215,16 @@ describe("ensurePersonaServerChat", () => {
     expect(setters.setServerChatPersonaMemoryMode.mock.calls[0]).toEqual([null])
     expect(setters.setServerChatMetaLoaded.mock.calls[0]).toEqual([false])
     expect(createChat).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
         assistant_kind: "persona",
         assistant_id: "garden-helper",
-        persona_memory_mode: "read_write"
-      }),
+        persona_memory_mode: "read_only",
+        state: "in-progress",
+        topic_label: undefined,
+        cluster_id: undefined,
+        source: undefined,
+        external_ref: undefined
+      },
       undefined
     )
     expect(setters.setServerChatId).toHaveBeenLastCalledWith("persona-chat-4")
@@ -232,7 +237,64 @@ describe("ensurePersonaServerChat", () => {
     expect(result).toEqual({
       chatId: "persona-chat-4",
       historyId: "history-4",
-      personaMemoryMode: "read_write"
+      personaMemoryMode: "read_only"
+    })
+  })
+
+  it("does not carry read_write from a different stale persona chat into a new persona chat", async () => {
+    const setters = createSetterBundle()
+    const createChat = vi.fn().mockResolvedValue({
+      id: "persona-chat-5",
+      title: "New persona chat",
+      assistant_kind: "persona",
+      assistant_id: "research-helper",
+      persona_memory_mode: "read_only",
+      character_id: null
+    })
+    const ensureServerChatHistoryId = vi.fn().mockResolvedValue("history-5")
+
+    const result = await ensurePersonaServerChat({
+      assistant: {
+        kind: "persona",
+        id: "research-helper",
+        name: "Research Helper"
+      },
+      serverChatId: "persona-chat-old",
+      serverChatTitle: "Old persona chat",
+      serverChatAssistantKind: "persona",
+      serverChatAssistantId: "garden-helper",
+      serverChatPersonaMemoryMode: "read_write",
+      serverChatState: "in-progress",
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      historyId: "history-old",
+      temporaryChat: false,
+      createChat,
+      ensureServerChatHistoryId,
+      invalidateServerChatHistory: vi.fn(),
+      ...setters
+    })
+
+    expect(setters.setServerChatPersonaMemoryMode.mock.calls[0]).toEqual([null])
+    expect(createChat).toHaveBeenCalledWith(
+      {
+        assistant_kind: "persona",
+        assistant_id: "research-helper",
+        persona_memory_mode: "read_only",
+        state: "in-progress",
+        topic_label: undefined,
+        cluster_id: undefined,
+        source: undefined,
+        external_ref: undefined
+      },
+      undefined
+    )
+    expect(result).toEqual({
+      chatId: "persona-chat-5",
+      historyId: "history-5",
+      personaMemoryMode: "read_only"
     })
   })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
@@ -49,6 +49,7 @@ describe("ensurePersonaServerChat", () => {
       serverChatAssistantKind: null,
       serverChatAssistantId: null,
       serverChatPersonaMemoryMode: null,
+      serverChatMetaLoaded: false,
       serverChatState: "in-progress",
       serverChatTopic: null,
       serverChatClusterId: null,
@@ -106,6 +107,7 @@ describe("ensurePersonaServerChat", () => {
       serverChatAssistantKind: null,
       serverChatAssistantId: null,
       serverChatPersonaMemoryMode: null,
+      serverChatMetaLoaded: false,
       serverChatState: "in-progress",
       serverChatTopic: null,
       serverChatClusterId: null,
@@ -145,6 +147,7 @@ describe("ensurePersonaServerChat", () => {
       serverChatAssistantKind: "persona",
       serverChatAssistantId: "garden-helper",
       serverChatPersonaMemoryMode: "read_write",
+      serverChatMetaLoaded: true,
       serverChatState: "in-progress",
       serverChatTopic: null,
       serverChatClusterId: null,
@@ -194,6 +197,7 @@ describe("ensurePersonaServerChat", () => {
       serverChatAssistantKind: "character",
       serverChatAssistantId: "42",
       serverChatPersonaMemoryMode: "read_write",
+      serverChatMetaLoaded: true,
       serverChatState: "resolved",
       serverChatTopic: "Old topic",
       serverChatClusterId: "old-cluster",
@@ -264,6 +268,7 @@ describe("ensurePersonaServerChat", () => {
       serverChatAssistantKind: "persona",
       serverChatAssistantId: "garden-helper",
       serverChatPersonaMemoryMode: "read_write",
+      serverChatMetaLoaded: true,
       serverChatState: "in-progress",
       serverChatTopic: null,
       serverChatClusterId: null,
@@ -294,6 +299,46 @@ describe("ensurePersonaServerChat", () => {
     expect(result).toEqual({
       chatId: "persona-chat-5",
       historyId: "history-5",
+      personaMemoryMode: "read_only"
+    })
+  })
+
+  it("does not reset a restored server chat before assistant metadata hydrates", async () => {
+    const setters = createSetterBundle()
+    const createChat = vi.fn()
+    const ensureServerChatHistoryId = vi.fn().mockResolvedValue("history-restored")
+
+    const result = await ensurePersonaServerChat({
+      assistant: {
+        kind: "persona",
+        id: "garden-helper",
+        name: "Garden Helper"
+      },
+      serverChatId: "restored-chat",
+      serverChatTitle: "Restored chat",
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      serverChatPersonaMemoryMode: "read_write",
+      serverChatMetaLoaded: false,
+      serverChatState: "resolved",
+      serverChatTopic: "Restored topic",
+      serverChatClusterId: "restored-cluster",
+      serverChatSource: "restored-source",
+      serverChatExternalRef: "restored-ref",
+      historyId: "history-restored",
+      temporaryChat: false,
+      createChat,
+      ensureServerChatHistoryId,
+      invalidateServerChatHistory: vi.fn(),
+      ...setters
+    })
+
+    expect(createChat).not.toHaveBeenCalled()
+    expect(setters.setServerChatId).not.toHaveBeenCalledWith(null)
+    expect(setters.setServerChatMetaLoaded).not.toHaveBeenCalledWith(false)
+    expect(result).toEqual({
+      chatId: "restored-chat",
+      historyId: "history-restored",
       personaMemoryMode: "read_only"
     })
   })

--- a/apps/packages/ui/src/hooks/chat/personaServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/personaServerChat.ts
@@ -136,14 +136,17 @@ export const ensurePersonaServerChat = async ({
       ? serverChatIdOverride.trim()
       : null
   const resolvedServerChatId = overrideChatId || serverChatId
-  const personaMemoryMode =
-    serverChatPersonaMemoryMode ?? DEFAULT_PERSONA_MEMORY_MODE
   const assistantId = String(assistant.id)
-  const shouldResetServerChat =
+  const isMatchingPersonaChat =
     Boolean(resolvedServerChatId) &&
-    (serverChatAssistantKind !== "persona" ||
-      !serverChatAssistantId ||
-      String(serverChatAssistantId) !== assistantId)
+    serverChatAssistantKind === "persona" &&
+    Boolean(serverChatAssistantId) &&
+    String(serverChatAssistantId) === assistantId
+  const personaMemoryMode = isMatchingPersonaChat
+    ? serverChatPersonaMemoryMode ?? DEFAULT_PERSONA_MEMORY_MODE
+    : DEFAULT_PERSONA_MEMORY_MODE
+  const shouldResetServerChat =
+    Boolean(resolvedServerChatId) && !isMatchingPersonaChat
 
   if (shouldResetServerChat) {
     resetAssistantServerChatState({
@@ -169,11 +172,19 @@ export const ensurePersonaServerChat = async ({
       assistant_kind: "persona",
       assistant_id: assistantId,
       persona_memory_mode: personaMemoryMode,
-      state: serverChatState || "in-progress",
-      topic_label: serverChatTopic || undefined,
-      cluster_id: serverChatClusterId || undefined,
-      source: serverChatSource || undefined,
-      external_ref: serverChatExternalRef || undefined
+      state: shouldResetServerChat
+        ? "in-progress"
+        : serverChatState || "in-progress",
+      topic_label: shouldResetServerChat
+        ? undefined
+        : serverChatTopic || undefined,
+      cluster_id: shouldResetServerChat
+        ? undefined
+        : serverChatClusterId || undefined,
+      source: shouldResetServerChat ? undefined : serverChatSource || undefined,
+      external_ref: shouldResetServerChat
+        ? undefined
+        : serverChatExternalRef || undefined
     }, scope ? { scope } : undefined)
 
     let rawId: string | number | undefined

--- a/apps/packages/ui/src/hooks/chat/personaServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/personaServerChat.ts
@@ -177,19 +177,11 @@ export const ensurePersonaServerChat = async ({
       assistant_kind: "persona",
       assistant_id: assistantId,
       persona_memory_mode: personaMemoryMode,
-      state: shouldResetServerChat
-        ? "in-progress"
-        : serverChatState || "in-progress",
-      topic_label: shouldResetServerChat
-        ? undefined
-        : serverChatTopic || undefined,
-      cluster_id: shouldResetServerChat
-        ? undefined
-        : serverChatClusterId || undefined,
-      source: shouldResetServerChat ? undefined : serverChatSource || undefined,
-      external_ref: shouldResetServerChat
-        ? undefined
-        : serverChatExternalRef || undefined
+      state: "in-progress",
+      topic_label: undefined,
+      cluster_id: undefined,
+      source: undefined,
+      external_ref: undefined
     }, scope ? { scope } : undefined)
 
     let rawId: string | number | undefined

--- a/apps/packages/ui/src/hooks/chat/personaServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/personaServerChat.ts
@@ -14,6 +14,7 @@ type EnsurePersonaServerChatArgs = {
   serverChatAssistantKind: "character" | "persona" | null
   serverChatAssistantId: string | null
   serverChatPersonaMemoryMode: "read_only" | "read_write" | null
+  serverChatMetaLoaded?: boolean
   serverChatState: string | null
   serverChatTopic: string | null
   serverChatClusterId: string | null
@@ -101,6 +102,7 @@ export const ensurePersonaServerChat = async ({
   serverChatAssistantKind,
   serverChatAssistantId,
   serverChatPersonaMemoryMode,
+  serverChatMetaLoaded = false,
   serverChatState,
   serverChatTopic,
   serverChatClusterId,
@@ -139,6 +141,7 @@ export const ensurePersonaServerChat = async ({
   const assistantId = String(assistant.id)
   const isMatchingPersonaChat =
     Boolean(resolvedServerChatId) &&
+    serverChatMetaLoaded &&
     serverChatAssistantKind === "persona" &&
     Boolean(serverChatAssistantId) &&
     String(serverChatAssistantId) === assistantId
@@ -146,7 +149,9 @@ export const ensurePersonaServerChat = async ({
     ? serverChatPersonaMemoryMode ?? DEFAULT_PERSONA_MEMORY_MODE
     : DEFAULT_PERSONA_MEMORY_MODE
   const shouldResetServerChat =
-    Boolean(resolvedServerChatId) && !isMatchingPersonaChat
+    Boolean(resolvedServerChatId) &&
+    serverChatMetaLoaded &&
+    !isMatchingPersonaChat
 
   if (shouldResetServerChat) {
     resetAssistantServerChatState({

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -267,6 +267,7 @@ type UseChatActionsOptions = {
   serverChatAssistantKind: "character" | "persona" | null
   serverChatAssistantId: string | null
   serverChatPersonaMemoryMode: "read_only" | "read_write" | null
+  serverChatMetaLoaded?: boolean
   serverChatState: ConversationState | null
   serverChatTopic: string | null
   serverChatClusterId: string | null
@@ -354,6 +355,7 @@ export const useChatActions = ({
   serverChatAssistantKind,
   serverChatAssistantId,
   serverChatPersonaMemoryMode,
+  serverChatMetaLoaded = false,
   serverChatState,
   serverChatTopic,
   serverChatClusterId,
@@ -955,6 +957,7 @@ export const useChatActions = ({
         serverChatAssistantKind,
         serverChatAssistantId,
         serverChatPersonaMemoryMode,
+        serverChatMetaLoaded,
         serverChatState,
         serverChatTopic,
         serverChatClusterId,
@@ -985,6 +988,7 @@ export const useChatActions = ({
       invalidateServerChatHistory,
       serverChatAssistantId,
       serverChatAssistantKind,
+      serverChatMetaLoaded,
       serverChatClusterId,
       serverChatExternalRef,
       serverChatId,

--- a/apps/packages/ui/src/hooks/useMessage.tsx
+++ b/apps/packages/ui/src/hooks/useMessage.tsx
@@ -2469,6 +2469,7 @@ export const useMessage = () => {
               serverChatAssistantKind,
               serverChatAssistantId,
               serverChatPersonaMemoryMode,
+              serverChatMetaLoaded,
               serverChatState,
               serverChatTopic,
               serverChatClusterId,

--- a/apps/packages/ui/src/hooks/useMessageOption.tsx
+++ b/apps/packages/ui/src/hooks/useMessageOption.tsx
@@ -393,6 +393,7 @@ export const useMessageOption = (
     serverChatAssistantKind,
     serverChatAssistantId,
     serverChatPersonaMemoryMode,
+    serverChatMetaLoaded,
     serverChatState,
     serverChatTopic,
     serverChatClusterId,

--- a/backlog/tasks/task-476 - Implement-Persona-chat-startup-memory-isolation.md
+++ b/backlog/tasks/task-476 - Implement-Persona-chat-startup-memory-isolation.md
@@ -33,16 +33,20 @@ Implement the first Persona-backed Chat Startup hardening slice from #1908: prev
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Updated `apps/packages/ui/src/hooks/chat/personaServerChat.ts` so `read_write` is preserved only when reusing an existing matching Persona-backed server chat.
 - New Persona-backed chats after stale Character or different-Persona reset now start with explicit `read_only` and a fresh `in-progress` metadata payload instead of carrying stale topic/source/cluster/external-ref state.
-- Updated `apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts` to cover stale Character reset and stale different-Persona reset behavior.
-- Verified with `bunx vitest run src/hooks/chat/__tests__/personaServerChat.test.ts` from `apps/packages/ui`.
+- PR #1935 review follow-up: added `serverChatMetaLoaded` to the Persona startup helper and callers so a restored `serverChatId` with assistant metadata still hydrating is reused instead of reset or recreated prematurely.
+- Updated `apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts` to cover stale Character reset, stale different-Persona reset, and restored-chat metadata-hydration behavior.
+- Verified red/green with `bunx vitest run src/hooks/chat/__tests__/personaServerChat.test.ts --reporter=verbose` from `apps/packages/ui`.
+- Verified integration with `bunx vitest run src/hooks/chat/__tests__/personaServerChat.test.ts src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx --reporter=verbose` from `apps/packages/ui`.
 - Verified with `git diff --check`.
+- Ran frontend lint through the WebUI config; the only error reported in touched files was pre-existing `no-extra-boolean-cast` in `useChatActions.ts:3121`, outside this patch hunk. The WebUI-wide lint command exits 0 with existing warnings.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing shared UI baseline type debt outside this slice and reports no diagnostics for the Persona startup changes.
 - Bandit not applicable: no Python files changed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the first Persona-backed chat startup hardening slice. The Persona server chat helper now isolates newly created Persona chats from stale non-matching assistant state, while preserving `read_write` only for an already matching Persona session.
+Closed the PR #1935 review follow-up for Persona chat startup memory isolation. The helper now waits for server chat metadata before treating a restored chat ID as stale, while still defaulting unknown/unhydrated Persona startup memory to read_only and preserving read_write only for loaded matching Persona sessions.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-476 - Implement-Persona-chat-startup-memory-isolation.md
+++ b/backlog/tasks/task-476 - Implement-Persona-chat-startup-memory-isolation.md
@@ -1,0 +1,56 @@
+---
+id: TASK-476
+title: Implement Persona chat startup memory isolation
+status: Done
+labels:
+- persona
+- chat
+- webui
+- bugfix
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/issues/1908
+- https://github.com/rmusser01/tldw_server/pull/1929
+- Docs/superpowers/plans/2026-05-22-persona-backed-chat-startup-hardening.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first Persona-backed Chat Startup hardening slice from #1908: prevent stale non-Persona chat state from carrying read_write memory mode into newly created Persona-backed chats.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Persona server chat helper defaults new Persona-backed chats to explicit read_only after stale Character or different-Persona chat reset.
+- [x] #2 Existing matching Persona-backed chats preserve read_write when reused.
+- [x] #3 Focused WebUI tests cover stale Character and stale different-Persona memory isolation.
+- [x] #4 Verification commands and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Updated `apps/packages/ui/src/hooks/chat/personaServerChat.ts` so `read_write` is preserved only when reusing an existing matching Persona-backed server chat.
+- New Persona-backed chats after stale Character or different-Persona reset now start with explicit `read_only` and a fresh `in-progress` metadata payload instead of carrying stale topic/source/cluster/external-ref state.
+- Updated `apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts` to cover stale Character reset and stale different-Persona reset behavior.
+- Verified with `bunx vitest run src/hooks/chat/__tests__/personaServerChat.test.ts` from `apps/packages/ui`.
+- Verified with `git diff --check`.
+- Bandit not applicable: no Python files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the first Persona-backed chat startup hardening slice. The Persona server chat helper now isolates newly created Persona chats from stale non-matching assistant state, while preserving `read_write` only for an already matching Persona session.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-476 - Implement-Persona-chat-startup-memory-isolation.md
+++ b/backlog/tasks/task-476 - Implement-Persona-chat-startup-memory-isolation.md
@@ -34,7 +34,8 @@ Implement the first Persona-backed Chat Startup hardening slice from #1908: prev
 - Updated `apps/packages/ui/src/hooks/chat/personaServerChat.ts` so `read_write` is preserved only when reusing an existing matching Persona-backed server chat.
 - New Persona-backed chats after stale Character or different-Persona reset now start with explicit `read_only` and a fresh `in-progress` metadata payload instead of carrying stale topic/source/cluster/external-ref state.
 - PR #1935 review follow-up: added `serverChatMetaLoaded` to the Persona startup helper and callers so a restored `serverChatId` with assistant metadata still hydrating is reused instead of reset or recreated prematurely.
-- Updated `apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts` to cover stale Character reset, stale different-Persona reset, and restored-chat metadata-hydration behavior.
+- PR #1935 review follow-up: brand-new Persona chats now also use fresh `in-progress` metadata even when stale conversation metadata remains in the store.
+- Updated `apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts` to cover stale Character reset, stale different-Persona reset, brand-new chat stale metadata isolation, and restored-chat metadata-hydration behavior.
 - Verified red/green with `bunx vitest run src/hooks/chat/__tests__/personaServerChat.test.ts --reporter=verbose` from `apps/packages/ui`.
 - Verified integration with `bunx vitest run src/hooks/chat/__tests__/personaServerChat.test.ts src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx --reporter=verbose` from `apps/packages/ui`.
 - Verified with `git diff --check`.
@@ -46,7 +47,7 @@ Implement the first Persona-backed Chat Startup hardening slice from #1908: prev
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Closed the PR #1935 review follow-up for Persona chat startup memory isolation. The helper now waits for server chat metadata before treating a restored chat ID as stale, while still defaulting unknown/unhydrated Persona startup memory to read_only and preserving read_write only for loaded matching Persona sessions.
+Closed the PR #1935 review follow-up for Persona chat startup memory isolation. The helper now waits for server chat metadata before treating a restored chat ID as stale, always starts newly created Persona chats with fresh metadata, defaults unknown/unhydrated Persona startup memory to read_only, and preserves read_write only for loaded matching Persona sessions.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Prevent newly created Persona-backed chats from inheriting stale read_write memory mode from a Character or different-Persona server chat.
- Reset stale conversation payload metadata for the new Persona chat to fresh in-progress defaults.
- Preserve read_write only when reusing an existing matching Persona-backed chat, with focused regression coverage.

## Tracking
- Part of #1908
- Backlog: TASK-476

## Verification
- From apps/packages/ui: bunx vitest run src/hooks/chat/__tests__/personaServerChat.test.ts
- git diff --check
- git diff --cached --check
- Bandit skipped: no Python files changed.

## Change Summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Persona chat startup memory isolation so new Persona-backed chats never inherit stale `read_write` or metadata and always start with a fresh in-progress state. Implements TASK-476 (part of #1908) by deferring resets until assistant metadata loads and preserving `read_write` only for a loaded matching Persona.

- **Bug Fixes**
  - New Persona chats always start `read_only` with fresh `in-progress` metadata, ignoring any stale topic/source/cluster/external_ref in the store.
  - Preserve `read_write` only when reusing the same loaded Persona; different Persona or Character resets to `read_only`.
  - Added `serverChatMetaLoaded` to the helper and callers to avoid resetting/creating before metadata hydrates; expanded tests for stale Character, different Persona, stale store metadata, and restored-chat hydration.

<sup>Written for commit 5421f5f72dbb2a1af20c7c6160ed093cf2ccd217. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1935?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

