### PR TITLE
Document prototype workspace operational visibility

### DIFF
--- a/Docs/API-related/Prototype_Workspaces_API.md
+++ b/Docs/API-related/Prototype_Workspaces_API.md
@@ -217,6 +217,8 @@ The short version:
 
 Frontend/backend state names, HTTP status expectations, retryability, and frozen Risk Gate 4 decisions live in `Docs/API-related/Prototype_Workspaces_Contract_Matrix.md`.
 
+Operational setup, status-field diagnosis, and support escalation guidance live in `Docs/Operations/Prototype_Workspaces_Runbook.md`. Owner and collaborator workflow examples live in `Docs/User_Guides/Prototype_Workspaces.md`.
+
 ## Risk Gate 4 Error Contract
 
 Prototype-specific endpoint failures use the normal FastAPI `detail` envelope with a stable structured payload:
@@ -243,6 +245,34 @@ Contract rules:
 - Preview renewal returns `preview_unavailable` with 404 for missing/revoked handles and 409 for renewal conflicts.
 
 The generated OpenAPI contract references `PrototypeErrorResponse` for prototype route 403, 404, and 409 responses where those statuses are expected. Prototype 422 entries allow either `PrototypeErrorResponse` or FastAPI's `HTTPValidationError` because malformed request bodies are rejected before endpoint code can wrap them in the domain error envelope.
+
+## Risk Gate 7 Operational Visibility
+
+Gate 7 keeps the API contract frozen and documents how operators and product reviewers diagnose the collaboration surface before release review.
+
+Primary artifacts:
+
+- Operator runbook: `Docs/Operations/Prototype_Workspaces_Runbook.md`
+- User lifecycle guide: `Docs/User_Guides/Prototype_Workspaces.md`
+- Status/error matrix: `Docs/API-related/Prototype_Workspaces_Contract_Matrix.md`
+- Threat model: `Docs/Security/Prototype_Workspaces_Threat_Model.md`
+
+Support fields available without parsing messages:
+
+- workspace: `canonical_preview_status`, `publish_validation_status`
+- session: `runtime_status`, `preview_status`, `last_saved_snapshot_id`, `expires_at`, `revoked_at`
+- snapshot: `preview_health`
+- promotion request: `status`, `reviewed_by_user_id`, `review_notes`
+- job response/result: `job_id`, `job_type`, `status`, `idempotency_key`, `retryable`
+- structured error detail: `category`, `frontend_state`, `retryable`
+
+Operational rules:
+
+- Diagnose public-link entry, session, preview, bootstrap, and promotion failures with `category`, `frontend_state`, and `retryable`; do not branch on message text.
+- Retry only when `retryable = true` appears in the structured error or worker result.
+- Treat signing secret instability as a deployment incident because collaborator session tokens, resume cookies, and preview grants depend on stable signing.
+- Do not capture raw share tokens, session tokens, preview grants, passwords, or resume cookie values in support reports.
+- Gate 8 must provide release evidence for password-protected links, single-use and exhausted links, resume cookies, revoked links, archived workspaces, promotion conflicts, and promotion validation failures.
 
 ## Lifecycle Examples
 

--- a/Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
+++ b/Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
@@ -15,6 +15,8 @@ Risk Gate 1 security model: ../Security/Prototype_Workspaces_Threat_Model.md
 - Current gate: Risk Gate 4 contract freeze
 - Frozen by: Risk Gate 4
 - Fixture: `apps/tldw-frontend/e2e/fixtures/prototype-workspaces/contract-states.json` version 2
+- Operational docs: `Docs/Operations/Prototype_Workspaces_Runbook.md`
+- User guide: `Docs/User_Guides/Prototype_Workspaces.md`
 
 ## Structured Error Detail
 
@@ -61,6 +63,26 @@ Prototype-specific HTTP errors use FastAPI's normal outer envelope with a stable
 | `preview_boot` | `status = "ok"`, `job_type`, `retryable = false`, `preview_handle`, `preview_url` | `failure_code = "invalid_job_payload"` or `runtime_terminal` | `failure_code = "runtime_retryable"`, `retryable = true` | preview scope, snapshot, runtime profile version, target fingerprint | Same target retries renew the active handle; changed targets replace the handle for the scope. |
 | `snapshot_save` | `status = "ok"`, `job_type`, `retryable = false`, `snapshot_id` | `failure_code = "invalid_job_payload"` or `runtime_terminal` | `failure_code = "runtime_retryable"`, `retryable = true` | session and save request id; explicit snapshot id is reused on handler retry | UI can keep showing one saved revision for duplicate completion/retry paths. |
 | `publish_validate_and_promote` | `status = "promoted"`, `job_type`, `retryable = false`, canonical/candidate ids, optional `preview_handle` | `status = "failed"` or `"stale"`, `failure_code`, `retryable = false`, canonical/candidate ids | Reserved for future validators that explicitly return `retryable = true`; default validation failures are terminal | workspace, candidate snapshot, review baseline/canonical snapshot | Failed validation never advances canonical or last-known-good pointers. |
