### PR TITLE
Fix Persona chat resume metadata identity

### DIFF
--- a/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
@@ -227,12 +227,43 @@ describe("resolveServerChatAssistantIdentity", () => {
     })
   })
 
+  it("ignores legacy character_id when persona assistant metadata is present", () => {
+    expect(
+      resolveServerChatAssistantIdentity({
+        assistant_kind: "persona",
+        assistant_id: "garden-helper",
+        persona_memory_mode: "read_only",
+        character_id: 42
+      } as any)
+    ).toEqual({
+      assistantKind: "persona",
+      assistantId: "garden-helper",
+      characterId: null,
+      personaMemoryMode: "read_only"
+    })
+  })
+
   it("keeps persona identity even when memory mode metadata is invalid", () => {
     expect(
       resolveServerChatAssistantIdentity({
         assistant_kind: "persona",
         assistant_id: "garden-helper",
         persona_memory_mode: "session",
+        character_id: null
+      } as any)
+    ).toEqual({
+      assistantKind: "persona",
+      assistantId: "garden-helper",
+      characterId: null,
+      personaMemoryMode: null
+    })
+  })
+
+  it("keeps persona identity without synthesizing memory mode when metadata is missing", () => {
+    expect(
+      resolveServerChatAssistantIdentity({
+        assistant_kind: "persona",
+        assistant_id: "garden-helper",
         character_id: null
       } as any)
     ).toEqual({

--- a/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts
+++ b/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts
@@ -292,7 +292,7 @@ export const resolveServerChatAssistantIdentity = (
     return {
       assistantKind,
       assistantId,
-      characterId: characterId ?? null,
+      characterId: null,
       personaMemoryMode
     }
   }

--- a/backlog/tasks/task-479 - Harden-Persona-chat-resume-metadata-contract.md
+++ b/backlog/tasks/task-479 - Harden-Persona-chat-resume-metadata-contract.md
@@ -1,0 +1,55 @@
+---
+id: TASK-479
+title: Harden Persona chat resume metadata contract
+status: Done
+labels:
+- persona
+- chat
+- webui
+- tests
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1908
+- Docs/superpowers/plans/2026-05-22-persona-backed-chat-startup-hardening.md
+- https://github.com/rmusser01/tldw_server/pull/1940
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the resume metadata slice from the Persona-backed Chat Startup plan: add focused coverage so Persona-backed loaded chats preserve Persona identity even with legacy character metadata and never synthesize read_write from invalid/missing memory mode metadata.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Loader tests cover Persona metadata with legacy character_id present and preserve Persona identity.
+- [x] #2 Loader tests cover invalid and missing persona_memory_mode without escalating to read_write.
+- [x] #3 Legacy Character-only resume behavior remains covered.
+- [x] #4 Verification commands and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Updated `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts` so explicit Persona assistant metadata clears legacy `character_id` rather than preserving it into resumed Persona chat state.
+- Extended `apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts` with Persona resume coverage for legacy `character_id`, missing `persona_memory_mode`, and existing invalid memory-mode handling.
+- Verified red/green behavior: the new legacy `character_id` Persona case failed before the resolver change and passed after it.
+- Verified with `bunx vitest run src/hooks/__tests__/useServerChatLoader.test.ts --reporter=verbose` from `apps/packages/ui`.
+- Bandit not applicable: no Python files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Persona chat resume metadata resolution so Persona-backed loaded chats cannot leak legacy Character IDs into local server-chat state. Added focused loader coverage for legacy `character_id`, missing memory mode, invalid memory mode, and legacy Character fallback behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Prevent Persona-backed loaded chats from preserving legacy character_id into local server-chat identity state.
- Add loader contract coverage for Persona metadata with legacy character_id, missing persona_memory_mode, and invalid memory mode.
- Keep legacy Character-only resume fallback covered.

## Tracking
- Part of #1908
- Backlog: TASK-479

## Verification
- From apps/packages/ui: bunx vitest run src/hooks/__tests__/useServerChatLoader.test.ts --reporter=verbose
- git diff --check
- git diff --cached --check
- Bandit skipped: no Python files changed.

## Change Summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Persona chat resume by dropping legacy `character_id` when Persona metadata is present and not escalating missing/invalid `persona_memory_mode`. Adds focused loader tests and keeps the legacy Character-only resume fallback; addresses TASK-479 and part of #1908.

- **Bug Fixes**
  - In `resolveServerChatAssistantIdentity`, always set `characterId` to null for Persona assistants.
  - Added tests for Persona with legacy `character_id`, invalid or missing `persona_memory_mode`, plus legacy Character-only fallback.

<sup>Written for commit d048eae683d1adfdc0f5930bd80954a9cfdd1399. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1941?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

