### PR TITLE
Add chat assistant overlays and tracked identity controls

### DIFF
--- a/Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
@@ -1,0 +1,596 @@
+# Chat Character Overlay And Tracked Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve existing tracked character/persona chats while adding snapshot-based, non-destructive character/persona personality overlays for normal `/chat` conversations, with the main control surface in a side rail.
+
+**Architecture:** Keep the current tracked chat contract intact and add a separate `assistantOverlay` settings contract for normal chats. Resolve effective assistant mode from tracked chat metadata plus chat settings, route tracked and overlay sends differently, and add a right-rail control surface that reuses the existing picker and chat shell instead of replacing them.
+
+**Tech Stack:** React, TypeScript, Next.js route wrappers, shared `@/components` UI package, Plasmo/local storage utilities, FastAPI, Pydantic validation, pytest, Vitest, Testing Library, Browser plugin or Playwright for final UI verification.
+
+---
+
+## Source Spec
+
+- Design spec: `Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md`
+- Design Backlog task: `TASK-444`
+
+## Scope Constraints
+
+- Keep existing tracked character chats and tracked persona chats behaviorally unchanged.
+- Overlay is **snapshot-on-apply**, not live re-resolution.
+- Overlay lives in chat settings, not in tracked chat identity fields.
+- `Start tracked character/persona chat` uses tracked defaults; current plain-chat overlay, scene, style, and context do not implicitly carry forward.
+- No route split for character chat.
+- No removal of the existing composer, left sidebar, knowledge section, or artifacts panel.
+- No backend tracked chat contract rewrite.
+- Extension parity should reuse the same state contract, but desktop rail work lands first.
+
+## File Map
+
+### Existing Files To Modify
+
+- `apps/packages/ui/src/types/chat-session-settings.ts`
+  - Add `assistantOverlay` with explicit snapshot semantics.
+
+- `apps/packages/ui/src/services/chat-settings.ts`
+  - Normalize, persist, sync, and merge `assistantOverlay`.
+  - Preserve local-before-server-chat behavior.
+
+- `apps/packages/ui/src/hooks/useMessageOption.tsx`
+  - Remove destructive reset behavior keyed to assistant selection changes.
+
+- `apps/packages/ui/src/hooks/chat/useSelectServerChat.ts`
+  - Hydrate tracked state without making global selected assistant the active-chat truth.
+
+- `apps/packages/ui/src/hooks/useMessage.tsx`
+  - Route send behavior by effective assistant mode.
+
+- `apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts`
+  - Inject overlay personality snapshot with deterministic prompt ordering.
+
+- `apps/packages/ui/src/components/Common/AssistantSelect.tsx`
+  - Keep summary picker behavior intact while supporting rail-driven overlay apply.
+
+- `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+  - Render the desktop character-control rail inside the existing `/chat` shell.
+
+- `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+  - Add rail entry/status wiring where needed without rehoming the composer.
+
+- `apps/packages/ui/src/store/chat-surface-coordinator.ts`
+  - Add rail panel state.
+
+- `apps/packages/ui/src/routes/sidepanel-chat.tsx`
+  - Reuse the same effective-mode and overlay settings contract for extension chat flows.
+
+- `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
+  - Add sheet/drawer presentation for character controls if the sidepanel requires local UI glue.
+
+- `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+  - Validate `assistantOverlay` in chat settings payloads.
+
+### New Files To Create
+
+- `apps/packages/ui/src/hooks/chat/effective-assistant-state.ts`
+  - Pure resolver for `plain | overlay | tracked_character | tracked_persona`.
+
+- `apps/packages/ui/src/utils/assistant-overlay.ts`
+  - Build snapshot-on-apply overlay payloads from full character/persona detail.
+
+- `apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx`
+  - Main desktop character/persona control surface for `/chat`.
+
+- `apps/packages/ui/src/components/Option/Playground/CharacterControlRailSheet.tsx`
+  - Mobile/compact presentation wrapper if `Playground` already uses sheet patterns elsewhere.
+
+### New Or Modified Tests
+
+- `apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts`
+- `apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts`
+- `apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts`
+- `apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx`
+- `apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts`
+- `apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx`
+- `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx`
+- `apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts`
+- `apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx`
+- `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts`
+- `tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py`
+- `tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py`
+
+## Task 0: Execution Setup And Tracking
+
+**Files:**
+- Backlog tasks only unless the implementation branch setup requires a note in the design task.
+
+- [ ] **Step 1: Confirm branch and worktree state**
+
+Run:
+```bash
+git branch --show-current
+git status --short
+```
+
+Expected:
+- You know whether implementation needs a dedicated branch or worktree.
+- You do not stage unrelated dirty files.
+
+- [ ] **Step 2: Create implementation Backlog tasks**
+
+Use Backlog MCP or CLI to create:
+- parent task: `Implement chat character overlay and tracked identity`
+- child task 1: `Add chat assistant overlay settings contract and validation`
+- child task 2: `Add effective assistant mode resolver and remove destructive reset`
+- child task 3: `Implement overlay send-path and snapshot-on-apply behavior`
+- child task 4: `Add desktop character control rail`
+- child task 5: `Add sidepanel/mobile parity and final verification`
+
+Expected:
+- Each code-edit stage has a task before code changes begin.
+
+- [ ] **Step 3: Link this plan in the active Backlog tasks**
+
+Record:
+- `Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md`
+- `Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md`
+
+Expected:
+- Task records point at both the design spec and the implementation plan.
+
+- [ ] **Step 4: Commit task-tracking changes only if task files changed**
+
+Run:
+```bash
+git status --short backlog/tasks
+git add <exact implementation task files created in Step 2>
+git commit -m "chore: track chat overlay implementation tasks"
+```
+
+Expected:
+- Backlog tracking lands separately from code when practical.
+
+## Task 1: Add Overlay Settings Contract And Backend Validation
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/chat-session-settings.ts`
+- Modify: `apps/packages/ui/src/services/chat-settings.ts`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+- Test: `apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts`
+- Test: `apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts`
+- Test: `tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py`
+- Test: `tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py`
+
+- [ ] **Step 1: Write failing frontend tests for overlay normalization and local-first persistence**
+
+Add tests for:
+- accepting `assistantOverlay.system_prompt_snapshot`
+- rejecting malformed overlay payloads at normalization time
+- persisting overlay under `scratch` / `local:<historyId>` before `serverChatId` exists
+- reconciling local overlay into server-backed settings once a chat id exists
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts
+```
+
+Expected:
+- FAIL because `assistantOverlay` is not yet typed/normalized/synced.
+
+- [ ] **Step 2: Write failing backend tests for overlay settings roundtrip and validation**
+
+Add tests for:
+- successful `PUT /api/v1/chats/{id}/settings` roundtrip with `assistantOverlay`
+- rejection when `assistantOverlay.kind` is invalid
+- rejection when `assistantOverlay.system_prompt_snapshot` is the wrong type or oversize
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py -k "assistant_overlay or overlay" -v
+```
+
+Expected:
+- FAIL because backend validation does not yet know about `assistantOverlay`.
+
+- [ ] **Step 3: Implement the frontend settings contract**
+
+Implement:
+- `assistantOverlay` type in `ChatSettingsRecord`
+- optional-keys inclusion and coercion in `chat-settings.ts`
+- comparable merge behavior so timestamp-only differences do not force unnecessary writes
+
+Keep:
+- existing deep-research settings logic untouched
+- current `resolveChatSettingsKey()` semantics unchanged
+
+- [ ] **Step 4: Implement backend validation**
+
+Implement:
+- shape validation for `assistantOverlay.kind`, `id`, `name`, `avatar_url`, `system_prompt_snapshot`, `updatedAt`
+- bounded string checks consistent with the current settings payload style
+
+Do not:
+- add `assistantOverlay` to tracked chat identity models
+- repurpose `ChatSessionUpdate`
+
+- [ ] **Step 5: Run targeted frontend and backend tests**
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py -k "assistant_overlay or overlay" -v
+```
+
+Expected:
+- PASS on both suites.
+
+- [ ] **Step 6: Commit the settings-contract slice**
+
+Run:
+```bash
+git add apps/packages/ui/src/types/chat-session-settings.ts apps/packages/ui/src/services/chat-settings.ts apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py
+git commit -m "feat: add chat assistant overlay settings contract"
+```
+
+## Task 2: Add Effective Assistant Mode Resolution And Remove Destructive Resets
+
+**Files:**
+- Create: `apps/packages/ui/src/hooks/chat/effective-assistant-state.ts`
+- Modify: `apps/packages/ui/src/hooks/useMessageOption.tsx`
+- Modify: `apps/packages/ui/src/hooks/chat/useSelectServerChat.ts`
+- Test: `apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts`
+- Test: `apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Cover:
+- tracked character resolution from `assistant_kind + character_id`
+- tracked persona resolution from `assistant_kind + assistant_id`
+- overlay resolution from `settings.assistantOverlay`
+- plain resolution when neither exists
+- tracked modes winning over overlay when bad mixed data appears
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts
+```
+
+Expected:
+- FAIL because resolver does not exist.
+
+- [ ] **Step 2: Write failing hook test for non-destructive overlay changes**
+
+Cover:
+- changing overlay does not clear `messages`
+- changing overlay does not null `serverChatId`
+- changing overlay does not wipe `historyId`
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
+```
+
+Expected:
+- FAIL because the assistant-switch reset path is still destructive.
+
+- [ ] **Step 3: Implement the pure resolver**
+
+Implement:
+- one exported resolver with a stable return shape
+- no storage, no API calls, no React dependencies
+
+Return at minimum:
+- `mode`
+- `kind`
+- `id`
+- `displayName`
+- `avatarUrl`
+- `systemPromptSnapshot`
+- `source`
+
+- [ ] **Step 4: Replace destructive reset logic with conversation-keyed behavior**
+
+Update `useMessageOption.tsx` so resets happen only for actual conversation changes, not for overlay/assistant draft changes.
+
+Update `useSelectServerChat.ts` so:
+- tracked chat metadata still hydrates
+- global selected-assistant storage stops acting as the loaded chat’s source of truth
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx apps/packages/ui/src/hooks/__tests__/useMessageOption.selected-model-sync.test.tsx
+```
+
+Expected:
+- PASS, including existing selected-model sync coverage.
+
+- [ ] **Step 6: Commit the resolver/reset slice**
+
+Run:
+```bash
+git add apps/packages/ui/src/hooks/chat/effective-assistant-state.ts apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts apps/packages/ui/src/hooks/useMessageOption.tsx apps/packages/ui/src/hooks/chat/useSelectServerChat.ts apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
+git commit -m "fix: separate active assistant mode from destructive selection resets"
+```
+
+## Task 3: Implement Snapshot-On-Apply Overlay Resolution And Send Routing
+
+**Files:**
+- Create: `apps/packages/ui/src/utils/assistant-overlay.ts`
+- Modify: `apps/packages/ui/src/hooks/useMessage.tsx`
+- Modify: `apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts`
+- Modify as needed: `apps/packages/ui/src/components/Common/AssistantSelect.tsx`
+- Test: `apps/packages/ui/src/utils/__tests__/assistant-overlay.test.ts`
+- Test: `apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts`
+- Test: `apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx`
+
+- [ ] **Step 1: Write failing overlay snapshot tests**
+
+Cover:
+- persona overlay uses `getPersonaProfile()` detail, not catalog summary data
+- character overlay uses full character detail
+- stored payload captures `kind`, `id`, `name`, `avatar_url`, and `system_prompt_snapshot`
+- later source-record changes do not affect stored snapshot sends
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/utils/__tests__/assistant-overlay.test.ts
+```
+
+Expected:
+- FAIL because the snapshot builder does not exist.
+
+- [ ] **Step 2: Write failing prompt-ordering tests**
+
+Cover:
+- base system prompt resolves first
+- overlay snapshot appends second
+- actor/scene injection happens after overlay
+- web-search system message stays last
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts
+```
+
+Expected:
+- FAIL because normal chat mode does not yet encode overlay ordering.
+
+- [ ] **Step 3: Implement the snapshot-on-apply helper**
+
+Implement one helper that:
+- accepts `AssistantSelection`
+- fetches full detail via existing client methods
+- returns a normalized `assistantOverlay` payload for settings persistence
+
+Persona path:
+- use `tldwClient.getPersonaProfile(selection.id)`
+
+Character path:
+- use `tldwClient.getCharacter(selection.id, { forceRefresh: true })` only if the existing character summary lacks required prompt material
+
+Do not:
+- live re-resolve overlay during send
+- mutate tracked chat identity fields
+
+- [ ] **Step 4: Route sends by effective mode**
+
+Update `useMessage.tsx`:
+- `tracked_character` -> existing `characterChatMode`
+- `tracked_persona` -> existing persona-backed normal path
+- `overlay` -> `normalChatMode` with `assistantIdentity` and `systemPromptAppendix` from `assistantOverlay`
+- `plain` -> existing normal path
+
+Update `normalChatMode.ts` so overlay ordering is explicit and stable.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/utils/__tests__/assistant-overlay.test.ts apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+```
+
+Expected:
+- PASS, with persona overlay proving it uses detail fetch rather than summary-only catalog data.
+
+- [ ] **Step 6: Commit the send-path slice**
+
+Run:
+```bash
+git add apps/packages/ui/src/utils/assistant-overlay.ts apps/packages/ui/src/utils/__tests__/assistant-overlay.test.ts apps/packages/ui/src/hooks/useMessage.tsx apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts apps/packages/ui/src/components/Common/AssistantSelect.tsx apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+git commit -m "feat: add snapshot-based assistant overlay send path"
+```
+
+## Task 4: Add The Desktop Character Control Rail
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Playground/Playground.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+- Modify: `apps/packages/ui/src/store/chat-surface-coordinator.ts`
+- Test: `apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx`
+- Test: `apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts`
+
+- [ ] **Step 1: Write failing rail panel-state tests**
+
+Cover:
+- new `character-control` panel id registers cleanly
+- opening the rail does not break existing panel exclusivity rules
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts
+```
+
+Expected:
+- FAIL because the new panel id does not yet exist.
+
+- [ ] **Step 2: Write failing UI tests for overlay/tracked actions**
+
+Cover:
+- rail shows current mode summary
+- apply overlay action writes overlay
+- clear overlay preserves the thread
+- tracked actions are clearly separate from overlay actions
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
+```
+
+Expected:
+- FAIL because the rail does not exist.
+
+- [ ] **Step 3: Implement the rail shell and panel wiring**
+
+Implement:
+- new panel id in `chat-surface-coordinator.ts`
+- desktop rail rendering in `Playground.tsx`
+- minimal integration points in `PlaygroundForm.tsx` for status/entry
+
+Keep:
+- left history sidebar unchanged
+- composer available
+- no starter cards or route-level mode split
+
+- [ ] **Step 4: Implement rail actions**
+
+Wire:
+- `Apply overlay`
+- `Change overlay`
+- `Clear overlay`
+- `Start tracked character chat`
+- `Start tracked persona chat`
+- `Open tracked session`
+
+Honor:
+- tracked defaults win on tracked-start actions
+- overlay writes stay in settings only
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
+```
+
+Expected:
+- PASS with no regressions in existing coordinator behavior.
+
+- [ ] **Step 6: Commit the desktop-rail slice**
+
+Run:
+```bash
+git add apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx apps/packages/ui/src/components/Option/Playground/Playground.tsx apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx apps/packages/ui/src/store/chat-surface-coordinator.ts apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
+git commit -m "feat: add chat character control rail"
+```
+
+## Task 5: Add Sidepanel/Mobile Parity, Then Verify End-To-End
+
+**Files:**
+- Create if needed: `apps/packages/ui/src/components/Option/Playground/CharacterControlRailSheet.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-chat.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
+- Modify as needed: `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
+- Test: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts`
+- Test: `apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts`
+- Test: `apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts`
+
+- [ ] **Step 1: Write failing parity tests**
+
+Cover:
+- sidepanel can read the same effective assistant mode contract
+- overlay state survives sidepanel/local-chat hydration
+- mobile/sheet entry exposes overlay apply/change/clear actions
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts
+```
+
+Expected:
+- FAIL because sidepanel does not yet reuse the new contract everywhere it needs to.
+
+- [ ] **Step 2: Implement compact/sheet presentation and shared state wiring**
+
+Implement:
+- sheet/drawer wrapper if required for narrow layouts
+- sidepanel glue that reuses the same resolver and overlay settings contract
+
+Do not:
+- fork the overlay state model for extension
+- invent a separate route mode for character overlay
+
+- [ ] **Step 3: Run targeted frontend regression tests**
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/Playground.responsive-parity.guard.test.ts
+```
+
+Expected:
+- PASS with shared overlay semantics across desktop and sidepanel chat.
+
+- [ ] **Step 4: Run backend and frontend focused verification sweep**
+
+Run:
+```bash
+bunx vitest run apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py -k "assistant_overlay or overlay" -v
+```
+
+Expected:
+- PASS on all targeted suites.
+
+- [ ] **Step 5: Run Bandit on touched backend scope**
+
+Run:
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py -f json -o /tmp/bandit_chat_overlay.json
+```
+
+Expected:
+- No new findings in touched backend code.
+- If findings appear, fix them before moving on.
+
+- [ ] **Step 6: Verify in the browser**
+
+Use Browser plugin or Playwright against the local WebUI:
+
+Desktop checks:
+1. Open `/chat`.
+2. Start a plain chat, apply overlay before first send, reload, verify overlay persists.
+3. Send messages, change overlay mid-thread, verify history/chat id stay stable.
+4. Open a tracked character chat and verify existing tracked behavior is unchanged.
+
+Sidepanel/mobile checks:
+1. Open sidepanel chat.
+2. Apply overlay from compact controls.
+3. Verify no thread reset and correct rehydration.
+
+Expected:
+- Overlay and tracked modes remain clearly distinct.
+- No starter-card dependency appears.
+
+- [ ] **Step 7: Commit parity/hardening**
+
+Run:
+```bash
+git add <CharacterControlRailSheet.tsx if created> apps/packages/ui/src/routes/sidepanel-chat.tsx apps/packages/ui/src/components/Sidepanel/Chat/form.tsx apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts
+git commit -m "feat: add chat overlay parity and verification coverage"
+```
+
+## Done Checklist
+
+- [ ] Tracked character chats still behave exactly as before.
+- [ ] Tracked persona chats still behave exactly as before.
+- [ ] Plain chats can apply overlay before first send.
+- [ ] Overlay changes do not reset thread state.
+- [ ] Overlay is snapshot-on-apply, not live re-resolution.
+- [ ] Tracked-start actions use tracked defaults rather than carrying plain-chat overlay state forward.
+- [ ] Desktop `/chat` exposes the character rail without replacing existing UI.
+- [ ] Sidepanel/mobile surfaces reuse the same state contract.
+- [ ] Targeted frontend and backend tests pass.
+- [ ] Bandit result recorded.

