### PR TITLE
Lock WP11B route ownership contract

### DIFF
--- a/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import { STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS } from "../study-safety-specialized-route-jobs"
 
 const registryPathCandidates = [
   "src/routes/sidepanel-route-registry.tsx",
@@ -33,6 +34,18 @@ describe("sidepanel flashcards route registration", () => {
   it("registers a /flashcards route in the sidepanel registry", () => {
     expect(registrySource).toMatch(/path:\s*"\/flashcards"/)
     expect(registrySource).toContain("SidepanelFlashcards")
+  })
+
+  it("keeps flashcards as the only Task 11B sidepanel route", () => {
+    const sidepanelOnlyRoutes = STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS.filter(
+      (job) => job.route !== "/flashcards"
+    )
+
+    for (const job of sidepanelOnlyRoutes) {
+      expect(registrySource).not.toMatch(
+        new RegExp(`path:\\s*"${job.route.replace("/", "\\/")}"`)
+      )
+    }
   })
 
   it("lazy-imports the SidepanelFlashcards component", () => {

--- a/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx
@@ -1,0 +1,217 @@
+import React from "react"
+import { existsSync, readFileSync } from "node:fs"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+
+vi.mock("~/components/Layouts/Layout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="option-layout">{children}</div>
+  )
+}))
+
+vi.mock("@/components/Layouts/Layout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="option-layout">{children}</div>
+  )
+}))
+
+vi.mock("@/components/Common/PageShell", () => ({
+  PageShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="page-shell">{children}</div>
+  )
+}))
+
+vi.mock("@/components/Common/RouteErrorBoundary", () => ({
+  RouteErrorBoundary: ({
+    children,
+    routeId,
+    routeLabel
+  }: {
+    children: React.ReactNode
+    routeId: string
+    routeLabel: string
+  }) => (
+    <div
+      data-testid={`route-boundary-${routeId}`}
+      data-route-id={routeId}
+      data-route-label={routeLabel}
+    >
+      {children}
+    </div>
+  )
+}))
+
+vi.mock("@/components/Option/Evaluations/EvaluationsPlaygroundPage", () => ({
+  EvaluationsPlaygroundPage: () => (
+    <div data-testid="evaluations-playground-page">Evaluations</div>
+  )
+}))
+
+vi.mock("@/components/Flashcards/FlashcardsWorkspace", () => ({
+  FlashcardsWorkspace: () => (
+    <div data-testid="flashcards-workspace">Flashcards</div>
+  )
+}))
+
+vi.mock("@/components/Quiz/QuizWorkspace", () => ({
+  QuizWorkspace: () => <div data-testid="quiz-workspace">Quiz</div>
+}))
+
+vi.mock("@/components/ContentReview/ContentReviewPage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="content-review-page">Content Review</div>
+}))
+
+vi.mock("@/components/Option/DataTables", () => ({
+  DataTablesPage: () => <div data-testid="data-tables-page">Data Tables</div>
+}))
+
+vi.mock("@/components/Option/ChunkingPlayground", () => ({
+  ChunkingPlayground: () => (
+    <div data-testid="chunking-playground-page">Chunking</div>
+  )
+}))
+
+vi.mock("@/components/Option/KanbanPlayground", () => ({
+  KanbanPlayground: () => <div data-testid="kanban-playground">Kanban</div>
+}))
+
+import OptionEvaluations from "../option-evaluations"
+import OptionFlashcards from "../option-flashcards"
+import OptionQuiz from "../option-quiz"
+import OptionModerationPlayground from "../option-moderation-playground"
+import OptionContentReview from "../option-content-review"
+import OptionDataTables from "../option-data-tables"
+import OptionChunkingPlayground from "../option-chunking-playground"
+import OptionKanbanPlayground from "../option-kanban-playground"
+
+const resolveSourcePath = (candidates: string[]) => {
+  const path = candidates.find((candidate) => existsSync(candidate))
+  if (!path) {
+    throw new Error(`Unable to locate source file: ${candidates.join(", ")}`)
+  }
+  return path
+}
+
+const readWorkspaceSource = (candidates: string[]) =>
+  readFileSync(resolveSourcePath(candidates), "utf8")
+
+const sharedRouteCases = [
+  {
+    route: "/evaluations",
+    Component: OptionEvaluations,
+    routeId: "evaluations",
+    routeLabel: "Evaluations",
+    target: "evaluations-playground-page"
+  },
+  {
+    route: "/flashcards",
+    Component: OptionFlashcards,
+    routeId: "flashcards",
+    routeLabel: "Flashcards",
+    target: "flashcards-workspace"
+  },
+  {
+    route: "/quiz",
+    Component: OptionQuiz,
+    routeId: "quiz",
+    routeLabel: "Quiz",
+    target: "quiz-workspace"
+  },
+  {
+    route: "/content-review",
+    Component: OptionContentReview,
+    routeId: "content-review",
+    routeLabel: "Content Review",
+    target: "content-review-page"
+  },
+  {
+    route: "/data-tables",
+    Component: OptionDataTables,
+    routeId: "data-tables",
+    routeLabel: "Data Tables",
+    target: "data-tables-page"
+  },
+  {
+    route: "/chunking-playground",
+    Component: OptionChunkingPlayground,
+    routeId: "chunking-playground",
+    routeLabel: "Chunking Playground",
+    target: "chunking-playground-page"
+  },
+  {
+    route: "/kanban",
+    Component: OptionKanbanPlayground,
+    routeId: "kanban",
+    routeLabel: "Kanban",
+    target: "kanban-playground"
+  }
+] as const
+
+describe("study, safety, and specialized route boundaries", () => {
+  it.each(sharedRouteCases)(
+    "keeps $route wrapped by its canonical shared page boundary",
+    ({ Component, routeId, routeLabel, target }) => {
+      render(<Component />)
+
+      const boundary = screen.getByTestId(`route-boundary-${routeId}`)
+
+      expect(screen.getByTestId("option-layout")).toBeVisible()
+      expect(boundary).toHaveAttribute("data-route-id", routeId)
+      expect(boundary).toHaveAttribute("data-route-label", routeLabel)
+      expect(screen.getByTestId(target)).toBeVisible()
+    }
+  )
+
+  it("keeps the legacy moderation playground route redirected to moderation rules", async () => {
+    render(
+      <MemoryRouter initialEntries={["/moderation-playground"]}>
+        <Routes>
+          <Route
+            path="/moderation-playground"
+            element={<OptionModerationPlayground />}
+          />
+          <Route
+            path="/moderation/rules"
+            element={<div data-testid="moderation-rules-target" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByTestId("moderation-rules-target")).toBeVisible()
+  })
+
+  it("keeps the web-only claims review route as a content-review alias", () => {
+    const source = readWorkspaceSource([
+      "../../tldw-frontend/pages/claims-review.tsx",
+      "apps/tldw-frontend/pages/claims-review.tsx"
+    ])
+
+    expect(source).toContain("RouteRedirect")
+    expect(source).toContain('to="/content-review"')
+  })
+
+  it("keeps VN labs routes as web-only Next pages", () => {
+    const vnAssetsSource = readWorkspaceSource([
+      "../../tldw-frontend/pages/vn-assets.tsx",
+      "apps/tldw-frontend/pages/vn-assets.tsx"
+    ])
+    const vnPlaySource = readWorkspaceSource([
+      "../../tldw-frontend/pages/vn-play.tsx",
+      "apps/tldw-frontend/pages/vn-play.tsx"
+    ])
+
+    expect(vnAssetsSource).toContain(
+      "import('@web/components/vn-assets/VNAssetsWorkbench')"
+    )
+    expect(vnAssetsSource).toContain("ssr: false")
+    expect(vnPlaySource).toContain(
+      "import('@web/components/vn-play/VNPlayWorkspace')"
+    )
+    expect(vnPlaySource).toContain("ssr: false")
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
@@ -88,17 +87,6 @@ import OptionDataTables from "../option-data-tables"
 import OptionChunkingPlayground from "../option-chunking-playground"
 import OptionKanbanPlayground from "../option-kanban-playground"
 
-const resolveSourcePath = (candidates: string[]) => {
-  const path = candidates.find((candidate) => existsSync(candidate))
-  if (!path) {
-    throw new Error(`Unable to locate source file: ${candidates.join(", ")}`)
-  }
-  return path
-}
-
-const readWorkspaceSource = (candidates: string[]) =>
-  readFileSync(resolveSourcePath(candidates), "utf8")
-
 const sharedRouteCases = [
   {
     route: "/evaluations",
@@ -183,35 +171,5 @@ describe("study, safety, and specialized route boundaries", () => {
     )
 
     expect(await screen.findByTestId("moderation-rules-target")).toBeVisible()
-  })
-
-  it("keeps the web-only claims review route as a content-review alias", () => {
-    const source = readWorkspaceSource([
-      "../../tldw-frontend/pages/claims-review.tsx",
-      "apps/tldw-frontend/pages/claims-review.tsx"
-    ])
-
-    expect(source).toContain("RouteRedirect")
-    expect(source).toContain('to="/content-review"')
-  })
-
-  it("keeps VN labs routes as web-only Next pages", () => {
-    const vnAssetsSource = readWorkspaceSource([
-      "../../tldw-frontend/pages/vn-assets.tsx",
-      "apps/tldw-frontend/pages/vn-assets.tsx"
-    ])
-    const vnPlaySource = readWorkspaceSource([
-      "../../tldw-frontend/pages/vn-play.tsx",
-      "apps/tldw-frontend/pages/vn-play.tsx"
-    ])
-
-    expect(vnAssetsSource).toContain(
-      "import('@web/components/vn-assets/VNAssetsWorkbench')"
-    )
-    expect(vnAssetsSource).toContain("ssr: false")
-    expect(vnPlaySource).toContain(
-      "import('@web/components/vn-play/VNPlayWorkspace')"
-    )
-    expect(vnPlaySource).toContain("ssr: false")
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-jobs.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-jobs.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import {
+  STUDY_SAFETY_SPECIALIZED_ROUTE_FINDINGS,
+  STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS
+} from "../study-safety-specialized-route-jobs"
+import { getRouteMetadata } from "../route-metadata"
+
+const routes = [
+  "/evaluations",
+  "/flashcards",
+  "/quiz",
+  "/moderation-playground",
+  "/content-review",
+  "/claims-review",
+  "/data-tables",
+  "/chunking-playground",
+  "/kanban",
+  "/vn-assets",
+  "/vn-play"
+] as const
+
+describe("study, safety, and specialized route jobs", () => {
+  it("covers every Task 11B route once", () => {
+    expect(STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS.map((job) => job.route).sort()).toEqual(
+      Array.from(routes).sort()
+    )
+  })
+
+  it("keeps labels aligned with route metadata", () => {
+    for (const job of STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS) {
+      expect(job.label).toBe(getRouteMetadata(job.route)?.label)
+    }
+  })
+
+  it("keeps labels, jobs, and classifications usable", () => {
+    for (const job of STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS) {
+      expect(job.label).not.toHaveLength(0)
+      expect(job.primaryJob).not.toHaveLength(0)
+      expect(job.primaryActionLabel).not.toHaveLength(0)
+      expect(job.classification).not.toHaveLength(0)
+      expect(job.canonicalComponent).not.toHaveLength(0)
+      expect(job.visibilityDecision).not.toHaveLength(0)
+    }
+  })
+
+  it("maps all Task 11B audit findings", () => {
+    const covered = new Set(
+      STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS.flatMap((job) => job.findings)
+    )
+
+    for (const finding of STUDY_SAFETY_SPECIALIZED_ROUTE_FINDINGS) {
+      expect(covered.has(finding)).toBe(true)
+    }
+  })
+
+  it("preserves canonical ownership for aliases, labs, and shared routes", () => {
+    expect(STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          route: "/moderation-playground",
+          routeOwner: "shared_alias",
+          canonicalComponent: "Navigate:/moderation/rules",
+          visibilityDecision: "alias_only"
+        }),
+        expect.objectContaining({
+          route: "/claims-review",
+          routeOwner: "next_alias",
+          canonicalComponent: "RouteRedirect:/content-review",
+          visibilityDecision: "alias_only"
+        }),
+        expect.objectContaining({
+          route: "/vn-assets",
+          routeOwner: "next_page",
+          canonicalComponent: "VNAssetsWorkbench",
+          visibilityDecision: "labs_nav"
+        }),
+        expect.objectContaining({
+          route: "/vn-play",
+          routeOwner: "next_page",
+          canonicalComponent: "VNPlayWorkspace",
+          visibilityDecision: "labs_nav"
+        })
+      ])
+    )
+  })
+
+  it("keeps alias routes hidden and recoverable in route metadata", () => {
+    const aliases = [
+      ["/moderation-playground", "/moderation/rules"],
+      ["/claims-review", "/content-review"]
+    ] as const
+
+    for (const [route, destination] of aliases) {
+      const metadata = getRouteMetadata(route)
+
+      expect(metadata?.canonicalPath).toBe(destination)
+      expect(metadata?.redirectsTo).toBe(destination)
+      expect(metadata?.surface).toBe("redirect")
+      expect(metadata?.commandPalette).toBe("alias_only")
+      expect(metadata?.nav).toBe("hidden")
+      expect(metadata?.smoke).toBe("exclude")
+    }
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-jobs.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-jobs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  getStudySafetySpecializedRouteJob,
   STUDY_SAFETY_SPECIALIZED_ROUTE_FINDINGS,
   STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS
 } from "../study-safety-specialized-route-jobs"
@@ -29,6 +30,12 @@ describe("study, safety, and specialized route jobs", () => {
   it("keeps labels aligned with route metadata", () => {
     for (const job of STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS) {
       expect(job.label).toBe(getRouteMetadata(job.route)?.label)
+    }
+  })
+
+  it("looks up route jobs by canonical route", () => {
+    for (const job of STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS) {
+      expect(getStudySafetySpecializedRouteJob(job.route)).toBe(job)
     }
   })
 

--- a/apps/packages/ui/src/routes/option-evaluations.tsx
+++ b/apps/packages/ui/src/routes/option-evaluations.tsx
@@ -1,13 +1,15 @@
 import OptionLayout from "~/components/Layouts/Layout"
+import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
 import { EvaluationsPlaygroundPage } from "@/components/Option/Evaluations/EvaluationsPlaygroundPage"
 
 const OptionEvaluations = () => {
   return (
-    <OptionLayout>
-      <EvaluationsPlaygroundPage />
-    </OptionLayout>
+    <RouteErrorBoundary routeId="evaluations" routeLabel="Evaluations">
+      <OptionLayout>
+        <EvaluationsPlaygroundPage />
+      </OptionLayout>
+    </RouteErrorBoundary>
   )
 }
 
 export default OptionEvaluations
-

--- a/apps/packages/ui/src/routes/option-kanban-playground.tsx
+++ b/apps/packages/ui/src/routes/option-kanban-playground.tsx
@@ -5,7 +5,7 @@ import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
 
 const OptionKanbanPlayground = () => {
   return (
-    <RouteErrorBoundary routeId="kanban-playground" routeLabel="Kanban Playground">
+    <RouteErrorBoundary routeId="kanban" routeLabel="Kanban">
       <OptionLayout>
         <PageShell className="py-6" maxWidthClassName="max-w-7xl">
           <KanbanPlayground />

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -868,16 +868,17 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
   },
   {
     path: "/claims-review",
-    canonicalPath: "/claims-review",
+    canonicalPath: "/content-review",
     label: "Claims Review",
     group: "safety",
-    surface: "advanced_self_hosted",
+    surface: "redirect",
     availability: webOnly,
-    smoke: "include",
-    commandPalette: "show",
-    nav: "secondary",
+    redirectsTo: "/content-review",
+    smoke: "exclude",
+    commandPalette: "alias_only",
+    nav: "hidden",
     requiresBackend: true,
-    rationale: "Claims review is a focused verification workflow and secondary to content review."
+    rationale: "Legacy claims review route redirects to the canonical content review workflow."
   },
   {
     path: "/data-tables",

--- a/apps/packages/ui/src/routes/study-safety-specialized-route-jobs.ts
+++ b/apps/packages/ui/src/routes/study-safety-specialized-route-jobs.ts
@@ -1,0 +1,296 @@
+export type SpecializedRouteConcept =
+  | "evaluation"
+  | "study_flashcards"
+  | "study_quiz"
+  | "safety"
+  | "review_queue"
+  | "legacy_alias"
+  | "structured_data"
+  | "rag_tuning"
+  | "planning_board"
+  | "vn_assets"
+  | "vn_runtime"
+
+export type SpecializedRouteClassification =
+  | "advanced_self_hosted"
+  | "study_workspace"
+  | "operator_safety"
+  | "review_workflow"
+  | "beta_tool"
+  | "labs_tool"
+  | "legacy_alias"
+
+export type SpecializedRouteOwner =
+  | "shared_route"
+  | "shared_alias"
+  | "extension_route"
+  | "next_page"
+  | "next_alias"
+
+export type SpecializedRouteFinding =
+  | "F2 support"
+  | "F9 support"
+  | "F15 support"
+  | "F18 support"
+  | "F19 support"
+
+export type SpecializedRouteVisibilityDecision =
+  | "default_nav"
+  | "advanced_nav"
+  | "labs_nav"
+  | "alias_only"
+
+export type SpecializedRouteJob = {
+  route:
+    | "/evaluations"
+    | "/flashcards"
+    | "/quiz"
+    | "/moderation-playground"
+    | "/content-review"
+    | "/claims-review"
+    | "/data-tables"
+    | "/chunking-playground"
+    | "/kanban"
+    | "/vn-assets"
+    | "/vn-play"
+  concept: SpecializedRouteConcept
+  classification: SpecializedRouteClassification
+  label: string
+  primaryJob: string
+  primaryActionLabel: string
+  routeOwner: SpecializedRouteOwner
+  canonicalComponent: string
+  modes: string[]
+  findings: SpecializedRouteFinding[]
+  visibilityDecision: SpecializedRouteVisibilityDecision
+}
+
+export const STUDY_SAFETY_SPECIALIZED_ROUTE_FINDINGS = [
+  "F2 support",
+  "F9 support",
+  "F15 support",
+  "F18 support",
+  "F19 support"
+] as const satisfies SpecializedRouteFinding[]
+
+export const STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS: SpecializedRouteJob[] = [
+  {
+    route: "/evaluations",
+    concept: "evaluation",
+    classification: "advanced_self_hosted",
+    label: "Evaluations",
+    primaryJob:
+      "Define and inspect evaluation recipes, runs, datasets, webhooks, and history.",
+    primaryActionLabel: "Create evaluation",
+    routeOwner: "shared_route",
+    canonicalComponent: "EvaluationsPlaygroundPage",
+    modes: [
+      "Recipes",
+      "Review",
+      "Evaluations",
+      "Runs",
+      "Datasets",
+      "Webhooks",
+      "History"
+    ],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "advanced_nav"
+  },
+  {
+    route: "/flashcards",
+    concept: "study_flashcards",
+    classification: "study_workspace",
+    label: "Flashcards",
+    primaryJob:
+      "Study, manage, import, export, template, and schedule flashcards.",
+    primaryActionLabel: "Start studying",
+    routeOwner: "shared_route",
+    canonicalComponent: "FlashcardsWorkspace",
+    modes: ["Study", "Manage", "Import / Export", "Templates", "Scheduler"],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "default_nav"
+  },
+  {
+    route: "/quiz",
+    concept: "study_quiz",
+    classification: "study_workspace",
+    label: "Quiz",
+    primaryJob: "Take, generate, create, manage, and review quiz results.",
+    primaryActionLabel: "Take quiz",
+    routeOwner: "shared_route",
+    canonicalComponent: "QuizWorkspace",
+    modes: ["Take Quiz", "Generate", "Create", "Manage", "Results"],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "default_nav"
+  },
+  {
+    route: "/moderation-playground",
+    concept: "legacy_alias",
+    classification: "legacy_alias",
+    label: "Moderation Playground",
+    primaryJob: "Redirect to the canonical moderation rules workflow.",
+    primaryActionLabel: "Open Moderation Rules",
+    routeOwner: "shared_alias",
+    canonicalComponent: "Navigate:/moderation/rules",
+    modes: [],
+    findings: ["F2 support", "F18 support", "F19 support"],
+    visibilityDecision: "alias_only"
+  },
+  {
+    route: "/content-review",
+    concept: "review_queue",
+    classification: "review_workflow",
+    label: "Content Review",
+    primaryJob: "Review and commit drafts created before saving content.",
+    primaryActionLabel: "Open draft",
+    routeOwner: "shared_route",
+    canonicalComponent: "ContentReviewPage",
+    modes: ["Batch", "Drafts", "Edit", "Diff", "Metadata", "Actions"],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "advanced_nav"
+  },
+  {
+    route: "/claims-review",
+    concept: "legacy_alias",
+    classification: "legacy_alias",
+    label: "Claims Review",
+    primaryJob: "Redirect to the canonical content review queue.",
+    primaryActionLabel: "Open Content Review",
+    routeOwner: "next_alias",
+    canonicalComponent: "RouteRedirect:/content-review",
+    modes: [],
+    findings: ["F2 support", "F18 support"],
+    visibilityDecision: "alias_only"
+  },
+  {
+    route: "/data-tables",
+    concept: "structured_data",
+    classification: "beta_tool",
+    label: "Data Tables",
+    primaryJob: "Generate, save, preview, edit, and export structured tables.",
+    primaryActionLabel: "Create table",
+    routeOwner: "shared_route",
+    canonicalComponent: "DataTablesPage",
+    modes: ["My Tables", "Create Table"],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "advanced_nav"
+  },
+  {
+    route: "/chunking-playground",
+    concept: "rag_tuning",
+    classification: "advanced_self_hosted",
+    label: "Chunking Playground",
+    primaryJob: "Tune and compare chunking strategies.",
+    primaryActionLabel: "Run chunking",
+    routeOwner: "shared_route",
+    canonicalComponent: "ChunkingPlayground",
+    modes: ["Single", "Compare", "Templates", "Capabilities"],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "labs_nav"
+  },
+  {
+    route: "/kanban",
+    concept: "planning_board",
+    classification: "advanced_self_hosted",
+    label: "Kanban",
+    primaryJob: "Manage boards, cards, labels, due dates, imports, and exports.",
+    primaryActionLabel: "Create board",
+    routeOwner: "shared_route",
+    canonicalComponent: "KanbanPlayground",
+    modes: ["Boards", "Cards", "Import", "Export", "Archive"],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "advanced_nav"
+  },
+  {
+    route: "/vn-assets",
+    concept: "vn_assets",
+    classification: "labs_tool",
+    label: "VN Assets",
+    primaryJob: "Prepare VN asset packs and review generated variants.",
+    primaryActionLabel: "Create pack",
+    routeOwner: "next_page",
+    canonicalComponent: "VNAssetsWorkbench",
+    modes: ["Setup", "Matrix", "Generate", "Review", "Portability"],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "labs_nav"
+  },
+  {
+    route: "/vn-play",
+    concept: "vn_runtime",
+    classification: "labs_tool",
+    label: "VN Play",
+    primaryJob: "Run VN play sessions and inspect runtime state.",
+    primaryActionLabel: "New session",
+    routeOwner: "next_page",
+    canonicalComponent: "VNPlayWorkspace",
+    modes: [
+      "Sessions",
+      "Scene",
+      "Dialogue",
+      "Choices",
+      "Inspector",
+      "Checkpoints"
+    ],
+    findings: [
+      "F2 support",
+      "F9 support",
+      "F15 support",
+      "F18 support",
+      "F19 support"
+    ],
+    visibilityDecision: "labs_nav"
+  }
+]
+
+export const getStudySafetySpecializedRouteJob = (
+  route: SpecializedRouteJob["route"]
+): SpecializedRouteJob | undefined =>
+  STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS.find((job) => job.route === route)

--- a/apps/packages/ui/src/routes/study-safety-specialized-route-jobs.ts
+++ b/apps/packages/ui/src/routes/study-safety-specialized-route-jobs.ts
@@ -290,7 +290,11 @@ export const STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS: SpecializedRouteJob[] = [
   }
 ]
 
+const STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS_BY_ROUTE = new Map(
+  STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS.map((job) => [job.route, job])
+)
+
 export const getStudySafetySpecializedRouteJob = (
   route: SpecializedRouteJob["route"]
 ): SpecializedRouteJob | undefined =>
-  STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS.find((job) => job.route === route)
+  STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS_BY_ROUTE.get(route)

--- a/apps/tldw-frontend/__tests__/extension/study-safety-specialized-route-parity.test.tsx
+++ b/apps/tldw-frontend/__tests__/extension/study-safety-specialized-route-parity.test.tsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+vi.mock("@web/components/layout/WebLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="extension-option-layout">{children}</div>
+  )
+}))
+
+vi.mock("@/components/Common/PageShell", () => ({
+  PageShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="page-shell">{children}</div>
+  )
+}))
+
+vi.mock("@/components/Common/RouteErrorBoundary", () => ({
+  RouteErrorBoundary: ({
+    children,
+    routeId,
+    routeLabel
+  }: {
+    children: React.ReactNode
+    routeId: string
+    routeLabel: string
+  }) => (
+    <div
+      data-testid={`extension-route-boundary-${routeId}`}
+      data-route-id={routeId}
+      data-route-label={routeLabel}
+    >
+      {children}
+    </div>
+  )
+}))
+
+vi.mock("@/components/Option/Evaluations/EvaluationsPlaygroundPage", () => ({
+  EvaluationsPlaygroundPage: () => (
+    <div data-testid="extension-evaluations-page">Evaluations</div>
+  )
+}))
+
+vi.mock("@/components/Option/KanbanPlayground", () => ({
+  KanbanPlayground: () => (
+    <div data-testid="extension-kanban-page">Kanban</div>
+  )
+}))
+
+import OptionEvaluations from "@web/extension/routes/option-evaluations"
+import OptionKanbanPlayground from "@web/extension/routes/option-kanban-playground"
+
+describe("extension study, safety, and specialized route parity", () => {
+  it("wraps extension /evaluations with the canonical route boundary", () => {
+    render(<OptionEvaluations />)
+
+    const boundary = screen.getByTestId("extension-route-boundary-evaluations")
+
+    expect(boundary).toHaveAttribute("data-route-id", "evaluations")
+    expect(boundary).toHaveAttribute("data-route-label", "Evaluations")
+    expect(screen.getByTestId("extension-option-layout")).toBeVisible()
+    expect(screen.getByTestId("extension-evaluations-page")).toBeVisible()
+  })
+
+  it("wraps extension /kanban with the canonical route boundary", () => {
+    render(<OptionKanbanPlayground />)
+
+    const boundary = screen.getByTestId("extension-route-boundary-kanban")
+
+    expect(boundary).toHaveAttribute("data-route-id", "kanban")
+    expect(boundary).toHaveAttribute("data-route-label", "Kanban")
+    expect(screen.getByTestId("extension-option-layout")).toBeVisible()
+    expect(screen.getByTestId("extension-kanban-page")).toBeVisible()
+  })
+})

--- a/apps/tldw-frontend/__tests__/pages/study-safety-specialized-page-shims.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/study-safety-specialized-page-shims.test.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+const dynamicCalls = vi.hoisted(
+  () => [] as Array<{ ssr?: boolean }>
+)
+
+vi.mock("next/dynamic", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react")
+
+  return {
+    default: (_loader: () => unknown, options?: { ssr?: boolean }) => {
+      dynamicCalls.push({
+        ssr: options?.ssr
+      })
+
+      return function MockDynamicPage() {
+        return ReactModule.createElement("div", {
+          "data-testid": "dynamic-next-page"
+        })
+      }
+    }
+  }
+})
+
+vi.mock("@web/components/navigation/RouteRedirect", () => ({
+  RouteRedirect: ({ to }: { to: string }) => (
+    <div data-testid="route-redirect" data-to={to} />
+  )
+}))
+
+import ClaimsReviewPage from "@web/pages/claims-review"
+import VNAssetsPage from "@web/pages/vn-assets"
+import VNPlayPage from "@web/pages/vn-play"
+
+describe("study, safety, and specialized Next page shims", () => {
+  it("keeps claims-review as a content-review redirect page", () => {
+    render(<ClaimsReviewPage />)
+
+    expect(screen.getByTestId("route-redirect")).toHaveAttribute(
+      "data-to",
+      "/content-review"
+    )
+  })
+
+  it("keeps VN labs routes as client-only Next dynamic pages", () => {
+    render(<VNAssetsPage />)
+    render(<VNPlayPage />)
+
+    expect(dynamicCalls.filter((call) => call.ssr === false)).toHaveLength(2)
+    expect(screen.getAllByTestId("dynamic-next-page")).toHaveLength(2)
+  })
+})

--- a/apps/tldw-frontend/extension/routes/option-evaluations.tsx
+++ b/apps/tldw-frontend/extension/routes/option-evaluations.tsx
@@ -1,13 +1,15 @@
 import OptionLayout from "@web/components/layout/WebLayout"
+import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
 import { EvaluationsPlaygroundPage } from "@/components/Option/Evaluations/EvaluationsPlaygroundPage"
 
 const OptionEvaluations = () => {
   return (
-    <OptionLayout>
-      <EvaluationsPlaygroundPage />
-    </OptionLayout>
+    <RouteErrorBoundary routeId="evaluations" routeLabel="Evaluations">
+      <OptionLayout>
+        <EvaluationsPlaygroundPage />
+      </OptionLayout>
+    </RouteErrorBoundary>
   )
 }
 
 export default OptionEvaluations
-

--- a/apps/tldw-frontend/extension/routes/option-kanban-playground.tsx
+++ b/apps/tldw-frontend/extension/routes/option-kanban-playground.tsx
@@ -5,7 +5,7 @@ import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
 
 const OptionKanbanPlayground = () => {
   return (
-    <RouteErrorBoundary routeId="kanban-playground" routeLabel="Kanban Playground">
+    <RouteErrorBoundary routeId="kanban" routeLabel="Kanban">
       <OptionLayout>
         <PageShell className="py-6" maxWidthClassName="max-w-7xl">
           <KanbanPlayground />

--- a/backlog/tasks/task-418.9.1 - Implement-WP11B-study-safety-specialized-route-contract.md
+++ b/backlog/tasks/task-418.9.1 - Implement-WP11B-study-safety-specialized-route-contract.md
@@ -1,0 +1,71 @@
+---
+id: TASK-418.9.1
+title: Implement WP11B study safety specialized route contract
+status: Done
+labels:
+- webui
+- ux-audit
+- wp11b
+- routes
+- study
+- safety
+priority: medium
+parent_task_id: TASK-418.9
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-study-safety-specialized-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/routes/study-safety-specialized-route-jobs.ts
+- apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-jobs.test.ts
+- apps/packages/ui/src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx
+- apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
+- apps/packages/ui/src/routes/option-evaluations.tsx
+- apps/packages/ui/src/routes/option-kanban-playground.tsx
+- apps/packages/ui/src/routes/route-metadata.ts
+- backlog/tasks/task-418.9.1 - Implement-WP11B-study-safety-specialized-route-contract.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP11B Task 1 from the WebUI study/safety/specialized implementation plan. Add a pure route-job metadata contract and focused route/sidepanel tests for evaluations, flashcards, quiz, moderation playground, content review, claims review, data tables, chunking playground, kanban, VN assets, and VN play. Keep this slice frontend metadata/test-focused and avoid backend API changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Pure route-job contract covers every WP11B study, safety, review, and specialized route exactly once.
+- [x] Contract tests verify route labels, user jobs, classifications, audit finding coverage, and alias ownership.
+- [x] Route boundary tests verify shared route wrappers, moderation alias routing, claims-review alias routing, and Next-only VN page ownership.
+- [x] Sidepanel flashcards test verifies flashcards is the only WP11B route registered for sidepanel.
+- [x] Narrow route ownership fixes align evaluations error recovery, kanban route identity, and claims-review metadata with actual route behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verified a red state for the initial route-job test before adding `study-safety-specialized-route-jobs.ts`.
+- Cross-checked route ownership against `route-registry.tsx`, `deferred-options-route.tsx`, shared option route wrappers, and Next page files before locking the contract.
+- Updated `/claims-review` metadata to match its current Next redirect to `/content-review`; `/moderation-playground` was already a shared redirect to `/moderation/rules`.
+- Verification: `bunx vitest run src/routes/__tests__/study-safety-specialized-route-jobs.test.ts src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts src/routes/__tests__/route-metadata.coverage.test.ts src/routes/__tests__/route-registry.visibility.test.ts --maxWorkers=1 --no-file-parallelism` passed.
+- Verification: `git diff --check` passed.
+- Verification: `bunx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler src/routes/study-safety-specialized-route-jobs.ts` passed.
+- Typecheck note: package-wide `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` still fails on inherited baseline TypeScript debt outside this slice; no reported errors referenced the new route-job contract or changed route wrappers.
+- Bandit skipped because this slice touched TypeScript/Markdown only and no Python files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Added a pure WP11B route-job contract for evaluations, flashcards, quiz, moderation/content review aliases, data tables, chunking, kanban, and VN routes.
+- Added focused tests for route-job coverage, route boundary ownership, Next-only specialized pages, sidepanel flashcards isolation, and route metadata alias behavior.
+- Fixed narrow ownership mismatches found by the tests: evaluations now has a route error boundary, `/kanban` reports the canonical route id/label, and `/claims-review` metadata now matches its redirect to `/content-review`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.9.1 - Implement-WP11B-study-safety-specialized-route-contract.md
+++ b/backlog/tasks/task-418.9.1 - Implement-WP11B-study-safety-specialized-route-contract.md
@@ -21,6 +21,10 @@ modified_files:
 - apps/packages/ui/src/routes/option-evaluations.tsx
 - apps/packages/ui/src/routes/option-kanban-playground.tsx
 - apps/packages/ui/src/routes/route-metadata.ts
+- apps/tldw-frontend/extension/routes/option-evaluations.tsx
+- apps/tldw-frontend/extension/routes/option-kanban-playground.tsx
+- apps/tldw-frontend/__tests__/extension/study-safety-specialized-route-parity.test.tsx
+- apps/tldw-frontend/__tests__/pages/study-safety-specialized-page-shims.test.tsx
 - backlog/tasks/task-418.9.1 - Implement-WP11B-study-safety-specialized-route-contract.md
 ---
 
@@ -50,6 +54,10 @@ Execute WP11B Task 1 from the WebUI study/safety/specialized implementation plan
 - Verification: `bunx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler src/routes/study-safety-specialized-route-jobs.ts` passed.
 - Typecheck note: package-wide `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` still fails on inherited baseline TypeScript debt outside this slice; no reported errors referenced the new route-job contract or changed route wrappers.
 - Bandit skipped because this slice touched TypeScript/Markdown only and no Python files.
+- Review fix: matched extension `/evaluations` and `/kanban` route boundaries to shared route identities.
+- Review fix: changed `getStudySafetySpecializedRouteJob` to use a route map and added lookup coverage.
+- Review fix: removed cross-package filesystem source reads from the shared UI boundary test and moved Next page ownership checks into frontend tests that import the page modules.
+- Review-fix verification: `bunx vitest run __tests__/extension/study-safety-specialized-route-parity.test.tsx __tests__/pages/study-safety-specialized-page-shims.test.tsx --maxWorkers=1 --no-file-parallelism` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -58,6 +66,7 @@ Execute WP11B Task 1 from the WebUI study/safety/specialized implementation plan
 - Added a pure WP11B route-job contract for evaluations, flashcards, quiz, moderation/content review aliases, data tables, chunking, kanban, and VN routes.
 - Added focused tests for route-job coverage, route boundary ownership, Next-only specialized pages, sidepanel flashcards isolation, and route metadata alias behavior.
 - Fixed narrow ownership mismatches found by the tests: evaluations now has a route error boundary, `/kanban` reports the canonical route id/label, and `/claims-review` metadata now matches its redirect to `/content-review`.
+- Addressed PR review comments by adding extension route parity, route-map lookup, and frontend-owned page shim tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Add the WP11B study/safety/specialized route-job contract for evaluations, flashcards, quiz, review, data tables, chunking, kanban, and VN routes.
- Add focused route-job, boundary, sidepanel, and metadata tests for the mixed shared/alias/Next route ownership.
- Align narrow ownership mismatches found by tests: evaluations route error boundary, canonical /kanban boundary id/label, and /claims-review redirect metadata.

## Verification
- `bunx vitest run src/routes/__tests__/study-safety-specialized-route-jobs.test.ts src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts src/routes/__tests__/route-metadata.coverage.test.ts src/routes/__tests__/route-registry.visibility.test.ts --maxWorkers=1 --no-file-parallelism`
- `git diff --check origin/dev`
- `bunx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler src/routes/study-safety-specialized-route-jobs.ts`
- Package-wide `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` was attempted and failed on inherited baseline TypeScript errors outside this slice.
- Bandit skipped: TypeScript/Markdown-only slice.

## Change summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the WP11B study/safety/specialized route ownership contract and adds focused tests across the app and extension. Aligns evaluations and kanban boundaries and updates `/claims-review` to redirect to `/content-review`.

- **New Features**
  - Added `STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS` contract with coverage tests for labels vs metadata, audit findings, alias ownership, sidepanel restriction (flashcards only), and Next-only VN pages.
  - Added extension parity and Next page shim tests to ensure `/evaluations` and `/kanban` use the canonical route boundaries and that VN pages are client-only.

- **Bug Fixes**
  - Wrapped `/evaluations` in `RouteErrorBoundary` and corrected `/kanban` boundary id/label to `kanban` in both shared UI and the extension.
  - Updated `/claims-review` metadata to redirect to `/content-review`, hide from nav, and mark as alias-only.

<sup>Written for commit 9706f81898d53f49653a53cc0cb8842cd64c7b50. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1938?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