+
+## Operational Support Fields
+
+Risk Gate 7 does not change the frozen error/state contract. It records the fields operators and Frontend/Product reviewers should use when diagnosing support cases and preparing Gate 8 release evidence.
+
+| Surface | Fields | Support use |
+| --- | --- | --- |
+| Workspace detail | `canonical_preview_status`, `publish_validation_status` | Check whether the shared preview and last publish validation are healthy before inspecting branch state. |
+| Prototype session | `runtime_status`, `preview_status`, `last_saved_snapshot_id`, `expires_at`, `revoked_at` | Determine whether a branch is booting, active, failed, expired, revoked, or missing a saved candidate. |
+| Prototype snapshot | `preview_health` | Separate saved candidate existence from preview boot health. |
+| Promotion request | `status`, `reviewed_by_user_id`, `review_notes` | Explain pending, rejected, approved, promoted, failed, stale, and conflict outcomes to owners and collaborators. |
+| Job response/result | `job_id`, `job_type`, `status`, `idempotency_key`, `retryable` | Correlate UI actions with Jobs worker outcomes and decide whether retry is safe. |
+| Structured error detail | `category`, `frontend_state`, `retryable` | Map user-visible states to backend conditions without parsing messages. |
+| Audit/support breadcrumb | workspace id, session id, shared actor id, share-link id, promotion request id, `job_id` | Correlate logs and audit records without recording raw tokens, passwords, grants, or cookies. |
+
+Gate 8 handoff:
+
+- Backend/Core must preserve these field names or open a contract follow-up before changing them.
+- Frontend/Product must provide release evidence for password-protected entry, single-use and exhausted links, resume cookie continuation, revoked links, archived workspaces, promotion conflicts, and validation failures.
+- Operators should use the runbook for signing secret, quota, preview health, and promotion triage until a dedicated admin dashboard exists.
 
 ## Token And Session Security Dispositions
 

--- a/Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
+++ b/Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
@@ -76,7 +76,7 @@ Risk Gate 7 does not change the frozen error/state contract. It records the fiel
 | Promotion request | `status`, `reviewed_by_user_id`, `review_notes` | Explain pending, rejected, approved, promoted, failed, stale, and conflict outcomes to owners and collaborators. |
 | Job response/result | `job_id`, `job_type`, `status`, `idempotency_key`, `retryable` | Correlate UI actions with Jobs worker outcomes and decide whether retry is safe. |
 | Structured error detail | `category`, `frontend_state`, `retryable` | Map user-visible states to backend conditions without parsing messages. |
-| Audit/support breadcrumb | workspace id, session id, shared actor id, share-link id, promotion request id, `job_id` | Correlate logs and audit records without recording raw tokens, passwords, grants, or cookies. |
+| Audit/support breadcrumb | `workspace_id`, `session_id`, `shared_actor_id`, `share_link_id`, `promotion_request_id`, `job_id` | Correlate logs and audit records without recording raw tokens, passwords, grants, or cookies. |
 
 Gate 8 handoff:
 

--- a/Docs/Operations/Prototype_Workspaces_Runbook.md
+++ b/Docs/Operations/Prototype_Workspaces_Runbook.md
@@ -65,7 +65,7 @@ Use these fields before escalating to database inspection.
 | Workspace | `canonical_preview_status`, `publish_validation_status` | Determine whether the shared canonical preview is healthy and whether the last promotion validation succeeded, failed, or became stale. |
 | Session | `runtime_status`, `preview_status`, `last_saved_snapshot_id`, `expires_at`, `revoked_at` | Identify active, bootstrapping, failed, expired, or revoked owner/collaborator branches. |
 | Snapshot | `preview_health` | Distinguish a saved candidate that exists from a candidate whose preview cannot boot. |
-| Promotion request | `status`, `reviewed_by_user_id`, `review_notes` | Confirm whether the owner rejected, approved, promoted, failed, or left a request pending. The `promotion_requests` table is the durable support source. |
+| Promotion request | `status`, `reviewed_by_user_id`, `review_notes` | Confirm whether the owner rejected, approved, promoted, failed, or left a request pending. The `prototype_promotion_requests` table is the durable support source. |
 | Job response/result | `job_id`, `job_type`, `status`, `idempotency_key`, `retryable` | Correlate UI operations with worker outcomes and decide whether a retry is safe. |
 | Structured error | `category`, `frontend_state`, `retryable` | Match user-visible failures to the frozen Risk Gate 4 matrix without parsing message text. |
 
@@ -131,7 +131,7 @@ Current gaps for Gate 8:
 ## Incident Checklist
 
 1. Identify whether the reporter is the owner, designated promoter, or external collaborator.
