### PR TITLE
Test Persona assistant selection contract

### DIFF
--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -488,6 +488,13 @@ describe("AssistantSelect behavior", () => {
       targetTab: "Personas",
       targetName: "Guide Persona",
       expected: { kind: "persona", id: "persona-1", name: "Guide Persona" }
+    },
+    {
+      label: "none to character",
+      source: null,
+      targetTab: "Characters",
+      targetName: "Alpha",
+      expected: { kind: "character", id: "char-1", name: "Alpha" }
     }
   ])("supports $label from the assistant selector", async ({ source, targetTab, targetName, expected }) => {
     const user = userEvent.setup()

--- a/apps/packages/ui/src/types/__tests__/assistant-selection.test.ts
+++ b/apps/packages/ui/src/types/__tests__/assistant-selection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  assistantSelectionToCharacter,
+  characterToAssistantSelection,
+  isPersonaAssistantSelection,
+  normalizeAssistantSelection,
+  personaToAssistantSelection
+} from "../assistant-selection"
+
+describe("normalizeAssistantSelection", () => {
+  it("normalizes persona selections with numeric ids", () => {
+    expect(
+      normalizeAssistantSelection({
+        kind: "persona",
+        id: 42,
+        title: "Research Persona",
+        avatar_url: "https://example.com/avatar.png"
+      })
+    ).toEqual(
+      expect.objectContaining({
+        kind: "persona",
+        id: "42",
+        name: "Research Persona",
+        avatar_url: "https://example.com/avatar.png"
+      })
+    )
+  })
+
+  it.each([
+    ["blank string id", { kind: "persona", id: "   ", name: "Blank" }],
+    ["missing id", { kind: "persona", name: "Missing" }],
+    ["invalid kind", { kind: "workspace", id: "persona-1", name: "Invalid" }],
+    ["array payload", [{ kind: "persona", id: "persona-1" }]],
+    ["null payload", null]
+  ])("rejects %s", (_label, payload) => {
+    expect(normalizeAssistantSelection(payload)).toBeNull()
+    expect(isPersonaAssistantSelection(payload)).toBe(false)
+  })
+
+  it("uses stable persona fallback values for optional invalid text fields", () => {
+    expect(
+      personaToAssistantSelection({
+        id: "persona-1",
+        name: "",
+        slug: 7,
+        greeting: false,
+        system_prompt: { prompt: "invalid" },
+        extensions: ["invalid"]
+      })
+    ).toEqual(
+      expect.objectContaining({
+        kind: "persona",
+        id: "persona-1",
+        name: "Persona",
+        slug: null,
+        greeting: null,
+        system_prompt: null,
+        extensions: null
+      })
+    )
+  })
+
+  it("normalizes legacy character-like values without treating them as personas", () => {
+    const selection = characterToAssistantSelection({
+      id: 7,
+      title: "Legacy Character",
+      character_id: 7
+    })
+
+    expect(selection).toEqual(
+      expect.objectContaining({
+        kind: "character",
+        id: "7",
+        name: "Legacy Character"
+      })
+    )
+    expect(isPersonaAssistantSelection(selection)).toBe(false)
+    expect(assistantSelectionToCharacter(selection)).toEqual(
+      expect.objectContaining({
+        id: "7",
+        title: "Legacy Character",
+        character_id: 7
+      })
+    )
+  })
+})

--- a/backlog/tasks/task-477 - Harden-Persona-assistant-selection-contract-tests.md
+++ b/backlog/tasks/task-477 - Harden-Persona-assistant-selection-contract-tests.md
@@ -1,0 +1,55 @@
+---
+id: TASK-477
+title: Harden Persona assistant selection contract tests
+status: Done
+labels:
+- persona
+- chat
+- webui
+- tests
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1908
+- Docs/superpowers/plans/2026-05-22-persona-backed-chat-startup-hardening.md
+- https://github.com/rmusser01/tldw_server/pull/1935
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the assistant-selection contract slice from the Persona-backed Chat Startup plan: add focused coverage for Persona normalization and selector switching behavior, patching implementation only if tests reveal a current gap.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AssistantSelection tests cover Persona numeric IDs, blank IDs, invalid object shapes, and legacy Character-like values.
+- [x] #2 Assistant selector behavior confirms switching among Character, Persona, and none does not leak the previous assistant kind.
+- [x] #3 Any implementation changes are minimal and only address failing contract cases.
+- [x] #4 Verification commands and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `apps/packages/ui/src/types/__tests__/assistant-selection.test.ts` covering Persona numeric IDs, blank/missing IDs, invalid kinds, arrays/nulls, optional invalid text fields, and legacy Character-like normalization.
+- Extended `apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx` so the existing switching matrix also covers none-to-Character selection.
+- No production implementation changes were needed; the new contract coverage passed against the current code.
+- Verified with `bunx vitest run src/types/__tests__/assistant-selection.test.ts src/components/Common/__tests__/AssistantSelect.behavior.test.tsx --reporter=verbose` from `apps/packages/ui`.
+- Bandit not applicable: no Python files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added focused WebUI contract coverage for Persona assistant selection normalization and selector switching. This closes the assistant-selection test slice from the Persona-backed Chat Startup plan without changing runtime code.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds focused AssistantSelection contract tests for Persona normalization edge cases.
- Covers numeric Persona IDs, blank/missing IDs, invalid object shapes, optional invalid text fields, and legacy Character-like values.
- Extends AssistantSelect switching coverage to include none-to-Character alongside existing Character/Persona transitions.

## Tracking
- Part of #1908
- Backlog: TASK-477

## Verification
- From apps/packages/ui: bunx vitest run src/types/__tests__/assistant-selection.test.ts src/components/Common/__tests__/AssistantSelect.behavior.test.tsx --reporter=verbose
- git diff --check
- git diff --cached --check
- Bandit skipped: no Python files changed.

## Change Summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests that harden the AssistantSelection contract for Persona normalization and selector switching. This meets TASK-477 and addresses #1908 by covering numeric Persona IDs, blank/missing IDs, invalid payloads with stable fallbacks, legacy Character-like values, and a none-to-Character selector case.

<sup>Written for commit 0020e927394971723849972ebcc0df733644367f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1939?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

