### PR TITLE
Migrate document workspace page alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -44,28 +44,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentWorkspacePage.tsx:Alert#antd-alert-documentworkspacepage-type-info-line-949-1t584x5",
-    "path": "src/components/DocumentWorkspace/DocumentWorkspacePage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentWorkspacePage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentWorkspacePage.tsx:Alert#antd-alert-documentworkspacepage-type-warning-line-985-1jwh7qr",
-    "path": "src/components/DocumentWorkspace/DocumentWorkspacePage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/DocumentWorkspace/DocumentWorkspacePage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-errorstate-line-413-wx7ci2",
     "path": "src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
@@ -66,6 +66,7 @@ export const PdfDocument: React.FC<PdfDocumentProps> = ({
   onPageChange,
   pdfDocumentRef
 }) => {
+  const { t } = useTranslation(["option"])
   const [numPages, setNumPages] = useState<number>(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
@@ -992,9 +992,9 @@ export const DocumentWorkspacePage: React.FC = () => {
         >
           <div className="space-y-1">
             <ul className="list-disc pl-5">
-              {healthIssues.map((issue, index) => (
-                <li key={`${index}-${issue}`}>{issue}</li>
-              ))}
+            {healthIssues.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
             </ul>
             <div className="text-xs text-text-muted">
               {t(

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, Suspense } from "react
 import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 import { useStorage } from "@plasmohq/storage/hook"
-import { Alert, Drawer, Dropdown, Modal, notification, Tabs, Tooltip } from "antd"
+import { Drawer, Dropdown, Modal, notification, Tabs, Tooltip } from "antd"
 import {
   FileText,
   MessageSquare,
@@ -23,6 +23,7 @@ import {
   ChevronDown,
   CircleHelp
 } from "lucide-react"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { useDocumentWorkspaceStore } from "@/store/document-workspace"
 import { useMobile, useTablet } from "@/hooks/useMediaQuery"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
@@ -946,18 +947,18 @@ export const DocumentWorkspacePage: React.FC = () => {
   const loadingAlert =
     loadingDocumentId !== null ? (
       <div className="px-4 pt-2">
-        <Alert
-          type="info"
-          showIcon
+        <DesignSystemAlert
+          variant="info"
           title={t(
             "option:documentWorkspace.loadingDocument",
             "Loading document..."
           )}
-          description={t(
+        >
+          {t(
             "option:documentWorkspace.loadingDocumentHint",
             "Fetching the document file. This can take a moment for large files."
           )}
-        />
+        </DesignSystemAlert>
       </div>
     ) : null
 
@@ -982,29 +983,27 @@ export const DocumentWorkspacePage: React.FC = () => {
   const healthAlert =
     healthIssues.length > 0 ? (
       <div className="px-4 pt-2">
-        <Alert
-          type="warning"
-          showIcon
+        <DesignSystemAlert
+          variant="warning"
           title={t(
             "option:documentWorkspace.healthWarningTitle",
             "Document workspace storage unavailable"
           )}
-          description={
-            <div className="space-y-1">
-              <ul className="list-disc pl-5">
-                {healthIssues.map((issue, index) => (
-                  <li key={`${index}-${issue}`}>{issue}</li>
-                ))}
-              </ul>
-              <div className="text-xs text-text-muted">
-                {t(
-                  "option:documentWorkspace.healthWarningHint",
-                  "Some workspace features are temporarily unavailable. This usually resolves after restarting the server. If this persists, contact your administrator."
-                )}
-              </div>
+        >
+          <div className="space-y-1">
+            <ul className="list-disc pl-5">
+              {healthIssues.map((issue, index) => (
+                <li key={`${index}-${issue}`}>{issue}</li>
+              ))}
+            </ul>
+            <div className="text-xs text-text-muted">
+              {t(
+                "option:documentWorkspace.healthWarningHint",
+                "Some workspace features are temporarily unavailable. This usually resolves after restarting the server. If this persists, contact your administrator."
+              )}
             </div>
-          }
-        />
+          </div>
+        </DesignSystemAlert>
       </div>
     ) : null
 

--- a/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentWorkspacePageAlerts.design-system.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentWorkspacePageAlerts.design-system.test.tsx
@@ -1,0 +1,199 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DocumentWorkspacePage } from "../DocumentWorkspacePage"
+
+const testState = vi.hoisted(() => ({
+  workspace: {} as Record<string, unknown>,
+  searchParams: new URLSearchParams(),
+  getMediaDetails: vi.fn(() => new Promise(() => {})),
+  setSearchParams: vi.fn(),
+  setStorage: vi.fn(),
+  retrySync: vi.fn(),
+  forceSync: vi.fn(),
+  forceSave: vi.fn(),
+  messageError: vi.fn()
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key
+  })
+}))
+
+vi.mock("react-router-dom", () => ({
+  useSearchParams: () => [testState.searchParams, testState.setSearchParams]
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: () => [false, testState.setStorage]
+}))
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMobile: () => false,
+  useTablet: () => false
+}))
+
+vi.mock("@/hooks/useAntdMessage", () => ({
+  useAntdMessage: () => ({
+    error: testState.messageError
+  })
+}))
+
+vi.mock("@/store/document-workspace", () => ({
+  useDocumentWorkspaceStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(testState.workspace)
+}))
+
+vi.mock("@/hooks/document-workspace", () => ({
+  useAnnotations: vi.fn(),
+  useAnnotationSync: () => ({
+    retrySync: testState.retrySync,
+    forceSync: testState.forceSync
+  }),
+  useAnnotationSyncOnClose: vi.fn(),
+  useReadingProgress: vi.fn(),
+  useReadingProgressAutoSave: () => ({
+    forceSave: testState.forceSave
+  }),
+  useReadingProgressSaveOnClose: vi.fn(),
+  useResizablePanel: () => ({
+    width: 320,
+    handleMouseDown: vi.fn()
+  })
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: vi.fn()
+}))
+
+vi.mock("@/services/tldw", () => ({
+  tldwClient: {
+    getMediaDetails: testState.getMediaDetails
+  }
+}))
+
+vi.mock("antd", () => ({
+  Drawer: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  Dropdown: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  Modal: {
+    confirm: vi.fn()
+  },
+  notification: {
+    info: vi.fn(),
+    destroy: vi.fn()
+  },
+  Tabs: ({ items }: { items?: Array<{ key: string; children?: React.ReactNode }> }) => (
+    <div>
+      {items?.map((item) => (
+        <div key={item.key}>{item.children}</div>
+      ))}
+    </div>
+  ),
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock("../DocumentWorkspaceErrorBoundary", () => ({
+  DocumentWorkspaceErrorBoundary: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  )
+}))
+
+vi.mock("../DocumentShortcutsModal", () => ({
+  DocumentShortcutsModal: () => null
+}))
+
+vi.mock("../DocumentTabBar", () => ({
+  DocumentTabBar: () => null
+}))
+
+vi.mock("../SyncStatusIndicator", () => ({
+  SyncStatusIndicator: () => null
+}))
+
+vi.mock("../WorkspaceTips", () => ({
+  WorkspaceTour: () => null,
+  HighlightTip: () => null,
+  MultiDocTip: () => null,
+  resetTour: vi.fn(),
+  resetAllTips: vi.fn()
+}))
+
+vi.mock("../DocumentViewer", () => ({
+  DocumentViewer: () => <div data-testid="document-viewer" />
+}))
+
+vi.mock("../DocumentPickerModal", () => ({
+  default: () => null
+}))
+
+const createWorkspaceState = (
+  overrides: Partial<Record<string, unknown>> = {}
+): Record<string, unknown> => ({
+  activeDocumentId: null,
+  openDocuments: [],
+  openDocument: vi.fn(),
+  annotationsHealth: "ready",
+  progressHealth: "ready",
+  closeDocument: vi.fn(),
+  undoCloseDocument: vi.fn(),
+  annotationSyncStatus: "idle",
+  recentlyClosed: [],
+  ...overrides
+})
+
+const findRenderedAlert = async (container: HTMLElement, text: string) =>
+  waitFor(() => {
+    const alert = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="alert"], [role="status"]')
+    ).find((node) => node.textContent?.includes(text))
+
+    expect(alert).toBeTruthy()
+    return alert as HTMLElement
+  })
+
+describe("DocumentWorkspacePage design-system alerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    testState.workspace = createWorkspaceState()
+    testState.searchParams = new URLSearchParams()
+    testState.getMediaDetails.mockImplementation(() => new Promise(() => {}))
+  })
+
+  it("renders the auto-open loading state through the design-system Alert", async () => {
+    testState.searchParams = new URLSearchParams("open=42")
+
+    const { container } = render(<DocumentWorkspacePage />)
+
+    const loadingAlert = await findRenderedAlert(container, "Loading document...")
+    expect(loadingAlert).toHaveTextContent("Loading document...")
+    expect(loadingAlert).toHaveTextContent(
+      "Fetching the document file. This can take a moment for large files."
+    )
+    expect(loadingAlert.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+
+  it("renders workspace storage health issues through the design-system Alert", () => {
+    testState.workspace = createWorkspaceState({
+      annotationsHealth: "error",
+      progressHealth: "error"
+    })
+
+    const { container } = render(<DocumentWorkspacePage />)
+
+    const healthMessage = screen.getByText("Document workspace storage unavailable")
+    expect(healthMessage.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(screen.getByText("Annotations storage is unavailable on the server."))
+      .toBeInTheDocument()
+    expect(screen.getByText("Reading progress storage is unavailable on the server."))
+      .toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Some workspace features are temporarily unavailable. This usually resolves after restarting the server. If this persists, contact your administrator."
+      )
+    ).toBeInTheDocument()
+    expect(container.querySelectorAll('[data-ds-component="Alert"]')).toHaveLength(1)
+  })
+})

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -37,8 +37,8 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created and completed TASK-45.44.10.1 for the first narrow Document/Workspace slice: DocumentPickerModal Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1950. Before/after product-state verifier evidence in that child task reduced total baseline exceptions from 303 to 300 and Document/Workspace exceptions from 12 to 9.
 - Created and completed TASK-45.44.10.2 for the next narrow Document/Workspace slice: DocumentViewer PDF/EPUB Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1952. Verifier evidence after the slice reduces total baseline exceptions from 300 to 296 and Document/Workspace exceptions from 9 to 5.
-- Created TASK-45.44.10.3 for the next narrow Document/Workspace slice: DocumentWorkspacePage loading/health Alert migration. Initial verifier evidence after the slice reduces total baseline exceptions from 296 to 294 and Document/Workspace exceptions from 5 to 3.
-- Created TASK-45.44.10.4 to fix the merged PdfDocument design-system Alert translation binding discovered by the TypeScript check.
+- Created and completed TASK-45.44.10.3 for the next narrow Document/Workspace slice: DocumentWorkspacePage loading/health Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1955. Verifier evidence after the slice reduces total baseline exceptions from 296 to 294 and Document/Workspace exceptions from 5 to 3.
+- Created and completed TASK-45.44.10.4 to fix the merged PdfDocument design-system Alert translation binding discovered by the TypeScript check. PR: https://github.com/rmusser01/tldw_server/pull/1955.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -37,6 +37,8 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created and completed TASK-45.44.10.1 for the first narrow Document/Workspace slice: DocumentPickerModal Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1950. Before/after product-state verifier evidence in that child task reduced total baseline exceptions from 303 to 300 and Document/Workspace exceptions from 12 to 9.
 - Created and completed TASK-45.44.10.2 for the next narrow Document/Workspace slice: DocumentViewer PDF/EPUB Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1952. Verifier evidence after the slice reduces total baseline exceptions from 300 to 296 and Document/Workspace exceptions from 9 to 5.
+- Created TASK-45.44.10.3 for the next narrow Document/Workspace slice: DocumentWorkspacePage loading/health Alert migration. Initial verifier evidence after the slice reduces total baseline exceptions from 296 to 294 and Document/Workspace exceptions from 5 to 3.
+- Created TASK-45.44.10.4 to fix the merged PdfDocument design-system Alert translation binding discovered by the TypeScript check.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.3 - Migrate-DocumentWorkspacePage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.10.3 - Migrate-DocumentWorkspacePage-alerts-to-design-system-Alert.md
@@ -1,0 +1,77 @@
+---
+id: TASK-45.44.10.3
+title: Migrate DocumentWorkspacePage alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- document-workspace
+priority: medium
+parent_task_id: TASK-45.44.10
+references:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentWorkspacePageAlerts.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Document and Workspace product-state design-system migration by replacing the remaining AntD Alert product-state surfaces in DocumentWorkspacePage with the shared design-system Alert primitive. Keep scope limited to the page-level Alert states, focused tests, and removal of matching baseline entries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 DocumentWorkspacePage no longer imports or renders AntD Alert for the page-level loading document state.
+- [x] #2 DocumentWorkspacePage no longer imports or renders AntD Alert for the page-level workspace storage health state.
+- [x] #3 Loading and health states render through the shared design-system Alert primitive.
+- [x] #4 The two matching DocumentWorkspacePage product-state baseline rows are removed without introducing unbaselined findings.
+- [x] #5 Focused page tests and product-state verifier checks are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing focused tests that assert the page-level loading and health states render through `data-ds-component="Alert"`.
+2. Replace the DocumentWorkspacePage AntD Alert usages with the shared design-system Alert primitive while preserving layout and copy.
+3. Remove the two migrated DocumentWorkspacePage Alert rows from the product-state baseline.
+4. Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red test evidence: `bunx vitest run src/components/DocumentWorkspace/__tests__/DocumentWorkspacePageAlerts.design-system.test.tsx --reporter=dot` failed on missing `data-ds-component="Alert"` ancestors for both page-level states.
+- Migrated only the loading document and workspace storage health Alert surfaces to the shared design-system Alert primitive. Layout, copy, auto-open mechanics, and health issue construction were left unchanged.
+- Removed two baseline rows for `DocumentWorkspacePage.tsx`, reducing the Document/Workspace product-state baseline count from 5 to 3.
+- Verification:
+  - `bunx vitest run src/components/DocumentWorkspace/__tests__/DocumentWorkspacePageAlerts.design-system.test.tsx --reporter=dot` passed: 2 tests.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 54 tests.
+  - `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"` passed.
+  - `bun run verify:design-system-state` passed with 294 baseline exceptions total and 3 remaining Document/Workspace exceptions.
+  - `git diff --check` passed.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI type debt outside the current page Alert migration.
+- Bandit is not applicable to this UI-only TypeScript/React slice; no Python files were touched.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the DocumentWorkspacePage loading and workspace storage health Alert states from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both states, and removed the two matching baseline entries.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.10.3 - Migrate-DocumentWorkspacePage-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.10.3 - Migrate-DocumentWorkspacePage-alerts-to-design-system-Alert.md
@@ -10,6 +10,7 @@ labels:
 priority: medium
 parent_task_id: TASK-45.44.10
 references:
+- https://github.com/rmusser01/tldw_server/pull/1955
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
@@ -63,7 +64,7 @@ Continue the Document and Workspace product-state design-system migration by rep
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the DocumentWorkspacePage loading and workspace storage health Alert states from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both states, and removed the two matching baseline entries.
+Migrated the DocumentWorkspacePage loading and workspace storage health Alert states from AntD Alert to the shared design-system Alert primitive, added focused regression coverage for both states, and removed the two matching baseline entries. PR: https://github.com/rmusser01/tldw_server/pull/1955.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.4 - Fix-PdfDocument-design-system-Alert-translation-binding.md
+++ b/backlog/tasks/task-45.44.10.4 - Fix-PdfDocument-design-system-Alert-translation-binding.md
@@ -10,6 +10,7 @@ labels:
 priority: medium
 parent_task_id: TASK-45.44.10
 references:
+- https://github.com/rmusser01/tldw_server/pull/1955
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx
 modified_files:
@@ -51,7 +52,7 @@ Fix the missing translation function binding in PdfDocument introduced by the pr
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed the merged PdfDocument design-system Alert translation binding by calling `useTranslation` in the component before using `t(...)`.
+Fixed the merged PdfDocument design-system Alert translation binding by calling `useTranslation` in the component before using `t(...)`. PR: https://github.com/rmusser01/tldw_server/pull/1955.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.4 - Fix-PdfDocument-design-system-Alert-translation-binding.md
+++ b/backlog/tasks/task-45.44.10.4 - Fix-PdfDocument-design-system-Alert-translation-binding.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.44.10.4
+title: Fix PdfDocument design-system Alert translation binding
+status: Done
+labels:
+- design-system
+- webui
+- typescript
+- document-workspace
+priority: medium
+parent_task_id: TASK-45.44.10
+references:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx
+modified_files:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the missing translation function binding in PdfDocument introduced by the previous design-system Alert migration so the merged dev branch no longer has a direct cannot-find-name TypeScript error in the DocumentViewer alert code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PdfDocument binds the existing `useTranslation` hook before calling `t(...)` in design-system Alert content.
+- [x] #2 Focused DocumentViewer alert regression coverage still passes.
+- [x] #3 TypeScript check no longer reports the direct `PdfDocument.tsx` cannot-find-name `t` errors.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Use the existing react-i18next import by binding `t` inside PdfDocument before rendered Alert states call it.
+2. Run the focused DocumentViewer alert regression test and TypeScript check evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red evidence: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` reported `src/components/DocumentWorkspace/DocumentViewer/PdfViewer/PdfDocument.tsx(416,12): error TS2304: Cannot find name 't'.` and the same error at line 455.
+- Bound `const { t } = useTranslation(["option"])` inside `PdfDocument`, using the existing import.
+- Verification:
+  - `bunx vitest run src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx --reporter=dot` passed: 4 tests.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI type debt, but the direct `PdfDocument.tsx` missing-`t` errors are no longer present.
+- Bandit is not applicable to this UI-only TypeScript/React fix; no Python files were touched.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the merged PdfDocument design-system Alert translation binding by calling `useTranslation` in the component before using `t(...)`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replace the DocumentWorkspacePage loading-document and storage-health AntD Alert states with the shared design-system Alert primitive.
- Add focused regression coverage for both page-level states rendering through the design-system Alert marker.
- Remove the two migrated DocumentWorkspacePage baseline rows, reducing Document/Workspace exceptions from 5 to 3 and total baseline exceptions from 296 to 294.
- Fix the merged PdfDocument Alert translation binding so the previous missing t TypeScript errors are removed.

## Verification
- bunx vitest run src/components/DocumentWorkspace/__tests__/DocumentWorkspacePageAlerts.design-system.test.tsx --reporter=dot
- bunx vitest run src/components/DocumentWorkspace/DocumentViewer/__tests__/DocumentViewerAlerts.design-system.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- node -e "JSON.parse(require("fs").readFileSync("apps/packages/ui/scripts/design-system-product-state-baseline.json","utf8")); console.log("baseline json ok")"
- bun run verify:design-system-state
- git diff --check

## Known existing debt
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still fails on existing UI-wide TypeScript debt. The direct PdfDocument missing-t errors found on dev are no longer present.

Change summary: This keeps the migration scoped to the two remaining DocumentWorkspacePage Alert product states, preserves the existing loading and health-state behavior, and removes only the matching baseline rows so the guard count remains accurate. The small PdfDocument binding fix is included because the TypeScript check exposed a direct issue from the previously merged design-system Alert migration.