### PR TITLE
Harden prototype owner promotion review UX

### DIFF
--- a/Docs/superpowers/plans/2026-05-22-prototype-risk-gate-6-owner-review-plan.md
+++ b/Docs/superpowers/plans/2026-05-22-prototype-risk-gate-6-owner-review-plan.md
@@ -1,0 +1,143 @@
+# Prototype Risk Gate 6 Owner Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Harden the prototype workspace owner review and promotion UX for GitHub issue #1458.
+
+**Architecture:** Add the smallest backend contract surface the owner UI needs: promotion request summaries embedded in owner workspace detail, plus a typed review mutation for the existing review endpoint. The frontend then renders promotion request state separately from runtime state and disables approve/reject actions when backend semantics would reject, the branch session is not actionable, or validation/review is already terminal.
+
+**Tech Stack:** FastAPI/Pydantic backend, AuthNZ prototype repository, React, TanStack Query, Vitest/Testing Library, Bun.
+
+---
+
+### Task 1: Expose Promotion Requests In Owner Detail
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py`
+- Test: `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py`
+- Test: `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py`
+
+- [x] **Step 1: Write failing repository test**
+
+Add coverage that `list_promotion_requests_for_workspace(workspace_id)` returns only that workspace's requests ordered by newest update first.
+
+- [x] **Step 2: Run repository test red**
+
+Run: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py -q -k promotion_requests_for_workspace`
+
+Expected: FAIL because the repository method does not exist.
+
+- [x] **Step 3: Add minimal repository method**
+
+Implement the method using the existing AuthNZ repo query style and `_normalize_promotion_request_row`.
+
+- [x] **Step 4: Add endpoint/schema failing test**
+
+Add coverage that `GET /api/v1/prototype-workspaces/{id}` includes `promotion_requests` with pending/stale records and candidate/session ids.
+
+- [x] **Step 5: Run endpoint test red**
+
+Run: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py -q -k promotion_requests`
+
+Expected: FAIL because the response schema/detail builder does not expose promotion requests.
+
+- [x] **Step 6: Add response schema and detail builder field**
+
+Add `PrototypePromotionRequestSummaryResponse` and `promotion_requests` to `PrototypeWorkspaceDetailResponse`; call the repo method in `_build_workspace_detail_response`.
+
+- [x] **Step 7: Run backend focused tests green**
+
+Run: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py -q -k "promotion_requests or owner_can_review_promotion_request or stale_promotion_response_shape"`
+
+Expected: PASS.
+
+### Task 2: Add Frontend Review Client And Hook
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/prototype-workspace.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts`
+- Modify: `apps/packages/ui/src/hooks/usePrototypeWorkspaces.ts`
+- Test: `apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx`
+
+- [x] **Step 1: Write failing hook/client tests**
+
+Add tests for:
+- `useReviewPrototypePromotionRequest` posts approve/reject payloads to `/prototype-promotions/{id}/review`.
+- structured review errors from the contract fixture are preserved.
+
+- [x] **Step 2: Run frontend hook tests red**
+
+Run: `bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism`
+
+Expected: FAIL because review types/client/hook do not exist.
+
+- [x] **Step 3: Add types, client function, and mutation hook**
+
+Add `PrototypePromotionReviewInput`, `PrototypePromotionReviewResult`, `reviewPrototypePromotionRequestRequest`, and `useReviewPrototypePromotionRequest`. Invalidate workspace detail and promotion query keys on success.
+
+- [x] **Step 4: Run hook tests green**
+
+Run: `bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism`
+
+Expected: PASS.
+
+### Task 3: Harden Owner Review UX
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceOwnerView.tsx`
+- Test: `apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx`
+
+- [x] **Step 1: Write failing owner-view tests**
+
+Cover:
+- pending promotion request renders candidate/session/reviewer context and enables approve/reject.
+- stale/conflict/failed/promoted/rejected states render distinct user-facing state copy.
+- approve is disabled when the request is terminal, stale, conflict, failed, lacks a candidate snapshot, has a revoked/expired branch session, or review is in flight.
+- branch inventory distinguishes runtime status from preview status and marks revoked/expired sessions as not actionable.
+
+- [x] **Step 2: Run owner-view tests red**
+
+Run: `bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx --maxWorkers=1 --no-file-parallelism`
+
+Expected: FAIL because the component does not render promotion requests or review actions yet.
+
+- [x] **Step 3: Implement owner review surface**
+
+Render a promotion review section that derives action availability from request status and snapshot/session presence. Wire approve/reject to the review mutation and show validation results without mixing them with runtime branch state.
+
+- [x] **Step 4: Run owner-view tests green**
+
+Run: `bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx --maxWorkers=1 --no-file-parallelism`
+
+Expected: PASS.
+
+### Task 4: Verify And Close Out
+
+**Files:**
+- Modify: `backlog/tasks/task-479 - Risk-Gate-6-prototype-owner-review-and-promotion-UX-hardening.md`
+
+- [x] **Step 1: Run focused frontend suite**
+
+Run: `bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism`
+
+- [x] **Step 2: Run focused backend suite**
+
+Run: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q`
+
+- [x] **Step 3: Run Bandit for touched backend paths**
+
+Run: `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_risk_gate_6.json`
+
+- [x] **Step 4: Run whitespace check**
+
+Run: `git diff --check`
+
+- [x] **Step 5: Update Backlog task**
+
+Record verification results, known skips, and final summary in `TASK-479`.
+
+- [x] **Step 6: Commit**
+
+Commit the implementation with a message that names Risk Gate 6 and issue #1458.

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceOwnerView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceOwnerView.tsx
@@ -18,38 +18,57 @@ interface PrototypeWorkspaceOwnerViewProps {
   workspace?: PrototypeWorkspaceDetail | null
 }
 
-const promotionStatusCopy: Record<string, string> = {
+const prototypeReviewStateCopy: Record<string, string> = {
   pending: "Pending owner review",
   approved: "Approved",
   rejected: "Rejected",
   promoted: "Promoted",
   stale: "Stale candidate",
+  promotion_stale: "Stale candidate",
+  conflict: "Promotion conflict",
+  promotion_conflict: "Promotion conflict",
+  validation_running: "Validation running",
+  validation_failed: "Validation failed",
+  promotion_validation_failed: "Validation failed",
   failed: "Promotion failed",
-  conflict: "Promotion conflict"
+  promotion_failed: "Promotion failed"
 }
 
-const promotionReviewResultCopy: Record<string, string> = {
-  promoted: "Promoted",
-  rejected: "Rejected",
-  stale: "Stale candidate",
-  failed: "Promotion failed",
-  conflict: "Promotion conflict"
-}
+const normalizePrototypeState = (value: string | null | undefined) =>
+  (value ?? "").trim().toLowerCase().replace(/[-\s]+/g, "_")
 
-const terminalPromotionStatuses = new Set([
-  "approved",
-  "rejected",
-  "promoted",
-  "stale",
-  "failed",
-  "conflict"
-])
+const toDisplayLabel = (value: string) =>
+  value
+    .split(/[_-\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+
+const getPrototypeReviewStateCopy = (status: string | null | undefined) => {
+  const normalized = normalizePrototypeState(status)
+  return (
+    prototypeReviewStateCopy[normalized] ??
+    (normalized ? toDisplayLabel(normalized) : null)
+  )
+}
 
 const getPromotionStatusCopy = (status: string | null | undefined) =>
-  promotionStatusCopy[(status ?? "").toLowerCase()] ?? "Unknown review state"
+  getPrototypeReviewStateCopy(status) ?? "Unknown review state"
 
-const getReviewResultCopy = (status: string | null | undefined) =>
-  promotionReviewResultCopy[(status ?? "").toLowerCase()] ?? "Review completed"
+const getReviewResultCopy = (
+  status: string | null | undefined,
+  failureCode?: string | null
+) => {
+  const failureState = normalizePrototypeState(failureCode)
+  if (
+    failureState === "publish_validation_failed" ||
+    failureState === "promotion_validation_failed" ||
+    failureState === "validation_failed"
+  ) {
+    return "Validation failed"
+  }
+  return getPrototypeReviewStateCopy(status) ?? "Review completed"
+}
 
 const isSessionActionable = (session: PrototypeWorkspaceSessionSummary) => {
   if (session.is_revoked || session.revoked_at) {
@@ -65,6 +84,14 @@ const getReviewResultReason = (details: Record<string, unknown> | undefined) => 
   const reason = details?.reason
   return typeof reason === "string" && reason.trim() ? reason : null
 }
+
+const getReviewErrorTitle = (detail?: {
+  frontend_state?: string
+  category?: string
+}) =>
+  getPrototypeReviewStateCopy(detail?.frontend_state) ??
+  getPrototypeReviewStateCopy(detail?.category) ??
+  "Review failed"
 
 export const PrototypeWorkspaceOwnerView = ({
   prototypeWorkspaceId,
@@ -146,25 +173,33 @@ export const PrototypeWorkspaceOwnerView = ({
     setShareToken(token.raw_token ?? token.token ?? token.token_prefix)
   }
 
-  const canReviewPromotion = (promotion: PrototypePromotionRequest) => {
+  const canApprovePromotion = (promotion: PrototypePromotionRequest) => {
     const status = promotion.status.toLowerCase()
     const session = sessionsById.get(promotion.prototype_session_id)
     return (
       status === "pending" &&
-      !terminalPromotionStatuses.has(status) &&
-      Boolean(session) &&
-      Boolean(session && isSessionActionable(session)) &&
-      Boolean(snapshotsById.get(promotion.candidate_snapshot_id)) &&
+      !!session &&
+      isSessionActionable(session) &&
+      !!snapshotsById.get(promotion.candidate_snapshot_id) &&
       !reviewPromotion.isPending &&
-      Boolean(resolvedWorkspaceId)
+      !!resolvedWorkspaceId
     )
   }
+
+  const canRejectPromotion = (promotion: PrototypePromotionRequest) =>
+    promotion.status.toLowerCase() === "pending" &&
+    !reviewPromotion.isPending &&
+    !!resolvedWorkspaceId
 
   const handleReviewPromotion = async (
     promotion: PrototypePromotionRequest,
     decision: "approve" | "reject"
   ) => {
-    if (!resolvedWorkspaceId || !canReviewPromotion(promotion)) {
+    const canSubmit =
+      decision === "approve"
+        ? canApprovePromotion(promotion)
+        : canRejectPromotion(promotion)
+    if (!resolvedWorkspaceId || !canSubmit) {
       return
     }
     await reviewPromotion.mutateAsync({
@@ -378,7 +413,10 @@ export const PrototypeWorkspaceOwnerView = ({
             className="mb-3 rounded border px-3 py-2 text-sm"
           >
             <div className="font-medium">
-              {getReviewResultCopy(reviewPromotion.data.status)}
+              {getReviewResultCopy(
+                reviewPromotion.data.status,
+                reviewPromotion.data.failure_code
+              )}
             </div>
             <div className="text-muted-foreground">
               Candidate {reviewPromotion.data.candidate_snapshot_id}
@@ -398,10 +436,18 @@ export const PrototypeWorkspaceOwnerView = ({
         ) : null}
         {reviewError ? (
           <div className="mb-3 rounded border border-destructive px-3 py-2 text-sm">
-            <div className="font-medium">Review failed</div>
+            <div className="font-medium">
+              {getReviewErrorTitle(reviewError.detail)}
+            </div>
             <div className="text-muted-foreground">
               {reviewError.detail?.message ?? reviewError.message ?? "Promotion review failed"}
             </div>
+            {reviewError.detail?.category ? (
+              <div className="text-muted-foreground">
+                {getPrototypeReviewStateCopy(reviewError.detail.category) ??
+                  reviewError.detail.category}
+              </div>
+            ) : null}
           </div>
         ) : null}
         <div className="space-y-2 text-sm">
@@ -411,7 +457,8 @@ export const PrototypeWorkspaceOwnerView = ({
             workspace?.promotion_requests.map((promotion) => {
               const candidate = snapshotsById.get(promotion.candidate_snapshot_id)
               const session = sessionsById.get(promotion.prototype_session_id)
-              const reviewable = canReviewPromotion(promotion)
+              const canApprove = canApprovePromotion(promotion)
+              const canReject = canRejectPromotion(promotion)
               return (
                 <div
                   key={promotion.id}
@@ -430,7 +477,7 @@ export const PrototypeWorkspaceOwnerView = ({
                         className="rounded border px-3 py-1"
                         aria-label={`Approve promotion ${promotion.id}`}
                         onClick={() => void handleReviewPromotion(promotion, "approve")}
-                        disabled={!reviewable}
+                        disabled={!canApprove}
                       >
                         Approve
                       </button>
@@ -438,7 +485,7 @@ export const PrototypeWorkspaceOwnerView = ({
                         className="rounded border px-3 py-1"
                         aria-label={`Reject promotion ${promotion.id}`}
                         onClick={() => void handleReviewPromotion(promotion, "reject")}
-                        disabled={!reviewable}
+                        disabled={!canReject}
                       >
                         Reject
                       </button>

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceOwnerView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceOwnerView.tsx
@@ -1,12 +1,69 @@
 import { useMemo, useState } from "react"
 import { useCreateToken } from "@/hooks/useSharing"
-import { useCreateOwnerBranchSession, useCreatePrototypeWorkspace } from "@/hooks/usePrototypeWorkspaces"
+import {
+  useCreateOwnerBranchSession,
+  useCreatePrototypeWorkspace,
+  useReviewPrototypePromotionRequest
+} from "@/hooks/usePrototypeWorkspaces"
 import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
-import type { PrototypeWorkspaceDetail } from "@/types/prototype-workspace"
+import type {
+  PrototypePromotionRequest,
+  PrototypeWorkspaceDetail,
+  PrototypeWorkspaceSessionSummary,
+  PrototypeWorkspaceSnapshotSummary
+} from "@/types/prototype-workspace"
 
 interface PrototypeWorkspaceOwnerViewProps {
   prototypeWorkspaceId?: string | null
   workspace?: PrototypeWorkspaceDetail | null
+}
+
+const promotionStatusCopy: Record<string, string> = {
+  pending: "Pending owner review",
+  approved: "Approved",
+  rejected: "Rejected",
+  promoted: "Promoted",
+  stale: "Stale candidate",
+  failed: "Promotion failed",
+  conflict: "Promotion conflict"
+}
+
+const promotionReviewResultCopy: Record<string, string> = {
+  promoted: "Promoted",
+  rejected: "Rejected",
+  stale: "Stale candidate",
+  failed: "Promotion failed",
+  conflict: "Promotion conflict"
+}
+
+const terminalPromotionStatuses = new Set([
+  "approved",
+  "rejected",
+  "promoted",
+  "stale",
+  "failed",
+  "conflict"
+])
+
+const getPromotionStatusCopy = (status: string | null | undefined) =>
+  promotionStatusCopy[(status ?? "").toLowerCase()] ?? "Unknown review state"
+
+const getReviewResultCopy = (status: string | null | undefined) =>
+  promotionReviewResultCopy[(status ?? "").toLowerCase()] ?? "Review completed"
+
+const isSessionActionable = (session: PrototypeWorkspaceSessionSummary) => {
+  if (session.is_revoked || session.revoked_at) {
+    return false
+  }
+  if (!session.expires_at) {
+    return true
+  }
+  return new Date(session.expires_at).getTime() > Date.now()
+}
+
+const getReviewResultReason = (details: Record<string, unknown> | undefined) => {
+  const reason = details?.reason
+  return typeof reason === "string" && reason.trim() ? reason : null
 }
 
 export const PrototypeWorkspaceOwnerView = ({
@@ -32,6 +89,23 @@ export const PrototypeWorkspaceOwnerView = ({
   const resolvedWorkspaceId = prototypeWorkspaceId ?? activeWorkspaceId
   const createOwnerSession = useCreateOwnerBranchSession(resolvedWorkspaceId ?? "")
   const createToken = useCreateToken()
+  const reviewPromotion = useReviewPrototypePromotionRequest()
+
+  const sessionsById = useMemo(() => {
+    const map = new Map<string, PrototypeWorkspaceSessionSummary>()
+    for (const session of workspace?.sessions ?? []) {
+      map.set(session.id, session)
+    }
+    return map
+  }, [workspace?.sessions])
+
+  const snapshotsById = useMemo(() => {
+    const map = new Map<string, PrototypeWorkspaceSnapshotSummary>()
+    for (const snapshot of workspace?.snapshots ?? []) {
+      map.set(snapshot.snapshot_id, snapshot)
+    }
+    return map
+  }, [workspace?.snapshots])
 
   const shareUrl = useMemo(() => {
     if (!shareToken) {
@@ -71,6 +145,51 @@ export const PrototypeWorkspaceOwnerView = ({
     })
     setShareToken(token.raw_token ?? token.token ?? token.token_prefix)
   }
+
+  const canReviewPromotion = (promotion: PrototypePromotionRequest) => {
+    const status = promotion.status.toLowerCase()
+    const session = sessionsById.get(promotion.prototype_session_id)
+    return (
+      status === "pending" &&
+      !terminalPromotionStatuses.has(status) &&
+      Boolean(session) &&
+      Boolean(session && isSessionActionable(session)) &&
+      Boolean(snapshotsById.get(promotion.candidate_snapshot_id)) &&
+      !reviewPromotion.isPending &&
+      Boolean(resolvedWorkspaceId)
+    )
+  }
+
+  const handleReviewPromotion = async (
+    promotion: PrototypePromotionRequest,
+    decision: "approve" | "reject"
+  ) => {
+    if (!resolvedWorkspaceId || !canReviewPromotion(promotion)) {
+      return
+    }
+    await reviewPromotion.mutateAsync({
+      promotion_request_id: promotion.id,
+      prototype_workspace_id: resolvedWorkspaceId,
+      decision,
+      ...(decision === "approve" && workspace?.canonical_snapshot_id
+        ? { review_baseline_snapshot_id: workspace.canonical_snapshot_id }
+        : {})
+    })
+  }
+
+  const reviewError = reviewPromotion.error as
+    | {
+        detail?: {
+          message?: string
+          frontend_state?: string
+          category?: string
+        }
+        message?: string
+      }
+    | null
+  const reviewResultReason = reviewPromotion.data
+    ? getReviewResultReason(reviewPromotion.data.details)
+    : null
 
   return (
     <div
@@ -202,11 +321,15 @@ export const PrototypeWorkspaceOwnerView = ({
             workspace?.sessions.map((session) => (
               <div
                 key={session.id}
+                data-testid={`prototype-branch-session-${session.id}`}
                 className="rounded border px-3 py-2"
               >
                 <div className="font-medium">{session.id}</div>
-                <div className="text-muted-foreground">
-                  {session.actor_type} · {session.runtime_status} · preview {session.preview_status}
+                <div className="grid gap-1 text-muted-foreground md:grid-cols-4">
+                  <span>{session.actor_type}</span>
+                  <span>Runtime {session.runtime_status}</span>
+                  <span>Preview {session.preview_status}</span>
+                  <span>{isSessionActionable(session) ? "Actionable" : "Not actionable"}</span>
                 </div>
               </div>
             ))
@@ -237,6 +360,109 @@ export const PrototypeWorkspaceOwnerView = ({
                 </div>
               </div>
             ))
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Promotion review</h2>
+          <p className="text-sm text-muted-foreground">
+            Review collaborator candidate snapshots without mixing review state with
+            runtime or preview health.
+          </p>
+        </div>
+        {reviewPromotion.data ? (
+          <div
+            data-testid="prototype-promotion-review-result"
+            className="mb-3 rounded border px-3 py-2 text-sm"
+          >
+            <div className="font-medium">
+              {getReviewResultCopy(reviewPromotion.data.status)}
+            </div>
+            <div className="text-muted-foreground">
+              Candidate {reviewPromotion.data.candidate_snapshot_id}
+              {reviewPromotion.data.failure_code
+                ? ` · ${reviewPromotion.data.failure_code}`
+                : null}
+              {reviewPromotion.data.preview_handle
+                ? ` · preview ${reviewPromotion.data.preview_handle}`
+                : null}
+            </div>
+            {reviewResultReason ? (
+              <div className="text-muted-foreground">
+                {reviewResultReason}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        {reviewError ? (
+          <div className="mb-3 rounded border border-destructive px-3 py-2 text-sm">
+            <div className="font-medium">Review failed</div>
+            <div className="text-muted-foreground">
+              {reviewError.detail?.message ?? reviewError.message ?? "Promotion review failed"}
+            </div>
+          </div>
+        ) : null}
+        <div className="space-y-2 text-sm">
+          {(workspace?.promotion_requests ?? []).length === 0 ? (
+            <p className="text-muted-foreground">No promotion requests yet.</p>
+          ) : (
+            workspace?.promotion_requests.map((promotion) => {
+              const candidate = snapshotsById.get(promotion.candidate_snapshot_id)
+              const session = sessionsById.get(promotion.prototype_session_id)
+              const reviewable = canReviewPromotion(promotion)
+              return (
+                <div
+                  key={promotion.id}
+                  data-testid={`prototype-promotion-request-${promotion.id}`}
+                  className="rounded border px-3 py-2"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium">{promotion.id}</div>
+                      <div className="text-muted-foreground">
+                        {getPromotionStatusCopy(promotion.status)}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        className="rounded border px-3 py-1"
+                        aria-label={`Approve promotion ${promotion.id}`}
+                        onClick={() => void handleReviewPromotion(promotion, "approve")}
+                        disabled={!reviewable}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        className="rounded border px-3 py-1"
+                        aria-label={`Reject promotion ${promotion.id}`}
+                        onClick={() => void handleReviewPromotion(promotion, "reject")}
+                        disabled={!reviewable}
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </div>
+                  <div className="mt-2 grid gap-1 text-muted-foreground md:grid-cols-2">
+                    <span>Candidate {promotion.candidate_snapshot_id}</span>
+                    <span>Session {promotion.prototype_session_id}</span>
+                    <span>
+                      {promotion.requested_by_shared_actor_id
+                        ? `Shared actor ${promotion.requested_by_shared_actor_id}`
+                        : `User ${promotion.requested_by_user_id ?? "unknown"}`}
+                    </span>
+                    <span>
+                      {candidate ? "Candidate snapshot present" : "Candidate snapshot missing"}
+                    </span>
+                    <span>
+                      {session ? "Branch session present" : "Branch session missing"}
+                    </span>
+                    {promotion.review_notes ? <span>{promotion.review_notes}</span> : null}
+                  </div>
+                </div>
+              )
+            })
           )}
         </div>
       </section>

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx
@@ -1,0 +1,339 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { PrototypeWorkspaceOwnerView } from "../PrototypeWorkspaceOwnerView"
+import type { PrototypeWorkspaceDetail } from "@/types/prototype-workspace"
+
+const hookState = vi.hoisted(() => ({
+  useCreatePrototypeWorkspace: vi.fn(),
+  useCreateOwnerBranchSession: vi.fn(),
+  useReviewPrototypePromotionRequest: vi.fn(),
+  useCreateToken: vi.fn()
+}))
+
+vi.mock("@/hooks/usePrototypeWorkspaces", () => ({
+  useCreatePrototypeWorkspace: (...args: unknown[]) =>
+    hookState.useCreatePrototypeWorkspace(...args),
+  useCreateOwnerBranchSession: (...args: unknown[]) =>
+    hookState.useCreateOwnerBranchSession(...args),
+  useReviewPrototypePromotionRequest: (...args: unknown[]) =>
+    hookState.useReviewPrototypePromotionRequest(...args)
+}))
+
+vi.mock("@/hooks/useSharing", () => ({
+  useCreateToken: (...args: unknown[]) => hookState.useCreateToken(...args)
+}))
+
+const buildWorkspace = (
+  overrides: Partial<PrototypeWorkspaceDetail> = {}
+): PrototypeWorkspaceDetail => ({
+  id: "pw_owner_review",
+  owner_user_id: 1,
+  title: "Owner review prototype",
+  creation_source: "prompt",
+  canonical_snapshot_id: "psnap_canonical",
+  last_known_good_snapshot_id: "psnap_canonical",
+  canonical_preview_status: "ready",
+  publish_validation_status: "validated",
+  preview_policy: {},
+  share_policy: {},
+  runtime_policy: {},
+  designated_promoter_ids: [],
+  created_at: "2026-05-22T00:00:00Z",
+  updated_at: "2026-05-22T00:00:00Z",
+  is_archived: false,
+  viewer_role: "owner",
+  sessions: [
+    {
+      id: "pss_collab",
+      prototype_workspace_id: "pw_owner_review",
+      base_snapshot_id: "psnap_canonical",
+      actor_shared_actor_id: "psa_1",
+      actor_type: "external_collaborator",
+      share_link_id: 1,
+      runtime_status: "running",
+      preview_status: "ready",
+      created_at: "2026-05-22T00:00:00Z",
+      updated_at: "2026-05-22T00:00:00Z",
+      is_revoked: false
+    }
+  ],
+  snapshots: [
+    {
+      snapshot_id: "psnap_candidate",
+      prototype_workspace_id: "pw_owner_review",
+      parent_snapshot_id: "psnap_canonical",
+      created_from_session_id: "pss_collab",
+      author_shared_actor_id: "psa_1",
+      storage_ref: "prototype://candidate",
+      diff_summary: {},
+      prompt_summary: "Candidate revision",
+      preview_health: {},
+      created_at: "2026-05-22T00:00:00Z",
+      is_canonical: false,
+      is_last_known_good: false
+    },
+    {
+      snapshot_id: "psnap_canonical",
+      prototype_workspace_id: "pw_owner_review",
+      diff_summary: {},
+      preview_health: {},
+      created_at: "2026-05-21T00:00:00Z",
+      is_canonical: true,
+      is_last_known_good: true
+    }
+  ],
+  promotion_requests: [
+    {
+      id: "ppr_pending",
+      prototype_workspace_id: "pw_owner_review",
+      prototype_session_id: "pss_collab",
+      candidate_snapshot_id: "psnap_candidate",
+      requested_by_shared_actor_id: "psa_1",
+      requested_by_user_id: null,
+      status: "pending",
+      reviewed_by_user_id: null,
+      review_notes: null,
+      created_at: "2026-05-22T00:00:00Z",
+      updated_at: "2026-05-22T00:00:00Z"
+    }
+  ],
+  ...overrides
+})
+
+describe("PrototypeWorkspaceOwnerView", () => {
+  const reviewMutateAsync = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hookState.useCreatePrototypeWorkspace.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    })
+    hookState.useCreateOwnerBranchSession.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    })
+    hookState.useCreateToken.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    })
+    reviewMutateAsync.mockResolvedValue({
+      status: "promoted",
+      prototype_workspace_id: "pw_owner_review",
+      candidate_snapshot_id: "psnap_candidate",
+      canonical_snapshot_id: "psnap_candidate",
+      preview_handle: "pph_promoted",
+      details: {}
+    })
+    hookState.useReviewPrototypePromotionRequest.mockReturnValue({
+      isPending: false,
+      mutateAsync: reviewMutateAsync,
+      data: null,
+      error: null
+    })
+  })
+
+  it("renders pending promotion requests with explicit owner review actions", async () => {
+    const user = userEvent.setup()
+    render(
+      <PrototypeWorkspaceOwnerView
+        prototypeWorkspaceId="pw_owner_review"
+        workspace={buildWorkspace()}
+      />
+    )
+
+    const request = screen.getByTestId("prototype-promotion-request-ppr_pending")
+    expect(request).toHaveTextContent("Pending owner review")
+    expect(request).toHaveTextContent("Candidate psnap_candidate")
+    expect(request).toHaveTextContent("Session pss_collab")
+    expect(request).toHaveTextContent("Shared actor psa_1")
+
+    const approve = within(request).getByRole("button", {
+      name: "Approve promotion ppr_pending"
+    })
+    const reject = within(request).getByRole("button", {
+      name: "Reject promotion ppr_pending"
+    })
+    expect(approve).toBeEnabled()
+    expect(reject).toBeEnabled()
+
+    await user.click(approve)
+
+    expect(reviewMutateAsync).toHaveBeenCalledWith({
+      promotion_request_id: "ppr_pending",
+      prototype_workspace_id: "pw_owner_review",
+      decision: "approve",
+      review_baseline_snapshot_id: "psnap_canonical"
+    })
+  })
+
+  it("renders terminal promotion states distinctly and disables review actions", () => {
+    render(
+      <PrototypeWorkspaceOwnerView
+        prototypeWorkspaceId="pw_owner_review"
+        workspace={buildWorkspace({
+          promotion_requests: [
+            {
+              id: "ppr_stale",
+              prototype_workspace_id: "pw_owner_review",
+              prototype_session_id: "pss_collab",
+              candidate_snapshot_id: "psnap_candidate",
+              requested_by_user_id: null,
+              requested_by_shared_actor_id: "psa_1",
+              status: "stale",
+              reviewed_by_user_id: 1,
+              review_notes: "Candidate is stale",
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z"
+            },
+            {
+              id: "ppr_rejected",
+              prototype_workspace_id: "pw_owner_review",
+              prototype_session_id: "pss_collab",
+              candidate_snapshot_id: "psnap_candidate",
+              requested_by_user_id: null,
+              requested_by_shared_actor_id: "psa_1",
+              status: "rejected",
+              reviewed_by_user_id: 1,
+              review_notes: "Validation failed",
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z"
+            },
+            {
+              id: "ppr_promoted",
+              prototype_workspace_id: "pw_owner_review",
+              prototype_session_id: "pss_collab",
+              candidate_snapshot_id: "psnap_candidate",
+              requested_by_user_id: null,
+              requested_by_shared_actor_id: "psa_1",
+              status: "promoted",
+              reviewed_by_user_id: 1,
+              review_notes: null,
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z"
+            }
+          ]
+        })}
+      />
+    )
+
+    const stale = screen.getByTestId("prototype-promotion-request-ppr_stale")
+    const rejected = screen.getByTestId("prototype-promotion-request-ppr_rejected")
+    const promoted = screen.getByTestId("prototype-promotion-request-ppr_promoted")
+
+    expect(stale).toHaveTextContent("Stale candidate")
+    expect(rejected).toHaveTextContent("Rejected")
+    expect(rejected).toHaveTextContent("Validation failed")
+    expect(promoted).toHaveTextContent("Promoted")
+
+    for (const request of [stale, rejected, promoted]) {
+      expect(
+        within(request).getByRole("button", { name: /Approve promotion/ })
+      ).toBeDisabled()
+      expect(
+        within(request).getByRole("button", { name: /Reject promotion/ })
+      ).toBeDisabled()
+    }
+  })
+
+  it("surfaces validation-failed review results separately from branch runtime state", () => {
+    hookState.useReviewPrototypePromotionRequest.mockReturnValue({
+      isPending: false,
+      mutateAsync: reviewMutateAsync,
+      data: {
+        status: "failed",
+        failure_code: "publish_validation_failed",
+        prototype_workspace_id: "pw_owner_review",
+        candidate_snapshot_id: "psnap_candidate",
+        canonical_snapshot_id: "psnap_canonical",
+        preview_handle: null,
+        details: { reason: "Validator rejected the candidate" }
+      },
+      error: null
+    })
+
+    render(
+      <PrototypeWorkspaceOwnerView
+        prototypeWorkspaceId="pw_owner_review"
+        workspace={buildWorkspace()}
+      />
+    )
+
+    const result = screen.getByTestId("prototype-promotion-review-result")
+    expect(result).toHaveTextContent("Promotion failed")
+    expect(result).toHaveTextContent("publish_validation_failed")
+    expect(result).toHaveTextContent("Validator rejected the candidate")
+  })
+
+  it("separates branch runtime and preview status and marks revoked sessions not actionable", () => {
+    render(
+      <PrototypeWorkspaceOwnerView
+        prototypeWorkspaceId="pw_owner_review"
+        workspace={buildWorkspace({
+          sessions: [
+            {
+              id: "pss_revoked",
+              prototype_workspace_id: "pw_owner_review",
+              base_snapshot_id: "psnap_canonical",
+              actor_shared_actor_id: "psa_1",
+              actor_type: "external_collaborator",
+              share_link_id: 1,
+              runtime_status: "revoked",
+              preview_status: "revoked",
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z",
+              revoked_at: "2026-05-22T01:00:00Z",
+              is_revoked: true
+            }
+          ]
+        })}
+      />
+    )
+
+    const session = screen.getByTestId("prototype-branch-session-pss_revoked")
+    expect(session).toHaveTextContent("Runtime revoked")
+    expect(session).toHaveTextContent("Preview revoked")
+    expect(session).toHaveTextContent("Not actionable")
+  })
+
+  it("disables pending promotion review when the branch session is revoked", () => {
+    render(
+      <PrototypeWorkspaceOwnerView
+        prototypeWorkspaceId="pw_owner_review"
+        workspace={buildWorkspace({
+          sessions: [
+            {
+              id: "pss_collab",
+              prototype_workspace_id: "pw_owner_review",
+              base_snapshot_id: "psnap_canonical",
+              actor_shared_actor_id: "psa_1",
+              actor_type: "external_collaborator",
+              share_link_id: 1,
+              runtime_status: "revoked",
+              preview_status: "revoked",
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z",
+              revoked_at: "2026-05-22T01:00:00Z",
+              is_revoked: true
+            }
+          ]
+        })}
+      />
+    )
+
+    const request = screen.getByTestId("prototype-promotion-request-ppr_pending")
+    expect(
+      within(request).getByRole("button", {
+        name: "Approve promotion ppr_pending"
+      })
+    ).toBeDisabled()
+    expect(
+      within(request).getByRole("button", {
+        name: "Reject promotion ppr_pending"
+      })
+    ).toBeDisabled()
+  })
+})

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx
@@ -214,6 +214,45 @@ describe("PrototypeWorkspaceOwnerView", () => {
               review_notes: null,
               created_at: "2026-05-22T00:00:00Z",
               updated_at: "2026-05-22T00:00:00Z"
+            },
+            {
+              id: "ppr_validation_running",
+              prototype_workspace_id: "pw_owner_review",
+              prototype_session_id: "pss_collab",
+              candidate_snapshot_id: "psnap_candidate",
+              requested_by_user_id: null,
+              requested_by_shared_actor_id: "psa_1",
+              status: "validation-running",
+              reviewed_by_user_id: null,
+              review_notes: null,
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z"
+            },
+            {
+              id: "ppr_validation_failed",
+              prototype_workspace_id: "pw_owner_review",
+              prototype_session_id: "pss_collab",
+              candidate_snapshot_id: "psnap_candidate",
+              requested_by_user_id: null,
+              requested_by_shared_actor_id: "psa_1",
+              status: "validation-failed",
+              reviewed_by_user_id: 1,
+              review_notes: "Publish validation failed",
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z"
+            },
+            {
+              id: "ppr_promotion_failed",
+              prototype_workspace_id: "pw_owner_review",
+              prototype_session_id: "pss_collab",
+              candidate_snapshot_id: "psnap_candidate",
+              requested_by_user_id: null,
+              requested_by_shared_actor_id: "psa_1",
+              status: "promotion-failed",
+              reviewed_by_user_id: 1,
+              review_notes: "Promotion failed",
+              created_at: "2026-05-22T00:00:00Z",
+              updated_at: "2026-05-22T00:00:00Z"
             }
           ]
         })}
@@ -223,13 +262,32 @@ describe("PrototypeWorkspaceOwnerView", () => {
     const stale = screen.getByTestId("prototype-promotion-request-ppr_stale")
     const rejected = screen.getByTestId("prototype-promotion-request-ppr_rejected")
     const promoted = screen.getByTestId("prototype-promotion-request-ppr_promoted")
+    const validationRunning = screen.getByTestId(
+      "prototype-promotion-request-ppr_validation_running"
+    )
+    const validationFailed = screen.getByTestId(
+      "prototype-promotion-request-ppr_validation_failed"
+    )
+    const promotionFailed = screen.getByTestId(
+      "prototype-promotion-request-ppr_promotion_failed"
+    )
 
     expect(stale).toHaveTextContent("Stale candidate")
     expect(rejected).toHaveTextContent("Rejected")
     expect(rejected).toHaveTextContent("Validation failed")
     expect(promoted).toHaveTextContent("Promoted")
+    expect(validationRunning).toHaveTextContent("Validation running")
+    expect(validationFailed).toHaveTextContent("Validation failed")
+    expect(promotionFailed).toHaveTextContent("Promotion failed")
 
-    for (const request of [stale, rejected, promoted]) {
+    for (const request of [
+      stale,
+      rejected,
+      promoted,
+      validationRunning,
+      validationFailed,
+      promotionFailed
+    ]) {
       expect(
         within(request).getByRole("button", { name: /Approve promotion/ })
       ).toBeDisabled()
@@ -263,9 +321,34 @@ describe("PrototypeWorkspaceOwnerView", () => {
     )
 
     const result = screen.getByTestId("prototype-promotion-review-result")
-    expect(result).toHaveTextContent("Promotion failed")
+    expect(result).toHaveTextContent("Validation failed")
     expect(result).toHaveTextContent("publish_validation_failed")
     expect(result).toHaveTextContent("Validator rejected the candidate")
+  })
+
+  it("surfaces structured review error state and category", () => {
+    hookState.useReviewPrototypePromotionRequest.mockReturnValue({
+      isPending: false,
+      mutateAsync: reviewMutateAsync,
+      data: null,
+      error: {
+        detail: {
+          message: "Canonical snapshot changed",
+          frontend_state: "promotion_conflict",
+          category: "promotion_conflict"
+        }
+      }
+    })
+
+    render(
+      <PrototypeWorkspaceOwnerView
+        prototypeWorkspaceId="pw_owner_review"
+        workspace={buildWorkspace()}
+      />
+    )
+
+    expect(screen.getAllByText("Promotion conflict")).toHaveLength(2)
+    expect(screen.getByText("Canonical snapshot changed")).toBeInTheDocument()
   })
 
   it("separates branch runtime and preview status and marks revoked sessions not actionable", () => {
@@ -299,7 +382,8 @@ describe("PrototypeWorkspaceOwnerView", () => {
     expect(session).toHaveTextContent("Not actionable")
   })
 
-  it("disables pending promotion review when the branch session is revoked", () => {
+  it("keeps pending rejection available when the branch session is revoked", async () => {
+    const user = userEvent.setup()
     render(
       <PrototypeWorkspaceOwnerView
         prototypeWorkspaceId="pw_owner_review"
@@ -330,10 +414,51 @@ describe("PrototypeWorkspaceOwnerView", () => {
         name: "Approve promotion ppr_pending"
       })
     ).toBeDisabled()
+    const reject = within(request).getByRole("button", {
+      name: "Reject promotion ppr_pending"
+    })
+    expect(reject).toBeEnabled()
+
+    await user.click(reject)
+
+    expect(reviewMutateAsync).toHaveBeenCalledWith({
+      promotion_request_id: "ppr_pending",
+      prototype_workspace_id: "pw_owner_review",
+      decision: "reject"
+    })
+  })
+
+  it("keeps pending rejection available when the candidate snapshot is missing", () => {
+    render(
+      <PrototypeWorkspaceOwnerView
+        prototypeWorkspaceId="pw_owner_review"
+        workspace={buildWorkspace({
+          snapshots: [
+            {
+              snapshot_id: "psnap_canonical",
+              prototype_workspace_id: "pw_owner_review",
+              diff_summary: {},
+              preview_health: {},
+              created_at: "2026-05-21T00:00:00Z",
+              is_canonical: true,
+              is_last_known_good: true
+            }
+          ]
+        })}
+      />
+    )
+
+    const request = screen.getByTestId("prototype-promotion-request-ppr_pending")
+    expect(request).toHaveTextContent("Candidate snapshot missing")
+    expect(
+      within(request).getByRole("button", {
+        name: "Approve promotion ppr_pending"
+      })
+    ).toBeDisabled()
     expect(
       within(request).getByRole("button", {
         name: "Reject promotion ppr_pending"
       })
-    ).toBeDisabled()
+    ).toBeEnabled()
   })
 })

--- a/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
@@ -20,7 +20,8 @@ import {
   useCreateCollaboratorBranchSession,
   useCreateOwnerBranchSession,
   useCreatePromotionRequest,
-  useCreatePrototypeWorkspace
+  useCreatePrototypeWorkspace,
+  useReviewPrototypePromotionRequest
 } from "@/hooks/usePrototypeWorkspaces"
 import { getPrototypeContractState } from "@/test-utils/prototype-contract-fixtures"
 
@@ -310,9 +311,9 @@ describe("usePrototypeWorkspaces", () => {
       )
     )
 
-    const { result } = renderHook(() => useCreatePromotionRequest(), {
-      wrapper: buildWrapper()
-    })
+    const { queryClient, wrapper } = buildWrapperWithClient()
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useCreatePromotionRequest(), { wrapper })
 
     await act(async () => {
       await result.current.mutateAsync({
@@ -341,6 +342,99 @@ describe("usePrototypeWorkspaces", () => {
           })
         })
       )
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: prototypeWorkspaceQueryKeys.workspace("pw_1")
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: prototypeWorkspaceQueryKeys.promotions("pw_1")
+      })
+    })
+  })
+
+  it("reviews a prototype promotion request through the authenticated tldw fetch helper", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "promoted",
+          prototype_workspace_id: "pw_1",
+          candidate_snapshot_id: "psnap_1",
+          canonical_snapshot_id: "psnap_1",
+          preview_handle: "pph_1",
+          details: {}
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { queryClient, wrapper } = buildWrapperWithClient()
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useReviewPrototypePromotionRequest(), {
+      wrapper
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        promotion_request_id: "ppr_1",
+        prototype_workspace_id: "pw_1",
+        decision: "approve",
+        review_notes: "Ship it",
+        review_baseline_snapshot_id: "psnap_base"
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/api/v1/prototype-promotions/ppr_1/review",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json"
+          }),
+          body: JSON.stringify({
+            decision: "approve",
+            review_notes: "Ship it",
+            review_baseline_snapshot_id: "psnap_base"
+          })
+        })
+      )
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: prototypeWorkspaceQueryKeys.workspace("pw_1")
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: prototypeWorkspaceQueryKeys.promotions("pw_1")
+      })
+    })
+  })
+
+  it("preserves structured prototype promotion review errors for owner-state mapping", async () => {
+    const promotionConflict = getPrototypeContractState("promotion_conflict")
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify(promotionConflict.mockResponse),
+        {
+          status: promotionConflict.httpStatus,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => useReviewPrototypePromotionRequest(), {
+      wrapper: buildWrapper()
+    })
+
+    await expect(
+      result.current.mutateAsync({
+        promotion_request_id: "ppr_1",
+        prototype_workspace_id: "pw_1",
+        decision: "approve"
+      })
+    ).rejects.toMatchObject({
+      status: promotionConflict.httpStatus,
+      detail: promotionConflict.mockResponse.detail,
+      message: promotionConflict.mockResponse.detail.message
     })
   })
 })

--- a/apps/packages/ui/src/hooks/usePrototypeWorkspaces.ts
+++ b/apps/packages/ui/src/hooks/usePrototypeWorkspaces.ts
@@ -4,6 +4,8 @@ import type {
   PrototypeWorkspaceDetail,
   PrototypePromotionCreateInput,
   PrototypePromotionRequest,
+  PrototypePromotionReviewInput,
+  PrototypePromotionReviewResult,
   PrototypeSessionJob,
   PrototypeWorkspace,
   PrototypeWorkspaceCreateInput,
@@ -14,7 +16,8 @@ import {
   createPrototypeOwnerBranchSessionRequest,
   createPrototypePromotionRequestRequest,
   createPrototypeWorkspaceRequest,
-  getPrototypeWorkspaceRequest
+  getPrototypeWorkspaceRequest,
+  reviewPrototypePromotionRequestRequest
 } from "@/services/tldw/domains/prototype-workspaces"
 
 export const prototypeWorkspaceQueryKeys = {
@@ -113,11 +116,41 @@ export const useCreatePromotionRequest = () => {
   >({
     mutationFn: createPrototypePromotionRequestRequest,
     onSuccess: async (_promotion, variables) => {
-      await queryClient.invalidateQueries({
-        queryKey: prototypeWorkspaceQueryKeys.promotions(
-          variables.prototype_workspace_id
-        )
-      })
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: prototypeWorkspaceQueryKeys.workspace(
+            variables.prototype_workspace_id
+          )
+        }),
+        queryClient.invalidateQueries({
+          queryKey: prototypeWorkspaceQueryKeys.promotions(
+            variables.prototype_workspace_id
+          )
+        })
+      ])
+    }
+  })
+}
+
+export const useReviewPrototypePromotionRequest = () => {
+  const queryClient = useQueryClient()
+  return useMutation<
+    PrototypePromotionReviewResult,
+    Error,
+    PrototypePromotionReviewInput
+  >({
+    mutationFn: reviewPrototypePromotionRequestRequest,
+    onSuccess: async (reviewResult, variables) => {
+      const workspaceId =
+        reviewResult.prototype_workspace_id || variables.prototype_workspace_id
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: prototypeWorkspaceQueryKeys.workspace(workspaceId)
+        }),
+        queryClient.invalidateQueries({
+          queryKey: prototypeWorkspaceQueryKeys.promotions(workspaceId)
+        })
+      ])
     }
   })
 }

--- a/apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts
+++ b/apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts
@@ -6,6 +6,8 @@ import type {
   PrototypeWorkspaceDetail,
   PrototypePromotionCreateInput,
   PrototypePromotionRequest,
+  PrototypePromotionReviewInput,
+  PrototypePromotionReviewResult,
   PrototypeSessionJob,
   PrototypeWorkspace,
   PrototypeWorkspaceCreateInput,
@@ -75,6 +77,18 @@ export const createPrototypePromotionRequestRequest = (
   body: PrototypePromotionCreateInput
 ) => jsonPost<PrototypePromotionRequest>("/prototype-promotions", body)
 
+export const reviewPrototypePromotionRequestRequest = (
+  input: PrototypePromotionReviewInput
+) =>
+  jsonPost<PrototypePromotionReviewResult>(
+    `/prototype-promotions/${encodeURIComponent(input.promotion_request_id)}/review`,
+    {
+      decision: input.decision,
+      review_notes: input.review_notes,
+      review_baseline_snapshot_id: input.review_baseline_snapshot_id
+    }
+  )
+
 export const exchangePrototypePrivateLinkRequest = (
   token: string,
   body: PrototypeLinkExchangeRequest
@@ -119,6 +133,13 @@ export const prototypeWorkspaceMethods = {
     body: PrototypePromotionCreateInput
   ): Promise<PrototypePromotionRequest> {
     return createPrototypePromotionRequestRequest(body)
+  },
+
+  async reviewPrototypePromotionRequest(
+    this: TldwApiClientCore,
+    body: PrototypePromotionReviewInput
+  ): Promise<PrototypePromotionReviewResult> {
+    return reviewPrototypePromotionRequestRequest(body)
   },
 
   async exchangePrototypePrivateLink(

--- a/apps/packages/ui/src/types/prototype-workspace.ts
+++ b/apps/packages/ui/src/types/prototype-workspace.ts
@@ -74,6 +74,7 @@ export interface PrototypeWorkspaceDetail extends PrototypeWorkspace {
   viewer_role: PrototypeWorkspaceViewerRole
   sessions: PrototypeWorkspaceSessionSummary[]
   snapshots: PrototypeWorkspaceSnapshotSummary[]
+  promotion_requests: PrototypePromotionRequest[]
 }
 
 export interface PrototypeWorkspaceSessionCreateInput {
@@ -117,4 +118,22 @@ export interface PrototypePromotionRequest {
   review_notes?: string | null
   created_at: string
   updated_at: string
+}
+
+export interface PrototypePromotionReviewInput {
+  promotion_request_id: string
+  prototype_workspace_id: string
+  decision: "approve" | "reject"
+  review_notes?: string | null
+  review_baseline_snapshot_id?: string | null
+}
+
+export interface PrototypePromotionReviewResult {
+  status: string
+  failure_code?: string | null
+  prototype_workspace_id: string
+  candidate_snapshot_id: string
+  canonical_snapshot_id?: string | null
+  preview_handle?: string | null
+  details: Record<string, unknown>
 }

--- a/backlog/tasks/task-479 - Risk-Gate-6-prototype-owner-review-and-promotion-UX-hardening.md
+++ b/backlog/tasks/task-479 - Risk-Gate-6-prototype-owner-review-and-promotion-UX-hardening.md
@@ -4,7 +4,7 @@ title: Risk Gate 6 prototype owner review and promotion UX hardening
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-22 19:47'
+updated_date: '2026-05-22 20:11'
 labels:
   - prototype-workspaces
   - risk-gate
@@ -54,6 +54,14 @@ Verification on 2026-05-22 after rebasing onto origin/dev:
 - source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_risk_gate_6_review_fixes.json: 0 findings.
 - git diff --check HEAD: passed.
 - NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false: exits 2 with 284 existing repo-wide diagnostics; filtering the output for touched PrototypeWorkspace files returned no matches.
+
+PR #1945 follow-up addressed CodeRabbit's remaining pre-merge docstring coverage warning by adding concise docstrings to the new promotion request summary schema and new promotion inventory regression tests. The human-written Change summary gate remains a human-owner action and must not be satisfied with AI-authored text.
+
+Verification on 2026-05-22 for docstring follow-up:
+- AST guard for newly added Python definitions: passed.
+- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q: 112 passed, 5 warnings.
+- source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_risk_gate_6_docstring_followup.json: 0 findings.
+- git diff --check: passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-479 - Risk-Gate-6-prototype-owner-review-and-promotion-UX-hardening.md
+++ b/backlog/tasks/task-479 - Risk-Gate-6-prototype-owner-review-and-promotion-UX-hardening.md
@@ -1,0 +1,74 @@
+---
+id: TASK-479
+title: Risk Gate 6 prototype owner review and promotion UX hardening
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-22 19:30'
+labels:
+  - prototype-workspaces
+  - risk-gate
+  - frontend
+  - product
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1458'
+  - 'https://github.com/rmusser01/tldw_server/issues/1440'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-09-prototype-workspace-productionization-issue-tree-design.md
+  - Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1458 under tracker #1440. Harden the Frontend/Product owner review and promotion UX so owners can distinguish review, runtime, validation, stale/conflict, and promotion failure states; promotion actions align with backend authority and validation semantics; branch/session inventory supports review decisions; and focused frontend tests cover the main owner review transitions. Keep backend changes limited to verified contract gaps.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Owner workspace detail exposes promotion request inventory for review.
+- [x] #2 Owner UI distinguishes promotion review status from branch runtime and preview status.
+- [x] #3 Frontend review mutation preserves structured contract errors and invalidates workspace detail plus promotion query state.
+- [x] #4 Focused backend/frontend verification and Bandit completed.
+- [x] #5 Approve/reject actions are gated to pending requests with present candidate snapshot, actionable branch session, resolved workspace id, and no review in flight.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-22-prototype-risk-gate-6-owner-review-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the narrow backend contract gap by adding promotion request summaries to owner workspace detail through PrototypeWorkspacesRepo, Pydantic response schemas, and the detail endpoint builder. Added frontend review input/result types, review service method, TanStack mutation hook, and owner review UI that renders review state separately from runtime/preview health. Added regression coverage for repository filtering/ordering, endpoint response shape, hook request/error/invalidation behavior, and owner-view review/actionability states.
+
+Verification on 2026-05-22 after rebasing onto origin/dev:
+- bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism: 4 files, 26 tests passed.
+- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q: 111 passed, 5 warnings.
+- source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_risk_gate_6_rebased.json: 0 findings.
+- git diff --check HEAD: passed.
+- NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false: exits 2 with 284 existing repo-wide diagnostics; filtering the output for touched PrototypeWorkspace files returned no matches.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Risk Gate 6 owner review UX is implemented. Owners can see promotion request inventory in workspace detail, review pending requests from the owner surface, and distinguish review status from runtime/preview health. Promotion review and promotion creation hooks now refresh the workspace detail state that carries review inventory. Regression tests cover the backend contract and frontend owner-review behavior.
+
+Known skips/blockers: no required verification skipped. Repo-wide UI typecheck remains blocked by existing diagnostics outside the touched PrototypeWorkspace files; AI-generated PR still needs the required human-written Change summary before merge.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-479 - Risk-Gate-6-prototype-owner-review-and-promotion-UX-hardening.md
+++ b/backlog/tasks/task-479 - Risk-Gate-6-prototype-owner-review-and-promotion-UX-hardening.md
@@ -4,7 +4,7 @@ title: Risk Gate 6 prototype owner review and promotion UX hardening
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-22 19:30'
+updated_date: '2026-05-22 19:47'
 labels:
   - prototype-workspaces
   - risk-gate
@@ -33,7 +33,7 @@ Implement GitHub issue #1458 under tracker #1440. Harden the Frontend/Product ow
 - [x] #2 Owner UI distinguishes promotion review status from branch runtime and preview status.
 - [x] #3 Frontend review mutation preserves structured contract errors and invalidates workspace detail plus promotion query state.
 - [x] #4 Focused backend/frontend verification and Bandit completed.
-- [x] #5 Approve/reject actions are gated to pending requests with present candidate snapshot, actionable branch session, resolved workspace id, and no review in flight.
+- [x] #5 Approve actions require pending requests with present candidate snapshot and actionable branch session; pending reject remains available for stuck revoked/missing-snapshot requests.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,9 +48,10 @@ Docs/superpowers/plans/2026-05-22-prototype-risk-gate-6-owner-review-plan.md
 Implemented the narrow backend contract gap by adding promotion request summaries to owner workspace detail through PrototypeWorkspacesRepo, Pydantic response schemas, and the detail endpoint builder. Added frontend review input/result types, review service method, TanStack mutation hook, and owner review UI that renders review state separately from runtime/preview health. Added regression coverage for repository filtering/ordering, endpoint response shape, hook request/error/invalidation behavior, and owner-view review/actionability states.
 
 Verification on 2026-05-22 after rebasing onto origin/dev:
-- bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism: 4 files, 26 tests passed.
-- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q: 111 passed, 5 warnings.
-- source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_risk_gate_6_rebased.json: 0 findings.
+- Addressed PR #1945 review comments: explicit validation-running/validation-failed/promotion-failed owner copy; separate approve/reject predicates matching backend reject semantics; structured error frontend_state/category rendering; defensive filtering of unparseable promotion request rows.
+- bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism: 4 files, 28 tests passed.
+- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q: 112 passed, 5 warnings.
+- source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_risk_gate_6_review_fixes.json: 0 findings.
 - git diff --check HEAD: passed.
 - NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false: exits 2 with 284 existing repo-wide diagnostics; filtering the output for touched PrototypeWorkspace files returned no matches.
 <!-- SECTION:NOTES:END -->
@@ -58,7 +59,7 @@ Verification on 2026-05-22 after rebasing onto origin/dev:
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Risk Gate 6 owner review UX is implemented. Owners can see promotion request inventory in workspace detail, review pending requests from the owner surface, and distinguish review status from runtime/preview health. Promotion review and promotion creation hooks now refresh the workspace detail state that carries review inventory. Regression tests cover the backend contract and frontend owner-review behavior.
+Risk Gate 6 owner review UX is implemented. Owners can see promotion request inventory in workspace detail, review pending requests from the owner surface, and distinguish review status from runtime/preview health. Promotion review and promotion creation hooks now refresh the workspace detail state that carries review inventory. PR review fixes keep reject available for stuck pending requests, render structured failure states, explicitly cover validation/promotion failure states, and avoid empty promotion-request rows in API detail responses.
 
 Known skips/blockers: no required verification skipped. Repo-wide UI typecheck remains blocked by existing diagnostics outside the touched PrototypeWorkspace files; AI-generated PR still needs the required human-written Change summary before merge.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
@@ -276,6 +276,7 @@ async def _build_workspace_detail_response(repo: Any, workspace: dict[str, Any])
     """Build an owner-facing workspace detail response with sessions and snapshots."""
     sessions = await repo.list_sessions_for_workspace(str(workspace["id"]))
     snapshots = await repo.list_snapshots_for_workspace(str(workspace["id"]))
+    promotion_requests = await repo.list_promotion_requests_for_workspace(str(workspace["id"]))
     canonical_snapshot_id = str(workspace.get("canonical_snapshot_id") or "")
     last_known_good_snapshot_id = str(workspace.get("last_known_good_snapshot_id") or "")
 
@@ -294,6 +295,7 @@ async def _build_workspace_detail_response(repo: Any, workspace: dict[str, Any])
             "viewer_role": "owner",
             "sessions": sessions,
             "snapshots": snapshot_records,
+            "promotion_requests": promotion_requests,
         }
     )
 

--- a/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
@@ -143,6 +143,8 @@ class PrototypeWorkspaceSnapshotSummaryResponse(BaseModel):
 
 
 class PrototypePromotionRequestSummaryResponse(BaseModel):
+    """Owner-facing summary of a collaborator promotion request."""
+
     id: str
     prototype_workspace_id: str
     prototype_session_id: str

--- a/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
@@ -142,10 +142,25 @@ class PrototypeWorkspaceSnapshotSummaryResponse(BaseModel):
     is_last_known_good: bool = False
 
 
+class PrototypePromotionRequestSummaryResponse(BaseModel):
+    id: str
+    prototype_workspace_id: str
+    prototype_session_id: str
+    candidate_snapshot_id: str
+    requested_by_user_id: int | None = None
+    requested_by_shared_actor_id: str | None = None
+    status: str
+    reviewed_by_user_id: int | None = None
+    review_notes: str | None = None
+    created_at: str
+    updated_at: str
+
+
 class PrototypeWorkspaceDetailResponse(PrototypeWorkspaceResponse):
     viewer_role: Literal["owner", "internal_collaborator"] = "owner"
     sessions: list[PrototypeWorkspaceSessionSummaryResponse] = Field(default_factory=list)
     snapshots: list[PrototypeWorkspaceSnapshotSummaryResponse] = Field(default_factory=list)
+    promotion_requests: list[PrototypePromotionRequestSummaryResponse] = Field(default_factory=list)
 
 
 class PrototypeWorkspaceSessionCreateRequest(BaseModel):

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -1115,6 +1115,21 @@ class PrototypeWorkspacesRepo:
         )
         return self._normalize_promotion_request_row(self._row_to_dict(row) if row else None)
 
+    async def list_promotion_requests_for_workspace(self, prototype_workspace_id: str) -> list[dict[str, Any]]:
+        """Return owner-review promotion requests for one prototype workspace."""
+        rows = await self.db_pool.fetchall(
+            """
+            SELECT id, prototype_workspace_id, prototype_session_id, candidate_snapshot_id,
+                   requested_by_user_id, requested_by_shared_actor_id, status,
+                   reviewed_by_user_id, review_notes, created_at, updated_at
+            FROM prototype_promotion_requests
+            WHERE prototype_workspace_id = ?
+            ORDER BY updated_at DESC, created_at DESC
+            """,
+            (prototype_workspace_id,),
+        )
+        return [self._normalize_promotion_request_row(self._row_to_dict(r)) or {} for r in rows]
+
     async def update_promotion_request(
         self,
         promotion_request_id: str,

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -1128,7 +1128,12 @@ class PrototypeWorkspacesRepo:
             """,
             (prototype_workspace_id,),
         )
-        return [self._normalize_promotion_request_row(self._row_to_dict(r)) or {} for r in rows]
+        promotion_requests: list[dict[str, Any]] = []
+        for row in rows:
+            normalized = self._normalize_promotion_request_row(self._row_to_dict(row))
+            if normalized:
+                promotion_requests.append(normalized)
+        return promotion_requests
 
     async def update_promotion_request(
         self,

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -260,6 +260,67 @@ class TestPrototypeWorkspaceEndpoints:
         assert body["snapshots"][1]["snapshot_id"] == seed_snapshot["snapshot_id"]
         assert body["snapshots"][1]["is_canonical"] is True
 
+    def test_owner_workspace_detail_includes_promotion_request_inventory(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, seed_snapshot = _seed_workspace(test_services, title="Promotion inventory prototype")
+        access_context = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+            share_link_id=63,
+        )
+        session_result = _run(
+            test_services.service.create_or_reuse_branch_session(
+                prototype_workspace_id=workspace["id"],
+                actor_type="external_collaborator",
+                actor_shared_actor_id=access_context.shared_actor_id,
+                request_nonce="req_promotion_inventory",
+                share_link_id=63,
+            )
+        )
+        session = session_result["session"]
+        candidate_snapshot = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_promotion_inventory_candidate",
+                created_by_shared_actor_id=access_context.shared_actor_id,
+                parent_snapshot_id=seed_snapshot["snapshot_id"],
+                created_from_session_id=session["id"],
+                storage_ref="prototype://promotion-inventory-candidate",
+                prompt_summary="Inventory candidate",
+            )
+        )
+        promotion_request = _run(
+            test_services.repo.create_promotion_request(
+                prototype_workspace_id=workspace["id"],
+                prototype_session_id=session["id"],
+                candidate_snapshot_id=candidate_snapshot["snapshot_id"],
+                requested_by_shared_actor_id=access_context.shared_actor_id,
+            )
+        )
+
+        resp = client.get(f"/api/v1/prototype-workspaces/{workspace['id']}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["promotion_requests"] == [
+            {
+                "id": promotion_request["id"],
+                "prototype_workspace_id": workspace["id"],
+                "prototype_session_id": session["id"],
+                "candidate_snapshot_id": candidate_snapshot["snapshot_id"],
+                "requested_by_user_id": None,
+                "requested_by_shared_actor_id": access_context.shared_actor_id,
+                "status": "pending",
+                "reviewed_by_user_id": None,
+                "review_notes": None,
+                "created_at": promotion_request["created_at"],
+                "updated_at": promotion_request["updated_at"],
+            }
+        ]
+
     def test_owner_can_create_workspace_and_request_branch_session(self, client: TestClient) -> None:
         created = client.post(
             "/api/v1/prototype-workspaces",

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -265,6 +265,7 @@ class TestPrototypeWorkspaceEndpoints:
         client: TestClient,
         test_services: SimpleNamespace,
     ) -> None:
+        """Workspace detail includes pending promotion requests needed by the owner UI."""
         workspace, seed_snapshot = _seed_workspace(test_services, title="Promotion inventory prototype")
         access_context = _seed_external_access(
             test_services,

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -562,6 +562,106 @@ async def test_find_active_session_filters_candidate_in_sql() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_promotion_requests_for_workspace_filters_and_orders_requests(
+    repo,
+    prototype_db,
+) -> None:
+    workspace = await repo.create_workspace(owner_user_id=1, title="review queue", creation_source="prompt")
+    other_workspace = await repo.create_workspace(owner_user_id=1, title="other queue", creation_source="prompt")
+    base_snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_review_queue_base",
+        created_by_user_id=1,
+    )
+    other_snapshot = await repo.create_snapshot(
+        prototype_workspace_id=other_workspace["id"],
+        snapshot_id="snap_review_queue_other_base",
+        created_by_user_id=1,
+    )
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=91,
+        display_name="Review queue stakeholder",
+        runtime_policy_profile="locked_collab",
+    )
+    other_actor = await repo.create_shared_actor(
+        prototype_workspace_id=other_workspace["id"],
+        share_link_id=92,
+        display_name="Other stakeholder",
+        runtime_policy_profile="locked_collab",
+    )
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=base_snapshot["snapshot_id"],
+        actor_type="external_collaborator",
+        actor_shared_actor_id=actor["id"],
+        share_link_id=91,
+    )
+    other_session = await repo.create_session(
+        prototype_workspace_id=other_workspace["id"],
+        base_snapshot_id=other_snapshot["snapshot_id"],
+        actor_type="external_collaborator",
+        actor_shared_actor_id=other_actor["id"],
+        share_link_id=92,
+    )
+    older_candidate = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_review_queue_candidate_old",
+        created_by_shared_actor_id=actor["id"],
+        parent_snapshot_id=base_snapshot["snapshot_id"],
+        created_from_session_id=session["id"],
+    )
+    newer_candidate = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_review_queue_candidate_new",
+        created_by_shared_actor_id=actor["id"],
+        parent_snapshot_id=base_snapshot["snapshot_id"],
+        created_from_session_id=session["id"],
+    )
+    other_candidate = await repo.create_snapshot(
+        prototype_workspace_id=other_workspace["id"],
+        snapshot_id="snap_review_queue_other_candidate",
+        created_by_shared_actor_id=other_actor["id"],
+        parent_snapshot_id=other_snapshot["snapshot_id"],
+        created_from_session_id=other_session["id"],
+    )
+
+    older_request = await repo.create_promotion_request(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        candidate_snapshot_id=older_candidate["snapshot_id"],
+        requested_by_shared_actor_id=actor["id"],
+    )
+    newer_request = await repo.create_promotion_request(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        candidate_snapshot_id=newer_candidate["snapshot_id"],
+        requested_by_shared_actor_id=actor["id"],
+    )
+    await repo.create_promotion_request(
+        prototype_workspace_id=other_workspace["id"],
+        prototype_session_id=other_session["id"],
+        candidate_snapshot_id=other_candidate["snapshot_id"],
+        requested_by_shared_actor_id=other_actor["id"],
+    )
+    prototype_db.execute(
+        "UPDATE prototype_promotion_requests SET updated_at = ? WHERE id = ?",
+        ("2026-01-01T00:00:00+00:00", older_request["id"]),
+    )
+    prototype_db.execute(
+        "UPDATE prototype_promotion_requests SET updated_at = ? WHERE id = ?",
+        ("2026-01-02T00:00:00+00:00", newer_request["id"]),
+    )
+    prototype_db.commit()
+
+    requests = await repo.list_promotion_requests_for_workspace(workspace["id"])
+
+    assert [request["id"] for request in requests] == [newer_request["id"], older_request["id"]]
+    assert {request["prototype_workspace_id"] for request in requests} == {workspace["id"]}
+    assert requests[0]["candidate_snapshot_id"] == newer_candidate["snapshot_id"]
+
+
+@pytest.mark.asyncio
 async def test_cleanup_retained_state_revokes_expired_records_and_stales_pending_promotions(
     repo,
     prototype_db,

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -566,6 +566,7 @@ async def test_list_promotion_requests_for_workspace_filters_and_orders_requests
     repo,
     prototype_db,
 ) -> None:
+    """Promotion inventory is scoped to one workspace and ordered newest first."""
     workspace = await repo.create_workspace(
         owner_user_id=1,
         title="review queue",
@@ -670,6 +671,7 @@ async def test_list_promotion_requests_for_workspace_filters_unparseable_rows(
     repo,
     monkeypatch,
 ) -> None:
+    """Unparseable promotion request rows are omitted from the owner inventory."""
     workspace = await repo.create_workspace(owner_user_id=1, title="review queue", creation_source="prompt")
     base_snapshot = await repo.create_snapshot(
         prototype_workspace_id=workspace["id"],

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -566,7 +566,11 @@ async def test_list_promotion_requests_for_workspace_filters_and_orders_requests
     repo,
     prototype_db,
 ) -> None:
-    workspace = await repo.create_workspace(owner_user_id=1, title="review queue", creation_source="prompt")
+    workspace = await repo.create_workspace(
+        owner_user_id=1,
+        title="review queue",
+        creation_source="prompt",
+    )
     other_workspace = await repo.create_workspace(owner_user_id=1, title="other queue", creation_source="prompt")
     base_snapshot = await repo.create_snapshot(
         prototype_workspace_id=workspace["id"],
@@ -659,6 +663,50 @@ async def test_list_promotion_requests_for_workspace_filters_and_orders_requests
     assert [request["id"] for request in requests] == [newer_request["id"], older_request["id"]]
     assert {request["prototype_workspace_id"] for request in requests} == {workspace["id"]}
     assert requests[0]["candidate_snapshot_id"] == newer_candidate["snapshot_id"]
+
+
+@pytest.mark.asyncio
+async def test_list_promotion_requests_for_workspace_filters_unparseable_rows(
+    repo,
+    monkeypatch,
+) -> None:
+    workspace = await repo.create_workspace(owner_user_id=1, title="review queue", creation_source="prompt")
+    base_snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_review_queue_filter_base",
+        created_by_user_id=1,
+    )
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=93,
+        display_name="Review queue stakeholder",
+        runtime_policy_profile="locked_collab",
+    )
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=base_snapshot["snapshot_id"],
+        actor_type="external_collaborator",
+        actor_shared_actor_id=actor["id"],
+        share_link_id=93,
+    )
+    candidate = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_review_queue_filter_candidate",
+        created_by_shared_actor_id=actor["id"],
+        parent_snapshot_id=base_snapshot["snapshot_id"],
+        created_from_session_id=session["id"],
+    )
+    await repo.create_promotion_request(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        candidate_snapshot_id=candidate["snapshot_id"],
+        requested_by_shared_actor_id=actor["id"],
+    )
+    monkeypatch.setattr(repo, "_normalize_promotion_request_row", lambda _row: None)
+
+    requests = await repo.list_promotion_requests_for_workspace(workspace["id"])
+
+    assert requests == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds owner workspace promotion request inventory to the workspace detail contract.
- Adds typed frontend promotion review client/hook support with workspace-detail invalidation.
- Adds the owner promotion review surface with distinct review/runtime/preview states, explicit validation/promotion failure copy, and separate approve/reject action gating.
- Addresses review feedback by preserving structured error state/category details, filtering unparseable promotion request rows, and documenting newly added Python definitions used by the promotion inventory contract/tests.

## Test plan
- [x] bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism
  - 4 files, 28 tests passed
- [x] AST guard for newly added Python definitions
  - added definitions have docstrings
- [x] source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q
  - 112 passed, 5 warnings
- [x] source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_risk_gate_6_docstring_followup.json
  - 0 findings
- [x] git diff --check
- [x] NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false
  - exits 2 with 284 existing repo-wide diagnostics; filtering the output for touched PrototypeWorkspace files returned no matches.

## Risk gate
- Closes #1458 under #1440.

## Merge note
- AI-generated PR: merge still requires the human requester to add the required human-written Change summary explaining what changed and why these implementation choices were made.