-2. Capture workspace id, session id, promotion request id, job_id, and approximate timestamp. Do not capture tokens, passwords, preview grants, or cookies.
+2. Capture `workspace_id`, `session_id`, `promotion_request_id`, `job_id`, and approximate timestamp. Do not capture tokens, passwords, preview grants, or cookies.
 3. Map the user-visible state to the contract matrix using `category`, `frontend_state`, and `retryable`.
 4. Check workspace, session, snapshot, promotion request, and job status fields listed above.
 5. Retry only retryable worker failures; otherwise ask the owner or collaborator to create a fresh link/session/branch as appropriate.

--- a/Docs/Operations/Prototype_Workspaces_Runbook.md
+++ b/Docs/Operations/Prototype_Workspaces_Runbook.md
@@ -1,0 +1,157 @@
+# Prototype Workspaces Operations Runbook
+
+## Purpose
+
+This runbook is for operators and support engineers running the Prototype Workspaces collaboration surface. It covers runtime setup, link/session diagnosis, preview health, promotion review failures, and the support fields available before a full admin dashboard exists.
+
+Canonical contracts:
+
+- API overview: `Docs/API-related/Prototype_Workspaces_API.md`
+- Frontend/backend state matrix: `Docs/API-related/Prototype_Workspaces_Contract_Matrix.md`
+- Security model: `Docs/Security/Prototype_Workspaces_Threat_Model.md`
+
+## Setup Checklist
+
+Before enabling public prototype collaboration:
+
+- Apply AuthNZ migrations `086` and `087` so prototype workspace tables and the `prototype_workspace` share-token resource type exist.
+- Confirm the API process has a stable signing secret. `PrototypeAccessService` requires `JWT_SECRET_KEY` or `SINGLE_USER_API_KEY`; preview grants use an explicit preview secret or the same stable server secret fallback.
+- Run Jobs workers for domain `prototype_workspaces` on queue `default`.
+- Confirm runtime policy names used by workspaces are configured server-side, especially `runtime_policy.owner_profile` and `runtime_policy.external_collaborator_profile`.
+- Configure share-token use counts, session expiry, preview-grant TTLs, and cleanup retention before exposing links outside trusted testers.
+- Keep frontend routes `/prototype-workspaces` and `/share/:token` behind the intended rollout flag until Gate 8 release evidence is complete.
+
+## Signing Secret Posture
+
+Prototype collaborator session tokens, resume cookies, and preview grants are signed. The signing secret must be stable across API restarts or active collaborators will lose access and preview renewals will fail.
+
+Operational rules:
+
+- Do not use an ephemeral generated secret in deployed environments.
+- Treat a signing secret rotation as a planned session invalidation event unless a dedicated rotation flow exists.
+- Before rotation, drain or pause new public link exchange, notify owners that active collaborator sessions may need new links, and let Jobs workers finish in-flight prototype jobs where practical.
+- After rotation, revoke or expire old share links whose collaborators cannot resume cleanly, then ask owners to create fresh private links.
+- Never log raw share tokens, session tokens, preview grants, passwords, or cookie values while diagnosing signing failures.
+
+Current gap for Gate 8: automated secret-age checks and dual-secret token verification are not implemented. Operators must validate the configured secret manually during rollout.
+
+## Runtime And Jobs Behavior
+
+Prototype runtime work uses the shared Jobs module rather than a prototype-specific queue.
+
+Job types:
+
+- `branch_session_bootstrap`: creates or reuses an owner or collaborator branch session and initializes runtime state.
+- `preview_boot`: starts or renews a preview target and returns a brokered preview handle.
+- `snapshot_save`: persists a session-owned candidate snapshot.
+- `publish_validate_and_promote`: validates a candidate and advances canonical state only on success.
+
+Job responses and result payloads should expose:
+
+- `job_id`
+- `job_type`
+- `status`
+- `idempotency_key`
+- `retryable`
+
+Use `idempotency_key` to identify duplicate requests and worker retries. Retry only when the job result or structured error sets `retryable = true`. Terminal runtime failures such as archived workspaces, revoked actors, expired sessions, missing snapshots, and permission failures require a fresh link, fresh session, or owner action.
+
+## Status Fields For Support
+
+Use these fields before escalating to database inspection.
+
+| Area | Fields | How to use them |
+| --- | --- | --- |
+| Workspace | `canonical_preview_status`, `publish_validation_status` | Determine whether the shared canonical preview is healthy and whether the last promotion validation succeeded, failed, or became stale. |
+| Session | `runtime_status`, `preview_status`, `last_saved_snapshot_id`, `expires_at`, `revoked_at` | Identify active, bootstrapping, failed, expired, or revoked owner/collaborator branches. |
+| Snapshot | `preview_health` | Distinguish a saved candidate that exists from a candidate whose preview cannot boot. |
+| Promotion request | `status`, `reviewed_by_user_id`, `review_notes` | Confirm whether the owner rejected, approved, promoted, failed, or left a request pending. The `promotion_requests` table is the durable support source. |
+| Job response/result | `job_id`, `job_type`, `status`, `idempotency_key`, `retryable` | Correlate UI operations with worker outcomes and decide whether a retry is safe. |
+| Structured error | `category`, `frontend_state`, `retryable` | Match user-visible failures to the frozen Risk Gate 4 matrix without parsing message text. |
+
+Audit breadcrumbs are available through the existing audit/logging paths and should be correlated with these status fields. The expected audit subjects are workspace creation, share-link exchange, shared-actor resume/revocation, branch bootstrap, preview grant renewal, snapshot save, promotion submission, and promotion review. Gate 7 documents the taxonomy and support workflow; Gate 8 should attach release evidence for the exact dashboards, logs, or queries operators will use in production.
+
+## Link And Session Triage
+
+Use the structured error `category`, `frontend_state`, and `retryable` fields first.
+
+| Symptom | Likely state | Operator response |
+| --- | --- | --- |
+| Collaborator sees unavailable link before entering | Invalid, expired, revoked, exhausted, missing, or owner-mismatched link | Keep response non-enumerating. Ask the owner to confirm the link is current and issue a new link if needed. |
+| Collaborator sees password prompt | `password_required`, retryable | This is expected for password-protected links without a valid resume cookie. |
+| Collaborator sees password rejected | `invalid_password`, retryable | Ask the owner to confirm the password out of band. Do not log the submitted password. |
+| Single-use link worked once, then fails in another browser | `exhausted_link` | Expected for max-use links. Same-browser resume may still work if the resume cookie is valid. |
+| Same browser resumes without password | Valid resume cookie | Expected when browser-session resume is allowed and the actor/link/session are still active. |
+| Revoked link fails after owner action | `invalid_or_unavailable_link` before exchange or `inactive_session` after exchange | Expected. Ask the owner to create a new link if collaboration should continue. |
+| Archived workspace link fails | `workspace_unavailable` | Expected. Owner must unarchive or create a new workspace. |
+| Active collaborator session suddenly fails | `inactive_session` | Check `expires_at`, `revoked_at`, actor revocation, and signing secret stability. A fresh link/session is usually required. |
+
+## Preview Health Triage
+
+Preview access is intentionally brokered. Clients should never receive raw runtime target URLs.
+
+When preview renewal fails:
+
+1. Check the frontend/backend state matrix for `preview_unavailable`.
+2. Inspect the session `preview_status` and snapshot `preview_health`.
+3. Check the related `preview_boot` job by `job_id` or `idempotency_key`.
+4. Retry only when the result marks `retryable = true`.
+5. If the handle is missing, revoked, expired, or bound to a stale target, start a fresh preview flow from the current workspace/session state.
+
+If the canonical preview is unhealthy but collaborator branch previews work, inspect workspace `canonical_preview_status` and the latest promoted snapshot. A failed collaborator preview does not change the canonical preview unless a promotion was approved and validation succeeded.
+
+## Promotion Triage
+
+Promotion is owner-reviewed and validation-gated.
+
+Common support cases:
+
+- `stale`: the canonical snapshot changed after the collaborator started from an older baseline. The collaborator should create a new branch from the current canonical snapshot.
+- `promotion_conflict`: validation found a conflict that cannot be auto-promoted. The owner should review the candidate and ask for changes or reject the request.
+- `promotion_validation_failed`: validation failed without advancing canonical or last-known-good pointers. Retry only when the response marks `retryable = true`.
+- rejected request: review `status`, `reviewed_by_user_id`, and `review_notes` to explain owner intent without inspecting runtime internals.
+
+Never manually update canonical snapshot pointers to bypass validation. If an approved promotion does not advance canonical state, correlate the `publish_validate_and_promote` job and workspace `publish_validation_status`.
+
+## Quotas, Rate Limits, And Cleanup
+
+Current quota and rate-limit controls are intentionally conservative:
+
+- Public share exchange can return 429 when the configured rate limit is exceeded.
+- Share links can have max-use limits; exhausted links remain non-enumerating to collaborators.
+- Session expiry and preview-grant TTLs limit stale collaborator access.
+- Cleanup retention can revoke or delete inactive prototype collaboration rows according to the persistence contract.
+
+Current gaps for Gate 8:
+
+- There is no dedicated quota dashboard for prototype workspace collaboration.
+- Operators need deployment-specific log or database queries to summarize exhausted links, near-expiry sessions, and repeated preview failures.
+- Rate-limit tuning should be validated against the expected number of external stakeholders per workspace before wider rollout.
+
+## Incident Checklist
+
+1. Identify whether the reporter is the owner, designated promoter, or external collaborator.
+2. Capture workspace id, session id, promotion request id, job_id, and approximate timestamp. Do not capture tokens, passwords, preview grants, or cookies.
+3. Map the user-visible state to the contract matrix using `category`, `frontend_state`, and `retryable`.
+4. Check workspace, session, snapshot, promotion request, and job status fields listed above.
+5. Retry only retryable worker failures; otherwise ask the owner or collaborator to create a fresh link/session/branch as appropriate.
+6. If many users are affected after a deploy or restart, verify signing secret stability and Jobs worker availability first.
+7. Record the resolution and any missing observability in the Gate 8 handoff.
+
+## Gate 8 Handoff
+
+Backend/Core deliverables already documented here:
+
+- stable setup prerequisites
+- signing secret posture
+- Jobs behavior and retry rules
+- support status fields
+- failure-state triage
+- audit breadcrumb taxonomy
+
+Frontend/Product deliverables to close in Gate 8:
+
+- release evidence that user-facing states match the frozen contract fixture
+- owner/collaborator walkthrough screenshots or test recordings for password-protected, single-use, resumed, revoked, archived, exhausted, and promotion-conflict flows
+- final support handoff that names the exact logs, dashboards, or admin surfaces used by operators
+- product decision on whether quota/preview status belongs in the initial UI or operator-only docs

