### PR TITLE
Improve evaluations recovery states

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -1419,39 +1419,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/DatasetsTab.tsx:Alert",
-    "path": "src/components/Option/Evaluations/tabs/DatasetsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/DatasetsTab.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/EvaluationsTab.tsx:Alert#antd-alert-evaluationstab-type-error-line-286-lsy1sa",
-    "path": "src/components/Option/Evaluations/tabs/EvaluationsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/EvaluationsTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/EvaluationsTab.tsx:Alert#antd-alert-evaluationstab-type-warning-line-390-1xxjkjc",
-    "path": "src/components/Option/Evaluations/tabs/EvaluationsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/EvaluationsTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/recipe-configs/RagAnswerQualityConfig.tsx:Alert#antd-alert-raganswerqualityconfig-type-error-line-469-ctgble",
     "path": "src/components/Option/Evaluations/tabs/recipe-configs/RagAnswerQualityConfig.tsx",
     "rule": "antd-product-state-import",
@@ -1525,94 +1492,6 @@
     "state": "allowed_legacy_exception",
     "owner": "design-system",
     "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/recipe-configs/RagRetrievalTuningConfig.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RunsTab.tsx:Alert#antd-alert-runstab-type-info-line-292-h54t5s",
-    "path": "src/components/Option/Evaluations/tabs/RunsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RunsTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RunsTab.tsx:Alert#antd-alert-runstab-type-warning-line-448-19qcn1z",
-    "path": "src/components/Option/Evaluations/tabs/RunsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RunsTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/RunsTab.tsx:Alert#antd-alert-runstab-type-warning-line-654-vf1vls",
-    "path": "src/components/Option/Evaluations/tabs/RunsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/RunsTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx:Alert#antd-alert-syntheticreviewtab-type-error-line-225-1jv4dt5",
-    "path": "src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx:Alert#antd-alert-syntheticreviewtab-type-success-line-208-1h3ienz",
-    "path": "src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/WebhooksTab.tsx:Alert#antd-alert-webhookstab-type-info-line-256-1kpxwdg",
-    "path": "src/components/Option/Evaluations/tabs/WebhooksTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/WebhooksTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/WebhooksTab.tsx:Alert#antd-alert-webhookstab-type-success-line-156-vqfri",
-    "path": "src/components/Option/Evaluations/tabs/WebhooksTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/WebhooksTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Evaluations/tabs/WebhooksTab.tsx:Alert#antd-alert-webhookstab-type-warning-line-180-18m1kkw",
-    "path": "src/components/Option/Evaluations/tabs/WebhooksTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Evaluations/tabs/WebhooksTab.tsx before the stable duplicate-id guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
   },

