### PR TITLE
Harden design-system baseline reporting

### DIFF
--- a/Docs/Design/tldw_web_design_system_baseline_reporting.md
+++ b/Docs/Design/tldw_web_design_system_baseline_reporting.md
@@ -1,0 +1,63 @@
+# tldw Web Design-System Baseline Reporting
+
+Date: 2026-05-22
+
+## Purpose
+
+The product-state guard is the live source of truth for remaining WebUI and
+extension design-system migration debt. GitHub issues own public tracker state,
+and Backlog.md records execution evidence, but both must be refreshed from the
+verifier output rather than hand-counted.
+
+This document defines the reporting and cleanup workflow for migration PRs.
+
+## Report Sections
+
+Run the verifier from the UI package:
+
+```bash
+bun run verify:design-system-state
+```
+
+The report includes detailed finding lists plus grouped summaries:
+
+- `Baseline exceptions`: active migration targets plus allowed legacy entries
+  that still match live findings.
+- `By product area`: counts grouped by the tracker path ownership map from the
+  remaining-work design.
+- `By rule`: counts by guard rule, such as `antd-product-state-import` or
+  `canonical-state-label`.
+- `By migration queue`: counts by the baseline entry migration queue.
+- `Stale baseline cleanup summary`: baseline rows that no longer match a live
+  finding and should be removed instead of carried forward.
+
+Stale baseline entries are warnings, not verifier failures, so migration PRs
+must actively remove stale rows before recording final counts.
+
+## Migration PR Workflow
+
+1. Before changing code, run `bun run verify:design-system-state` and record the
+   relevant product-area total, rule split, and migration queue count.
+2. Migrate a narrow set of product-state UI to shared design-system primitives
+   or the design-system state registry.
+3. Remove the migrated baseline entries from
+   `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
+4. Re-run `bun run verify:design-system-state`.
+5. If `Stale baseline cleanup summary` lists entries owned by the PR scope,
+   remove those baseline rows and re-run the verifier.
+6. Update the GitHub product-area or governance issue first with the before
+   count, after count, rule split, verifier command, and PR link.
+7. Update the Backlog task with the same evidence and note that GitHub owns the
+   canonical current count.
+
+## Closure Rules
+
+- A product-area issue can close only after the current verifier output reports
+  zero baseline exceptions for that area.
+- A governance issue can close when it delivers the promised guard, policy,
+  CI path, ownership decision, documentation, or visual QA artifact and records
+  verification.
+- If a new baseline exception is intentionally introduced, the baseline reason
+  must include the owning tracker issue, and the `migrationQueue` must match the
+  tracker queue slug.
+

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -51,6 +51,7 @@ export const PRODUCT_STATE_AREA_OWNERSHIP = [
       "src/components/Option/Ingestion",
       "src/components/Option/Library",
       "src/components/Option/Media",
+      "src/components/Media",
       "src/components/Option/Sources",
       "src/components/Option/DataTables",
       "src/components/Option/AudiobookStudio",
@@ -127,28 +128,6 @@ export const PRODUCT_STATE_AREA_OWNERSHIP = [
     paths: [
       "src/components/Option/WritingPlayground",
       "src/components/Review"
-    ]
-  },
-  {
-    area: PRODUCT_STATE_AREA_FALLBACK,
-    paths: [
-      "src/components/Option/Chatbooks",
-      "src/components/Option/Collections",
-      "src/components/Option/ChatWorkflows",
-      "src/components/Option/Speech",
-      "src/components/Option/ScheduledTasks",
-      "src/components/Common/Settings",
-      "src/components/Common/StorageQuotaBanner.tsx",
-      "src/components/Option/AgentRegistry",
-      "src/components/Option/Dictionaries",
-      "src/components/Option/STT",
-      "src/components/WorkflowEditor",
-      "src/components/Common/LocaleJsonDiagnostics.tsx",
-      "src/components/Common/PromptInsertModal.tsx",
-      "src/components/Option/Items",
-      "src/components/Option/KanbanPlayground",
-      "src/components/Option/Models",
-      "src/components/Option/SharedWithMe"
     ]
   }
 ]
@@ -1655,14 +1634,7 @@ function appendEntryDetail(lines, label, value) {
 function formatBaselineTotals(entries) {
   return [
     `Baseline exceptions: ${entries.length}`,
-    "By product area:",
-    ...formatCountGroupBy(entries, (entry) =>
-      productStateAreaForPath(entry.path)
-    ),
-    "By rule:",
-    ...formatCountGroup(entries, "rule"),
-    "By migration queue:",
-    ...formatCountGroup(entries, "migrationQueue")
+    ...formatBaselineBreakdownLines(entries)
   ].join("\n")
 }
 
@@ -1670,6 +1642,12 @@ function formatStaleBaselineTotals(entries) {
   return [
     "Stale baseline cleanup summary",
     `Stale baseline entries: ${entries.length}`,
+    ...formatBaselineBreakdownLines(entries)
+  ].join("\n")
+}
+
+function formatBaselineBreakdownLines(entries) {
+  return [
     "By product area:",
     ...formatCountGroupBy(entries, (entry) =>
       productStateAreaForPath(entry.path)
@@ -1678,7 +1656,7 @@ function formatStaleBaselineTotals(entries) {
     ...formatCountGroup(entries, "rule"),
     "By migration queue:",
     ...formatCountGroup(entries, "migrationQueue")
-  ].join("\n")
+  ]
 }
 
 function formatCountGroup(entries, field) {
@@ -1703,11 +1681,9 @@ function formatCountGroupBy(entries, selectLabel) {
 }
 
 function pathMatchesOwnedPath(relativePath, ownedPath) {
-  const normalizedOwnedPath = normalizePath(ownedPath)
-
   return (
-    relativePath === normalizedOwnedPath ||
-    relativePath.startsWith(`${normalizedOwnedPath}/`)
+    relativePath === ownedPath ||
+    relativePath.startsWith(`${ownedPath}/`)
   )
 }
 

--- a/apps/packages/ui/scripts/design-system-product-state-rules.mjs
+++ b/apps/packages/ui/scripts/design-system-product-state-rules.mjs
@@ -32,6 +32,127 @@ export const CANONICAL_ROOTS = [
   "src/assets/tailwind-shared.css"
 ]
 
+export const PRODUCT_STATE_AREA_FALLBACK =
+  "Other shared surfaces and long-tail triage"
+
+export const PRODUCT_STATE_AREA_OWNERSHIP = [
+  {
+    area: "Chat and Playground",
+    paths: [
+      "src/components/Option/Playground",
+      "src/components/Common/Playground",
+      "src/components/Sidepanel/Chat",
+      "src/routes/sidepanel-chat.tsx"
+    ]
+  },
+  {
+    area: "Ingestion, Library, and media",
+    paths: [
+      "src/components/Option/Ingestion",
+      "src/components/Option/Library",
+      "src/components/Option/Media",
+      "src/components/Option/Sources",
+      "src/components/Option/DataTables",
+      "src/components/Option/AudiobookStudio",
+      "src/components/Option/ChunkingPlayground",
+      "src/components/Common/QuickIngest",
+      "src/components/Timeline"
+    ]
+  },
+  {
+    area: "Jobs, Scheduler, and Watchlists",
+    paths: [
+      "src/components/Option/Watchlists",
+      "src/components/Option/AgentTasks",
+      "src/components/Common/Workflow"
+    ]
+  },
+  {
+    area: "MCP and ACP",
+    paths: [
+      "src/components/Option/MCPHub",
+      "src/components/Option/ACPPlayground",
+      "src/components/Option/WorkspacePlayground"
+    ]
+  },
+  {
+    area: "Evaluations",
+    paths: ["src/components/Option/Evaluations"]
+  },
+  {
+    area: "Settings and account/security",
+    paths: [
+      "src/components/Option/Settings",
+      "src/components/Option/Setup",
+      "src/components/Option/Integrations",
+      "src/components/Option/TTS"
+    ]
+  },
+  {
+    area: "Admin and health expansion",
+    paths: ["src/components/Option/Admin"]
+  },
+  {
+    area: "Prompt and Prompt Studio",
+    paths: [
+      "src/components/Option/Prompt",
+      "src/components/Option/PromptStudio"
+    ]
+  },
+  {
+    area: "Flashcards, Quiz, and study flows",
+    paths: [
+      "src/components/Flashcards",
+      "src/components/Quiz",
+      "src/components/StudySuggestions"
+    ]
+  },
+  {
+    area: "Document and Workspace surfaces",
+    paths: [
+      "src/components/DocumentWorkspace",
+      "src/components/Option/Workspace"
+    ]
+  },
+  {
+    area: "Character, Persona, and presentation surfaces",
+    paths: [
+      "src/components/Option/Characters",
+      "src/components/Option/PresentationStudio",
+      "src/components/PersonaGarden"
+    ]
+  },
+  {
+    area: "Writing and Review surfaces",
+    paths: [
+      "src/components/Option/WritingPlayground",
+      "src/components/Review"
+    ]
+  },
+  {
+    area: PRODUCT_STATE_AREA_FALLBACK,
+    paths: [
+      "src/components/Option/Chatbooks",
+      "src/components/Option/Collections",
+      "src/components/Option/ChatWorkflows",
+      "src/components/Option/Speech",
+      "src/components/Option/ScheduledTasks",
+      "src/components/Common/Settings",
+      "src/components/Common/StorageQuotaBanner.tsx",
+      "src/components/Option/AgentRegistry",
+      "src/components/Option/Dictionaries",
+      "src/components/Option/STT",
+      "src/components/WorkflowEditor",
+      "src/components/Common/LocaleJsonDiagnostics.tsx",
+      "src/components/Common/PromptInsertModal.tsx",
+      "src/components/Option/Items",
+      "src/components/Option/KanbanPlayground",
+      "src/components/Option/Models",
+      "src/components/Option/SharedWithMe"
+    ]
+  }
+]
+
 const CANONICAL_STATE_LABELS = [
   "Unavailable",
   "Setup required",
@@ -340,6 +461,7 @@ export function formatReport(result) {
 
   if (staleBaseline.length > 0) {
     sections.push(formatEntryList("Stale baseline entries", staleBaseline))
+    sections.push(formatStaleBaselineTotals(staleBaseline))
   }
 
   const remainingBaseline = sortedEntries([
@@ -351,6 +473,22 @@ export function formatReport(result) {
   }
 
   return sections.join("\n\n")
+}
+
+export function productStateAreaForPath(relativePath) {
+  const normalizedPath = normalizePath(relativePath)
+
+  for (const ownership of PRODUCT_STATE_AREA_OWNERSHIP) {
+    if (
+      ownership.paths.some((ownedPath) =>
+        pathMatchesOwnedPath(normalizedPath, ownedPath)
+      )
+    ) {
+      return ownership.area
+    }
+  }
+
+  return PRODUCT_STATE_AREA_FALLBACK
 }
 
 function isExcludedPath(relativePath) {
@@ -1517,6 +1655,25 @@ function appendEntryDetail(lines, label, value) {
 function formatBaselineTotals(entries) {
   return [
     `Baseline exceptions: ${entries.length}`,
+    "By product area:",
+    ...formatCountGroupBy(entries, (entry) =>
+      productStateAreaForPath(entry.path)
+    ),
+    "By rule:",
+    ...formatCountGroup(entries, "rule"),
+    "By migration queue:",
+    ...formatCountGroup(entries, "migrationQueue")
+  ].join("\n")
+}
+
+function formatStaleBaselineTotals(entries) {
+  return [
+    "Stale baseline cleanup summary",
+    `Stale baseline entries: ${entries.length}`,
+    "By product area:",
+    ...formatCountGroupBy(entries, (entry) =>
+      productStateAreaForPath(entry.path)
+    ),
     "By rule:",
     ...formatCountGroup(entries, "rule"),
     "By migration queue:",
@@ -1525,19 +1682,33 @@ function formatBaselineTotals(entries) {
 }
 
 function formatCountGroup(entries, field) {
+  return formatCountGroupBy(entries, (entry) => entry[field])
+}
+
+function formatCountGroupBy(entries, selectLabel) {
   const counts = new Map()
 
   for (const entry of entries) {
-    if (!entry[field]) {
+    const label = selectLabel(entry)
+    if (!label) {
       continue
     }
 
-    counts.set(entry[field], (counts.get(entry[field]) ?? 0) + 1)
+    counts.set(label, (counts.get(label) ?? 0) + 1)
   }
 
   return [...counts.entries()]
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([label, count]) => `- ${label}: ${count}`)
+}
+
+function pathMatchesOwnedPath(relativePath, ownedPath) {
+  const normalizedOwnedPath = normalizePath(ownedPath)
+
+  return (
+    relativePath === normalizedOwnedPath ||
+    relativePath.startsWith(`${normalizedOwnedPath}/`)
+  )
 }
 
 function lineForNode(sourceFile, node) {

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -1341,6 +1341,12 @@ describe("design-system product-state guard baseline handling", () => {
   })
 
   it("groups baseline totals by product area using the tracker path map", () => {
+    expect(
+      guard.productStateAreaForPath(
+        "src/components/Media/MediaIngestJobsPanel.tsx"
+      )
+    ).toBe("Ingestion, Library, and media")
+
     const report = guard.formatReport({
       blocked: [],
       activeMigrationTargets: [

--- a/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/product-state-guard.test.ts
@@ -1335,7 +1335,102 @@ describe("design-system product-state guard baseline handling", () => {
     expect(report).toContain("Baseline exceptions: 2")
     expect(report).toContain("local-status-badge: 1")
     expect(report).toContain("local-empty-state: 1")
+    expect(report).toContain("By product area:")
+    expect(report).toContain("Other shared surfaces and long-tail triage: 2")
     expect(report).toContain("shared-product-state: 2")
+  })
+
+  it("groups baseline totals by product area using the tracker path map", () => {
+    const report = guard.formatReport({
+      blocked: [],
+      activeMigrationTargets: [
+        {
+          id: "antd-product-state-import:src/components/Option/Watchlists/JobsTab.tsx:Alert",
+          path: "src/components/Option/Watchlists/JobsTab.tsx",
+          rule: "antd-product-state-import",
+          subject: "Alert",
+          message: "Alert from AntD is rendering product-state UI directly.",
+          replacement: "tldw design-system state primitive",
+          state: "active_migration_target",
+          owner: "design-system",
+          reason: "Selected for the next watchlists cleanup.",
+          migrationQueue: "jobs-scheduler-watchlists"
+        }
+      ],
+      allowedLegacy: [
+        {
+          id: "canonical-state-label:src/components/Option/Playground/PlaygroundTopbar.tsx:Ready",
+          path: "src/components/Option/Playground/PlaygroundTopbar.tsx",
+          rule: "canonical-state-label",
+          subject: "Ready",
+          message: "Use the design-system state registry label.",
+          replacement: "design-system state registry",
+          state: "allowed_legacy_exception",
+          owner: "design-system",
+          reason: "Existing ready label before the guard.",
+          migrationQueue: "chat-playground"
+        },
+        {
+          id: "antd-product-state-import:src/components/Option/Admin/ServerHealth.tsx:Alert",
+          path: "src/components/Option/Admin/ServerHealth.tsx",
+          rule: "antd-product-state-import",
+          subject: "Alert",
+          message: "Alert from AntD is rendering product-state UI directly.",
+          replacement: "tldw design-system state primitive",
+          state: "allowed_legacy_exception",
+          owner: "design-system",
+          reason: "Existing admin alert before the guard.",
+          migrationQueue: "admin-health"
+        }
+      ],
+      staleBaseline: [],
+      baselineErrors: []
+    })
+
+    expect(report).toContain("By product area:")
+    expect(report).toContain("Admin and health expansion: 1")
+    expect(report).toContain("Chat and Playground: 1")
+    expect(report).toContain("Jobs, Scheduler, and Watchlists: 1")
+  })
+
+  it("summarizes stale baseline cleanup by rule and product area", () => {
+    const report = guard.formatReport({
+      blocked: [],
+      activeMigrationTargets: [],
+      allowedLegacy: [],
+      staleBaseline: [
+        {
+          id: "antd-product-state-import:src/components/Option/Settings/HealthStatus.tsx:Alert",
+          path: "src/components/Option/Settings/HealthStatus.tsx",
+          rule: "antd-product-state-import",
+          subject: "Alert",
+          state: "allowed_legacy_exception",
+          owner: "design-system",
+          reason: "Migrated settings alert should be removed.",
+          replacement: "tldw design-system state primitive",
+          migrationQueue: "settings-account-security"
+        },
+        {
+          id: "canonical-state-label:src/components/Option/Playground/ReadyLabel.tsx:Ready",
+          path: "src/components/Option/Playground/ReadyLabel.tsx",
+          rule: "canonical-state-label",
+          subject: "Ready",
+          state: "allowed_legacy_exception",
+          owner: "design-system",
+          reason: "Migrated ready label should be removed.",
+          replacement: "design-system state registry",
+          migrationQueue: "chat-playground"
+        }
+      ],
+      baselineErrors: []
+    })
+
+    expect(report).toContain("Stale baseline cleanup summary")
+    expect(report).toContain("Stale baseline entries: 2")
+    expect(report).toContain("canonical-state-label: 1")
+    expect(report).toContain("antd-product-state-import: 1")
+    expect(report).toContain("Chat and Playground: 1")
+    expect(report).toContain("Settings and account/security: 1")
   })
 
   it("formats an empty result as no product-state guard issues", () => {

--- a/backlog/tasks/task-45.44 - Track-remaining-tldw-design-system-migration-and-governance.md
+++ b/backlog/tasks/task-45.44 - Track-remaining-tldw-design-system-migration-and-governance.md
@@ -3,20 +3,22 @@ id: TASK-45.44
 title: Track remaining tldw design-system migration and governance
 status: In Progress
 assignee: []
-created_date: '2026-05-14 03:07'
-updated_date: '2026-05-14 03:48'
+created_date: 2026-05-14 03:07
+updated_date: 2026-05-14 03:48
 labels:
-  - design-system
-  - webui
-  - extension
+- design-system
+- webui
+- extension
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1655'
-  - >-
-    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1655
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_baseline_reporting.md
 parent_task_id: TASK-45
 priority: medium
+documentation:
+- Docs/Design/tldw_web_design_system_baseline_reporting.md
 ---
 
 ## Description

--- a/backlog/tasks/task-45.44.14 - Harden-design-system-baseline-reporting-and-stale-entry-cleanup.md
+++ b/backlog/tasks/task-45.44.14 - Harden-design-system-baseline-reporting-and-stale-entry-cleanup.md
@@ -37,16 +37,16 @@ Mirror the linked GitHub governance issue. Closure requires a durable guard, doc
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add focused guard tests for product-area baseline totals and stale-baseline cleanup summary.
-2. Extend the product-state reporter with the tracker path ownership map and grouped stale cleanup totals.
-3. Add a durable baseline reporting workflow document for migration PRs.
-4. Verify focused guard coverage, the live design-system verifier, docs formatting checks, and git diff hygiene.
+1. Address Qodo media ownership by adding a failing guard test for `src/components/Media/...` product-area mapping, then update the ownership map.
+2. Address Gemini reporter maintainability comments by removing the redundant fallback map entry, extracting shared grouping lines, and avoiding per-comparison normalization for constant ownership paths.
+3. Address Qodo artifact discoverability by linking the baseline reporting doc from the parent Backlog epic and the governance task.
+4. Re-run focused guard tests, live verifier, baseline JSON parse, and git diff checks; then update PR/GitHub threads.
 <!-- SECTION:PLAN:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added product-area grouping to the design-system product-state verifier using the tracker path ownership map, and added a stale-baseline cleanup summary so resolved baseline rows are visible without becoming blocking failures. Added focused guard tests for product-area totals and stale cleanup reporting, plus Docs/Design/tldw_web_design_system_baseline_reporting.md to document the migration PR count refresh and stale-row removal workflow. PR: https://github.com/rmusser01/tldw_server/pull/1948. Verification: red focused guard test failed on missing product-area and stale cleanup sections; green focused guard test passed 54/54; bun run verify:design-system-state passed with 303 baseline exceptions and no stale cleanup section; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touches frontend JavaScript/TypeScript tests, markdown, and Backlog metadata only.
+Added product-area grouping to the design-system product-state verifier using the tracker path ownership map, and added a stale-baseline cleanup summary so resolved baseline rows are visible without becoming blocking failures. Added focused guard tests for product-area totals and stale cleanup reporting, plus Docs/Design/tldw_web_design_system_baseline_reporting.md to document the migration PR count refresh and stale-row removal workflow. PR: https://github.com/rmusser01/tldw_server/pull/1948. Review follow-up: mapped `src/components/Media/...` into the Ingestion, Library, and media area with regression coverage, removed the redundant explicit fallback area entry, extracted shared baseline breakdown formatting, avoided per-comparison normalization for constant ownership paths, linked the baseline-reporting doc from the parent Backlog epic, and updated GitHub epic #1655 to link the doc and PR. Verification: red focused guard test failed on missing product-area and stale cleanup sections; red media ownership test failed while `src/components/Media/...` still mapped to fallback; green focused guard test passed 54/54; bun run verify:design-system-state passed with 303 baseline exceptions and no stale cleanup section; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touches frontend JavaScript/TypeScript tests, markdown, and Backlog metadata only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.14 - Harden-design-system-baseline-reporting-and-stale-entry-cleanup.md
+++ b/backlog/tasks/task-45.44.14 - Harden-design-system-baseline-reporting-and-stale-entry-cleanup.md
@@ -3,21 +3,21 @@ id: TASK-45.44.14
 title: Harden design-system baseline reporting and stale-entry cleanup
 status: Done
 assignee: []
-created_date: '2026-05-14 03:20'
-updated_date: '2026-05-22 20:09'
+created_date: 2026-05-14 03:20
+updated_date: 2026-05-22 20:09
 labels:
-  - design-system
-  - webui
-  - extension
-  - governance
+- design-system
+- webui
+- extension
+- governance
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1671'
-  - >-
-    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-  - Docs/Design/tldw_web_design_system_baseline_reporting.md
+- https://github.com/rmusser01/tldw_server/issues/1671
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- Docs/Design/tldw_web_design_system_baseline_reporting.md
+- https://github.com/rmusser01/tldw_server/pull/1948
 documentation:
-  - Docs/Design/tldw_web_design_system_baseline_reporting.md
+- Docs/Design/tldw_web_design_system_baseline_reporting.md
 parent_task_id: TASK-45.44
 priority: medium
 ---
@@ -46,7 +46,7 @@ Mirror the linked GitHub governance issue. Closure requires a durable guard, doc
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added product-area grouping to the design-system product-state verifier using the tracker path ownership map, and added a stale-baseline cleanup summary so resolved baseline rows are visible without becoming blocking failures. Added focused guard tests for product-area totals and stale cleanup reporting, plus Docs/Design/tldw_web_design_system_baseline_reporting.md to document the migration PR count refresh and stale-row removal workflow. Verification: red focused guard test failed on missing product-area and stale cleanup sections; green focused guard test passed 54/54; bun run verify:design-system-state passed with 303 baseline exceptions and no stale cleanup section; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touches frontend JavaScript/TypeScript tests, markdown, and Backlog metadata only.
+Added product-area grouping to the design-system product-state verifier using the tracker path ownership map, and added a stale-baseline cleanup summary so resolved baseline rows are visible without becoming blocking failures. Added focused guard tests for product-area totals and stale cleanup reporting, plus Docs/Design/tldw_web_design_system_baseline_reporting.md to document the migration PR count refresh and stale-row removal workflow. PR: https://github.com/rmusser01/tldw_server/pull/1948. Verification: red focused guard test failed on missing product-area and stale cleanup sections; green focused guard test passed 54/54; bun run verify:design-system-state passed with 303 baseline exceptions and no stale cleanup section; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touches frontend JavaScript/TypeScript tests, markdown, and Backlog metadata only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.14 - Harden-design-system-baseline-reporting-and-stale-entry-cleanup.md
+++ b/backlog/tasks/task-45.44.14 - Harden-design-system-baseline-reporting-and-stale-entry-cleanup.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-45.44.14
 title: Harden design-system baseline reporting and stale-entry cleanup
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-14 03:20'
+updated_date: '2026-05-22 20:09'
 labels:
   - design-system
   - webui
@@ -14,6 +15,9 @@ references:
   - 'https://github.com/rmusser01/tldw_server/issues/1671'
   - >-
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+  - Docs/Design/tldw_web_design_system_baseline_reporting.md
+documentation:
+  - Docs/Design/tldw_web_design_system_baseline_reporting.md
 parent_task_id: TASK-45.44
 priority: medium
 ---
@@ -26,16 +30,31 @@ Mirror the linked GitHub governance issue. Closure requires a durable guard, doc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The linked GitHub issue owns public status.
-- [ ] #2 Backlog notes record PR links and verification evidence.
+- [x] #1 The linked GitHub issue owns public status.
+- [x] #2 Backlog notes record PR links and verification evidence.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused guard tests for product-area baseline totals and stale-baseline cleanup summary.
+2. Extend the product-state reporter with the tracker path ownership map and grouped stale cleanup totals.
+3. Add a durable baseline reporting workflow document for migration PRs.
+4. Verify focused guard coverage, the live design-system verifier, docs formatting checks, and git diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added product-area grouping to the design-system product-state verifier using the tracker path ownership map, and added a stale-baseline cleanup summary so resolved baseline rows are visible without becoming blocking failures. Added focused guard tests for product-area totals and stale cleanup reporting, plus Docs/Design/tldw_web_design_system_baseline_reporting.md to document the migration PR count refresh and stale-row removal workflow. Verification: red focused guard test failed on missing product-area and stale cleanup sections; green focused guard test passed 54/54; bun run verify:design-system-state passed with 303 baseline exceptions and no stale cleanup section; baseline JSON parse passed; git diff --check passed. Bandit skipped because this slice touches frontend JavaScript/TypeScript tests, markdown, and Backlog metadata only.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary

### What changed
- Added product-area grouping to the design-system product-state verifier using the tracker path ownership map.
- Added a stale-baseline cleanup summary so removed or migrated baseline rows are visible in report output without becoming blocking failures.
- Added focused guard coverage for product-area totals and stale cleanup reporting.
- Added `Docs/Design/tldw_web_design_system_baseline_reporting.md` to document count refresh, stale-row removal, GitHub issue updates, and Backlog evidence expectations for migration PRs.

### Why
The design-system tracker uses GitHub as the public status source and the verifier as live truth. Reporting only rule and migration-queue totals made it hard to update product-area issues accurately, and stale baseline rows could remain after migrations. This gives migration PRs the grouped counts and cleanup workflow needed to keep tracker state aligned with verifier output.

## Validation
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"`
- `git diff --check`

## UX audit
- No runtime UI surface is changed.
- This only changes the design-system governance verifier output and documentation.

## Risk and rollback
- Risk: low. The guard findings and exit-code behavior are unchanged; this only adds grouped report sections.
- Rollback: revert this PR to restore the prior report format and remove the new documentation artifact.

## Notes
- Bandit skipped: this slice only touches frontend JavaScript/TypeScript tests, markdown, and Backlog metadata.
- Linked tracker issue: #1671.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds product-area grouping and a stale-baseline cleanup summary to the design-system product-state verifier to make tracker updates easier and prevent migrated rows from lingering. Aligns verifier output with the remaining-work tracker and governance issue #1671.

- **New Features**
  - Group baseline totals by product area using the tracker path ownership map; includes `src/components/Media/...` under “Ingestion, Library, and media.”
  - Add a “Stale baseline cleanup summary” with counts by area, rule, and migration queue; stale rows warn only and don’t fail the guard.
  - Add focused tests for area totals and cleanup reporting, plus a short workflow doc at `Docs/Design/tldw_web_design_system_baseline_reporting.md`; minor cleanup to ownership logic and shared breakdown formatting.

<sup>Written for commit 90339dd7b83fa8130024d595477830c6249cdf11. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1948?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