--- a/Docs/User_Guides/Prototype_Workspaces.md
+++ b/Docs/User_Guides/Prototype_Workspaces.md
@@ -1,0 +1,97 @@
+# Prototype Workspaces User Guide
+
+## Overview
+
+Prototype Workspaces let an owner share a working app prototype with outside collaborators without letting every collaborator change the shared canonical version directly.
+
+The main roles are:
+
+- Owner: creates the workspace, shares private links, reviews promotion requests, and controls the canonical prototype.
+- Collaborator: opens a private link, works in an isolated branch session, saves candidate snapshots, and asks the owner to promote a candidate.
+- Designated promoter: an internal user allowed by the owner to review or promote candidates.
+
+## Owner Flow
+
+1. Create a prototype workspace from the prototype workspace page.
+2. Review the seed canonical snapshot and current canonical preview state.
+3. Start an owner branch session when you want to make changes without immediately changing the canonical prototype.
+4. Create a private share link for outside collaborators.
+5. Choose whether the link is password-protected, whether browser resume is allowed, and how many times the link can be used.
+6. Review incoming promotion requests from collaborator branches.
+7. Approve only candidates that should become the shared canonical prototype. Reject candidates that need more work.
+
+The canonical prototype changes only after an owner or designated promoter approves a candidate and validation succeeds.
+
+## Collaborator Flow
+
+1. Open the private `/share/:token` link from the owner.
+2. Enter the password if the link is password-protected.
+3. Enter a display name on first use so the owner can identify the branch and promotion request.
+4. Work in the isolated collaborator branch session.
+5. Save a candidate snapshot when the branch has a useful change.
+6. Submit a promotion request for owner review.
+
+Collaborators do not become full user accounts. The system creates a scoped shared actor for the workspace and link.
+
+## Link And Resume Behavior
+
+Password-protected links require the password unless the same browser has a valid resume cookie for the same active link and collaborator. The resume cookie is only a browser-binding hint; it is not a durable password or session token that should be copied between devices.
+
+Single-use links can be used once for a first-time collaborator. If the same browser has a valid resume cookie, that collaborator may resume even after the first use. A different browser or user sees an exhausted link once the use count is spent.
+
+If a link is expired, revoked, exhausted, invalid, or points to a missing workspace, the collaborator sees a generic unavailable-link state. This is intentional so public link responses do not reveal which links exist.
+
+If the workspace is archived, the collaborator sees that the workspace is unavailable. The owner must unarchive it or create a new workspace before collaboration can continue.
+
+## Common Examples
+
+### Password-protected link
+
+The owner creates a private link with a password and sends the link and password separately. The collaborator opens the link, sees a password prompt, enters the password, and then starts their branch. If the password is wrong, the prompt remains visible and can be retried.
+
+### Single-use and exhausted link
+
+The owner creates a single-use link for one stakeholder. The first successful collaborator entry consumes the link. If another person opens it later in a different browser, they see an exhausted link as a generic unavailable-link state. The original collaborator can still resume from the same browser if resume is allowed and the resume cookie is valid.
+
+### Resume cookie
+
+A collaborator closes the browser tab after starting work. Later, they open the same private link in the same browser. If the owner has not revoked the link or workspace access and the session is still active, the resume cookie lets the collaborator continue without re-entering the password.
+
+### Revoked link
+
+The owner revokes a link after sending it. New visitors see an unavailable link. A collaborator who already exchanged the link may see their session become inactive and should ask the owner for a fresh link if work should continue.
+
+### Archived workspace
+
+The owner archives the workspace while a collaborator still has the link. The collaborator cannot enter or continue the workspace. The owner should unarchive the workspace or create a new share link from an active workspace.
+
+### Promotion conflict
+
+A collaborator submits a candidate after the canonical prototype changed. The owner may see a stale or promotion conflict state instead of a successful promotion. The collaborator should start from the current canonical prototype, reapply the useful changes, and submit a new request.
+
+### Validation failure
+
+The owner approves a candidate, but validation fails. The canonical prototype does not change. The collaborator should inspect the candidate branch, make a safer change, save a new snapshot, and submit another promotion request.
+
+## Owner Review Outcomes
+
+Promotion requests can end in these user-visible outcomes:
+
+- Approved and promoted: the candidate becomes canonical after validation.
+- Rejected: the owner records review notes and the canonical prototype does not change.
+- Stale: the candidate was based on an older canonical snapshot.
+- Promotion conflict: validation detected a conflict that needs a new candidate or owner decision.
+- Validation failure: the candidate did not pass publish validation and the canonical prototype remains unchanged.
+
+## Safety Expectations
+
+- Do not save share tokens, session tokens, passwords, preview grants, or resume cookies into notes, screenshots, or bug reports.
+- Share passwords separately from the private link.
+- Ask the owner for a fresh link when a link or session is unavailable and the work should continue.
+- Treat collaborator branches as drafts until the owner promotes a candidate.
+
+## Gate 8 Handoff
+
+Backend/Core owns the operational contracts, status fields, and security behavior. Frontend/Product owns the release evidence that these user flows render correctly and stay understandable for owners and collaborators.
+
+Gate 8 should include product review evidence for password-protected entry, single-use and exhausted links, resume cookie continuation, revoked link handling, archived workspace handling, promotion conflict handling, and validation failure recovery.

