### PR TITLE
Migrate ReferencesTab empty states to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -44,28 +44,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-errorstate-line-413-wx7ci2",
-    "path": "src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx:Empty#antd-empty-serverunavailablestate-line-347-1tj2dm7",
-    "path": "src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardDocumentRow.tsx:Alert#antd-alert-flashcarddocumentrow-type-error-line-414-o4coyq",
     "path": "src/components/Flashcards/components/FlashcardDocumentRow.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
@@ -417,6 +417,7 @@ const ErrorState: React.FC<{ error: Error }> = ({ error }) => {
         variant="inline"
         size="md"
         icon={FileText}
+        iconClassName="text-error"
         title={t(
           "option:documentWorkspace.referencesError",
           "Failed to load references"

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
@@ -23,6 +23,7 @@ import {
 import { useConnectionStore } from "@/store/connection"
 import { tldwClient } from "@/services/tldw"
 import { useQueryClient } from "@tanstack/react-query"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
 import { LoadingState as SharedLoadingState } from "@/components/ui/feedback/LoadingState"
 
 /** FNV-1a 32-bit hash for generating stable, short identifiers from reference text. */
@@ -344,9 +345,11 @@ const ServerUnavailableState: React.FC = () => {
   const { t } = useTranslation(["option", "common"])
   return (
     <div className="flex h-full items-center justify-center p-4">
-      <Empty
-        image={<BookOpen className="h-10 w-10 text-muted mx-auto mb-2" />}
-        description={t(
+      <EmptyState
+        variant="inline"
+        size="md"
+        icon={BookOpen}
+        title={t(
           "option:documentWorkspace.serverUnavailable",
           "Connect to your server in Settings to use this feature"
         )}
@@ -410,19 +413,16 @@ const ErrorState: React.FC<{ error: Error }> = ({ error }) => {
   const { t } = useTranslation(["option", "common"])
   return (
     <div className="flex h-full items-center justify-center p-4">
-      <Empty
+      <EmptyState
+        variant="inline"
+        size="md"
+        icon={FileText}
+        title={t(
+          "option:documentWorkspace.referencesError",
+          "Failed to load references"
+        )}
         description={
-          <div>
-            <p className="text-error mb-1">
-              {t(
-                "option:documentWorkspace.referencesError",
-                "Failed to load references"
-              )}
-            </p>
-            <p className="text-xs text-text-muted">
-              {error.message || t("common:unknownError", "An unknown error occurred")}
-            </p>
-          </div>
+          error.message || t("common:unknownError", "An unknown error occurred")
         }
       />
     </div>

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ReferencesTab } from "../ReferencesTab"
+import { useDocumentWorkspaceStore } from "@/store/document-workspace"
+import { useConnectionStore } from "@/store/connection"
+
+const mockUseDocumentReferences = vi.fn()
+
+vi.mock("@/hooks/document-workspace", async () => {
+  const actual = await vi.importActual<any>("@/hooks/document-workspace")
+  return {
+    ...actual,
+    useDocumentReferences: (...args: any[]) => mockUseDocumentReferences(...args)
+  }
+})
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue || _key
+  })
+}))
+
+const renderReferencesTab = () => {
+  const queryClient = new QueryClient()
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReferencesTab />
+    </QueryClientProvider>
+  )
+}
+
+describe("ReferencesTab design-system empty states", () => {
+  beforeEach(() => {
+    useDocumentWorkspaceStore.setState({ activeDocumentId: 1 })
+    const previousConnectionState = useConnectionStore.getState().state
+    useConnectionStore.setState({
+      state: {
+        ...previousConnectionState,
+        isConnected: true,
+        mode: "normal"
+      }
+    })
+    mockUseDocumentReferences.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+      isFetching: false
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useDocumentWorkspaceStore.setState({ activeDocumentId: null })
+    const previousConnectionState = useConnectionStore.getState().state
+    useConnectionStore.setState({
+      state: {
+        ...previousConnectionState,
+        isConnected: false,
+        mode: "normal"
+      }
+    })
+    vi.clearAllMocks()
+  })
+
+  it("renders the server-unavailable state through the design-system EmptyState", () => {
+    const previousConnectionState = useConnectionStore.getState().state
+    useConnectionStore.setState({
+      state: {
+        ...previousConnectionState,
+        isConnected: false,
+        mode: "normal"
+      }
+    })
+
+    const { container } = renderReferencesTab()
+
+    const message = screen.getByText("Connect to your server in Settings to use this feature")
+    expect(message.closest('[data-ds-component="EmptyState"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-ds-component="EmptyState"]')).toHaveLength(1)
+  })
+
+  it("renders reference load errors through the design-system EmptyState", () => {
+    mockUseDocumentReferences.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("Reference endpoint unavailable"),
+      isFetching: false
+    })
+
+    const { container } = renderReferencesTab()
+
+    const title = screen.getByText("Failed to load references")
+    expect(title.closest('[data-ds-component="EmptyState"]')).not.toBeNull()
+    expect(screen.getByText("Reference endpoint unavailable")).toBeInTheDocument()
+    expect(container.querySelectorAll('[data-ds-component="EmptyState"]')).toHaveLength(1)
+  })
+})

--- a/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx
@@ -32,12 +32,17 @@ const renderReferencesTab = () => {
 }
 
 describe("ReferencesTab design-system empty states", () => {
+  let previousWorkspaceState = useDocumentWorkspaceStore.getState()
+  let previousConnectionStoreState = useConnectionStore.getState()
+
   beforeEach(() => {
+    previousWorkspaceState = useDocumentWorkspaceStore.getState()
+    previousConnectionStoreState = useConnectionStore.getState()
+
     useDocumentWorkspaceStore.setState({ activeDocumentId: 1 })
-    const previousConnectionState = useConnectionStore.getState().state
     useConnectionStore.setState({
       state: {
-        ...previousConnectionState,
+        ...previousConnectionStoreState.state,
         isConnected: true,
         mode: "normal"
       }
@@ -52,15 +57,8 @@ describe("ReferencesTab design-system empty states", () => {
 
   afterEach(() => {
     cleanup()
-    useDocumentWorkspaceStore.setState({ activeDocumentId: null })
-    const previousConnectionState = useConnectionStore.getState().state
-    useConnectionStore.setState({
-      state: {
-        ...previousConnectionState,
-        isConnected: false,
-        mode: "normal"
-      }
-    })
+    useDocumentWorkspaceStore.setState(previousWorkspaceState)
+    useConnectionStore.setState(previousConnectionStoreState)
     vi.clearAllMocks()
   })
 
@@ -92,7 +90,9 @@ describe("ReferencesTab design-system empty states", () => {
     const { container } = renderReferencesTab()
 
     const title = screen.getByText("Failed to load references")
-    expect(title.closest('[data-ds-component="EmptyState"]')).not.toBeNull()
+    const emptyState = title.closest('[data-ds-component="EmptyState"]')
+    expect(emptyState).not.toBeNull()
+    expect(emptyState?.querySelector("svg")).toHaveClass("text-error")
     expect(screen.getByText("Reference endpoint unavailable")).toBeInTheDocument()
     expect(container.querySelectorAll('[data-ds-component="EmptyState"]')).toHaveLength(1)
   })

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -39,6 +39,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created and completed TASK-45.44.10.2 for the next narrow Document/Workspace slice: DocumentViewer PDF/EPUB Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1952. Verifier evidence after the slice reduces total baseline exceptions from 300 to 296 and Document/Workspace exceptions from 9 to 5.
 - Created and completed TASK-45.44.10.3 for the next narrow Document/Workspace slice: DocumentWorkspacePage loading/health Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1955. Verifier evidence after the slice reduces total baseline exceptions from 296 to 294 and Document/Workspace exceptions from 5 to 3.
 - Created and completed TASK-45.44.10.4 to fix the merged PdfDocument design-system Alert translation binding discovered by the TypeScript check. PR: https://github.com/rmusser01/tldw_server/pull/1955.
+- Created and completed TASK-45.44.10.5 for the next narrow Document/Workspace slice: ReferencesTab server-unavailable/error EmptyState migration. PR: https://github.com/rmusser01/tldw_server/pull/1959. Verifier evidence after the slice reduces total baseline exceptions from 294 to 292 and Document/Workspace exceptions from 3 to 1.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.5 - Migrate-ReferencesTab-empty-states-to-design-system-EmptyState.md
+++ b/backlog/tasks/task-45.44.10.5 - Migrate-ReferencesTab-empty-states-to-design-system-EmptyState.md
@@ -1,0 +1,77 @@
+---
+id: TASK-45.44.10.5
+title: Migrate ReferencesTab empty states to design-system EmptyState
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- document-workspace
+priority: medium
+parent_task_id: TASK-45.44.10
+references:
+- apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Document and Workspace product-state design-system migration by replacing the remaining AntD Empty product-state surfaces in ReferencesTab with the shared design-system EmptyState primitive. Keep scope limited to the two ReferencesTab empty states, focused tests, and removal of matching baseline entries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ReferencesTab no longer renders AntD Empty for the server-unavailable product state.
+- [x] #2 ReferencesTab no longer renders AntD Empty for the reference-load error product state.
+- [x] #3 Both migrated states render through the shared design-system EmptyState primitive.
+- [x] #4 The two matching ReferencesTab product-state baseline rows are removed without introducing unbaselined findings.
+- [x] #5 Focused ReferencesTab tests and product-state verifier checks are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing focused tests that assert ReferencesTab server-unavailable and generic error empty states render through the shared design-system EmptyState marker.
+2. Replace the ReferencesTab AntD Empty product-state usages with the shared design-system EmptyState primitive while preserving copy.
+3. Remove the two migrated ReferencesTab Empty rows from the product-state baseline.
+4. Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red test evidence: `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx --reporter=dot` failed on missing `data-ds-component="EmptyState"` ancestors for both states before the component migration.
+- Migrated only the guarded ReferencesTab server-unavailable and reference-load error Empty surfaces to the shared design-system EmptyState primitive. The no-references and filtered-empty states remain out of scope for this product-state baseline slice.
+- Removed two baseline rows for `ReferencesTab.tsx`, reducing total product-state baseline exceptions from 294 to 292 and Document/Workspace exceptions from 3 to 1.
+- Verification:
+  - `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx --reporter=dot` passed: 2 tests.
+  - `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx --reporter=dot` passed: 3 tests.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 54 tests.
+  - `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"` passed.
+  - `bun run verify:design-system-state` passed with 292 baseline exceptions total and 1 remaining Document/Workspace exception.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI type debt outside the touched ReferencesTab files; `/tmp/tldw_refs_tab_tsc.log` contains no `ReferencesTab` or `design-system-empty` matches.
+- Bandit is not applicable to this UI-only TypeScript/React slice; no Python files were touched.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.10.5 - Migrate-ReferencesTab-empty-states-to-design-system-EmptyState.md
+++ b/backlog/tasks/task-45.44.10.5 - Migrate-ReferencesTab-empty-states-to-design-system-EmptyState.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.10.5
 title: Migrate ReferencesTab empty states to design-system EmptyState
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -10,6 +10,7 @@ labels:
 priority: medium
 parent_task_id: TASK-45.44.10
 references:
+- https://github.com/rmusser01/tldw_server/pull/1959
 - apps/packages/ui/src/components/DocumentWorkspace/LeftSidebar/ReferencesTab.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
@@ -63,15 +64,16 @@ Continue the Document and Workspace product-state design-system migration by rep
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the ReferencesTab server-unavailable and reference-load error states from AntD Empty to the shared design-system EmptyState primitive, added focused regression coverage for both states, and removed the two matching baseline entries. PR: https://github.com/rmusser01/tldw_server/pull/1959.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.44.10.5 - Migrate-ReferencesTab-empty-states-to-design-system-EmptyState.md
+++ b/backlog/tasks/task-45.44.10.5 - Migrate-ReferencesTab-empty-states-to-design-system-EmptyState.md
@@ -50,13 +50,16 @@ Continue the Document and Workspace product-state design-system migration by rep
 - Red test evidence: `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx --reporter=dot` failed on missing `data-ds-component="EmptyState"` ancestors for both states before the component migration.
 - Migrated only the guarded ReferencesTab server-unavailable and reference-load error Empty surfaces to the shared design-system EmptyState primitive. The no-references and filtered-empty states remain out of scope for this product-state baseline slice.
 - Removed two baseline rows for `ReferencesTab.tsx`, reducing total product-state baseline exceptions from 294 to 292 and Document/Workspace exceptions from 3 to 1.
+- PR review remediation:
+  - Added `iconClassName="text-error"` to the reference-load error EmptyState and covered it with a focused assertion. Red evidence: the focused test failed because the icon still had `text-text-subtle`; after the change it passed.
+  - Updated the focused test to snapshot and fully restore `useDocumentWorkspaceStore` and `useConnectionStore` state in `afterEach`, matching the nearby loading-state test pattern and avoiding singleton store leakage.
 - Verification:
   - `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx --reporter=dot` passed: 2 tests.
   - `bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx --reporter=dot` passed: 3 tests.
   - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 54 tests.
   - `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"` passed.
   - `bun run verify:design-system-state` passed with 292 baseline exceptions total and 1 remaining Document/Workspace exception.
-  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI type debt outside the touched ReferencesTab files; `/tmp/tldw_refs_tab_tsc.log` contains no `ReferencesTab` or `design-system-empty` matches.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI type debt outside the touched ReferencesTab files; `/tmp/tldw_refs_tab_review_tsc.log` contains no `ReferencesTab` or `design-system-empty` matches.
 - Bandit is not applicable to this UI-only TypeScript/React slice; no Python files were touched.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->


### PR DESCRIPTION
Summary
- Replace ReferencesTab server-unavailable and reference-load error AntD Empty product states with design-system EmptyState.
- Add focused regression coverage for both states.
- Remove two product-state baseline rows, reducing total exceptions 294 to 292 and Document/Workspace exceptions 3 to 1.

Verification
- bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.design-system-empty.test.tsx --reporter=dot passed: 2 tests.
- bunx vitest run src/components/DocumentWorkspace/LeftSidebar/__tests__/ReferencesTab.test.tsx --reporter=dot passed: 3 tests.
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 54 tests.
- node baseline JSON parse passed.
- bun run verify:design-system-state passed with 292 total baseline exceptions and 1 remaining Document/Workspace exception.
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still fails on existing repo-wide UI TypeScript debt outside the touched ReferencesTab files; the captured log had no ReferencesTab or design-system-empty matches.
- git diff --cached --check passed.

Change summary
This keeps the slice limited to the two guard-baselined ReferencesTab states so the product-state baseline moves down without changing unrelated empty states in the tab. EmptyState gives the recovery and error UI the canonical design-system marker the guard expects while preserving existing copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `ReferencesTab` server-unavailable and reference-load error states from AntD `Empty` to the design-system `EmptyState`. Aligns with the product-state guard and reduces baseline exceptions.

- **Refactors**
  - Replaced AntD `Empty` with `EmptyState` in `ReferencesTab` for server-unavailable and load-error states; error state now uses a red icon.
  - Added focused tests that assert the `EmptyState` marker and error-icon styling; ensured store state is restored between tests.
  - Removed two baseline exceptions (total 294 → 292; Document/Workspace 3 → 1).

<sup>Written for commit 33055e5cfd9fb5502cd49f72ec034acb932b78bb. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1959?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

