### PR TITLE
Test Persona first-send chat startup contract

### DIFF
--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
@@ -249,7 +249,14 @@ describe("useChatActions persona integration", () => {
       source: undefined,
       external_ref: undefined
     })
+    expect(options.setServerChatId).toHaveBeenCalledWith("persona-chat-1")
     expect(options.setServerChatCharacterId).toHaveBeenCalledWith(null)
+    expect(options.setServerChatAssistantKind).toHaveBeenCalledWith("persona")
+    expect(options.setServerChatAssistantId).toHaveBeenCalledWith("garden-helper")
+    expect(options.setServerChatPersonaMemoryMode).toHaveBeenCalledWith(
+      "read_only"
+    )
+    expect(options.setServerChatMetaLoaded).toHaveBeenCalledWith(true)
     expect(normalChatModeMock).toHaveBeenCalledWith(
       "Hello persona",
       "",
@@ -299,16 +306,23 @@ describe("useChatActions persona integration", () => {
     expect(options.setServerChatAssistantId).toHaveBeenCalledWith(null)
     expect(options.setServerChatPersonaMemoryMode).toHaveBeenCalledWith(null)
     expect(options.setServerChatMetaLoaded).toHaveBeenCalledWith(false)
+    expect(options.setServerChatTitle).toHaveBeenCalledWith(null)
+    expect(options.setServerChatState).toHaveBeenCalledWith("in-progress")
+    expect(options.setServerChatVersion).toHaveBeenCalledWith(null)
+    expect(options.setServerChatTopic).toHaveBeenCalledWith(null)
+    expect(options.setServerChatClusterId).toHaveBeenCalledWith(null)
+    expect(options.setServerChatSource).toHaveBeenCalledWith(null)
+    expect(options.setServerChatExternalRef).toHaveBeenCalledWith(null)
     expect(createChatMock).toHaveBeenCalledWith({
-        assistant_kind: "persona",
-        assistant_id: "garden-helper",
-        persona_memory_mode: "read_only",
-        state: "in-progress",
-        topic_label: undefined,
-        cluster_id: undefined,
-        source: undefined,
-        external_ref: undefined
-      })
+      assistant_kind: "persona",
+      assistant_id: "garden-helper",
+      persona_memory_mode: "read_only",
+      state: "in-progress",
+      topic_label: undefined,
+      cluster_id: undefined,
+      source: undefined,
+      external_ref: undefined
+    })
     expect(options.setServerChatAssistantKind).toHaveBeenLastCalledWith("persona")
     expect(options.setServerChatAssistantId).toHaveBeenLastCalledWith(
       "garden-helper"

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
@@ -168,6 +168,7 @@ const createHookOptions = () => ({
   serverChatAssistantKind: null,
   serverChatAssistantId: null,
   serverChatPersonaMemoryMode: null,
+  serverChatMetaLoaded: false,
   serverChatState: "in-progress" as const,
   serverChatTopic: null,
   serverChatClusterId: null,
@@ -238,12 +239,79 @@ describe("useChatActions persona integration", () => {
       })
     })
 
-    expect(createChatMock).toHaveBeenCalledWith(
+    expect(createChatMock).toHaveBeenCalledWith({
+      assistant_kind: "persona",
+      assistant_id: "garden-helper",
+      persona_memory_mode: "read_only",
+      state: "in-progress",
+      topic_label: undefined,
+      cluster_id: undefined,
+      source: undefined,
+      external_ref: undefined
+    })
+    expect(options.setServerChatCharacterId).toHaveBeenCalledWith(null)
+    expect(normalChatModeMock).toHaveBeenCalledWith(
+      "Hello persona",
+      "",
+      false,
+      [],
+      [],
+      expect.any(AbortSignal),
       expect.objectContaining({
+        assistantIdentity: {
+          name: "Garden Helper",
+          avatarUrl: undefined
+        },
+        historyId: "history-persona",
+        serverChatId: "persona-chat-1"
+      })
+    )
+  })
+
+  it("does not forward stale character state into the first persona send", async () => {
+    const options = {
+      ...createHookOptions(),
+      serverChatId: "character-chat-1",
+      serverChatTitle: "Old character chat",
+      serverChatCharacterId: 42,
+      serverChatAssistantKind: "character" as const,
+      serverChatAssistantId: "42",
+      serverChatPersonaMemoryMode: "read_write" as const,
+      serverChatMetaLoaded: true,
+      serverChatState: "resolved" as const,
+      serverChatTopic: "Old topic",
+      serverChatClusterId: "old-cluster",
+      serverChatSource: "old-source",
+      serverChatExternalRef: "old-ref"
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Hello persona",
+        image: ""
+      })
+    })
+
+    expect(options.setServerChatId).toHaveBeenCalledWith(null)
+    expect(options.setServerChatCharacterId).toHaveBeenCalledWith(null)
+    expect(options.setServerChatAssistantKind).toHaveBeenCalledWith(null)
+    expect(options.setServerChatAssistantId).toHaveBeenCalledWith(null)
+    expect(options.setServerChatPersonaMemoryMode).toHaveBeenCalledWith(null)
+    expect(options.setServerChatMetaLoaded).toHaveBeenCalledWith(false)
+    expect(createChatMock).toHaveBeenCalledWith({
         assistant_kind: "persona",
         assistant_id: "garden-helper",
-        persona_memory_mode: "read_only"
+        persona_memory_mode: "read_only",
+        state: "in-progress",
+        topic_label: undefined,
+        cluster_id: undefined,
+        source: undefined,
+        external_ref: undefined
       })
