### PR TITLE
Migrate document viewer alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -33,50 +33,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx:Alert#antd-alert-epubviewer-type-error-line-592-1w9pq4c",
-    "path": "src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx:Alert#antd-alert-epubviewer-type-warning-line-576-x5j1x0",
-    "path": "src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx:Alert#antd-alert-pdfdocument-type-error-failed-to-load-pdf-lin-1vmdcny",
-    "path": "src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx:Alert#antd-alert-pdfdocument-type-warning-no-document-url-plea-1uewu4b",
-    "path": "src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx:Result",
     "path": "src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Spin, Alert } from "antd"
+import { Spin } from "antd"
 import type { Book, Rendition, NavItem } from "epubjs"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { useDocumentWorkspaceStore } from "@/store/document-workspace"
 import { TextSelectionPopover } from "../TextSelectionPopover"
 import { EpubSearch } from "./EpubSearch"
@@ -573,15 +574,15 @@ export const EpubViewer: React.FC<EpubViewerProps> = ({
   if (!url) {
     return (
       <div className="flex h-full items-center justify-center p-4">
-        <Alert
-          type="warning"
+        <DesignSystemAlert
+          variant="warning"
           title={t("option:documentWorkspace.noUrl", "No document URL")}
-          description={t(
+        >
+          {t(
             "option:documentWorkspace.selectDocument",
             "Please select a document to view"
           )}
-          showIcon
-        />
+        </DesignSystemAlert>
       </div>
     )
   }
@@ -589,12 +590,12 @@ export const EpubViewer: React.FC<EpubViewerProps> = ({
   if (error) {
     return (
       <div className="flex h-full items-center justify-center p-4">
-        <Alert
-          type="error"
+        <DesignSystemAlert
+          variant="error"
           title={t("option:documentWorkspace.loadError", "Failed to load EPUB")}
-          description={error}
-          showIcon
-        />
+        >
+          {error}
+        </DesignSystemAlert>
       </div>
     )
   }

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState, useRef, useEffect, useLayoutEffect } from "react"
 import { Document, pdfjs } from "react-pdf"
 import type { DocumentProps } from "react-pdf"
-import { Spin, Alert } from "antd"
+import { Spin } from "antd"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { PdfPage } from "./PdfPage"
 import { TextSelectionPopover } from "../TextSelectionPopover"
 import { useTextSelection } from "@/hooks/document-workspace/useTextSelection"
@@ -407,12 +408,12 @@ export const PdfDocument: React.FC<PdfDocumentProps> = ({
   if (!url) {
     return (
       <div className="flex h-full items-center justify-center p-4">
-        <Alert
-          type="warning"
+        <DesignSystemAlert
+          variant="warning"
           title="No document URL"
-          description="Please select a document to view"
-          showIcon
-        />
+        >
+          Please select a document to view
+        </DesignSystemAlert>
       </div>
     )
   }
@@ -446,12 +447,12 @@ export const PdfDocument: React.FC<PdfDocumentProps> = ({
           </div>
         }
         error={
-          <Alert
-            type="error"
+          <DesignSystemAlert
+            variant="error"
             title="Failed to load PDF"
-            description={error || "An error occurred while loading the document"}
-            showIcon
-          />
+          >
+            {error || "An error occurred while loading the document"}
+          </DesignSystemAlert>
         }
       >
         {loading ? null : viewMode === "single" ? (

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useRef, useEffect, useLayoutEffect } from
 import { Document, pdfjs } from "react-pdf"
 import type { DocumentProps } from "react-pdf"
 import { Spin } from "antd"
+import { useTranslation } from "react-i18next"
 import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { PdfPage } from "./PdfPage"
 import { TextSelectionPopover } from "../TextSelectionPopover"

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
@@ -413,7 +413,7 @@ export const PdfDocument: React.FC<PdfDocumentProps> = ({
           variant="warning"
           title="No document URL"
         >
-          Please select a document to view
+          {t("option:documentWorkspace.selectDocument", "Please select a document to view")}
         </DesignSystemAlert>
       </div>
     )

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
@@ -451,7 +451,7 @@ export const PdfDocument: React.FC<PdfDocumentProps> = ({
             variant="error"
             title="Failed to load PDF"
           >
-            {error || "An error occurred while loading the document"}
+            {error || t("option:documentWorkspace.genericLoadError", "An error occurred while loading the document")}
           </DesignSystemAlert>
         }
       >

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx
@@ -1,0 +1,161 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { EpubViewer } from "../EpubViewer"
+import { PdfDocument } from "../PdfViewer/PdfDocument"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+vi.mock("@/store/document-workspace", () => {
+  const state = {
+    currentPage: 1,
+    setCurrentPage: vi.fn(),
+    setTotalPages: vi.fn(),
+    currentCfi: null,
+    setCurrentCfi: vi.fn(),
+    setCurrentPercentage: vi.fn(),
+    setCurrentChapterTitle: vi.fn(),
+    annotations: [],
+    epubTheme: "light",
+    epubScrollMode: "paginated",
+    epubSpreadMode: "none",
+    epubFontSize: 100,
+    epubFontFamily: "serif",
+    epubLineHeight: 1.5
+  }
+
+  const useDocumentWorkspaceStore = (selector: (store: typeof state) => unknown) =>
+    selector(state)
+  useDocumentWorkspaceStore.getState = () => state
+
+  return { useDocumentWorkspaceStore }
+})
+
+vi.mock("@/hooks/document-workspace/useEpubSettings", () => ({
+  EPUB_THEMES: {
+    light: { body: {} }
+  },
+  FONT_FAMILY_CSS: {
+    serif: "serif"
+  }
+}))
+
+vi.mock("../TextSelectionPopover", () => ({
+  TextSelectionPopover: () => null
+}))
+
+vi.mock("../EpubViewer/EpubSearch", () => ({
+  EpubSearch: () => null
+}))
+
+vi.mock("epubjs", () => ({
+  default: () => ({
+    ready: Promise.reject(new Error("EPUB load failed")),
+    destroy: vi.fn()
+  })
+}))
+
+vi.mock("react-pdf", () => ({
+  pdfjs: {
+    version: "4.10.38",
+    GlobalWorkerOptions: {
+      workerSrc: ""
+    }
+  },
+  Document: ({ error }: { error?: React.ReactNode }) => (
+    <div data-testid="pdf-document">{error}</div>
+  )
+}))
+
+vi.mock("../PdfViewer/PdfPage", () => ({
+  PdfPage: () => null
+}))
+
+vi.mock("@/hooks/document-workspace/useTextSelection", () => ({
+  useTextSelection: () => ({
+    selection: null,
+    clearSelection: vi.fn()
+  })
+}))
+
+vi.mock("@/utils/browser-runtime", () => ({
+  getBrowserRuntime: () => null,
+  isExtensionRuntime: () => false
+}))
+
+vi.mock("antd", () => ({
+  Spin: () => <div>Loading</div>
+}))
+
+describe("document viewer design-system alerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the EPUB missing-url state through the design-system Alert", () => {
+    const { container } = render(<EpubViewer url="" documentId={7} />)
+
+    const alert = screen.getByRole("alert")
+    expect(alert).toHaveTextContent("No document URL")
+    expect(alert).toHaveTextContent("Please select a document to view")
+    expect(alert.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+
+  it("renders EPUB load errors through the design-system Alert", async () => {
+    const { container } = render(<EpubViewer url="/broken.epub" documentId={7} />)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("Failed to load EPUB")
+    expect(alert).toHaveTextContent("EPUB load failed")
+    expect(alert.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+
+  it("renders the PDF missing-url state through the design-system Alert", () => {
+    const { container } = render(
+      <PdfDocument
+        documentId={11}
+        currentPage={1}
+        zoomLevel={100}
+        viewMode="single"
+        onLoadSuccess={vi.fn()}
+        onLoadError={vi.fn()}
+        onPageChange={vi.fn()}
+      />
+    )
+
+    const alert = screen.getByRole("alert")
+    expect(alert).toHaveTextContent("No document URL")
+    expect(alert).toHaveTextContent("Please select a document to view")
+    expect(alert.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+
+  it("provides PDF load errors through the design-system Alert", async () => {
+    const { container } = render(
+      <PdfDocument
+        url="/broken.pdf"
+        documentId={11}
+        currentPage={1}
+        zoomLevel={100}
+        viewMode="single"
+        onLoadSuccess={vi.fn()}
+        onLoadError={vi.fn()}
+        onPageChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed to load PDF")
+    })
+    const alert = screen.getByRole("alert")
+    expect(alert).toHaveTextContent("An error occurred while loading the document")
+    expect(alert.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+})

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -36,6 +36,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created and completed TASK-45.44.10.1 for the first narrow Document/Workspace slice: DocumentPickerModal Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1950. Before/after product-state verifier evidence in that child task reduced total baseline exceptions from 303 to 300 and Document/Workspace exceptions from 12 to 9.
+- Created TASK-45.44.10.2 for the next narrow Document/Workspace slice: DocumentViewer PDF/EPUB Alert migration. Initial verifier evidence after the slice reduces total baseline exceptions from 300 to 296 and Document/Workspace exceptions from 9 to 5.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -36,7 +36,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created and completed TASK-45.44.10.1 for the first narrow Document/Workspace slice: DocumentPickerModal Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1950. Before/after product-state verifier evidence in that child task reduced total baseline exceptions from 303 to 300 and Document/Workspace exceptions from 12 to 9.
-- Created TASK-45.44.10.2 for the next narrow Document/Workspace slice: DocumentViewer PDF/EPUB Alert migration. Initial verifier evidence after the slice reduces total baseline exceptions from 300 to 296 and Document/Workspace exceptions from 9 to 5.
+- Created and completed TASK-45.44.10.2 for the next narrow Document/Workspace slice: DocumentViewer PDF/EPUB Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1952. Verifier evidence after the slice reduces total baseline exceptions from 300 to 296 and Document/Workspace exceptions from 9 to 5.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.2 - Migrate-DocumentViewer-PDF-and-EPUB-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.10.2 - Migrate-DocumentViewer-PDF-and-EPUB-alerts-to-design-system-Alert.md
@@ -1,0 +1,80 @@
+---
+id: TASK-45.44.10.2
+title: Migrate DocumentViewer PDF and EPUB alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- document-workspace
+priority: medium
+parent_task_id: TASK-45.44.10
+references:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Document and Workspace product-state design-system migration by replacing the remaining AntD Alert product-state surfaces in EpubViewer and PdfDocument with the shared design-system Alert primitive while preserving no-document-url and load-error behavior. Keep scope limited to viewer alerts, focused tests, and removal of matching baseline entries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 EpubViewer no longer imports or renders AntD Alert for product-state no-url or load-error states.
+- [x] #2 PdfDocument no longer imports or renders AntD Alert for product-state no-url or load-error states.
+- [x] #3 EPUB no-document-url and load-error states render through the shared design-system Alert primitive.
+- [x] #4 PDF no-document-url and load-error states render through the shared design-system Alert primitive.
+- [x] #5 The four matching product-state baseline rows are removed without introducing unbaselined findings.
+- [x] #6 Focused viewer tests and product-state verifier checks are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing focused tests that assert EPUB/PDF no-url and load-error states render with `data-ds-component="Alert"`.
+2. Replace the EpubViewer and PdfDocument AntD Alert usages with the shared design-system Alert primitive while keeping viewer mechanics unchanged.
+3. Remove the four migrated viewer Alert rows from the product-state baseline.
+4. Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red test evidence: `bunx vitest run src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx --reporter=dot` failed on the missing `data-ds-component="Alert"` ancestor for EPUB/PDF no-url and load-error states.
+- Migrated only the DocumentViewer PDF/EPUB Alert surfaces to the shared design-system Alert primitive. Spin/loading behavior, PDF rendering, EPUB setup, search, and selection mechanics were left unchanged.
+- Removed four baseline rows for `EpubViewer/index.tsx` and `PdfViewer/PdfDocument.tsx`, reducing the Document/Workspace product-state baseline count from 9 to 5.
+- Verification:
+  - `bunx vitest run src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx --reporter=dot` passed: 4 tests.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 54 tests.
+  - `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"` passed.
+  - `bun run verify:design-system-state` passed with 296 baseline exceptions total and 5 remaining Document/Workspace exceptions.
+  - `git diff --check` passed.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI type debt outside the touched DocumentViewer files.
+- Bandit is not applicable to this UI-only TypeScript/React slice; no Python files were touched.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the DocumentViewer EPUB/PDF warning and load-error Alert surfaces from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for all four states, and removed the four matching baseline entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.10.2 - Migrate-DocumentViewer-PDF-and-EPUB-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.10.2 - Migrate-DocumentViewer-PDF-and-EPUB-alerts-to-design-system-Alert.md
@@ -10,6 +10,7 @@ labels:
 priority: medium
 parent_task_id: TASK-45.44.10
 references:
+- https://github.com/rmusser01/tldw_server/pull/1952
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/EpubViewer/index.tsx
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -66,7 +67,7 @@ Continue the Document and Workspace product-state design-system migration by rep
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the DocumentViewer EPUB/PDF warning and load-error Alert surfaces from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for all four states, and removed the four matching baseline entries.
+Migrated the DocumentViewer EPUB/PDF warning and load-error Alert surfaces from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for all four states, and removed the four matching baseline entries. PR: https://github.com/rmusser01/tldw_server/pull/1952.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Replace DocumentViewer EPUB/PDF AntD Alert product-state UI with the shared design-system Alert primitive.
- Add focused tests for EPUB/PDF no-url and load-error states rendering through the design-system Alert marker.
- Remove the four migrated baseline rows, reducing Document/Workspace exceptions from 9 to 5 and total baseline exceptions from 300 to 296.

## Verification
- bunx vitest run src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"
- bun run verify:design-system-state
- git diff --check

## Known existing debt
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still fails on existing UI-wide TypeScript debt outside the touched DocumentViewer files.

Change summary: This slice keeps the migration deliberately narrow: it only replaces the four DocumentViewer Alert product states covered by the baseline, preserves existing PDF/EPUB viewer mechanics, adds behavior-level regression coverage for the shared design-system wrapper, and removes only the matching baseline entries so the guard count stays reliable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated DocumentViewer EPUB/PDF alerts from `antd` to the design-system `Alert`, keeping behavior the same and localizing PDF messages. Added focused tests.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` in `EpubViewer` and `PdfDocument` for no-URL and load-error states.
  - Wired PDF alert copy to `react-i18next` with sensible fallbacks; EPUB already used `t`.
  - Added tests to assert design-system `Alert` renders for EPUB/PDF missing-URL and load-error cases.
  - Removed four matching baseline entries (300→296 total; Document/Workspace 9→5) and recorded verifier results in TASK-45.44.10.2.

<sup>Written for commit 81f19129e5361df5d98d4cb095816be9562d134a. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1952?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