--- a/Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
+++ b/Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
@@ -166,7 +166,7 @@ assistantOverlay?: {
   id: string
   name: string
   avatar_url?: string | null
-  system_prompt?: string | null
+  system_prompt_snapshot?: string | null
   updatedAt: string
 } | null
 ```
@@ -177,6 +177,24 @@ This should be:
 - accepted by the frontend optional-keys list in [chat-settings.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/chat-settings.ts:31);
 - validated in [_validate_chat_settings_payload](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:1017);
 - persisted through the existing [update_chat_settings](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:5787) flow.
+
+### Overlay Snapshot Semantics
+
+Overlay uses **snapshot-on-apply** semantics.
+
+When the user applies a character/persona as overlay:
+
+- resolve full source detail first; do not treat catalog-summary data as the final prompt source;
+- persist a prompt snapshot into `assistantOverlay.system_prompt_snapshot`;
+- persist `kind`, `id`, `name`, and `avatar_url` as provenance and display metadata only.
+
+At send time:
+
+- use the stored snapshot from chat settings;
+- do not live re-resolve the source character/persona by `kind/id`;
+- do not change overlay behavior because the underlying character/persona record changed later.
+
+This is required because the current persona catalog path used by [AssistantSelect.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/AssistantSelect.tsx:188) does not provide the full prompt contract that overlay needs.
 
 ### Why Settings, Not Chat Identity
 
@@ -278,6 +296,7 @@ Behavior:
 - write `assistantOverlay` to chat settings;
 - do not mutate conversation identity;
 - do not clear messages, history, `serverChatId`, or `historyId`.
+- when `serverChatId` does not exist yet, persist overlay locally under the existing `scratch` / `local:<historyId>` chat-settings keys and reconcile it when the chat is first materialized on the server.
 
 ### Change Overlay
 
@@ -294,12 +313,14 @@ Behavior:
 - explicit action;
 - create or open a tracked character-backed conversation;
 - tracked identity lives on the chat record.
+- tracked defaults win: current plain-chat overlay, scene, style, and context state do not implicitly carry forward into the tracked chat unless a later explicit import/apply action is designed for that purpose.
 
 ### Start Tracked Persona Chat
 
 - explicit action;
 - create or open a tracked persona-backed conversation;
 - tracked identity lives on the chat record.
+- tracked defaults win: current plain-chat overlay, scene, style, and context state do not implicitly carry forward into the tracked chat unless a later explicit import/apply action is designed for that purpose.
 
 ### Open Tracked Session
 
@@ -340,14 +361,27 @@ Overlay is deliberately narrower than tracked character/persona chat behavior.
 
 ### Overlay Prompt Source
 
-For v1, overlay steering should reuse the selected assistant's prompt material from [AssistantSelection](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/types/assistant-selection.ts:9).
+For v1, overlay steering should resolve full source detail at apply time, snapshot the resolved personality prompt into chat settings, and then use that stored snapshot for subsequent sends.
 
 Use:
 
 - `assistantIdentity` for name/avatar in [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:122);
-- `systemPromptAppendix` in [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:144) and [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:488) to inject character/persona behavior instructions.
+- `systemPromptAppendix` in [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:144) and [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:488) to inject the stored `assistantOverlay.system_prompt_snapshot`.
 
 This is intentionally narrower than the tracked chat completion builder in [character_chat_sessions.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:4701).
+
+### Overlay Prompt Ordering
+
+Overlay prompt composition should be explicit and deterministic:
+
+1. resolve the base normal-chat system prompt using the current existing rules;
+2. append the overlay personality block from `assistantOverlay.system_prompt_snapshot`;
+3. inject actor/scene instructions;
+4. append any web-search system message.
+
+This keeps overlay behavior compatible with the current `systemPromptAppendix` hook while making the precedence contract explicit.
+
+In v1, overlay remains a personality layer. It does not replace explicit task, safety, tool, or context instructions supplied by the rest of the normal-chat path.
 
 ## Frontend Architecture Changes
 
@@ -396,7 +430,7 @@ Extend [_validate_chat_settings_payload](/Users/macbook-dev/Documents/GitHub/tld
 - `assistantOverlay.id`
 - `assistantOverlay.name`
 - optional `assistantOverlay.avatar_url`
-- optional `assistantOverlay.system_prompt`
+- optional `assistantOverlay.system_prompt_snapshot`
 - `assistantOverlay.updatedAt`
 
 The settings merge path in [update_chat_settings](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:5787) should remain the persistence mechanism.
@@ -488,6 +522,7 @@ The frontend currently attempts persona memory mode updates from [ConversationTa
 
 - tracked chats still load as tracked;
 - plain chats can store overlay state;
+- plain chats can store overlay state before first server-chat creation and reconcile it later;
 - changing overlay does not clear the thread.
 
 ## Stage 2: Send Path Split
@@ -575,5 +610,6 @@ The frontend currently attempts persona memory mode updates from [ConversationTa
 - Changing overlay mid-chat does not reset the conversation.
 - Clearing overlay mid-chat does not reset the conversation.
 - Overlay state persists through chat settings and reload.
+- Overlay state can be applied before first send and survives server-chat materialization.
 - Overlay chats are not reclassified as tracked character/persona sessions.
 - The main character/persona control surface is a side rail, while the existing `/chat` UI remains in place.

--- a/Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
+++ b/Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
@@ -1,0 +1,579 @@
+# Chat Character Overlay And Tracked Identity Design
+
+**Date:** 2026-05-22
+**Surface:** WebUI `/chat` and extension sidepanel chat flows
+**Status:** Approved in-session
+**Backlog:** TASK-444
+
+---
+
+## Goal
+
+Preserve existing tracked character/persona chats while adding a separate, non-destructive way to apply character/persona personality to a normal conversation.
+
+The end state is one chat surface with a clearer contract:
+
+- tracked character/persona chats still behave as tracked chats;
+- normal chats can borrow character/persona personality without becoming tracked chats;
+- assistant switching in a normal chat does not reset the thread;
+- the main character/persona control surface lives in a side rail, not in starter cards, not in a drawer-first setup flow, and not primarily in the composer.
+
+## Product Decision
+
+The current code collapses two different concepts into one `selectedAssistant` path:
+
+1. conversation ownership and storage;
+2. assistant personality and presentation.
+
+That is the root design error.
+
+This design splits them into separate concepts:
+
+- **tracked identity**: a conversation is owned by a character or persona and should keep current character/persona chat semantics;
+- **assistant overlay**: a conversation remains a normal chat, but assistant replies are steered to sound like a selected character or persona.
+
+Those concepts must use different persistence and send paths.
+
+## Required Outcomes
+
+The implementation must support both of these behaviors at the same time:
+
+1. Existing character/persona chats continue to be tracked to the selected character/persona exactly as they are today.
+2. A user can add, change, or clear a character/persona on an existing non-character/persona conversation and use it only for assistant personality, without resetting or reclassifying the chat.
+
+## Problem
+
+The current `/chat` flow conflates tracked identity with UI selection and send-time routing:
+
+- assistant selection is stored globally in [useSelectedAssistant.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useSelectedAssistant.ts:59);
+- tracked chat hydration writes back into that same global selection in [useSelectServerChat.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts:151);
+- assistant changes can clear thread state in [useMessageOption.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessageOption.tsx:265);
+- send routing in [useMessage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessage.tsx:2452) treats character/persona as chat-path changes rather than a product-level distinction between tracked ownership and overlay behavior;
+- normal-chat prompt assembly in [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:365) does not use selected assistant identity for personality steering;
+- the backend tracked chat path in [character_chat_sessions.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:4628) correctly uses conversation identity, but that same model should not be forced onto plain chats.
+
+The result is destructive switching and unclear semantics.
+
+## Implementation Anchors
+
+The design should stay grounded in the current code:
+
+- `/chat` shell and transcript layout:
+  - [Playground.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/Playground.tsx:1705)
+  - [PlaygroundForm.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx:4962)
+- existing chat sidebar:
+  - [ChatSidebar.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/ChatSidebar.tsx:400)
+- existing assistant picker:
+  - [AssistantSelect.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/AssistantSelect.tsx:101)
+- existing normal-chat prompt assembly:
+  - [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:117)
+- existing tracked send routing:
+  - [useMessage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessage.tsx:2452)
+- existing chat settings pipeline:
+  - [chat-session-settings.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/types/chat-session-settings.ts:45)
+  - [chat-settings.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/chat-settings.ts:31)
+  - [useChatSettingsRecord.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useChatSettingsRecord.ts:14)
+- tracked chat backend contract:
+  - [chat_session_schemas.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py:42)
+  - [character_chat_sessions.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:4628)
+
+## Non-Goals
+
+- No new starter cards.
+- No dedicated Character Chat route.
+- No separate Character Chat workspace that replaces the existing `/chat` shell.
+- No removal of the existing composer, toolbar, sidebar, knowledge panel, or artifacts panel.
+- No forced conversion of normal chats into tracked chats.
+- No regression to current tracked character/persona chat storage.
+- No broad redesign of chat history navigation.
+
+## Terminology
+
+Use these terms consistently:
+
+| Term | Meaning |
+| --- | --- |
+| Tracked identity | Conversation ownership stored on the chat record via `character_id` / `assistant_kind` / `assistant_id`. |
+| Assistant overlay | A per-conversation personality layer stored in chat settings that does not change conversation ownership. |
+| Plain chat | A conversation with neither tracked identity nor overlay. |
+| Tracked character chat | A conversation owned by a character. |
+| Tracked persona chat | A conversation owned by a persona. |
+| Character rail | The side-rail control surface for identity, behavior, scene, context, saved setups, and session actions. |
+
+Do not describe overlay state as "the chat is now a character chat." It is still a normal chat.
+
+## State Model
+
+The current conversation has one effective assistant mode:
+
+- `plain`
+- `overlay`
+- `tracked_character`
+- `tracked_persona`
+
+These modes are mutually exclusive.
+
+Tracked identity and overlay cannot be active at the same time for one conversation. In v1, tracked chats do not layer overlay on top.
+
+### Plain
+
+- no tracked identity;
+- no overlay;
+- current normal chat behavior.
+
+### Overlay
+
+- no tracked identity;
+- `assistantOverlay` exists in conversation settings;
+- assistant replies use selected character/persona personality only;
+- chat remains classified as a normal conversation.
+
+### Tracked Character
+
+- `assistant_kind == "character"` and `character_id` is set;
+- current tracked character chat behavior remains canonical.
+
+### Tracked Persona
+
+- `assistant_kind == "persona"` and `assistant_id` is set;
+- current tracked persona chat behavior remains canonical.
+
+## Data Contract
+
+### Tracked Identity
+
+Tracked identity remains on the conversation record and continues to use the current backend contract:
+
+- `character_id`
+- `assistant_kind`
+- `assistant_id`
+- `persona_memory_mode`
+
+This stays defined by:
+
+- [ChatSessionCreate](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py:42)
+- [ChatSessionResponse](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py:147)
+
+### Assistant Overlay
+
+Assistant overlay should live in chat settings, not in tracked identity fields.
+
+Add to [ChatSettingsRecord](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/types/chat-session-settings.ts:45):
+
+```ts
+assistantOverlay?: {
+  kind: "character" | "persona"
+  id: string
+  name: string
+  avatar_url?: string | null
+  system_prompt?: string | null
+  updatedAt: string
+} | null
+```
+
+This should be:
+
+- normalized in [chat-settings.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/chat-settings.ts:252);
+- accepted by the frontend optional-keys list in [chat-settings.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/services/chat-settings.ts:31);
+- validated in [_validate_chat_settings_payload](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:1017);
+- persisted through the existing [update_chat_settings](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:5787) flow.
+
+### Why Settings, Not Chat Identity
+
+Overlay is not conversation ownership. If overlay writes `assistant_kind`, `assistant_id`, or `character_id`, then:
+
+- plain chats will be reclassified as tracked chats;
+- tracked-session filters will become inaccurate;
+- conversation lists will not distinguish ownership from presentation;
+- changing overlay will start acting like a chat replacement operation again.
+
+That is explicitly out of scope for overlay behavior.
+
+## Effective Assistant Resolution
+
+Introduce one derived resolver for the current conversation:
+
+Inputs:
+
+- server chat metadata;
+- chat settings;
+- optional rail draft selection while the picker is open.
+
+Resolution order:
+
+1. if `assistant_kind == "character"` and `character_id` is present -> `tracked_character`
+2. if `assistant_kind == "persona"` and `assistant_id` is present -> `tracked_persona`
+3. if `settings.assistantOverlay` exists -> `overlay`
+4. otherwise -> `plain`
+
+The resolver should return:
+
+- `mode`
+- `kind`
+- `id`
+- `displayName`
+- `avatarUrl`
+- `systemPrompt`
+- `source: "tracked" | "overlay" | "none"`
+
+This resolver should replace ad hoc assistant checks in:
+
+- [useMessage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessage.tsx:2452)
+- [useMessageOption.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessageOption.tsx:265)
+- [useSelectServerChat.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts:151)
+
+## UI Model
+
+The UI must expose the split between tracked identity and overlay directly, rather than hiding it behind one generic assistant picker.
+
+### Character Rail
+
+Add a persistent right-side character rail to `/chat`.
+
+Placement:
+
+- desktop: beside the transcript using the same shell pattern currently used for the artifacts panel in [Playground.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/Playground.tsx:1813);
+- mobile and narrow sidepanel layouts: sheet/drawer variant with the same state model.
+
+The rail is an additive control plane. It does not replace the existing composer or left sidebar.
+
+### Rail Sections
+
+The rail should own:
+
+1. current assistant mode and summary;
+2. identity picker and clear/change actions;
+3. behavior prompt summary;
+4. style/preset summary;
+5. scene summary;
+6. context summary;
+7. saved setups;
+8. tracked recent sessions.
+
+### Existing UI Preservation
+
+Keep:
+
+- [ComposerToolbar.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx:110)
+- [AssistantSelect.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/AssistantSelect.tsx:101)
+- [ChatSidebar.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/ChatSidebar.tsx:400)
+- [PlaygroundKnowledgeSection.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/PlaygroundKnowledgeSection.tsx:31)
+
+But change their role:
+
+- the rail becomes the main character/persona control surface;
+- the composer remains usable but secondary for identity control;
+- `AssistantSelect` becomes the picker the rail invokes, not the workflow container.
+
+## Rail Actions
+
+Each rail action must map to one write path.
+
+### Apply Overlay
+
+Available from `plain` or existing `overlay`.
+
+Behavior:
+
+- write `assistantOverlay` to chat settings;
+- do not mutate conversation identity;
+- do not clear messages, history, `serverChatId`, or `historyId`.
+
+### Change Overlay
+
+- overwrite `assistantOverlay`;
+- preserve the same conversation.
+
+### Clear Overlay
+
+- set `assistantOverlay = null`;
+- preserve the same conversation.
+
+### Start Tracked Character Chat
+
+- explicit action;
+- create or open a tracked character-backed conversation;
+- tracked identity lives on the chat record.
+
+### Start Tracked Persona Chat
+
+- explicit action;
+- create or open a tracked persona-backed conversation;
+- tracked identity lives on the chat record.
+
+### Open Tracked Session
+
+- explicit session navigation;
+- does not mutate the current conversation into a tracked chat.
+
+## Send Routing
+
+In [useMessage.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessage.tsx:2452), route by effective mode rather than by a single assistant selection:
+
+- `tracked_character` -> current `characterChatMode`
+- `tracked_persona` -> current persona-backed `normalChatMode` flow
+- `overlay` -> `normalChatMode` with injected personality steering
+- `plain` -> current `normalChatMode`
+
+This keeps tracked paths intact while isolating overlay logic to the normal-chat path.
+
+## Overlay Prompt Semantics
+
+Overlay is deliberately narrower than tracked character/persona chat behavior.
+
+### Overlay Should Do
+
+- change assistant display name and avatar;
+- change assistant personality through prompt steering;
+- persist per conversation;
+- survive reload;
+- allow change/clear without resetting the thread.
+
+### Overlay Should Not Do
+
+- change conversation ownership;
+- use persona durable-memory mode;
+- use tracked character greeting-session semantics;
+- use tracked character memory rows as if the chat were character-owned;
+- reclassify the conversation in tracked-character or tracked-persona session views;
+- automatically attach worldbook/lorebook character bindings that assume tracked ownership.
+
+### Overlay Prompt Source
+
+For v1, overlay steering should reuse the selected assistant's prompt material from [AssistantSelection](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/types/assistant-selection.ts:9).
+
+Use:
+
+- `assistantIdentity` for name/avatar in [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:122);
+- `systemPromptAppendix` in [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:144) and [normalChatMode.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts:488) to inject character/persona behavior instructions.
+
+This is intentionally narrower than the tracked chat completion builder in [character_chat_sessions.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:4701).
+
+## Frontend Architecture Changes
+
+### 1. Stop Treating Global Assistant Selection As Active Chat Truth
+
+[useSelectedAssistant.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useSelectedAssistant.ts:59) should no longer act as the canonical active assistant for the conversation.
+
+Keep it only for:
+
+- picker/default memory;
+- rail draft selection;
+- compatibility migration while the new effective-state resolver rolls out.
+
+Active conversation mode must come from:
+
+- tracked chat metadata; or
+- `assistantOverlay` in chat settings.
+
+### 2. Remove Destructive Assistant Switch Resets
+
+The assistant-switch reset block in [useMessageOption.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessageOption.tsx:265) is incompatible with overlay behavior and should be replaced with logic keyed to actual conversation changes, not picker changes.
+
+### 3. Preserve Tracked Hydration Without Reimposing Global Selection
+
+[useSelectServerChat.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts:151) should continue to hydrate tracked chat metadata, but it should not make global assistant selection the active source of truth for the loaded chat.
+
+### 4. Add New Rail Panel State
+
+Extend [chat-surface-coordinator.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/store/chat-surface-coordinator.ts:6) with a new optional panel id for the character rail.
+
+This keeps the new rail within the same panel-ownership model already used for server history, model catalog, and artifacts-adjacent layout.
+
+## Backend Architecture Changes
+
+### 1. Preserve Tracked Chat Contract
+
+Do not repurpose [ChatSessionUpdate](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py:124) for overlay behavior.
+
+Tracked identity and overlay state must remain separate.
+
+### 2. Validate Overlay Settings
+
+Extend [_validate_chat_settings_payload](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:1017) to validate:
+
+- `assistantOverlay.kind`
+- `assistantOverlay.id`
+- `assistantOverlay.name`
+- optional `assistantOverlay.avatar_url`
+- optional `assistantOverlay.system_prompt`
+- `assistantOverlay.updatedAt`
+
+The settings merge path in [update_chat_settings](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:5787) should remain the persistence mechanism.
+
+### 3. Keep Tracked Completion Path Unchanged
+
+Tracked chats should continue using the current `complete-v2` flow in [character_chat_sessions.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:4628).
+
+No overlay feature should alter tracked-chat prompt composition.
+
+## Saved Setups
+
+Saved setups should follow the same split as runtime state.
+
+### Overlay-Applied Setup
+
+Applying a setup to the current plain chat should:
+
+- write `assistantOverlay` when setup identity is intended as overlay;
+- apply scene/style/behavior settings through chat settings;
+- preserve conversation identity.
+
+### Tracked Setup
+
+Opening a setup as a tracked chat should:
+
+- create or open a tracked character/persona conversation;
+- preserve current tracked session semantics.
+
+The default "apply here" behavior for normal chats should prefer overlay, not tracked conversion.
+
+Reuse existing startup-template plumbing where possible:
+
+- [startup-template-bundles.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/startup-template-bundles.ts:12)
+- [usePromptTemplates.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/hooks/usePromptTemplates.ts:23)
+
+## Recent Sessions
+
+Tracked recent sessions must remain based on tracked conversation identity only.
+
+Overlayed plain chats should not be grouped or labeled as tracked character/persona sessions simply because they currently use overlay personality.
+
+This keeps:
+
+- character/persona session history accurate;
+- plain chat history accurate;
+- rail actions understandable.
+
+## Extension And Sidepanel Parity
+
+The state model should be shared across WebUI and extension chat surfaces even if the presentation differs.
+
+Requirements:
+
+- tracked chat metadata keeps working in extension handoff;
+- `assistantOverlay` persists through shared chat settings flows;
+- desktop WebUI can use a persistent right rail;
+- extension sidepanel and mobile surfaces can render the same controls in a sheet/drawer form;
+- neither surface should rely on starter cards or route-level character mode.
+
+## Risks
+
+### Global Selection Leakage
+
+If global selected-assistant storage remains authoritative, overlay or tracked state will leak across chats.
+
+### Prompt Richness Mismatch
+
+Tracked persona chat prompt assembly is richer than a simple `system_prompt` append. That is acceptable for overlay v1 as long as it is explicit that overlay is personality steering, not full tracked persona runtime.
+
+### Existing Contract Mismatch Around Persona Memory Updates
+
+The frontend currently attempts persona memory mode updates from [ConversationTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/Settings/tabs/ConversationTab.tsx:860), while backend tracked chat update support is narrower in [character_chat_sessions.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:5667). That inconsistency should not be expanded by overlay work and should be resolved only if the tracked chat controls touched by this effort require it.
+
+## Rollout Stages
+
+## Stage 1: State Split And Persistence
+
+**Goal:** Introduce explicit overlay state without changing tracked chat semantics.
+
+**Scope:**
+
+- add `assistantOverlay` typing and normalization;
+- validate overlay in backend chat settings;
+- add effective assistant-state resolver;
+- stop destructive assistant-switch resets.
+
+**Success Criteria:**
+
+- tracked chats still load as tracked;
+- plain chats can store overlay state;
+- changing overlay does not clear the thread.
+
+## Stage 2: Send Path Split
+
+**Goal:** Make tracked and overlay chats use different behavior paths.
+
+**Scope:**
+
+- route sends by effective mode in `useMessage.tsx`;
+- keep tracked character/persona behavior unchanged;
+- inject overlay personality through `normalChatMode`.
+
+**Success Criteria:**
+
+- tracked chats still use current completion flows;
+- overlay chats use current conversation id and history;
+- overlay visibly changes assistant behavior.
+
+## Stage 3: Character Rail
+
+**Goal:** Add the main character/persona control surface without replacing existing chat UI.
+
+**Scope:**
+
+- add new right-rail panel component;
+- wire rail actions to overlay writes and tracked session actions;
+- keep composer and sidebar intact.
+
+**Success Criteria:**
+
+- desktop `/chat` exposes a persistent rail for identity controls;
+- users can apply/change/clear overlay from the rail;
+- users can start or open tracked sessions from the rail.
+
+## Stage 4: Parity And Hardening
+
+**Goal:** Ensure reload, mobile, and extension parity.
+
+**Scope:**
+
+- reload restoration for tracked and overlay states;
+- mobile/sidepanel sheet version of the rail;
+- recent-session and saved-setup classification fixes.
+
+**Success Criteria:**
+
+- reload restores the correct mode;
+- overlay does not become tracked after reload;
+- extension flow follows the same state contract.
+
+## Testing
+
+### Unit
+
+- `assistantOverlay` normalization and validation
+- effective assistant-state resolution
+- settings merge behavior for overlay updates
+
+### Integration
+
+- tracked character chat remains tracked
+- tracked persona chat remains tracked
+- plain chat with overlay keeps the same conversation id
+- changing overlay mid-chat does not clear messages
+- clearing overlay mid-chat does not clear messages
+
+### UI
+
+- rail apply/change/clear flows
+- tracked-session open flows
+- saved setup apply-in-place vs tracked-open behavior
+- desktop and mobile layout coverage
+
+### Regression
+
+- no starter-card dependency for character/persona control
+- no assistant-switch thread reset in normal chats
+- tracked recent-session classification unchanged
+
+## Acceptance Criteria
+
+- Existing tracked character chats behave exactly as they do today.
+- Existing tracked persona chats behave exactly as they do today.
+- A plain chat can apply a character/persona overlay and keep the same chat id, thread, and history.
+- Changing overlay mid-chat does not reset the conversation.
+- Clearing overlay mid-chat does not reset the conversation.
+- Overlay state persists through chat settings and reload.
+- Overlay chats are not reclassified as tracked character/persona sessions.
+- The main character/persona control surface is a side rail, while the existing `/chat` UI remains in place.

--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -7,6 +7,9 @@ import { useTranslation } from "react-i18next"
 import type { PersonaInfo } from "@/routes/personaTypes"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { useSelectedAssistant } from "@/hooks/useSelectedAssistant"
+import { resolveEffectiveAssistantState } from "@/hooks/chat/effective-assistant-state"
+import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord"
+import { useStoreMessageOption } from "@/store/option"
 import {
   OPEN_ASSISTANT_SELECT_EVENT,
   type AssistantSelectOpenDetail,
@@ -17,13 +20,18 @@ import {
   personaToAssistantSelection,
   type AssistantSelection
 } from "@/types/assistant-selection"
-import { scheduleFocusFirstVisibleElement } from "@/utils/focus-return"
+import {
+  buildAssistantOverlaySnapshotFromSelection,
+  resolveAssistantOverlaySnapshot
+} from "@/utils/assistant-overlay"
 
 type Props = {
   className?: string
   iconClassName?: string
   showLabel?: boolean
   variant?: "inline" | "dropdown"
+  labelOverride?: string
+  selectionModePreference?: "tracked" | "overlay"
 }
 
 type CharacterSummary = Record<string, unknown> & {
@@ -103,43 +111,61 @@ export const AssistantSelect: React.FC<Props> = ({
   className = "text-text-muted",
   iconClassName = "size-5",
   showLabel = true,
-  variant = "inline"
+  variant = "inline",
+  labelOverride,
+  selectionModePreference = "tracked"
 }) => {
   const { t } = useTranslation(["option", "common"])
   const [selectedAssistant, setSelectedAssistant] =
     useSelectedAssistant(null)
+  const historyId = useStoreMessageOption((state) => state.historyId)
+  const serverChatId = useStoreMessageOption((state) => state.serverChatId)
+  const serverChatAssistantKind = useStoreMessageOption(
+    (state) => state.serverChatAssistantKind
+  )
+  const serverChatAssistantId = useStoreMessageOption(
+    (state) => state.serverChatAssistantId
+  )
+  const serverChatCharacterId = useStoreMessageOption(
+    (state) => state.serverChatCharacterId
+  )
+  const { settings, updateSettings } = useChatSettingsRecord({
+    historyId,
+    serverChatId
+  })
   const [open, setOpen] = React.useState(false)
   const [searchText, setSearchText] = React.useState("")
+  const [selectionMode, setSelectionMode] = React.useState<"tracked" | "overlay">(
+    selectionModePreference
+  )
   const [activeTab, setActiveTab] = React.useState<"character" | "persona">(
     selectedAssistant?.kind ?? "character"
   )
   const [characters, setCharacters] = React.useState<CharacterSummary[]>([])
   const [personas, setPersonas] = React.useState<PersonaInfo[]>([])
-  const [charactersLoading, setCharactersLoading] = React.useState(true)
-  const [personasLoading, setPersonasLoading] = React.useState(true)
-  const [charactersError, setCharactersError] = React.useState(false)
-  const [personasError, setPersonasError] = React.useState(false)
   const [favoriteCharacters, setFavoriteCharacters] = useStorage<
     FavoriteCharacter[]
   >("favoriteCharacters", [])
   const searchInputRef = React.useRef<InputRef | null>(null)
-  const triggerButtonRef = React.useRef<HTMLButtonElement | null>(null)
-  const returnFocusSelectorRef = React.useRef<string | null>(null)
-
-  const restoreReturnFocus = React.useCallback(() => {
-    const selector = returnFocusSelectorRef.current
-    returnFocusSelectorRef.current = null
-    if (!selector) {
-      if (variant === "dropdown" && typeof window !== "undefined") {
-        window.requestAnimationFrame(() => {
-          triggerButtonRef.current?.focus()
-        })
-      }
-      return
-    }
-
-    scheduleFocusFirstVisibleElement(selector)
-  }, [variant])
+  const effectiveAssistantState = React.useMemo(
+    () =>
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: serverChatAssistantKind,
+          assistantId: serverChatAssistantId,
+          characterId: serverChatCharacterId
+        },
+        settings: settings ?? null,
+        draftSelection: selectedAssistant
+      }),
+    [
+      selectedAssistant,
+      serverChatAssistantId,
+      serverChatAssistantKind,
+      serverChatCharacterId,
+      settings
+    ]
+  )
 
   React.useEffect(() => {
     if (selectedAssistant?.kind === "character" || selectedAssistant?.kind === "persona") {
@@ -156,11 +182,9 @@ export const AssistantSelect: React.FC<Props> = ({
       if (requestedTab === "character" || requestedTab === "persona") {
         setActiveTab(requestedTab as AssistantSelectTab)
       }
-      returnFocusSelectorRef.current =
-        typeof detail?.returnFocusSelector === "string" &&
-        detail.returnFocusSelector.trim().length > 0
-          ? detail.returnFocusSelector.trim()
-          : null
+      setSelectionMode(
+        detail?.applyAs === "overlay" ? "overlay" : selectionModePreference
+      )
       setSearchText("")
       setOpen(true)
     }
@@ -169,7 +193,7 @@ export const AssistantSelect: React.FC<Props> = ({
     return () => {
       window.removeEventListener(OPEN_ASSISTANT_SELECT_EVENT, handleOpen)
     }
-  }, [])
+  }, [selectionModePreference])
 
   React.useEffect(() => {
     if (!open || typeof window === "undefined") return
@@ -199,76 +223,32 @@ export const AssistantSelect: React.FC<Props> = ({
     }
   }, [open])
 
-  const loadCharacters = React.useCallback(
-    async (isCancelled: () => boolean = () => false) => {
-      setCharactersLoading(true)
-      setCharactersError(false)
-      try {
-        await tldwClient.initialize()
-        if (typeof tldwClient.listAllCharacters !== "function") {
-          if (!isCancelled()) {
-            setCharacters([])
-          }
-          return
-        }
-        const result = await tldwClient.listAllCharacters()
-        if (!isCancelled()) {
-          setCharacters(Array.isArray(result) ? (result as CharacterSummary[]) : [])
-        }
-      } catch {
-        if (!isCancelled()) {
-          setCharacters([])
-          setCharactersError(true)
-        }
-      } finally {
-        if (!isCancelled()) {
-          setCharactersLoading(false)
-        }
-      }
-    },
-    []
-  )
-
-  const loadPersonas = React.useCallback(
-    async (isCancelled: () => boolean = () => false) => {
-      setPersonasLoading(true)
-      setPersonasError(false)
-      try {
-        await tldwClient.initialize()
-        if (typeof tldwClient.listPersonaProfiles !== "function") {
-          if (!isCancelled()) {
-            setPersonas([])
-          }
-          return
-        }
-        const result = await tldwClient.listPersonaProfiles()
-        if (!isCancelled()) {
-          setPersonas(Array.isArray(result) ? (result as PersonaInfo[]) : [])
-        }
-      } catch {
-        if (!isCancelled()) {
-          setPersonas([])
-          setPersonasError(true)
-        }
-      } finally {
-        if (!isCancelled()) {
-          setPersonasLoading(false)
-        }
-      }
-    },
-    []
-  )
-
   React.useEffect(() => {
     let cancelled = false
-    const isCancelled = () => cancelled
 
-    void loadCharacters(isCancelled)
-    void loadPersonas(isCancelled)
+    const loadOptions = async () => {
+      await tldwClient.initialize().catch(() => null)
+
+      if (typeof tldwClient.listAllCharacters === "function") {
+        const result = await tldwClient.listAllCharacters().catch(() => [])
+        if (!cancelled && Array.isArray(result)) {
+          setCharacters(result as CharacterSummary[])
+        }
+      }
+
+      if (typeof tldwClient.listPersonaProfiles === "function") {
+        const result = await tldwClient.listPersonaProfiles().catch(() => [])
+        if (!cancelled && Array.isArray(result)) {
+          setPersonas(result as PersonaInfo[])
+        }
+      }
+    }
+
+    void loadOptions()
     return () => {
       cancelled = true
     }
-  }, [loadCharacters, loadPersonas])
+  }, [])
 
   const characterEntries = React.useMemo(
     () =>
@@ -386,27 +366,67 @@ export const AssistantSelect: React.FC<Props> = ({
   )
 
   const handleSelect = React.useCallback(
-    (entry: AssistantSelection) => {
+    async (entry: AssistantSelection) => {
+      const isTrackedMode =
+        effectiveAssistantState.mode === "tracked_character" ||
+        effectiveAssistantState.mode === "tracked_persona"
+      if (selectionMode === "overlay" && isTrackedMode) {
+        setOpen(false)
+        setSearchText("")
+        setSelectionMode(selectionModePreference)
+        return
+      }
+
+      await setSelectedAssistant(entry)
+      if (selectionMode === "overlay") {
+        let overlaySnapshot = buildAssistantOverlaySnapshotFromSelection(entry)
+        try {
+          overlaySnapshot = await resolveAssistantOverlaySnapshot(entry)
+        } catch (error) {
+          console.warn(
+            "[AssistantSelect] Failed to resolve overlay snapshot; using summary fallback",
+            error
+          )
+        }
+
+        try {
+          await updateSettings({
+            assistantOverlay: overlaySnapshot
+          })
+        } catch (error) {
+          console.warn(
+            "[AssistantSelect] Failed to persist assistant overlay; keeping local selection",
+            error
+          )
+        }
+      }
       setOpen(false)
       setSearchText("")
-      restoreReturnFocus()
-      void setSelectedAssistant(entry)
+      setSelectionMode(selectionModePreference)
     },
-    [restoreReturnFocus, setSelectedAssistant]
+    [
+      effectiveAssistantState.mode,
+      selectionMode,
+      selectionModePreference,
+      setSelectedAssistant,
+      updateSettings
+    ]
   )
 
   const handleOpenChange = React.useCallback((nextOpen: boolean) => {
     setOpen(nextOpen)
+    if (nextOpen) {
+      setSelectionMode(selectionModePreference)
+    }
     if (!nextOpen) {
       setSearchText("")
-      restoreReturnFocus()
+      setSelectionMode(selectionModePreference)
     }
-  }, [restoreReturnFocus])
+  }, [selectionModePreference])
 
   const openActorSettings = React.useCallback(() => {
     setOpen(false)
     setSearchText("")
-    restoreReturnFocus()
     try {
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent("tldw:open-actor-settings"))
@@ -414,9 +434,10 @@ export const AssistantSelect: React.FC<Props> = ({
     } catch {
       // no-op
     }
-  }, [restoreReturnFocus])
+  }, [])
 
   const buttonLabel =
+    labelOverride ||
     selectedAssistant?.name ||
     t("option:assistant.selectAssistant", "Select character or persona")
 
@@ -455,55 +476,9 @@ export const AssistantSelect: React.FC<Props> = ({
     activeTabDefinition?.emptyLabel ??
     t("option:assistant.noAssistants", "No assistants available.")
   const activeTabShowsFavorites = activeTabDefinition?.showFavorites ?? false
-  const activeTabLoading =
-    activeTab === "character" ? charactersLoading : personasLoading
-  const activeTabError =
-    activeTab === "character" ? charactersError : personasError
-  const retryActiveTabLoad =
-    activeTab === "character" ? loadCharacters : loadPersonas
-  const activeTabErrorLabel =
-    activeTab === "character"
-      ? t(
-          "option:assistant.charactersLoadError",
-          "Could not load characters."
-        )
-      : t("option:assistant.personasLoadError", "Could not load personas.")
-  const activeTabRetryLabel =
-    activeTab === "character"
-      ? t("option:assistant.retryCharacters", "Retry characters")
-      : t("option:assistant.retryPersonas", "Retry personas")
-  const catalogLoadingLabel = t(
-    "option:assistant.catalogLoadingStatus",
-    "Loading character and persona catalogs"
-  )
-  const activeTabLoadingLabel = t(
-    "option:assistant.loadingCatalogs",
-    "Loading characters and personas"
-  )
 
   const activeTabContent =
-    activeTabLoading ? (
-      <div
-        role="status"
-        aria-label={catalogLoadingLabel}
-        className="px-3 py-4 text-center text-sm text-text-subtle"
-      >
-        {activeTabLoadingLabel}
-      </div>
-    ) : activeTabError ? (
-      <div className="space-y-2 px-3 py-4 text-center text-sm text-text-subtle">
-        <p>{activeTabErrorLabel}</p>
-        <button
-          type="button"
-          className="rounded-md border border-border bg-surface px-2 py-1 text-xs font-medium text-text hover:bg-surface2"
-          onClick={() => {
-            void retryActiveTabLoad()
-          }}
-        >
-          {activeTabRetryLabel}
-        </button>
-      </div>
-    ) : activeTabEntries.length === 0 ? (
+    activeTabEntries.length === 0 ? (
       <div className="px-3 py-4 text-center text-sm text-text-subtle">
         {activeTabEmptyLabel}
       </div>
@@ -540,7 +515,7 @@ export const AssistantSelect: React.FC<Props> = ({
                   className={`flex min-w-0 flex-1 items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition ${
                     isActive
                       ? "border-primary bg-primary/10 text-text"
-                      : "border-border bg-surface text-text hover:bg-surface2"
+                      : "border-border bg-background text-text hover:bg-surface2"
                   }`}
                   onClick={() => {
                     void handleSelect(entry)
@@ -597,10 +572,7 @@ export const AssistantSelect: React.FC<Props> = ({
     )
 
   const content = (
-    <div
-      data-testid="assistant-select-panel"
-      className="w-[320px] rounded-lg border border-border bg-elevated shadow-lg"
-    >
+    <div className="w-[320px] rounded-lg border border-border bg-background shadow-lg">
       <div className="border-b border-border p-2">
         <Input
           ref={searchInputRef}
@@ -673,20 +645,20 @@ export const AssistantSelect: React.FC<Props> = ({
       placement="topLeft"
       trigger={["click"]}
     >
-      <button
-        ref={triggerButtonRef}
-        type="button"
-        data-testid="character-select"
-        className={`inline-flex items-center gap-2 ${className}`.trim()}
-        aria-label={buttonLabel}
-        aria-expanded={open}
-        title={buttonLabel}
-      >
-        <UserCircle2 className={iconClassName} />
-        {showLabel ? (
-          <span className="max-w-[180px] truncate text-sm">{buttonLabel}</span>
-        ) : null}
-      </button>
+      <Tooltip title={buttonLabel}>
+        <button
+          type="button"
+          data-testid="character-select"
+          className={`inline-flex items-center gap-2 ${className}`.trim()}
+          aria-label={buttonLabel}
+          aria-expanded={open}
+        >
+          <UserCircle2 className={iconClassName} />
+          {showLabel ? (
+            <span className="max-w-[180px] truncate text-sm">{buttonLabel}</span>
+          ) : null}
+        </button>
+      </Tooltip>
     </Dropdown>
   )
 }

--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -20,6 +20,7 @@ import {
   personaToAssistantSelection,
   type AssistantSelection
 } from "@/types/assistant-selection"
+import { scheduleFocusFirstVisibleElement } from "@/utils/focus-return"
 import {
   buildAssistantOverlaySnapshotFromSelection,
   resolveAssistantOverlaySnapshot
@@ -143,10 +144,16 @@ export const AssistantSelect: React.FC<Props> = ({
   )
   const [characters, setCharacters] = React.useState<CharacterSummary[]>([])
   const [personas, setPersonas] = React.useState<PersonaInfo[]>([])
+  const [charactersLoading, setCharactersLoading] = React.useState(true)
+  const [personasLoading, setPersonasLoading] = React.useState(true)
+  const [charactersError, setCharactersError] = React.useState(false)
+  const [personasError, setPersonasError] = React.useState(false)
   const [favoriteCharacters, setFavoriteCharacters] = useStorage<
     FavoriteCharacter[]
   >("favoriteCharacters", [])
   const searchInputRef = React.useRef<InputRef | null>(null)
+  const triggerButtonRef = React.useRef<HTMLButtonElement | null>(null)
+  const returnFocusSelectorRef = React.useRef<string | null>(null)
   const effectiveAssistantState = React.useMemo(
     () =>
       resolveEffectiveAssistantState({
@@ -167,6 +174,21 @@ export const AssistantSelect: React.FC<Props> = ({
     ]
   )
 
+  const restoreReturnFocus = React.useCallback(() => {
+    const selector = returnFocusSelectorRef.current
+    returnFocusSelectorRef.current = null
+    if (!selector) {
+      if (variant === "dropdown" && typeof window !== "undefined") {
+        window.requestAnimationFrame(() => {
+          triggerButtonRef.current?.focus()
+        })
+      }
+      return
+    }
+
+    scheduleFocusFirstVisibleElement(selector)
+  }, [variant])
+
   React.useEffect(() => {
     if (selectedAssistant?.kind === "character" || selectedAssistant?.kind === "persona") {
       setActiveTab(selectedAssistant.kind)
@@ -182,6 +204,11 @@ export const AssistantSelect: React.FC<Props> = ({
       if (requestedTab === "character" || requestedTab === "persona") {
         setActiveTab(requestedTab as AssistantSelectTab)
       }
+      returnFocusSelectorRef.current =
+        typeof detail?.returnFocusSelector === "string" &&
+        detail.returnFocusSelector.trim().length > 0
+          ? detail.returnFocusSelector.trim()
+          : null
       setSelectionMode(
         detail?.applyAs === "overlay" ? "overlay" : selectionModePreference
       )
@@ -223,32 +250,76 @@ export const AssistantSelect: React.FC<Props> = ({
     }
   }, [open])
 
+  const loadCharacters = React.useCallback(
+    async (isCancelled: () => boolean = () => false) => {
+      setCharactersLoading(true)
+      setCharactersError(false)
+      try {
+        await tldwClient.initialize()
+        if (typeof tldwClient.listAllCharacters !== "function") {
+          if (!isCancelled()) {
+            setCharacters([])
+          }
+          return
+        }
+        const result = await tldwClient.listAllCharacters()
+        if (!isCancelled()) {
+          setCharacters(Array.isArray(result) ? (result as CharacterSummary[]) : [])
+        }
+      } catch {
+        if (!isCancelled()) {
+          setCharacters([])
+          setCharactersError(true)
+        }
+      } finally {
+        if (!isCancelled()) {
+          setCharactersLoading(false)
+        }
+      }
+    },
+    []
+  )
+
+  const loadPersonas = React.useCallback(
+    async (isCancelled: () => boolean = () => false) => {
+      setPersonasLoading(true)
+      setPersonasError(false)
+      try {
+        await tldwClient.initialize()
+        if (typeof tldwClient.listPersonaProfiles !== "function") {
+          if (!isCancelled()) {
+            setPersonas([])
+          }
+          return
+        }
+        const result = await tldwClient.listPersonaProfiles()
+        if (!isCancelled()) {
+          setPersonas(Array.isArray(result) ? (result as PersonaInfo[]) : [])
+        }
+      } catch {
+        if (!isCancelled()) {
+          setPersonas([])
+          setPersonasError(true)
+        }
+      } finally {
+        if (!isCancelled()) {
+          setPersonasLoading(false)
+        }
+      }
+    },
+    []
+  )
+
   React.useEffect(() => {
     let cancelled = false
+    const isCancelled = () => cancelled
 
-    const loadOptions = async () => {
-      await tldwClient.initialize().catch(() => null)
-
-      if (typeof tldwClient.listAllCharacters === "function") {
-        const result = await tldwClient.listAllCharacters().catch(() => [])
-        if (!cancelled && Array.isArray(result)) {
-          setCharacters(result as CharacterSummary[])
-        }
-      }
-
-      if (typeof tldwClient.listPersonaProfiles === "function") {
-        const result = await tldwClient.listPersonaProfiles().catch(() => [])
-        if (!cancelled && Array.isArray(result)) {
-          setPersonas(result as PersonaInfo[])
-        }
-      }
-    }
-
-    void loadOptions()
+    void loadCharacters(isCancelled)
+    void loadPersonas(isCancelled)
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loadCharacters, loadPersonas])
 
   const characterEntries = React.useMemo(
     () =>
@@ -374,9 +445,14 @@ export const AssistantSelect: React.FC<Props> = ({
         setOpen(false)
         setSearchText("")
         setSelectionMode(selectionModePreference)
+        restoreReturnFocus()
         return
       }
 
+      setOpen(false)
+      setSearchText("")
+      setSelectionMode(selectionModePreference)
+      restoreReturnFocus()
       await setSelectedAssistant(entry)
       if (selectionMode === "overlay") {
         let overlaySnapshot = buildAssistantOverlaySnapshotFromSelection(entry)
@@ -400,12 +476,10 @@ export const AssistantSelect: React.FC<Props> = ({
           )
         }
       }
-      setOpen(false)
-      setSearchText("")
-      setSelectionMode(selectionModePreference)
     },
     [
       effectiveAssistantState.mode,
+      restoreReturnFocus,
       selectionMode,
       selectionModePreference,
       setSelectedAssistant,
@@ -421,12 +495,14 @@ export const AssistantSelect: React.FC<Props> = ({
     if (!nextOpen) {
       setSearchText("")
       setSelectionMode(selectionModePreference)
+      restoreReturnFocus()
     }
-  }, [selectionModePreference])
+  }, [restoreReturnFocus, selectionModePreference])
 
   const openActorSettings = React.useCallback(() => {
     setOpen(false)
     setSearchText("")
+    restoreReturnFocus()
     try {
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent("tldw:open-actor-settings"))
@@ -434,7 +510,7 @@ export const AssistantSelect: React.FC<Props> = ({
     } catch {
       // no-op
     }
-  }, [])
+  }, [restoreReturnFocus])
 
   const buttonLabel =
     labelOverride ||
@@ -476,9 +552,55 @@ export const AssistantSelect: React.FC<Props> = ({
     activeTabDefinition?.emptyLabel ??
     t("option:assistant.noAssistants", "No assistants available.")
   const activeTabShowsFavorites = activeTabDefinition?.showFavorites ?? false
+  const activeTabLoading =
+    activeTab === "character" ? charactersLoading : personasLoading
+  const activeTabError =
+    activeTab === "character" ? charactersError : personasError
+  const retryActiveTabLoad =
+    activeTab === "character" ? loadCharacters : loadPersonas
+  const activeTabErrorLabel =
+    activeTab === "character"
+      ? t(
+          "option:assistant.charactersLoadError",
+          "Could not load characters."
+        )
+      : t("option:assistant.personasLoadError", "Could not load personas.")
+  const activeTabRetryLabel =
+    activeTab === "character"
+      ? t("option:assistant.retryCharacters", "Retry characters")
+      : t("option:assistant.retryPersonas", "Retry personas")
+  const catalogLoadingLabel = t(
+    "option:assistant.catalogLoadingStatus",
+    "Loading character and persona catalogs"
+  )
+  const activeTabLoadingLabel = t(
+    "option:assistant.loadingCatalogs",
+    "Loading characters and personas"
+  )
 
   const activeTabContent =
-    activeTabEntries.length === 0 ? (
+    activeTabLoading ? (
+      <div
+        role="status"
+        aria-label={catalogLoadingLabel}
+        className="px-3 py-4 text-center text-sm text-text-subtle"
+      >
+        {activeTabLoadingLabel}
+      </div>
+    ) : activeTabError ? (
+      <div className="space-y-2 px-3 py-4 text-center text-sm text-text-subtle">
+        <p>{activeTabErrorLabel}</p>
+        <button
+          type="button"
+          className="rounded-md border border-border bg-surface px-2 py-1 text-xs font-medium text-text hover:bg-surface2"
+          onClick={() => {
+            void retryActiveTabLoad()
+          }}
+        >
+          {activeTabRetryLabel}
+        </button>
+      </div>
+    ) : activeTabEntries.length === 0 ? (
       <div className="px-3 py-4 text-center text-sm text-text-subtle">
         {activeTabEmptyLabel}
       </div>
@@ -572,7 +694,10 @@ export const AssistantSelect: React.FC<Props> = ({
     )
 
   const content = (
-    <div className="w-[320px] rounded-lg border border-border bg-background shadow-lg">
+    <div
+      data-testid="assistant-select-panel"
+      className="w-[320px] rounded-lg border border-border bg-background shadow-lg"
+    >
       <div className="border-b border-border p-2">
         <Input
           ref={searchInputRef}
@@ -647,6 +772,7 @@ export const AssistantSelect: React.FC<Props> = ({
     >
       <Tooltip title={buttonLabel}>
         <button
+          ref={triggerButtonRef}
           type="button"
           data-testid="character-select"
           className={`inline-flex items-center gap-2 ${className}`.trim()}

--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -148,6 +148,9 @@ const renderAssistantSelect = (
 
   render(
     <QueryClientProvider client={queryClient}>
+      <button id="assistant-rail-trigger" type="button">
+        Runtime rail trigger
+      </button>
       <AssistantSelect variant="dropdown" {...props} />
     </QueryClientProvider>
   )
@@ -202,6 +205,58 @@ describe("AssistantSelect behavior", () => {
     expect(screen.queryByRole("button", { name: "Alpha" })).toBeNull()
   })
 
+  it("announces character and persona catalog loading in the selector", async () => {
+    mocks.listAllCharacters.mockReturnValue(new Promise(() => {}))
+    mocks.listPersonaProfiles.mockReturnValue(new Promise(() => {}))
+
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    await user.click(
+      await screen.findByRole("button", { name: "Select character or persona" })
+    )
+
+    const status = await screen.findByRole("status", {
+      name: /loading character and persona catalogs/i
+    })
+    expect(status).toHaveTextContent("Loading characters and personas")
+  })
+
+  it("shows a retryable character catalog failure instead of an empty list", async () => {
+    mocks.listAllCharacters.mockRejectedValueOnce(new Error("characters failed"))
+
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    await user.click(
+      await screen.findByRole("button", { name: "Select character or persona" })
+    )
+
+    expect(
+      await screen.findByText(/could not load characters/i)
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /retry characters/i }))
+
+    expect(mocks.listAllCharacters).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps loaded characters usable when persona catalog loading fails", async () => {
+    mocks.listPersonaProfiles.mockRejectedValueOnce(new Error("personas failed"))
+
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    await user.click(
+      await screen.findByRole("button", { name: "Select character or persona" })
+    )
+
+    expect(await screen.findByRole("button", { name: "Alpha" })).toBeInTheDocument()
+    await user.click(await screen.findByRole("tab", { name: "Personas" }))
+    expect(
+      await screen.findByText(/could not load personas/i)
+    ).toBeInTheDocument()
+  })
+
   it("does not select a character when its favorite star is clicked", async () => {
     const user = userEvent.setup()
     renderAssistantSelect()
@@ -233,6 +288,93 @@ describe("AssistantSelect behavior", () => {
       "aria-selected",
       "true"
     )
+  })
+
+  it("returns focus to the requested rail trigger after selection", async () => {
+    const user = userEvent.setup()
+    renderAssistantSelect()
+    const railTrigger = screen.getByRole("button", {
+      name: "Runtime rail trigger"
+    })
+
+    window.dispatchEvent(
+      new CustomEvent("tldw:open-assistant-select", {
+        detail: {
+          tab: "persona",
+          source: "playground-cockpit",
+          returnFocusSelector: "#assistant-rail-trigger"
+        }
+      })
+    )
+
+    await user.click(await screen.findByRole("button", { name: "Guide Persona" }))
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(railTrigger)
+    })
+  })
+
+  it("closes the menu and restores focus without waiting for selection persistence", async () => {
+    const user = userEvent.setup()
+    let resolveSelection: (() => void) | undefined
+    mocks.setSelectedAssistant.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSelection = resolve
+        })
+    )
+
+    renderAssistantSelect()
+    const railTrigger = screen.getByRole("button", {
+      name: "Runtime rail trigger"
+    })
+
+    window.dispatchEvent(
+      new CustomEvent("tldw:open-assistant-select", {
+        detail: {
+          tab: "character",
+          source: "playground-cockpit",
+          returnFocusSelector: "#assistant-rail-trigger"
+        }
+      })
+    )
+
+    await user.click(await screen.findByRole("button", { name: "Alpha" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-select-menu")).toBeNull()
+      expect(document.activeElement).toBe(railTrigger)
+    })
+    expect(mocks.setSelectedAssistant).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "character", id: "char-1", name: "Alpha" })
+    )
+
+    resolveSelection?.()
+  })
+
+  it("returns focus to the requested rail trigger after Escape closes the menu", async () => {
+    renderAssistantSelect()
+    const railTrigger = screen.getByRole("button", {
+      name: "Runtime rail trigger"
+    })
+
+    window.dispatchEvent(
+      new CustomEvent("tldw:open-assistant-select", {
+        detail: {
+          tab: "character",
+          source: "playground-cockpit",
+          returnFocusSelector: "#assistant-rail-trigger"
+        }
+      })
+    )
+
+    expect(await screen.findByRole("button", { name: "Alpha" })).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: "Escape" })
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(railTrigger)
+    })
   })
 
   it("labels identity and optional scene choices without mixing character and persona concepts", async () => {

--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -7,14 +7,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   listAllCharacters: vi.fn(async () => []),
   listPersonaProfiles: vi.fn(async () => []),
-  selectedAssistant: {
-    value: null as null | {
-      kind: "character" | "persona"
-      id: string
-      name: string
-    }
-  },
-  setSelectedAssistant: vi.fn(async () => undefined)
+  getPersonaProfile: vi.fn(async () => null),
+  getCharacter: vi.fn(async () => null),
+  setSelectedAssistant: vi.fn(async () => undefined),
+  updateSettings: vi.fn(async () => null)
+}))
+
+const state = vi.hoisted(() => ({
+  option: {
+    historyId: "history-overlay-1",
+    serverChatId: "chat-overlay-1",
+    serverChatAssistantKind: null as string | null,
+    serverChatAssistantId: null as string | null,
+    serverChatCharacterId: null as string | null
+  }
 }))
 
 vi.mock("react-i18next", () => ({
@@ -32,16 +38,31 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
     initialize: vi.fn(async () => null),
     listAllCharacters: mocks.listAllCharacters,
-    listPersonaProfiles: mocks.listPersonaProfiles
+    listPersonaProfiles: mocks.listPersonaProfiles,
+    getPersonaProfile: mocks.getPersonaProfile,
+    getCharacter: mocks.getCharacter
   }
 }))
 
 vi.mock("@/hooks/useSelectedAssistant", () => ({
   useSelectedAssistant: () => [
-    mocks.selectedAssistant.value,
+    null,
     mocks.setSelectedAssistant,
     { isLoading: false, setRenderValue: vi.fn() }
   ]
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(state.option)
+}))
+
+vi.mock("@/hooks/chat/useChatSettingsRecord", () => ({
+  useChatSettingsRecord: () => ({
+    settings: null,
+    updateSettings: mocks.updateSettings,
+    chatKey: "chat-overlay-1"
+  })
 }))
 
 vi.mock("antd", async () => {
@@ -105,7 +126,9 @@ vi.mock("antd", async () => {
 
 import { AssistantSelect } from "../AssistantSelect"
 
-const renderAssistantSelect = () => {
+const renderAssistantSelect = (
+  props: React.ComponentProps<typeof AssistantSelect> = {}
+) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -116,10 +139,7 @@ const renderAssistantSelect = () => {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <button id="assistant-rail-trigger" type="button">
-        Runtime rail trigger
-      </button>
-      <AssistantSelect variant="dropdown" />
+      <AssistantSelect variant="dropdown" {...props} />
     </QueryClientProvider>
   )
 }
@@ -127,14 +147,32 @@ const renderAssistantSelect = () => {
 describe("AssistantSelect behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.selectedAssistant.value = null
+    state.option = {
+      historyId: "history-overlay-1",
+      serverChatId: "chat-overlay-1",
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      serverChatCharacterId: null
+    }
     mocks.listAllCharacters.mockResolvedValue([
-      { id: "char-1", name: "Alpha" },
+      { id: "char-1", name: "Alpha", system_prompt: "Summary prompt" },
       { id: "char-2", name: "Beta" }
     ])
     mocks.listPersonaProfiles.mockResolvedValue([
       { id: "persona-1", name: "Guide Persona" }
     ])
+    mocks.getPersonaProfile.mockResolvedValue({
+      id: "persona-1",
+      name: "Guide Persona",
+      avatar_url: "https://example.com/guide-full.png",
+      system_prompt: "Persona full prompt"
+    })
+    mocks.getCharacter.mockResolvedValue({
+      id: "char-1",
+      name: "Alpha",
+      avatar_url: "https://example.com/alpha-full.png",
+      system_prompt: "Character full prompt"
+    })
   })
 
   it("opens a searchable menu and filters visible characters", async () => {
@@ -152,74 +190,6 @@ describe("AssistantSelect behavior", () => {
 
     expect(await screen.findByRole("button", { name: "Beta" })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Alpha" })).toBeNull()
-  })
-
-  it("announces character and persona catalog loading in the selector", async () => {
-    mocks.listAllCharacters.mockReturnValue(new Promise(() => {}))
-    mocks.listPersonaProfiles.mockReturnValue(new Promise(() => {}))
-
-    const user = userEvent.setup()
-    renderAssistantSelect()
-
-    await user.click(
-      await screen.findByRole("button", { name: "Select character or persona" })
-    )
-
-    const status = await screen.findByRole("status", {
-      name: /loading character and persona catalogs/i
-    })
-    expect(status).toHaveTextContent("Loading characters and personas")
-  })
-
-  it("shows a retryable character catalog failure instead of an empty list", async () => {
-    mocks.listAllCharacters.mockRejectedValueOnce(new Error("characters failed"))
-
-    const user = userEvent.setup()
-    renderAssistantSelect()
-
-    await user.click(
-      await screen.findByRole("button", { name: "Select character or persona" })
-    )
-
-    expect(
-      await screen.findByText(/could not load characters/i)
-    ).toBeInTheDocument()
-    await user.click(screen.getByRole("button", { name: /retry characters/i }))
-
-    expect(mocks.listAllCharacters).toHaveBeenCalledTimes(2)
-  })
-
-  it("keeps loaded characters usable when persona catalog loading fails", async () => {
-    mocks.listPersonaProfiles.mockRejectedValueOnce(new Error("personas failed"))
-
-    const user = userEvent.setup()
-    renderAssistantSelect()
-
-    await user.click(
-      await screen.findByRole("button", { name: "Select character or persona" })
-    )
-
-    expect(await screen.findByRole("button", { name: "Alpha" })).toBeInTheDocument()
-    await user.click(await screen.findByRole("tab", { name: "Personas" }))
-    expect(
-      await screen.findByText(/could not load personas/i)
-    ).toBeInTheDocument()
-  })
-
-  it("uses solid design-token backgrounds for the selector panel", async () => {
-    const user = userEvent.setup()
-    renderAssistantSelect()
-
-    await user.click(
-      await screen.findByRole("button", { name: "Select character or persona" })
-    )
-
-    const panel = await screen.findByTestId("assistant-select-panel")
-    expect(panel).toHaveClass("bg-elevated")
-    expect(panel).not.toHaveClass("bg-background")
-    expect(await screen.findByRole("button", { name: "Alpha" })).toHaveClass(
-      "bg-surface"
-    )
   })
 
   it("does not select a character when its favorite star is clicked", async () => {
@@ -253,111 +223,6 @@ describe("AssistantSelect behavior", () => {
       "aria-selected",
       "true"
     )
-  })
-
-  it("opens the persona tab from an assistant-select event", async () => {
-    renderAssistantSelect()
-
-    window.dispatchEvent(
-      new CustomEvent("tldw:open-assistant-select", {
-        detail: { tab: "persona", source: "playground-cockpit" }
-      })
-    )
-
-    expect(
-      await screen.findByRole("button", { name: "Guide Persona" })
-    ).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: "Personas" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    )
-  })
-
-  it("returns focus to the requested rail trigger after selection", async () => {
-    const user = userEvent.setup()
-    renderAssistantSelect()
-    const railTrigger = screen.getByRole("button", {
-      name: "Runtime rail trigger"
-    })
-
-    window.dispatchEvent(
-      new CustomEvent("tldw:open-assistant-select", {
-        detail: {
-          tab: "persona",
-          source: "playground-cockpit",
-          returnFocusSelector: "#assistant-rail-trigger"
-        }
-      })
-    )
-
-    await user.click(await screen.findByRole("button", { name: "Guide Persona" }))
-
-    await waitFor(() => {
-      expect(document.activeElement).toBe(railTrigger)
-    })
-  })
-
-  it("closes the menu and restores focus without waiting for selection persistence", async () => {
-    const user = userEvent.setup()
-    let resolveSelection: (() => void) | undefined
-    mocks.setSelectedAssistant.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveSelection = resolve
-        })
-    )
-
-    renderAssistantSelect()
-    const railTrigger = screen.getByRole("button", {
-      name: "Runtime rail trigger"
-    })
-
-    window.dispatchEvent(
-      new CustomEvent("tldw:open-assistant-select", {
-        detail: {
-          tab: "character",
-          source: "playground-cockpit",
-          returnFocusSelector: "#assistant-rail-trigger"
-        }
-      })
-    )
-
-    await user.click(await screen.findByRole("button", { name: "Alpha" }))
-
-    await waitFor(() => {
-      expect(screen.queryByTestId("assistant-select-menu")).toBeNull()
-      expect(document.activeElement).toBe(railTrigger)
-    })
-    expect(mocks.setSelectedAssistant).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "character", id: "char-1", name: "Alpha" })
-    )
-
-    resolveSelection?.()
-  })
-
-  it("returns focus to the requested rail trigger after Escape closes the menu", async () => {
-    renderAssistantSelect()
-    const railTrigger = screen.getByRole("button", {
-      name: "Runtime rail trigger"
-    })
-
-    window.dispatchEvent(
-      new CustomEvent("tldw:open-assistant-select", {
-        detail: {
-          tab: "character",
-          source: "playground-cockpit",
-          returnFocusSelector: "#assistant-rail-trigger"
-        }
-      })
-    )
-
-    expect(await screen.findByRole("button", { name: "Alpha" })).toBeInTheDocument()
-
-    fireEvent.keyDown(document, { key: "Escape" })
-
-    await waitFor(() => {
-      expect(document.activeElement).toBe(railTrigger)
-    })
   })
 
   it("labels identity and optional scene choices without mixing character and persona concepts", async () => {
@@ -458,6 +323,7 @@ describe("AssistantSelect behavior", () => {
         }
       })
     )
+    expect(mocks.updateSettings).not.toHaveBeenCalled()
   })
 
   it.each([
@@ -538,5 +404,217 @@ describe("AssistantSelect behavior", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("assistant-select-menu")).toBeNull()
     })
+  })
+
+  it("resolves persona overlay snapshots from full persona detail on apply", async () => {
+    const user = userEvent.setup()
+    renderAssistantSelect()
+
+    window.dispatchEvent(
+      new CustomEvent("tldw:open-assistant-select", {
+        detail: {
+          tab: "persona",
+          applyAs: "overlay",
+          source: "character-control-rail"
+        }
+      })
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Guide Persona" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.getPersonaProfile).toHaveBeenCalledWith("persona-1")
+    })
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      assistantOverlay: expect.objectContaining({
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        avatar_url: "https://example.com/guide-full.png",
+        system_prompt_snapshot: "Persona full prompt"
+      })
+    })
+  })
+
+  it("refreshes character detail for overlay snapshots when summary prompt material is missing", async () => {
+    const user = userEvent.setup()
+    mocks.listAllCharacters.mockResolvedValue([
+      { id: "char-2", name: "Beta" }
+    ])
+    mocks.getCharacter.mockResolvedValue({
+      id: "char-2",
+      name: "Beta",
+      avatar_url: "https://example.com/beta-full.png",
+      system_prompt: "Character fetched prompt"
+    })
+
+    renderAssistantSelect()
+
+    window.dispatchEvent(
+      new CustomEvent("tldw:open-assistant-select", {
+        detail: {
+          tab: "character",
+          applyAs: "overlay",
+          source: "character-control-rail"
+        }
+      })
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Beta" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.getCharacter).toHaveBeenCalledWith("char-2", {
+        forceRefresh: true
+      })
+    })
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      assistantOverlay: expect.objectContaining({
+        kind: "character",
+        id: "char-2",
+        name: "Beta",
+        avatar_url: "https://example.com/beta-full.png",
+        system_prompt_snapshot: "Character fetched prompt"
+      })
+    })
+  })
+
+  it("still applies persona selection when persona detail lookup fails", async () => {
+    const user = userEvent.setup()
+    mocks.getPersonaProfile.mockRejectedValueOnce(
+      new Error("persona detail unavailable")
+    )
+
+    renderAssistantSelect()
+
+    window.dispatchEvent(
+      new CustomEvent("tldw:open-assistant-select", {
+        detail: {
+          tab: "persona",
+          applyAs: "overlay",
+          source: "character-control-rail"
+        }
+      })
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Guide Persona" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.setSelectedAssistant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "persona",
+          id: "persona-1",
+          name: "Guide Persona"
+        })
+      )
+    })
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      assistantOverlay: expect.objectContaining({
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        system_prompt_snapshot: null
+      })
+    })
+  })
+
+  it("still applies local selection when overlay settings persistence fails", async () => {
+    const user = userEvent.setup()
+    mocks.updateSettings.mockRejectedValueOnce(new Error("settings write failed"))
+
+    renderAssistantSelect()
+
+    window.dispatchEvent(
+      new CustomEvent("tldw:open-assistant-select", {
+        detail: {
+          tab: "persona",
+          applyAs: "overlay",
+          source: "character-control-rail"
+        }
+      })
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Guide Persona" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.setSelectedAssistant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "persona",
+          id: "persona-1",
+          name: "Guide Persona"
+        })
+      )
+    })
+  })
+
+  it("uses the prop-driven overlay selection path and custom label without requiring an open event", async () => {
+    const user = userEvent.setup()
+    renderAssistantSelect({
+      selectionModePreference: "overlay",
+      labelOverride: "Apply overlay"
+    })
+
+    await user.click(
+      await screen.findByRole("button", { name: "Apply overlay" })
+    )
+    await user.click(
+      await screen.findByRole("tab", { name: "Personas" })
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Guide Persona" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.setSelectedAssistant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "persona",
+          id: "persona-1",
+          name: "Guide Persona"
+        })
+      )
+    })
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      assistantOverlay: expect.objectContaining({
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        avatar_url: "https://example.com/guide-full.png",
+        system_prompt_snapshot: "Persona full prompt"
+      })
+    })
+  })
+
+  it("refuses overlay writes when the current chat is already tracked", async () => {
+    const user = userEvent.setup()
+    state.option = {
+      historyId: "history-overlay-1",
+      serverChatId: "chat-overlay-1",
+      serverChatAssistantKind: "character",
+      serverChatAssistantId: null,
+      serverChatCharacterId: "char-9"
+    }
+
+    renderAssistantSelect({
+      selectionModePreference: "overlay",
+      labelOverride: "Apply overlay"
+    })
+
+    await user.click(
+      await screen.findByRole("button", { name: "Apply overlay" })
+    )
+    await user.click(
+      await screen.findByRole("tab", { name: "Personas" })
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Guide Persona" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.setSelectedAssistant).not.toHaveBeenCalled()
+    })
+    expect(mocks.updateSettings).not.toHaveBeenCalled()
   })
 })

--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -9,6 +9,15 @@ const mocks = vi.hoisted(() => ({
   listPersonaProfiles: vi.fn(async () => []),
   getPersonaProfile: vi.fn(async () => null),
   getCharacter: vi.fn(async () => null),
+  selectedAssistant: {
+    value: null as
+      | null
+      | {
+          kind: "character" | "persona"
+          id: string
+          name: string
+        }
+  },
   setSelectedAssistant: vi.fn(async () => undefined),
   updateSettings: vi.fn(async () => null)
 }))
@@ -46,7 +55,7 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
 
 vi.mock("@/hooks/useSelectedAssistant", () => ({
   useSelectedAssistant: () => [
-    null,
+    mocks.selectedAssistant.value,
     mocks.setSelectedAssistant,
     { isLoading: false, setRenderValue: vi.fn() }
   ]
@@ -147,6 +156,7 @@ const renderAssistantSelect = (
 describe("AssistantSelect behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.selectedAssistant.value = null
     state.option = {
       historyId: "history-overlay-1",
       serverChatId: "chat-overlay-1",

--- a/apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx
@@ -1,0 +1,264 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord"
+import { resolveEffectiveAssistantState } from "@/hooks/chat/effective-assistant-state"
+import { useClearChat } from "@/hooks/chat/useClearChat"
+import { useSelectServerChat } from "@/hooks/chat/useSelectServerChat"
+import {
+  type ServerChatHistoryItem,
+  useServerChatHistory
+} from "@/hooks/useServerChatHistory"
+import { useSelectedAssistant } from "@/hooks/useSelectedAssistant"
+import { useStoreMessageOption } from "@/store/option"
+import { dispatchOpenAssistantSelect } from "@/utils/assistant-select-events"
+
+const isTrackedSession = (item: ServerChatHistoryItem): boolean =>
+  item.assistant_kind === "character" ||
+  item.assistant_kind === "persona" ||
+  item.character_id != null
+
+const resolveModeLabel = (
+  mode: ReturnType<typeof resolveEffectiveAssistantState>["mode"]
+): string => {
+  if (mode === "overlay") return "Overlay personality"
+  if (mode === "tracked_character") return "Tracked character chat"
+  if (mode === "tracked_persona") return "Tracked persona chat"
+  return "Plain chat"
+}
+
+export const CharacterControlRail = () => {
+  const { t } = useTranslation(["playground", "common"])
+  const historyId = useStoreMessageOption((state) => state.historyId)
+  const serverChatId = useStoreMessageOption((state) => state.serverChatId)
+  const serverChatAssistantKind = useStoreMessageOption(
+    (state) => state.serverChatAssistantKind
+  )
+  const serverChatAssistantId = useStoreMessageOption(
+    (state) => state.serverChatAssistantId
+  )
+  const serverChatCharacterId = useStoreMessageOption(
+    (state) => state.serverChatCharacterId
+  )
+  const [selectedAssistant, setSelectedAssistant] = useSelectedAssistant(null)
+  const { settings, updateSettings } = useChatSettingsRecord({
+    historyId,
+    serverChatId
+  })
+  const clearChat = useClearChat()
+  const selectServerChat = useSelectServerChat()
+  const { data: serverChatHistory = [] } = useServerChatHistory("", {
+    filterMode: "all"
+  })
+
+  const effectiveAssistantState = React.useMemo(
+    () =>
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: serverChatAssistantKind,
+          assistantId: serverChatAssistantId,
+          characterId: serverChatCharacterId
+        },
+        settings: settings ?? null,
+        draftSelection: selectedAssistant
+      }),
+    [
+      selectedAssistant,
+      serverChatAssistantId,
+      serverChatAssistantKind,
+      serverChatCharacterId,
+      settings
+    ]
+  )
+
+  const trackedSessions = React.useMemo(
+    () => serverChatHistory.filter(isTrackedSession).slice(0, 6),
+    [serverChatHistory]
+  )
+  const isTrackedMode =
+    effectiveAssistantState.mode === "tracked_character" ||
+    effectiveAssistantState.mode === "tracked_persona"
+
+  const overlayTab =
+    effectiveAssistantState.kind === "persona" ? "persona" : "character"
+  const overlayActionLabel =
+    effectiveAssistantState.mode === "overlay"
+      ? t("playground:characterRail.changeOverlay", "Change overlay")
+      : t("playground:characterRail.applyOverlay", "Apply overlay")
+
+  const handleOverlaySelect = React.useCallback(() => {
+    dispatchOpenAssistantSelect({
+      tab: overlayTab,
+      applyAs: "overlay",
+      source: "character-control-rail"
+    })
+  }, [overlayTab])
+
+  const handleClearOverlay = React.useCallback(async () => {
+    await updateSettings({
+      assistantOverlay: null
+    })
+    await setSelectedAssistant(null)
+  }, [setSelectedAssistant, updateSettings])
+
+  const handleStartTracked = React.useCallback(
+    async (tab: "character" | "persona") => {
+      await updateSettings({
+        assistantOverlay: null
+      })
+      await setSelectedAssistant(null)
+      clearChat()
+      dispatchOpenAssistantSelect({
+        tab,
+        applyAs: "tracked",
+        source: "character-control-rail"
+      })
+    },
+    [clearChat, setSelectedAssistant, updateSettings]
+  )
+
+  return (
+    <aside
+      data-testid="character-control-rail"
+      aria-label={t("playground:characterRail.title", "Character controls")}
+      className="flex h-full min-h-0 w-full flex-col border-l border-border bg-surface"
+    >
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-text">
+              {t("playground:characterRail.title", "Character controls")}
+            </h2>
+            <p className="mt-1 text-xs text-text-muted">
+              {t(
+                "playground:characterRail.subtitle",
+                "Overlay and tracked character/persona controls for this chat."
+              )}
+            </p>
+          </div>
+          <span className="inline-flex items-center rounded-full border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text">
+            {resolveModeLabel(effectiveAssistantState.mode)}
+          </span>
+        </div>
+        {effectiveAssistantState.displayName && (
+          <p className="mt-2 text-sm text-text">
+            {effectiveAssistantState.displayName}
+          </p>
+        )}
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+        <section className="space-y-2">
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+              {t("playground:characterRail.overlayHeading", "Overlay")}
+            </h3>
+            <p className="mt-1 text-xs text-text-muted">
+              {isTrackedMode
+                ? t(
+                    "playground:characterRail.overlayUnavailableTracked",
+                    "Overlay is unavailable while this chat is already tracked to a character or persona."
+                  )
+                : t(
+                    "playground:characterRail.overlayBody",
+                    "Use a character or persona as the assistant personality without changing conversation ownership."
+                  )}
+            </p>
+          </div>
+          {!isTrackedMode ? (
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handleOverlaySelect}
+                className="inline-flex items-center rounded-md border border-border bg-surface2 px-3 py-1.5 text-xs font-medium text-text hover:bg-surface"
+              >
+                {overlayActionLabel}
+              </button>
+              {effectiveAssistantState.mode === "overlay" && (
+                <button
+                  type="button"
+                  onClick={() => void handleClearOverlay()}
+                  className="inline-flex items-center rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-surface2"
+                >
+                  {t("playground:characterRail.clearOverlay", "Clear overlay")}
+                </button>
+              )}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="space-y-2">
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+              {t("playground:characterRail.trackedHeading", "Tracked chats")}
+            </h3>
+            <p className="mt-1 text-xs text-text-muted">
+              {t(
+                "playground:characterRail.trackedBody",
+                "Start or open chats that stay attached to a specific character or persona."
+              )}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <button
+              type="button"
+              onClick={() => void handleStartTracked("character")}
+              className="inline-flex items-center justify-center rounded-md border border-border bg-surface2 px-3 py-1.5 text-xs font-medium text-text hover:bg-surface"
+            >
+              {t(
+                "playground:characterRail.startTrackedCharacter",
+                "Start tracked character chat"
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleStartTracked("persona")}
+              className="inline-flex items-center justify-center rounded-md border border-border bg-surface2 px-3 py-1.5 text-xs font-medium text-text hover:bg-surface"
+            >
+              {t(
+                "playground:characterRail.startTrackedPersona",
+                "Start tracked persona chat"
+              )}
+            </button>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+            {t("playground:characterRail.trackedSessions", "Tracked sessions")}
+          </h3>
+          {trackedSessions.length > 0 ? (
+            <div className="flex flex-col gap-2">
+              {trackedSessions.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => selectServerChat(item)}
+                  aria-label={item.title || t("common:untitled", "Untitled")}
+                  className="flex items-start justify-between rounded-md border border-border bg-surface px-3 py-2 text-left hover:bg-surface2"
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm text-text">
+                      {item.title || t("common:untitled", "Untitled")}
+                    </span>
+                    <span className="mt-1 block text-[11px] text-text-muted">
+                      {item.assistant_kind === "persona"
+                        ? t("playground:characterRail.personaSession", "Persona")
+                        : t("playground:characterRail.characterSession", "Character")}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-text-muted">
+              {t(
+                "playground:characterRail.noTrackedSessions",
+                "No tracked character or persona sessions yet."
+              )}
+            </p>
+          )}
+        </section>
+      </div>
+    </aside>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -131,6 +131,7 @@ import {
   type CharacterChatReadinessAction,
 } from "@/utils/chat-model-availability";
 import type { Character } from "@/types/character";
+import { CharacterControlRail } from "./CharacterControlRail";
 
 type ChatModelCatalog = Awaited<ReturnType<typeof fetchChatModels>>;
 
@@ -504,6 +505,9 @@ export const Playground = () => {
         : (selectedCharacter?.name ?? null);
   const setRouteContext = useChatSurfaceCoordinatorStore(
     (state) => state.setRouteContext,
+  );
+  const characterControlVisible = useChatSurfaceCoordinatorStore(
+    (state) => state.visiblePanels["character-control"],
   );
   const normalizedChatLayoutMode: PlaygroundCockpitMode =
     chatLayoutMode === "focus" || chatLayoutMode === "cockpit"
@@ -3418,6 +3422,11 @@ export const Playground = () => {
             </div>
           </div>
         </PlaygroundCockpitShell>
+        {characterControlVisible && !isMobileViewport && (
+          <div className="hidden h-full w-[28%] min-w-[280px] max-w-[360px] shrink-0 lg:flex">
+            <CharacterControlRail />
+          </div>
+        )}
         {artifactsOpen && (
           <>
             <div className="hidden h-full w-[36%] min-w-[280px] max-w-[520px] shrink-0 lg:flex">

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -1388,6 +1388,22 @@ export const PlaygroundForm = ({
     };
   }, [markOptionalPanelEngaged, setOptionalPanelVisible, voiceChatEnabled]);
 
+  React.useEffect(() => {
+    const showCharacterControl = !isMobileViewport;
+    setOptionalPanelVisible("character-control", showCharacterControl);
+    if (showCharacterControl) {
+      markOptionalPanelEngaged("character-control");
+    }
+
+    return () => {
+      setOptionalPanelVisible("character-control", false);
+    };
+  }, [
+    isMobileViewport,
+    markOptionalPanelEngaged,
+    setOptionalPanelVisible,
+  ]);
+
   // Auto-select model on initial load when no model is selected
   // Priority: 1) First favorite model, 2) First available model
   React.useEffect(() => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  dispatchOpenAssistantSelect: vi.fn(),
+  updateSettings: vi.fn(async () => null),
+  clearChat: vi.fn(),
+  selectServerChat: vi.fn(),
+  setSelectedAssistant: vi.fn(async () => undefined)
+}))
+
+const state = vi.hoisted(() => ({
+  selectedAssistant: null as Record<string, unknown> | null,
+  settings: {
+    assistantOverlay: {
+      kind: "persona",
+      id: "persona-1",
+      name: "Guide Persona",
+      avatar_url: null,
+      system_prompt_snapshot: "Persona prompt",
+      updatedAt: "2026-05-22T12:00:00.000Z"
+    }
+  } as Record<string, unknown> | null,
+  option: {
+    historyId: "history-1",
+    serverChatId: "chat-1",
+    serverChatAssistantKind: null,
+    serverChatAssistantId: null,
+    serverChatCharacterId: null
+  },
+  history: [
+    {
+      id: "tracked-chat-1",
+      title: "Captain Mira",
+      assistant_kind: "character",
+      character_id: "char-1",
+      created_at: "2026-05-22T12:00:00.000Z"
+    },
+    {
+      id: "plain-chat-1",
+      title: "Plain chat",
+      assistant_kind: null,
+      character_id: null,
+      created_at: "2026-05-21T12:00:00.000Z"
+    }
+  ] as Array<Record<string, unknown>>
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@/hooks/useSelectedAssistant", () => ({
+  useSelectedAssistant: () => [
+    state.selectedAssistant,
+    mocks.setSelectedAssistant,
+    { isLoading: false, setRenderValue: vi.fn() }
+  ]
+}))
+
+vi.mock("@/hooks/chat/useChatSettingsRecord", () => ({
+  useChatSettingsRecord: () => ({
+    settings: state.settings,
+    updateSettings: mocks.updateSettings,
+    chatKey: "server:chat-1"
+  })
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (selector: (input: typeof state.option) => unknown) =>
+    selector(state.option)
+}))
+
+vi.mock("@/utils/assistant-select-events", () => ({
+  dispatchOpenAssistantSelect: mocks.dispatchOpenAssistantSelect
+}))
+
+vi.mock("@/hooks/chat/useClearChat", () => ({
+  useClearChat: () => mocks.clearChat
+}))
+
+vi.mock("@/hooks/chat/useSelectServerChat", () => ({
+  useSelectServerChat: () => mocks.selectServerChat
+}))
+
+vi.mock("@/hooks/useServerChatHistory", () => ({
+  useServerChatHistory: () => ({
+    data: state.history,
+    total: state.history.length
+  })
+}))
+
+import { CharacterControlRail } from "../CharacterControlRail"
+
+describe("CharacterControlRail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.selectedAssistant = null
+    state.settings = {
+      assistantOverlay: {
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        avatar_url: null,
+        system_prompt_snapshot: "Persona prompt",
+        updatedAt: "2026-05-22T12:00:00.000Z"
+      }
+    }
+    state.option = {
+      historyId: "history-1",
+      serverChatId: "chat-1",
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      serverChatCharacterId: null
+    }
+    state.history = [
+      {
+        id: "tracked-chat-1",
+        title: "Captain Mira",
+        assistant_kind: "character",
+        character_id: "char-1",
+        created_at: "2026-05-22T12:00:00.000Z"
+      },
+      {
+        id: "plain-chat-1",
+        title: "Plain chat",
+        assistant_kind: null,
+        character_id: null,
+        created_at: "2026-05-21T12:00:00.000Z"
+      }
+    ]
+  })
+
+  it("renders the current mode summary and tracked sessions separately", () => {
+    render(<CharacterControlRail />)
+
+    expect(screen.getByText("Overlay personality")).toBeInTheDocument()
+    expect(screen.getByText("Guide Persona")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Tracked sessions" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Captain Mira" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Plain chat" })).toBeNull()
+  })
+
+  it("opens the assistant picker with explicit overlay intent", async () => {
+    const user = userEvent.setup()
+    render(<CharacterControlRail />)
+
+    await user.click(screen.getByRole("button", { name: "Change overlay" }))
+
+    expect(mocks.dispatchOpenAssistantSelect).toHaveBeenCalledWith({
+      tab: "persona",
+      applyAs: "overlay",
+      source: "character-control-rail"
+    })
+    expect(mocks.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it("clears overlay settings without resetting the conversation", async () => {
+    const user = userEvent.setup()
+    render(<CharacterControlRail />)
+
+    await user.click(screen.getByRole("button", { name: "Clear overlay" }))
+
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      assistantOverlay: null
+    })
+    expect(mocks.clearChat).not.toHaveBeenCalled()
+  })
+
+  it("keeps tracked-start actions separate from overlay actions", async () => {
+    const user = userEvent.setup()
+    render(<CharacterControlRail />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Start tracked character chat" })
+    )
+
+    expect(mocks.clearChat).toHaveBeenCalledTimes(1)
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      assistantOverlay: null
+    })
+    expect(mocks.dispatchOpenAssistantSelect).toHaveBeenCalledWith({
+      tab: "character",
+      applyAs: "tracked",
+      source: "character-control-rail"
+    })
+  })
+
+  it("does not expose overlay actions when the current chat is already tracked", () => {
+    state.settings = {
+      assistantOverlay: {
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        avatar_url: null,
+        system_prompt_snapshot: "Persona prompt",
+        updatedAt: "2026-05-22T12:00:00.000Z"
+      }
+    }
+    state.option = {
+      historyId: "history-1",
+      serverChatId: "chat-1",
+      serverChatAssistantKind: "character",
+      serverChatAssistantId: null,
+      serverChatCharacterId: "char-7"
+    }
+
+    render(<CharacterControlRail />)
+
+    expect(screen.getByText("Tracked character chat")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Apply overlay" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Change overlay" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Clear overlay" })).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, waitFor } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 
 import { Playground } from "../Playground"
 import { useChatSurfaceCoordinatorStore } from "@/store/chat-surface-coordinator"
@@ -55,6 +55,10 @@ vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
 
 vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
   PlaygroundChat: () => <div data-testid="playground-chat" />
+}))
+
+vi.mock("@/components/Option/Playground/CharacterControlRail", () => ({
+  CharacterControlRail: () => <div data-testid="character-control-rail" />
 }))
 
 vi.mock("@/components/Sidepanel/Chat/ArtifactsPanel", () => ({
@@ -198,13 +202,15 @@ describe("Playground coordinator integration", () => {
         "server-history": false,
         "mcp-tools": false,
         "audio-health": false,
-        "model-catalog": false
+        "model-catalog": false,
+        "character-control": false
       },
       engagedPanels: {
         "server-history": false,
         "mcp-tools": false,
         "audio-health": false,
-        "model-catalog": false
+        "model-catalog": false,
+        "character-control": false
       }
     })
   })
@@ -236,6 +242,19 @@ describe("Playground coordinator integration", () => {
     await waitFor(() => {
       expect(restoreSession).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it("renders the character control rail when the coordinator marks it visible", () => {
+    useChatSurfaceCoordinatorStore.setState((state) => ({
+      visiblePanels: {
+        ...state.visiblePanels,
+        "character-control": true
+      }
+    }))
+
+    render(<Playground />)
+
+    expect(screen.getByTestId("character-control-rail")).toBeInTheDocument()
   })
 
   it("applies explicit character chat route ids before persisted session restore", async () => {

--- a/apps/packages/ui/src/components/Sidepanel/Chat/CharacterControlsSheet.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/CharacterControlsSheet.tsx
@@ -1,0 +1,255 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { AssistantSelect } from "@/components/Common/AssistantSelect"
+import { Button } from "@/components/Common/Button"
+import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord"
+import { resolveEffectiveAssistantState } from "@/hooks/chat/effective-assistant-state"
+import { useClearChat } from "@/hooks/chat/useClearChat"
+import { useSelectServerChat } from "@/hooks/chat/useSelectServerChat"
+import { useServerChatHistory, type ServerChatHistoryItem } from "@/hooks/useServerChatHistory"
+import { useSelectedAssistant } from "@/hooks/useSelectedAssistant"
+import { useStoreMessageOption } from "@/store/option"
+import { dispatchOpenAssistantSelect } from "@/utils/assistant-select-events"
+
+type CharacterControlsSheetProps = {
+  beforeTrackedStart?: (() => Promise<void>) | (() => void)
+  onRequestClose?: () => void
+}
+
+const isTrackedSession = (item: ServerChatHistoryItem): boolean =>
+  item.assistant_kind === "character" ||
+  item.assistant_kind === "persona" ||
+  item.character_id != null
+
+const resolveAssistantModeLabel = (
+  mode: ReturnType<typeof resolveEffectiveAssistantState>["mode"]
+) => {
+  if (mode === "overlay") return "Overlay personality"
+  if (mode === "tracked_character") return "Tracked character chat"
+  if (mode === "tracked_persona") return "Tracked persona chat"
+  return "Plain chat"
+}
+
+export const CharacterControlsSheet = ({
+  beforeTrackedStart,
+  onRequestClose
+}: CharacterControlsSheetProps) => {
+  const { t } = useTranslation(["playground", "common"])
+  const historyId = useStoreMessageOption((state) => state.historyId)
+  const serverChatId = useStoreMessageOption((state) => state.serverChatId)
+  const serverChatAssistantKind = useStoreMessageOption(
+    (state) => state.serverChatAssistantKind
+  )
+  const serverChatAssistantId = useStoreMessageOption(
+    (state) => state.serverChatAssistantId
+  )
+  const serverChatCharacterId = useStoreMessageOption(
+    (state) => state.serverChatCharacterId
+  )
+  const [selectedAssistant, setSelectedAssistant] = useSelectedAssistant(null)
+  const { settings, updateSettings } = useChatSettingsRecord({
+    historyId,
+    serverChatId
+  })
+  const clearChat = useClearChat()
+  const selectServerChat = useSelectServerChat()
+  const { data: serverChatHistory = [] } = useServerChatHistory("", {
+    filterMode: "all"
+  })
+
+  const effectiveAssistantState = React.useMemo(
+    () =>
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: serverChatAssistantKind,
+          assistantId: serverChatAssistantId,
+          characterId: serverChatCharacterId
+        },
+        settings: settings ?? null,
+        draftSelection: selectedAssistant
+      }),
+    [
+      selectedAssistant,
+      serverChatAssistantId,
+      serverChatAssistantKind,
+      serverChatCharacterId,
+      settings
+    ]
+  )
+
+  const trackedSessions = React.useMemo(
+    () => serverChatHistory.filter(isTrackedSession).slice(0, 6),
+    [serverChatHistory]
+  )
+
+  const isTrackedMode =
+    effectiveAssistantState.mode === "tracked_character" ||
+    effectiveAssistantState.mode === "tracked_persona"
+  const overlayTab =
+    effectiveAssistantState.kind === "persona" ? "persona" : "character"
+  const overlayActionLabel =
+    effectiveAssistantState.mode === "overlay"
+      ? t("playground:characterRail.changeOverlay", "Change overlay")
+      : t("playground:characterRail.applyOverlay", "Apply overlay")
+
+  const handleClearAssistantOverlay = React.useCallback(async () => {
+    await updateSettings({
+      assistantOverlay: null
+    })
+    await setSelectedAssistant(null)
+  }, [setSelectedAssistant, updateSettings])
+
+  const handleStartTracked = React.useCallback(
+    async (tab: "character" | "persona") => {
+      await updateSettings({
+        assistantOverlay: null
+      })
+      await setSelectedAssistant(null)
+      await beforeTrackedStart?.()
+      onRequestClose?.()
+      clearChat()
+      dispatchOpenAssistantSelect({
+        tab,
+        applyAs: "tracked",
+        source: "sidepanel-character-controls"
+      })
+    },
+    [beforeTrackedStart, clearChat, onRequestClose, setSelectedAssistant, updateSettings]
+  )
+
+  const handleOpenTrackedSession = React.useCallback(
+    (item: ServerChatHistoryItem) => {
+      onRequestClose?.()
+      selectServerChat(item)
+    },
+    [onRequestClose, selectServerChat]
+  )
+
+  return (
+    <div
+      data-testid="chat-character-controls-sheet"
+      className="flex flex-col gap-4"
+    >
+      <div className="space-y-1">
+        <p className="text-sm text-text">
+          {resolveAssistantModeLabel(effectiveAssistantState.mode)}
+        </p>
+        {effectiveAssistantState.displayName ? (
+          <p className="text-xs text-text-subtle">
+            {effectiveAssistantState.displayName}
+          </p>
+        ) : null}
+      </div>
+
+      <section className="space-y-2">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-text-subtle">
+            {t("playground:characterRail.overlayHeading", "Overlay")}
+          </p>
+          <p className="text-sm text-text-subtle">
+            {isTrackedMode
+              ? t(
+                  "playground:characterRail.overlayUnavailableTracked",
+                  "Overlay is unavailable while this chat is already tracked to a character or persona."
+                )
+              : t(
+                  "playground:characterRail.overlayBody",
+                  "Use a character or persona as the assistant personality without changing conversation ownership."
+                )}
+          </p>
+        </div>
+        {!isTrackedMode ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <AssistantSelect
+              variant="dropdown"
+              showLabel
+              selectionModePreference="overlay"
+              labelOverride={overlayActionLabel}
+              iconClassName="h-4 w-4"
+              className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-medium text-text hover:bg-surface2"
+            />
+            {effectiveAssistantState.mode === "overlay" ? (
+              <Button
+                variant="outline"
+                onClick={() => void handleClearAssistantOverlay()}
+              >
+                {t("playground:characterRail.clearOverlay", "Clear overlay")}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="space-y-2">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-text-subtle">
+            {t("playground:characterRail.trackedHeading", "Tracked chats")}
+          </p>
+          <p className="text-sm text-text-subtle">
+            {t(
+              "playground:characterRail.trackedBody",
+              "Start or open chats that stay attached to a specific character or persona."
+            )}
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Button
+            variant="outline"
+            onClick={() => void handleStartTracked("character")}
+          >
+            {t(
+              "playground:characterRail.startTrackedCharacter",
+              "Start tracked character chat"
+            )}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => void handleStartTracked("persona")}
+          >
+            {t(
+              "playground:characterRail.startTrackedPersona",
+              "Start tracked persona chat"
+            )}
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-xs uppercase tracking-wide text-text-subtle">
+          {t("playground:characterRail.trackedSessions", "Tracked sessions")}
+        </p>
+        {trackedSessions.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            {trackedSessions.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => handleOpenTrackedSession(item)}
+                aria-label={item.title || t("common:untitled", "Untitled")}
+                className="flex items-start justify-between rounded-md border border-border bg-surface px-3 py-2 text-left hover:bg-surface2"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate text-sm text-text">
+                    {item.title || t("common:untitled", "Untitled")}
+                  </span>
+                  <span className="mt-1 block text-[11px] text-text-muted">
+                    {item.assistant_kind === "persona"
+                      ? t("playground:characterRail.personaSession", "Persona")
+                      : t("playground:characterRail.characterSession", "Character")}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-text-muted">
+            {t(
+              "playground:characterRail.noTrackedSessions",
+              "No tracked character or persona sessions yet."
+            )}
+          </p>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/CharacterControlsSheet.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/CharacterControlsSheet.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  dispatchOpenAssistantSelect: vi.fn(),
+  updateSettings: vi.fn(async () => null),
+  clearChat: vi.fn(),
+  selectServerChat: vi.fn(),
+  setSelectedAssistant: vi.fn(async () => undefined),
+  beforeTrackedStart: vi.fn(async () => undefined),
+  onRequestClose: vi.fn(),
+  assistantSelect: vi.fn((props: Record<string, unknown>) => props)
+}))
+
+const state = vi.hoisted(() => ({
+  selectedAssistant: null as Record<string, unknown> | null,
+  settings: {
+    assistantOverlay: null
+  } as Record<string, unknown> | null,
+  option: {
+    historyId: "history-1",
+    serverChatId: "chat-1",
+    serverChatAssistantKind: null as string | null,
+    serverChatAssistantId: null as string | null,
+    serverChatCharacterId: null as string | null
+  },
+  history: [
+    {
+      id: "tracked-chat-1",
+      title: "Captain Mira",
+      assistant_kind: "character",
+      character_id: "char-1",
+      created_at: "2026-05-22T12:00:00.000Z"
+    },
+    {
+      id: "plain-chat-1",
+      title: "Plain chat",
+      assistant_kind: null,
+      character_id: null,
+      created_at: "2026-05-21T12:00:00.000Z"
+    }
+  ] as Array<Record<string, unknown>>
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@/components/Common/AssistantSelect", () => ({
+  AssistantSelect: (props: Record<string, unknown>) => {
+    mocks.assistantSelect(props)
+    return (
+      <button type="button">
+        {String(props.labelOverride ?? "AssistantSelect")}
+      </button>
+    )
+  }
+}))
+
+vi.mock("@/hooks/useSelectedAssistant", () => ({
+  useSelectedAssistant: () => [
+    state.selectedAssistant,
+    mocks.setSelectedAssistant,
+    { isLoading: false, setRenderValue: vi.fn() }
+  ]
+}))
+
+vi.mock("@/hooks/chat/useChatSettingsRecord", () => ({
+  useChatSettingsRecord: () => ({
+    settings: state.settings,
+    updateSettings: mocks.updateSettings,
+    chatKey: "server:chat-1"
+  })
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (selector: (input: typeof state.option) => unknown) =>
+    selector(state.option)
+}))
+
+vi.mock("@/utils/assistant-select-events", () => ({
+  dispatchOpenAssistantSelect: mocks.dispatchOpenAssistantSelect
+}))
+
+vi.mock("@/hooks/chat/useClearChat", () => ({
+  useClearChat: () => mocks.clearChat
+}))
+
+vi.mock("@/hooks/chat/useSelectServerChat", () => ({
+  useSelectServerChat: () => mocks.selectServerChat
+}))
+
+vi.mock("@/hooks/useServerChatHistory", () => ({
+  useServerChatHistory: () => ({
+    data: state.history,
+    total: state.history.length
+  })
+}))
+
+import { CharacterControlsSheet } from "../CharacterControlsSheet"
+
+describe("CharacterControlsSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.selectedAssistant = null
+    state.settings = {
+      assistantOverlay: null
+    }
+    state.option = {
+      historyId: "history-1",
+      serverChatId: "chat-1",
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      serverChatCharacterId: null
+    }
+    state.history = [
+      {
+        id: "tracked-chat-1",
+        title: "Captain Mira",
+        assistant_kind: "character",
+        character_id: "char-1",
+        created_at: "2026-05-22T12:00:00.000Z"
+      },
+      {
+        id: "plain-chat-1",
+        title: "Plain chat",
+        assistant_kind: null,
+        character_id: null,
+        created_at: "2026-05-21T12:00:00.000Z"
+      }
+    ]
+  })
+
+  it("shows overlay and tracked actions separately for plain chats", () => {
+    render(
+      <CharacterControlsSheet
+        beforeTrackedStart={mocks.beforeTrackedStart}
+        onRequestClose={mocks.onRequestClose}
+      />
+    )
+
+    expect(screen.getByTestId("chat-character-controls-sheet")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Apply overlay" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Start tracked character chat" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Start tracked persona chat" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Captain Mira" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Plain chat" })).toBeNull()
+  })
+
+  it("shows clear overlay only when the current chat is in overlay mode", () => {
+    state.settings = {
+      assistantOverlay: {
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        avatar_url: null,
+        system_prompt_snapshot: "Persona prompt",
+        updatedAt: "2026-05-22T12:00:00.000Z"
+      }
+    }
+
+    render(<CharacterControlsSheet />)
+
+    expect(screen.getByRole("button", { name: "Change overlay" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Clear overlay" })).toBeInTheDocument()
+  })
+
+  it("hides overlay actions when the current chat is already tracked", () => {
+    state.option = {
+      historyId: "history-1",
+      serverChatId: "chat-1",
+      serverChatAssistantKind: "character",
+      serverChatAssistantId: null,
+      serverChatCharacterId: "char-7"
+    }
+    state.settings = {
+      assistantOverlay: {
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        avatar_url: null,
+        system_prompt_snapshot: "Persona prompt",
+        updatedAt: "2026-05-22T12:00:00.000Z"
+      }
+    }
+
+    render(<CharacterControlsSheet />)
+
+    expect(screen.getByText("Tracked character chat")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Apply overlay" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Change overlay" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Clear overlay" })).toBeNull()
+    expect(screen.getByRole("button", { name: "Start tracked character chat" })).toBeInTheDocument()
+  })
+
+  it("clears overlay state before starting a tracked chat", async () => {
+    const user = userEvent.setup()
+    state.settings = {
+      assistantOverlay: {
+        kind: "persona",
+        id: "persona-1",
+        name: "Guide Persona",
+        avatar_url: null,
+        system_prompt_snapshot: "Persona prompt",
+        updatedAt: "2026-05-22T12:00:00.000Z"
+      }
+    }
+
+    render(
+      <CharacterControlsSheet
+        beforeTrackedStart={mocks.beforeTrackedStart}
+        onRequestClose={mocks.onRequestClose}
+      />
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Start tracked character chat" })
+    )
+
+    expect(mocks.beforeTrackedStart).toHaveBeenCalledTimes(1)
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      assistantOverlay: null
+    })
+    expect(mocks.setSelectedAssistant).toHaveBeenCalledWith(null)
+    expect(mocks.onRequestClose).toHaveBeenCalledTimes(1)
+    expect(mocks.clearChat).toHaveBeenCalledTimes(1)
+    expect(mocks.dispatchOpenAssistantSelect).toHaveBeenCalledWith({
+      tab: "character",
+      applyAs: "tracked",
+      source: "sidepanel-character-controls"
+    })
+  })
+
+  it("opens tracked sessions through the standard server-chat selection path", async () => {
+    const user = userEvent.setup()
+    render(
+      <CharacterControlsSheet
+        beforeTrackedStart={mocks.beforeTrackedStart}
+        onRequestClose={mocks.onRequestClose}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Captain Mira" }))
+
+    expect(mocks.selectServerChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "tracked-chat-1",
+        title: "Captain Mira"
+      })
+    )
+    expect(mocks.onRequestClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts
@@ -17,6 +17,22 @@ if (!chatFormPath) {
 
 const chatFormSource = readFileSync(chatFormPath, "utf8")
 
+const characterControlsSheetPathCandidates = [
+  "src/components/Sidepanel/Chat/CharacterControlsSheet.tsx",
+  "../packages/ui/src/components/Sidepanel/Chat/CharacterControlsSheet.tsx",
+  "apps/packages/ui/src/components/Sidepanel/Chat/CharacterControlsSheet.tsx"
+]
+
+const characterControlsSheetPath = characterControlsSheetPathCandidates.find((candidate) =>
+  existsSync(candidate)
+)
+
+if (!characterControlsSheetPath) {
+  throw new Error("Unable to locate Sidepanel character controls sheet source for compact toolbar contract test")
+}
+
+const characterControlsSheetSource = readFileSync(characterControlsSheetPath, "utf8")
+
 const controlRowPathCandidates = [
   "src/components/Sidepanel/Chat/ControlRow.tsx",
   "../packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx",
@@ -36,6 +52,17 @@ const controlRowSource = readFileSync(controlRowPath, "utf8")
 describe("sidepanel chat compact toolbar contract", () => {
   it("keeps compact icon controls at a minimum 44px touch target", () => {
     expect(chatFormSource).toMatch(/h-11 w-11 min-h-\[44px\] min-w-\[44px\]/)
+  })
+
+  it("reuses the effective assistant overlay contract for compact character controls", () => {
+    expect(chatFormSource).toContain("resolveEffectiveAssistantState")
+    expect(chatFormSource).toContain("chat-character-controls-trigger")
+    expect(chatFormSource).toContain("CharacterControlsSheet")
+    expect(characterControlsSheetSource).toContain("chat-character-controls-sheet")
+    expect(characterControlsSheetSource).toContain("playground:characterRail.applyOverlay")
+    expect(characterControlsSheetSource).toContain("playground:characterRail.clearOverlay")
+    expect(characterControlsSheetSource).toContain("playground:characterRail.startTrackedCharacter")
+    expect(characterControlsSheetSource).toContain("playground:characterRail.startTrackedPersona")
   })
 
   it("includes visible compact labels for key icon actions", () => {

--- a/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
@@ -31,7 +31,8 @@ import {
   FileText,
   Globe,
   Headphones,
-  Settings2
+  Settings2,
+  UserCircle2
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { getVariable } from "@/utils/select-variable"
@@ -103,10 +104,6 @@ import { useSetting } from "@/hooks/useSetting"
 import { useFocusComposerOnConnect } from "@/hooks/useComposerFocus"
 import { useQuickIngestStore } from "@/store/quick-ingest"
 import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
-import {
-  createQuickIngestSessionSeedFromOpenDetail,
-  type QuickIngestOpenDetail
-} from "@/utils/quick-ingest-open"
 import { useUiModeStore } from "@/store/ui-mode"
 import { useStoreMessageOption } from "@/store/option"
 import { shallow } from "zustand/shallow"
@@ -120,11 +117,13 @@ import { createRenderPerfTracker } from "@/utils/perf/render-profiler"
 import { useComposerQueue } from "@/components/Chat/composer/hooks/useComposerQueue"
 import { useConversationContextComposition } from "@/hooks/chat/useConversationContextComposition"
 import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord"
+import { resolveEffectiveAssistantState } from "@/hooks/chat/effective-assistant-state"
 import {
   buildAvailableChatModelIds,
   findUnavailableChatModel,
   normalizeChatModelId
 } from "@/utils/chat-model-availability"
+import { createSafeStorage } from "@/utils/safe-storage"
 import {
   DEFAULT_CHARACTER_STORAGE_KEY,
   defaultCharacterStorage,
@@ -143,6 +142,8 @@ import { browser } from "wxt/browser"
 import type { Character } from "@/types/character"
 import type { QueuedRequest } from "@/utils/chat-request-queue"
 import { AudioSourcePicker } from "@/components/Common/AudioSourcePicker"
+import { CharacterControlsSheet } from "@/components/Sidepanel/Chat/CharacterControlsSheet"
+import { getSidepanelOverlayResumeMarkerKey } from "@/utils/sidepanel-overlay-resume"
 
 type Props = {
   dropedFile: File | undefined
@@ -182,6 +183,8 @@ export const SidepanelForm = ({
     shouldEnableOptionalResource(state, "audio-health")
   )
   const [typing, setTyping] = React.useState<boolean>(false)
+  const [characterControlsOpen, setCharacterControlsOpen] =
+    React.useState(false)
   const { t } = useTranslation(["playground", "common", "option", "sidepanel"])
   const notification = useAntdNotification()
   const [chatWithWebsiteEmbedding] = useStorage(
@@ -491,14 +494,12 @@ export const SidepanelForm = ({
   const {
     quickIngestSession,
     createDraftQuickIngestSession,
-    upsertQuickIngestSession,
     showQuickIngestSession,
     hideQuickIngestSession
   } = useQuickIngestSessionStore(
     (state) => ({
       quickIngestSession: state.session,
       createDraftQuickIngestSession: state.createDraftSession,
-      upsertQuickIngestSession: state.upsertSession,
       showQuickIngestSession: state.showSession,
       hideQuickIngestSession: state.hideSession
     }),
@@ -688,14 +689,76 @@ export const SidepanelForm = ({
     setQueuedMessages,
     serverChatId
   } = useMessage()
+  const serverChatAssistantKind = useStoreMessageOption(
+    (state) => state.serverChatAssistantKind
+  )
+  const serverChatAssistantId = useStoreMessageOption(
+    (state) => state.serverChatAssistantId
+  )
+  const serverChatCharacterId = useStoreMessageOption(
+    (state) => state.serverChatCharacterId
+  )
   const { settings: conversationContextSettings, updateSettings } =
     useChatSettingsRecord({
       historyId,
       serverChatId
     })
+  const effectiveAssistantState = React.useMemo(
+    () =>
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: serverChatAssistantKind,
+          assistantId: serverChatAssistantId,
+          characterId: serverChatCharacterId
+        },
+        settings: conversationContextSettings ?? null
+      }),
+    [
+      conversationContextSettings,
+      serverChatAssistantId,
+      serverChatAssistantKind,
+      serverChatCharacterId
+    ]
+  )
+  const sidepanelOverlayResumeStorageRef = React.useRef(
+    createSafeStorage({ area: "local" })
+  )
+  const overlayResumeMarkerKey = React.useMemo(
+    () => getSidepanelOverlayResumeMarkerKey(storageKey),
+    [storageKey]
+  )
+  const handlePrepareTrackedStart = React.useCallback(async () => {
+    if (!overlayResumeMarkerKey) return
+    try {
+      await sidepanelOverlayResumeStorageRef.current.remove(overlayResumeMarkerKey)
+    } catch {
+      // no-op
+    }
+  }, [overlayResumeMarkerKey])
   const previousServerChatIdRef = React.useRef<string | null | undefined>(
     serverChatId
   )
+
+  React.useEffect(() => {
+    if (!overlayResumeMarkerKey) return
+
+    const storage = sidepanelOverlayResumeStorageRef.current
+    const syncOverlayResumeMarker = async () => {
+      try {
+        if (effectiveAssistantState.mode === "overlay") {
+          await storage.set(overlayResumeMarkerKey, {
+            updatedAt: new Date().toISOString()
+          })
+          return
+        }
+        await storage.remove(overlayResumeMarkerKey)
+      } catch {
+        // no-op
+      }
+    }
+
+    void syncOverlayResumeMarker()
+  }, [effectiveAssistantState.mode, overlayResumeMarkerKey])
 
   React.useEffect(() => {
     const previous = previousServerChatIdRef.current
@@ -894,16 +957,12 @@ export const SidepanelForm = ({
     browserSupportsSpeechRecognition || hasServerStt || hasServerVoiceChat
 
   // Composer window events hook
-  const handleOpenQuickIngest = React.useCallback((detail?: QuickIngestOpenDetail) => {
-    const seed = createQuickIngestSessionSeedFromOpenDetail(detail)
+  const handleOpenQuickIngest = React.useCallback(() => {
     setAutoProcessQueuedIngest(false)
     if (quickIngestSession) {
-      if (seed) {
-        upsertQuickIngestSession(seed)
-      }
       showQuickIngestSession()
     } else {
-      createDraftQuickIngestSession(seed ?? undefined)
+      createDraftQuickIngestSession()
     }
     setIngestOpen(true)
     requestAnimationFrame(() => {
@@ -912,8 +971,7 @@ export const SidepanelForm = ({
   }, [
     createDraftQuickIngestSession,
     quickIngestSession,
-    showQuickIngestSession,
-    upsertQuickIngestSession
+    showQuickIngestSession
   ])
 
   const {
@@ -2003,23 +2061,18 @@ export const SidepanelForm = ({
     window.dispatchEvent(new CustomEvent("tldw:toggle-rag"))
   }, [])
 
-  const handleQuickIngestOpen = React.useCallback((detail?: QuickIngestOpenDetail) => {
-    const seed = createQuickIngestSessionSeedFromOpenDetail(detail)
+  const handleQuickIngestOpen = React.useCallback(() => {
     setAutoProcessQueuedIngest(false)
     if (quickIngestSession) {
-      if (seed) {
-        upsertQuickIngestSession(seed)
-      }
       showQuickIngestSession()
     } else {
-      createDraftQuickIngestSession(seed ?? undefined)
+      createDraftQuickIngestSession()
     }
     setIngestOpen(true)
   }, [
     createDraftQuickIngestSession,
     quickIngestSession,
-    showQuickIngestSession,
-    upsertQuickIngestSession
+    showQuickIngestSession
   ])
 
   const handleProcessQueuedIngest = React.useCallback(() => {
@@ -3074,6 +3127,27 @@ export const SidepanelForm = ({
                                         </button>
                                       </Tooltip>
                                     )}
+                                    <Tooltip
+                                      title={t(
+                                        "playground:characterRail.title",
+                                        "Character controls"
+                                      )}
+                                    >
+                                      <button
+                                        type="button"
+                                        data-testid="chat-character-controls-trigger"
+                                        onClick={() =>
+                                          setCharacterControlsOpen(true)
+                                        }
+                                        className="inline-flex h-11 w-11 min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border bg-surface text-text-muted transition-colors hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                                        aria-label={t(
+                                          "playground:characterRail.title",
+                                          "Character controls"
+                                        )}
+                                      >
+                                        <UserCircle2 className="h-4 w-4" />
+                                      </button>
+                                    </Tooltip>
                                   </>
                                 ) : (
                                   <Tooltip title={t("tooltip.stopStreaming")}>
@@ -3395,6 +3469,32 @@ export const SidepanelForm = ({
                                     {t("playground:actions.speechShort", "Dictate")}
                                   </span>
                                 </div>
+                                <div className="flex flex-col items-center gap-1">
+                                  <Tooltip
+                                    title={t(
+                                      "playground:characterRail.title",
+                                      "Character controls"
+                                    )}
+                                  >
+                                    <button
+                                      type="button"
+                                      data-testid="chat-character-controls-trigger"
+                                      onClick={() =>
+                                        setCharacterControlsOpen(true)
+                                      }
+                                      className="h-11 w-11 min-h-[44px] min-w-[44px] rounded-full border border-border p-0 text-text-muted transition-colors hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                                      aria-label={t(
+                                        "playground:characterRail.title",
+                                        "Character controls"
+                                      )}
+                                    >
+                                      <UserCircle2 className="h-4 w-4" />
+                                    </button>
+                                  </Tooltip>
+                                  <span className="text-[10px] font-medium leading-none text-text-subtle">
+                                    {t("playground:characterRail.shortLabel", "Character")}
+                                  </span>
+                                </div>
                               </div>
                             )}
                           </div>
@@ -3589,6 +3689,18 @@ export const SidepanelForm = ({
       {openActorSettings && (
         <ActorPopout open={openActorSettings} setOpen={setOpenActorSettings} />
       )}
+      <Modal
+        open={characterControlsOpen}
+        onCancel={() => setCharacterControlsOpen(false)}
+        footer={null}
+        title={t("playground:characterRail.title", "Character controls")}
+        centered
+      >
+        <CharacterControlsSheet
+          beforeTrackedStart={handlePrepareTrackedStart}
+          onRequestClose={() => setCharacterControlsOpen(false)}
+        />
+      </Modal>
       {documentGeneratorOpen && (
         <DocumentGeneratorDrawer
           open={documentGeneratorOpen}

--- a/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
@@ -104,6 +104,10 @@ import { useSetting } from "@/hooks/useSetting"
 import { useFocusComposerOnConnect } from "@/hooks/useComposerFocus"
 import { useQuickIngestStore } from "@/store/quick-ingest"
 import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
+import {
+  createQuickIngestSessionSeedFromOpenDetail,
+  type QuickIngestOpenDetail
+} from "@/utils/quick-ingest-open"
 import { useUiModeStore } from "@/store/ui-mode"
 import { useStoreMessageOption } from "@/store/option"
 import { shallow } from "zustand/shallow"
@@ -494,12 +498,14 @@ export const SidepanelForm = ({
   const {
     quickIngestSession,
     createDraftQuickIngestSession,
+    upsertQuickIngestSession,
     showQuickIngestSession,
     hideQuickIngestSession
   } = useQuickIngestSessionStore(
     (state) => ({
       quickIngestSession: state.session,
       createDraftQuickIngestSession: state.createDraftSession,
+      upsertQuickIngestSession: state.upsertSession,
       showQuickIngestSession: state.showSession,
       hideQuickIngestSession: state.hideSession
     }),
@@ -957,12 +963,16 @@ export const SidepanelForm = ({
     browserSupportsSpeechRecognition || hasServerStt || hasServerVoiceChat
 
   // Composer window events hook
-  const handleOpenQuickIngest = React.useCallback(() => {
+  const handleOpenQuickIngest = React.useCallback((detail?: QuickIngestOpenDetail) => {
+    const seed = createQuickIngestSessionSeedFromOpenDetail(detail)
     setAutoProcessQueuedIngest(false)
     if (quickIngestSession) {
+      if (seed) {
+        upsertQuickIngestSession(seed)
+      }
       showQuickIngestSession()
     } else {
-      createDraftQuickIngestSession()
+      createDraftQuickIngestSession(seed ?? undefined)
     }
     setIngestOpen(true)
     requestAnimationFrame(() => {
@@ -971,7 +981,8 @@ export const SidepanelForm = ({
   }, [
     createDraftQuickIngestSession,
     quickIngestSession,
-    showQuickIngestSession
+    showQuickIngestSession,
+    upsertQuickIngestSession
   ])
 
   const {
@@ -2061,18 +2072,23 @@ export const SidepanelForm = ({
     window.dispatchEvent(new CustomEvent("tldw:toggle-rag"))
   }, [])
 
-  const handleQuickIngestOpen = React.useCallback(() => {
+  const handleQuickIngestOpen = React.useCallback((detail?: QuickIngestOpenDetail) => {
+    const seed = createQuickIngestSessionSeedFromOpenDetail(detail)
     setAutoProcessQueuedIngest(false)
     if (quickIngestSession) {
+      if (seed) {
+        upsertQuickIngestSession(seed)
+      }
       showQuickIngestSession()
     } else {
-      createDraftQuickIngestSession()
+      createDraftQuickIngestSession(seed ?? undefined)
     }
     setIngestOpen(true)
   }, [
     createDraftQuickIngestSession,
     quickIngestSession,
-    showQuickIngestSession
+    showQuickIngestSession,
+    upsertQuickIngestSession
   ])
 
   const handleProcessQueuedIngest = React.useCallback(() => {

--- a/apps/packages/ui/src/hooks/__tests__/useMessage.assistant-overlay.guard.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/useMessage.assistant-overlay.guard.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const sourcePath = path.resolve(testDir, "../useMessage.tsx")
+
+describe("useMessage assistant overlay guard", () => {
+  it("does not clear server chat state when assistant selection changes", () => {
+    const source = readFileSync(sourcePath, "utf8")
+
+    expect(source).not.toContain(
+      "// Reset server chat when assistant identity changes"
+    )
+    expect(source).not.toMatch(
+      /React\.useEffect\(\(\) => \{\s*setServerChatId\(null\);\s*\}, \[selectedAssistant\?\.id, selectedAssistant\?\.kind\]\);/m
+    )
+  })
+
+  it("routes plain draft selections through tracked send-mode fallback", () => {
+    const source = readFileSync(sourcePath, "utf8")
+
+    expect(source).toContain("draftAssistantKind: selectedAssistant?.kind ?? null")
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/useMessage.routing-mode.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/useMessage.routing-mode.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveUseMessageSendMode } from "@/hooks/useMessage.routing"
+
+describe("useMessage routing mode resolution", () => {
+  it("prefers tracked character over overlay", () => {
+    expect(
+      resolveUseMessageSendMode({
+        effectiveMode: "tracked_character",
+        hasEffectiveAssistant: true
+      })
+    ).toBe("tracked_character")
+  })
+
+  it("prefers tracked persona over overlay", () => {
+    expect(
+      resolveUseMessageSendMode({
+        effectiveMode: "tracked_persona",
+        hasEffectiveAssistant: true
+      })
+    ).toBe("tracked_persona")
+  })
+
+  it("keeps plain mode when no effective assistant exists", () => {
+    expect(
+      resolveUseMessageSendMode({
+        effectiveMode: "plain",
+        hasEffectiveAssistant: false
+      })
+    ).toBe("plain")
+  })
+
+  it("preserves tracked-character startup for a plain chat with a character draft selection", () => {
+    expect(
+      resolveUseMessageSendMode({
+        effectiveMode: "plain",
+        hasEffectiveAssistant: true,
+        draftAssistantKind: "character"
+      })
+    ).toBe("tracked_character")
+  })
+
+  it("preserves tracked-persona startup for a plain chat with a persona draft selection", () => {
+    expect(
+      resolveUseMessageSendMode({
+        effectiveMode: "plain",
+        hasEffectiveAssistant: true,
+        draftAssistantKind: "persona"
+      })
+    ).toBe("tracked_persona")
+  })
+
+  it("uses overlay routing when overlay state is active", () => {
+    expect(
+      resolveUseMessageSendMode({
+        effectiveMode: "overlay",
+        hasEffectiveAssistant: true,
+        draftAssistantKind: "persona"
+      })
+    ).toBe("overlay")
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
@@ -1,0 +1,380 @@
+import React from "react"
+import { renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  storeState,
+  chatBaseState,
+  selectedAssistantState,
+  chatSettingsState,
+  setSelectedAssistantSpy,
+  lastUseChatActionsArgs,
+  defaultRagSettings
+} = vi.hoisted(() => {
+  const state: Record<string, any> = {
+    selectedModel: null,
+    setSelectedModel: vi.fn(),
+    webSearch: false,
+    setWebSearch: vi.fn(),
+    toolChoice: "none",
+    setToolChoice: vi.fn(),
+    isSearchingInternet: false,
+    setIsSearchingInternet: vi.fn(),
+    queuedMessages: [],
+    addQueuedMessage: vi.fn(),
+    setQueuedMessages: vi.fn(),
+    clearQueuedMessages: vi.fn(),
+    selectedKnowledge: null,
+    setSelectedKnowledge: vi.fn(),
+    temporaryChat: false,
+    setTemporaryChat: vi.fn(),
+    documentContext: null,
+    setDocumentContext: vi.fn(),
+    uploadedFiles: [],
+    setUploadedFiles: vi.fn(),
+    contextFiles: [],
+    setContextFiles: vi.fn(),
+    actionInfo: null,
+    setActionInfo: vi.fn(),
+    fileRetrievalEnabled: false,
+    setFileRetrievalEnabled: vi.fn(),
+    ragMediaIds: null,
+    setRagMediaIds: vi.fn(),
+    ragSearchMode: "hybrid",
+    setRagSearchMode: vi.fn(),
+    ragTopK: 8,
+    setRagTopK: vi.fn(),
+    ragEnableGeneration: true,
+    setRagEnableGeneration: vi.fn(),
+    ragEnableCitations: true,
+    setRagEnableCitations: vi.fn(),
+    ragSources: [],
+    setRagSources: vi.fn(),
+    ragAdvancedOptions: {},
+    setRagAdvancedOptions: vi.fn(),
+    ragPinnedResults: [],
+    setRagPinnedResults: vi.fn(),
+    serverChatId: "chat-1",
+    setServerChatId: vi.fn(),
+    serverChatTitle: "Tracked conversation",
+    setServerChatTitle: vi.fn(),
+    serverChatCharacterId: null,
+    setServerChatCharacterId: vi.fn(),
+    serverChatAssistantKind: null,
+    setServerChatAssistantKind: vi.fn(),
+    serverChatAssistantId: null,
+    setServerChatAssistantId: vi.fn(),
+    serverChatPersonaMemoryMode: null,
+    setServerChatPersonaMemoryMode: vi.fn(),
+    serverChatMetaLoaded: true,
+    setServerChatMetaLoaded: vi.fn(),
+    serverChatLoadState: "loaded",
+    setServerChatLoadState: vi.fn(),
+    serverChatLoadError: null,
+    setServerChatLoadError: vi.fn(),
+    serverChatState: null,
+    setServerChatState: vi.fn(),
+    serverChatVersion: 1,
+    setServerChatVersion: vi.fn(),
+    serverChatTopic: null,
+    setServerChatTopic: vi.fn(),
+    serverChatClusterId: null,
+    setServerChatClusterId: vi.fn(),
+    serverChatSource: null,
+    setServerChatSource: vi.fn(),
+    serverChatExternalRef: null,
+    setServerChatExternalRef: vi.fn(),
+    messageSteeringMode: "none",
+    setMessageSteeringMode: vi.fn(),
+    messageSteeringForceNarrate: false,
+    setMessageSteeringForceNarrate: vi.fn(),
+    clearMessageSteering: vi.fn(),
+    replyTarget: null,
+    clearReplyTarget: vi.fn()
+  }
+
+  const chatBaseState = {
+    messages: [
+      {
+        id: "msg-1",
+        role: "assistant",
+        message: "Existing reply",
+        isBot: true,
+        sources: []
+      }
+    ],
+    setMessages: vi.fn(),
+    history: [
+      {
+        role: "assistant",
+        content: "Existing reply"
+      }
+    ],
+    setHistory: vi.fn(),
+    streaming: false,
+    setStreaming: vi.fn(),
+    isFirstMessage: false,
+    setIsFirstMessage: vi.fn(),
+    historyId: "history-1",
+    setHistoryId: vi.fn(),
+    isLoading: false,
+    setIsLoading: vi.fn(),
+    isProcessing: false,
+    setIsProcessing: vi.fn(),
+    chatMode: "normal",
+    setChatMode: vi.fn(),
+    isEmbedding: false,
+    setIsEmbedding: vi.fn(),
+    selectedQuickPrompt: null,
+    setSelectedQuickPrompt: vi.fn(),
+    selectedSystemPrompt: null,
+    setSelectedSystemPrompt: vi.fn(),
+    useOCR: false,
+    setUseOCR: vi.fn()
+  }
+
+  const selectedAssistantState = {
+    current: {
+      kind: "persona",
+      id: "overlay-1",
+      name: "Overlay One"
+    } as Record<string, unknown> | null
+  }
+  const chatSettingsState = {
+    current: {
+      assistantOverlay: {
+        kind: "persona",
+        id: "overlay-1",
+        name: "Overlay One",
+        avatar_url: null,
+        system_prompt_snapshot: "Snapshot one",
+        updatedAt: "2026-05-22T12:00:00.000Z"
+      }
+    } as Record<string, unknown> | null
+  }
+
+  return {
+    storeState: state,
+    chatBaseState,
+    selectedAssistantState,
+    chatSettingsState,
+    setSelectedAssistantSpy: vi.fn(),
+    lastUseChatActionsArgs: { value: null as Record<string, unknown> | null },
+    defaultRagSettings: {
+      top_k: 8,
+      min_score: 0.2,
+      enable_reranking: true
+    }
+  }
+})
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn()
+  })
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue || _key
+  })
+}))
+
+vi.mock("@/context", () => ({
+  usePageAssist: () => ({
+    controller: null,
+    setController: vi.fn()
+  })
+}))
+
+vi.mock("@/store/webui", () => ({
+  useWebUI: () => ({
+    ttsEnabled: false
+  })
+}))
+
+vi.mock("@/hooks/useAntdNotification", () => ({
+  useAntdNotification: () => ({
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/chat/useChatBaseState", () => ({
+  useChatBaseState: () => chatBaseState
+}))
+
+vi.mock("@/hooks/chat/useSelectServerChat", () => ({
+  useSelectServerChat: () => vi.fn()
+}))
+
+vi.mock("@/hooks/chat/useServerChatHistoryId", () => ({
+  useServerChatHistoryId: () => ({
+    ensureServerChatHistoryId: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/chat/useServerChatLoader", () => ({
+  useServerChatLoader: vi.fn()
+}))
+
+vi.mock("@/hooks/chat/useChatSettingsRecord", () => ({
+  useChatSettingsRecord: () => ({
+    settings: chatSettingsState.current,
+    updateSettings: vi.fn(),
+    chatKey: "server:chat-1"
+  })
+}))
+
+vi.mock("@/hooks/chat/useClearChat", () => ({
+  useClearChat: () => vi.fn()
+}))
+
+vi.mock("@/hooks/chat/useCompareMode", () => ({
+  useCompareMode: () => ({
+    compareMode: false,
+    setCompareMode: vi.fn(),
+    compareFeatureEnabled: false,
+    setCompareFeatureEnabled: vi.fn(),
+    compareSelectedModels: [],
+    setCompareSelectedModels: vi.fn(),
+    compareSelectionByCluster: {},
+    setCompareSelectionForCluster: vi.fn(),
+    compareActiveModelsByCluster: {},
+    setCompareActiveModelsForCluster: vi.fn(),
+    compareParentByHistory: {},
+    setCompareParentForHistory: vi.fn(),
+    compareCanonicalByCluster: {},
+    setCompareCanonicalForCluster: vi.fn(),
+    compareContinuationModeByCluster: {},
+    setCompareContinuationModeForCluster: vi.fn(),
+    compareSplitChats: {},
+    setCompareSplitChat: vi.fn(),
+    compareMaxModels: 4,
+    setCompareMaxModels: vi.fn(),
+    compareModeActive: false,
+    markCompareHistoryCreated: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/chat/useChatActions", () => ({
+  useChatActions: (args: Record<string, unknown>) => {
+    lastUseChatActionsArgs.value = args
+    return {
+      onSubmit: vi.fn(),
+      sendPerModelReply: vi.fn(),
+      regenerateLastMessage: vi.fn(),
+      stopStreamingRequest: vi.fn(),
+      editMessage: vi.fn(),
+      deleteMessage: vi.fn(),
+      toggleMessagePinned: vi.fn(),
+      createChatBranch: vi.fn(),
+      createCompareBranch: vi.fn()
+    }
+  }
+}))
+
+vi.mock("@/hooks/useSelectedCharacter", () => ({
+  useSelectedCharacter: () => [null, vi.fn()]
+}))
+
+vi.mock("@/hooks/useSelectedAssistant", () => ({
+  useSelectedAssistant: () => [selectedAssistantState.current, setSelectedAssistantSpy]
+}))
+
+vi.mock("@/hooks/useSetting", () => ({
+  useSetting: () => [25]
+}))
+
+vi.mock("@/services/rag/unified-rag", () => ({
+  DEFAULT_RAG_SETTINGS: defaultRagSettings,
+  toRagAdvancedOptions: vi.fn((value) => value || {})
+}))
+
+vi.mock("@/store/model", () => ({
+  useStoreChatModelSettings: () => ({ apiProvider: undefined })
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (selector?: (state: Record<string, unknown>) => unknown) =>
+    selector ? selector(storeState) : storeState
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (_key: string, defaultValue: unknown) =>
+    [defaultValue, vi.fn(), { isLoading: false }] as const
+}))
+
+import { useMessageOption } from "@/hooks/useMessageOption"
+
+describe("useMessageOption assistant overlay changes", () => {
+  beforeEach(() => {
+    storeState.serverChatId = "chat-1"
+    storeState.serverChatAssistantKind = null
+    storeState.serverChatAssistantId = null
+    storeState.serverChatCharacterId = null
+    selectedAssistantState.current = {
+      kind: "persona",
+      id: "overlay-1",
+      name: "Overlay One"
+    }
+    chatSettingsState.current = {
+      assistantOverlay: {
+        kind: "persona",
+        id: "overlay-1",
+        name: "Overlay One",
+        avatar_url: null,
+        system_prompt_snapshot: "Snapshot one",
+        updatedAt: "2026-05-22T12:00:00.000Z"
+      }
+    }
+    chatBaseState.messages = [
+      {
+        id: "msg-1",
+        role: "assistant",
+        message: "Existing reply",
+        isBot: true,
+        sources: []
+      }
+    ]
+    chatBaseState.history = [
+      {
+        role: "assistant",
+        content: "Existing reply"
+      }
+    ]
+    chatBaseState.historyId = "history-1"
+    chatBaseState.setMessages.mockReset()
+    chatBaseState.setHistory.mockReset()
+    chatBaseState.setHistoryId.mockReset()
+    storeState.setServerChatId.mockReset()
+  })
+
+  it("does not clear the loaded conversation when the overlay selection changes", () => {
+    const { rerender } = renderHook(() => useMessageOption())
+
+    selectedAssistantState.current = {
+      kind: "persona",
+      id: "overlay-2",
+      name: "Overlay Two"
+    }
+    chatSettingsState.current = {
+      assistantOverlay: {
+        kind: "persona",
+        id: "overlay-2",
+        name: "Overlay Two",
+        avatar_url: null,
+        system_prompt_snapshot: "Snapshot two",
+        updatedAt: "2026-05-22T12:01:00.000Z"
+      }
+    }
+    rerender()
+
+    expect(storeState.setServerChatId).not.toHaveBeenCalledWith(null)
+    expect(chatBaseState.setMessages).not.toHaveBeenCalledWith([])
+    expect(chatBaseState.setHistory).not.toHaveBeenCalledWith([])
+    expect(chatBaseState.setHistoryId).not.toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts
+++ b/apps/packages/ui/src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { SystemMessage } from "@/types/messages"
+
+const mocks = vi.hoisted(() => ({
+  systemPromptForNonRagOption: vi.fn(async () => "Base system prompt"),
+  getPromptById: vi.fn(async () => null),
+  humanMessageFormatter: vi.fn(async () => ({ role: "user", content: "Hello" })),
+  systemPromptFormatter: vi.fn(async ({ content }: { content: string }) =>
+    new SystemMessage({ content })
+  ),
+  maybeInjectActorMessage: vi.fn(async (history: unknown[], actorSettings: unknown) =>
+    actorSettings
+      ? [...history, new SystemMessage({ content: "Actor scene injection" })]
+      : history
+  ),
+  runChatPipeline: vi.fn()
+}))
+
+vi.mock("~/services/tldw-server", () => ({
+  systemPromptForNonRagOption: mocks.systemPromptForNonRagOption,
+  getWebSearchPrompt: vi.fn(async () => "Search wrapper\n{search_results}")
+}))
+
+vi.mock("@/db/dexie/helpers", () => ({
+  getPromptById: mocks.getPromptById
+}))
+
+vi.mock("@/utils/human-message", () => ({
+  humanMessageFormatter: mocks.humanMessageFormatter
+}))
+
+vi.mock("@/utils/system-message", () => ({
+  systemPromptFormatter: mocks.systemPromptFormatter
+}))
+
+vi.mock("@/utils/actor", () => ({
+  maybeInjectActorMessage: mocks.maybeInjectActorMessage
+}))
+
+vi.mock("@/services/search", () => ({
+  getSearchSettings: vi.fn(async () => ({
+    searchProvider: "google",
+    totalSearchResults: 1
+  }))
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn(async () => null),
+    webSearch: vi.fn(async () => ({
+      web_search_results_dict: {
+        results: [
+          {
+            title: "Source title",
+            url: "https://example.com/source",
+            snippet: "Search snippet"
+          }
+        ]
+      }
+    }))
+  }
+}))
+
+vi.mock("./../chatModePipeline", () => ({
+  runChatPipeline: mocks.runChatPipeline
+}))
+
+import { normalChatMode } from "../normalChatMode"
+
+describe("normalChatMode overlay prompt ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.runChatPipeline.mockImplementation(
+      async (mode, message, image, isRegenerate, messages, history, signal, params) =>
+        mode.preparePrompt({
+          ...params,
+          message,
+          image,
+          isRegenerate,
+          messages,
+          history,
+          signal,
+          createdAt: 0,
+          generateMessageId: "assistant-1",
+          resolvedAssistantMessageId: "assistant-1",
+          resolvedAssistantParentMessageId: "user-1",
+          resolvedModelId: params.selectedModel,
+          regenerateVariants: [],
+          modelInfo: null
+        })
+    )
+  })
+
+  it("keeps base prompt first, overlay second, actor after overlay, and web search last", async () => {
+    const prompt = await normalChatMode(
+      "Where should I go?",
+      "",
+      false,
+      [],
+      [],
+      new AbortController().signal,
+      {
+        selectedModel: "gpt-test",
+        useOCR: false,
+        selectedSystemPrompt: "",
+        currentChatModelSettings: {},
+        overlaySystemPrompt: "Overlay snapshot prompt",
+        actorSettings: { isEnabled: true } as never,
+        webSearch: true,
+        setMessages: vi.fn(),
+        saveMessageOnSuccess: vi.fn(async () => null),
+        saveMessageOnError: vi.fn(async () => null),
+        setHistory: vi.fn(),
+        setIsProcessing: vi.fn(),
+        setStreaming: vi.fn(),
+        setAbortController: vi.fn(),
+        historyId: null,
+        setHistoryId: vi.fn()
+      }
+    )
+
+    expect(prompt.chatHistory).toHaveLength(4)
+    expect((prompt.chatHistory[0] as SystemMessage).content).toBe("Base system prompt")
+    expect((prompt.chatHistory[1] as SystemMessage).content).toBe("Overlay snapshot prompt")
+    expect((prompt.chatHistory[2] as SystemMessage).content).toBe("Actor scene injection")
+    expect((prompt.chatHistory[3] as SystemMessage).content).toContain("Source title")
+  })
+
+  it("keeps generic systemPromptAppendix appended to the active base prompt", async () => {
+    const prompt = await normalChatMode(
+      "Hello",
+      "",
+      false,
+      [],
+      [],
+      new AbortController().signal,
+      {
+        selectedModel: "gpt-test",
+        useOCR: false,
+        selectedSystemPrompt: "",
+        currentChatModelSettings: {},
+        systemPromptAppendix: "Formatting guide suffix",
+        setMessages: vi.fn(),
+        saveMessageOnSuccess: vi.fn(async () => null),
+        saveMessageOnError: vi.fn(async () => null),
+        setHistory: vi.fn(),
+        setIsProcessing: vi.fn(),
+        setStreaming: vi.fn(),
+        setAbortController: vi.fn(),
+        historyId: null,
+        setHistoryId: vi.fn()
+      }
+    )
+
+    expect(prompt.chatHistory).toHaveLength(1)
+    expect((prompt.chatHistory[0] as SystemMessage).content).toBe(
+      "Base system prompt\n\nFormatting guide suffix"
+    )
+  })
+})

--- a/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts
+++ b/apps/packages/ui/src/hooks/chat-modes/normalChatMode.ts
@@ -142,6 +142,7 @@ type NormalChatModeParams = {
   uploadedFiles?: any[]
   actorSettings?: ActorSettings
   systemPromptAppendix?: string
+  overlaySystemPrompt?: string
   webSearch?: boolean
   setIsSearchingInternet?: (value: boolean) => void
   clusterId?: string
@@ -485,17 +486,15 @@ const normalChatModeDefinition: ChatModeDefinition<NormalChatModeParams> = {
       ctx.historyForModel ?? ctx.history,
       ctx.selectedModel
     )
+    const baseSystemPrompts: string[] = []
+    const overlayPrompt = ctx.overlaySystemPrompt?.trim() || ""
     const resolvePromptWithAppendix = (content?: string | null) =>
       appendSystemPromptSuffix(content || "", ctx.systemPromptAppendix)
 
     if (!selectedPrompt) {
       const resolvedDefaultPrompt = resolvePromptWithAppendix(prompt)
       if (resolvedDefaultPrompt) {
-        applicationChatHistory.unshift(
-          await systemPromptFormatter({
-            content: resolvedDefaultPrompt
-          })
-        )
+        baseSystemPrompts.push(resolvedDefaultPrompt)
       }
     }
 
@@ -508,11 +507,9 @@ const normalChatModeDefinition: ChatModeDefinition<NormalChatModeParams> = {
         selectedPrompt.system_prompt ?? selectedPrompt.content
       const resolvedSelectedPrompt =
         resolvePromptWithAppendix(selectedPromptContent)
-      applicationChatHistory.unshift(
-        await systemPromptFormatter({
-          content: resolvedSelectedPrompt
-        })
-      )
+      if (resolvedSelectedPrompt) {
+        baseSystemPrompts.push(resolvedSelectedPrompt)
+      }
       promptContent = resolvedSelectedPrompt
     }
 
@@ -520,12 +517,25 @@ const normalChatModeDefinition: ChatModeDefinition<NormalChatModeParams> = {
       const resolvedTemporaryPrompt = resolvePromptWithAppendix(
         ctx.currentChatModelSettings.systemPrompt
       )
-      applicationChatHistory.unshift(
-        await systemPromptFormatter({
-          content: resolvedTemporaryPrompt
-        })
-      )
+      if (resolvedTemporaryPrompt) {
+        baseSystemPrompts.push(resolvedTemporaryPrompt)
+      }
       promptContent = resolvedTemporaryPrompt
+    }
+
+    if (overlayPrompt) {
+      baseSystemPrompts.push(overlayPrompt)
+    }
+
+    if (baseSystemPrompts.length > 0) {
+      const promptMessages = await Promise.all(
+        baseSystemPrompts.map((content) =>
+          systemPromptFormatter({
+            content
+          })
+        )
+      )
+      applicationChatHistory = [...promptMessages, ...applicationChatHistory]
     }
 
     const templatesActive = !!ctx.selectedSystemPrompt

--- a/apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveEffectiveAssistantState } from "@/hooks/chat/effective-assistant-state"
+
+describe("resolveEffectiveAssistantState", () => {
+  it("resolves a tracked character from assistant_kind and character_id", () => {
+    expect(
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: "character",
+          characterId: "char-17",
+          displayName: "Rin",
+          avatarUrl: "https://cdn.example.test/rin.png",
+          systemPromptSnapshot: "Stay in character."
+        },
+        settings: null
+      })
+    ).toEqual({
+      mode: "tracked_character",
+      kind: "character",
+      id: "char-17",
+      displayName: "Rin",
+      avatarUrl: "https://cdn.example.test/rin.png",
+      systemPromptSnapshot: "Stay in character.",
+      source: "tracked"
+    })
+  })
+
+  it("resolves a tracked persona from assistant_kind and assistant_id", () => {
+    expect(
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: "persona",
+          assistantId: "persona-9",
+          displayName: "Analyst",
+          avatarUrl: "https://cdn.example.test/analyst.png",
+          systemPromptSnapshot: "Be concise."
+        },
+        settings: null
+      })
+    ).toEqual({
+      mode: "tracked_persona",
+      kind: "persona",
+      id: "persona-9",
+      displayName: "Analyst",
+      avatarUrl: "https://cdn.example.test/analyst.png",
+      systemPromptSnapshot: "Be concise.",
+      source: "tracked"
+    })
+  })
+
+  it("resolves an overlay from settings.assistantOverlay", () => {
+    expect(
+      resolveEffectiveAssistantState({
+        tracked: null,
+        settings: {
+          assistantOverlay: {
+            kind: "persona",
+            id: "overlay-22",
+            name: "Overlay Persona",
+            avatar_url: "https://cdn.example.test/overlay.png",
+            system_prompt_snapshot: "Use the overlay snapshot.",
+            updatedAt: "2026-05-22T12:00:00.000Z"
+          }
+        }
+      })
+    ).toEqual({
+      mode: "overlay",
+      kind: "persona",
+      id: "overlay-22",
+      displayName: "Overlay Persona",
+      avatarUrl: "https://cdn.example.test/overlay.png",
+      systemPromptSnapshot: "Use the overlay snapshot.",
+      source: "overlay"
+    })
+  })
+
+  it("resolves plain mode when neither tracked metadata nor overlay exists", () => {
+    expect(
+      resolveEffectiveAssistantState({
+        tracked: null,
+        settings: null
+      })
+    ).toEqual({
+      mode: "plain",
+      kind: null,
+      id: null,
+      displayName: null,
+      avatarUrl: null,
+      systemPromptSnapshot: null,
+      source: "none"
+    })
+  })
+
+  it("lets tracked modes win over overlay when mixed data appears", () => {
+    expect(
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: "character",
+          characterId: "char-99",
+          displayName: "Tracked Character",
+          avatarUrl: "https://cdn.example.test/tracked.png",
+          systemPromptSnapshot: "Tracked snapshot."
+        },
+        settings: {
+          assistantOverlay: {
+            kind: "persona",
+            id: "overlay-99",
+            name: "Overlay Persona",
+            avatar_url: "https://cdn.example.test/overlay.png",
+            system_prompt_snapshot: "Overlay snapshot.",
+            updatedAt: "2026-05-22T12:00:00.000Z"
+          }
+        }
+      })
+    ).toEqual({
+      mode: "tracked_character",
+      kind: "character",
+      id: "char-99",
+      displayName: "Tracked Character",
+      avatarUrl: "https://cdn.example.test/tracked.png",
+      systemPromptSnapshot: "Tracked snapshot.",
+      source: "tracked"
+    })
+  })
+
+  it("falls back to draft metadata when tracked presentation fields are sparse", () => {
+    expect(
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: "character",
+          characterId: "char-5",
+          displayName: "   ",
+          avatarUrl: null,
+          systemPromptSnapshot: null
+        },
+        settings: null,
+        draftSelection: {
+          kind: "character",
+          id: "char-5",
+          name: "Draft Character",
+          avatar_url: "https://cdn.example.test/draft-character.png",
+          system_prompt: "Draft character prompt"
+        }
+      })
+    ).toEqual({
+      mode: "tracked_character",
+      kind: "character",
+      id: "char-5",
+      displayName: "Draft Character",
+      avatarUrl: "https://cdn.example.test/draft-character.png",
+      systemPromptSnapshot: "Draft character prompt",
+      source: "tracked"
+    })
+  })
+
+  it("falls back to draft metadata when overlay presentation fields are sparse", () => {
+    expect(
+      resolveEffectiveAssistantState({
+        tracked: null,
+        settings: {
+          assistantOverlay: {
+            kind: "persona",
+            id: "overlay-7",
+            name: "   ",
+            avatar_url: null,
+            system_prompt_snapshot: null,
+            updatedAt: "2026-05-22T12:00:00.000Z"
+          }
+        },
+        draftSelection: {
+          kind: "persona",
+          id: "overlay-7",
+          name: "Draft Overlay",
+          avatar_url: "https://cdn.example.test/draft-overlay.png",
+          system_prompt: "Draft overlay prompt"
+        }
+      })
+    ).toEqual({
+      mode: "overlay",
+      kind: "persona",
+      id: "overlay-7",
+      displayName: "Draft Overlay",
+      avatarUrl: "https://cdn.example.test/draft-overlay.png",
+      systemPromptSnapshot: "Draft overlay prompt",
+      source: "overlay"
+    })
+  })
+})

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import React from "react"
+import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useChatActions } from "../useChatActions"
+
+const {
+  createChatMock,
+  streamCharacterChatCompletionMock,
+  persistCharacterCompletionMock,
+  normalChatModeMock
+} = vi.hoisted(() => ({
+  createChatMock: vi.fn(),
+  streamCharacterChatCompletionMock: vi.fn(),
+  persistCharacterCompletionMock: vi.fn(async () => ({
+    assistant_message_id: "assistant-server-1",
+    version: 1
+  })),
+  normalChatModeMock: vi.fn()
+}))
+
+vi.mock("@/hooks/chat-modes/normalChatMode", () => ({
+  normalChatMode: normalChatModeMock
+}))
+
+vi.mock("@/hooks/chat-modes/continueChatMode", () => ({
+  continueChatMode: vi.fn()
+}))
+
+vi.mock("@/hooks/chat-modes/ragMode", () => ({
+  ragMode: vi.fn()
+}))
+
+vi.mock("@/hooks/chat-modes/tabChatMode", () => ({
+  tabChatMode: vi.fn()
+}))
+
+vi.mock("@/hooks/chat-modes/documentChatMode", () => ({
+  documentChatMode: vi.fn()
+}))
+
+vi.mock("@/hooks/utils/messageHelpers", () => ({
+  validateBeforeSubmit: vi.fn(() => true),
+  createSaveMessageOnSuccess: vi.fn(
+    () =>
+      async (_payload?: unknown): Promise<string | null> =>
+        "history-character"
+  ),
+  createSaveMessageOnError: vi.fn(
+    () =>
+      async (_payload?: unknown): Promise<string | null> =>
+        "history-character"
+  )
+}))
+
+vi.mock("@/hooks/handlers/messageHandlers", () => ({
+  createRegenerateLastMessage: vi.fn(() => vi.fn()),
+  createEditMessage: vi.fn(() => vi.fn()),
+  createStopStreamingRequest: vi.fn(() => vi.fn()),
+  createBranchMessage: vi.fn(() => vi.fn())
+}))
+
+vi.mock("@/db/dexie/helpers", () => ({
+  generateID: vi.fn(() => "generated-id"),
+  saveHistory: vi.fn(),
+  saveMessage: vi.fn(),
+  updateHistory: vi.fn(),
+  updateMessage: vi.fn(),
+  updateMessageMedia: vi.fn(async () => null),
+  removeMessageByIndex: vi.fn(),
+  formatToChatHistory: vi.fn((items: unknown) => items),
+  formatToMessage: vi.fn((items: unknown) => items),
+  getSessionFiles: vi.fn(async () => []),
+  getPromptById: vi.fn(async () => null)
+}))
+
+vi.mock("@/db/dexie/nickname", () => ({
+  getModelNicknameByID: vi.fn(async () => null)
+}))
+
+vi.mock("@/db/dexie/branch", () => ({
+  generateBranchFromMessageIds: vi.fn(async () => null)
+}))
+
+vi.mock("@/services/actor-settings", () => ({
+  getActorSettingsForChat: vi.fn(async () => null)
+}))
+
+vi.mock("@/utils/selected-character-storage", () => ({
+  SELECTED_CHARACTER_STORAGE_KEY: "selected_character",
+  selectedCharacterStorage: {
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => null)
+  },
+  selectedCharacterSyncStorage: {
+    get: vi.fn(async () => null)
+  },
+  parseSelectedCharacterValue: vi.fn((value: unknown) => value)
+}))
+
+vi.mock("@/hooks/chat/useChatSettingsRecord", () => ({
+  useChatSettingsRecord: () => ({
+    settings: {},
+    updateSettings: vi.fn()
+  })
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (_key: string, defaultValue: unknown) => {
+    const [value] = React.useState(defaultValue)
+    return [value, vi.fn()] as const
+  }
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: {
+    getState: () => ({ selectedModel: "deepseek-chat" as string | null })
+  }
+}))
+
+vi.mock("@/services/tldw/server-capabilities", () => ({
+  getServerCapabilities: vi.fn(async () => ({ hasChatSaveToDb: false }))
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    createChat: createChatMock,
+    streamCharacterChatCompletion: streamCharacterChatCompletionMock,
+    persistCharacterCompletion: persistCharacterCompletionMock,
+    addChatMessage: vi.fn(async () => ({ id: "user-server-1", version: 1 })),
+    initialize: vi.fn(async () => null)
+  }
+}))
+
+const createHookOptions = () => ({
+  t: (_key: string, fallback?: string) => fallback || _key,
+  notification: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn()
+  },
+  abortController: null,
+  setAbortController: vi.fn(),
+  messages: [],
+  setMessages: vi.fn(),
+  history: [],
+  setHistory: vi.fn(),
+  historyId: "history-character",
+  setHistoryId: vi.fn(),
+  temporaryChat: false,
+  selectedModel: "deepseek-chat",
+  useOCR: false,
+  selectedSystemPrompt: null,
+  selectedKnowledge: null,
+  toolChoice: "auto" as const,
+  webSearch: false,
+  currentChatModelSettings: {
+    apiProvider: "openai",
+    setSystemPrompt: vi.fn()
+  },
+  setIsSearchingInternet: vi.fn(),
+  setIsProcessing: vi.fn(),
+  setStreaming: vi.fn(),
+  setActionInfo: vi.fn(),
+  fileRetrievalEnabled: false,
+  ragMediaIds: null,
+  ragSearchMode: "hybrid" as const,
+  ragTopK: 8,
+  ragEnableGeneration: true,
+  ragEnableCitations: true,
+  ragSources: [],
+  ragAdvancedOptions: {},
+  serverChatId: "tracked-chat-1",
+  serverChatTitle: "Tracked character chat",
+  serverChatCharacterId: "char-tracked",
+  serverChatAssistantKind: "character" as const,
+  serverChatAssistantId: null,
+  serverChatPersonaMemoryMode: null,
+  serverChatState: "in-progress" as const,
+  serverChatTopic: null,
+  serverChatClusterId: null,
+  serverChatSource: null,
+  serverChatExternalRef: null,
+  setServerChatId: vi.fn(),
+  setServerChatTitle: vi.fn(),
+  setServerChatCharacterId: vi.fn(),
+  setServerChatAssistantKind: vi.fn(),
+  setServerChatAssistantId: vi.fn(),
+  setServerChatPersonaMemoryMode: vi.fn(),
+  setServerChatMetaLoaded: vi.fn(),
+  setServerChatState: vi.fn(),
+  setServerChatVersion: vi.fn(),
+  setServerChatTopic: vi.fn(),
+  setServerChatClusterId: vi.fn(),
+  setServerChatSource: vi.fn(),
+  setServerChatExternalRef: vi.fn(),
+  ensureServerChatHistoryId: vi.fn(async () => "history-character"),
+  contextFiles: [],
+  setContextFiles: vi.fn(),
+  documentContext: null,
+  setDocumentContext: vi.fn(),
+  uploadedFiles: [],
+  compareModeActive: false,
+  compareSelectedModels: [],
+  compareMaxModels: 3,
+  compareFeatureEnabled: false,
+  markCompareHistoryCreated: vi.fn(),
+  replyTarget: null,
+  clearReplyTarget: vi.fn(),
+  messageSteeringPrompts: null,
+  setSelectedQuickPrompt: vi.fn(),
+  setSelectedSystemPrompt: vi.fn(),
+  invalidateServerChatHistory: vi.fn(),
+  selectedCharacter: {
+    id: "char-stale",
+    name: "Stale Character",
+    system_prompt: "Stale prompt"
+  },
+  selectedAssistant: null,
+  messageSteeringMode: "none" as const,
+  messageSteeringForceNarrate: false,
+  clearMessageSteering: vi.fn()
+})
+
+describe("useChatActions character integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    normalChatModeMock.mockResolvedValue(undefined)
+    createChatMock.mockResolvedValue({
+      id: "unexpected-new-chat",
+      character_id: "char-stale",
+      title: "Wrong chat"
+    })
+    streamCharacterChatCompletionMock.mockImplementation(async function* () {
+      yield {
+        choices: [
+          {
+            delta: {
+              content: "Tracked reply"
+            }
+          }
+        ]
+      }
+    })
+  })
+
+  it("keeps tracked character routing anchored to current chat metadata when global character state is stale", async () => {
+    const options = createHookOptions()
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Hello tracked character",
+        image: ""
+      })
+    })
+
+    expect(createChatMock).not.toHaveBeenCalled()
+    expect(streamCharacterChatCompletionMock).toHaveBeenCalledTimes(1)
+    expect(streamCharacterChatCompletionMock).toHaveBeenCalledWith(
+      "tracked-chat-1",
+      expect.objectContaining({
+        include_character_context: true,
+        model: "deepseek-chat"
+      }),
+      expect.any(Object)
+    )
+    expect(normalChatModeMock).not.toHaveBeenCalled()
+    expect(options.setServerChatId).not.toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
@@ -7,10 +7,12 @@ import { useChatActions } from "../useChatActions"
 
 const {
   createChatMock,
-  normalChatModeMock
+  normalChatModeMock,
+  streamCharacterChatCompletionMock
 } = vi.hoisted(() => ({
   createChatMock: vi.fn(),
-  normalChatModeMock: vi.fn()
+  normalChatModeMock: vi.fn(),
+  streamCharacterChatCompletionMock: vi.fn()
 }))
 
 vi.mock("@/hooks/chat-modes/normalChatMode", () => ({
@@ -94,8 +96,8 @@ vi.mock("@/utils/selected-character-storage", () => ({
 
 vi.mock("@/hooks/chat/useChatSettingsRecord", () => ({
   useChatSettingsRecord: () => ({
-    chatSettings: {},
-    updateChatSettings: vi.fn()
+    settings: {},
+    updateSettings: vi.fn()
   })
 }))
 
@@ -119,6 +121,7 @@ vi.mock("@/services/tldw/server-capabilities", () => ({
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
     createChat: createChatMock,
+    streamCharacterChatCompletion: streamCharacterChatCompletionMock,
     initialize: vi.fn(async () => null)
   }
 }))
@@ -340,6 +343,51 @@ describe("useChatActions persona integration", () => {
           avatarUrl: undefined
         },
         serverChatId: "persona-chat-1"
+      })
+    )
+  })
+
+  it("keeps persona routing ahead of character fallback when persona chats carry a character id", async () => {
+    const options = {
+      ...createHookOptions(),
+      serverChatId: "persona-chat-existing",
+      serverChatAssistantKind: "persona" as const,
+      serverChatAssistantId: "garden-helper",
+      serverChatCharacterId: "char-shadow",
+      selectedCharacter: {
+        id: "char-stale",
+        name: "Stale Character",
+        system_prompt: "Stale prompt"
+      }
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Stay persona",
+        image: ""
+      })
+    })
+
+    expect(streamCharacterChatCompletionMock).not.toHaveBeenCalled()
+    expect(createChatMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        character_id: expect.anything()
+      })
+    )
+    expect(normalChatModeMock).toHaveBeenCalledWith(
+      "Stay persona",
+      "",
+      false,
+      [],
+      [],
+      expect.any(AbortSignal),
+      expect.objectContaining({
+        assistantIdentity: {
+          name: "Garden Helper",
+          avatarUrl: undefined
+        },
+        serverChatId: "persona-chat-existing"
       })
     )
   })

--- a/apps/packages/ui/src/hooks/chat/effective-assistant-state.ts
+++ b/apps/packages/ui/src/hooks/chat/effective-assistant-state.ts
@@ -1,0 +1,151 @@
+import type { AssistantSelection, AssistantKind } from "@/types/assistant-selection"
+import type { ChatSettingsRecord } from "@/types/chat-session-settings"
+
+type TrackedAssistantMetadata = {
+  assistantKind?: string | null
+  assistantId?: string | number | null
+  characterId?: string | number | null
+  displayName?: string | null
+  avatarUrl?: string | null
+  systemPromptSnapshot?: string | null
+}
+
+type ResolveEffectiveAssistantStateInput = {
+  tracked?: TrackedAssistantMetadata | null
+  settings?: Pick<ChatSettingsRecord, "assistantOverlay"> | null
+  draftSelection?: AssistantSelection | null
+}
+
+export type EffectiveAssistantState = {
+  mode: "tracked_character" | "tracked_persona" | "overlay" | "plain"
+  kind: AssistantKind | null
+  id: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  systemPromptSnapshot: string | null
+  source: "tracked" | "overlay" | "none"
+}
+
+const normalizeId = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value)
+  }
+  return null
+}
+
+const normalizeText = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const getMatchingDraftSelection = (
+  draftSelection: AssistantSelection | null | undefined,
+  kind: AssistantKind,
+  id: string
+) =>
+  draftSelection?.kind === kind && draftSelection.id === id
+    ? draftSelection
+    : null
+
+export const resolveEffectiveAssistantState = ({
+  tracked,
+  settings,
+  draftSelection
+}: ResolveEffectiveAssistantStateInput): EffectiveAssistantState => {
+  const trackedAssistantKind = tracked?.assistantKind
+  const trackedCharacterId = normalizeId(tracked?.characterId)
+  if (trackedAssistantKind === "character" && trackedCharacterId) {
+    const matchedDraft = getMatchingDraftSelection(
+      draftSelection,
+      "character",
+      trackedCharacterId
+    )
+    return {
+      mode: "tracked_character",
+      kind: "character",
+      id: trackedCharacterId,
+      displayName:
+        normalizeText(tracked?.displayName) ??
+        normalizeText(matchedDraft?.name) ??
+        "Assistant",
+      avatarUrl:
+        normalizeText(tracked?.avatarUrl) ??
+        normalizeText(matchedDraft?.avatar_url) ??
+        null,
+      systemPromptSnapshot:
+        normalizeText(tracked?.systemPromptSnapshot) ??
+        normalizeText(matchedDraft?.system_prompt) ??
+        null,
+      source: "tracked"
+    }
+  }
+
+  const trackedAssistantId = normalizeId(tracked?.assistantId)
+  if (trackedAssistantKind === "persona" && trackedAssistantId) {
+    const matchedDraft = getMatchingDraftSelection(
+      draftSelection,
+      "persona",
+      trackedAssistantId
+    )
+    return {
+      mode: "tracked_persona",
+      kind: "persona",
+      id: trackedAssistantId,
+      displayName:
+        normalizeText(tracked?.displayName) ??
+        normalizeText(matchedDraft?.name) ??
+        "Persona",
+      avatarUrl:
+        normalizeText(tracked?.avatarUrl) ??
+        normalizeText(matchedDraft?.avatar_url) ??
+        null,
+      systemPromptSnapshot:
+        normalizeText(tracked?.systemPromptSnapshot) ??
+        normalizeText(matchedDraft?.system_prompt) ??
+        null,
+      source: "tracked"
+    }
+  }
+
+  const overlay = settings?.assistantOverlay
+  if (overlay) {
+    const matchedDraft = getMatchingDraftSelection(
+      draftSelection,
+      overlay.kind,
+      overlay.id
+    )
+    return {
+      mode: "overlay",
+      kind: overlay.kind,
+      id: overlay.id,
+      displayName:
+        normalizeText(overlay.name) ??
+        normalizeText(matchedDraft?.name) ??
+        null,
+      avatarUrl:
+        normalizeText(overlay.avatar_url) ??
+        normalizeText(matchedDraft?.avatar_url) ??
+        null,
+      systemPromptSnapshot:
+        normalizeText(overlay.system_prompt_snapshot) ??
+        normalizeText(matchedDraft?.system_prompt) ??
+        null,
+      source: "overlay"
+    }
+  }
+
+  return {
+    mode: "plain",
+    kind: null,
+    id: null,
+    displayName: null,
+    avatarUrl: null,
+    systemPromptSnapshot: null,
+    source: "none"
+  }
+}

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -57,7 +57,6 @@ import {
   type ImageGenerationRequestSnapshot
 } from "@/utils/image-generation-chat"
 import {
-  parseProviderQualifiedModelSelection,
   resolveApiProviderForModel,
   resolveExplicitProviderForSelectedModel
 } from "@/utils/resolve-api-provider"
@@ -99,7 +98,6 @@ import {
   chatSubmitFailed,
   chatSubmitSkipped,
   normalizeChatSubmitResult,
-  resolveCompareModelSelection,
   resolveTurnFileRetrievalEnabled,
   resolveTurnRagMediaIds,
   shouldUseRagForTurn,
@@ -141,12 +139,6 @@ import {
 type ChatModelSettingsStore = ChatModelSettings & {
   setSystemPrompt?: (prompt: string) => void
 }
-
-const applySelectionProviderToSettings = (
-  settings: ChatModelSettingsStore,
-  provider?: string
-): ChatModelSettingsStore =>
-  provider ? { ...settings, apiProvider: provider } : settings
 
 type ChatModeOverrides = {
   historyId?: string | null
@@ -517,6 +509,49 @@ export const useChatActions = ({
     return selectedCharacter
   }, [selectedCharacter])
 
+  const resolveTrackedCharacterForCurrentChat = React.useCallback((): Character | null => {
+    if (serverChatAssistantKind !== "character") return null
+    if (serverChatCharacterId == null) return null
+
+    const trackedCharacterId = String(serverChatCharacterId)
+    if (
+      selectedCharacter?.id != null &&
+      String(selectedCharacter.id) === trackedCharacterId
+    ) {
+      return selectedCharacter
+    }
+
+    if (
+      selectedAssistant?.kind === "character" &&
+      String(selectedAssistant.id) === trackedCharacterId
+    ) {
+      return {
+        id: trackedCharacterId,
+        name: selectedAssistant.name,
+        avatar_url:
+          typeof selectedAssistant.avatar_url === "string"
+            ? selectedAssistant.avatar_url
+            : null,
+        system_prompt:
+          typeof selectedAssistant.system_prompt === "string"
+            ? selectedAssistant.system_prompt
+            : null
+      }
+    }
+
+    return {
+      id: trackedCharacterId,
+      name: "Assistant",
+      avatar_url: null,
+      system_prompt: null
+    }
+  }, [
+    selectedAssistant,
+    selectedCharacter,
+    serverChatAssistantKind,
+    serverChatCharacterId
+  ])
+
   const baseSaveMessageOnSuccess = createSaveMessageOnSuccess(
     temporaryChat,
     setHistoryId as (
@@ -877,12 +912,8 @@ export const useChatActions = ({
       serverChatId: resolvedServerChatId
     })
 
-    const effectiveModelSelection = parseProviderQualifiedModelSelection(
-      getEffectiveSelectedModel(overrides.selectedModel)
-    )
-    const effectiveChatModelSettings = applySelectionProviderToSettings(
-      currentChatModelSettings,
-      effectiveModelSelection.provider
+    const effectiveSelectedModel = getEffectiveSelectedModel(
+      overrides.selectedModel
     )
     const resolvedSelectedSystemPrompt = Object.prototype.hasOwnProperty.call(
       overrides,
@@ -904,12 +935,12 @@ export const useChatActions = ({
         : webSearch
 
     return {
-      selectedModel: effectiveModelSelection.modelId || "",
+      selectedModel: effectiveSelectedModel || "",
       useOCR: resolvedUseOCR,
       selectedSystemPrompt: resolvedSelectedSystemPrompt,
       selectedKnowledge,
       toolChoice: resolvedToolChoice,
-      currentChatModelSettings: effectiveChatModelSettings,
+      currentChatModelSettings,
       setMessages,
       setIsSearchingInternet,
       saveMessageOnSuccess,
@@ -2080,9 +2111,7 @@ export const useChatActions = ({
   }
 
   const validateBeforeSubmitFn = () => {
-    const effectiveModelSelection = parseProviderQualifiedModelSelection(
-      getEffectiveSelectedModel()
-    )
+    const effectiveSelectedModel = getEffectiveSelectedModel()
     if (compareModeActive) {
       const maxModels =
         typeof compareMaxModels === "number" && compareMaxModels > 0
@@ -2112,11 +2141,7 @@ export const useChatActions = ({
       }
       return true
     }
-    return validateBeforeSubmit(
-      effectiveModelSelection.modelId || "",
-      t,
-      notification
-    )
+    return validateBeforeSubmit(effectiveSelectedModel || "", t, notification)
   }
 
   const onSubmit = async ({
@@ -2168,14 +2193,6 @@ export const useChatActions = ({
   }): Promise<ChatSubmitResult> => {
     const effectiveSelectedModel = getEffectiveSelectedModel(
       requestOverrides?.selectedModel
-    )
-    const effectiveModelSelection = parseProviderQualifiedModelSelection(
-      effectiveSelectedModel
-    )
-    const effectiveRequestModel = effectiveModelSelection.modelId || ""
-    const effectiveProviderSettings = applySelectionProviderToSettings(
-      currentChatModelSettings,
-      effectiveModelSelection.provider
     )
     setStreaming(true)
     const trimmedImageBackendOverride =
@@ -2361,17 +2378,17 @@ export const useChatActions = ({
       const imageBackendCandidates = hasExplicitImageBackend
         ? [trimmedImageBackendOverride]
         : resolveImageBackendCandidates(
-            effectiveProviderSettings?.apiProvider,
-            effectiveRequestModel
+            currentChatModelSettings?.apiProvider,
+            effectiveSelectedModel
           )
       if (hasExplicitImageBackend || imageBackendCandidates.length > 0) {
         const resolvedImageModelLabel = hasExplicitImageBackend
           ? trimmedImageBackendOverride ||
-            effectiveRequestModel ||
-            effectiveProviderSettings?.apiProvider ||
+            (effectiveSelectedModel || "").trim() ||
+            currentChatModelSettings?.apiProvider ||
             "image-generation"
-          : effectiveRequestModel ||
-            effectiveProviderSettings?.apiProvider ||
+          : (effectiveSelectedModel || "").trim() ||
+            currentChatModelSettings?.apiProvider ||
             "image-generation"
         const enhancedChatModeParams = {
           ...chatModeParamsWithRegen,
@@ -2458,38 +2475,8 @@ export const useChatActions = ({
         const baseHistory = memory || history
 
         if (!compareModeActive) {
-          const resolvedSelectedCharacter = await resolveSelectedCharacter()
-          if (resolvedSelectedCharacter?.id) {
-            const resolvedModel = effectiveRequestModel
-            if (!resolvedModel) {
-              notification.error({
-                message: t("error"),
-                description: t("validationSelectModel")
-              })
-              setIsProcessing(false)
-              setStreaming(false)
-              setAbortController(null)
-              return chatSubmitSkipped("No model selected for character chat")
-            }
-            markSteeringApplied()
-            const characterResult = await characterChatMode({
-              message,
-              image,
-              isRegenerate,
-              messages: baseMessages,
-              history: baseHistory,
-              signal,
-              model: resolvedModel,
-              regenerateFromMessage,
-              character: resolvedSelectedCharacter,
-              messageSteering: messageSteeringForTurn,
-              serverChatIdOverride
-            })
-            return toChatSubmitResult(characterResult)
-          }
-
           if (isPersonaAssistantSelection(selectedAssistant)) {
-            const resolvedModel = effectiveRequestModel
+            const resolvedModel = effectiveSelectedModel?.trim()
             if (!resolvedModel) {
               notification.error({
                 message: t("error"),
@@ -2534,6 +2521,38 @@ export const useChatActions = ({
             )
             return toChatSubmitResult(personaResult)
           }
+
+          const resolvedSelectedCharacter =
+            resolveTrackedCharacterForCurrentChat() ||
+            (await resolveSelectedCharacter())
+          if (resolvedSelectedCharacter?.id) {
+            const resolvedModel = effectiveSelectedModel?.trim()
+            if (!resolvedModel) {
+              notification.error({
+                message: t("error"),
+                description: t("validationSelectModel")
+              })
+              setIsProcessing(false)
+              setStreaming(false)
+              setAbortController(null)
+              return chatSubmitSkipped("No model selected for character chat")
+            }
+            markSteeringApplied()
+            const characterResult = await characterChatMode({
+              message,
+              image,
+              isRegenerate,
+              messages: baseMessages,
+              history: baseHistory,
+              signal,
+              model: resolvedModel,
+              regenerateFromMessage,
+              character: resolvedSelectedCharacter,
+              messageSteering: messageSteeringForTurn,
+              serverChatIdOverride
+            })
+            return toChatSubmitResult(characterResult)
+          }
         }
 
         if (!compareModeActive) {
@@ -2557,8 +2576,8 @@ export const useChatActions = ({
           const modelsRaw =
             compareSelectedModels && compareSelectedModels.length > 0
               ? compareSelectedModels
-              : effectiveRequestModel
-                ? [effectiveRequestModel]
+              : effectiveSelectedModel
+                ? [effectiveSelectedModel]
                 : []
           if (modelsRaw.length === 0) {
             throw new Error("No models selected for Compare mode")
@@ -2629,11 +2648,8 @@ export const useChatActions = ({
             }
             activeHistoryId = "temp"
           } else if (!activeHistoryId) {
-            const firstModelSelection = parseProviderQualifiedModelSelection(
-              uniqueModels[0] || effectiveRequestModel
-            )
             const title = await generateTitle(
-              firstModelSelection.modelId || effectiveRequestModel,
+              uniqueModels[0] || effectiveSelectedModel || "",
               message,
               message
             )
@@ -2649,7 +2665,7 @@ export const useChatActions = ({
             await saveMessage({
               id: compareUserMessageId,
               history_id: activeHistoryId,
-              name: effectiveRequestModel || uniqueModels[0] || "You",
+              name: effectiveSelectedModel || uniqueModels[0] || "You",
               role: "user",
               content: message,
               images: resolvedImage ? [resolvedImage] : [],
@@ -2682,12 +2698,8 @@ export const useChatActions = ({
             uploadedFiles: uploadedFiles
           }
 
-          const comparePromises = models.map(async (modelKey) => {
-            const modelSelection = resolveCompareModelSelection(modelKey)
-            const historyForModel = buildHistoryForModel(
-              baseMessages,
-              modelSelection.historyModelKey
-            )
+          const comparePromises = models.map(async (modelId) => {
+            const historyForModel = buildHistoryForModel(baseMessages, modelId)
             try {
               return toChatSubmitResult(
                 await normalChatMode(
@@ -2699,15 +2711,10 @@ export const useChatActions = ({
                   signal,
                   {
                     ...compareEnhancedParams,
-                    currentChatModelSettings:
-                      applySelectionProviderToSettings(
-                        compareEnhancedParams.currentChatModelSettings,
-                        modelSelection.provider
-                      ),
-                    selectedModel: modelSelection.selectedModel,
+                    selectedModel: modelId,
                     clusterId,
                     assistantMessageType: "compare:reply",
-                    modelIdOverride: modelSelection.historyModelKey,
+                    modelIdOverride: modelId,
                     assistantParentMessageId: compareUserMessageId,
                     historyForModel
                   }
@@ -2797,11 +2804,10 @@ export const useChatActions = ({
     const baseHistory = history
     const userMessageId = generateID()
     const assistantMessageId = generateID()
-    const modelSelection = resolveCompareModelSelection(modelId)
     const userParentMessageId = getLastThreadMessageId(
       baseMessages,
       clusterId,
-      modelSelection.historyModelKey
+      modelId
     )
 
     try {
@@ -2812,20 +2818,13 @@ export const useChatActions = ({
         ...chatModeParams,
         uploadedFiles: uploadedFiles
       }
-      const historyForModel = buildHistoryForModel(
-        baseMessages,
-        modelSelection.historyModelKey
-      )
+      const historyForModel = buildHistoryForModel(baseMessages, modelId)
       const perModelOverrides = {
-        selectedModel: modelSelection.selectedModel,
-        currentChatModelSettings: applySelectionProviderToSettings(
-          enhancedChatModeParams.currentChatModelSettings,
-          modelSelection.provider
-        ),
+        selectedModel: modelId,
         clusterId,
         userMessageType: "compare:perModelUser",
         assistantMessageType: "compare:reply",
-        modelIdOverride: modelSelection.historyModelKey,
+        modelIdOverride: modelId,
         userMessageId,
         assistantMessageId,
         userParentMessageId,
@@ -3170,12 +3169,7 @@ export const useChatActions = ({
       return null
     }
 
-    const modelSelection = resolveCompareModelSelection(modelId)
-    const messageIds = getCompareBranchMessageIds(
-      messages,
-      clusterId,
-      modelSelection.historyModelKey
-    )
+    const messageIds = getCompareBranchMessageIds(messages, clusterId, modelId)
     if (messageIds.length === 0) {
       return null
     }

--- a/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts
@@ -49,7 +49,13 @@ export const useSelectServerChat = () => {
     setServerChatClusterId,
     setServerChatSource,
     setServerChatExternalRef,
-    setServerChatMetaLoaded
+    setServerChatMetaLoaded,
+    setWebSearch,
+    setSelectedSystemPrompt,
+    setSelectedQuickPrompt,
+    setContextFiles,
+    setSelectedKnowledge,
+    setRagMediaIds
   } = useStoreMessageOption(
     (state) => ({
       setIsSearchingInternet: state.setIsSearchingInternet,
@@ -68,7 +74,13 @@ export const useSelectServerChat = () => {
       setServerChatClusterId: state.setServerChatClusterId,
       setServerChatSource: state.setServerChatSource,
       setServerChatExternalRef: state.setServerChatExternalRef,
-      setServerChatMetaLoaded: state.setServerChatMetaLoaded
+      setServerChatMetaLoaded: state.setServerChatMetaLoaded,
+      setWebSearch: state.setWebSearch,
+      setSelectedSystemPrompt: state.setSelectedSystemPrompt,
+      setSelectedQuickPrompt: state.setSelectedQuickPrompt,
+      setContextFiles: state.setContextFiles,
+      setSelectedKnowledge: state.setSelectedKnowledge,
+      setRagMediaIds: state.setRagMediaIds
     }),
     shallow
   )
@@ -83,6 +95,12 @@ export const useSelectServerChat = () => {
       setHistoryId(null)
       setHistory([])
       setMessages([])
+      setWebSearch(false)
+      setSelectedSystemPrompt("")
+      setSelectedQuickPrompt(null)
+      setContextFiles([])
+      setSelectedKnowledge(null)
+      setRagMediaIds(null)
       setServerChatId(chat.id)
       setServerChatTitle(chat.title || "")
       const assistantIdentity = resolveServerChatAssistantIdentity(
@@ -124,6 +142,11 @@ export const useSelectServerChat = () => {
       setIsProcessing,
       setIsSearchingInternet,
       setMessages,
+      setContextFiles,
+      setRagMediaIds,
+      setSelectedKnowledge,
+      setSelectedQuickPrompt,
+      setSelectedSystemPrompt,
       setServerChatAssistantId,
       setServerChatAssistantKind,
       setServerChatCharacterId,
@@ -139,7 +162,8 @@ export const useSelectServerChat = () => {
       setServerChatTitle,
       setServerChatTopic,
       setServerChatVersion,
-      setStreaming
+      setStreaming,
+      setWebSearch
     ]
   )
 }

--- a/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/useSelectServerChat.ts
@@ -3,19 +3,11 @@ import { useNavigate } from "react-router-dom"
 import { Modal } from "antd"
 import { shallow } from "zustand/shallow"
 import { useChatBaseState } from "@/hooks/chat/useChatBaseState"
-import { useSelectedAssistant } from "@/hooks/useSelectedAssistant"
 import { useStoreMessageOption } from "@/store/option"
-import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { cleanupAntOverlays } from "@/utils/cleanup-ant-overlays"
 import { normalizeConversationState } from "@/utils/conversation-state"
 import { updatePageTitle } from "@/utils/update-page-title"
-import { collectGreetings } from "@/utils/character-greetings"
 import type { ServerChatSummary } from "@/services/tldw/TldwApiClient"
-import {
-  characterToAssistantSelection,
-  personaToAssistantSelection
-} from "@/types/assistant-selection"
-import type { Character } from "@/types/character"
 import { resolveServerChatAssistantIdentity } from "@/hooks/chat/useServerChatLoader"
 
 const resolveCharacterId = (value: unknown): string | number | null => {
@@ -29,63 +21,8 @@ const resolveCharacterId = (value: unknown): string | number | null => {
   return null
 }
 
-const normalizeSelectedCharacter = (raw: unknown): Character | null => {
-  if (!raw || typeof raw !== "object") return null
-  const candidate = raw as Record<string, unknown>
-  const idSource = resolveCharacterId(
-    candidate.id ?? candidate.slug ?? candidate.name ?? candidate.title
-  )
-  const nameSource = (
-    candidate.name ??
-    candidate.title ??
-    candidate.slug
-  ) as string | undefined
-  if (!idSource || typeof nameSource !== "string" || nameSource.trim().length === 0) {
-    return null
-  }
-  const greetings = collectGreetings(candidate as any)
-  return {
-    id: String(idSource),
-    name: nameSource.trim(),
-    avatar_url:
-      typeof candidate.avatar_url === "string" ? candidate.avatar_url : null,
-    image_base64:
-      typeof candidate.image_base64 === "string" ? candidate.image_base64 : null,
-    image_mime:
-      typeof candidate.image_mime === "string" ? candidate.image_mime : null,
-    system_prompt:
-      typeof candidate.system_prompt === "string"
-        ? candidate.system_prompt
-        : typeof candidate.systemPrompt === "string"
-          ? candidate.systemPrompt
-          : typeof candidate.instructions === "string"
-            ? candidate.instructions
-            : null,
-    greeting: greetings[0] ?? null,
-    slug: typeof candidate.slug === "string" ? candidate.slug : null,
-    title: typeof candidate.title === "string" ? candidate.title : null,
-    tags: Array.isArray(candidate.tags)
-      ? candidate.tags
-          .map((tag) => (typeof tag === "string" ? tag.trim() : ""))
-          .filter((tag) => tag.length > 0)
-      : undefined,
-    extensions:
-      candidate.extensions &&
-      typeof candidate.extensions === "object" &&
-      !Array.isArray(candidate.extensions)
-        ? (candidate.extensions as Record<string, unknown>)
-        : null,
-    version:
-      typeof candidate.version === "number" && Number.isFinite(candidate.version)
-        ? candidate.version
-        : undefined
-  }
-}
-
 export const useSelectServerChat = () => {
   const navigate = useNavigate()
-  const [, setSelectedAssistant] = useSelectedAssistant(null)
-  const assistantSyncRequestRef = React.useRef(0)
   const {
     setHistory,
     setHistoryId,
@@ -112,13 +49,7 @@ export const useSelectServerChat = () => {
     setServerChatClusterId,
     setServerChatSource,
     setServerChatExternalRef,
-    setServerChatMetaLoaded,
-    setWebSearch,
-    setSelectedSystemPrompt,
-    setSelectedQuickPrompt,
-    setContextFiles,
-    setSelectedKnowledge,
-    setRagMediaIds
+    setServerChatMetaLoaded
   } = useStoreMessageOption(
     (state) => ({
       setIsSearchingInternet: state.setIsSearchingInternet,
@@ -137,13 +68,7 @@ export const useSelectServerChat = () => {
       setServerChatClusterId: state.setServerChatClusterId,
       setServerChatSource: state.setServerChatSource,
       setServerChatExternalRef: state.setServerChatExternalRef,
-      setServerChatMetaLoaded: state.setServerChatMetaLoaded,
-      setWebSearch: state.setWebSearch,
-      setSelectedSystemPrompt: state.setSelectedSystemPrompt,
-      setSelectedQuickPrompt: state.setSelectedQuickPrompt,
-      setContextFiles: state.setContextFiles,
-      setSelectedKnowledge: state.setSelectedKnowledge,
-      setRagMediaIds: state.setRagMediaIds
+      setServerChatMetaLoaded: state.setServerChatMetaLoaded
     }),
     shallow
   )
@@ -158,12 +83,6 @@ export const useSelectServerChat = () => {
       setHistoryId(null)
       setHistory([])
       setMessages([])
-      setWebSearch(false)
-      setSelectedSystemPrompt("")
-      setSelectedQuickPrompt(null as unknown as string)
-      setContextFiles([])
-      setSelectedKnowledge(null)
-      setRagMediaIds(null)
       setServerChatId(chat.id)
       setServerChatTitle(chat.title || "")
       const assistantIdentity = resolveServerChatAssistantIdentity(
@@ -176,60 +95,6 @@ export const useSelectServerChat = () => {
       setServerChatPersonaMemoryMode(assistantIdentity.personaMemoryMode)
       setServerChatLoadState("loading")
       setServerChatLoadError(null)
-      const syncRequestId = assistantSyncRequestRef.current + 1
-      assistantSyncRequestRef.current = syncRequestId
-      const syncSelectedAssistant = async () => {
-        if (assistantIdentity.assistantKind === "persona" && assistantIdentity.assistantId) {
-          try {
-            await tldwClient.initialize().catch(() => null)
-            const persona = await tldwClient.getPersonaProfile(
-              assistantIdentity.assistantId
-            )
-            if (assistantSyncRequestRef.current !== syncRequestId) return
-            await setSelectedAssistant(
-              personaToAssistantSelection({
-                ...persona,
-                id: assistantIdentity.assistantId,
-                name: persona?.name || "Persona"
-              })
-            )
-          } catch (error) {
-            if (assistantSyncRequestRef.current !== syncRequestId) return
-            console.warn("[useSelectServerChat] Failed to sync persona", {
-              chatId: chat.id,
-              assistantId: assistantIdentity.assistantId,
-              error
-            })
-            await setSelectedAssistant(
-              personaToAssistantSelection({
-                id: assistantIdentity.assistantId,
-                name: "Persona"
-              })
-            )
-          }
-          return
-        }
-        if (characterId == null) {
-          await setSelectedAssistant(null)
-          return
-        }
-        try {
-          await tldwClient.initialize().catch(() => null)
-          const character = await tldwClient.getCharacter(characterId)
-          if (assistantSyncRequestRef.current !== syncRequestId) return
-          const normalized = normalizeSelectedCharacter(character)
-          await setSelectedAssistant(characterToAssistantSelection(normalized))
-        } catch (error) {
-          if (assistantSyncRequestRef.current !== syncRequestId) return
-          console.warn("[useSelectServerChat] Failed to sync character", {
-            chatId: chat.id,
-            characterId,
-            error
-          })
-          await setSelectedAssistant(null)
-        }
-      }
-      void syncSelectedAssistant()
       setIsProcessing(false)
       setStreaming(false)
       setIsEmbedding(false)
@@ -259,10 +124,6 @@ export const useSelectServerChat = () => {
       setIsProcessing,
       setIsSearchingInternet,
       setMessages,
-      setSelectedAssistant,
-      setSelectedKnowledge,
-      setSelectedQuickPrompt,
-      setSelectedSystemPrompt,
       setServerChatAssistantId,
       setServerChatAssistantKind,
       setServerChatCharacterId,
@@ -278,10 +139,7 @@ export const useSelectServerChat = () => {
       setServerChatTitle,
       setServerChatTopic,
       setServerChatVersion,
-      setContextFiles,
-      setRagMediaIds,
-      setStreaming,
-      setWebSearch
+      setStreaming
     ]
   )
 }

--- a/apps/packages/ui/src/hooks/useMessage.routing.ts
+++ b/apps/packages/ui/src/hooks/useMessage.routing.ts
@@ -1,0 +1,43 @@
+import type { EffectiveAssistantState } from "@/hooks/chat/effective-assistant-state"
+
+export type UseMessageSendMode =
+  | "tracked_character"
+  | "tracked_persona"
+  | "overlay"
+  | "plain"
+
+export const resolveUseMessageSendMode = ({
+  effectiveMode,
+  hasEffectiveAssistant,
+  draftAssistantKind
+}: {
+  effectiveMode: EffectiveAssistantState["mode"]
+  hasEffectiveAssistant: boolean
+  draftAssistantKind?: "character" | "persona" | null
+}): UseMessageSendMode => {
+  if (effectiveMode === "tracked_character") {
+    return "tracked_character"
+  }
+
+  if (effectiveMode === "tracked_persona") {
+    return "tracked_persona"
+  }
+
+  if (effectiveMode === "overlay") {
+    return "overlay"
+  }
+
+  if (!hasEffectiveAssistant) {
+    return "plain"
+  }
+
+  if (draftAssistantKind === "character") {
+    return "tracked_character"
+  }
+
+  if (draftAssistantKind === "persona") {
+    return "tracked_persona"
+  }
+
+  return "plain"
+}

--- a/apps/packages/ui/src/hooks/useMessage.tsx
+++ b/apps/packages/ui/src/hooks/useMessage.tsx
@@ -83,15 +83,20 @@ import {
   isGreetingMessageType,
 } from "@/utils/character-greetings";
 import { resolveServerChatAssistantIdentity } from "@/hooks/chat/useServerChatLoader";
+import { resolveEffectiveAssistantState } from "@/hooks/chat/effective-assistant-state";
+import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord";
 import {
+  assistantSelectionToCharacter,
   characterToAssistantSelection,
   isPersonaAssistantSelection,
   personaToAssistantSelection,
+  type AssistantSelection,
 } from "@/types/assistant-selection";
 import { ensurePersonaServerChat } from "@/hooks/chat/personaServerChat";
 import { useChatLoopState } from "@/services/chat-loop/hooks";
 import { subscribeChatLoopEvents } from "@/services/chat-loop/bridge";
 import { extractChatLoopEvent } from "@/services/chat-loop/stream";
+import { resolveUseMessageSendMode } from "@/hooks/useMessage.routing";
 
 const extractToolCalls = (generationInfo: unknown): ToolCall[] | undefined => {
   if (!generationInfo || typeof generationInfo !== "object") return undefined;
@@ -212,6 +217,55 @@ export const useMessage = () => {
     setServerChatExternalRef,
   } = useStoreMessageOption();
   const notification = useAntdNotification();
+  const { settings: chatSettings } = useChatSettingsRecord({
+    historyId,
+    serverChatId,
+  });
+  const effectiveAssistantState = React.useMemo(
+    () =>
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: serverChatAssistantKind,
+          assistantId: serverChatAssistantId,
+          characterId: serverChatCharacterId,
+        },
+        settings: chatSettings ?? null,
+        draftSelection: selectedAssistant,
+      }),
+    [
+      chatSettings,
+      selectedAssistant,
+      serverChatAssistantId,
+      serverChatAssistantKind,
+      serverChatCharacterId,
+    ],
+  );
+  const effectiveSelectedAssistant = React.useMemo<AssistantSelection | null>(() => {
+    if (effectiveAssistantState.mode === "plain") {
+      return selectedAssistant;
+    }
+
+    const matchesDraftSelection =
+      selectedAssistant?.kind === effectiveAssistantState.kind &&
+      selectedAssistant.id === effectiveAssistantState.id;
+    const draftMetadata = matchesDraftSelection ? selectedAssistant : null;
+
+    return {
+      ...draftMetadata,
+      kind: effectiveAssistantState.kind!,
+      id: effectiveAssistantState.id!,
+      name:
+        effectiveAssistantState.displayName ??
+        draftMetadata?.name ??
+        (effectiveAssistantState.kind === "persona" ? "Persona" : "Assistant"),
+      avatar_url:
+        effectiveAssistantState.avatarUrl ?? draftMetadata?.avatar_url ?? null,
+      system_prompt:
+        effectiveAssistantState.systemPromptSnapshot ??
+        draftMetadata?.system_prompt ??
+        null,
+    };
+  }, [effectiveAssistantState, selectedAssistant]);
   const [sidepanelTemporaryChat] = useStorage("sidepanelTemporaryChat", false);
   const [speechToTextLanguage, setSpeechToTextLanguage] = useStorage(
     "speechToTextLanguage",
@@ -356,11 +410,6 @@ export const useMessage = () => {
     setServerChatTopic,
     setServerChatVersion,
   ]);
-
-  React.useEffect(() => {
-    // Reset server chat when assistant identity changes
-    setServerChatId(null);
-  }, [selectedAssistant?.id, selectedAssistant?.kind]);
 
   // Local embedding store removed; rely on tldw_server RAG
 
@@ -1157,10 +1206,12 @@ export const useMessage = () => {
     history: ChatHistory,
     signal: AbortSignal,
     model: string,
+    characterOverride?: Character | null,
     regenerateFromMessage?: Message,
     serverChatIdOverride?: string | null,
   ) => {
     setStreaming(true);
+    const activeCharacter = characterOverride ?? selectedCharacter;
     const resolveGreetingText = (): string => {
       const fromMessages = messages.find(
         (entry) =>
@@ -1184,7 +1235,7 @@ export const useMessage = () => {
         return fromHistory.content.trim();
       }
 
-      const fromCharacter = collectGreetings(selectedCharacter as any).find(
+      const fromCharacter = collectGreetings(activeCharacter as any).find(
         (candidate) =>
           typeof candidate === "string" && candidate.trim().length > 0,
       );
@@ -1229,7 +1280,7 @@ export const useMessage = () => {
         ? normalizeMessageVariants(regenerateFromMessage)
         : [];
 
-    if (!selectedCharacter?.id) {
+    if (!activeCharacter?.id) {
       throw new Error("No character selected");
     }
 
@@ -1254,9 +1305,9 @@ export const useMessage = () => {
       // Visual placeholder
       const modelInfo = await getModelNicknameByID(model);
       const characterName =
-        selectedCharacter?.name || modelInfo?.model_name || model;
+        activeCharacter?.name || modelInfo?.model_name || model;
       const characterAvatar =
-        selectedCharacter?.avatar_url || modelInfo?.model_avatar;
+        activeCharacter?.avatar_url || modelInfo?.model_avatar;
       const createdAt = Date.now();
       const hasGreetingInMessages = messages.some((entry) => {
         if (!entry?.isBot) return false;
@@ -1350,7 +1401,7 @@ export const useMessage = () => {
           | undefined;
 
         const created = (await tldwClient.createChat({
-          character_id: selectedCharacter.id,
+          character_id: activeCharacter.id,
           state: serverChatState || "in-progress",
           topic_label: serverChatTopic || undefined,
           cluster_id: serverChatClusterId || undefined,
@@ -1404,7 +1455,7 @@ export const useMessage = () => {
         setServerChatId(normalizedId);
         setServerChatTitle(String((created as any)?.title || ""));
         setServerChatCharacterId(
-          (created as any)?.character_id ?? selectedCharacter?.id ?? null,
+          (created as any)?.character_id ?? activeCharacter?.id ?? null,
         );
         setServerChatMetaLoaded(true);
         invalidateServerChatHistory();
@@ -1612,7 +1663,7 @@ export const useMessage = () => {
         let metadataExtra: Record<string, unknown> | undefined;
         try {
           fallbackSpeakerId = Number.parseInt(
-            String(selectedCharacter.id),
+            String(activeCharacter.id),
             10,
           );
           speakerCharacterId =
@@ -2448,7 +2499,27 @@ export const useMessage = () => {
         );
       } else {
         if (resolvedChatMode === "normal") {
-          if (selectedCharacter?.id) {
+          const sendMode = resolveUseMessageSendMode({
+            effectiveMode: effectiveAssistantState.mode,
+            hasEffectiveAssistant: Boolean(effectiveSelectedAssistant),
+            draftAssistantKind: selectedAssistant?.kind ?? null,
+          });
+          const trackedCharacterForSend =
+            sendMode === "tracked_character"
+              ? (() => {
+                  if (
+                    selectedCharacter?.id != null &&
+                    String(selectedCharacter.id) === effectiveAssistantState.id
+                  ) {
+                    return selectedCharacter;
+                  }
+                  return assistantSelectionToCharacter<Character & Record<string, unknown>>(
+                    effectiveSelectedAssistant,
+                  );
+                })()
+              : null;
+
+          if (sendMode === "tracked_character" && trackedCharacterForSend?.id) {
             await characterChatMode(
               message,
               image,
@@ -2457,12 +2528,13 @@ export const useMessage = () => {
               memory || history,
               signal,
               model,
+              trackedCharacterForSend,
               regenerateFromMessage,
               serverChatIdOverride,
             );
-          } else if (isPersonaAssistantSelection(selectedAssistant)) {
+          } else if (sendMode === "tracked_persona" && isPersonaAssistantSelection(effectiveSelectedAssistant)) {
             const personaServerChat = await ensurePersonaServerChat({
-              assistant: selectedAssistant,
+              assistant: effectiveSelectedAssistant,
               serverChatIdOverride,
               serverChatId,
               serverChatTitle,
@@ -2518,10 +2590,10 @@ export const useMessage = () => {
                   options?: { preserveServerChatId?: boolean },
                 ) => void,
                 assistantIdentity: {
-                  name: selectedAssistant.name,
+                  name: effectiveSelectedAssistant.name,
                   avatarUrl:
-                    typeof selectedAssistant.avatar_url === "string"
-                      ? selectedAssistant.avatar_url
+                    typeof effectiveSelectedAssistant.avatar_url === "string"
+                      ? effectiveSelectedAssistant.avatar_url
                       : undefined,
                 },
                 saveMessageOnSuccess: (data) =>
@@ -2532,6 +2604,47 @@ export const useMessage = () => {
                 webSearch: resolvedWebSearch,
                 setIsSearchingInternet,
                 uploadedFiles,
+                regenerateFromMessage,
+                ...conversationContextOverrides,
+                ...replyOverrides,
+              },
+            );
+          } else if (sendMode === "overlay" && effectiveSelectedAssistant) {
+            await normalChatMode(
+              message,
+              image,
+              isRegenerate,
+              chatHistory || messages,
+              memory || history,
+              signal,
+              {
+                selectedModel: model,
+                useOCR: resolvedUseOCR,
+                selectedSystemPrompt: resolvedSelectedSystemPrompt,
+                currentChatModelSettings,
+                setMessages,
+                saveMessageOnSuccess,
+                saveMessageOnError,
+                setHistory,
+                setIsProcessing,
+                setStreaming,
+                setAbortController,
+                historyId,
+                setHistoryId: setHistoryId as (
+                  id: string,
+                  options?: { preserveServerChatId?: boolean },
+                ) => void,
+                assistantIdentity: {
+                  name: effectiveSelectedAssistant.name,
+                  avatarUrl:
+                    typeof effectiveSelectedAssistant.avatar_url === "string"
+                      ? effectiveSelectedAssistant.avatar_url
+                      : undefined,
+                },
+                overlaySystemPrompt:
+                  effectiveAssistantState.systemPromptSnapshot ?? undefined,
+                webSearch: resolvedWebSearch,
+                setIsSearchingInternet,
                 regenerateFromMessage,
                 ...conversationContextOverrides,
                 ...replyOverrides,

--- a/apps/packages/ui/src/hooks/useMessageOption.tsx
+++ b/apps/packages/ui/src/hooks/useMessageOption.tsx
@@ -19,7 +19,10 @@ import { useSelectedModel } from "@/hooks/chat/useSelectedModel";
 import { usePromptPersistence } from "@/hooks/chat/usePromptPersistence";
 import { useRagSettings } from "@/hooks/chat/useRagSettings";
 import { useFileUpload } from "@/hooks/chat/useFileUpload";
+import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord";
+import { resolveEffectiveAssistantState } from "@/hooks/chat/effective-assistant-state";
 import { useSelectedAssistant } from "@/hooks/useSelectedAssistant";
+import type { AssistantSelection } from "@/types/assistant-selection";
 import type { Character } from "@/types/character";
 import { useSelectedCharacter } from "@/hooks/useSelectedCharacter";
 import { useSetting } from "@/hooks/useSetting";
@@ -32,11 +35,6 @@ import type { MessageSteeringPromptTemplates } from "@/types/message-steering";
 import { useChatLoopState } from "@/services/chat-loop/hooks";
 import { subscribeChatLoopEvents } from "@/services/chat-loop/bridge";
 import type { ChatScope } from "@/types/chat-scope";
-
-const buildAssistantKey = (
-  kind: string | null | undefined,
-  id: string | number | null | undefined,
-) => (kind && id != null ? `${kind}:${String(id)}` : null);
 
 export const useMessageOption = (
   opts: { forceCompareEnabled?: boolean; scope?: ChatScope } = {},
@@ -257,48 +255,54 @@ export const useMessageOption = (
     t,
     scope: opts.scope,
   });
-
-  const lastAssistantKeyRef = React.useRef<string | null>(
-    buildAssistantKey(selectedAssistant?.kind, selectedAssistant?.id),
-  );
-
-  React.useEffect(() => {
-    const nextAssistantKey = buildAssistantKey(
-      selectedAssistant?.kind,
-      selectedAssistant?.id,
-    );
-    if (lastAssistantKeyRef.current === nextAssistantKey) {
-      return;
-    }
-    const activeServerAssistantKey = buildAssistantKey(
-      serverChatAssistantKind,
-      serverChatAssistantId ?? serverChatCharacterId,
-    );
-    if (
-      serverChatId &&
-      nextAssistantKey &&
-      nextAssistantKey === activeServerAssistantKey
-    ) {
-      lastAssistantKeyRef.current = nextAssistantKey;
-      return;
-    }
-    lastAssistantKeyRef.current = nextAssistantKey;
-    setServerChatId(null);
-    setMessages([]);
-    setHistory([]);
-    setHistoryId(null);
-  }, [
-    selectedAssistant?.id,
-    selectedAssistant?.kind,
-    serverChatAssistantId,
-    serverChatAssistantKind,
-    serverChatCharacterId,
+  const { settings: chatSettings } = useChatSettingsRecord({
+    historyId,
     serverChatId,
-    setHistory,
-    setHistoryId,
-    setMessages,
-    setServerChatId,
-  ]);
+  });
+  const effectiveAssistantState = React.useMemo(
+    () =>
+      resolveEffectiveAssistantState({
+        tracked: {
+          assistantKind: serverChatAssistantKind,
+          assistantId: serverChatAssistantId,
+          characterId: serverChatCharacterId,
+        },
+        settings: chatSettings ?? null,
+        draftSelection: selectedAssistant,
+      }),
+    [
+      chatSettings,
+      selectedAssistant,
+      serverChatAssistantId,
+      serverChatAssistantKind,
+      serverChatCharacterId,
+    ],
+  );
+  const effectiveSelectedAssistant = React.useMemo<AssistantSelection | null>(() => {
+    if (effectiveAssistantState.mode === "plain") {
+      return selectedAssistant;
+    }
+
+    const matchesDraftSelection =
+      selectedAssistant?.kind === effectiveAssistantState.kind &&
+      selectedAssistant.id === effectiveAssistantState.id;
+    const draftMetadata = matchesDraftSelection ? selectedAssistant : null;
+
+    return {
+      ...draftMetadata,
+      kind: effectiveAssistantState.kind!,
+      id: effectiveAssistantState.id!,
+      name:
+        effectiveAssistantState.displayName ??
+        draftMetadata?.name ??
+        (effectiveAssistantState.kind === "persona" ? "Persona" : "Assistant"),
+      avatar_url: effectiveAssistantState.avatarUrl ?? draftMetadata?.avatar_url ?? null,
+      system_prompt:
+        effectiveAssistantState.systemPromptSnapshot ??
+        draftMetadata?.system_prompt ??
+        null,
+    };
+  }, [effectiveAssistantState, selectedAssistant]);
 
   React.useEffect(() => {
     if (!serverChatId || temporaryChat) return;
@@ -433,7 +437,7 @@ export const useMessageOption = (
     setSelectedSystemPrompt,
     invalidateServerChatHistory,
     selectedCharacter,
-    selectedAssistant,
+    selectedAssistant: effectiveSelectedAssistant,
     scope: opts.scope,
   });
   const onSubmit = React.useCallback(
@@ -584,7 +588,7 @@ export const useMessageOption = (
     setCompareMaxModels,
     selectedCharacter,
     setSelectedCharacter,
-    selectedAssistant,
+    selectedAssistant: effectiveSelectedAssistant,
     setSelectedAssistant,
     replyTarget,
     clearReplyTarget,

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-chat-resume.test.ts
@@ -10,7 +10,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/utils/safe-storage", () => ({
   createSafeStorage: () => ({
     get: (key: string) => mocks.storageGet(key)
-  })
+  }),
+  safeStorageSerde: {}
 }))
 
 vi.mock("@/services/app", () => ({
@@ -109,6 +110,104 @@ describe("hasResumableSidepanelChat", () => {
               queuedMessages: [],
               modelSettings: {}
             }
+          }
+        }
+      }
+      return null
+    })
+
+    await expect(hasResumableSidepanelChat()).resolves.toBe(false)
+  })
+
+  it("treats a blank persisted tab scaffold with a matching per-tab overlay marker as resumable", async () => {
+    const matchingOverlayResumeKey =
+      "sidepanelChatOverlayResume:tldw:sidepanelChatDraft:tab-1"
+    const unrelatedOverlayResumeKey =
+      "sidepanelChatOverlayResume:tldw:sidepanelChatDraft:tab-2"
+
+    mocks.storageGet.mockImplementation(async (key: string) => {
+      if (key === "sidepanelChatTabsState:tab-7") {
+        return {
+          tabs: [{ id: "tab-1" }],
+          activeTabId: "tab-1",
+          snapshotsById: {
+            "tab-1": {
+              history: [],
+              messages: [],
+              chatMode: "normal",
+              historyId: null,
+              webSearch: false,
+              toolChoice: "none",
+              selectedModel: null,
+              selectedSystemPrompt: null,
+              selectedQuickPrompt: null,
+              temporaryChat: false,
+              useOCR: false,
+              serverChatId: null,
+              serverChatState: null,
+              serverChatTopic: null,
+              serverChatClusterId: null,
+              serverChatSource: null,
+              serverChatExternalRef: null,
+              queuedMessages: [],
+              modelSettings: {}
+            }
+          }
+        }
+      }
+      if (key === matchingOverlayResumeKey) {
+        return {
+          updatedAt: "2026-05-22T12:00:00.000Z"
+        }
+      }
+      if (key === unrelatedOverlayResumeKey) return null
+      return null
+    })
+
+    await expect(hasResumableSidepanelChat()).resolves.toBe(true)
+    expect(mocks.storageGet).toHaveBeenCalledWith(matchingOverlayResumeKey)
+    expect(mocks.storageGet).not.toHaveBeenCalledWith(unrelatedOverlayResumeKey)
+  })
+
+  it("does not treat unrelated scratch overlays as resumable for a blank persisted tab scaffold", async () => {
+    mocks.storageGet.mockImplementation(async (key: string) => {
+      if (key === "sidepanelChatTabsState:tab-7") {
+        return {
+          tabs: [{ id: "tab-1" }],
+          activeTabId: "tab-1",
+          snapshotsById: {
+            "tab-1": {
+              history: [],
+              messages: [],
+              chatMode: "normal",
+              historyId: null,
+              webSearch: false,
+              toolChoice: "none",
+              selectedModel: null,
+              selectedSystemPrompt: null,
+              selectedQuickPrompt: null,
+              temporaryChat: false,
+              useOCR: false,
+              serverChatId: null,
+              serverChatState: null,
+              serverChatTopic: null,
+              serverChatClusterId: null,
+              serverChatSource: null,
+              serverChatExternalRef: null,
+              queuedMessages: [],
+              modelSettings: {}
+            }
+          }
+        }
+      }
+      if (key === "chatSettings:scratch") {
+        return {
+          assistantOverlay: {
+            kind: "persona",
+            id: "persona-1",
+            name: "Guide Persona",
+            system_prompt_snapshot: "Stay in character.",
+            updatedAt: "2026-05-22T12:00:00.000Z"
           }
         }
       }

--- a/apps/packages/ui/src/routes/sidepanel-chat-resume.ts
+++ b/apps/packages/ui/src/routes/sidepanel-chat-resume.ts
@@ -4,8 +4,17 @@ import {
   getRecentChatFromCopilot
 } from "@/db/dexie/helpers"
 import { copilotResumeLastChat } from "@/services/app"
+import {
+  getChatSettingsStorageKey,
+  normalizeChatSettingsRecord,
+  resolveChatSettingsKey
+} from "@/services/chat-settings"
 import type { SidepanelChatSnapshot, SidepanelChatTab } from "@/store/sidepanel-chat-tabs"
 import { createSafeStorage } from "@/utils/safe-storage"
+import {
+  getSidepanelDraftStorageKey,
+  getSidepanelOverlayResumeMarkerKey
+} from "@/utils/sidepanel-overlay-resume"
 import type { ChatHistory, Message as ChatMessage } from "~/store/option"
 
 export type LegacySidepanelChatSnapshot = {
@@ -43,10 +52,31 @@ export const readSidepanelRuntimeTabId = async (): Promise<number | null> => {
   }
 }
 
-const hasRestorableSnapshot = (
+const hasOverlayDraftSettings = async (
+  storage: ReturnType<typeof createSafeStorage>,
   snapshot: SidepanelChatSnapshot | undefined,
   tab: SidepanelChatTab | undefined
-): boolean => {
+): Promise<boolean> => {
+  const chatKey = resolveChatSettingsKey({
+    historyId: snapshot?.historyId ?? tab?.historyId ?? null,
+    serverChatId: snapshot?.serverChatId ?? tab?.serverChatId ?? null
+  })
+  if (chatKey === "scratch") {
+    const draftKey = getSidepanelDraftStorageKey(tab?.id)
+    const resumeMarkerKey = getSidepanelOverlayResumeMarkerKey(draftKey)
+    if (!resumeMarkerKey) return false
+    return Boolean(await storage.get(resumeMarkerKey))
+  }
+  const settingsKey = getChatSettingsStorageKey(chatKey)
+  const storedSettings = await storage.get(settingsKey)
+  return Boolean(normalizeChatSettingsRecord(storedSettings)?.assistantOverlay)
+}
+
+const hasRestorableSnapshot = async (
+  snapshot: SidepanelChatSnapshot | undefined,
+  tab: SidepanelChatTab | undefined,
+  storage: ReturnType<typeof createSafeStorage>
+): Promise<boolean> => {
   if (tab?.historyId || tab?.serverChatId || tab?.serverChatTopic) {
     return true
   }
@@ -55,16 +85,20 @@ const hasRestorableSnapshot = (
     return false
   }
 
-  return Boolean(
+  if (
     snapshot.history.length > 0 ||
-      snapshot.messages.length > 0 ||
-      snapshot.historyId ||
-      snapshot.serverChatId ||
-      snapshot.serverChatTopic ||
-      snapshot.serverChatClusterId ||
-      snapshot.serverChatExternalRef ||
-      snapshot.queuedMessages.length > 0
-  )
+    snapshot.messages.length > 0 ||
+    snapshot.historyId ||
+    snapshot.serverChatId ||
+    snapshot.serverChatTopic ||
+    snapshot.serverChatClusterId ||
+    snapshot.serverChatExternalRef ||
+    snapshot.queuedMessages.length > 0
+  ) {
+    return true
+  }
+
+  return hasOverlayDraftSettings(storage, snapshot, tab)
 }
 
 export const hasResumableSidepanelChat = async (): Promise<boolean> => {
@@ -85,9 +119,11 @@ export const hasResumableSidepanelChat = async (): Promise<boolean> => {
       if (
         candidate &&
         Array.isArray(candidate.tabs) &&
-        candidate.tabs.some((tab) =>
-          hasRestorableSnapshot(candidate.snapshotsById?.[tab.id], tab)
-        )
+        (await Promise.all(
+          candidate.tabs.map((tab) =>
+            hasRestorableSnapshot(candidate.snapshotsById?.[tab.id], tab, storage)
+          )
+        )).some(Boolean)
       ) {
         return true
       }

--- a/apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts
+++ b/apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts
@@ -105,6 +105,24 @@ describe("chat settings assistant overlay", () => {
     expect(tooLongName?.assistantOverlay).toBeUndefined()
   })
 
+  it("trims assistantOverlay optional string fields during normalization", () => {
+    const settings = normalizeChatSettingsRecord({
+      schemaVersion: 2,
+      updatedAt: "2026-05-22T18:00:00.000Z",
+      assistantOverlay: buildOverlay({
+        avatar_url: "  https://example.com/avatar-trimmed.png  ",
+        system_prompt_snapshot: "  Stay concise.  "
+      })
+    })
+
+    expect(settings?.assistantOverlay).toEqual(
+      expect.objectContaining({
+        avatar_url: "https://example.com/avatar-trimmed.png",
+        system_prompt_snapshot: "Stay concise."
+      })
+    )
+  })
+
   it("persists assistantOverlay locally before a server chat id exists", async () => {
     const scratch = await applyChatSettingsPatch({
       historyId: null,

--- a/apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts
+++ b/apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const storageState = vi.hoisted(() => {
+  const store = new Map<string, unknown>()
+  return {
+    store,
+    get: vi.fn(async (key: string) => store.get(key)),
+    set: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value)
+    }),
+    remove: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+    initialize: vi.fn(async () => undefined),
+    getChatSettings: vi.fn(),
+    updateChatSettings: vi.fn()
+  }
+})
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: storageState.get,
+    set: storageState.set,
+    remove: storageState.remove
+  })
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: (...args: unknown[]) => storageState.initialize(...args),
+    getChatSettings: (...args: unknown[]) => storageState.getChatSettings(...args),
+    updateChatSettings: (...args: unknown[]) =>
+      storageState.updateChatSettings(...args)
+  }
+}))
+
+import {
+  applyChatSettingsPatch,
+  getChatSettingsStorageKey,
+  normalizeChatSettingsRecord,
+  resolveChatSettingsKey
+} from "@/services/chat-settings"
+
+const buildOverlay = (overrides: Record<string, unknown> = {}) => ({
+  kind: "persona",
+  id: "persona-7",
+  name: "Planner",
+  avatar_url: "https://example.com/avatar.png",
+  system_prompt_snapshot: "You are concise and structured.",
+  updatedAt: "2026-05-22T18:00:00.000Z",
+  ...overrides
+})
+
+describe("chat settings assistant overlay", () => {
+  beforeEach(() => {
+    storageState.store.clear()
+    vi.clearAllMocks()
+  })
+
+  it("accepts assistantOverlay.system_prompt_snapshot during normalization", () => {
+    const settings = normalizeChatSettingsRecord({
+      schemaVersion: 2,
+      updatedAt: "2026-05-22T18:00:00.000Z",
+      assistantOverlay: buildOverlay()
+    })
+
+    expect(settings?.assistantOverlay).toEqual(
+      expect.objectContaining({
+        system_prompt_snapshot: "You are concise and structured."
+      })
+    )
+  })
+
+  it("rejects malformed assistantOverlay payloads during normalization", () => {
+    const settings = normalizeChatSettingsRecord({
+      schemaVersion: 2,
+      updatedAt: "2026-05-22T18:00:00.000Z",
+      assistantOverlay: buildOverlay({
+        kind: "invalid-kind",
+        system_prompt_snapshot: { text: "bad" }
+      })
+    })
+
+    expect(settings?.assistantOverlay).toBeUndefined()
+  })
+
+  it("rejects oversized assistantOverlay id and name during normalization", () => {
+    const oversized = "x".repeat(20_001)
+    const tooLongId = normalizeChatSettingsRecord({
+      schemaVersion: 2,
+      updatedAt: "2026-05-22T18:00:00.000Z",
+      assistantOverlay: buildOverlay({
+        id: oversized
+      })
+    })
+    const tooLongName = normalizeChatSettingsRecord({
+      schemaVersion: 2,
+      updatedAt: "2026-05-22T18:00:00.000Z",
+      assistantOverlay: buildOverlay({
+        name: oversized
+      })
+    })
+
+    expect(tooLongId?.assistantOverlay).toBeUndefined()
+    expect(tooLongName?.assistantOverlay).toBeUndefined()
+  })
+
+  it("persists assistantOverlay locally before a server chat id exists", async () => {
+    const scratch = await applyChatSettingsPatch({
+      historyId: null,
+      serverChatId: null,
+      patch: {
+        assistantOverlay: buildOverlay({
+          id: "persona-scratch"
+        })
+      }
+    })
+    const local = await applyChatSettingsPatch({
+      historyId: "history-overlay-1",
+      serverChatId: null,
+      patch: {
+        assistantOverlay: buildOverlay({
+          id: "persona-local"
+        })
+      }
+    })
+
+    expect(scratch?.assistantOverlay?.id).toBe("persona-scratch")
+    expect(local?.assistantOverlay?.id).toBe("persona-local")
+    expect(
+      storageState.store.get(
+        getChatSettingsStorageKey(
+          resolveChatSettingsKey({ historyId: null, serverChatId: null })
+        )
+      )
+    ).toMatchObject({
+      assistantOverlay: expect.objectContaining({ id: "persona-scratch" })
+    })
+    expect(
+      storageState.store.get(
+        getChatSettingsStorageKey(
+          resolveChatSettingsKey({
+            historyId: "history-overlay-1",
+            serverChatId: null
+          })
+        )
+      )
+    ).toMatchObject({
+      assistantOverlay: expect.objectContaining({ id: "persona-local" })
+    })
+  })
+
+  it("merges a partial local overlay patch into the existing valid overlay", async () => {
+    const historyId = "history-overlay-preserve"
+    const storageKey = getChatSettingsStorageKey(
+      resolveChatSettingsKey({
+        historyId,
+        serverChatId: null
+      })
+    )
+    storageState.store.set(storageKey, {
+      schemaVersion: 2,
+      updatedAt: "2026-05-22T18:00:00.000Z",
+      assistantOverlay: buildOverlay({
+        id: "persona-existing",
+        name: "Existing Overlay"
+      })
+    })
+
+    const next = await applyChatSettingsPatch({
+      historyId,
+      serverChatId: null,
+      patch: {
+        assistantOverlay: {
+          name: "Renamed Only"
+        } as never
+      }
+    })
+
+    expect(next?.assistantOverlay).toEqual(
+      expect.objectContaining({
+        id: "persona-existing",
+        name: "Renamed Only"
+      })
+    )
+    expect(storageState.store.get(storageKey)).toMatchObject({
+      assistantOverlay: expect.objectContaining({
+        id: "persona-existing",
+        name: "Renamed Only"
+      })
+    })
+  })
+
+  it("preserves an existing valid local overlay when a merged overlay patch remains invalid", async () => {
+    const historyId = "history-overlay-invalid-merge"
+    const storageKey = getChatSettingsStorageKey(
+      resolveChatSettingsKey({
+        historyId,
+        serverChatId: null
+      })
+    )
+    storageState.store.set(storageKey, {
+      schemaVersion: 2,
+      updatedAt: "2026-05-22T18:00:00.000Z",
+      assistantOverlay: buildOverlay({
+        id: "persona-existing",
+        name: "Existing Overlay"
+      })
+    })
+
+    const next = await applyChatSettingsPatch({
+      historyId,
+      serverChatId: null,
+      patch: {
+        assistantOverlay: {
+          name: "x".repeat(20_001)
+        } as never
+      }
+    })
+
+    expect(next?.assistantOverlay).toEqual(
+      expect.objectContaining({
+        id: "persona-existing",
+        name: "Existing Overlay"
+      })
+    )
+    expect(storageState.store.get(storageKey)).toMatchObject({
+      assistantOverlay: expect.objectContaining({
+        id: "persona-existing",
+        name: "Existing Overlay"
+      })
+    })
+  })
+
+  it("allows assistantOverlay to be cleared explicitly with null", async () => {
+    const historyId = "history-overlay-clear"
+
+    await applyChatSettingsPatch({
+      historyId,
+      serverChatId: null,
+      patch: {
+        assistantOverlay: buildOverlay({
+          id: "persona-clear"
+        })
+      }
+    })
+
+    const next = await applyChatSettingsPatch({
+      historyId,
+      serverChatId: null,
+      patch: {
+        assistantOverlay: null
+      }
+    })
+
+    expect(next?.assistantOverlay).toBeNull()
+    expect(
+      storageState.store.get(
+        getChatSettingsStorageKey(
+          resolveChatSettingsKey({
+            historyId,
+            serverChatId: null
+          })
+        )
+      )
+    ).toMatchObject({
+      assistantOverlay: null
+    })
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts
+++ b/apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts
@@ -145,6 +145,55 @@ describe("syncChatSettingsForServerChat", () => {
     )
     expect(result).toEqual(localSettings)
   })
+
+  it("reconciles locally persisted assistant overlay settings once a server chat id exists", async () => {
+    const historyId = "history-overlay-sync"
+    const serverChatId = "chat-overlay-sync"
+    const localSettings = createSettings({
+      updatedAt: "2026-05-22T18:10:00.000Z",
+      assistantOverlay: {
+        kind: "persona",
+        id: "persona-11",
+        name: "Research Guide",
+        avatar_url: "https://example.com/persona-11.png",
+        system_prompt_snapshot: "Keep answers structured and calm.",
+        updatedAt: "2026-05-22T18:10:00.000Z"
+      }
+    })
+    state.storage.set(
+      getChatSettingsStorageKey(
+        resolveChatSettingsKey({ historyId, serverChatId: null })
+      ),
+      localSettings
+    )
+    state.remoteSettings = null
+
+    const result = await syncChatSettingsForServerChat({
+      historyId,
+      serverChatId
+    })
+
+    expect(mocks.updateChatSettings).toHaveBeenCalledTimes(1)
+    expect(mocks.updateChatSettings).toHaveBeenCalledWith(
+      serverChatId,
+      expect.objectContaining({
+        assistantOverlay: expect.objectContaining({
+          id: "persona-11",
+          system_prompt_snapshot: "Keep answers structured and calm."
+        })
+      })
+    )
+    expect(
+      state.storage.get(
+        getChatSettingsStorageKey(
+          resolveChatSettingsKey({ historyId: null, serverChatId })
+        )
+      )
+    ).toMatchObject({
+      assistantOverlay: expect.objectContaining({ id: "persona-11" })
+    })
+    expect(result).toEqual(localSettings)
+  })
 })
 
 describe("normalizeChatSettingsRecord", () => {

--- a/apps/packages/ui/src/services/chat-settings.ts
+++ b/apps/packages/ui/src/services/chat-settings.ts
@@ -114,7 +114,8 @@ const asOptionalBoundedString = (
   if (value === null) return null
   if (typeof value !== "string") return undefined
   if (value.length > maxLength) return undefined
-  return value.trim().length > 0 ? value : null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
 }
 
 const asNonNegativeInteger = (value: unknown): number | null => {

--- a/apps/packages/ui/src/services/chat-settings.ts
+++ b/apps/packages/ui/src/services/chat-settings.ts
@@ -4,6 +4,7 @@ import { buildChatLinkedResearchPath } from "@/components/Option/Playground/rese
 import { normalizeConversationContextIdList } from "@/services/conversation-context/conversationContextSettings"
 import {
   CHAT_SETTINGS_SCHEMA_VERSION,
+  ChatAssistantOverlay,
   ChatSettingsRecord,
   CharacterMemoryEntry,
   ConversationContextSettings,
@@ -28,6 +29,16 @@ const DEEP_RESEARCH_ATTACHMENT_ALLOWED_KEYS = new Set([
   "attached_at",
   "updatedAt"
 ])
+const ASSISTANT_OVERLAY_ALLOWED_KEYS = new Set([
+  "kind",
+  "id",
+  "name",
+  "avatar_url",
+  "system_prompt_snapshot",
+  "updatedAt"
+])
+const ASSISTANT_OVERLAY_ALLOWED_KINDS = new Set(["character", "persona"])
+const MAX_ASSISTANT_OVERLAY_TEXT_CHARS = 20_000
 const CHAT_SETTINGS_OPTIONAL_KEYS = [
   "autoSummaryEnabled",
   "autoSummaryThresholdMessages",
@@ -50,7 +61,8 @@ const CHAT_SETTINGS_OPTIONAL_KEYS = [
   "conversationContext",
   "chat_dictionary_ids",
   "summary",
-  "imageEventSyncMode"
+  "imageEventSyncMode",
+  "assistantOverlay"
 ] as const
 
 export const getChatSettingsStorageKey = (chatKey: string) =>
@@ -78,11 +90,31 @@ const asNonEmptyString = (value: unknown): string | null => {
   return trimmed.length > 0 ? trimmed : null
 }
 
+const asBoundedNonEmptyString = (
+  value: unknown,
+  maxLength = MAX_ASSISTANT_OVERLAY_TEXT_CHARS
+): string | null => {
+  const text = asNonEmptyString(value)
+  if (!text || text.length > maxLength) return null
+  return text
+}
+
 const asIsoString = (value: unknown): string | null => {
   const text = asNonEmptyString(value)
   if (!text) return null
   const parsed = Date.parse(text)
   return Number.isNaN(parsed) ? null : text
+}
+
+const asOptionalBoundedString = (
+  value: unknown,
+  maxLength = MAX_ASSISTANT_OVERLAY_TEXT_CHARS
+): string | null | undefined => {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== "string") return undefined
+  if (value.length > maxLength) return undefined
+  return value.trim().length > 0 ? value : null
 }
 
 const asNonNegativeInteger = (value: unknown): number | null => {
@@ -208,6 +240,56 @@ const sanitizeDeepResearchAttachment = (
   }
 }
 
+const sanitizeAssistantOverlay = (
+  value: unknown
+): ChatAssistantOverlay | null => {
+  if (!isRecord(value)) return null
+  const keys = Object.keys(value)
+  if (keys.some((key) => !ASSISTANT_OVERLAY_ALLOWED_KEYS.has(key))) {
+    return null
+  }
+
+  const kind =
+    typeof value.kind === "string" ? value.kind.trim().toLowerCase() : null
+  const id = asBoundedNonEmptyString(value.id)
+  const name = asBoundedNonEmptyString(value.name)
+  const updatedAt = asIsoString(value.updatedAt)
+
+  if (
+    !kind ||
+    !ASSISTANT_OVERLAY_ALLOWED_KINDS.has(kind) ||
+    !id ||
+    !name ||
+    !updatedAt
+  ) {
+    return null
+  }
+
+  const avatarUrl = asOptionalBoundedString(value.avatar_url)
+  if (value.avatar_url !== undefined && avatarUrl === undefined) {
+    return null
+  }
+
+  const systemPromptSnapshot = asOptionalBoundedString(
+    value.system_prompt_snapshot
+  )
+  if (
+    value.system_prompt_snapshot !== undefined &&
+    systemPromptSnapshot === undefined
+  ) {
+    return null
+  }
+
+  return {
+    kind: kind as ChatAssistantOverlay["kind"],
+    id,
+    name,
+    avatar_url: avatarUrl,
+    system_prompt_snapshot: systemPromptSnapshot,
+    updatedAt
+  }
+}
+
 const sanitizeDeepResearchAttachmentHistory = (
   value: unknown,
   excludedRunIds?: Iterable<string | null | undefined>
@@ -265,6 +347,18 @@ const coerceSettings = (raw: any): ChatSettingsRecord | null => {
     updatedAt
   }
   normalizeConversationContextMirrors(next, raw)
+  if (Object.prototype.hasOwnProperty.call(raw, "assistantOverlay")) {
+    if (raw.assistantOverlay === null) {
+      next.assistantOverlay = null
+    } else {
+      const sanitizedOverlay = sanitizeAssistantOverlay(raw.assistantOverlay)
+      if (sanitizedOverlay) {
+        next.assistantOverlay = sanitizedOverlay
+      } else {
+        delete next.assistantOverlay
+      }
+    }
+  }
   const hasAttachment = Object.prototype.hasOwnProperty.call(
     raw,
     "deepResearchAttachment"
@@ -455,6 +549,36 @@ export const mergeChatSettings = (
   return merged
 }
 
+const buildPatchedChatSettingsInput = (
+  existing: ChatSettingsRecord | null,
+  patch: Partial<ChatSettingsRecord>
+): Record<string, unknown> => {
+  const next: Record<string, unknown> = {
+    ...(existing || {
+      schemaVersion: CHAT_SETTINGS_SCHEMA_VERSION,
+      updatedAt: new Date().toISOString()
+    }),
+    ...patch,
+    schemaVersion: CHAT_SETTINGS_SCHEMA_VERSION,
+    updatedAt: new Date().toISOString()
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, "assistantOverlay")) {
+    if (patch.assistantOverlay === null) {
+      next.assistantOverlay = null
+    } else if (isRecord(patch.assistantOverlay) && isRecord(existing?.assistantOverlay)) {
+      next.assistantOverlay = {
+        ...existing?.assistantOverlay,
+        ...patch.assistantOverlay
+      }
+    } else {
+      next.assistantOverlay = patch.assistantOverlay as unknown
+    }
+  }
+
+  return next
+}
+
 export const getChatSettingsForKey = async (
   chatKey: string
 ): Promise<ChatSettingsRecord | null> => {
@@ -586,20 +710,28 @@ export const applyChatSettingsPatch = async (params: {
   const { historyId, serverChatId, patch } = params
   const chatKey = resolveChatSettingsKey({ historyId, serverChatId })
   const existing = await getChatSettingsForKey(chatKey)
+  const patchedInput = buildPatchedChatSettingsInput(existing, patch)
+  const normalized = normalizeChatSettingsRecord(patchedInput)
+  const assistantOverlayPatched = Object.prototype.hasOwnProperty.call(
+    patch,
+    "assistantOverlay"
+  )
   const next =
-    normalizeChatSettingsRecord({
-      ...(existing || {
-        schemaVersion: CHAT_SETTINGS_SCHEMA_VERSION,
-        updatedAt: new Date().toISOString()
-      }),
-      ...patch,
-      schemaVersion: CHAT_SETTINGS_SCHEMA_VERSION,
-      updatedAt: new Date().toISOString()
-    }) ||
+    normalized ||
     ({
       schemaVersion: CHAT_SETTINGS_SCHEMA_VERSION,
       updatedAt: new Date().toISOString()
     } as ChatSettingsRecord)
+
+  if (
+    normalized &&
+    assistantOverlayPatched &&
+    patch.assistantOverlay !== null &&
+    existing?.assistantOverlay !== undefined &&
+    normalized.assistantOverlay === undefined
+  ) {
+    next.assistantOverlay = existing.assistantOverlay
+  }
 
   const saved = await saveChatSettingsForKey(chatKey, next)
   if (!saved) {

--- a/apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts
+++ b/apps/packages/ui/src/store/__tests__/chat-surface-coordinator.test.ts
@@ -7,6 +7,25 @@ import {
 } from "@/store/chat-surface-coordinator"
 
 describe("chat-surface-coordinator", () => {
+  it("tracks the character control panel alongside the existing optional panels", () => {
+    const store = createChatSurfaceCoordinatorStore()
+
+    expect(store.getState().visiblePanels).toHaveProperty("character-control", false)
+    expect(store.getState().engagedPanels).toHaveProperty("character-control", false)
+
+    store.getState().setPanelVisible("character-control", true)
+
+    expect(
+      shouldEnableOptionalResource(store.getState(), "character-control")
+    ).toBe(false)
+
+    store.getState().markPanelEngaged("character-control")
+
+    expect(
+      shouldEnableOptionalResource(store.getState(), "character-control")
+    ).toBe(true)
+  })
+
   it("keeps server history disabled until the user engages the panel", () => {
     const store = createChatSurfaceCoordinatorStore()
 
@@ -22,5 +41,21 @@ describe("chat-surface-coordinator", () => {
     expect(
       shouldEnableOptionalResource(store.getState(), "server-history")
     ).toBe(true)
+  })
+
+  it("does not enable a panel that was engaged before it becomes visible", () => {
+    const store = createChatSurfaceCoordinatorStore()
+
+    store.getState().markPanelEngaged("mcp-tools")
+
+    expect(shouldEnableOptionalResource(store.getState(), "mcp-tools")).toBe(
+      false
+    )
+
+    store.getState().setPanelVisible("mcp-tools", true)
+
+    expect(shouldEnableOptionalResource(store.getState(), "mcp-tools")).toBe(
+      true
+    )
   })
 })

--- a/apps/packages/ui/src/store/chat-surface-coordinator.ts
+++ b/apps/packages/ui/src/store/chat-surface-coordinator.ts
@@ -8,6 +8,7 @@ export type OptionalPanelId =
   | "mcp-tools"
   | "audio-health"
   | "model-catalog"
+  | "character-control"
 
 export type ChatSurfaceCoordinatorState = {
   routeId: string | null
@@ -26,7 +27,8 @@ const DEFAULT_OPTIONAL_PANELS: Record<OptionalPanelId, boolean> = {
   "server-history": false,
   "mcp-tools": false,
   "audio-health": false,
-  "model-catalog": false
+  "model-catalog": false,
+  "character-control": false
 }
 
 export const createChatSurfaceCoordinatorState = (

--- a/apps/packages/ui/src/types/chat-session-settings.ts
+++ b/apps/packages/ui/src/types/chat-session-settings.ts
@@ -33,6 +33,15 @@ export type DeepResearchAttachment = ChatResearchContext & {
   updatedAt: string
 }
 
+export type ChatAssistantOverlay = {
+  kind: "character" | "persona"
+  id: string
+  name: string
+  avatar_url?: string | null
+  system_prompt_snapshot?: string | null
+  updatedAt: string
+}
+
 export type AuthorNotePosition =
   | "before_system"
   | `depth:${number}`
@@ -70,6 +79,7 @@ export type ChatSettingsRecord = {
   chat_dictionary_ids?: number[]
   summary?: ChatSummary | null
   imageEventSyncMode?: "off" | "on"
+  assistantOverlay?: ChatAssistantOverlay | null
   deepResearchAttachment?: DeepResearchAttachment | null
   deepResearchPinnedAttachment?: DeepResearchAttachment | null
   deepResearchAttachmentHistory?: DeepResearchAttachment[]

--- a/apps/packages/ui/src/utils/__tests__/assistant-overlay.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/assistant-overlay.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getPersonaProfile: vi.fn(async () => null),
+  getCharacter: vi.fn(async () => null)
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    getPersonaProfile: mocks.getPersonaProfile,
+    getCharacter: mocks.getCharacter
+  }
+}))
+
+import { resolveAssistantOverlaySnapshot } from "../assistant-overlay"
+
+describe("resolveAssistantOverlaySnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("uses full persona profile detail instead of catalog summary data", async () => {
+    mocks.getPersonaProfile.mockResolvedValue({
+      id: "persona-1",
+      name: "Research Guide",
+      avatar_url: "https://example.com/persona-full.png",
+      system_prompt: "Persona full prompt"
+    })
+
+    await expect(
+      resolveAssistantOverlaySnapshot({
+        kind: "persona",
+        id: "persona-1",
+        name: "Summary Name",
+        avatar_url: "https://example.com/persona-summary.png",
+        system_prompt: "Persona summary prompt"
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "persona",
+        id: "persona-1",
+        name: "Research Guide",
+        avatar_url: "https://example.com/persona-full.png",
+        system_prompt_snapshot: "Persona full prompt"
+      })
+    )
+  })
+
+  it("refreshes character detail when summary data is missing prompt material", async () => {
+    mocks.getCharacter.mockResolvedValue({
+      id: "char-2",
+      name: "Beta",
+      avatar_url: "https://example.com/beta-full.png",
+      system_prompt: "Character fetched prompt"
+    })
+
+    await expect(
+      resolveAssistantOverlaySnapshot({
+        kind: "character",
+        id: "char-2",
+        name: "Beta"
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "character",
+        id: "char-2",
+        name: "Beta",
+        avatar_url: "https://example.com/beta-full.png",
+        system_prompt_snapshot: "Character fetched prompt"
+      })
+    )
+
+    expect(mocks.getCharacter).toHaveBeenCalledWith("char-2", {
+      forceRefresh: true
+    })
+  })
+
+  it("uses full character detail instead of summary payload data at apply time", async () => {
+    mocks.getCharacter.mockResolvedValue({
+      id: "char-1",
+      name: "Alpha Full",
+      avatar_url: "https://example.com/alpha-full.png",
+      system_prompt: "Alpha full prompt"
+    })
+
+    await expect(
+      resolveAssistantOverlaySnapshot({
+        kind: "character",
+        id: "char-1",
+        name: "Alpha Summary",
+        avatar_url: "https://example.com/alpha-summary.png",
+        system_prompt: "Alpha summary prompt"
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "character",
+        id: "char-1",
+        name: "Alpha Full",
+        avatar_url: "https://example.com/alpha-full.png",
+        system_prompt_snapshot: "Alpha full prompt"
+      })
+    )
+
+    expect(mocks.getCharacter).toHaveBeenCalledWith("char-1", {
+      forceRefresh: true
+    })
+  })
+
+  it("stores the normalized snapshot payload shape", async () => {
+    mocks.getCharacter.mockResolvedValue({
+      id: "char-1",
+      name: "Alpha Full",
+      avatar_url: "https://example.com/alpha.png",
+      system_prompt: "Alpha full prompt"
+    })
+
+    const result = await resolveAssistantOverlaySnapshot({
+      kind: "character",
+      id: "char-1",
+      name: "Alpha Summary"
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "character",
+        id: "char-1",
+        name: "Alpha Full",
+        avatar_url: "https://example.com/alpha.png",
+        system_prompt_snapshot: "Alpha full prompt"
+      })
+    )
+    expect(typeof result.updatedAt).toBe("string")
+  })
+
+  it("preserves prior snapshot content even if source records later change", async () => {
+    mocks.getPersonaProfile.mockResolvedValueOnce({
+      id: "persona-9",
+      name: "Planner",
+      avatar_url: "https://example.com/planner-v1.png",
+      system_prompt: "Prompt v1"
+    })
+    mocks.getPersonaProfile.mockResolvedValueOnce({
+      id: "persona-9",
+      name: "Planner Updated",
+      avatar_url: "https://example.com/planner-v2.png",
+      system_prompt: "Prompt v2"
+    })
+
+    const first = await resolveAssistantOverlaySnapshot({
+      kind: "persona",
+      id: "persona-9",
+      name: "Planner"
+    })
+    const second = await resolveAssistantOverlaySnapshot({
+      kind: "persona",
+      id: "persona-9",
+      name: "Planner"
+    })
+
+    expect(first.system_prompt_snapshot).toBe("Prompt v1")
+    expect(second.system_prompt_snapshot).toBe("Prompt v2")
+    expect(first.system_prompt_snapshot).not.toBe(second.system_prompt_snapshot)
+  })
+
+  it("falls back to persona summary data when full detail lookup fails", async () => {
+    mocks.getPersonaProfile.mockRejectedValueOnce(new Error("persona detail unavailable"))
+
+    await expect(
+      resolveAssistantOverlaySnapshot({
+        kind: "persona",
+        id: "persona-2",
+        name: "Summary Persona",
+        avatar_url: "https://example.com/persona-summary.png",
+        system_prompt: "Persona summary prompt"
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        kind: "persona",
+        id: "persona-2",
+        name: "Summary Persona",
+        avatar_url: "https://example.com/persona-summary.png",
+        system_prompt_snapshot: "Persona summary prompt"
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/utils/assistant-overlay.ts
+++ b/apps/packages/ui/src/utils/assistant-overlay.ts
@@ -1,0 +1,104 @@
+import type { AssistantSelection } from "@/types/assistant-selection"
+import type { ChatAssistantOverlay } from "@/types/chat-session-settings"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+
+const normalizeText = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const buildOverlayPayload = ({
+  kind,
+  id,
+  name,
+  avatarUrl,
+  systemPrompt
+}: {
+  kind: ChatAssistantOverlay["kind"]
+  id: string
+  name: string
+  avatarUrl?: string | null
+  systemPrompt?: string | null
+}): ChatAssistantOverlay => ({
+  kind,
+  id,
+  name,
+  avatar_url: avatarUrl ?? null,
+  system_prompt_snapshot: systemPrompt ?? null,
+  updatedAt: new Date().toISOString()
+})
+
+export const buildAssistantOverlaySnapshotFromSelection = (
+  selection: AssistantSelection
+): ChatAssistantOverlay =>
+  buildOverlayPayload({
+    kind: selection.kind,
+    id: selection.id,
+    name:
+      normalizeText(selection.name) ??
+      (selection.kind === "persona" ? "Persona" : "Assistant"),
+    avatarUrl: normalizeText(selection.avatar_url) ?? null,
+    systemPrompt: normalizeText(selection.system_prompt) ?? null
+  })
+
+export const resolveAssistantOverlaySnapshot = async (
+  selection: AssistantSelection
+): Promise<ChatAssistantOverlay> => {
+  if (selection.kind === "persona") {
+    let profile = null
+    try {
+      profile = await tldwClient.getPersonaProfile(selection.id)
+    } catch (error) {
+      console.warn(
+        "[assistant-overlay] Failed to load persona detail; using summary snapshot",
+        error
+      )
+    }
+
+    return buildOverlayPayload({
+      kind: "persona",
+      id: selection.id,
+      name:
+        normalizeText(profile?.name) ??
+        normalizeText(selection.name) ??
+        "Persona",
+      avatarUrl:
+        normalizeText(profile?.avatar_url) ??
+        normalizeText(selection.avatar_url) ??
+        null,
+      systemPrompt:
+        normalizeText(profile?.system_prompt) ??
+        normalizeText(selection.system_prompt) ??
+        null
+    })
+  }
+
+  let detail = null
+  try {
+    detail = await tldwClient.getCharacter(selection.id, { forceRefresh: true })
+  } catch (error) {
+    console.warn(
+      "[assistant-overlay] Failed to refresh character detail; using summary snapshot",
+      error
+    )
+  }
+
+  return buildOverlayPayload({
+    kind: "character",
+    id: selection.id,
+    name:
+      normalizeText(detail?.name) ??
+      normalizeText(detail?.title) ??
+      normalizeText(selection.name) ??
+      "Assistant",
+    avatarUrl:
+      normalizeText(detail?.avatar_url) ??
+      normalizeText(selection.avatar_url) ??
+      null,
+    systemPrompt:
+      normalizeText(detail?.system_prompt) ??
+      normalizeText(selection.system_prompt) ??
+      null
+  })
+}

--- a/apps/packages/ui/src/utils/assistant-select-events.ts
+++ b/apps/packages/ui/src/utils/assistant-select-events.ts
@@ -4,6 +4,7 @@ export type AssistantSelectTab = "character" | "persona"
 
 export type AssistantSelectOpenDetail = {
   tab?: AssistantSelectTab
+  applyAs?: "tracked" | "overlay"
   source?: string
   returnFocusSelector?: string
 }

--- a/apps/packages/ui/src/utils/sidepanel-overlay-resume.ts
+++ b/apps/packages/ui/src/utils/sidepanel-overlay-resume.ts
@@ -1,0 +1,18 @@
+import { STORAGE_KEYS } from "@/config/ui-constants"
+
+export const SIDEPANEL_OVERLAY_RESUME_MARKER_PREFIX =
+  "sidepanelChatOverlayResume"
+
+export const getSidepanelDraftStorageKey = (
+  tabId: string | null | undefined
+) =>
+  tabId
+    ? `${STORAGE_KEYS.SIDEPANEL_CHAT_DRAFT}:${tabId}`
+    : STORAGE_KEYS.SIDEPANEL_CHAT_DRAFT
+
+export const getSidepanelOverlayResumeMarkerKey = (
+  draftKey: string | null | undefined
+) =>
+  draftKey
+    ? `${SIDEPANEL_OVERLAY_RESUME_MARKER_PREFIX}:${draftKey}`
+    : null

--- a/apps/tldw-frontend/e2e/smoke/sidepanel-nextgen-composer.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/sidepanel-nextgen-composer.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test, type Page } from "@playwright/test"
+import type { Page } from "@playwright/test"
+import { expect, seedAuth, test } from "./smoke.setup"
+import { dismissConnectionModals, waitForConnection } from "../utils/helpers"
 
 /**
  * Smoke test for the Primer composer wire-up in the Sidepanel debug
@@ -6,16 +8,30 @@ import { expect, test, type Page } from "@playwright/test"
  */
 
 const bypassOnboarding = async (page: Page) => {
-  await page.addInitScript(() => {
-    try {
-      window.localStorage.setItem("assistant_setup_dismissed", "true")
-    } catch {
-      /* ignore */
-    }
+  await seedAuth(page, {
+    authMode: "single-user",
+    apiKey: "test-key-not-placeholder",
+    allowOffline: true,
   })
 }
 
 const mockComposerProfile = async (page: Page) => {
+  await page.route(/\/api\/v1\/config\/docs-info.*/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ docs_url: "http://localhost/docs" }),
+    })
+  })
+
+  await page.route(/\/api\/v1\/health.*/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "ok" }),
+    })
+  })
+
   await page.route(/\/api\/v1\/users\/me\/profile.*/, async (route) => {
     const method = route.request().method()
     if (method === "GET") {
@@ -41,6 +57,28 @@ const mockComposerProfile = async (page: Page) => {
   })
 }
 
+const forceDemoConnection = async (page: Page) => {
+  await page.waitForFunction(
+    () => Boolean((window as { __tldw_useConnectionStore?: unknown }).__tldw_useConnectionStore),
+    undefined,
+    { timeout: 15_000 }
+  )
+
+  await page.evaluate(() => {
+    const store = (window as {
+      __tldw_useConnectionStore?: {
+        getState?: () => {
+          setDemoMode?: () => void
+          markFirstRunComplete?: () => Promise<void>
+        }
+      }
+    }).__tldw_useConnectionStore
+    const actions = store?.getState?.()
+    actions?.setDemoMode?.()
+    void actions?.markFirstRunComplete?.()
+  })
+}
+
 test.describe("sidepanel · nextgen composer wire-up", () => {
   test("flag OFF: no nextgen composer rendered", async ({ page }) => {
     test.setTimeout(90_000)
@@ -61,6 +99,9 @@ test.describe("sidepanel · nextgen composer wire-up", () => {
     await bypassOnboarding(page)
     await mockComposerProfile(page)
     await page.goto("/__debug__/sidepanel-chat?nextgenComposer=1")
+    await forceDemoConnection(page)
+    await waitForConnection(page, 30_000)
+    await dismissConnectionModals(page)
 
     const wrapper = page.locator('[data-testid="nextgen-composer-wrapper"]')
     await expect(wrapper).toBeVisible({ timeout: 30_000 })
@@ -81,6 +122,9 @@ test.describe("sidepanel · nextgen composer wire-up", () => {
       }
     })
     await page.goto("/__debug__/sidepanel-chat?nextgenComposer=1")
+    await forceDemoConnection(page)
+    await waitForConnection(page, 30_000)
+    await dismissConnectionModals(page)
 
     const wrapper = page.locator('[data-testid="nextgen-composer-wrapper"]')
     await expect(wrapper).toBeVisible({ timeout: 30_000 })
@@ -94,11 +138,44 @@ test.describe("sidepanel · nextgen composer wire-up", () => {
     await bypassOnboarding(page)
     await mockComposerProfile(page)
     await page.goto("/__debug__/sidepanel-chat?nextgenComposer=1")
+    await forceDemoConnection(page)
+    await waitForConnection(page, 30_000)
+    await dismissConnectionModals(page)
 
     const wrapper = page.locator('[data-testid="nextgen-composer-wrapper"]')
     await expect(wrapper).toBeVisible({ timeout: 30_000 })
     // Real sidepanel textarea now lives inside the wrapper via textareaSlot.
     const chatInput = wrapper.locator('[data-testid="chat-input"]')
     await expect(chatInput).toBeVisible()
+  })
+
+  test("flag ON: mobile sidepanel shows character controls trigger and opens sheet", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000)
+    await bypassOnboarding(page)
+    await mockComposerProfile(page)
+    await page.setViewportSize({ width: 360, height: 800 })
+    await page.goto("/__debug__/sidepanel-chat?nextgenComposer=1")
+    await forceDemoConnection(page)
+    await waitForConnection(page, 30_000)
+    await dismissConnectionModals(page)
+
+    const wrapper = page.locator('[data-testid="nextgen-composer-wrapper"]')
+    await expect(wrapper).toBeVisible({ timeout: 30_000 })
+
+    const trigger = page.locator('[data-testid="chat-character-controls-trigger"]')
+    await expect(trigger).toBeVisible()
+    await trigger.click()
+
+    await expect(
+      page.locator('[data-testid="chat-character-controls-sheet"]')
+    ).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Start tracked character chat" })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Start tracked persona chat" })
+    ).toBeVisible()
   })
 })

--- a/backlog/tasks/task-444 - Design-chat-character-overlay-and-tracked-identity-rail-model.md
+++ b/backlog/tasks/task-444 - Design-chat-character-overlay-and-tracked-identity-rail-model.md
@@ -1,0 +1,49 @@
+---
+id: TASK-444
+title: Design /chat character overlay and tracked identity rail model
+status: In Progress
+labels:
+- design
+- chat
+- webui
+- extension
+- characters
+- personas
+priority: high
+documentation:
+- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
+modified_files:
+- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-445 - Implement-chat-character-overlay-and-tracked-identity.md
+++ b/backlog/tasks/task-445 - Implement-chat-character-overlay-and-tracked-identity.md
@@ -1,9 +1,9 @@
 ---
-id: TASK-444
-title: Design /chat character overlay and tracked identity rail model
+id: TASK-445
+title: Implement chat character overlay and tracked identity
 status: In Progress
 labels:
-- design
+- implementation
 - chat
 - webui
 - extension
@@ -13,15 +13,12 @@ priority: high
 documentation:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
-modified_files:
-- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
-- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+Implement the /chat tracked-vs-overlay assistant identity model from the approved design spec and implementation plan, preserving tracked character/persona chats while adding snapshot-based personality overlays for normal conversations and a side-rail control surface.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-445 - Implement-chat-character-overlay-and-tracked-identity.md
+++ b/backlog/tasks/task-445 - Implement-chat-character-overlay-and-tracked-identity.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-445
 title: Implement chat character overlay and tracked identity
-status: In Progress
+status: Done
 labels:
 - implementation
 - chat
@@ -34,7 +34,7 @@ Implement the /chat tracked-vs-overlay assistant identity model from the approve
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented the approved tracked-vs-overlay assistant identity model across `/chat` and sidepanel surfaces. The completed slices now cover: assistant overlay settings contract and normalization, chat-scoped effective assistant state resolution, non-destructive overlay send behavior in normal chat mode, character control rail UI for the main chat surface, and sidepanel/mobile parity including scratch-tab overlay resume markers and the sidepanel character-controls sheet. The post-review hardening pass then blocked overlay writes in tracked chats, cleared overlay state before tracked-start actions, extracted a runtime-tested sidepanel character-controls sheet, and shared the sidepanel overlay-resume key helper between the form and resume detector. Final verification across the implementation stack included focused frontend vitest coverage, backend overlay settings pytest coverage, the sidepanel nextgen composer smoke spec, a direct Chromium check of the live sidepanel debug route, and Bandit reporting no findings while being unable to parse the touched TypeScript files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-446 - Add-chat-assistant-overlay-settings-contract-and-validation.md
+++ b/backlog/tasks/task-446 - Add-chat-assistant-overlay-settings-contract-and-validation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-446
 title: Add chat assistant overlay settings contract and validation
-status: In Progress
+status: Done
 labels:
 - implementation
 - chat
@@ -12,6 +12,14 @@ priority: high
 documentation:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/types/chat-session-settings.ts
+- apps/packages/ui/src/services/chat-settings.ts
+- apps/packages/ui/src/services/__tests__/chat-settings.overlay.test.ts
+- apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts
+- tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+- tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py
+- tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py
 ---
 
 ## Description
@@ -33,7 +41,7 @@ Add the assistantOverlay chat settings contract across frontend and backend vali
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Completed Task 1 on branch codex/chat-character-overlay-tracked-identity in commit 4f81fbdc4. Verification: `bunx vitest run src/services/__tests__/chat-settings.overlay.test.ts src/services/__tests__/chat-settings.sync.test.ts` -> 12 passed; `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py -k "assistant_overlay or overlay" -v` -> 8 passed, 25 deselected; `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py -f json -o /tmp/bandit_chat_overlay_task1.json` -> no new findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-446 - Add-chat-assistant-overlay-settings-contract-and-validation.md
+++ b/backlog/tasks/task-446 - Add-chat-assistant-overlay-settings-contract-and-validation.md
@@ -1,19 +1,15 @@
 ---
-id: TASK-444
-title: Design /chat character overlay and tracked identity rail model
+id: TASK-446
+title: Add chat assistant overlay settings contract and validation
 status: In Progress
 labels:
-- design
+- implementation
 - chat
-- webui
-- extension
-- characters
-- personas
+- frontend
+- backend
+- settings
 priority: high
 documentation:
-- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
-- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
-modified_files:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 ---
@@ -21,7 +17,7 @@ modified_files:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+Add the assistantOverlay chat settings contract across frontend and backend validation, including local-first persistence before server chat creation and sync reconciliation.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-447 - Add-effective-assistant-mode-resolver-and-remove-destructive-reset.md
+++ b/backlog/tasks/task-447 - Add-effective-assistant-mode-resolver-and-remove-destructive-reset.md
@@ -1,19 +1,14 @@
 ---
-id: TASK-444
-title: Design /chat character overlay and tracked identity rail model
-status: In Progress
+id: TASK-447
+title: Add effective assistant mode resolver and remove destructive reset
+status: To Do
 labels:
-- design
+- implementation
 - chat
-- webui
-- extension
-- characters
-- personas
+- frontend
+- state
 priority: high
 documentation:
-- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
-- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
-modified_files:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 ---
@@ -21,7 +16,7 @@ modified_files:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+Introduce a pure tracked-vs-overlay assistant mode resolver and remove the destructive assistant-switch reset behavior from the /chat flow.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-447 - Add-effective-assistant-mode-resolver-and-remove-destructive-reset.md
+++ b/backlog/tasks/task-447 - Add-effective-assistant-mode-resolver-and-remove-destructive-reset.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-447
 title: Add effective assistant mode resolver and remove destructive reset
-status: To Do
+status: Done
 labels:
 - implementation
 - chat
@@ -11,6 +11,15 @@ priority: high
 documentation:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/hooks/chat/effective-assistant-state.ts
+- apps/packages/ui/src/hooks/useMessageOption.tsx
+- apps/packages/ui/src/hooks/chat/useSelectServerChat.ts
+- apps/packages/ui/src/hooks/chat/useChatActions.ts
+- apps/packages/ui/src/hooks/chat/__tests__/effective-assistant-state.test.ts
+- apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
+- apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+- apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
 ---
 
 ## Description
@@ -32,7 +41,7 @@ Introduce a pure tracked-vs-overlay assistant mode resolver and remove the destr
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Completed Task 2 on branch codex/chat-character-overlay-tracked-identity. Verification: `node node_modules/vitest/vitest.mjs --config vitest.config.ts run src/hooks/chat/__tests__/effective-assistant-state.test.ts src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx src/hooks/__tests__/useMessageOption.selected-model-sync.test.tsx src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx` from `apps/packages/ui` -> 5 test files passed, 14 tests passed. Bandit is not applicable to this frontend-only TypeScript slice; running `python -m bandit -r apps/packages/ui/src/hooks/chat/effective-assistant-state.ts apps/packages/ui/src/hooks/useMessageOption.tsx apps/packages/ui/src/hooks/chat/useSelectServerChat.ts apps/packages/ui/src/hooks/chat/useChatActions.ts -f json -o /private/tmp/bandit_task447.json` produced parser errors on `.ts/.tsx` inputs and no actionable findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-448 - Implement-overlay-send-path-and-snapshot-on-apply-behavior.md
+++ b/backlog/tasks/task-448 - Implement-overlay-send-path-and-snapshot-on-apply-behavior.md
@@ -1,19 +1,15 @@
 ---
-id: TASK-444
-title: Design /chat character overlay and tracked identity rail model
-status: In Progress
+id: TASK-448
+title: Implement overlay send path and snapshot-on-apply behavior
+status: To Do
 labels:
-- design
+- implementation
 - chat
-- webui
-- extension
-- characters
+- frontend
 - personas
+- characters
 priority: high
 documentation:
-- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
-- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
-modified_files:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 ---
@@ -21,7 +17,7 @@ modified_files:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+Implement snapshot-on-apply overlay resolution from full character/persona detail and route normal chat sends through overlay-aware prompt assembly without changing tracked chat semantics.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-448 - Implement-overlay-send-path-and-snapshot-on-apply-behavior.md
+++ b/backlog/tasks/task-448 - Implement-overlay-send-path-and-snapshot-on-apply-behavior.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-448
 title: Implement overlay send path and snapshot-on-apply behavior
-status: To Do
+status: Done
 labels:
 - implementation
 - chat
@@ -33,7 +33,7 @@ Implement snapshot-on-apply overlay resolution from full character/persona detai
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Task 3 now separates overlay application from ordinary assistant selection, persists overlay snapshots in chat settings using resolved source detail, preserves tracked character/persona send paths, and prevents overlay changes from clearing the active conversation. Verification: `node node_modules/vitest/vitest.mjs --config vitest.config.ts run src/utils/__tests__/assistant-overlay.test.ts src/components/Common/__tests__/AssistantSelect.behavior.test.tsx src/components/Common/__tests__/AssistantSelect.tabs.test.tsx src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts src/hooks/__tests__/useMessage.routing-mode.test.ts src/hooks/__tests__/useMessage.assistant-overlay.guard.test.ts src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx` -> 7 files passed, 29 tests passed. Bandit not applicable because the touched scope in this task is TypeScript/TSX only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-449 - Add-desktop-character-control-rail.md
+++ b/backlog/tasks/task-449 - Add-desktop-character-control-rail.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-449
 title: Add desktop character control rail
-status: To Do
+status: Done
 labels:
 - implementation
 - chat
@@ -32,7 +32,7 @@ Add the main /chat desktop character/persona control rail as an additive surface
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added the desktop character control rail as an additive right-side `/chat` surface. The rail now shows the current plain/overlay/tracked mode summary, separates overlay actions from tracked-start actions, exposes tracked-session open actions, and mounts through the chat surface coordinator without replacing the existing transcript/composer UI. The coordinator gained a `character-control` panel id, `PlaygroundForm` now enables that panel on desktop only, and `Playground` renders the rail when the coordinator marks it visible. Verification: `node node_modules/vitest/vitest.mjs --config vitest.config.ts run src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/store/__tests__/chat-surface-coordinator.test.ts` -> 3 files passed, 10 tests passed. Bandit not applicable because the touched scope in this task is TypeScript/TSX only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-449 - Add-desktop-character-control-rail.md
+++ b/backlog/tasks/task-449 - Add-desktop-character-control-rail.md
@@ -1,19 +1,14 @@
 ---
-id: TASK-444
-title: Design /chat character overlay and tracked identity rail model
-status: In Progress
+id: TASK-449
+title: Add desktop character control rail
+status: To Do
 labels:
-- design
+- implementation
 - chat
-- webui
-- extension
-- characters
-- personas
+- frontend
+- ui
 priority: high
 documentation:
-- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
-- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
-modified_files:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 ---
@@ -21,7 +16,7 @@ modified_files:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+Add the main /chat desktop character/persona control rail as an additive surface for overlay and tracked-session actions without replacing the existing chat UI.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-450 - Add-sidepanel-mobile-parity-and-final-verification-for-chat-overlay-identity.md
+++ b/backlog/tasks/task-450 - Add-sidepanel-mobile-parity-and-final-verification-for-chat-overlay-identity.md
@@ -1,19 +1,15 @@
 ---
-id: TASK-444
-title: Design /chat character overlay and tracked identity rail model
-status: In Progress
+id: TASK-450
+title: Add sidepanel mobile parity and final verification for chat overlay identity
+status: To Do
 labels:
-- design
+- implementation
 - chat
-- webui
+- frontend
 - extension
-- characters
-- personas
+- verification
 priority: high
 documentation:
-- Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
-- Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
-modified_files:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
 ---
@@ -21,7 +17,7 @@ modified_files:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Write a design spec for /chat that preserves tracked character/persona chats while adding non-destructive character/persona personality overlays for normal conversations, with a side-rail control surface and no thread resets.
+Reuse the same tracked-vs-overlay assistant state contract in sidepanel/mobile chat surfaces and complete targeted verification, browser checks, and Bandit for the feature.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-450 - Add-sidepanel-mobile-parity-and-final-verification-for-chat-overlay-identity.md
+++ b/backlog/tasks/task-450 - Add-sidepanel-mobile-parity-and-final-verification-for-chat-overlay-identity.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-450
 title: Add sidepanel mobile parity and final verification for chat overlay identity
-status: To Do
+status: Done
 labels:
 - implementation
 - chat
@@ -12,6 +12,18 @@ priority: high
 documentation:
 - Docs/superpowers/specs/2026-05-22-chat-character-overlay-and-tracked-identity-design.md
 - Docs/superpowers/plans/2026-05-22-chat-character-overlay-and-tracked-identity-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/components/Common/AssistantSelect.tsx
+- apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+- apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/CharacterControlsSheet.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/CharacterControlsSheet.test.tsx
+- apps/packages/ui/src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts
+- apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+- apps/packages/ui/src/routes/sidepanel-chat-resume.ts
+- apps/packages/ui/src/utils/sidepanel-overlay-resume.ts
+- apps/tldw-frontend/e2e/smoke/sidepanel-nextgen-composer.spec.ts
 ---
 
 ## Description
@@ -33,7 +45,7 @@ Reuse the same tracked-vs-overlay assistant state contract in sidepanel/mobile c
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Addressed the follow-up review issues on sidepanel/mobile parity. The sidepanel character-controls sheet now mirrors the approved tracked-vs-overlay model: overlay actions are unavailable in tracked chats, tracked-start actions are explicit, tracked sessions are surfaced, and tracked-start clears overlay state first. AssistantSelect now refuses overlay writes when the active chat is tracked, and the sidepanel overlay-resume key contract is shared between the form and resume detector. Verification: `bunx vitest run ...` on the 11-file UI slice passed (52 tests), `bun run e2e:pw -- e2e/smoke/sidepanel-nextgen-composer.spec.ts --reporter=line` passed (5 tests), direct Chromium verification against `http://127.0.0.1:8080/__debug__/sidepanel-chat?nextgenComposer=1` confirmed the sheet opens and shows both tracked-start actions, and Bandit reported no findings while failing to parse the touched TypeScript files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -213,6 +213,7 @@ _CHAR_CHAT_SESSIONS_NONCRITICAL_EXCEPTIONS = (
 THROTTLE_WINDOW_SIZE = 100
 MAX_CHAT_SETTINGS_BYTES = 200_000
 MAX_AUTHOR_NOTE_CHARS = 20_000