--- a/Docs/User_Guides/index.md
+++ b/Docs/User_Guides/index.md
@@ -81,6 +81,10 @@ This section is organized by product surface so you can quickly find the right d
 - [Google Keep Notes Import and Export](WebUI_Extension/Google_Keep_Notes_Import_Export_Guide.md)
 - [Workflows Examples](WebUI_Extension/Workflows_Examples.md)
 
+### Prototype Workspaces
+
+- [Prototype Workspaces User Guide](Prototype_Workspaces.md)
+
 ## Integrations and Experiments
 
 - [Getting Started with ACP](Integrations_Experiments/Getting_Started_with_ACP.md)

--- a/Docs/superpowers/plans/2026-05-22-prototype-risk-gate-7-ops-docs-plan.md
+++ b/Docs/superpowers/plans/2026-05-22-prototype-risk-gate-7-ops-docs-plan.md
@@ -1,0 +1,114 @@
+# Prototype Risk Gate 7 Ops Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #1460 by documenting prototype workspace operational visibility, support workflows, and owner/collaborator examples needed before the Risk Gate 8 release review.
+
+**Architecture:** Keep this as a documentation-first slice. Add one operator runbook, one user-facing lifecycle guide, small links/status-field updates to existing prototype API/contract docs, and a focused pytest guard that checks the required support examples remain present.
+
+**Tech Stack:** Markdown docs under `Docs/`, existing pytest suite under `tldw_Server_API/tests/PrototypeWorkspaces`, Backlog.md task tracking.
+
+---
+
+### Task 1: Operator Runbook
+
+**Files:**
+- Create: `Docs/Operations/Prototype_Workspaces_Runbook.md`
+
+- [x] **Step 1: Draft the runbook sections**
+
+Include:
+- setup/configuration prerequisites
+- signing secret expectations and rotation posture
+- runtime bootstrap and Jobs behavior
+- preview health and preview grant diagnosis
+- quotas/rate limits and current gaps
+- promotion validation/promotion request diagnosis
+- status fields and audit/support breadcrumbs
+- incident triage checklist
+
+- [x] **Step 2: Verify runbook references current contract terms**
+
+Run: `rg -n "runtime_status|preview_status|preview_health|promotion_requests|retryable|signing secret" Docs/Operations/Prototype_Workspaces_Runbook.md`
+
+Expected: every term appears in the relevant operational section.
+
+### Task 2: User Lifecycle Guide
+
+**Files:**
+- Create: `Docs/User_Guides/Prototype_Workspaces.md`
+- Modify: `Docs/User_Guides/index.md`
+
+- [x] **Step 1: Draft owner and collaborator flows**
+
+Include:
+- owner creates workspace and share link
+- collaborator enters password-protected link
+- single-use/exhausted link behavior
+- resume cookie behavior
+- revoked/expired/archived link outcomes
+- collaborator branch/session expectations
+- promotion request, rejection, validation failure, conflict, and success outcomes
+
+- [x] **Step 2: Verify user examples cover all required issue scenarios**
+
+Run: `rg -n "password-protected|single-use|resume cookie|revoked|archived|exhausted|promotion conflict" Docs/User_Guides/Prototype_Workspaces.md`
+
+Expected: every required scenario appears.
+
+### Task 3: API And Contract Cross-Links
+
+**Files:**
+- Modify: `Docs/API-related/Prototype_Workspaces_API.md`
+- Modify: `Docs/API-related/Prototype_Workspaces_Contract_Matrix.md`
+
+- [x] **Step 1: Add a Risk Gate 7 section to the API guide**
+
+Document where operators/users should look for runbooks, user guides, status fields, job result fields, and support diagnosis.
+
+- [x] **Step 2: Add operational status/support checklist to the contract matrix**
+
+List fields available for support:
+- workspace `canonical_preview_status`, `publish_validation_status`
+- session `runtime_status`, `preview_status`, `last_saved_snapshot_id`, `expires_at`, `revoked_at`
+- snapshot `preview_health`
+- promotion request `status`, `reviewed_by_user_id`, `review_notes`
+- job response `job_id`, `job_type`, `status`, `idempotency_key`
+- structured error `category`, `frontend_state`, `retryable`
+
+### Task 4: Docs Contract Guard
+
+**Files:**
+- Create: `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py`
+
+- [x] **Step 1: Add a focused docs presence test**
+
+Use `pathlib.Path` to read the new runbook and user guide. Assert they include the required operational field names and issue-required examples.
+
+- [x] **Step 2: Run the docs guard**
+
+Run: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py -q`
+
+Expected: pass.
+
+### Task 5: Verification And Task Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md`
+
+- [x] **Step 1: Run focused verification**
+
+Run:
+- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py -q`
+- `git diff --check`
+- Bandit is not required unless production Python code changes; document the skip if docs/test-only.
+
+- [x] **Step 2: Update Backlog task**
+
+Mark acceptance criteria and DoD complete, record verification and known skips, and add final summary.
+
+- [x] **Step 3: Commit**
+
+Run:
+- `git add Docs/Operations/Prototype_Workspaces_Runbook.md Docs/User_Guides/Prototype_Workspaces.md Docs/API-related/Prototype_Workspaces_API.md Docs/API-related/Prototype_Workspaces_Contract_Matrix.md tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py "backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md" Docs/superpowers/plans/2026-05-22-prototype-risk-gate-7-ops-docs-plan.md`
+- `git commit -m "Document prototype workspace operational visibility"`

--- a/backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md
+++ b/backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md
@@ -1,0 +1,62 @@
+---
+id: TASK-481
+title: Risk Gate 7 prototype operational visibility and documentation
+status: Done
+labels:
+- prototype-workspaces
+- risk-gate
+- operations
+- documentation
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/issues/1460
+- https://github.com/rmusser01/tldw_server/issues/1440
+documentation:
+- Docs/superpowers/specs/2026-05-09-prototype-workspace-productionization-issue-tree-design.md
+- Docs/API-related/Prototype_Workspaces_Contract_Matrix.md
+- Docs/superpowers/plans/2026-05-22-prototype-risk-gate-7-ops-docs-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1460 under tracker #1440. Burn down operational support risk for prototype workspace collaboration by documenting runtime bootstrap, preview health, signing secrets, quotas, job behavior, owner/collaborator workflows, failure examples, and available status/audit fields. Keep implementation scoped to documentation and light status-surface wiring where existing code already exposes the data.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Operator docs explain setup, configuration, and failure diagnosis for prototype workspace collaboration.
+- [x] #2 Product docs explain owner and collaborator lifecycle without relying on implementation internals.
+- [x] #3 Runtime, preview, sharing, promotion, and support-observability fields/events are documented and covered by tests where practical.
+- [x] #4 Split Backend/Core and Frontend/Product deliverables are recorded clearly for Risk Gate 8 handoff.
+- [x] #5 Focused verification, docs hygiene, and Bandit if backend code changes occur are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Plan: `Docs/superpowers/plans/2026-05-22-prototype-risk-gate-7-ops-docs-plan.md`
+- Added `Docs/Operations/Prototype_Workspaces_Runbook.md` for operator setup, signing-secret posture, Jobs behavior, status-field diagnosis, preview/promotion triage, quotas, incident handling, and Gate 8 handoff.
+- Added `Docs/User_Guides/Prototype_Workspaces.md` for owner and collaborator lifecycle examples, including password-protected links, single-use/exhausted links, resume cookies, revoked links, archived workspaces, promotion conflicts, and validation failures.
+- Cross-linked Gate 7 artifacts from `Docs/API-related/Prototype_Workspaces_API.md` and recorded operational support fields in `Docs/API-related/Prototype_Workspaces_Contract_Matrix.md`.
+- Added `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py` as a focused docs-contract guard.
+- Verification: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py -q` passed with 3 tests.
+- Verification: `git diff --check` passed.
+- Bandit: skipped because this slice changed docs plus a docs-contract test only; no production Python code changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Risk Gate 7 operational visibility documentation is now covered by an operator runbook, a user lifecycle guide, API/contract cross-links, and a focused pytest guard that keeps the required support fields and failure examples present for Gate 8 release review.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md
+++ b/backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md
@@ -11,6 +11,7 @@ priority: high
 references:
 - https://github.com/rmusser01/tldw_server/issues/1460
 - https://github.com/rmusser01/tldw_server/issues/1440
