### PR TITLE
Migrate SourceSeenDrawer alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2684,17 +2684,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx:Alert",
-    "path": "src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx:Alert#antd-alert-flowcheckdiffpanel-type-info-no-diff-availabl-4fd87r",
     "path": "src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react"
 import {
-  Alert,
   Button,
   Descriptions,
   Drawer,
@@ -13,6 +12,7 @@ import {
 } from "antd"
 import { RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { clearSourceSeen, getSourceSeenStats } from "@/services/watchlists"
 import type { SourceSeenStats } from "@/types/watchlists"
 import { formatRelativeTime } from "@/utils/dateFormatters"
@@ -123,7 +123,12 @@ export const SourceSeenDrawer: React.FC<SourceSeenDrawerProps> = ({
           <Spin size="large" />
         </div>
       ) : error ? (
-        <Alert type="error" showIcon title={error} className="mb-4" />
+        <Alert
+          variant="error"
+          title={error}
+          className="mb-4"
+          data-testid="alert-error"
+        />
       ) : stats ? (
         <div className="space-y-6">
           {/* Stats section */}

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceSeenDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceSeenDrawer.test.tsx
@@ -270,8 +270,10 @@ describe("SourceSeenDrawer", () => {
         <SourceSeenDrawer open={true} onClose={vi.fn()} sourceId={42} />
       )
       await waitFor(() => {
-        expect(screen.getByTestId("alert-error")).toBeInTheDocument()
-        expect(screen.getByTestId("alert-error")).toHaveTextContent("Network error")
+        const alert = screen.getByTestId("alert-error")
+        expect(alert).toBeInTheDocument()
+        expect(alert).toHaveTextContent("Network error")
+        expect(alert.closest("[data-ds-component='Alert']")).toBeInTheDocument()
       })
     } finally {
       consoleErrorSpy.mockRestore()

--- a/backlog/tasks/task-45.44.9.6 - Migrate-SourceSeenDrawer-error-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.6 - Migrate-SourceSeenDrawer-error-alert-to-design-system-Alert.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.44.9.6
+title: Migrate SourceSeenDrawer error alert to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-22 19:28'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+  - watchlists
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1666'
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.9
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the Watchlists SourceSeenDrawer load error UI off AntD Alert and onto the canonical design-system Alert while preserving loading, retry/context, and seen-item list behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SourceSeenDrawer load error callout renders the design-system Alert primitive instead of AntD Alert.
+- [x] #2 Existing focused SourceSeenDrawer coverage proves the error text remains visible and wrapped in the canonical design-system marker.
+- [x] #3 Design-system product-state verifier passes with the stale SourceSeenDrawer Alert baseline entry removed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing SourceSeenDrawer test assertion requiring the load-error callout to render with the design-system Alert marker.
+2. Replace the SourceSeenDrawer AntD Alert usage with the canonical design-system Alert primitive while preserving error copy and spacing.
+3. Remove the SourceSeenDrawer Alert entry from the product-state baseline and run focused tests plus the design-system verifier.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red/green completed. Added a failing SourceSeenDrawer error-state assertion requiring the load-error callout to be wrapped by the canonical data-ds-component Alert marker; the initial focused run failed because the AntD Alert mock rendered only the error text. Replaced the SourceSeenDrawer AntD Alert import/usage with the shared design-system Alert primitive while preserving the existing error title and spacing, and removed the stale SourceSeenDrawer Alert baseline entry.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the Watchlists SourceSeenDrawer load-error callout from AntD Alert to the design-system Alert primitive. Focused coverage now verifies the error text renders in the canonical Alert wrapper, and the product-state baseline no longer contains the SourceSeenDrawer Alert exception. Verification: red focused SourceSeenDrawer test failed on the missing design-system marker; green focused SourceSeenDrawer test passed 14/14; bun run verify:design-system-state passed with 316 allowed legacy exceptions; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.9.6 - Migrate-SourceSeenDrawer-error-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.6 - Migrate-SourceSeenDrawer-error-alert-to-design-system-Alert.md
@@ -4,19 +4,19 @@ title: Migrate SourceSeenDrawer error alert to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-22 19:28'
+updated_date: 2026-05-22 19:28
 labels:
-  - design-system
-  - webui
-  - extension
-  - product-state
-  - watchlists
+- design-system
+- webui
+- extension
+- product-state
+- watchlists
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1666'
-  - >-
-    apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx
-  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1666
+- apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceSeenDrawer.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1944
 parent_task_id: TASK-45.44.9
 priority: medium
 ---


### PR DESCRIPTION
## Summary
- Migrate SourceSeenDrawer load-error callout from AntD Alert to the shared design-system Alert primitive.
- Add focused coverage for the design-system Alert marker while preserving the error text.
- Remove the stale SourceSeenDrawer product-state baseline entry.

## Test Plan
- bunx vitest run src/components/Option/Watchlists/SourcesTab/__tests__/SourceSeenDrawer.test.tsx --reporter=dot
- bun run verify:design-system-state
- node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"
- git diff --check

## Notes
- Draft PR. Per project policy, a human-authored Change summary is still required before merge.
- Bandit skipped: frontend TSX/test/JSON/Backlog markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the SourceSeenDrawer load-error callout from `antd` `Alert` to the design-system `Alert` to align UI and satisfy product-state checks.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` from `@/components/ui/primitives`; switched to `variant="error"` and added `data-testid="alert-error"`.
  - Updated tests to assert the error is wrapped by `[data-ds-component='Alert']`.
  - Removed the stale `Alert` exception from `design-system-product-state-baseline.json`.
  - Added a backlog task entry documenting the migration and referencing this PR.

<sup>Written for commit 42d59e3d4c01e5907cb4ad2e42e508aed6732bdc. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1944?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