+MAX_ASSISTANT_OVERLAY_TEXT_CHARS = MAX_AUTHOR_NOTE_CHARS
 DEFAULT_AUTO_SUMMARY_THRESHOLD_MESSAGES = 40
 DEFAULT_AUTO_SUMMARY_WINDOW_MESSAGES = 12
 MAX_AUTO_SUMMARY_LINES = 24
@@ -1262,6 +1263,80 @@ def _validate_chat_settings_payload(
         owner_user_id=owner_user_id,
         strip_invalid_reference=strip_invalid_deep_research,
     )
+
+    assistant_overlay = settings.get("assistantOverlay")
+    if assistant_overlay is not None:
+        if not isinstance(assistant_overlay, dict):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid assistantOverlay. Expected object or null",
+            )
+        unknown_keys = sorted(
+            set(assistant_overlay.keys())
+            - {"kind", "id", "name", "avatar_url", "system_prompt_snapshot", "updatedAt"}
+        )
+        if unknown_keys:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "Invalid assistantOverlay. Unknown keys: "
+                    + ", ".join(unknown_keys)
+                ),
+            )
+
+        kind = assistant_overlay.get("kind")
+        if not isinstance(kind, str) or kind.strip().lower() not in {"character", "persona"}:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid assistantOverlay.kind. Allowed values: character, persona",
+            )
+        assistant_overlay["kind"] = kind.strip().lower()
+
+        for field_name in ("id", "name"):
+            field_value = assistant_overlay.get(field_name)
+            if not isinstance(field_value, str) or not field_value.strip():
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Invalid assistantOverlay.{field_name}. Expected non-empty string",
+                )
+            if len(field_value) > MAX_ASSISTANT_OVERLAY_TEXT_CHARS:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=(
+                        f"assistantOverlay.{field_name} exceeds "
+                        f"{MAX_ASSISTANT_OVERLAY_TEXT_CHARS} characters"
+                    ),
+                )
+            assistant_overlay[field_name] = field_value.strip()
+
+        for field_name in ("avatar_url", "system_prompt_snapshot"):
+            field_value = assistant_overlay.get(field_name)
+            if field_value is None:
+                continue
+            if not isinstance(field_value, str):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Invalid assistantOverlay.{field_name}. Expected string or null",
+                )
+            if len(field_value) > MAX_ASSISTANT_OVERLAY_TEXT_CHARS:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=(
+                        f"assistantOverlay.{field_name} exceeds "
+                        f"{MAX_ASSISTANT_OVERLAY_TEXT_CHARS} characters"
+                    ),
+                )
+            if field_name == "avatar_url":
+                assistant_overlay[field_name] = field_value.strip() or None
+            elif not field_value.strip():
+                assistant_overlay[field_name] = None
+
+        overlay_updated_at = assistant_overlay.get("updatedAt")
+        if not isinstance(overlay_updated_at, str) or _parse_iso_timestamp(overlay_updated_at) is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid assistantOverlay.updatedAt. Expected ISO timestamp string",
+            )
 
     memory_by_id = settings.get("characterMemoryById")
     if memory_by_id is not None:

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -47,6 +47,7 @@ from tldw_Server_API.app.api.v1.schemas.chat_conversation_schemas import (
 )
 from tldw_Server_API.app.api.v1.schemas.chat_session_schemas import (
     AuthorNoteInfoResponse,
+    AssistantOverlaySettings,
     CharacterChatCompletionPrepRequest,
     CharacterChatCompletionPrepResponse,
     CharacterChatCompletionV2Request,
@@ -1266,77 +1267,85 @@ def _validate_chat_settings_payload(
 
     assistant_overlay = settings.get("assistantOverlay")
     if assistant_overlay is not None:
-        if not isinstance(assistant_overlay, dict):
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Invalid assistantOverlay. Expected object or null",
+        try:
+            validated_overlay = AssistantOverlaySettings.model_validate(
+                assistant_overlay
             )
-        unknown_keys = sorted(
-            set(assistant_overlay.keys())
-            - {"kind", "id", "name", "avatar_url", "system_prompt_snapshot", "updatedAt"}
-        )
-        if unknown_keys:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(
-                    "Invalid assistantOverlay. Unknown keys: "
-                    + ", ".join(unknown_keys)
-                ),
-            )
+        except ValidationError as exc:
+            errors = exc.errors()
+            if any(error.get("type") == "model_type" for error in errors):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Invalid assistantOverlay. Expected object or null",
+                ) from exc
 