+- https://github.com/rmusser01/tldw_server/pull/1949
 documentation:
 - Docs/superpowers/specs/2026-05-09-prototype-workspace-productionization-issue-tree-design.md
 - Docs/API-related/Prototype_Workspaces_Contract_Matrix.md

--- a/backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md
+++ b/backlog/tasks/task-481 - Risk-Gate-7-prototype-operational-visibility-and-documentation.md
@@ -44,6 +44,7 @@ Implement GitHub issue #1460 under tracker #1440. Burn down operational support 
 - Verification: `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py -q` passed with 3 tests.
 - Verification: `git diff --check` passed.
 - Bandit: skipped because this slice changed docs plus a docs-contract test only; no production Python code changed.
+- PR review follow-up: corrected the operator runbook's durable promotion table name to `prototype_promotion_requests`, added a helper docstring, and made audit breadcrumb field names exact snake_case values in the contract matrix. Re-ran the focused docs guard and `git diff --check`; both passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py
@@ -7,6 +7,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _read_doc(relative_path: str) -> str:
+    """Read a project documentation file as lowercase text for term guards."""
     return (PROJECT_ROOT / relative_path).read_text(encoding="utf-8").lower()
 
 
@@ -21,6 +22,7 @@ def test_operator_runbook_documents_support_fields() -> None:
         "canonical_preview_status",
         "publish_validation_status",
         "promotion request",
