### PR TITLE
Migrate FlowCheckDiffPanel alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2563,28 +2563,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx:Alert#antd-alert-flowcheckdiffpanel-type-info-no-diff-availabl-4fd87r",
-    "path": "src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx:Alert#antd-alert-flowcheckdiffpanel-type-warning-flow-issues-l-qjd9ai",
-    "path": "src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx:Alert#antd-alert-templatepreviewpane-type-error-line-270-1somb8x",
     "path": "src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Alert, Button, Radio, Space } from "antd"
+import { Button, Radio, Space } from "antd"
 
+import { Alert } from "@/components/ui/primitives"
 import type { TemplateComposerFlowCheckMode, TemplateComposerFlowIssue } from "@/services/watchlists"
 
 interface FlowCheckDiffPanelProps {
@@ -40,12 +41,9 @@ export const FlowCheckDiffPanel: React.FC<FlowCheckDiffPanelProps> = ({
       </div>
 
       {issues.length > 0 ? (
-        <Alert
-          type="warning"
-          showIcon
-          title="Flow issues"
-          description={issues.map((issue) => issue.message).join("; ")}
-        />
+        <Alert variant="warning" title="Flow issues">
+          {issues.map((issue) => issue.message).join("; ")}
+        </Alert>
       ) : null}
 
       {trimmedDiff ? (
@@ -57,12 +55,9 @@ export const FlowCheckDiffPanel: React.FC<FlowCheckDiffPanelProps> = ({
           {trimmedDiff}
         </pre>
       ) : (
-        <Alert
-          type="info"
-          showIcon
-          title="No diff available yet"
-          description="Run flow-check to generate suggestions."
-        />
+        <Alert variant="info" title="No diff available yet">
+          Run flow-check to generate suggestions.
+        </Alert>
       )}
 
       <Space size={8}>

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
@@ -42,7 +42,13 @@ export const FlowCheckDiffPanel: React.FC<FlowCheckDiffPanelProps> = ({
 
       {issues.length > 0 ? (
         <Alert variant="warning" title="Flow issues">
-          {issues.map((issue) => issue.message).join("; ")}
+          <ul className="list-inside list-disc">
+            {issues.map((issue, index) => (
+              <li key={`${issue.section_id ?? "flow-issue"}-${index}`}>
+                {issue.message}
+              </li>
+            ))}
+          </ul>
         </Alert>
       ) : null}
 

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/FlowCheckDiffPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/FlowCheckDiffPanel.test.tsx
@@ -64,7 +64,10 @@ describe("FlowCheckDiffPanel", () => {
     render(
       <FlowCheckDiffPanel
         diff=""
-        issues={[{ message: "Missing required section" }]}
+        issues={[
+          { severity: "warning", message: "Missing required section" },
+          { severity: "warning", message: "Duplicate transition target" }
+        ]}
         onAcceptChunk={vi.fn()}
         onRejectChunk={vi.fn()}
       />
@@ -75,6 +78,8 @@ describe("FlowCheckDiffPanel", () => {
 
     expect(issueText).toBeInTheDocument()
     expect(noDiffText).toBeInTheDocument()
+    expect(screen.getByText("Duplicate transition target")).toBeInTheDocument()
+    expect(screen.getAllByRole("listitem")).toHaveLength(2)
     expect(issueText.closest("[data-ds-component='Alert']")).toBeInTheDocument()
     expect(noDiffText.closest("[data-ds-component='Alert']")).toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/FlowCheckDiffPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/FlowCheckDiffPanel.test.tsx
@@ -59,4 +59,23 @@ describe("FlowCheckDiffPanel", () => {
     expect(onAcceptChunk).toHaveBeenCalledWith("all")
     expect(onRejectChunk).toHaveBeenCalledWith("all")
   })
+
+  it("renders flow-check callouts with design-system Alert wrappers", () => {
+    render(
+      <FlowCheckDiffPanel
+        diff=""
+        issues={[{ message: "Missing required section" }]}
+        onAcceptChunk={vi.fn()}
+        onRejectChunk={vi.fn()}
+      />
+    )
+
+    const issueText = screen.getByText("Missing required section", { exact: false })
+    const noDiffText = screen.getByText("Run flow-check to generate suggestions.", { exact: false })
+
+    expect(issueText).toBeInTheDocument()
+    expect(noDiffText).toBeInTheDocument()
+    expect(issueText.closest("[data-ds-component='Alert']")).toBeInTheDocument()
+    expect(noDiffText.closest("[data-ds-component='Alert']")).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/FlowCheckDiffPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/FlowCheckDiffPanel.test.tsx
@@ -75,11 +75,13 @@ describe("FlowCheckDiffPanel", () => {
 
     const issueText = screen.getByText("Missing required section", { exact: false })
     const noDiffText = screen.getByText("Run flow-check to generate suggestions.", { exact: false })
+    const alertWrappers = document.querySelectorAll("[data-ds-component='Alert']")
 
     expect(issueText).toBeInTheDocument()
     expect(noDiffText).toBeInTheDocument()
     expect(screen.getByText("Duplicate transition target")).toBeInTheDocument()
     expect(screen.getAllByRole("listitem")).toHaveLength(2)
+    expect(alertWrappers).toHaveLength(2)
     expect(issueText.closest("[data-ds-component='Alert']")).toBeInTheDocument()
     expect(noDiffText.closest("[data-ds-component='Alert']")).toBeInTheDocument()
   })

--- a/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
@@ -4,19 +4,19 @@ title: Migrate FlowCheckDiffPanel alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-22 19:46'
+updated_date: 2026-05-22 19:46
 labels:
-  - design-system
-  - webui
-  - extension
-  - product-state
-  - watchlists
+- design-system
+- webui
+- extension
+- product-state
+- watchlists
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1660'
-  - >-
-    apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
-  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1660
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/1946
 parent_task_id: TASK-45.44.3
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
@@ -4,19 +4,20 @@ title: Migrate FlowCheckDiffPanel alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-05-22 19:46
+updated_date: '2026-05-22 19:52'
 labels:
-- design-system
-- webui
-- extension
-- product-state
-- watchlists
+  - design-system
+  - webui
+  - extension
+  - product-state
+  - watchlists
 dependencies: []
 references:
-- https://github.com/rmusser01/tldw_server/issues/1660
-- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
-- apps/packages/ui/scripts/design-system-product-state-baseline.json
-- https://github.com/rmusser01/tldw_server/pull/1946
+  - 'https://github.com/rmusser01/tldw_server/issues/1660'
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/1946'
 parent_task_id: TASK-45.44.3
 priority: medium
 ---
@@ -45,13 +46,13 @@ Move the Watchlists Template FlowCheckDiffPanel flow-issue and empty-diff callou
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-TDD red/green completed. Added a focused FlowCheckDiffPanel test requiring the flow-issues and no-diff callout text to be inside canonical data-ds-component Alert wrappers; the corrected red run failed because the existing AntD Alert mock rendered the callout text without that marker. Replaced the component's AntD Alert import/usages with the shared design-system Alert primitive while preserving titles, descriptions, mode controls, and accept/reject actions. Removed the two FlowCheckDiffPanel Alert baseline entries.
+TDD red/green completed. Added a focused FlowCheckDiffPanel test requiring the flow-issues and no-diff callout text to be inside canonical data-ds-component Alert wrappers; the corrected red run failed because the existing AntD Alert mock rendered the callout text without that marker. Replaced the component's AntD Alert import/usages with the shared design-system Alert primitive while preserving titles, descriptions, mode controls, and accept/reject actions. Removed the two FlowCheckDiffPanel Alert baseline entries. Review follow-up: Gemini requested list markup for multiple flow issues. Added a red test requiring two listitems for two issues, then rendered issue messages as a list inside the design-system Alert.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated FlowCheckDiffPanel flow-issues and no-diff callouts from AntD Alert to the design-system Alert primitive. Focused coverage now verifies both callouts preserve their copy and render within canonical Alert wrappers. Removed the two FlowCheckDiffPanel product-state baseline exceptions. Verification: red focused FlowCheckDiffPanel test failed on the missing design-system marker; green focused FlowCheckDiffPanel test passed 2/2; bun run verify:design-system-state passed with 303 allowed legacy exceptions; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+Migrated FlowCheckDiffPanel flow-issues and no-diff callouts from AntD Alert to the design-system Alert primitive. Focused coverage now verifies both callouts preserve their copy and render within canonical Alert wrappers, with multiple flow issues rendered as list items for readability. Removed the two FlowCheckDiffPanel product-state baseline exceptions. Verification: red focused FlowCheckDiffPanel test failed on the missing design-system marker; review-fix red test failed on semicolon-flattened issue text; green focused FlowCheckDiffPanel test passed 2/2; bun run verify:design-system-state passed with 303 allowed legacy exceptions; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.44.3.3
+title: Migrate FlowCheckDiffPanel alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-22 19:46'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+  - watchlists
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1660'
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/FlowCheckDiffPanel.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the Watchlists Template FlowCheckDiffPanel flow-issue and empty-diff callouts off AntD Alert and onto the canonical design-system Alert primitive while preserving existing copy and mode/action behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FlowCheckDiffPanel warning and empty-diff callouts render the design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused coverage proves the flow-issues and no-diff callouts preserve their copy and canonical Alert marker.
+- [x] #3 Design-system product-state verifier passes with FlowCheckDiffPanel Alert baseline entries removed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing FlowCheckDiffPanel assertions requiring both flow-issues and no-diff callouts to render with the design-system Alert marker.
+2. Replace the component's AntD Alert usage with the canonical design-system Alert primitive while preserving titles, descriptions, and existing buttons/radio controls.
+3. Remove the FlowCheckDiffPanel Alert entries from the product-state baseline and run focused tests plus the design-system verifier.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red/green completed. Added a focused FlowCheckDiffPanel test requiring the flow-issues and no-diff callout text to be inside canonical data-ds-component Alert wrappers; the corrected red run failed because the existing AntD Alert mock rendered the callout text without that marker. Replaced the component's AntD Alert import/usages with the shared design-system Alert primitive while preserving titles, descriptions, mode controls, and accept/reject actions. Removed the two FlowCheckDiffPanel Alert baseline entries.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated FlowCheckDiffPanel flow-issues and no-diff callouts from AntD Alert to the design-system Alert primitive. Focused coverage now verifies both callouts preserve their copy and render within canonical Alert wrappers. Removed the two FlowCheckDiffPanel product-state baseline exceptions. Verification: red focused FlowCheckDiffPanel test failed on the missing design-system marker; green focused FlowCheckDiffPanel test passed 2/2; bun run verify:design-system-state passed with 303 allowed legacy exceptions; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.3 - Migrate-FlowCheckDiffPanel-alerts-to-design-system-Alert.md
@@ -46,13 +46,29 @@ Move the Watchlists Template FlowCheckDiffPanel flow-issue and empty-diff callou
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-TDD red/green completed. Added a focused FlowCheckDiffPanel test requiring the flow-issues and no-diff callout text to be inside canonical data-ds-component Alert wrappers; the corrected red run failed because the existing AntD Alert mock rendered the callout text without that marker. Replaced the component's AntD Alert import/usages with the shared design-system Alert primitive while preserving titles, descriptions, mode controls, and accept/reject actions. Removed the two FlowCheckDiffPanel Alert baseline entries. Review follow-up: Gemini requested list markup for multiple flow issues. Added a red test requiring two listitems for two issues, then rendered issue messages as a list inside the design-system Alert.
+- TDD red/green completed for FlowCheckDiffPanel design-system Alert marker coverage.
+- Added a focused FlowCheckDiffPanel test requiring flow-issues and no-diff callout text to be inside canonical data-ds-component Alert wrappers.
+- Initial red failure confirmed the AntD Alert mock rendered callout text without a design-system Alert marker.
+- Replaced FlowCheckDiffPanel AntD Alert usage with the shared design-system Alert while preserving titles, descriptions, mode controls, and accept/reject actions.
+- Removed the two FlowCheckDiffPanel Alert baseline entries from the product-state baseline.
+- Review follow-up: rendered multiple flow issues as list items inside the design-system Alert and hardened the test to require two distinct Alert wrappers.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated FlowCheckDiffPanel flow-issues and no-diff callouts from AntD Alert to the design-system Alert primitive. Focused coverage now verifies both callouts preserve their copy and render within canonical Alert wrappers, with multiple flow issues rendered as list items for readability. Removed the two FlowCheckDiffPanel product-state baseline exceptions. Verification: red focused FlowCheckDiffPanel test failed on the missing design-system marker; review-fix red test failed on semicolon-flattened issue text; green focused FlowCheckDiffPanel test passed 2/2; bun run verify:design-system-state passed with 303 allowed legacy exceptions; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+Migrated FlowCheckDiffPanel flow-issues and no-diff callouts from AntD Alert to the design-system Alert primitive. Focused coverage now verifies both callouts preserve their copy and render within canonical Alert wrappers, with multiple flow issues rendered as list items for readability.
+
+Removed the two FlowCheckDiffPanel product-state baseline exceptions.
+
+Verification:
+- Red test: focused FlowCheckDiffPanel test failed on the missing design-system marker.
+- Review-fix red test: focused FlowCheckDiffPanel test failed on semicolon-flattened issue text.
+- Green test: focused FlowCheckDiffPanel test passed 2/2.
+- Design-system verifier: `bun run verify:design-system-state` passed with 303 allowed legacy exceptions.
+- Baseline JSON parse: passed.
+- `git diff --check`: passed.
+- Bandit: skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary

### What changed
- Migrated `FlowCheckDiffPanel` flow-issues and no-diff callouts from AntD `Alert` to the shared design-system `Alert` primitive.
- Rendered multiple flow-check issues as list items inside the warning `Alert` so each issue remains readable.
- Added focused test coverage that verifies both callouts render as separate canonical `Alert` wrappers and that multiple flow issues render as list items.
- Removed the two stale `FlowCheckDiffPanel` product-state baseline exceptions.
- Recorded the work and verification results in Backlog task `TASK-45.44.3.3`.

### Why
This keeps the watchlists template flow-check UI aligned with the design-system migration while preserving the existing copy, mode controls, and accept/reject actions. Removing the matching baseline entries keeps the product-state guard debt count accurate after this slice.

## Validation
- `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/FlowCheckDiffPanel.test.tsx --reporter=dot`
- `bun run verify:design-system-state`
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"`
- `git diff --check`

## UX audit
- Scope is limited to existing inline warning/info callouts in `FlowCheckDiffPanel`.
- Existing titles, descriptions, radio controls, and accept/reject actions are preserved.
- Multiple flow issues now scan better as a list instead of a semicolon-separated sentence.
- No new layout surface, navigation pattern, or visual asset is introduced.

## Watchlists accessibility
- Callout text remains visible text in the existing panel flow.
- Multiple issues are represented with semantic list/listitem markup.
- Existing controls and actions are unchanged.

## Watchlists scale
- This is a narrow migration slice for one TemplatesTab component.
- Baseline debt decreases by two product-state exceptions.
- The focused test now guards against accidentally collapsing the two callouts into one `Alert` wrapper.

## Risk and rollback
- Risk: low. The change swaps the callout primitive and preserves the surrounding behavior.
- Rollback: revert the migration commit(s) and restore the two removed baseline entries if the shared `Alert` introduces an unexpected regression.

## Notes
- Bandit skipped: this slice only touches frontend TSX/test/JSON and Backlog markdown.
- Per project policy, this PR includes a human-written change summary explaining both what changed and why these implementation choices were made.