-        kind = assistant_overlay.get("kind")
-        if not isinstance(kind, str) or kind.strip().lower() not in {"character", "persona"}:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Invalid assistantOverlay.kind. Allowed values: character, persona",
+            unknown_keys = sorted(
+                str(error["loc"][0])
+                for error in errors
+                if error.get("type") == "extra_forbidden" and error.get("loc")
             )
-        assistant_overlay["kind"] = kind.strip().lower()
+            if unknown_keys:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        "Invalid assistantOverlay. Unknown keys: "
+                        + ", ".join(unknown_keys)
+                    ),
+                ) from exc
 
-        for field_name in ("id", "name"):
-            field_value = assistant_overlay.get(field_name)
-            if not isinstance(field_value, str) or not field_value.strip():
+            first_error = errors[0] if errors else {}
+            error_loc = first_error.get("loc") or ()
+            field_name = str(error_loc[0]) if error_loc else ""
+            error_type = str(first_error.get("type") or "")
+
+            if field_name == "kind":
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Invalid assistantOverlay.kind. Allowed values: character, persona",
+                ) from exc
+
+            if field_name in {"id", "name"}:
+                if error_type == "string_too_long":
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=(
+                            f"assistantOverlay.{field_name} exceeds "
+                            f"{MAX_ASSISTANT_OVERLAY_TEXT_CHARS} characters"
+                        ),
+                    ) from exc
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=f"Invalid assistantOverlay.{field_name}. Expected non-empty string",
-                )
-            if len(field_value) > MAX_ASSISTANT_OVERLAY_TEXT_CHARS:
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail=(
-                        f"assistantOverlay.{field_name} exceeds "
-                        f"{MAX_ASSISTANT_OVERLAY_TEXT_CHARS} characters"
-                    ),
-                )
-            assistant_overlay[field_name] = field_value.strip()
+                ) from exc
 