+        "prototype_promotion_requests",
         "job_id",
         "job_type",
         "idempotency_key",
@@ -63,3 +65,5 @@ def test_api_and_contract_docs_link_gate_7_artifacts() -> None:
     assert "prototype_workspaces_runbook.md" in api_doc
     assert "prototype_workspaces.md" in api_doc
     assert "operational support fields" in contract_doc
+    assert "`workspace_id`, `session_id`, `shared_actor_id`" in contract_doc
+    assert "`share_link_id`, `promotion_request_id`, `job_id`" in contract_doc

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py
@@ -1,0 +1,65 @@
+"""Guard required prototype workspace operational documentation."""
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read_doc(relative_path: str) -> str:
+    return (PROJECT_ROOT / relative_path).read_text(encoding="utf-8").lower()
+
+
+def test_operator_runbook_documents_support_fields() -> None:
+    """Risk Gate 7 operator docs must expose support and diagnosis fields."""
+    runbook = _read_doc("Docs/Operations/Prototype_Workspaces_Runbook.md")
+
+    required_terms = [
+        "runtime_status",
+        "preview_status",
+        "preview_health",
+        "canonical_preview_status",
+        "publish_validation_status",
+        "promotion request",
+        "job_id",
+        "job_type",
+        "idempotency_key",
+        "category",
+        "frontend_state",
+        "retryable",
+        "signing secret",
+        "quota",
+        "audit",
+    ]
+
+    for term in required_terms:
+        assert term in runbook
+
+
+def test_user_guide_documents_required_failure_examples() -> None:
+    """Risk Gate 7 user docs must cover owner and collaborator edge cases."""
+    user_guide = _read_doc("Docs/User_Guides/Prototype_Workspaces.md")
+
+    required_examples = [
+        "password-protected",
+        "single-use",
+        "resume cookie",
+        "revoked link",
+        "archived workspace",
+        "exhausted link",
+        "promotion conflict",
+        "validation failure",
+    ]
+
+    for example in required_examples:
+        assert example in user_guide
+
+
+def test_api_and_contract_docs_link_gate_7_artifacts() -> None:
+    """Existing prototype API docs should point support readers to Gate 7 docs."""
+    api_doc = _read_doc("Docs/API-related/Prototype_Workspaces_API.md")
+    contract_doc = _read_doc("Docs/API-related/Prototype_Workspaces_Contract_Matrix.md")
+
+    assert "prototype_workspaces_runbook.md" in api_doc
+    assert "prototype_workspaces.md" in api_doc
+    assert "operational support fields" in contract_doc


### PR DESCRIPTION
## Summary

- Adds a Prototype Workspaces operator runbook covering setup, signing-secret posture, Jobs behavior, support fields, preview/promotion triage, quotas, and incident handling.
- Adds a user-facing Prototype Workspaces guide for owner/collaborator lifecycle examples, including password-protected links, single-use/exhausted links, resume cookies, revoked links, archived workspaces, promotion conflicts, and validation failures.
- Cross-links the Gate 7 docs from the API/contract docs and adds a focused docs-contract pytest guard.

Closes #1460. Refs #1440.

## Test Plan

- [x] `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py -q`
- [x] `git diff --check`
- [x] Bandit skipped: docs plus docs-contract test only; no production Python changed.

## Human Change Summary Required Before Merge

Per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`, the human requester must replace this section with a summary in their own words explaining what changed and why these implementation choices were made.
