### PR TITLE
Govern WebUI route metadata inventory

### DIFF
--- a/apps/packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts
@@ -1,133 +1,38 @@
-import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
 
 import { PAGES } from "../../../../../tldw-frontend/e2e/smoke/page-inventory"
-import { getRouteMetadata, ROUTE_METADATA } from "../route-metadata"
-import * as routePathExports from "../route-paths"
+import {
+  getRouteMetadata,
+  normalizeRoutePath,
+  ROUTE_METADATA
+} from "../route-metadata"
+import {
+  extractRoutePathsFromRouteObjects,
+  readFirstExistingSource
+} from "./route-registry-ast-helpers"
 
 const sorted = (values: string[]): string[] => [...values].sort()
 
-const pageEntryByPath = new Map(PAGES.map((entry) => [entry.path, entry]))
+const pageEntryByPath = new Map(
+  PAGES.map((entry) => [normalizeRoutePath(entry.path), entry])
+)
 const testDir = path.dirname(fileURLToPath(import.meta.url))
-const routePathConstants = routePathExports as Record<string, unknown>
-
-const routeRegistryPath = [
-  path.resolve(testDir, "../route-registry.tsx"),
-  "src/routes/route-registry.tsx",
-  "packages/ui/src/routes/route-registry.tsx",
-  "../packages/ui/src/routes/route-registry.tsx",
-  "apps/packages/ui/src/routes/route-registry.tsx"
-].find((candidate) => existsSync(candidate))
-
-if (!routeRegistryPath) {
-  throw new Error("Unable to locate route-registry.tsx for governance test")
-}
-
-const getPropertyNameText = (name: ts.PropertyName): string | undefined => {
-  if (
-    ts.isIdentifier(name) ||
-    ts.isStringLiteral(name) ||
-    ts.isNumericLiteral(name)
-  ) {
-    return name.text
-  }
-
-  return undefined
-}
-
-const getObjectProperty = (
-  objectLiteral: ts.ObjectLiteralExpression,
-  propertyName: string
-): ts.PropertyAssignment | undefined =>
-  objectLiteral.properties.find(
-    (property): property is ts.PropertyAssignment =>
-      ts.isPropertyAssignment(property) &&
-      getPropertyNameText(property.name) === propertyName
-  )
-
-const readRoutePathExpression = (
-  expression: ts.Expression,
-  context: string
-): string => {
-  if (
-    ts.isStringLiteral(expression) ||
-    ts.isNoSubstitutionTemplateLiteral(expression)
-  ) {
-    return expression.text
-  }
-
-  if (ts.isIdentifier(expression)) {
-    const value = routePathConstants[expression.text]
-
-    if (typeof value === "string") {
-      return value
-    }
-
-    throw new Error(
-      `Unable to resolve route path constant ${expression.text} in ${context}`
-    )
-  }
-
-  throw new Error(
-    `Unsupported route path expression ${expression.getText()} in ${context}`
-  )
-}
-
-const extractRoutePathsFromRouteObjects = (
-  source: string,
-  fileName: string
-): string[] => {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  )
-  const routePaths: string[] = []
-
-  const visit = (node: ts.Node) => {
-    if (ts.isObjectLiteralExpression(node)) {
-      const pathProperty = getObjectProperty(node, "path")
-      const kindProperty = getObjectProperty(node, "kind")
-
-      if (
-        pathProperty &&
-        kindProperty &&
-        ts.isStringLiteral(kindProperty.initializer) &&
-        kindProperty.initializer.text === "options"
-      ) {
-        const { line } = sourceFile.getLineAndCharacterOfPosition(
-          pathProperty.getStart(sourceFile)
-        )
-        routePaths.push(
-          readRoutePathExpression(
-            pathProperty.initializer,
-            `${fileName}:${line + 1}`
-          )
-        )
-      }
-    }
-
-    ts.forEachChild(node, visit)
-  }
-
-  visit(sourceFile)
-
-  return Array.from(new Set(routePaths)).sort()
-}
+const routeRegistry = readFirstExistingSource(
+  [path.resolve(testDir, "../route-registry.tsx")],
+  "shared route-registry.tsx"
+)
 
 const optionRegistryPaths = extractRoutePathsFromRouteObjects(
-  readFileSync(routeRegistryPath, "utf8"),
-  routeRegistryPath
+  routeRegistry.source,
+  routeRegistry.path,
+  { kind: "options" }
 )
 
 describe("route governance metadata coverage", () => {
   it("does not define duplicate smoke inventory paths", () => {
-    const paths = PAGES.map((entry) => entry.path)
+    const paths = PAGES.map((entry) => normalizeRoutePath(entry.path))
     const duplicatePaths = paths.filter(
       (path, index) => paths.indexOf(path) !== index
     )
@@ -136,9 +41,9 @@ describe("route governance metadata coverage", () => {
   })
 
   it("covers every shared option route", () => {
-    const missingMetadata = optionRegistryPaths
-      .filter((path) => !path.includes(":"))
-      .filter((path) => !getRouteMetadata(path))
+    const missingMetadata = optionRegistryPaths.filter(
+      (path) => !getRouteMetadata(path)
+    )
 
     expect(sorted(missingMetadata)).toEqual([])
   })
@@ -170,7 +75,7 @@ describe("route governance metadata coverage", () => {
       .filter((metadata) => metadata.availability.includes("web"))
       .filter((metadata) => metadata.smoke === "include")
       .filter((metadata) => {
-        const pageEntry = pageEntryByPath.get(metadata.path)
+        const pageEntry = pageEntryByPath.get(normalizeRoutePath(metadata.path))
 
         return !pageEntry || Boolean(pageEntry.skip)
       })

--- a/apps/packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts
@@ -1,0 +1,190 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import * as ts from "typescript"
+import { describe, expect, it } from "vitest"
+
+import { PAGES } from "../../../../../tldw-frontend/e2e/smoke/page-inventory"
+import { getRouteMetadata, ROUTE_METADATA } from "../route-metadata"
+import * as routePathExports from "../route-paths"
+
+const sorted = (values: string[]): string[] => [...values].sort()
+
+const pageEntryByPath = new Map(PAGES.map((entry) => [entry.path, entry]))
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const routePathConstants = routePathExports as Record<string, unknown>
+
+const routeRegistryPath = [
+  path.resolve(testDir, "../route-registry.tsx"),
+  "src/routes/route-registry.tsx",
+  "packages/ui/src/routes/route-registry.tsx",
+  "../packages/ui/src/routes/route-registry.tsx",
+  "apps/packages/ui/src/routes/route-registry.tsx"
+].find((candidate) => existsSync(candidate))
+
+if (!routeRegistryPath) {
+  throw new Error("Unable to locate route-registry.tsx for governance test")
+}
+
+const getPropertyNameText = (name: ts.PropertyName): string | undefined => {
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteral(name) ||
+    ts.isNumericLiteral(name)
+  ) {
+    return name.text
+  }
+
+  return undefined
+}
+
+const getObjectProperty = (
+  objectLiteral: ts.ObjectLiteralExpression,
+  propertyName: string
+): ts.PropertyAssignment | undefined =>
+  objectLiteral.properties.find(
+    (property): property is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(property) &&
+      getPropertyNameText(property.name) === propertyName
+  )
+
+const readRoutePathExpression = (
+  expression: ts.Expression,
+  context: string
+): string => {
+  if (
+    ts.isStringLiteral(expression) ||
+    ts.isNoSubstitutionTemplateLiteral(expression)
+  ) {
+    return expression.text
+  }
+
+  if (ts.isIdentifier(expression)) {
+    const value = routePathConstants[expression.text]
+
+    if (typeof value === "string") {
+      return value
+    }
+
+    throw new Error(
+      `Unable to resolve route path constant ${expression.text} in ${context}`
+    )
+  }
+
+  throw new Error(
+    `Unsupported route path expression ${expression.getText()} in ${context}`
+  )
+}
+
+const extractRoutePathsFromRouteObjects = (
+  source: string,
+  fileName: string
+): string[] => {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  const routePaths: string[] = []
+
+  const visit = (node: ts.Node) => {
+    if (ts.isObjectLiteralExpression(node)) {
+      const pathProperty = getObjectProperty(node, "path")
+      const kindProperty = getObjectProperty(node, "kind")
+
+      if (
+        pathProperty &&
+        kindProperty &&
+        ts.isStringLiteral(kindProperty.initializer) &&
+        kindProperty.initializer.text === "options"
+      ) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(
+          pathProperty.getStart(sourceFile)
+        )
+        routePaths.push(
+          readRoutePathExpression(
+            pathProperty.initializer,
+            `${fileName}:${line + 1}`
+          )
+        )
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  return Array.from(new Set(routePaths)).sort()
+}
+
+const optionRegistryPaths = extractRoutePathsFromRouteObjects(
+  readFileSync(routeRegistryPath, "utf8"),
+  routeRegistryPath
+)
+
+describe("route governance metadata coverage", () => {
+  it("does not define duplicate smoke inventory paths", () => {
+    const paths = PAGES.map((entry) => entry.path)
+    const duplicatePaths = paths.filter(
+      (path, index) => paths.indexOf(path) !== index
+    )
+
+    expect(sorted(duplicatePaths)).toEqual([])
+  })
+
+  it("covers every shared option route", () => {
+    const missingMetadata = optionRegistryPaths
+      .filter((path) => !path.includes(":"))
+      .filter((path) => !getRouteMetadata(path))
+
+    expect(sorted(missingMetadata)).toEqual([])
+  })
+
+  it("requires every active smoke inventory route to have metadata", () => {
+    const missingMetadata = PAGES
+      .filter((entry) => !entry.skip)
+      .filter((entry) => !getRouteMetadata(entry.path))
+      .map((entry) => entry.path)
+
+    expect(sorted(missingMetadata)).toEqual([])
+  })
+
+  it("requires skipped smoke inventory routes to have metadata and reasons", () => {
+    const invalidSkippedRoutes = PAGES
+      .filter((entry) => entry.skip)
+      .filter((entry) => {
+        const metadata = getRouteMetadata(entry.path)
+
+        return !metadata || !entry.skip?.trim() || metadata.smoke === "include"
+      })
+      .map((entry) => entry.path)
+
+    expect(sorted(invalidSkippedRoutes)).toEqual([])
+  })
+
+  it("keeps included web smoke routes active in the page inventory", () => {
+    const missingIncludedRoutes = ROUTE_METADATA
+      .filter((metadata) => metadata.availability.includes("web"))
+      .filter((metadata) => metadata.smoke === "include")
+      .filter((metadata) => {
+        const pageEntry = pageEntryByPath.get(metadata.path)
+
+        return !pageEntry || Boolean(pageEntry.skip)
+      })
+      .map((metadata) => metadata.path)
+
+    expect(sorted(missingIncludedRoutes)).toEqual([])
+  })
+
+  it("does not run smoke-excluded routes as active page inventory entries", () => {
+    const activeExcludedRoutes = PAGES
+      .filter((entry) => !entry.skip)
+      .filter((entry) => getRouteMetadata(entry.path)?.smoke === "exclude")
+      .map((entry) => entry.path)
+
+    expect(sorted(activeExcludedRoutes)).toEqual([])
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/route-registry-ast-helpers.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry-ast-helpers.ts
@@ -1,0 +1,154 @@
+import { existsSync, readFileSync } from "node:fs"
+import * as ts from "typescript"
+
+import * as routePathExports from "../route-paths"
+
+const routePathConstants = routePathExports as Record<string, unknown>
+
+export type RouteRegistrySource = {
+  path: string
+  source: string
+}
+
+export type RouteObjectExtractionOptions = {
+  kind?: string
+  requireNav?: boolean
+}
+
+export const uniqueSorted = (values: string[]): string[] =>
+  Array.from(new Set(values)).sort()
+
+export const resolveFirstExistingPath = (
+  candidates: string[],
+  label: string
+): string => {
+  const sourcePath = candidates.find((candidate) => existsSync(candidate))
+
+  if (!sourcePath) {
+    throw new Error(`Unable to locate ${label}`)
+  }
+
+  return sourcePath
+}
+
+export const readFirstExistingSource = (
+  candidates: string[],
+  label: string
+): RouteRegistrySource => {
+  const sourcePath = resolveFirstExistingPath(candidates, label)
+
+  return {
+    path: sourcePath,
+    source: readFileSync(sourcePath, "utf8")
+  }
+}
+
+export const getPropertyNameText = (
+  name: ts.PropertyName
+): string | undefined => {
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteral(name) ||
+    ts.isNumericLiteral(name)
+  ) {
+    return name.text
+  }
+
+  return undefined
+}
+
+export const getObjectProperty = (
+  objectLiteral: ts.ObjectLiteralExpression,
+  propertyName: string
+): ts.PropertyAssignment | undefined =>
+  objectLiteral.properties.find(
+    (property): property is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(property) &&
+      getPropertyNameText(property.name) === propertyName
+  )
+
+export const readRoutePathExpression = (
+  expression: ts.Expression,
+  context: string
+): string => {
+  if (
+    ts.isStringLiteral(expression) ||
+    ts.isNoSubstitutionTemplateLiteral(expression)
+  ) {
+    return expression.text
+  }
+
+  if (ts.isIdentifier(expression)) {
+    const value = routePathConstants[expression.text]
+
+    if (typeof value === "string") {
+      return value
+    }
+
+    throw new Error(
+      `Unable to resolve route path constant ${expression.text} in ${context}`
+    )
+  }
+
+  throw new Error(
+    `Unsupported route path expression ${expression.getText()} in ${context}`
+  )
+}
+
+export const extractRoutePathsFromRouteObjects = (
+  source: string,
+  fileName: string,
+  options: RouteObjectExtractionOptions = {}
+): string[] => {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  const routePaths: string[] = []
+
+  const matchesKind = (objectLiteral: ts.ObjectLiteralExpression): boolean => {
+    if (!options.kind) {
+      return true
+    }
+
+    const kindProperty = getObjectProperty(objectLiteral, "kind")
+
+    if (!kindProperty || !ts.isStringLiteral(kindProperty.initializer)) {
+      return false
+    }
+
+    return kindProperty.initializer.text === options.kind
+  }
+
+  const visit = (node: ts.Node) => {
+    if (ts.isObjectLiteralExpression(node)) {
+      const pathProperty = getObjectProperty(node, "path")
+      const navProperty = getObjectProperty(node, "nav")
+
+      if (
+        pathProperty &&
+        matchesKind(node) &&
+        (!options.requireNav || navProperty)
+      ) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(
+          pathProperty.getStart(sourceFile)
+        )
+        routePaths.push(
+          readRoutePathExpression(
+            pathProperty.initializer,
+            `${fileName}:${line + 1}`
+          )
+        )
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  return uniqueSorted(routePaths)
+}

--- a/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-availability.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-availability.test.ts
@@ -1,177 +1,62 @@
-import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
 
 import {
   getRouteMetadata,
   isRouteVisibleForSurface
 } from "../route-metadata"
-import * as routePathExports from "../route-paths"
-
-const readFirstExistingSource = (
-  candidates: string[],
-  label: string
-): string => {
-  const sourcePath = candidates.find((candidate) => existsSync(candidate))
-
-  if (!sourcePath) {
-    throw new Error(`Unable to locate ${label}`)
-  }
-
-  return readFileSync(sourcePath, "utf8")
-}
+import {
+  extractRoutePathsFromRouteObjects,
+  readFirstExistingSource,
+  uniqueSorted
+} from "./route-registry-ast-helpers"
 
 const testDir = path.dirname(fileURLToPath(import.meta.url))
-const routePathConstants = routePathExports as Record<string, unknown>
 
-const sharedSidepanelRegistrySource = readFirstExistingSource(
-  [
-    path.resolve(testDir, "../sidepanel-route-registry.tsx"),
-    "src/routes/sidepanel-route-registry.tsx",
-    "packages/ui/src/routes/sidepanel-route-registry.tsx",
-    "../packages/ui/src/routes/sidepanel-route-registry.tsx",
-    "apps/packages/ui/src/routes/sidepanel-route-registry.tsx"
-  ],
+const sharedSidepanelRegistry = readFirstExistingSource(
+  [path.resolve(testDir, "../sidepanel-route-registry.tsx")],
   "shared sidepanel-route-registry.tsx"
 )
 
-const extensionSidepanelRegistrySource = readFirstExistingSource(
+const extensionSidepanelRegistry = readFirstExistingSource(
   [
     path.resolve(
       testDir,
       "../../../../../tldw-frontend/extension/routes/sidepanel-route-registry.tsx"
-    ),
-    "../../tldw-frontend/extension/routes/sidepanel-route-registry.tsx",
-    "tldw-frontend/extension/routes/sidepanel-route-registry.tsx",
-    "apps/tldw-frontend/extension/routes/sidepanel-route-registry.tsx"
+    )
   ],
   "extension sidepanel-route-registry.tsx"
 )
 
-const extensionOptionRegistrySource = readFirstExistingSource(
+const extensionOptionRegistry = readFirstExistingSource(
   [
     path.resolve(
       testDir,
       "../../../../../tldw-frontend/extension/routes/route-registry.tsx"
-    ),
-    "../../tldw-frontend/extension/routes/route-registry.tsx",
-    "tldw-frontend/extension/routes/route-registry.tsx",
-    "apps/tldw-frontend/extension/routes/route-registry.tsx"
+    )
   ],
   "extension route-registry.tsx"
 )
 
-const uniqueSorted = (values: string[]): string[] =>
-  Array.from(new Set(values)).sort()
-
-const getPropertyNameText = (name: ts.PropertyName): string | undefined => {
-  if (
-    ts.isIdentifier(name) ||
-    ts.isStringLiteral(name) ||
-    ts.isNumericLiteral(name)
-  ) {
-    return name.text
-  }
-
-  return undefined
-}
-
-const getObjectProperty = (
-  objectLiteral: ts.ObjectLiteralExpression,
-  propertyName: string
-): ts.PropertyAssignment | undefined =>
-  objectLiteral.properties.find(
-    (property): property is ts.PropertyAssignment =>
-      ts.isPropertyAssignment(property) &&
-      getPropertyNameText(property.name) === propertyName
-  )
-
-const readRoutePathExpression = (
-  expression: ts.Expression,
-  context: string
-): string => {
-  if (
-    ts.isStringLiteral(expression) ||
-    ts.isNoSubstitutionTemplateLiteral(expression)
-  ) {
-    return expression.text
-  }
-
-  if (ts.isIdentifier(expression)) {
-    const value = routePathConstants[expression.text]
-
-    if (typeof value === "string") {
-      return value
-    }
-
-    throw new Error(
-      `Unable to resolve route path constant ${expression.text} in ${context}`
-    )
-  }
-
-  throw new Error(
-    `Unsupported route path expression ${expression.getText()} in ${context}`
-  )
-}
-
-const extractRoutePathsFromRouteObjects = (
-  source: string,
-  fileName: string,
-  options: { requireNav?: boolean } = {}
-): string[] => {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  )
-  const routePaths: string[] = []
-
-  const visit = (node: ts.Node) => {
-    if (ts.isObjectLiteralExpression(node)) {
-      const pathProperty = getObjectProperty(node, "path")
-      const navProperty = getObjectProperty(node, "nav")
-
-      if (pathProperty && (!options.requireNav || navProperty)) {
-        const { line } = sourceFile.getLineAndCharacterOfPosition(
-          pathProperty.getStart(sourceFile)
-        )
-        routePaths.push(
-          readRoutePathExpression(
-            pathProperty.initializer,
-            `${fileName}:${line + 1}`
-          )
-        )
-      }
-    }
-
-    ts.forEachChild(node, visit)
-  }
-
-  visit(sourceFile)
-
-  return uniqueSorted(routePaths)
-}
-
 const sidepanelRoutePaths = uniqueSorted([
   ...extractRoutePathsFromRouteObjects(
-    sharedSidepanelRegistrySource,
-    "shared sidepanel-route-registry.tsx"
+    sharedSidepanelRegistry.source,
+    sharedSidepanelRegistry.path,
+    { kind: "sidepanel" }
   ),
   ...extractRoutePathsFromRouteObjects(
-    extensionSidepanelRegistrySource,
-    "extension sidepanel-route-registry.tsx"
+    extensionSidepanelRegistry.source,
+    extensionSidepanelRegistry.path,
+    { kind: "sidepanel" }
   )
 ])
 
 const extensionOptionNavPaths = uniqueSorted(
   extractRoutePathsFromRouteObjects(
-    extensionOptionRegistrySource,
-    "extension route-registry.tsx",
-    { requireNav: true }
+    extensionOptionRegistry.source,
+    extensionOptionRegistry.path,
+    { kind: "options", requireNav: true }
   ).filter(
     (routePath) =>
       !routePath.includes(":") && !sidepanelRoutePaths.includes(routePath)
@@ -180,10 +65,14 @@ const extensionOptionNavPaths = uniqueSorted(
 
 describe("sidepanel route availability metadata", () => {
   it("keeps extension sidepanel chat reachable at both root and /chat", () => {
-    expect(extensionSidepanelRegistrySource).toMatch(/path\s*:\s*["']\/["']/)
-    expect(extensionSidepanelRegistrySource).toMatch(/path\s*:\s*["']\/chat["']/)
-    expect(extensionOptionRegistrySource).toMatch(/path\s*:\s*["']\/["']/)
-    expect(extensionOptionRegistrySource).toMatch(/path\s*:\s*["']\/chat["']/)
+    expect(extensionSidepanelRegistry.source).toMatch(/path\s*:\s*["']\/["']/)
+    expect(extensionSidepanelRegistry.source).toMatch(
+      /path\s*:\s*["']\/chat["']/
+    )
+    expect(extensionOptionRegistry.source).toMatch(/path\s*:\s*["']\/["']/)
+    expect(extensionOptionRegistry.source).toMatch(
+      /path\s*:\s*["']\/chat["']/
+    )
   })
 
   it("declares sidepanel availability for every shared or extension sidepanel route", () => {

--- a/apps/packages/ui/src/routes/__tests__/route-registry.visibility.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.visibility.test.ts
@@ -1,147 +1,38 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
 
 import { getRouteMetadata, ROUTE_METADATA } from "../route-metadata"
-import * as routePathExports from "../route-paths"
+import {
+  extractRoutePathsFromRouteObjects,
+  readFirstExistingSource,
+  resolveFirstExistingPath
+} from "./route-registry-ast-helpers"
 
 const isDynamicRoutePath = (routePath: string): boolean =>
   routePath.includes(":") || routePath.includes("*")
 
 const testDir = path.dirname(fileURLToPath(import.meta.url))
-const routePathConstants = routePathExports as Record<string, unknown>
-
-const routeRegistryPathCandidates = [
-  path.resolve(testDir, "../route-registry.tsx"),
-  "src/routes/route-registry.tsx",
-  "packages/ui/src/routes/route-registry.tsx",
-  "../packages/ui/src/routes/route-registry.tsx",
-  "apps/packages/ui/src/routes/route-registry.tsx"
-]
-
-const routeRegistryPath = routeRegistryPathCandidates.find((candidate) =>
-  existsSync(candidate)
+const routeRegistry = readFirstExistingSource(
+  [path.resolve(testDir, "../route-registry.tsx")],
+  "shared route-registry.tsx"
 )
 
-if (!routeRegistryPath) {
-  throw new Error("Unable to locate route-registry.tsx for visibility test")
-}
-
-const routeRegistrySource = readFileSync(routeRegistryPath, "utf8")
-
-const getPropertyNameText = (name: ts.PropertyName): string | undefined => {
-  if (
-    ts.isIdentifier(name) ||
-    ts.isStringLiteral(name) ||
-    ts.isNumericLiteral(name)
-  ) {
-    return name.text
-  }
-
-  return undefined
-}
-
-const getObjectProperty = (
-  objectLiteral: ts.ObjectLiteralExpression,
-  propertyName: string
-): ts.PropertyAssignment | undefined =>
-  objectLiteral.properties.find(
-    (property): property is ts.PropertyAssignment =>
-      ts.isPropertyAssignment(property) &&
-      getPropertyNameText(property.name) === propertyName
-  )
-
-const readRoutePathExpression = (
-  expression: ts.Expression,
-  context: string
-): string => {
-  if (
-    ts.isStringLiteral(expression) ||
-    ts.isNoSubstitutionTemplateLiteral(expression)
-  ) {
-    return expression.text
-  }
-
-  if (ts.isIdentifier(expression)) {
-    const value = routePathConstants[expression.text]
-
-    if (typeof value === "string") {
-      return value
-    }
-
-    throw new Error(
-      `Unable to resolve route path constant ${expression.text} in ${context}`
-    )
-  }
-
-  throw new Error(
-    `Unsupported route path expression ${expression.getText()} in ${context}`
-  )
-}
-
-const extractRoutePathsFromRouteObjects = (
-  source: string,
-  fileName: string
-): string[] => {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  )
-  const routePaths: string[] = []
-
-  const visit = (node: ts.Node) => {
-    if (ts.isObjectLiteralExpression(node)) {
-      const pathProperty = getObjectProperty(node, "path")
-
-      if (pathProperty) {
-        const { line } = sourceFile.getLineAndCharacterOfPosition(
-          pathProperty.getStart(sourceFile)
-        )
-        routePaths.push(
-          readRoutePathExpression(
-            pathProperty.initializer,
-            `${fileName}:${line + 1}`
-          )
-        )
-      }
-    }
-
-    ts.forEachChild(node, visit)
-  }
-
-  visit(sourceFile)
-
-  return Array.from(new Set(routePaths)).sort()
-}
-
 const optionRegistryPaths = extractRoutePathsFromRouteObjects(
-  routeRegistrySource,
-  routeRegistryPath
+  routeRegistry.source,
+  routeRegistry.path,
+  { kind: "options" }
 )
 
 const nonDynamicOptionRegistryPaths = optionRegistryPaths.filter(
   (routePath) => !isDynamicRoutePath(routePath)
 )
 
-const frontendPagesRootCandidates = [
-  path.resolve(process.cwd(), "../../tldw-frontend/pages"),
-  path.resolve(process.cwd(), "tldw-frontend/pages"),
-  path.resolve(process.cwd(), "apps/tldw-frontend/pages"),
-  path.resolve(testDir, "../../../../../tldw-frontend/pages")
-]
-
-const frontendPagesRoot = frontendPagesRootCandidates.find((candidate) =>
-  existsSync(candidate)
+const frontendPagesRoot = resolveFirstExistingPath(
+  [path.resolve(testDir, "../../../../../tldw-frontend/pages")],
+  "tldw-frontend/pages for visibility test"
 )
-
-if (!frontendPagesRoot) {
-  throw new Error("Unable to locate tldw-frontend/pages for visibility test")
-}
 
 const routePathToPageCandidates = (routePath: string): string[] => {
   const normalizedPath = routePath === "/" ? "/index" : routePath

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -23,6 +23,7 @@ export type RouteGroup =
   | "safety"
   | "specialized"
   | "documentation"
+  | "marketing"
   | "account"
 
 export type RouteAvailability =
@@ -1264,6 +1265,224 @@ const ROUTE_REGISTRY_METADATA: RouteMetadata[] = [
     "Monitoring Admin",
     "Monitoring is an operator route for service status and diagnostics."
   ),
+  adminRoute(
+    "/admin/api-keys",
+    "API Keys Admin",
+    "API key administration is a Next-only operator page outside normal user navigation.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/billing",
+    "Billing Admin",
+    "Billing administration is an operator page and remains separate from hosted user billing.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/data-ops",
+    "Data Operations Admin",
+    "Data operations administration is a Next-only operator workflow.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/maintenance",
+    "Maintenance Admin",
+    "Maintenance controls are operator-only and should stay out of default user navigation.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/orgs",
+    "Organizations Admin",
+    "Organization administration is operator-owned and deployment-mode dependent.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/rate-limiting",
+    "Rate Limiting Admin",
+    "Rate-limit administration is an operator-only controls page.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/rbac",
+    "RBAC Admin",
+    "RBAC administration is an operator-only access-control page.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/usage",
+    "Usage Admin",
+    "Usage administration is an operator-only reporting page.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/watchlists-items",
+    "Watchlists Items Admin",
+    "Watchlist item administration is an operator drill-down page.",
+    {
+      availability: webOnly
+    }
+  ),
+  adminRoute(
+    "/admin/watchlists-runs",
+    "Watchlists Runs Admin",
+    "Watchlist run administration is an operator placeholder and drill-down page.",
+    {
+      availability: webOnly
+    }
+  ),
+  registryRoute({
+    path: "/auth/magic-link",
+    label: "Magic Link Sign-In",
+    group: "account",
+    surface: "hosted_only",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Hosted magic-link auth lives outside the self-hosted WebUI distribution."
+  }),
+  registryRoute({
+    path: "/auth/reset-password",
+    label: "Reset Password",
+    group: "account",
+    surface: "hosted_only",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Hosted password-reset auth lives outside the self-hosted WebUI distribution."
+  }),
+  registryRoute({
+    path: "/auth/verify-email",
+    label: "Verify Email",
+    group: "account",
+    surface: "hosted_only",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Hosted email verification lives outside the self-hosted WebUI distribution."
+  }),
+  registryRoute({
+    path: "/billing/success",
+    label: "Billing Success",
+    group: "account",
+    surface: "hosted_only",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Hosted billing completion is represented by a self-hosted placeholder."
+  }),
+  registryRoute({
+    path: "/billing/cancel",
+    label: "Billing Cancel",
+    group: "account",
+    surface: "hosted_only",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Hosted billing cancellation is represented by a self-hosted placeholder."
+  }),
+  registryRoute({
+    path: "/chat/agent",
+    canonicalPath: "/agent",
+    label: "Agent Chat",
+    group: "chat",
+    surface: "advanced_self_hosted",
+    availability: webOnly,
+    smoke: "include",
+    commandPalette: "hide",
+    nav: "hidden",
+    requiresBackend: true,
+    rationale: "Legacy web wrapper for the sidepanel agent chat route remains in smoke inventory."
+  }),
+  registryRoute({
+    path: "/media/:id/view",
+    canonicalPath: "/media",
+    label: "Media Item View Redirect",
+    group: "media_library",
+    surface: "redirect",
+    availability: webOnly,
+    aliases: ["/media/123/view"],
+    redirectsTo: "/media",
+    smoke: "exclude",
+    commandPalette: "alias_only",
+    nav: "hidden",
+    requiresBackend: true,
+    rationale: "Dynamic media view redirects into the canonical media library surface."
+  }),
+  registryRoute({
+    path: "/connectors/browse",
+    label: "Connector Browse",
+    group: "operations",
+    surface: "labs_beta",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Connector browse is a placeholder child route under the connectors hub."
+  }),
+  registryRoute({
+    path: "/connectors/jobs",
+    label: "Connector Jobs",
+    group: "operations",
+    surface: "labs_beta",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Connector jobs is a placeholder child route under the connectors hub."
+  }),
+  registryRoute({
+    path: "/connectors/sources",
+    label: "Connector Sources",
+    group: "operations",
+    surface: "labs_beta",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Connector sources is a placeholder child route under the connectors hub."
+  }),
+  registryRoute({
+    path: "/for/journalists",
+    label: "For Journalists",
+    group: "marketing",
+    surface: "default_self_hosted",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Audience landing page is public web content rather than application navigation."
+  }),
+  registryRoute({
+    path: "/for/osint",
+    label: "For OSINT",
+    group: "marketing",
+    surface: "default_self_hosted",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Audience landing page is public web content rather than application navigation."
+  }),
+  registryRoute({
+    path: "/for/researchers",
+    label: "For Researchers",
+    group: "marketing",
+    surface: "default_self_hosted",
+    availability: webOnly,
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Audience landing page is public web content rather than application navigation."
+  }),
   registryRoute({
     path: "/sources/new",
     label: "New Source",

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -1397,7 +1397,7 @@ const ROUTE_REGISTRY_METADATA: RouteMetadata[] = [
   }),
   registryRoute({
     path: "/chat/agent",
-    canonicalPath: "/agent",
+    canonicalPath: "/agents",
     label: "Agent Chat",
     group: "chat",
     surface: "advanced_self_hosted",
@@ -1493,6 +1493,54 @@ const ROUTE_REGISTRY_METADATA: RouteMetadata[] = [
     rationale: "Source creation is a task route owned by the sources workflow."
   }),
   registryRoute({
+    path: "/sources/:sourceId",
+    canonicalPath: "/sources",
+    label: "Source Detail",
+    group: "knowledge",
+    surface: "default_self_hosted",
+    smoke: "manual",
+    commandPalette: "hide",
+    nav: "hidden",
+    requiresBackend: true,
+    rationale: "Dynamic source detail route belongs to the canonical Sources workflow."
+  }),
+  registryRoute({
+    path: "/share/:token",
+    canonicalPath: "/shared",
+    label: "Public Share",
+    group: "knowledge",
+    surface: "advanced_self_hosted",
+    smoke: "manual",
+    commandPalette: "hide",
+    nav: "hidden",
+    requiresBackend: true,
+    rationale: "Tokenized public share route depends on share state and should not appear in navigation."
+  }),
+  registryRoute({
+    path: "/knowledge/thread/:threadId",
+    canonicalPath: "/knowledge",
+    label: "Knowledge Thread",
+    group: "knowledge",
+    surface: "default_self_hosted",
+    smoke: "manual",
+    commandPalette: "hide",
+    nav: "hidden",
+    requiresBackend: true,
+    rationale: "Dynamic knowledge thread routes resolve inside the canonical Knowledge workspace."
+  }),
+  registryRoute({
+    path: "/knowledge/shared/:shareToken",
+    canonicalPath: "/knowledge",
+    label: "Shared Knowledge Thread",
+    group: "knowledge",
+    surface: "advanced_self_hosted",
+    smoke: "manual",
+    commandPalette: "hide",
+    nav: "hidden",
+    requiresBackend: true,
+    rationale: "Shared knowledge thread links are tokenized stateful routes under the Knowledge workspace."
+  }),
+  registryRoute({
     path: "/companion/conversation",
     label: "Companion Conversation",
     group: "chat",
@@ -1578,6 +1626,17 @@ const ROUTE_REGISTRY_METADATA: RouteMetadata[] = [
     rationale: "Presentation startup flow is a nested task route owned by Presentation Studio."
   }),
   registryRoute({
+    path: "/presentation-studio/:projectId",
+    canonicalPath: "/presentation-studio",
+    label: "Presentation Detail",
+    group: "workspace",
+    surface: "labs_beta",
+    smoke: "manual",
+    commandPalette: "hide",
+    nav: "hidden",
+    rationale: "Dynamic presentation project route belongs to the canonical Presentation Studio workflow."
+  }),
+  registryRoute({
     path: "/moderation",
     label: "Moderation Review",
     group: "safety",
@@ -1634,7 +1693,7 @@ export const ROUTE_METADATA: RouteMetadata[] = [
   ...ROUTE_REGISTRY_METADATA
 ]
 
-const normalizeRoutePath = (path: string): string => {
+export const normalizeRoutePath = (path: string): string => {
   const trimmed = path.trim()
   if (!trimmed) {
     return "/"

--- a/apps/tldw-frontend/e2e/smoke/page-inventory.ts
+++ b/apps/tldw-frontend/e2e/smoke/page-inventory.ts
@@ -37,12 +37,6 @@ export const PAGES: PageEntry[] = [
   { path: "/chat", name: "Chat", category: "chat", expectedTestId: "chat-input" },
   { path: "/chat/agent", name: "Agent Chat", category: "chat" },
   { path: "/persona", name: "Persona Chat", category: "chat" },
-  {
-    path: "/chat/settings",
-    name: "Chat Settings (Page)",
-    category: "chat",
-    skip: "Covered in Stage 5 release gate; intermittently stalls all-pages webpack route traversal in CI.",
-  },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Media
@@ -50,7 +44,12 @@ export const PAGES: PageEntry[] = [
   { path: "/media", name: "Media", category: "media" },
   { path: "/media-multi", name: "Media Multi", category: "media" },
   { path: "/media-trash", name: "Media Trash", category: "media" },
-  { path: "/media/123/view", name: "Media View (Redirect)", category: "media" },
+  {
+    path: "/media/123/view",
+    name: "Media View (Redirect)",
+    category: "media",
+    skip: "Dynamic redirect alias covered by the route metadata contract."
+  },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Settings (20+ pages)
@@ -107,7 +106,12 @@ export const PAGES: PageEntry[] = [
   { path: "/kanban", name: "Kanban", category: "workspace" },
   { path: "/data-tables", name: "Data Tables", category: "workspace" },
   { path: "/content-review", name: "Content Review", category: "workspace" },
-  { path: "/claims-review", name: "Claims Review", category: "workspace" },
+  {
+    path: "/claims-review",
+    name: "Claims Review",
+    category: "workspace",
+    skip: "Legacy redirect alias covered by the route metadata contract."
+  },
   { path: "/integrations", name: "Integrations", category: "workspace" },
   { path: "/scheduled-tasks", name: "Scheduled Tasks", category: "workspace" },
   { path: "/watchlists", name: "Watchlists", category: "workspace" },
@@ -122,7 +126,12 @@ export const PAGES: PageEntry[] = [
   { path: "/collections", name: "Collections", category: "workspace" },
   { path: "/evaluations", name: "Evaluations", category: "workspace" },
   { path: "/search", name: "Search", category: "workspace" },
-  { path: "/review", name: "Review", category: "workspace" },
+  {
+    path: "/review",
+    name: "Review",
+    category: "workspace",
+    skip: "Legacy redirect alias covered by the route metadata contract."
+  },
   { path: "/reading", name: "Reading", category: "workspace" },
   { path: "/items", name: "Items", category: "workspace" },
   { path: "/chunking-playground", name: "Chunking Playground", category: "workspace" },
@@ -136,7 +145,12 @@ export const PAGES: PageEntry[] = [
   { path: "/dictionaries", name: "Dictionaries", category: "knowledge" },
   { path: "/characters", name: "Characters", category: "knowledge" },
   { path: "/prompts", name: "Prompts", category: "knowledge" },
-  { path: "/prompt-studio", name: "Prompt Studio", category: "knowledge" },
+  {
+    path: "/prompt-studio",
+    name: "Prompt Studio",
+    category: "knowledge",
+    skip: "Legacy redirect alias covered by the route metadata contract."
+  },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Audio
@@ -144,7 +158,12 @@ export const PAGES: PageEntry[] = [
   { path: "/tts", name: "TTS", category: "audio" },
   { path: "/stt", name: "STT", category: "audio" },
   { path: "/speech", name: "Speech", category: "audio" },
-  { path: "/audio", name: "Audio", category: "audio" },
+  {
+    path: "/audio",
+    name: "Audio",
+    category: "audio",
+    skip: "Legacy redirect alias covered by the route metadata contract."
+  },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Connectors
@@ -244,7 +263,12 @@ export const PAGES: PageEntry[] = [
   // ═══════════════════════════════════════════════════════════════════════════
   // Settings (missing)
   // ═══════════════════════════════════════════════════════════════════════════
-  { path: "/settings/image-gen", name: "Image Gen Settings", category: "settings" },
+  {
+    path: "/settings/image-gen",
+    name: "Image Gen Settings",
+    category: "settings",
+    skip: "Legacy redirect alias covered by the route metadata contract."
+  },
   { path: "/settings/image-generation", name: "Image Generation Settings", category: "settings" },
   { path: "/settings/mcp-hub", name: "MCP Hub Settings", category: "settings" },
   { path: "/settings/splash", name: "Splash Settings", category: "settings" },
@@ -263,11 +287,6 @@ export const PAGES: PageEntry[] = [
   { path: "/billing", name: "Billing", category: "other" },
   { path: "/billing/success", name: "Billing Success", category: "other" },
   { path: "/billing/cancel", name: "Billing Cancel", category: "other" },
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // Settings Chat (page-level — distinct from settings/chat)
-  // ═══════════════════════════════════════════════════════════════════════════
-  { path: "/chat/settings", name: "Chat Settings Page", category: "chat", skip: "Covered in Stage 5 release gate" }
 ]
 
 /**

--- a/backlog/tasks/task-418.10.1 - Implement-WP12-route-governance-metadata-and-inventory-coverage.md
+++ b/backlog/tasks/task-418.10.1 - Implement-WP12-route-governance-metadata-and-inventory-coverage.md
@@ -12,6 +12,7 @@ priority: high
 parent_task_id: TASK-418.10
 references:
 - TASK-418.10
+- https://github.com/rmusser01/tldw_server/pull/1953
 documentation:
 - Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
 - Docs/superpowers/plans/2026-05-17-webui-extension-ux-remediation-implementation-plan.md

--- a/backlog/tasks/task-418.10.1 - Implement-WP12-route-governance-metadata-and-inventory-coverage.md
+++ b/backlog/tasks/task-418.10.1 - Implement-WP12-route-governance-metadata-and-inventory-coverage.md
@@ -1,0 +1,61 @@
+---
+id: TASK-418.10.1
+title: Implement WP12 route governance metadata and inventory coverage
+status: Done
+labels:
+- ux
+- webui
+- extension
+- governance
+- tests
+priority: high
+parent_task_id: TASK-418.10
+references:
+- TASK-418.10
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+- Docs/superpowers/plans/2026-05-17-webui-extension-ux-remediation-implementation-plan.md
+- Docs/superpowers/specs/2026-05-17-webui-extension-ux-remediation-program-design.md
+modified_files:
+- apps/packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts
+- apps/packages/ui/src/routes/route-metadata.ts
+- apps/tldw-frontend/e2e/smoke/page-inventory.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute the first implementation slice from the WebUI/extension UX remediation Task 12 plan. Add deterministic route governance coverage that checks route metadata against shared route registries, extension routes, sidepanel availability, and smoke inventory decisions. Keep scope frontend-governance/test focused; do not change backend APIs or route-family UX unless a trivial test harness alignment is required.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Route governance metadata coverage test exists and covers duplicate inventory paths, shared option routes, active and skipped page inventory metadata, included smoke route activity, and excluded alias activity.
+- [x] #2 Missing Next-only smoke inventory routes have explicit route metadata with user-facing classification and rationale.
+- [x] #3 Redirect alias rows in page inventory are skipped with metadata-backed reasons, and stale `/chat/settings` inventory rows are removed.
+- [x] #4 Focused route Vitest and Playwright route metadata smoke checks pass; full TypeScript baseline result is recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added route-governance metadata coverage as a deterministic Vitest guard for shared option-route metadata, active smoke inventory metadata ownership, skipped inventory reasons, included smoke route inventory presence, duplicate page inventory paths, and smoke-excluded alias handling.
+
+The red phase exposed 23 active inventory routes without metadata, two stale `/chat/settings` entries, and five active redirect aliases. Added metadata for Next-only admin/auth/billing/connector/marketing/agent/media redirect pages and marked redirect aliases as skipped in `page-inventory.ts`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the first WP12 route-governance slice. Added deterministic metadata/inventory coverage for duplicate smoke inventory paths, shared option-route metadata ownership, active and skipped smoke inventory metadata ownership, active inclusion for `smoke: "include"` web routes, and prevention of active smoke runs for `smoke: "exclude"` alias rows. Added missing route metadata for Next-only admin, hosted auth/billing, connector placeholder, marketing landing, legacy agent, and dynamic media redirect pages. Removed stale `/chat/settings` smoke entries and marked redirect aliases as skipped in page inventory. Verification: focused route Vitest suite passed (21 tests), Playwright route metadata smoke contract passed (3 tests), `git diff --check` passed, targeted ESLint exited 0 with package-base ignore warnings for shared UI files, and full `bunx tsc --noEmit` was attempted but failed on existing unrelated baseline errors outside the touched route governance files. Bandit skipped because this slice touched TypeScript/Markdown only and no Python code.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.10.1.1 - Address-PR-1953-route-governance-review-comments.md
+++ b/backlog/tasks/task-418.10.1.1 - Address-PR-1953-route-governance-review-comments.md
@@ -1,0 +1,71 @@
+---
+id: TASK-418.10.1.1
+title: Address PR 1953 route governance review comments
+status: Done
+labels:
+- wp12
+- review
+- webui
+priority: High
+parent_task_id: TASK-418.10.1
+references:
+- https://github.com/rmusser01/tldw_server/pull/1953
+modified_files:
+- apps/packages/ui/src/routes/__tests__/route-registry-ast-helpers.ts
+- apps/packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.visibility.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-availability.test.ts
+- apps/packages/ui/src/routes/route-metadata.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve PR 1953 review feedback for the WP12 route governance slice: normalized smoke inventory duplicate detection, shared route-registry AST helpers, dynamic-route metadata coverage, robust test path resolution, and /chat/agent canonical path cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Governance duplicate checks use the same path normalization semantics as route metadata lookup.
+- [x] #2 Route-registry AST parsing helpers are shared by the affected route tests instead of duplicated.
+- [x] #3 Parameterized shared option routes are covered by route metadata governance.
+- [x] #4 /chat/agent canonical path points directly to the main web Agents surface.
+- [x] #5 Focused route governance tests and smoke metadata contract pass, or any unrelated baseline failures are documented.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Resolved PR 1953 review feedback by:
+
+- Sharing route-registry AST parsing helpers across the governance, visibility, and sidepanel availability tests.
+- Resolving route-registry fixtures relative to the test file instead of using working-directory candidate lists.
+- Exporting and reusing `normalizeRoutePath` for smoke inventory duplicate detection.
+- Covering dynamic shared option routes with metadata: `/sources/:sourceId`, `/share/:token`, `/knowledge/thread/:threadId`, `/knowledge/shared/:shareToken`, and `/presentation-studio/:projectId`.
+- Canonicalizing `/chat/agent` directly to `/agents`.
+
+Verification:
+
+- `bunx vitest run ../packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts ../packages/ui/src/routes/__tests__/route-metadata.coverage.test.ts ../packages/ui/src/routes/__tests__/route-registry.visibility.test.ts ../packages/ui/src/routes/__tests__/route-registry.sidepanel-availability.test.ts`: 21 passed.
+- `bunx playwright test e2e/smoke/route-contract-stage2.spec.ts --grep "Route metadata smoke inventory contract" --reporter=line`: 3 passed after escalated local server bind.
+- `git diff --check`: passed.
+- `bunx tsc --noEmit`: still fails on existing baseline issues outside touched route-governance files (MediaReadAlongPopover, Watchlists quick setup/run drawer, WorkspacePlayground, shortcut config, persona live control, admin llamacpp e2e typing).
+- Bandit skipped: touched files are TypeScript tests/metadata and Backlog task records only.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all current PR 1953 review comments for the WP12 route governance slice: duplicate route inventory checks now normalize paths, AST route extraction is shared, dynamic routes are governed by metadata, path resolution is test-file-relative, and /chat/agent now canonicalizes to /agents.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Adds WP12 route-governance metadata coverage for shared option routes, smoke inventory ownership, skipped route reasons, duplicate inventory paths, and smoke-excluded alias handling.
- Adds explicit route metadata for Next-only admin, hosted auth/billing, connector placeholder, marketing landing, legacy agent, and dynamic route pages.
- Removes stale `/chat/settings` smoke inventory rows and marks redirect aliases as skipped with metadata-backed reasons.
- Addresses review feedback by sharing route-registry AST helpers, normalizing duplicate checks with the metadata normalizer, resolving test fixtures relative to test files, covering parameterized route placeholders, and canonicalizing `/chat/agent` to `/agents`.

## Validation

- [x] `bunx vitest run ../packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts ../packages/ui/src/routes/__tests__/route-metadata.coverage.test.ts ../packages/ui/src/routes/__tests__/route-registry.visibility.test.ts ../packages/ui/src/routes/__tests__/route-registry.sidepanel-availability.test.ts`
- [x] `bunx playwright test e2e/smoke/route-contract-stage2.spec.ts --grep "Route metadata smoke inventory contract" --reporter=line`
- [x] `git diff --check`
- [x] Targeted ESLint from `apps/tldw-frontend` exited 0 but reported shared UI package files as ignored because they are outside that app's ESLint base path.
- [ ] `bunx tsc --noEmit` currently fails on existing baseline errors outside this slice: read-along popover scope typing, Watchlists quick setup/run stats typing, Workspace Playground capability predicate typing, shortcut config persistence typing, Persona live control narrowing, and llama.cpp E2E fixture typing.

## UX Audit Checklist (v2 Stage 5)

- [x] Smoke tests: route metadata smoke inventory contract passes for included routes, internal QA/debug exclusions, and alias-to-canonical ownership.
- [x] Smoke tests: governance unit tests cover duplicate inventory paths, active/skipped metadata ownership, and smoke include/exclude consistency.
- [x] AntD deprecations: not applicable to this route-governance slice; no AntD UI components were changed.
- [x] Placeholder validation: connector child placeholders, hosted auth/billing placeholders, marketing landing pages, and redirect aliases now have explicit metadata ownership.
- [x] Placeholder validation: skipped redirect aliases remain out of active all-pages smoke runs while retaining metadata-backed reasons.
- [x] Flashcards items: route ownership remains unchanged and is covered by shared route metadata governance.
- [x] Watchlists items: Watchlists and admin Watchlists route metadata remain covered without changing Watchlists UI behavior.

## Watchlists Accessibility Checklist

- [x] No Watchlists UI, keyboard, focus, live-region, or form behavior changed in this PR.
- [x] Watchlists route labels/groups remain explicit in route metadata for recognition and navigation ownership.
- [x] Admin Watchlists item/run routes are classified as operator drill-down pages and hidden from default user navigation.

## Watchlists Scale Checklist

- [x] No Watchlists list rendering, filtering, pagination, polling, job execution, or bulk-action logic changed.
- [x] No Watchlists API contracts, database queries, queue behavior, or background processing paths changed.
- [x] Route governance only adds metadata coverage for Watchlists ownership and does not increase runtime route-rendering cost.

## Risk & Rollback

- Risk level: Low. The changes are limited to route metadata, smoke inventory classification, route-governance tests, and Backlog task documentation.
- Rollback plan: revert `3f9a6f908` and the earlier WP12 route-governance commits on this branch if route metadata governance causes unexpected smoke or registry behavior.
- Backend/API impact: none. No backend endpoints, schemas, migrations, auth behavior, or persisted data formats changed.

## Human Change Summary

Repository policy requires a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds route-governance metadata coverage and aligns the smoke page inventory so routes are classified, deduplicated, and tested deterministically. Addresses WP12 review feedback by normalizing path checks, sharing AST helpers, and covering key dynamic routes.

- **New Features**
  - Added a Vitest guard that checks shared option routes, duplicate inventory paths, required metadata for active/skipped entries, and inclusion/exclusion rules.
  - Expanded `route-metadata` with Next-only admin, hosted auth/billing, connector placeholders, audience landing pages, legacy agent chat (canonicalized to `/agents`), dynamic media view redirect, and dynamic routes (`/sources/:sourceId`, `/share/:token`, `/knowledge/thread/:threadId`, `/knowledge/shared/:shareToken`, `/presentation-studio/:projectId`).
  - Updated Playwright page inventory: removed `/chat/settings`; marked alias/redirect routes (e.g., `/media/123/view`, legacy workspace/knowledge/audio aliases) as skipped with metadata-backed reasons.

- **Refactors**
  - Introduced shared route-registry AST helpers for tests and exported `normalizeRoutePath` for consistent duplicate detection.
  - Tests now resolve registries relative to test files and filter by `kind` (options/sidepanel) for precise coverage. Linked to the WP12 backlog task for traceability.

<sup>Written for commit 3f9a6f9086e43f30f0f6f6726b809a5493cd3e83. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1953?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->