-        for field_name in ("avatar_url", "system_prompt_snapshot"):
-            field_value = assistant_overlay.get(field_name)
-            if field_value is None:
-                continue
-            if not isinstance(field_value, str):
+            if field_name in {"avatar_url", "system_prompt_snapshot"}:
+                if error_type == "string_too_long":
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=(
+                            f"assistantOverlay.{field_name} exceeds "
+                            f"{MAX_ASSISTANT_OVERLAY_TEXT_CHARS} characters"
+                        ),
+                    ) from exc
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=f"Invalid assistantOverlay.{field_name}. Expected string or null",
-                )
-            if len(field_value) > MAX_ASSISTANT_OVERLAY_TEXT_CHARS:
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail=(
-                        f"assistantOverlay.{field_name} exceeds "
-                        f"{MAX_ASSISTANT_OVERLAY_TEXT_CHARS} characters"
-                    ),
-                )
-            if field_name == "avatar_url":
-                assistant_overlay[field_name] = field_value.strip() or None
-            elif not field_value.strip():
-                assistant_overlay[field_name] = None
+                ) from exc
 
-        overlay_updated_at = assistant_overlay.get("updatedAt")
-        if not isinstance(overlay_updated_at, str) or _parse_iso_timestamp(overlay_updated_at) is None:
+            if field_name == "updatedAt":
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Invalid assistantOverlay.updatedAt. Expected ISO timestamp string",
+                ) from exc
+
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Invalid assistantOverlay.updatedAt. Expected ISO timestamp string",
-            )
+                detail="Invalid assistantOverlay",
+            ) from exc
+
+        settings["assistantOverlay"] = validated_overlay.model_dump(
+            exclude_unset=True
+        )
 
     memory_by_id = settings.get("characterMemoryById")
     if memory_by_id is not None:

