### PR TITLE
Migrate source form test alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2673,28 +2673,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx:Alert#antd-alert-sourceformmodal-type-error-line-440-1b05f6o",
-    "path": "src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx:Alert#antd-alert-sourceformmodal-type-info-line-423-bgehad",
-    "path": "src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx:Alert",
     "path": "src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useLayoutEffect, useRef } from "react"
-import { Alert, Button, Form, Input, Modal, Select, message } from "antd"
+import { Button, Form, Input, Modal, Select, message } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { testWatchlistSource, testWatchlistSourceDraft } from "@/services/watchlists"
 import type { JobPreviewResult, SourcePreviewDiagnostics } from "@/types/watchlists"
 import type { WatchlistSource, SourceType } from "@/types/watchlists"
@@ -424,10 +425,10 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
           </div>
           {testResult && (
             <Alert
-              type={Number(testResult.total || 0) > 0 ? "success" : "warning"}
-              showIcon
+              variant={Number(testResult.total || 0) > 0 ? "success" : "warning"}
               title={t("watchlists:sources.form.testSourceSummary", "Test Summary")}
-              description={t(
+            >
+              {t(
                 "watchlists:sources.form.testSourceSummaryDescription",
                 "{{total}} preview item{{plural}}, {{ingestable}} ingestable, {{filtered}} filtered.",
                 {
@@ -437,41 +438,35 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
                   plural: Number(testResult.total || 0) === 1 ? "" : "s"
                 }
               )}
-            />
+            </Alert>
           )}
           {diagnosticsLines.length > 0 && (
             <Alert
-              type="info"
-              showIcon
-              message={t(
+              variant="info"
+              title={t(
                 "watchlists:sources.form.validationDiagnostics",
                 "Validation diagnostics"
               )}
-              description={(
-                <div className="space-y-1">
-                  {diagnosticsLines.map((line) => (
-                    <div key={line}>{line}</div>
-                  ))}
-                </div>
-              )}
-            />
+            >
+              <div className="space-y-1">
+                {diagnosticsLines.map((line) => (
+                  <div key={line}>{line}</div>
+                ))}
+              </div>
+            </Alert>
           )}
           {testError && (
             <Alert
-              type="error"
-              showIcon
+              variant="error"
               title={testError}
-              description={testErrorHint || testError}
-              action={(
-                <Button
-                  size="small"
-                  onClick={() => void handleTestSource()}
-                  loading={testingSource}
-                >
-                  {t("watchlists:errors.retry", "Retry")}
-                </Button>
-              )}
-            />
+              action={{
+                label: t("watchlists:errors.retry", "Retry"),
+                onClick: () => void handleTestSource(),
+                loading: testingSource
+              }}
+            >
+              {testErrorHint || testError}
+            </Alert>
           )}
         </div>
 

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
@@ -178,6 +178,10 @@ describe("SourceFormModal test-source preflight", () => {
       )
       expect(screen.getByText("Test Summary")).toBeInTheDocument()
     })
+    const summaryAlert = screen
+      .getByText("Test Summary")
+      .closest("[data-ds-component='Alert']")
+    expect(summaryAlert).toHaveAttribute("data-ds-component", "Alert")
   })
 
   it("tests unsaved draft feeds without requiring save", async () => {
@@ -313,6 +317,10 @@ describe("SourceFormModal test-source preflight", () => {
       expect(screen.getByText("title selector matched 0 nodes")).toBeInTheDocument()
       expect(screen.getByText("Dedupe preview key: guid_xpath")).toBeInTheDocument()
     })
+    const diagnosticsAlert = screen
+      .getByText("Validation diagnostics")
+      .closest("[data-ds-component='Alert']")
+    expect(diagnosticsAlert).toHaveAttribute("data-ds-component", "Alert")
   })
 
   it("shows inline remediation guidance when draft preflight fails", async () => {
@@ -339,6 +347,10 @@ describe("SourceFormModal test-source preflight", () => {
         screen.getByText(/Use a canonical YouTube feed URL \(channel_id or playlist_id\) and retry\./)
       ).toBeInTheDocument()
     })
+    const errorAlert = screen
+      .getByText("Could not test feed preflight.")
+      .closest("[data-ds-component='Alert']")
+    expect(errorAlert).toHaveAttribute("data-ds-component", "Alert")
 
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
 

--- a/backlog/tasks/task-45.44.9.5 - Migrate-SourceFormModal-test-source-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.5 - Migrate-SourceFormModal-test-source-alerts-to-design-system-Alert.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.44.9.5
+title: Migrate SourceFormModal test-source alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+- watchlists
+priority: medium
+parent_task_id: TASK-45.44.9
+references:
+- https://github.com/rmusser01/tldw_server/issues/1666
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1936
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the Watchlists SourceFormModal test-source diagnostics and error alert UI off AntD Alert and onto the canonical design-system Alert, clearing the current guard blocked/stale mismatch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SourceFormModal test-source diagnostics and error alerts render the design-system Alert primitive instead of AntD Alert.
+- [x] #2 Retry behavior and remediation copy remain covered by focused tests.
+- [x] #3 Design-system product-state verifier passes with stale SourceFormModal Alert baseline entries removed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing SourceFormModal test-source assertions requiring the diagnostics and error alerts to render with the design-system Alert marker.
+2. Replace the relevant SourceFormModal AntD Alert usages with the canonical design-system Alert primitive while preserving text, variant, and retry behavior.
+3. Remove stale SourceFormModal Alert baseline entries and run focused test plus product-state verifier.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+TDD red/green completed. Added failing assertions for SourceFormModal summary, diagnostics, and error callouts requiring the design-system Alert marker. Replaced the AntD Alert import/usages in the test-source block with the canonical design-system Alert primitive while preserving summary, diagnostics, remediation copy, and retry behavior. Removed the two stale SourceFormModal Alert baseline entries.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated SourceFormModal test-source summary, diagnostics, and error callouts from AntD Alert to the design-system Alert primitive. Added focused test-source coverage for the design-system Alert marker while preserving retry behavior and remediation guidance. Removed stale SourceFormModal Alert exceptions from the product-state baseline. Verification: bunx vitest run src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx; bun run verify:design-system-state; git diff --check. Bandit skipped: frontend-only TSX/test/JSON change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates SourceFormModal test-source summary, diagnostics, and error callouts from AntD `Alert` to the design-system `Alert`.
- Adds focused SourceFormModal test-source coverage for the design-system Alert marker while preserving retry/remediation behavior.
- Removes the stale SourceFormModal `Alert` exceptions from the product-state baseline.

## Verification
- `bunx vitest run src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx`
- `bun run verify:design-system-state`
- `git diff --check`

## Backlog
- `TASK-45.44.9.5`

## Change Summary
TODO: Human-authored summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates SourceFormModal test-source alerts from AntD to the design-system `Alert` for consistent UI and product-state compliance. Satisfies TASK-45.44.9.5 and preserves retry/remediation behavior.

- **Refactors**
  - Replaced AntD `Alert` with design-system `Alert` (summary, diagnostics, error) in `SourceFormModal`.
  - Updated tests to assert `[data-ds-component='Alert']` for summary/diagnostics/error while keeping retry action coverage.
  - Wired `variant`, `title`, children content, and `action` props to match previous behavior; error retry now uses `action={{ label, onClick, loading }}`.
  - Removed two stale `SourceFormModal` `Alert` exceptions from the design-system product-state baseline.

<sup>Written for commit 0fbdfac2e3e53ed26d47c9fa668f564e84e21443. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1936?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