--- a/apps/packages/ui/src/components/Option/Evaluations/components/EvaluationRecoveryCallout.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/EvaluationRecoveryCallout.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { RecoveryCallout } from "@/components/ui/state"
 
 type ApiResponseLike = {
@@ -21,12 +22,28 @@ const getErrorMessage = (error: unknown): string | null => {
   if (!error) return null
   if (error instanceof Error) return error.message
   if (typeof error === "string") return error
+  if (Array.isArray(error)) {
+    const messages = error.map(getErrorMessage).filter(Boolean)
+    return messages.length > 0 ? messages.join("; ") : null
+  }
   if (typeof error === "object") {
     const record = error as Record<string, unknown>
-    const nested = record.error || record.message
-    return typeof nested === "string" ? nested : null
+    const nested = record.error || record.message || record.detail || record.msg
+    if (!nested || nested === error) return null
+    return getErrorMessage(nested)
   }
   return String(error)
+}
+
+const HTTP_STATUS_PREFIX_PATTERN = /^HTTP\s+\d+\b/i
+
+const hasHttpStatusPrefix = (message: string, status: number): boolean => {
+  const trimmedMessage = message.trim()
+  const matchingStatusPattern = new RegExp(`^HTTP\\s+${status}\\b`, "i")
+  return (
+    matchingStatusPattern.test(trimmedMessage) ||
+    HTTP_STATUS_PREFIX_PATTERN.test(trimmedMessage)
+  )
 }
 
 export const getEvaluationRecoveryDetail = (
@@ -37,7 +54,11 @@ export const getEvaluationRecoveryDetail = (
   const thrownError = getErrorMessage(error)
   const status = response?.status
 
-  if (responseError && status) return `HTTP ${status}: ${responseError}`
+  if (responseError && status) {
+    return hasHttpStatusPrefix(responseError, status)
+      ? responseError
+      : `HTTP ${status}: ${responseError}`
+  }
   if (responseError) return responseError
   if (thrownError) return thrownError
   if (status) return `HTTP ${status}`
@@ -49,21 +70,42 @@ export const EvaluationRecoveryCallout: React.FC<EvaluationRecoveryCalloutProps>
   endpoint,
   error,
   response,
-  message = "Check server connection and try again. Open Health & diagnostics if this continues.",
+  message,
   className,
   "data-testid": dataTestId
 }) => {
+  const { t } = useTranslation()
   const detail = getEvaluationRecoveryDetail(error, response)
   const diagnostics = [
-    { label: "Request path", value: endpoint },
-    ...(detail ? [{ label: "Details", value: detail }] : [])
+    {
+      label: t("evaluations:recoveryRequestPathLabel", {
+        defaultValue: "Request path"
+      }),
+      value: endpoint
+    },
+    ...(detail
+      ? [
+          {
+            label: t("evaluations:recoveryDetailsLabel", {
+              defaultValue: "Details"
+            }),
+            value: detail
+          }
+        ]
+      : [])
   ]
 
   return (
     <RecoveryCallout
       state="unavailable"
       title={title}
-      message={message}
+      message={
+        message ??
+        t("evaluations:recoveryDefaultMessage", {
+          defaultValue:
+            "Check server connection and try again. Open Health & diagnostics if this continues."
+        })
+      }
       diagnostics={diagnostics}
       className={className}
       data-testid={dataTestId}

--- a/apps/packages/ui/src/components/Option/Evaluations/components/EvaluationRecoveryCallout.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/EvaluationRecoveryCallout.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import { RecoveryCallout } from "@/components/ui/state"
+
+type ApiResponseLike = {
+  ok?: boolean
+  status?: number
+  error?: unknown
+}
+
+type EvaluationRecoveryCalloutProps = {
+  title: React.ReactNode
+  endpoint: string
+  error?: unknown
+  response?: ApiResponseLike | null
+  message?: React.ReactNode
+  className?: string
+  "data-testid"?: string
+}
+
+const getErrorMessage = (error: unknown): string | null => {
+  if (!error) return null
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  if (typeof error === "object") {
+    const record = error as Record<string, unknown>
+    const nested = record.error || record.message
+    return typeof nested === "string" ? nested : null
+  }
+  return String(error)
+}
+
+export const getEvaluationRecoveryDetail = (
+  error?: unknown,
+  response?: ApiResponseLike | null
+): string | null => {
+  const responseError = getErrorMessage(response?.error)
+  const thrownError = getErrorMessage(error)
+  const status = response?.status
+
+  if (responseError && status) return `HTTP ${status}: ${responseError}`
+  if (responseError) return responseError
+  if (thrownError) return thrownError
+  if (status) return `HTTP ${status}`
+  return null
+}
+
+export const EvaluationRecoveryCallout: React.FC<EvaluationRecoveryCalloutProps> = ({
+  title,
+  endpoint,
+  error,
+  response,
+  message = "Check server connection and try again. Open Health & diagnostics if this continues.",
+  className,
+  "data-testid": dataTestId
+}) => {
+  const detail = getEvaluationRecoveryDetail(error, response)
+  const diagnostics = [
+    { label: "Request path", value: endpoint },
+    ...(detail ? [{ label: "Details", value: detail }] : [])
+  ]
+
+  return (
+    <RecoveryCallout
+      state="unavailable"
+      title={title}
+      message={message}
+      diagnostics={diagnostics}
+      className={className}
+      data-testid={dataTestId}
+    />
+  )
+}
+
+export default EvaluationRecoveryCallout

--- a/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationRecoveryCallout.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationRecoveryCallout.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  EvaluationRecoveryCallout,
+  getEvaluationRecoveryDetail
+} from "../EvaluationRecoveryCallout"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      key === "evaluations:recoveryDefaultMessage"
+        ? "Translated recovery default"
+        : options?.defaultValue || key
+  })
+}))
+
+describe("EvaluationRecoveryCallout", () => {
+  it("renders the default recovery message through the evaluations i18n hook", () => {
+    const { container } = render(
+      <EvaluationRecoveryCallout
+        title="Unable to load evaluations"
+        endpoint="/api/v1/evaluations"
+      />
+    )
+
+    expect(screen.getByText("Translated recovery default")).toBeInTheDocument()
+    expect(
+      screen.getByText("/api/v1/evaluations")
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-ds-component="RecoveryCallout"]')
+    ).toBeInTheDocument()
+  })
+
+  it("extracts FastAPI detail fields from backend error payloads", () => {
+    expect(
+      getEvaluationRecoveryDetail(undefined, {
+        ok: false,
+        status: 422,
+        error: { detail: "Dataset rows are invalid" }
+      })
+    ).toBe("HTTP 422: Dataset rows are invalid")
+
+    expect(
+      getEvaluationRecoveryDetail(undefined, {
+        ok: false,
+        status: 422,
+        error: { detail: [{ msg: "Field required" }] }
+      })
+    ).toBe("HTTP 422: Field required")
+  })
+
+  it("does not duplicate HTTP status prefixes from the request layer", () => {
+    expect(
+      getEvaluationRecoveryDetail(undefined, {
+        ok: false,
+        status: 404,
+        error: "HTTP 404"
+      })
+    ).toBe("HTTP 404")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/DatasetsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/DatasetsTab.tsx
@@ -5,7 +5,6 @@
 
 import React from "react"
 import {
-  Alert,
   Button,
   Card,
   Empty,
@@ -28,6 +27,7 @@ import {
 } from "../hooks/useDatasets"
 import { useEvaluationsStore } from "@/store/evaluations"
 import { CopyButton, DatasetUpload, JsonEditor } from "../components"
+import { EvaluationRecoveryCallout } from "../components/EvaluationRecoveryCallout"
 import type { DatasetResponse, DatasetSample } from "@/services/evaluations"
 
 const { Text } = Typography
@@ -62,7 +62,12 @@ export const DatasetsTab: React.FC = () => {
   }))
 
   // Queries & mutations
-  const { data: datasetListResp, isLoading: datasetsLoading, isError: datasetsError } =
+  const {
+    data: datasetListResp,
+    isLoading: datasetsLoading,
+    isError: datasetsError,
+    error: datasetsErrorValue
+  } =
     useDatasetsList()
   const createDatasetMutation = useCreateDataset()
   const deleteDatasetMutation = useDeleteDataset()
@@ -185,12 +190,13 @@ export const DatasetsTab: React.FC = () => {
             <Spin />
           </div>
         ) : datasetsError || datasetListResp?.ok === false ? (
-          <Alert
-            type="warning"
-            showIcon
+          <EvaluationRecoveryCallout
             title={t("evaluations:datasetsErrorTitle", {
               defaultValue: "Unable to load datasets"
             })}
+            endpoint="/api/v1/evaluations/datasets"
+            error={datasetsErrorValue}
+            response={datasetListResp}
           />
         ) : datasets.length === 0 ? (
           <Empty

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/EvaluationsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/EvaluationsTab.tsx
@@ -5,7 +5,6 @@
 
 import React, { useEffect } from "react"
 import {
-  Alert,
   Button,
   Card,
   Empty,
@@ -30,6 +29,7 @@ import {
 import { useDatasetsList } from "../hooks/useDatasets"
 import { useEvaluationsStore } from "@/store/evaluations"
 import { CopyButton, CreateEvaluationWizard } from "../components"
+import { EvaluationRecoveryCallout } from "../components/EvaluationRecoveryCallout"
 import type { EvaluationSummary } from "@/services/evaluations"
 
 const { Text } = Typography
@@ -42,6 +42,7 @@ export const EvaluationsTab: React.FC = () => {
   // Store state
   const {
     selectedEvalId,
+    setActiveTab,
     setSelectedEvalId,
     setSelectedRunId,
     editingEvalId,
@@ -61,6 +62,7 @@ export const EvaluationsTab: React.FC = () => {
     regenerateEvalIdempotencyKey
   } = useEvaluationsStore((s) => ({
     selectedEvalId: s.selectedEvalId,
+    setActiveTab: s.setActiveTab,
     setSelectedEvalId: s.setSelectedEvalId,
     setSelectedRunId: s.setSelectedRunId,
     editingEvalId: s.editingEvalId,
@@ -81,9 +83,19 @@ export const EvaluationsTab: React.FC = () => {
   }))
 
   // Queries
-  const { data: evalListResp, isLoading: evalsLoading, isError: evalsError } =
+  const {
+    data: evalListResp,
+    isLoading: evalsLoading,
+    isError: evalsError,
+    error: evalsErrorValue
+  } =
     useEvaluationsList({ limit: 20 })
-  const { data: evalDetailResp, isLoading: evalDetailLoading, isError: evalDetailError } =
+  const {
+    data: evalDetailResp,
+    isLoading: evalDetailLoading,
+    isError: evalDetailError,
+    error: evalDetailErrorValue
+  } =
     useEvaluationDetail(selectedEvalId)
   const { data: evalDefaults } = useEvaluationDefaults()
   const { data: datasetListResp, isLoading: datasetsLoading } = useDatasetsList()
@@ -283,23 +295,31 @@ export const EvaluationsTab: React.FC = () => {
             <Spin />
           </div>
         ) : evalsError || evalListResp?.ok === false ? (
-          <Alert
-            type="error"
+          <EvaluationRecoveryCallout
             title={t("evaluations:loadErrorTitle", {
               defaultValue: "Unable to load evaluations"
             })}
-            description={t("evaluations:loadErrorDescription", {
+            message={t("evaluations:loadErrorDescription", {
               defaultValue:
                 "Check your tldw server connection and API credentials, then try again."
             })}
+            endpoint="/api/v1/evaluations"
+            error={evalsErrorValue}
+            response={evalListResp}
           />
         ) : evaluations.length === 0 ? (
           <Empty
             description={t("evaluations:emptyList", {
               defaultValue:
-                "No evaluations yet. Once you create one, it will appear here."
+                "No evaluations yet. Start with Recipes for guided setup, or create a custom evaluation."
             })}
-          />
+          >
+            <Button type="link" onClick={() => setActiveTab("recipes")}>
+              {t("evaluations:openRecipesCta", {
+                defaultValue: "Open Recipes"
+              })}
+            </Button>
+          </Empty>
         ) : (
           <div className="flex flex-col gap-2">
             {evaluations.map((ev: EvaluationSummary) => (
@@ -387,11 +407,13 @@ export const EvaluationsTab: React.FC = () => {
             <Spin />
           </div>
         ) : evalDetailError || evalDetailResp?.ok === false ? (
-          <Alert
-            type="warning"
+          <EvaluationRecoveryCallout
             title={t("evaluations:detailErrorTitle", {
               defaultValue: "Unable to load evaluation details"
             })}
+            endpoint={`/api/v1/evaluations/${selectedEvalId}`}
+            error={evalDetailErrorValue}
+            response={evalDetailResp}
           />
         ) : evalDetail ? (
           <div className="space-y-2 text-xs">

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/HistoryTab.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/HistoryTab.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "react-i18next"
 import { useFetchHistory, historyTypePresets } from "../hooks/useHistory"
 import { useEvaluationsStore } from "@/store/evaluations"
 import { CopyButton } from "../components"
+import { EvaluationRecoveryCallout } from "../components/EvaluationRecoveryCallout"
 
 const { Text } = Typography
 
@@ -115,7 +116,15 @@ export const HistoryTab: React.FC = () => {
 
         <Divider />
 
-        {fetchHistoryMutation.isPending ? (
+        {fetchHistoryMutation.isError ? (
+          <EvaluationRecoveryCallout
+            title={t("evaluations:historyFetchErrorTitle", {
+              defaultValue: "Unable to fetch history"
+            })}
+            endpoint="/api/v1/evaluations/history"
+            error={fetchHistoryMutation.error}
+          />
+        ) : fetchHistoryMutation.isPending ? (
           <div className="flex justify-center py-4">
             <Spin size="small" />
           </div>

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/RecipesTab.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/RecipesTab.tsx
@@ -32,6 +32,7 @@ import {
   useValidateRecipeDataset
 } from "../hooks/useRecipes"
 import { JsonEditor } from "../components"
+import { EvaluationRecoveryCallout } from "../components/EvaluationRecoveryCallout"
 import { EmbeddingsModelSelectionConfig } from "./recipe-configs/EmbeddingsModelSelectionConfig"
 import { RagAnswerQualityConfig } from "./recipe-configs/RagAnswerQualityConfig"
 import { RagRetrievalTuningConfig } from "./recipe-configs/RagRetrievalTuningConfig"
@@ -1479,14 +1480,13 @@ export const RecipesTab: React.FC = () => {
             <Spin />
           </div>
         ) : manifestsError ? (
-          <DesignSystemAlert
-            variant="warning"
+          <EvaluationRecoveryCallout
             title={t("evaluations:recipesLoadErrorTitle", {
               defaultValue: "Unable to load recipes"
             })}
-          >
-            {(manifestsErrorValue as Error | null)?.message}
-          </DesignSystemAlert>
+            endpoint="/api/v1/evaluations/recipes"
+            error={manifestsErrorValue}
+          />
         ) : manifests.length === 0 ? (
           <Empty
             description={t("evaluations:recipesEmpty", {
@@ -1958,14 +1958,17 @@ export const RecipesTab: React.FC = () => {
                 <Spin />
               </div>
             ) : reportError ? (
-              <DesignSystemAlert
-                variant="error"
+              <EvaluationRecoveryCallout
                 title={t("evaluations:recipeReportLoadErrorTitle", {
                   defaultValue: "Unable to load the recipe report"
                 })}
-              >
-                {(reportErrorValue as Error | null)?.message || null}
-              </DesignSystemAlert>
+                endpoint={
+                  currentRunId
+                    ? `/api/v1/evaluations/recipe-runs/${currentRunId}/report`
+                    : "/api/v1/evaluations/recipe-runs/{run_id}/report"
+                }
+                error={reportErrorValue}
+              />
             ) : report ? (
               <div className="space-y-4">
                 {report.confidence_summary && (

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/RunsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/RunsTab.tsx
@@ -5,7 +5,6 @@
 
 import React, { useEffect, useMemo, useState } from "react"
 import {
-  Alert,
   Button,
   Card,
   Collapse,
@@ -36,6 +35,7 @@ import {
 } from "../hooks/useRuns"
 import { useEvaluationsList } from "../hooks/useEvaluations"
 import { useEvaluationsStore } from "@/store/evaluations"
+import { EvaluationRecoveryCallout } from "../components/EvaluationRecoveryCallout"
 import {
   CopyButton,
   JsonEditor,
@@ -107,9 +107,19 @@ export const RunsTab: React.FC = () => {
   const { data: evalListResp } = useEvaluationsList({ limit: 20 })
   const { data: rateLimitsResp, isLoading: rateLimitsLoading, isError: rateLimitsError } =
     useRateLimits()
-  const { data: runsListResp, isLoading: runsLoading, isError: runsError } =
+  const {
+    data: runsListResp,
+    isLoading: runsLoading,
+    isError: runsError,
+    error: runsErrorValue
+  } =
     useRunsList(selectedEvalId)
-  const { data: runDetailResp, isLoading: runDetailLoading, isError: runDetailError } =
+  const {
+    data: runDetailResp,
+    isLoading: runDetailLoading,
+    isError: runDetailError,
+    error: runDetailErrorValue
+  } =
     useRunDetail(selectedRunId)
   const { data: compareRunAResp } = useRunDetail(compareRunAId, {
     enablePolling: false,
@@ -289,15 +299,19 @@ export const RunsTab: React.FC = () => {
             </Text>
           ) : (
             <>
-              <Alert
-                type="info"
-                showIcon
-                className="mb-2 text-xs"
-                title={t("evaluations:runPollingHint", {
-                  defaultValue:
-                    "Runs execute asynchronously. The UI polls every ~3s until status leaves running/pending."
-                })}
-              />
+              <div className="mb-2 rounded-md border border-border bg-bg-muted/40 p-3 text-xs text-text-muted">
+                <Text strong className="block text-text">
+                  {t("evaluations:runPollingTitle", {
+                    defaultValue: "Run status updates"
+                  })}
+                </Text>
+                <p className="mb-0 mt-1">
+                  {t("evaluations:runPollingHint", {
+                    defaultValue:
+                      "Runs execute asynchronously. The UI polls every ~3s until status leaves running/pending."
+                  })}
+                </p>
+              </div>
               <Form form={runForm} layout="vertical" size="small">
                 <Form.Item
                   label={t("evaluations:runModelLabelShort", {
@@ -445,12 +459,13 @@ export const RunsTab: React.FC = () => {
                   <Spin />
                 </div>
               ) : runsError || runsListResp?.ok === false ? (
-                <Alert
-                  type="warning"
-                  showIcon
+                <EvaluationRecoveryCallout
                   title={t("evaluations:runsErrorTitle", {
                     defaultValue: "Unable to load runs"
                   })}
+                  endpoint={`/api/v1/evaluations/${selectedEvalId}/runs`}
+                  error={runsErrorValue}
+                  response={runsListResp}
                 />
               ) : runs.length === 0 ? (
                 <Empty
@@ -651,12 +666,13 @@ export const RunsTab: React.FC = () => {
               <Spin />
             </div>
           ) : runDetailError || runDetailResp?.ok === false ? (
-            <Alert
-              type="warning"
-              showIcon
+            <EvaluationRecoveryCallout
               title={t("evaluations:runDetailErrorTitle", {
                 defaultValue: "Unable to load run details"
               })}
+              endpoint={`/api/v1/evaluations/runs/${selectedRunId}`}
+              error={runDetailErrorValue}
+              response={runDetailResp}
             />
           ) : runDetail ? (
             <div className="space-y-2 text-xs">

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx
@@ -5,7 +5,6 @@
 
 import React from "react"
 import {
-  Alert,
   Button,
   Card,
   Checkbox,
@@ -19,6 +18,8 @@ import {
 } from "antd"
 import { useTranslation } from "react-i18next"
 import { useEvaluationsStore } from "@/store/evaluations"
+import { StatePanel } from "@/components/ui/state"
+import { EvaluationRecoveryCallout } from "../components/EvaluationRecoveryCallout"
 import type { SyntheticEvalDraftSample } from "@/services/evaluations"
 import {
   usePromoteSyntheticEvalSamples,
@@ -43,6 +44,8 @@ const RECIPE_KIND_OPTIONS = [
   { value: "rag_retrieval_tuning", label: "RAG Retrieval Tuning" },
   { value: "rag_answer_quality", label: "RAG Answer Quality" }
 ]
+
+const EMPTY_SYNTHETIC_QUEUE_ITEMS: SyntheticEvalDraftSample[] = []
 
 const queryPreview = (sample: SyntheticEvalDraftSample): string =>
   String(
@@ -73,7 +76,9 @@ export const SyntheticReviewTab: React.FC = () => {
   const reviewMutation = useReviewSyntheticEvalSample()
   const promoteMutation = usePromoteSyntheticEvalSamples()
 
-  const rawQueueItems = Array.isArray(data?.data?.data) ? data.data.data : []
+  const rawQueueItems = Array.isArray(data?.data?.data)
+    ? data.data.data
+    : EMPTY_SYNTHETIC_QUEUE_ITEMS
   const queueItems = React.useMemo(
     () =>
       !storedBatchId && storedSampleIds.length > 0
@@ -84,9 +89,12 @@ export const SyntheticReviewTab: React.FC = () => {
   const totalQueueItems = typeof data?.data?.total === "number" ? data.data.total : queueItems.length
 
   React.useEffect(() => {
-    setSelectedIds((current) =>
-      current.filter((sampleId) => queueItems.some((sample) => sample.sample_id === sampleId))
-    )
+    setSelectedIds((current) => {
+      const nextSelectedIds = current.filter((sampleId) =>
+        queueItems.some((sample) => sample.sample_id === sampleId)
+      )
+      return nextSelectedIds.length === current.length ? current : nextSelectedIds
+    })
   }, [queueItems])
 
   const handleReviewAction = async (
@@ -205,14 +213,13 @@ export const SyntheticReviewTab: React.FC = () => {
         </div>
 
         {promoteMutation.data?.data?.dataset_id && (
-          <Alert
+          <StatePanel
+            state="ready"
             className="mt-4"
-            type="success"
-            showIcon
             title={t("evaluations:syntheticPromoteSuccessInlineTitle", {
               defaultValue: "Promoted dataset created"
             })}
-            description={`${promoteMutation.data.data.dataset_id} (${promoteMutation.data.data.sample_count})`}
+            message={`${promoteMutation.data.data.dataset_id} (${promoteMutation.data.data.sample_count})`}
           />
         )}
       </Card>
@@ -222,13 +229,12 @@ export const SyntheticReviewTab: React.FC = () => {
           <Spin />
         </div>
       ) : isError ? (
-        <Alert
-          type="error"
-          showIcon
+        <EvaluationRecoveryCallout
           title={t("evaluations:syntheticReviewLoadErrorTitle", {
             defaultValue: "Unable to load synthetic review queue"
           })}
-          description={(error as Error | null)?.message}
+          endpoint="/api/v1/evaluations/synthetic/queue"
+          error={error}
         />
       ) : queueItems.length === 0 ? (
         <Card>

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/WebhooksTab.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/WebhooksTab.tsx
@@ -5,7 +5,6 @@
 
 import React from "react"
 import {
-  Alert,
   Button,
   Card,
   Divider,
@@ -29,7 +28,9 @@ import {
 } from "../hooks/useWebhooks"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import { useEvaluationsStore } from "@/store/evaluations"
+import { StatePanel } from "@/components/ui/state"
 import { CopyButton } from "../components"
+import { EvaluationRecoveryCallout } from "../components/EvaluationRecoveryCallout"
 
 const { Text } = Typography
 
@@ -43,7 +44,12 @@ export const WebhooksTab: React.FC = () => {
   const webhookSecretText = useEvaluationsStore((s) => s.webhookSecretText)
 
   // Queries & mutations
-  const { data: webhooksResp, isLoading: webhooksLoading, isError: webhooksError } =
+  const {
+    data: webhooksResp,
+    isLoading: webhooksLoading,
+    isError: webhooksError,
+    error: webhooksErrorValue
+  } =
     useWebhooksList(isOnline)
   const registerMutation = useRegisterWebhook()
   const deleteMutation = useDeleteWebhook()
@@ -153,13 +159,13 @@ export const WebhooksTab: React.FC = () => {
           </Button>
 
           {webhookSecretText && (
-            <Alert
+            <StatePanel
+              state="ready"
               className="mt-3"
-              type="success"
               title={t("evaluations:webhookSecretTitle", {
                 defaultValue: "Webhook Secret"
               })}
-              description={
+              message={
                 <div className="flex items-center gap-2">
                   <code className="text-xs">{webhookSecretText}</code>
                   <CopyButton text={webhookSecretText} />
@@ -177,11 +183,13 @@ export const WebhooksTab: React.FC = () => {
             <Spin size="small" />
           </div>
         ) : webhooksError || webhooksResp?.ok === false ? (
-          <Alert
-            type="warning"
+          <EvaluationRecoveryCallout
             title={t("evaluations:webhookListErrorTitle", {
               defaultValue: "Unable to load webhooks"
             })}
+            endpoint="/api/v1/evaluations/webhooks"
+            error={webhooksErrorValue}
+            response={webhooksResp}
           />
         ) : webhooks.length === 0 ? (
           <Empty
@@ -253,35 +261,33 @@ export const WebhooksTab: React.FC = () => {
 
       {/* Webhook Info */}
       <Card size="small">
-        <Alert
-          type="info"
-          showIcon
-          title={t("evaluations:webhookInfoTitle", {
-            defaultValue: "About webhooks"
-          })}
-          description={
-            <ul className="mt-2 space-y-1 text-xs list-disc list-inside">
-              <li>
-                {t("evaluations:webhookInfoItem1", {
-                  defaultValue:
-                    "Webhooks receive POST requests when evaluation events occur."
-                })}
-              </li>
-              <li>
-                {t("evaluations:webhookInfoItem2", {
-                  defaultValue:
-                    "Use the secret to verify webhook signatures and prevent spoofing."
-                })}
-              </li>
-              <li>
-                {t("evaluations:webhookInfoItem3", {
-                  defaultValue:
-                    "Events include: started, completed, failed, cancelled, and progress updates."
-                })}
-              </li>
-            </ul>
-          }
-        />
+        <div className="space-y-2 text-sm text-text">
+          <Text strong>
+            {t("evaluations:webhookInfoTitle", {
+              defaultValue: "About webhooks"
+            })}
+          </Text>
+          <ul className="space-y-1 text-xs list-disc list-inside text-text-muted">
+            <li>
+              {t("evaluations:webhookInfoItem1", {
+                defaultValue:
+                  "Webhooks receive POST requests when evaluation events occur."
+              })}
+            </li>
+            <li>
+              {t("evaluations:webhookInfoItem2", {
+                defaultValue:
+                  "Use the secret to verify webhook signatures and prevent spoofing."
+              })}
+            </li>
+            <li>
+              {t("evaluations:webhookInfoItem3", {
+                defaultValue:
+                  "Events include: started, completed, failed, cancelled, and progress updates."
+              })}
+            </li>
+          </ul>
+        </div>
       </Card>
     </div>
   )

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/DatasetsTab.pagination.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/DatasetsTab.pagination.test.tsx
@@ -7,6 +7,25 @@ import { useEvaluationsStore } from "@/store/evaluations"
 
 const loadSpy = vi.fn()
 const closeViewerSpy = vi.fn()
+const datasetListState = {
+  data: {
+    ok: true,
+    data: {
+      data: [
+        {
+          id: "dataset-1",
+          name: "Dataset One",
+          sample_count: 6,
+          created: 0,
+          created_by: "user_123"
+        }
+      ]
+    }
+  },
+  isLoading: false,
+  isError: false,
+  error: null as Error | null
+}
 
 vi.mock("antd", async () => {
   const actual = await vi.importActual<any>("antd")
@@ -60,24 +79,7 @@ vi.mock("react-i18next", () => ({
 }))
 
 vi.mock("../../hooks/useDatasets", () => ({
-  useDatasetsList: () => ({
-    data: {
-      ok: true,
-      data: {
-        data: [
-          {
-            id: "dataset-1",
-            name: "Dataset One",
-            sample_count: 6,
-            created: 0,
-            created_by: "user_123"
-          }
-        ]
-      }
-    },
-    isLoading: false,
-    isError: false
-  }),
+  useDatasetsList: () => datasetListState,
   useCreateDataset: () => ({
     mutateAsync: vi.fn(),
     isPending: false
@@ -139,6 +141,23 @@ describe("DatasetsTab sample pagination", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    datasetListState.data = {
+      ok: true,
+      data: {
+        data: [
+          {
+            id: "dataset-1",
+            name: "Dataset One",
+            sample_count: 6,
+            created: 0,
+            created_by: "user_123"
+          }
+        ]
+      }
+    }
+    datasetListState.isLoading = false
+    datasetListState.isError = false
+    datasetListState.error = null
     useEvaluationsStore.getState().resetStore()
     useEvaluationsStore.setState({
       viewingDataset: {
@@ -175,5 +194,20 @@ describe("DatasetsTab sample pagination", () => {
 
     expect(screen.getByText(/sample-1/i)).toBeInTheDocument()
     expect(screen.queryByText(/sample-6/i)).not.toBeInTheDocument()
+  })
+
+  it("shows dataset endpoint diagnostics without replacing the create action", () => {
+    datasetListState.data = { ok: false, error: "HTTP 503" } as any
+    datasetListState.isError = true
+    datasetListState.error = new Error("HTTP 503")
+
+    render(<DatasetsTab />)
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Unable to load datasets")).toBeInTheDocument()
+    expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
+      "/api/v1/evaluations/datasets"
+    )
+    expect(screen.getByRole("button", { name: "New dataset" })).toBeEnabled()
   })
 })

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EvaluationsTab.empty-state.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EvaluationsTab.empty-state.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { EvaluationsTab } from "../EvaluationsTab"
 
 const storeState = {
   selectedEvalId: null as string | null,
+  setActiveTab: vi.fn(),
   setSelectedEvalId: vi.fn(),
   setSelectedRunId: vi.fn(),
   editingEvalId: null as string | null,
@@ -138,7 +139,7 @@ describe("EvaluationsTab empty-state guardrails", () => {
     render(<EvaluationsTab />)
 
     expect(
-      screen.getByText("No evaluations yet. Once you create one, it will appear here.")
+      screen.getByText("No evaluations yet. Start with Recipes for guided setup, or create a custom evaluation.")
     ).toBeInTheDocument()
     expect(
       screen.getByText("Select an evaluation to inspect its spec.")
@@ -148,5 +149,12 @@ describe("EvaluationsTab empty-state guardrails", () => {
     expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled()
   })
-})
 
+  it("offers a direct recovery path back to the recipe-first workflow", () => {
+    render(<EvaluationsTab />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Recipes" }))
+
+    expect(storeState.setActiveTab).toHaveBeenCalledWith("recipes")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/HistoryTab.filters.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/HistoryTab.filters.test.tsx
@@ -5,6 +5,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { HistoryTab } from "../HistoryTab"
 
 const fetchSpy = vi.fn()
+const fetchHistoryState = {
+  mutate: fetchSpy,
+  isPending: false,
+  isError: false,
+  error: null as Error | null
+}
 
 const storeState = {
   historyResults: [
@@ -75,10 +81,7 @@ vi.mock("../../hooks/useHistory", async () => {
   const actual = await vi.importActual<any>("../../hooks/useHistory")
   return {
     ...actual,
-    useFetchHistory: () => ({
-      mutate: fetchSpy,
-      isPending: false
-    })
+    useFetchHistory: () => fetchHistoryState
   }
 })
 
@@ -120,6 +123,9 @@ describe("HistoryTab filters and rendering", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    fetchHistoryState.isPending = false
+    fetchHistoryState.isError = false
+    fetchHistoryState.error = null
   })
 
   it("uses evaluation_type filters and renders backend evaluation rows", async () => {
@@ -148,5 +154,23 @@ describe("HistoryTab filters and rendering", () => {
         })
       )
     })
+  })
+
+  it("shows history recovery diagnostics without clearing entered filters", async () => {
+    fetchHistoryState.isError = true
+    fetchHistoryState.error = new Error("HTTP 503")
+
+    render(<HistoryTab />)
+
+    fireEvent.change(screen.getByTestId("history-user-filter"), {
+      target: { value: "user_456" }
+    })
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Unable to fetch history")).toBeInTheDocument()
+    expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
+      "/api/v1/evaluations/history"
+    )
+    expect(screen.getByTestId("history-user-filter")).toHaveValue("user_456")
   })
 })

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/RecipesTab.launch.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/RecipesTab.launch.test.tsx
@@ -204,12 +204,6 @@ const renderRecipesTab = (queryClient = createTestQueryClient()) => ({
   )
 })
 
-const expectDesignSystemAlertForText = (text: string) => {
-  const alert = screen.getByText(text).closest('[data-ds-component="Alert"]')
-  expect(alert).toHaveAttribute("data-ds-component", "Alert")
-  return alert
-}
-
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (
@@ -1610,8 +1604,11 @@ describe("RecipesTab recipe launch flow", () => {
 
     renderRecipesTab()
 
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
     expect(screen.getByText("Unable to load recipes")).toBeInTheDocument()
-    expectDesignSystemAlertForText("Unable to load recipes")
+    expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
+      "/api/v1/evaluations/recipes"
+    )
     expect(
       screen.getByText(
         "Add or update your API key in Settings -> tldw server, then try again."

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/RunsTab.benchmark-option.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/RunsTab.benchmark-option.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { render, screen } from "@testing-library/react"
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { RunsTab } from "../RunsTab"
 
 const storeState = {
@@ -26,6 +26,13 @@ const storeState = {
   adhocPayloadText: "{}",
   setAdhocPayloadText: vi.fn(),
   adhocResult: null as any
+}
+
+const runsListState = {
+  data: { data: { data: [] as any[] } },
+  isLoading: false,
+  isError: false,
+  error: null as Error | null
 }
 
 vi.mock("react-i18next", () => ({
@@ -55,11 +62,7 @@ vi.mock("@tanstack/react-query", () => ({
 vi.mock("../../hooks/useRuns", () => {
   return {
     useRateLimits: () => ({ data: null, isLoading: false, isError: false }),
-    useRunsList: () => ({
-      data: { data: { data: [] } },
-      isLoading: false,
-      isError: false
-    }),
+    useRunsList: () => runsListState,
     useRunDetail: () => ({ data: null, isLoading: false, isError: false }),
     useCreateRun: () => ({ mutateAsync: vi.fn(), isPending: false }),
     useCancelRun: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -146,8 +149,43 @@ describe("RunsTab benchmark run mode", () => {
     })
   })
 
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeState.selectedEvalId = null
+    storeState.selectedRunId = null
+    storeState.runConfigText = ""
+    storeState.datasetOverrideText = ""
+    storeState.adhocEndpoint = "benchmark-run"
+    storeState.selectedBenchmark = "bullshit_benchmark"
+    storeState.adhocPayloadText = "{}"
+    runsListState.data = { data: { data: [] } }
+    runsListState.isLoading = false
+    runsListState.isError = false
+    runsListState.error = null
+  })
+
   it("shows bullshit_benchmark in benchmark selector when benchmark-run mode is selected", async () => {
     render(<RunsTab />)
     expect(await screen.findByText("bullshit_benchmark")).toBeInTheDocument()
+  })
+
+  it("shows run-list recovery diagnostics without clearing run form input", () => {
+    storeState.selectedEvalId = "eval-1"
+    storeState.runConfigText = '{"temperature":0.2}'
+    runsListState.isError = true
+    runsListState.error = new Error("HTTP 503")
+
+    render(<RunsTab />)
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Unable to load runs")).toBeInTheDocument()
+    expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
+      "/api/v1/evaluations/eval-1/runs"
+    )
+    expect(
+      screen
+        .getAllByTestId("json-editor")
+        .some((editor) => (editor as HTMLTextAreaElement).value === '{"temperature":0.2}')
+    ).toBe(true)
   })
 })

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/SyntheticReviewTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/SyntheticReviewTab.test.tsx
@@ -30,7 +30,7 @@ const queueState = {
 
 const reviewMutateAsync = vi.fn()
 const promoteMutateAsync = vi.fn()
-const useSyntheticEvalQueueSpy = vi.fn(() => queueState)
+const useSyntheticEvalQueueSpy = vi.fn((_params?: unknown) => queueState)
 const storeState = {
   syntheticReviewRecipeKind: "rag_retrieval_tuning",
   syntheticReviewBatchId: "batch-123",
@@ -159,6 +159,27 @@ describe("SyntheticReviewTab", () => {
     promoteMutateAsync.mockReset()
     useSyntheticEvalQueueSpy.mockClear()
     storeState.setSyntheticReviewRecipeKind.mockReset()
+    queueState.data = {
+      data: {
+        data: [
+          {
+            sample_id: "draft-1",
+            recipe_kind: "rag_retrieval_tuning",
+            provenance: "synthetic_from_corpus",
+            review_state: "draft",
+            sample_payload: {
+              query: "What changed in the rollout?",
+              relevant_media_ids: [1]
+            },
+            sample_metadata: {}
+          }
+        ],
+        total: 1
+      }
+    }
+    queueState.isLoading = false
+    queueState.isError = false
+    queueState.error = null
   })
 
   it("requests the queue filtered to the stored generation batch when present", () => {
@@ -209,5 +230,19 @@ describe("SyntheticReviewTab", () => {
       sample_ids: ["draft-1"],
       dataset_name: "reviewed synthetic retrieval"
     })
+  })
+
+  it("shows synthetic queue endpoint diagnostics when the queue is unavailable", () => {
+    queueState.data = undefined as any
+    queueState.isError = true
+    queueState.error = new Error("HTTP 503")
+
+    render(<SyntheticReviewTab />)
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Unable to load synthetic review queue")).toBeInTheDocument()
+    expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
+      "/api/v1/evaluations/synthetic/queue"
+    )
   })
 })

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/WebhooksTab.contract.test.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/WebhooksTab.contract.test.tsx
@@ -10,6 +10,23 @@ const deleteSpy = vi.fn()
 const storeState = {
   webhookSecretText: null as string | null
 }
+const webhooksListState = {
+  data: {
+    ok: true,
+    data: [
+      {
+        webhook_id: 17,
+        url: "https://example.com/webhooks/evals",
+        events: ["evaluation.completed"],
+        status: "active",
+        created_at: "2026-03-29T12:00:00Z"
+      }
+    ]
+  },
+  isLoading: false,
+  isError: false,
+  error: null as Error | null
+}
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -42,22 +59,7 @@ vi.mock("../../components", () => ({
 }))
 
 vi.mock("../../hooks/useWebhooks", () => ({
-  useWebhooksList: () => ({
-    data: {
-      ok: true,
-      data: [
-        {
-          webhook_id: 17,
-          url: "https://example.com/webhooks/evals",
-          events: ["evaluation.completed"],
-          status: "active",
-          created_at: "2026-03-29T12:00:00Z"
-        }
-      ]
-    },
-    isLoading: false,
-    isError: false
-  }),
+  useWebhooksList: () => webhooksListState,
   useRegisterWebhook: () => ({
     mutateAsync: vi.fn(),
     isPending: false
@@ -110,6 +112,21 @@ describe("WebhooksTab backend contract", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    webhooksListState.data = {
+      ok: true,
+      data: [
+        {
+          webhook_id: 17,
+          url: "https://example.com/webhooks/evals",
+          events: ["evaluation.completed"],
+          status: "active",
+          created_at: "2026-03-29T12:00:00Z"
+        }
+      ]
+    }
+    webhooksListState.isLoading = false
+    webhooksListState.isError = false
+    webhooksListState.error = null
     vi.spyOn(Modal, "confirm").mockImplementation((config: any) => {
       void config?.onOk?.()
       return {
@@ -133,5 +150,20 @@ describe("WebhooksTab backend contract", () => {
     await waitFor(() => {
       expect(deleteSpy).toHaveBeenCalledWith("https://example.com/webhooks/evals")
     })
+  })
+
+  it("shows endpoint diagnostics while preserving the webhook registration form", () => {
+    webhooksListState.data = { ok: false, error: "HTTP 503" } as any
+    webhooksListState.isError = true
+    webhooksListState.error = new Error("HTTP 503")
+
+    render(<WebhooksTab />)
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Unable to load webhooks")).toBeInTheDocument()
+    expect(screen.getByLabelText("Diagnostics")).toHaveTextContent(
+      "/api/v1/evaluations/webhooks"
+    )
+    expect(screen.getByRole("button", { name: "Register webhook" })).toBeEnabled()
   })
 })

--- a/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
+++ b/apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
@@ -31,6 +31,12 @@ type MediaSearchResult = {
   url?: string
 }
 
+type EmbeddingDatasetSample = DatasetSample & {
+  query_id: string
+  input: string
+  expected_ids: string[]
+}
+
 const DEFAULT_RUN_CONFIG = {
   comparison_mode: "embedding_only",
   candidates: [],
@@ -141,7 +147,7 @@ const normalizeRunConfig = (
   }
 }
 
-const normalizeDataset = (dataset: DatasetSample[]): DatasetSample[] => {
+const normalizeDataset = (dataset: DatasetSample[]): EmbeddingDatasetSample[] => {
   const baseDataset = Array.isArray(dataset) ? dataset : []
   return baseDataset.map((sample, index) => {
     const record = sample && typeof sample === "object" ? (sample as Record<string, any>) : {}
@@ -151,7 +157,7 @@ const normalizeDataset = (dataset: DatasetSample[]): DatasetSample[] => {
         `q-${index + 1}`,
       input: String(record.input ?? record.query ?? ""),
       expected_ids: normalizeMediaIdArray(record.expected_ids)
-    } as DatasetSample
+    }
   })
 }
 
@@ -167,18 +173,20 @@ const normalizeMediaSearchResults = (payload: unknown): MediaSearchResult[] =>
     .map((item) => {
       const id = String(item?.id ?? item?.media_id ?? "").trim()
       if (!isIntegerId(id)) return null
-      return {
+      const url =
+        typeof item?.url === "string"
+          ? item.url
+          : typeof item?.source_url === "string"
+            ? item.source_url
+            : undefined
+      const result: MediaSearchResult = {
         id,
         title:
           String(item?.title ?? item?.name ?? item?.filename ?? `Media ${id}`).trim() ||
-          `Media ${id}`,
-        url:
-          typeof item?.url === "string"
-            ? item.url
-            : typeof item?.source_url === "string"
-              ? item.source_url
-              : undefined
+          `Media ${id}`
       }
+      if (url) result.url = url
+      return result
     })
     .filter((item): item is MediaSearchResult => item !== null)
 
@@ -196,11 +204,11 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
     [runConfig, manifest]
   )
   const normalizedDataset = React.useMemo(() => normalizeDataset(dataset), [dataset])
-  const editableDataset = React.useMemo<DatasetSample[]>(
+  const editableDataset = React.useMemo<EmbeddingDatasetSample[]>(
     () =>
       normalizedDataset.length > 0
         ? normalizedDataset
-        : ([{ query_id: "q-1", input: "", expected_ids: [] }] as DatasetSample[]),
+        : [{ query_id: "q-1", input: "", expected_ids: [] }],
     [normalizedDataset]
   )
   const candidateQuery = useEmbeddingRecipeCandidates(true)
@@ -230,7 +238,9 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
     onRunConfigChange(normalizeRunConfig(updater(normalizedRunConfig), manifest))
   }
 
-  const applyDataset = (updater: (current: DatasetSample[]) => DatasetSample[]) => {
+  const applyDataset = (
+    updater: (current: EmbeddingDatasetSample[]) => EmbeddingDatasetSample[]
+  ) => {
     onDatasetChange(
       updater(datasetSource === "inline" ? editableDataset : normalizedDataset)
     )
@@ -254,12 +264,12 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
 
   const updateDatasetSample = (
     sampleIndex: number,
-    updater: (sample: Record<string, any>) => DatasetSample
+    updater: (sample: EmbeddingDatasetSample) => EmbeddingDatasetSample
   ) => {
     applyDataset((current) =>
       current.map((sample, index) =>
         index === sampleIndex
-          ? updater({ ...(sample as Record<string, any>) })
+          ? updater(sample)
           : sample
       )
     )
@@ -272,7 +282,7 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
         query_id: `q-${current.length + 1}`,
         input: "",
         expected_ids: []
-      } as DatasetSample
+      }
     ])
   }
 
@@ -351,7 +361,7 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
       return {
         ...sample,
         expected_ids: nextIds
-      } as DatasetSample
+      }
     })
   }
 
@@ -406,21 +416,20 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
       <Card size="small" title="Queries">
         <div className="space-y-3">
           {editableDataset.map((sample, index) => {
-            const record = sample as Record<string, any>
             return (
-              <div key={`${record.query_id}-${index}`} className="space-y-2 border-b border-border-subtle pb-3 last:border-b-0 last:pb-0">
+              <div key={`${sample.query_id}-${index}`} className="space-y-2 border-b border-border-subtle pb-3 last:border-b-0 last:pb-0">
                 <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_160px]">
                   <div>
                     <Text strong>Query text {index + 1}</Text>
                     <Input
                       aria-label={`Query text ${index + 1}`}
                       className="mt-2"
-                      value={String(record.input ?? "")}
+                      value={sample.input}
                       onChange={(event) =>
                         updateDatasetSample(index, (current) => ({
                           ...current,
                           input: event.target.value
-                        } as DatasetSample))
+                        }))
                       }
                     />
                   </div>
@@ -446,11 +455,10 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
       <Card size="small" title="Expected sources">
         <div className="space-y-4">
           {editableDataset.map((sample, index) => {
-            const record = sample as Record<string, any>
-            const expectedIds = normalizeMediaIdArray(record.expected_ids)
+            const expectedIds = normalizeMediaIdArray(sample.expected_ids)
             const rowResults = searchResults[index] || []
             return (
-              <div key={`sources-${record.query_id}-${index}`} className="space-y-3 border-b border-border-subtle pb-4 last:border-b-0 last:pb-0">
+              <div key={`sources-${sample.query_id}-${index}`} className="space-y-3 border-b border-border-subtle pb-4 last:border-b-0 last:pb-0">
                 <div>
                   <Text strong>Expected media IDs {index + 1}</Text>
                   <Input
@@ -461,7 +469,7 @@ export const EmbeddingsModelSelectionConfig: React.FC<Props> = ({
                       updateDatasetSample(index, (current) => ({
                         ...current,
                         expected_ids: splitMediaIds(event.target.value)
-                      } as DatasetSample))
+                      }))
                     }
                   />
                 </div>

--- a/backlog/tasks/task-418.9.2 - Implement-WP11B-evaluations-readiness-and-recovery-states.md
+++ b/backlog/tasks/task-418.9.2 - Implement-WP11B-evaluations-readiness-and-recovery-states.md
@@ -17,6 +17,7 @@ documentation:
 modified_files:
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - apps/packages/ui/src/components/Option/Evaluations/components/EvaluationRecoveryCallout.tsx
+- apps/packages/ui/src/components/Option/Evaluations/components/__tests__/EvaluationRecoveryCallout.test.tsx
 - apps/packages/ui/src/components/Option/Evaluations/tabs/DatasetsTab.tsx
 - apps/packages/ui/src/components/Option/Evaluations/tabs/EvaluationsTab.tsx
 - apps/packages/ui/src/components/Option/Evaluations/tabs/HistoryTab.tsx
@@ -54,13 +55,15 @@ Execute WP11B Task 2 from the WebUI study/safety/specialized implementation plan
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Added a shared `EvaluationRecoveryCallout` wrapper around `RecoveryCallout` for evaluations endpoint diagnostics. Converted list/detail load failures in Recipes, Evaluations, Runs, Datasets, Webhooks, History, and Synthetic Review to the shared recovery callout. Added an Open Recipes action to the evaluations empty state. Replaced remaining product-state AntD Alerts in touched evaluations tabs with `StatePanel` or plain content and removed stale evaluations entries from the product-state guard baseline. Fixed a `SyntheticReviewTab` render loop by using a stable empty queue array and returning current selection state for no-op cleanup updates. Tightened the embeddings recipe config's local dataset/media-search typing so the evaluations subtree no longer contributes TypeScript errors.
 
-Verification recorded: focused evaluations Vitest suite 39 tests passed; route-boundary Vitest 8 tests passed; design-system product-state guard passed; Playwright evaluations recipes/synthetic smoke tests passed; targeted Chromium QA observed Unavailable diagnostics for `/api/v1/evaluations/recipes`, `/api/v1/evaluations`, `/api/v1/evaluations/datasets`, and `/api/v1/evaluations/webhooks` with Register webhook still enabled. TypeScript check was attempted with increased heap; repo-wide baseline failures remain outside this slice, and the filtered evaluations output is now empty. Bandit was not run because this slice touched TypeScript/JSON/Backlog only, no Python code.
+PR #1943 review follow-up: internationalized the recovery callout default message and diagnostics labels, added FastAPI `detail`/`msg` extraction including arrays, and prevented duplicate diagnostics such as `HTTP 404: HTTP 404`.
+
+Verification recorded: focused evaluations Vitest suite 42 tests passed; route-boundary Vitest 8 tests passed; design-system product-state guard passed; Playwright evaluations recipes/synthetic smoke tests passed; targeted Chromium QA observed Unavailable diagnostics for `/api/v1/evaluations/recipes`, `/api/v1/evaluations`, `/api/v1/evaluations/datasets`, and `/api/v1/evaluations/webhooks` with Register webhook still enabled. TypeScript check was attempted with increased heap; repo-wide baseline failures remain outside this slice, and the filtered evaluations output is empty. Bandit was not run because this slice touched TypeScript/JSON/Backlog only, no Python code.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented WP11B evaluations readiness/recovery states for endpoint and worker unavailability, with preservation-oriented regression coverage across the affected tabs. Browser QA confirmed rendered recovery diagnostics for recipes, evaluations, datasets, and webhooks, and existing guided/synthetic evaluations smoke flows still pass.
+Implemented WP11B evaluations readiness/recovery states for endpoint and worker unavailability, with preservation-oriented regression coverage across the affected tabs. Browser QA confirmed rendered recovery diagnostics for recipes, evaluations, datasets, and webhooks, and existing guided/synthetic evaluations smoke flows still pass. PR review comments on recovery-callout i18n, FastAPI detail parsing, and duplicate HTTP detail formatting are addressed with component-level regression tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-418.9.2 - Implement-WP11B-evaluations-readiness-and-recovery-states.md
+++ b/backlog/tasks/task-418.9.2 - Implement-WP11B-evaluations-readiness-and-recovery-states.md
@@ -1,0 +1,74 @@
+---
+id: TASK-418.9.2
+title: Implement WP11B evaluations readiness and recovery states
+status: Done
+labels:
+- ux
+- webui
+- extension
+- wp11b
+- evaluations
+- testing
+priority: High
+parent_task_id: TASK-418.9
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-study-safety-specialized-implementation-plan.md
+- Docs/superpowers/specs/2026-05-17-webui-extension-ux-remediation-program-design.md
+modified_files:
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- apps/packages/ui/src/components/Option/Evaluations/components/EvaluationRecoveryCallout.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/DatasetsTab.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/EvaluationsTab.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/HistoryTab.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/RecipesTab.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/recipe-configs/EmbeddingsModelSelectionConfig.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/RunsTab.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/SyntheticReviewTab.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/WebhooksTab.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/DatasetsTab.pagination.test.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/EvaluationsTab.empty-state.test.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/HistoryTab.filters.test.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/RecipesTab.launch.test.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/RunsTab.benchmark-option.test.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/SyntheticReviewTab.test.tsx
+- apps/packages/ui/src/components/Option/Evaluations/tabs/__tests__/WebhooksTab.contract.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP11B Task 2 from the WebUI study/safety/specialized implementation plan. Make /evaluations ready-or-recoverable for first-time and power users by adding focused readiness/recovery tests and scoped UI adjustments for workspace setup, beta identity, tab discoverability, empty states, worker/endpoint unavailability, and filter/form preservation. Route-boundary work from the original task is already covered by TASK-418.9.1 and PR #1938, so this slice starts from the post-merge route contract state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Endpoint and worker failures on `/evaluations` use design-system recovery states with clear failing request paths.
+- [x] Evaluation empty state gives first-time users a direct Recipes path while preserving custom-evaluation workflow.
+- [x] Runs, datasets, webhooks, history, recipes, and synthetic review preserve adjacent controls/state when endpoint calls fail.
+- [x] Evaluations tabs avoid new AntD product-state alerts and keep the design-system guard clean for touched files.
+- [x] Focused unit, route-boundary, design-system, and browser smoke verification is recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added a shared `EvaluationRecoveryCallout` wrapper around `RecoveryCallout` for evaluations endpoint diagnostics. Converted list/detail load failures in Recipes, Evaluations, Runs, Datasets, Webhooks, History, and Synthetic Review to the shared recovery callout. Added an Open Recipes action to the evaluations empty state. Replaced remaining product-state AntD Alerts in touched evaluations tabs with `StatePanel` or plain content and removed stale evaluations entries from the product-state guard baseline. Fixed a `SyntheticReviewTab` render loop by using a stable empty queue array and returning current selection state for no-op cleanup updates. Tightened the embeddings recipe config's local dataset/media-search typing so the evaluations subtree no longer contributes TypeScript errors.
+
+Verification recorded: focused evaluations Vitest suite 39 tests passed; route-boundary Vitest 8 tests passed; design-system product-state guard passed; Playwright evaluations recipes/synthetic smoke tests passed; targeted Chromium QA observed Unavailable diagnostics for `/api/v1/evaluations/recipes`, `/api/v1/evaluations`, `/api/v1/evaluations/datasets`, and `/api/v1/evaluations/webhooks` with Register webhook still enabled. TypeScript check was attempted with increased heap; repo-wide baseline failures remain outside this slice, and the filtered evaluations output is now empty. Bandit was not run because this slice touched TypeScript/JSON/Backlog only, no Python code.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented WP11B evaluations readiness/recovery states for endpoint and worker unavailability, with preservation-oriented regression coverage across the affected tabs. Browser QA confirmed rendered recovery diagnostics for recipes, evaluations, datasets, and webhooks, and existing guided/synthetic evaluations smoke flows still pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds a shared evaluations recovery callout with request-path diagnostics for endpoint failures.
- Converts evaluations, recipes, runs, datasets, webhooks, history, and synthetic review failure states to recoverable UI while preserving adjacent controls/state.
- Adds regression coverage for recovery diagnostics and fixes local embeddings recipe typing so the evaluations subtree is clean in the TypeScript filter.

## Test Plan
- [x] bunx vitest run src/components/Option/Evaluations/__tests__/EvaluationsPage.recipe-tab.test.tsx src/components/Option/Evaluations/tabs/__tests__/RecipesTab.launch.test.tsx src/components/Option/Evaluations/tabs/__tests__/EvaluationsTab.empty-state.test.tsx src/components/Option/Evaluations/tabs/__tests__/RunsTab.benchmark-option.test.tsx src/components/Option/Evaluations/tabs/__tests__/DatasetsTab.pagination.test.tsx src/components/Option/Evaluations/tabs/__tests__/HistoryTab.filters.test.tsx src/components/Option/Evaluations/tabs/__tests__/WebhooksTab.contract.test.tsx src/components/Option/Evaluations/tabs/__tests__/SyntheticReviewTab.test.tsx
- [x] bunx vitest run src/routes/__tests__/study-safety-specialized-route-boundaries.test.tsx
- [x] bun run verify:design-system-state
- [x] TLDW_WEB_AUTOSTART=false TLDW_WEB_URL=http://127.0.0.1:18011 NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 bunx playwright test e2e/smoke/evaluations-recipes-guided.spec.ts e2e/smoke/evaluations-synthetic-review.spec.ts --reporter=line --workers=1
- [x] NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false (repo-wide baseline still exits nonzero; filtered evaluations output is empty)
- [x] git diff --check

## Merge Note
Per repo policy, the human requester still needs to provide the final Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared recovery callout for Evaluations with request-path diagnostics and clean HTTP detail parsing, and keeps user inputs intact when endpoints are down. Also adds an “Open Recipes” CTA in the empty evaluations list to guide first-time users.

- **New Features**
  - Introduced `EvaluationRecoveryCallout` (i18n default messaging, FastAPI `detail/msg` extraction, de-duplicated `HTTP {status}`) using design-system `RecoveryCallout`.
  - Applied recoverable states to Evaluations list/detail, Datasets, Runs, Webhooks, History, Recipes (manifests and report), and Synthetic Review.
  - Preserves filters/forms and adjacent controls during failures; non-critical info/success notices now use `StatePanel` or plain content.
  - Replaced legacy AntD alerts with design-system components and removed related exceptions from the product-state guard.
  - Updated Evaluations empty state with an “Open Recipes” action.

- **Bug Fixes**
  - Stabilized Synthetic Review selection updates to avoid unnecessary re-renders.
  - Tightened typings in the embeddings recipe config (dataset and media-search shapes) so the Evaluations subtree is clean in the TypeScript filter.

<sup>Written for commit 886e4c82f6de055500efd778cb729bd12d170e16. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1943?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