--- a/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.core.LLM_Calls.routing.models import RoutingOverride
 ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
 ALLOWED_ASSISTANT_KINDS = ("character", "persona")
 ALLOWED_PERSONA_MEMORY_MODES = ("read_only", "read_write")
+MAX_ASSISTANT_OVERLAY_TEXT_CHARS = 20_000
 
 
 def _default_offset_pagination_aliases(response):
@@ -38,6 +39,100 @@ def _validate_conversation_state(value: Optional[str]) -> Optional[str]:
     if normalized not in ALLOWED_CONVERSATION_STATES:
         raise ValueError(f"Invalid state '{value}'. Allowed: {', '.join(ALLOWED_CONVERSATION_STATES)}")
     return normalized
+
+
+def _normalize_required_overlay_text(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.strip()
+    return value
+
+
+def _normalize_optional_overlay_text(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    return value
+
+
+def _normalize_overlay_timestamp(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.strip()
+    return value
+
+
+def _validate_iso_timestamp_text(value: str) -> str:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("Expected ISO timestamp string") from exc
+    return value
+
+
+class AssistantOverlaySettings(BaseModel):
+    """Normalized assistant personality overlay stored in per-chat settings."""
+
+    kind: Literal["character", "persona"] = Field(
+        ...,
+        description="Source identity kind for the overlay",
+    )
+    id: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_ASSISTANT_OVERLAY_TEXT_CHARS,
+        description="Stable character/persona identifier",
+    )
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_ASSISTANT_OVERLAY_TEXT_CHARS,
+        description="Display name snapshot captured when the overlay was applied",
+    )
+    avatar_url: str | None = Field(
+        default=None,
+        max_length=MAX_ASSISTANT_OVERLAY_TEXT_CHARS,
+        description="Optional avatar URL snapshot",
+    )
+    system_prompt_snapshot: str | None = Field(
+        default=None,
+        max_length=MAX_ASSISTANT_OVERLAY_TEXT_CHARS,
+        description="Optional system prompt snapshot captured on apply",
+    )
+    updatedAt: str = Field(
+        ...,
+        min_length=1,
+        description="ISO timestamp for the last overlay update",
+    )
+
+    model_config = {"extra": "forbid"}
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def _normalize_kind(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
+
+    @field_validator("id", "name", mode="before")
+    @classmethod
+    def _normalize_required_text(cls, value: Any) -> Any:
+        return _normalize_required_overlay_text(value)
+
+    @field_validator("avatar_url", "system_prompt_snapshot", mode="before")
+    @classmethod
+    def _normalize_optional_text(cls, value: Any) -> Any:
+        return _normalize_optional_overlay_text(value)
+
+    @field_validator("updatedAt", mode="before")
+    @classmethod
+    def _normalize_updated_at(cls, value: Any) -> Any:
+        return _normalize_overlay_timestamp(value)
+
+    @field_validator("updatedAt")
+    @classmethod
+    def _validate_updated_at(cls, value: str) -> str:
+        return _validate_iso_timestamp_text(value)
 
 class ChatSessionCreate(BaseModel):
     """Schema for creating a new chat session."""

--- a/tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py
+++ b/tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py
@@ -116,6 +116,193 @@ async def test_chat_settings_roundtrip_persists_deep_research_attachment(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_chat_settings_roundtrip_persists_assistant_overlay(monkeypatch):
+    tmpdir = tempfile.mkdtemp(prefix="chacha_assistant_overlay_")
+    monkeypatch.setenv("USER_DB_BASE_DIR", tmpdir)
+    reset_settings()
+    try:
+        from tldw_Server_API.app.main import app
+
+        headers = {"X-API-KEY": get_settings().SINGLE_USER_API_KEY}
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            chat_id = await _create_chat(client, headers)
+            payload = {
+                "settings": {
+                    "schemaVersion": 2,
+                    "updatedAt": "2026-05-22T20:00:00Z",
+                    "assistantOverlay": {
+                        "kind": "persona",
+                        "id": "persona-7",
+                        "name": "Research Guide",
+                        "avatar_url": "https://example.com/persona-7.png",
+                        "system_prompt_snapshot": "Be concise and evidence-driven.",
+                        "updatedAt": "2026-05-22T20:00:00Z",
+                    },
+                }
+            }
+
+            put_response = await client.put(
+                f"/api/v1/chats/{chat_id}/settings",
+                headers=headers,
+                json=payload,
+            )
+            assert put_response.status_code == 200, put_response.text
+            stored_put = put_response.json()["settings"]["assistantOverlay"]
+            assert stored_put["system_prompt_snapshot"] == "Be concise and evidence-driven."
+
+            get_response = await client.get(
+                f"/api/v1/chats/{chat_id}/settings",
+                headers=headers,
+            )
+            assert get_response.status_code == 200, get_response.text
+            stored = get_response.json()["settings"]["assistantOverlay"]
+            assert stored["kind"] == "persona"
+            assert stored["id"] == "persona-7"
+            assert stored["name"] == "Research Guide"
+            assert stored["avatar_url"] == "https://example.com/persona-7.png"
+            assert stored["system_prompt_snapshot"] == "Be concise and evidence-driven."
+    finally:
+        reset_settings()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_chat_settings_rejects_invalid_assistant_overlay_kind(monkeypatch):
+    tmpdir = tempfile.mkdtemp(prefix="chacha_assistant_overlay_kind_")
+    monkeypatch.setenv("USER_DB_BASE_DIR", tmpdir)
+    reset_settings()
+    try:
+        from tldw_Server_API.app.main import app
+
+        headers = {"X-API-KEY": get_settings().SINGLE_USER_API_KEY}
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            chat_id = await _create_chat(client, headers)
+            payload = {
+                "settings": {
+                    "schemaVersion": 2,
+                    "updatedAt": "2026-05-22T20:00:00Z",
+                    "assistantOverlay": {
+                        "kind": "regular",
+                        "id": "overlay-1",
+                        "name": "Overlay Name",
+                        "updatedAt": "2026-05-22T20:00:00Z",
+                    },
+                }
+            }
+
+            put_response = await client.put(
+                f"/api/v1/chats/{chat_id}/settings",
+                headers=headers,
+                json=payload,
+            )
+            assert put_response.status_code == 422, put_response.text
+            assert "assistantOverlay.kind" in put_response.json()["detail"]
+    finally:
+        reset_settings()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("oversized_field", ["id", "name"])
+async def test_chat_settings_rejects_oversized_assistant_overlay_identity_fields(
+    monkeypatch,
+    oversized_field,
+):
+    tmpdir = tempfile.mkdtemp(prefix="chacha_assistant_overlay_identity_")
+    monkeypatch.setenv("USER_DB_BASE_DIR", tmpdir)
+    reset_settings()
+    try:
+        from tldw_Server_API.app.main import app
+
+        headers = {"X-API-KEY": get_settings().SINGLE_USER_API_KEY}
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            chat_id = await _create_chat(client, headers)
+            assistant_overlay = {
+                "kind": "character",
+                "id": "overlay-2",
+                "name": "Overlay Name",
+                "updatedAt": "2026-05-22T20:00:00Z",
+            }
+            assistant_overlay[oversized_field] = "x" * 20_001
+            payload = {
+                "settings": {
+                    "schemaVersion": 2,
+                    "updatedAt": "2026-05-22T20:00:00Z",
+                    "assistantOverlay": assistant_overlay,
+                }
+            }
+
+            put_response = await client.put(
+                f"/api/v1/chats/{chat_id}/settings",
+                headers=headers,
+                json=payload,
+            )
+            assert put_response.status_code == 413, put_response.text
+            assert f"assistantOverlay.{oversized_field}" in put_response.json()["detail"]
+    finally:
+        reset_settings()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("assistant_overlay_overrides", "drop_updated_at", "expected_status", "expected_detail"),
+    [
+        ({"system_prompt_snapshot": {"text": "bad"}}, False, 422, "assistantOverlay.system_prompt_snapshot"),
+        ({"system_prompt_snapshot": "x" * 20_001}, False, 413, "assistantOverlay.system_prompt_snapshot"),
+        ({}, True, 422, "assistantOverlay.updatedAt"),
+    ],
+)
+async def test_chat_settings_rejects_invalid_assistant_overlay_prompt_snapshot(
+    monkeypatch,
+    assistant_overlay_overrides,
+    drop_updated_at,
+    expected_status,
+    expected_detail,
+):
+    tmpdir = tempfile.mkdtemp(prefix="chacha_assistant_overlay_prompt_")
+    monkeypatch.setenv("USER_DB_BASE_DIR", tmpdir)
+    reset_settings()
+    try:
+        from tldw_Server_API.app.main import app
+
+        headers = {"X-API-KEY": get_settings().SINGLE_USER_API_KEY}
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            chat_id = await _create_chat(client, headers)
+            assistant_overlay = {
+                "kind": "character",
+                "id": "overlay-2",
+                "name": "Overlay Name",
+                "updatedAt": "2026-05-22T20:00:00Z",
+                **assistant_overlay_overrides,
+            }
+            if drop_updated_at:
+                assistant_overlay.pop("updatedAt", None)
+            payload = {
+                "settings": {
+                    "schemaVersion": 2,
+                    "updatedAt": "2026-05-22T20:00:00Z",
+                    "assistantOverlay": assistant_overlay,
+                }
+            }
+
+            put_response = await client.put(
+                f"/api/v1/chats/{chat_id}/settings",
+                headers=headers,
+                json=payload,
+            )
+            assert put_response.status_code == expected_status, put_response.text
+            assert expected_detail in put_response.json()["detail"]
+    finally:
+        reset_settings()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
 async def test_chat_settings_canonicalize_owned_completed_deep_research_attachment(monkeypatch):
     tmpdir = tempfile.mkdtemp(prefix="chacha_deep_research_attachment_canonical_")
     monkeypatch.setenv("USER_DB_BASE_DIR", tmpdir)

--- a/tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py
+++ b/tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py
@@ -168,6 +168,51 @@ async def test_chat_settings_roundtrip_persists_assistant_overlay(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_chat_settings_normalizes_assistant_overlay_strings(monkeypatch):
+    tmpdir = tempfile.mkdtemp(prefix="chacha_assistant_overlay_trim_")
+    monkeypatch.setenv("USER_DB_BASE_DIR", tmpdir)
+    reset_settings()
+    try:
+        from tldw_Server_API.app.main import app
+
+        headers = {"X-API-KEY": get_settings().SINGLE_USER_API_KEY}
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            chat_id = await _create_chat(client, headers)
+            payload = {
+                "settings": {
+                    "schemaVersion": 2,
+                    "updatedAt": "2026-05-22T20:00:00Z",
+                    "assistantOverlay": {
+                        "kind": " Persona ",
+                        "id": " persona-7 ",
+                        "name": " Research Guide ",
+                        "avatar_url": " https://example.com/persona-7.png ",
+                        "system_prompt_snapshot": " Be concise and evidence-driven. ",
+                        "updatedAt": " 2026-05-22T20:00:00Z ",
+                    },
+                }
+            }
+
+            put_response = await client.put(
+                f"/api/v1/chats/{chat_id}/settings",
+                headers=headers,
+                json=payload,
+            )
+            assert put_response.status_code == 200, put_response.text
+            stored = put_response.json()["settings"]["assistantOverlay"]
+            assert stored["kind"] == "persona"
+            assert stored["id"] == "persona-7"
+            assert stored["name"] == "Research Guide"
+            assert stored["avatar_url"] == "https://example.com/persona-7.png"
+            assert stored["system_prompt_snapshot"] == "Be concise and evidence-driven."
+            assert stored["updatedAt"] == "2026-05-22T20:00:00Z"
+    finally:
+        reset_settings()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
 async def test_chat_settings_rejects_invalid_assistant_overlay_kind(monkeypatch):
     tmpdir = tempfile.mkdtemp(prefix="chacha_assistant_overlay_kind_")
     monkeypatch.setenv("USER_DB_BASE_DIR", tmpdir)

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py
@@ -135,6 +135,37 @@ def test_merge_conversation_settings_preserves_unknown_keys():
 
 
 @pytest.mark.unit
+def test_merge_conversation_settings_preserves_assistant_overlay_payload():
+    server = {
+        "schemaVersion": 2,
+        "updatedAt": "2026-05-22T20:00:00Z",
+        "assistantOverlay": {
+            "kind": "character",
+            "id": "char-1",
+            "name": "Server Overlay",
+            "system_prompt_snapshot": "server snapshot",
+            "updatedAt": "2026-05-22T20:00:00Z",
+        },
+    }
+    incoming = {
+        "schemaVersion": 2,
+        "updatedAt": "2026-05-22T20:00:01Z",
+        "assistantOverlay": {
+            "kind": "persona",
+            "id": "persona-9",
+            "name": "Incoming Overlay",
+            "system_prompt_snapshot": "incoming snapshot",
+            "updatedAt": "2026-05-22T20:00:01Z",
+        },
+    }
+
+    merged = sessions._merge_conversation_settings(server, incoming)
+
+    assert merged["assistantOverlay"] == incoming["assistantOverlay"]
+    assert merged["updatedAt"] == "2026-05-22T20:00:01Z"
+
+
+@pytest.mark.unit
 def test_persist_auto_summary_settings_upsert_does_not_touch_conversation_metadata():
     class _StubDB:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- add snapshot-based assistant overlays for normal `/chat` conversations while preserving tracked character/persona chats
- add the desktop character control rail plus the sidepanel/mobile character-controls sheet with tracked-vs-overlay guardrails
- validate and persist overlay settings across the backend/frontend settings pipeline, with sidepanel resume support and targeted regression coverage

## Test Plan
- [x] `bunx vitest run src/routes/__tests__/sidepanel-chat-resume.test.ts src/components/Common/__tests__/AssistantSelect.behavior.test.tsx src/components/Sidepanel/Chat/__tests__/CharacterControlsSheet.test.tsx src/components/Sidepanel/Chat/__tests__/form.mobile-toolbar.contract.test.ts src/routes/__tests__/sidepanel-chat.background-storage-stability.guard.test.ts src/components/Common/__tests__/AssistantSelect.tabs.test.tsx src/components/Option/Playground/__tests__/Playground.responsive-parity.guard.test.ts src/components/Option/Playground/__tests__/CharacterControlRail.test.tsx src/services/__tests__/chat-settings.overlay.test.ts src/hooks/chat/__tests__/effective-assistant-state.test.ts src/hooks/chat-modes/__tests__/normalChatMode.overlay.test.ts`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat/test_chat_settings_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_settings_merge.py -k "assistant_overlay or overlay" -v`
- [x] `bun run e2e:pw -- e2e/smoke/sidepanel-nextgen-composer.spec.ts --reporter=line`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/Common/AssistantSelect.tsx apps/packages/ui/src/components/Option/Playground/CharacterControlRail.tsx apps/packages/ui/src/components/Option/Playground/Playground.tsx apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx apps/packages/ui/src/components/Sidepanel/Chat/CharacterControlsSheet.tsx apps/packages/ui/src/components/Sidepanel/Chat/form.tsx apps/packages/ui/src/routes/sidepanel-chat.tsx apps/packages/ui/src/utils/sidepanel-overlay-resume.ts tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py -f json -o /private/tmp/bandit_chat_overlay_clean_pr.json` (no findings; Bandit cannot parse the TS/TSX files, so only the Python-touched scope was meaningfully checked)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds snapshot-based assistant overlays to normal `/chat`, letting you apply a character/persona without converting the thread. Adds a desktop right-rail and a sidepanel/mobile sheet to pick overlay vs tracked identity, with persisted settings and tab resume.

- **New Features**
  - Overlay model: new `assistantOverlay` chat setting built from full character/persona detail, injected as an overlay system prompt in `normalChatMode`, and applied without resetting history.
  - Controls: Character Control Rail (desktop via `Playground` optional panel) and Character Controls Sheet (sidepanel/mobile) with Apply as overlay, Start tracked chat, and Clear overlay; `AssistantSelect` supports “apply as overlay”.
  - Smarter routing: effective assistant state + send-mode resolver prefers tracked character/persona > overlay > plain and removes destructive resets when switching assistants.
  - Persistence: frontend and API validation/merge for `assistantOverlay`, local-to-server reconciliation once `serverChatId` exists, and sidepanel per-tab overlay resume markers for tab resume.

- **Migration**
  - No user action required. Deploy server and web UI together to support the new `assistantOverlay` settings contract.

<sup>Written for commit f88ea77f26081b534aaf7608b0967ea50ebde7da. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1956?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