+    expect(options.setServerChatAssistantKind).toHaveBeenLastCalledWith("persona")
+    expect(options.setServerChatAssistantId).toHaveBeenLastCalledWith(
+      "garden-helper"
     )
     expect(normalChatModeMock).toHaveBeenCalledWith(
       "Hello persona",
@@ -256,7 +324,8 @@ describe("useChatActions persona integration", () => {
         assistantIdentity: {
           name: "Garden Helper",
           avatarUrl: undefined
-        }
+        },
+        serverChatId: "persona-chat-1"
       })
     )
   })

--- a/backlog/tasks/task-478 - Harden-Persona-first-send-chat-startup-contract.md
+++ b/backlog/tasks/task-478 - Harden-Persona-first-send-chat-startup-contract.md
@@ -1,0 +1,58 @@
+---
+id: TASK-478
+title: Harden Persona first-send chat startup contract
+status: Done
+labels:
+- persona
+- chat
+- webui
+- tests
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1908
+- Docs/superpowers/plans/2026-05-22-persona-backed-chat-startup-hardening.md
+- https://github.com/rmusser01/tldw_server/pull/1935
+- https://github.com/rmusser01/tldw_server/pull/1939
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first-send Persona chat startup slice from the Persona-backed Chat Startup plan: ensure normal chat first send creates Persona-backed server chats with explicit read_only metadata and no stale Character identity leakage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 First-send integration coverage asserts selected Persona creates a server chat with assistant_kind persona, selected assistant_id, explicit read_only memory mode, and fresh metadata.
+- [x] #2 First-send integration coverage asserts stale Character identity is not forwarded into Persona chat state.
+- [x] #3 Any production changes are minimal and only address failing contract cases.
+- [x] #4 Verification commands and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Extended `apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx`.
+- Tightened the existing first-send Persona assertion so it verifies the exact `createChat` payload: `assistant_kind: "persona"`, selected Persona `assistant_id`, explicit `read_only`, fresh `in-progress` state, and no inherited topic/cluster/source/external-ref metadata.
+- Added a stale Character-state regression proving Persona first send resets stale Character chat metadata before creating the Persona-backed chat and does not forward the stale Character ID into the Persona path.
+- No production implementation changes were needed; current code satisfies the new first-send contract after the prior helper hardening.
+- Verified with `bunx vitest run src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx --reporter=verbose` from `apps/packages/ui`.
+- Verified adjacent helper coverage with `bunx vitest run src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx src/hooks/chat/__tests__/personaServerChat.test.ts --reporter=verbose` from `apps/packages/ui`.
+- Bandit not applicable: no Python files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added focused first-send integration coverage for Persona-backed chat startup. The tests now lock explicit `read_only` Persona session creation, fresh startup metadata, normal chat handoff, and stale Character metadata isolation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-478 - Harden-Persona-first-send-chat-startup-contract.md
+++ b/backlog/tasks/task-478 - Harden-Persona-first-send-chat-startup-contract.md
@@ -35,6 +35,8 @@ Implement the first-send Persona chat startup slice from the Persona-backed Chat
 - Extended `apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx`.
 - Tightened the existing first-send Persona assertion so it verifies the exact `createChat` payload: `assistant_kind: "persona"`, selected Persona `assistant_id`, explicit `read_only`, fresh `in-progress` state, and no inherited topic/cluster/source/external-ref metadata.
 - Added a stale Character-state regression proving Persona first send resets stale Character chat metadata before creating the Persona-backed chat and does not forward the stale Character ID into the Persona path.
+- Addressed PR #1940 review feedback by asserting the normal Persona creation path updates `serverChatId`, assistant kind/id, Persona memory mode, character ID, and metadata-loaded state.
+- Addressed PR #1940 review feedback by asserting stale Character reset also clears title, state, version, topic, cluster, source, and external ref.
 - No production implementation changes were needed; current code satisfies the new first-send contract after the prior helper hardening.
 - Verified with `bunx vitest run src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx --reporter=verbose` from `apps/packages/ui`.
 - Verified adjacent helper coverage with `bunx vitest run src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx src/hooks/chat/__tests__/personaServerChat.test.ts --reporter=verbose` from `apps/packages/ui`.


### PR DESCRIPTION
## Summary
- Tightens Persona first-send integration coverage for normal chat startup.
- Asserts Persona chat creation uses assistant_kind=persona, selected assistant_id, explicit read_only, and fresh metadata.
- Adds a stale Character-state regression so Persona first send does not forward stale Character identity or conversation metadata.

## Tracking
- Part of #1908
- Backlog: TASK-478

## Verification
- From apps/packages/ui: bunx vitest run src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx --reporter=verbose
- From apps/packages/ui: bunx vitest run src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx src/hooks/chat/__tests__/personaServerChat.test.ts --reporter=verbose
- git diff --check
- git diff --cached --check
- Bandit skipped: no Python files changed.

## Change Summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens tests for Persona first-send chat startup to lock the server-chat creation contract and stop stale Character state from leaking. Adds assertions that startup updates are applied (new serverChatId, assistant_kind/id=persona, read_only memory, meta-loaded=true), that stale Character sessions are fully reset (clears id/title/version and all topic/cluster/source/external_ref metadata, meta-loaded=false, state=in-progress), and that createChat payload and normal chat handoff include the new serverChatId; aligns with TASK-478 and #1908.

<sup>Written for commit 4b8b2edf87dd452b03176a24cd1d0657d7bb1de3. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1940?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

