### PR TITLE
Migrate DocumentPickerModal alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -33,39 +33,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentPickerModal.tsx:Alert#antd-alert-documentpickermodal-type-error-line-573-1sibda5",
-    "path": "src/components/DocumentWorkspace/DocumentPickerModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentPickerModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentPickerModal.tsx:Alert#antd-alert-documentpickermodal-type-warning-line-540-tljiul",
-    "path": "src/components/DocumentWorkspace/DocumentPickerModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentPickerModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentPickerModal.tsx:Alert#antd-alert-documentpickermodal-type-warning-line-551-1rq1a2f",
-    "path": "src/components/DocumentWorkspace/DocumentPickerModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentPickerModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx:Alert#antd-alert-epubviewer-type-error-line-592-1w9pq4c",
     "path": "src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentPickerModal.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentPickerModal.tsx
@@ -9,10 +9,10 @@ import {
   Spin,
   Empty,
   Tag,
-  Switch,
-  Alert
+  Switch
 } from "antd"
 import { Search, UploadCloud, FileText, BookOpen, PlayCircle } from "lucide-react"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw"
 import { useDebounce } from "@/hooks/useDebounce"
 import { useServerOnline } from "@/hooks/useServerOnline"
@@ -537,9 +537,8 @@ export const DocumentPickerModal: React.FC<DocumentPickerModalProps> = ({
       destroyOnClose
     >
       {!isOnline && (
-        <Alert
-          type="warning"
-          showIcon
+        <DesignSystemAlert
+          variant="warning"
           title={t(
             "option:documentWorkspace.serverRequired",
             "Connect to server to use document workspace"
@@ -548,31 +547,27 @@ export const DocumentPickerModal: React.FC<DocumentPickerModalProps> = ({
         />
       )}
       {uploadWarning && (
-        <Alert
-          type="warning"
-          showIcon
+        <DesignSystemAlert
+          variant="warning"
           title={uploadWarning.message}
           className="mb-3"
           action={
-            uploadWarning.mediaId ? (
-              <Button
-                size="small"
-                onClick={async () => {
-                  await setSetting(LAST_MEDIA_ID_SETTING, String(uploadWarning.mediaId))
-                  navigate("/media-multi")
-                  onClose()
-                }}
-              >
-                {t("option:documentWorkspace.openInMedia", "Open in Media")}
-              </Button>
-            ) : undefined
+            uploadWarning.mediaId
+              ? {
+                  label: t("option:documentWorkspace.openInMedia", "Open in Media"),
+                  onClick: async () => {
+                    await setSetting(LAST_MEDIA_ID_SETTING, String(uploadWarning.mediaId))
+                    navigate("/media-multi")
+                    onClose()
+                  }
+                }
+              : undefined
           }
         />
       )}
       {error && (
-        <Alert
-          type="error"
-          showIcon
+        <DesignSystemAlert
+          variant="error"
           title={error}
           className="mb-3"
         />

--- a/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentPickerModal.design-system.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentPickerModal.design-system.test.tsx
@@ -106,12 +106,6 @@ vi.mock("antd", () => {
         checked={checked}
         onChange={(event) => onChange(event.currentTarget.checked)}
       />
-    ),
-    Alert: ({ title, message, action }: any) => (
-      <div role="alert">
-        {title ?? message}
-        {action}
-      </div>
     )
   }
 })

--- a/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentPickerModal.design-system.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentPickerModal.design-system.test.tsx
@@ -1,0 +1,197 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DocumentPickerModal } from "../DocumentPickerModal"
+import { tldwClient } from "@/services/tldw"
+import { setSetting } from "@/services/settings/registry"
+import { useServerOnline } from "@/hooks/useServerOnline"
+
+const navigateMock = vi.fn()
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock
+}))
+
+vi.mock("@/hooks/useDebounce", () => ({
+  useDebounce: (value: string) => value
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: vi.fn()
+}))
+
+vi.mock("@/store/quick-ingest", () => ({
+  useQuickIngestStore: (selector: (state: { recentlyIngestedDocs: unknown[] }) => unknown) =>
+    selector({ recentlyIngestedDocs: [] })
+}))
+
+vi.mock("@/services/settings/registry", () => ({
+  setSetting: vi.fn()
+}))
+
+vi.mock("@/services/settings/ui-settings", () => ({
+  LAST_MEDIA_ID_SETTING: "lastMediaId"
+}))
+
+vi.mock("@/services/tldw", () => ({
+  tldwClient: {
+    listMedia: vi.fn(),
+    searchMedia: vi.fn(),
+    uploadMedia: vi.fn()
+  }
+}))
+
+vi.mock("antd", () => {
+  const Button = ({ children, icon, loading, onClick }: any) => (
+    <button type="button" disabled={loading} onClick={onClick}>
+      {icon}
+      {children}
+    </button>
+  )
+
+  const Input = ({ allowClear: _allowClear, prefix, value, onChange, placeholder }: any) => (
+    <label>
+      {placeholder}
+      {prefix}
+      <input aria-label={placeholder} value={value} onChange={onChange} />
+    </label>
+  )
+
+  const List = Object.assign(
+    ({ dataSource, renderItem }: any) => (
+      <ul>{dataSource.map((item: unknown) => renderItem(item))}</ul>
+    ),
+    {
+      Item: ({ children, actions }: any) => (
+        <li>
+          {children}
+          {actions}
+        </li>
+      )
+    }
+  )
+
+  const Empty = Object.assign(
+    ({ description }: any) => <div>{description}</div>,
+    { PRESENTED_IMAGE_SIMPLE: "simple" }
+  )
+
+  return {
+    Modal: ({ open, title, children }: any) =>
+      open ? (
+        <div role="dialog" aria-label={title}>
+          <h2>{title}</h2>
+          {children}
+        </div>
+      ) : null,
+    Tabs: ({ activeKey, items }: any) => (
+      <div>{items.find((item: any) => item.key === activeKey)?.children}</div>
+    ),
+    Input,
+    Button,
+    List,
+    Spin: () => <div>Loading</div>,
+    Empty,
+    Tag: ({ children }: any) => <span>{children}</span>,
+    Switch: ({ checked, onChange }: any) => (
+      <input
+        aria-label="Show non-document media"
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.currentTarget.checked)}
+      />
+    ),
+    Alert: ({ title, message, action }: any) => (
+      <div role="alert">
+        {title ?? message}
+        {action}
+      </div>
+    )
+  }
+})
+
+describe("DocumentPickerModal design-system states", () => {
+  const renderModal = (props?: Partial<React.ComponentProps<typeof DocumentPickerModal>>) =>
+    render(
+      <DocumentPickerModal
+        open
+        initialTab="upload"
+        onClose={vi.fn()}
+        onOpenDocument={vi.fn()}
+        {...props}
+      />
+    )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useServerOnline).mockReturnValue(true)
+    vi.mocked(tldwClient.listMedia).mockResolvedValue({ items: [] })
+    vi.mocked(tldwClient.searchMedia).mockResolvedValue({ items: [] })
+    vi.mocked(tldwClient.uploadMedia).mockResolvedValue({ result: { id: 17 } })
+  })
+
+  it("renders the offline server-required state through the design-system Alert", () => {
+    vi.mocked(useServerOnline).mockReturnValue(false)
+
+    const { container } = renderModal()
+
+    const offlineMessage = screen.getByText("Connect to server to use document workspace")
+    expect(offlineMessage.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+
+  it("renders unsupported upload errors through the design-system Alert", async () => {
+    const { container } = renderModal()
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]')
+
+    expect(fileInput).not.toBeNull()
+    fireEvent.change(fileInput!, {
+      target: {
+        files: [new File(["notes"], "notes.txt", { type: "text/plain" })]
+      }
+    })
+
+    const errorMessage = await screen.findByText("Only PDF and EPUB files are supported.")
+    expect(errorMessage.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+
+  it("preserves the upload storage warning action inside the design-system Alert", async () => {
+    const onClose = vi.fn()
+    vi.mocked(tldwClient.uploadMedia).mockResolvedValue({
+      result: {
+        id: 42,
+        warnings: ["original file could not be stored"]
+      }
+    })
+
+    const { container } = renderModal({ onClose })
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]')
+
+    expect(fileInput).not.toBeNull()
+    fireEvent.change(fileInput!, {
+      target: {
+        files: [new File(["pdf"], "paper.pdf", { type: "application/pdf" })]
+      }
+    })
+
+    const warningMessage = await screen.findByText(
+      "Upload finished, but the original file could not be stored. Open in Media to view extracted text, or re-upload after fixing storage."
+    )
+    expect(warningMessage.closest('[data-ds-component="Alert"]')).not.toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in Media" }))
+
+    await waitFor(() => {
+      expect(setSetting).toHaveBeenCalledWith("lastMediaId", "42")
+      expect(navigateMock).toHaveBeenCalledWith("/media-multi")
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.10
 title: 'Migrate design-system product state: Document and Workspace surfaces'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:20'
 labels:
@@ -28,9 +28,15 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 The linked GitHub issue owns current count and public status.
-- [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
+- [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
 - [ ] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Created and completed TASK-45.44.10.1 for the first narrow Document/Workspace slice: DocumentPickerModal Alert migration. Before/after product-state verifier evidence in that child task reduced total baseline exceptions from 303 to 300 and Document/Workspace exceptions from 12 to 9.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -35,7 +35,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-- Created and completed TASK-45.44.10.1 for the first narrow Document/Workspace slice: DocumentPickerModal Alert migration. Before/after product-state verifier evidence in that child task reduced total baseline exceptions from 303 to 300 and Document/Workspace exceptions from 12 to 9.
+- Created and completed TASK-45.44.10.1 for the first narrow Document/Workspace slice: DocumentPickerModal Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1950. Before/after product-state verifier evidence in that child task reduced total baseline exceptions from 303 to 300 and Document/Workspace exceptions from 12 to 9.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.1 - Migrate-DocumentPickerModal-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.10.1 - Migrate-DocumentPickerModal-alerts-to-design-system-Alert.md
@@ -51,12 +51,13 @@ Continue the Document and Workspace product-state design-system migration by rep
 - Migrated only the offline server-required, upload-storage warning, and error banners to `components/ui/primitives/Alert`; kept AntD Modal, Tabs, Button, List, Empty, Spin, Tag, and Switch mechanics unchanged.
 - Removed the three matching DocumentPickerModal AntD Alert rows from `design-system-product-state-baseline.json`.
 - Full UI TypeScript check still fails on inherited repo-wide debt outside the touched files; no diagnostics referenced DocumentPickerModal or its new focused test.
+- PR review follow-up: removed the unused AntD Alert mock entry from the focused design-system test so the mock surface matches the migrated component behavior.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated DocumentPickerModal's three product-state banners from AntD Alert to the shared design-system Alert primitive while preserving the upload-warning Open in Media action. Added focused regression coverage for offline, unsupported upload, and storage-warning states, and removed the three migrated baseline entries. PR: https://github.com/rmusser01/tldw_server/pull/1950. Verification: red focused test failed on missing design-system Alert markers; green focused DocumentPickerModal test passed 3/3; product-state guard unit test passed 54/54; `bun run verify:design-system-state` passed with baseline exceptions reduced from 303 to 300 and Document/Workspace exceptions reduced to 9; baseline JSON parse passed; `git diff --check` passed. Bandit skipped because this slice touches only TypeScript/TSX, JSON, and Backlog metadata.
+Migrated DocumentPickerModal's three product-state banners from AntD Alert to the shared design-system Alert primitive while preserving the upload-warning Open in Media action. Added focused regression coverage for offline, unsupported upload, and storage-warning states, removed the three migrated baseline entries, and removed the unused AntD Alert test mock after review. PR: https://github.com/rmusser01/tldw_server/pull/1950. Verification: red focused test failed on missing design-system Alert markers; green focused DocumentPickerModal test passed 3/3; product-state guard unit test passed 54/54; `bun run verify:design-system-state` passed with baseline exceptions reduced from 303 to 300 and Document/Workspace exceptions reduced to 9; review follow-up focused test passed 3/3; baseline JSON parse passed; `git diff --check` passed. Bandit skipped because this slice touches only TypeScript/TSX, JSON, and Backlog metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.1 - Migrate-DocumentPickerModal-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.10.1 - Migrate-DocumentPickerModal-alerts-to-design-system-Alert.md
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentPickerModal.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1950
 modified_files:
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentPickerModal.tsx
 - apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentPickerModal.design-system.test.tsx
@@ -55,7 +56,7 @@ Continue the Document and Workspace product-state design-system migration by rep
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated DocumentPickerModal's three product-state banners from AntD Alert to the shared design-system Alert primitive while preserving the upload-warning Open in Media action. Added focused regression coverage for offline, unsupported upload, and storage-warning states, and removed the three migrated baseline entries. Verification: red focused test failed on missing design-system Alert markers; green focused DocumentPickerModal test passed 3/3; product-state guard unit test passed 54/54; `bun run verify:design-system-state` passed with baseline exceptions reduced from 303 to 300 and Document/Workspace exceptions reduced to 9; baseline JSON parse passed; `git diff --check` passed. Bandit skipped because this slice touches only TypeScript/TSX, JSON, and Backlog metadata.
+Migrated DocumentPickerModal's three product-state banners from AntD Alert to the shared design-system Alert primitive while preserving the upload-warning Open in Media action. Added focused regression coverage for offline, unsupported upload, and storage-warning states, and removed the three migrated baseline entries. PR: https://github.com/rmusser01/tldw_server/pull/1950. Verification: red focused test failed on missing design-system Alert markers; green focused DocumentPickerModal test passed 3/3; product-state guard unit test passed 54/54; `bun run verify:design-system-state` passed with baseline exceptions reduced from 303 to 300 and Document/Workspace exceptions reduced to 9; baseline JSON parse passed; `git diff --check` passed. Bandit skipped because this slice touches only TypeScript/TSX, JSON, and Backlog metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.1 - Migrate-DocumentPickerModal-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.10.1 - Migrate-DocumentPickerModal-alerts-to-design-system-Alert.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.10.1
+title: Migrate DocumentPickerModal alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- document-workspace
+priority: medium
+parent_task_id: TASK-45.44.10
+references:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentPickerModal.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentPickerModal.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentPickerModal.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Document and Workspace product-state design-system migration by replacing DocumentPickerModal's remaining AntD Alert product-state surfaces with the shared design-system Alert primitive while preserving offline, upload-warning, and error behavior. Keep scope limited to this modal, focused tests, and removal of matching baseline entries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] DocumentPickerModal no longer imports AntD Alert for product-state UI.
+- [x] Offline server-required, upload storage warning, and error banners render through the shared design-system Alert primitive.
+- [x] Upload-warning Open in Media action behavior is preserved.
+- [x] The three matching DocumentPickerModal AntD Alert baseline entries are removed without introducing new unbaselined product-state findings.
+- [x] Focused tests and the design-system product-state verifier pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing focused tests that prove DocumentPickerModal alert states render with `data-ds-component="Alert"` and preserve upload-warning action behavior.
+2. Replace the three AntD Alert usages with the shared design-system Alert primitive, keeping AntD mechanics otherwise unchanged.
+3. Remove the migrated DocumentPickerModal baseline rows.
+4. Run focused component tests, product-state guard/unit verifier checks, baseline JSON parse, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red test evidence: the new focused DocumentPickerModal design-system test failed while the modal still rendered AntD Alert wrappers because each alert message lacked a `data-ds-component="Alert"` ancestor.
+- Migrated only the offline server-required, upload-storage warning, and error banners to `components/ui/primitives/Alert`; kept AntD Modal, Tabs, Button, List, Empty, Spin, Tag, and Switch mechanics unchanged.
+- Removed the three matching DocumentPickerModal AntD Alert rows from `design-system-product-state-baseline.json`.
+- Full UI TypeScript check still fails on inherited repo-wide debt outside the touched files; no diagnostics referenced DocumentPickerModal or its new focused test.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated DocumentPickerModal's three product-state banners from AntD Alert to the shared design-system Alert primitive while preserving the upload-warning Open in Media action. Added focused regression coverage for offline, unsupported upload, and storage-warning states, and removed the three migrated baseline entries. Verification: red focused test failed on missing design-system Alert markers; green focused DocumentPickerModal test passed 3/3; product-state guard unit test passed 54/54; `bun run verify:design-system-state` passed with baseline exceptions reduced from 303 to 300 and Document/Workspace exceptions reduced to 9; baseline JSON parse passed; `git diff --check` passed. Bandit skipped because this slice touches only TypeScript/TSX, JSON, and Backlog metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Migrates DocumentPickerModal offline, upload-warning, and error product-state banners from AntD Alert to the shared design-system Alert primitive while keeping the surrounding AntD modal/tab/list mechanics unchanged.
- Adds focused regression coverage for the three modal states and the upload-warning Open in Media action.
- Removes the three migrated DocumentPickerModal baseline rows and records the Document/Workspace slice in Backlog.

## Verification
- bunx vitest run src/components/DocumentWorkspace/__tests__/DocumentPickerModal.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"
- git diff --check

## Notes
- Full UI TypeScript still fails on inherited repo-wide debt outside this slice; no diagnostics referenced DocumentPickerModal or its new focused test.
- Bandit skipped because this touches TypeScript/TSX, JSON, and Backlog metadata only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated DocumentPickerModal product-state banners from `antd` `Alert` to the design-system `Alert` to unify UI and preserve behavior. Added focused tests and cleaned up the test mock after review; recorded the migration in backlog tasks.

- **Refactors**
  - Swapped `antd` `Alert` for design-system `Alert` in offline, upload-warning, and error states.
  - Preserved `antd` Modal/Tabs/List mechanics and the “Open in Media” action.
  - Added focused tests; removed an unused `Alert` mock to match the migrated component.
  - Removed 3 matching baseline exceptions for this modal.
  - Updated backlog: set TASK-45.44.10 to In Progress and added TASK-45.44.10.1 with PR link and before/after counts.

<sup>Written for commit 20f38eb5f7a33d5c52b44f0d538ff19e9808d265. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1950?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

