### PR TITLE
Govern WebUI headings and command targets

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
@@ -335,7 +335,7 @@ git commit -m "test: govern route inventory coverage"
 - Modify: `apps/packages/ui/src/components/Common/CommandPalette.tsx`
 - Modify: `apps/packages/ui/src/components/Common/CommandPaletteHost.tsx`
 
-- [ ] **Step 1: Write heading governance test**
+- [x] **Step 1: Write heading governance test**
 
 Create `route-heading-governance.spec.ts`:
 
@@ -362,7 +362,7 @@ test.describe("Route heading governance", () => {
 
 Before implementation, this simple test will fail on valid alias and exception routes. Replace the raw `h1Count` assertion with route metadata exception logic before committing.
 
-- [ ] **Step 2: Run heading test to verify failures**
+- [x] **Step 2: Run heading test to verify failures**
 
 Run:
 
@@ -372,7 +372,7 @@ bunx playwright test apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.
 
 Expected: FAIL until metadata exceptions are wired.
 
-- [ ] **Step 3: Add metadata-backed heading exceptions**
+- [x] **Step 3: Add metadata-backed heading exceptions**
 
 Update the test so:
 
@@ -381,7 +381,7 @@ Update the test so:
 - Alias and redirect routes assert the final canonical path or redirect panel.
 - Internal/debug routes are excluded from user-facing heading enforcement.
 
-- [ ] **Step 4: Add command target tests**
+- [x] **Step 4: Add command target tests**
 
 Create `CommandPalette.route-targets.test.tsx` to assert:
 
@@ -391,7 +391,7 @@ Create `CommandPalette.route-targets.test.tsx` to assert:
 - No two route commands share the same label with different targets.
 - Aliases either do not appear as separate commands or are labeled as aliases.
 
-- [ ] **Step 5: Run heading and command tests**
+- [x] **Step 5: Run heading and command tests**
 
 Run:
 
@@ -409,12 +409,18 @@ bunx playwright test apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit heading and command governance**
+- [x] **Step 6: Commit heading and command governance**
 
 ```bash
 git add apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.ts apps/packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx apps/packages/ui/src/components/Common/__tests__/CommandPalette.shortcuts.test.tsx apps/packages/ui/src/components/Common/CommandPalette.tsx apps/packages/ui/src/components/Common/CommandPaletteHost.tsx
 git commit -m "test: govern headings and command targets"
 ```
+
+Implementation outcome:
+- Added metadata-backed command labels and h1 policy helpers in route metadata.
+- Added command palette route-target governance and route heading governance tests.
+- Browser QA initially found `/media` and `/notes` heading failures; `/media` needed route test mocks, and `/notes` now exposes its existing title as the page `h1`.
+- Kept CommandPaletteHost and shortcut behavior unchanged because the new target contract passed without host changes.
 
 ### Task 3: Govern Sidepanel And Hosted Visibility
 

--- a/Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
@@ -412,15 +412,16 @@ Expected: PASS.
 - [x] **Step 6: Commit heading and command governance**
 
 ```bash
-git add apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.ts apps/packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx apps/packages/ui/src/components/Common/__tests__/CommandPalette.shortcuts.test.tsx apps/packages/ui/src/components/Common/CommandPalette.tsx apps/packages/ui/src/components/Common/CommandPaletteHost.tsx
+git add apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.ts apps/tldw-frontend/__tests__/smoke/route-heading-governance.metadata.test.ts apps/packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx apps/packages/ui/src/components/Common/__tests__/CommandPalette.shortcuts.test.tsx apps/packages/ui/src/components/Common/CommandPalette.tsx apps/packages/ui/src/components/Common/CommandPaletteHost.tsx
 git commit -m "test: govern headings and command targets"
 ```
 
 Implementation outcome:
 - Added metadata-backed command labels and h1 policy helpers in route metadata.
-- Added command palette route-target governance and route heading governance tests.
+- Added command palette route-target governance and frontend-owned route heading governance tests.
 - Browser QA initially found `/media` and `/notes` heading failures; `/media` needed route test mocks, and `/notes` now exposes its existing title as the page `h1`.
 - Kept CommandPaletteHost and shortcut behavior unchanged because the new target contract passed without host changes.
+- Follow-up review moved the metadata-only heading governance test out of `@tldw/ui` so the package no longer imports frontend smoke inventory.
 
 ### Task 3: Govern Sidepanel And Hosted Visibility
 

--- a/Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
@@ -419,9 +419,10 @@ git commit -m "test: govern headings and command targets"
 Implementation outcome:
 - Added metadata-backed command labels and h1 policy helpers in route metadata.
 - Added command palette route-target governance and frontend-owned route heading governance tests.
-- Browser QA initially found `/media` and `/notes` heading failures; `/media` needed route test mocks, and `/notes` now exposes its existing title as the page `h1`.
+- Browser QA initially found `/media` and `/notes` heading failures; `/media` needed route test mocks, and `/notes` is now a metadata-backed h1-policy exception because user-authored note content can contain document h1s.
 - Kept CommandPaletteHost and shortcut behavior unchanged because the new target contract passed without host changes.
 - Follow-up review moved the metadata-only heading governance test out of `@tldw/ui` so the package no longer imports frontend smoke inventory.
+- Follow-up review also added a non-empty browser route guard and made explicit `requiresH1: false` opt-outs require `h1ExceptionReason` directly.
 
 ### Task 3: Govern Sidepanel And Hosted Visibility
 

--- a/apps/packages/ui/src/assets/locale/en/common.json
+++ b/apps/packages/ui/src/assets/locale/en/common.json
@@ -446,7 +446,7 @@
   },
   "commandPalette": {
     "goToChat": "Go to Chat",
-    "goToKnowledge": "Go to Knowledge QA",
+    "goToKnowledge": "Go to Knowledge",
     "goToMedia": "Go to Media",
     "goToNotes": "Go to Notes",
     "goToPrompts": "Go to Prompts",
@@ -612,7 +612,7 @@
     "toggleSidebar": "Toggle sidebar",
     "goToPlayground": "Go to Playground",
     "goToMedia": "Go to Media",
-    "goToKnowledge": "Go to Knowledge QA",
+    "goToKnowledge": "Go to Knowledge",
     "goToNotes": "Go to Notes",
     "goToPrompts": "Go to Prompts",
     "goToFlashcards": "Go to Flashcards",

--- a/apps/packages/ui/src/components/Common/CommandPalette.tsx
+++ b/apps/packages/ui/src/components/Common/CommandPalette.tsx
@@ -195,7 +195,7 @@ export function CommandPalette({
       ...(!isSidepanel ? ([
         {
           id: "nav-knowledge",
-          label: t("common:commandPalette.goToKnowledge", "Go to Knowledge QA"),
+          label: t("common:commandPalette.goToKnowledge", "Go to Knowledge"),
           icon: <CombineIcon className="size-4" />,
           action: () => { navigate("/knowledge"); setOpen(false) },
           targetPath: "/knowledge",

--- a/apps/packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx
@@ -1,0 +1,131 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+
+import { CommandPalette } from "../CommandPalette"
+import type { ShortcutConfig } from "@/hooks/keyboard/useShortcutConfig"
+import {
+  getRouteCommandPaletteLabel,
+  getRouteMetadata,
+  normalizeRoutePath
+} from "@/routes/route-metadata"
+
+const mockShortcutConfig: ShortcutConfig = {
+  focusTextarea: { key: "Escape", shiftKey: true },
+  newChat: { key: "u", ctrlKey: true, shiftKey: true },
+  toggleSidebar: { key: "b", ctrlKey: true },
+  toggleChatMode: { key: "e", ctrlKey: true },
+  toggleWebSearch: { key: "w", altKey: true },
+  toggleQuickChatHelper: { key: "h", ctrlKey: true, shiftKey: true },
+  modePlayground: { key: "1", altKey: true },
+  modeSources: { key: "2", altKey: true },
+  modeMedia: { key: "3", altKey: true },
+  modeKnowledge: { key: "4", altKey: true },
+  modeNotes: { key: "5", altKey: true },
+  modePrompts: { key: "6", altKey: true },
+  modeFlashcards: { key: "7", altKey: true },
+  modeWorldBooks: { key: "8", altKey: true },
+  modeDictionaries: { key: "9", altKey: true },
+  modeCharacters: { key: "0", altKey: true }
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string) => defaultValue ?? key
+  })
+}))
+
+vi.mock("@/hooks/keyboard/useShortcutConfig", () => ({
+  useShortcutConfig: () => ({
+    shortcuts: mockShortcutConfig,
+    updateShortcut: vi.fn(),
+    resetShortcuts: vi.fn(),
+    resetShortcut: vi.fn()
+  })
+}))
+
+const renderOpenGlobalPalette = async (): Promise<HTMLElement[]> => {
+  render(
+    <MemoryRouter>
+      <CommandPalette />
+    </MemoryRouter>
+  )
+
+  window.dispatchEvent(new CustomEvent("tldw:open-command-palette"))
+  await screen.findByRole("dialog")
+
+  return screen
+    .getAllByRole("option")
+    .filter((option) =>
+      option.getAttribute("data-command-id")?.startsWith("nav-")
+    )
+}
+
+describe("CommandPalette route target governance", () => {
+  it("keeps default navigation commands backed by visible route metadata", async () => {
+    const navigationOptions = await renderOpenGlobalPalette()
+    const invalidTargets = navigationOptions
+      .map((option) => ({
+        commandId: option.getAttribute("data-command-id") ?? "",
+        targetPath: option.getAttribute("data-target-path") ?? ""
+      }))
+      .filter(({ targetPath }) => !targetPath || !getRouteMetadata(targetPath))
+
+    expect(invalidTargets).toEqual([])
+
+    for (const option of navigationOptions) {
+      const commandId = option.getAttribute("data-command-id")
+      const targetPath = option.getAttribute("data-target-path")
+      const metadata = getRouteMetadata(targetPath ?? "")
+
+      expect(metadata, `${commandId} target ${targetPath} has metadata`).toBeDefined()
+      expect(
+        metadata?.commandPalette,
+        `${commandId} target ${targetPath} must be command-palette visible`
+      ).toBe("show")
+    }
+  })
+
+  it("keeps default navigation command labels aligned with route metadata", async () => {
+    const navigationOptions = await renderOpenGlobalPalette()
+
+    for (const option of navigationOptions) {
+      const commandId = option.getAttribute("data-command-id")
+      const targetPath = option.getAttribute("data-target-path")
+      const metadata = getRouteMetadata(targetPath ?? "")
+
+      expect(metadata, `${commandId} target ${targetPath} has metadata`).toBeDefined()
+      expect(
+        within(option).getByText(getRouteCommandPaletteLabel(metadata!)),
+        `${commandId} label should match the command label for ${targetPath}`
+      ).toBeInTheDocument()
+    }
+  })
+
+  it("does not expose duplicate navigation labels for different routes", async () => {
+    const navigationOptions = await renderOpenGlobalPalette()
+    const targetsByLabel = new Map<string, Set<string>>()
+
+    for (const option of navigationOptions) {
+      const label = option.querySelector(".font-medium")?.textContent?.trim() ?? ""
+      const targetPath = normalizeRoutePath(
+        option.getAttribute("data-target-path") ?? ""
+      )
+
+      if (!targetsByLabel.has(label)) {
+        targetsByLabel.set(label, new Set())
+      }
+      targetsByLabel.get(label)?.add(targetPath)
+    }
+
+    const duplicateLabels = [...targetsByLabel.entries()]
+      .filter(([, targets]) => targets.size > 1)
+      .map(([label, targets]) => ({
+        label,
+        targets: [...targets].sort()
+      }))
+
+    expect(duplicateLabels).toEqual([])
+  })
+})

--- a/apps/packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx
@@ -63,6 +63,12 @@ const renderOpenGlobalPalette = async (): Promise<HTMLElement[]> => {
 }
 
 describe("CommandPalette route target governance", () => {
+  it("uses route-owned command label overrides for settings routes", () => {
+    expect(getRouteCommandPaletteLabel("/settings/health")).toBe(
+      "Go to Health & Diagnostics"
+    )
+  })
+
   it("keeps default navigation commands backed by visible route metadata", async () => {
     const navigationOptions = await renderOpenGlobalPalette()
     const invalidTargets = navigationOptions
@@ -108,10 +114,15 @@ describe("CommandPalette route target governance", () => {
     const targetsByLabel = new Map<string, Set<string>>()
 
     for (const option of navigationOptions) {
-      const label = option.querySelector(".font-medium")?.textContent?.trim() ?? ""
       const targetPath = normalizeRoutePath(
         option.getAttribute("data-target-path") ?? ""
       )
+      const metadata = getRouteMetadata(targetPath)
+      expect(
+        metadata,
+        `${option.getAttribute("data-command-id")} target ${targetPath} has metadata`
+      ).toBeDefined()
+      const label = getRouteCommandPaletteLabel(metadata!)
 
       if (!targetsByLabel.has(label)) {
         targetsByLabel.set(label, new Set())

--- a/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
@@ -340,9 +340,11 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
           <div className="flex-shrink-0 border-b border-border p-4 bg-surface">
             {/* ---- Always visible: Header row ---- */}
             <div className="flex items-center justify-between mb-3">
-              <div className="text-xs uppercase tracking-[0.16em] text-text-muted">
-                {t('option:notesSearch.headerLabel', { defaultValue: 'Notes' })}
-                <span className="ml-2 text-text-subtle">
+              <div className="flex min-w-0 items-baseline">
+                <h1 className="text-xs uppercase tracking-[0.16em] text-text-muted">
+                  {t('option:notesSearch.headerLabel', { defaultValue: 'Notes' })}
+                </h1>
+                <span className="ml-2 text-xs uppercase tracking-[0.16em] text-text-subtle">
                   {hasActiveFilters
                     ? t('option:notesSearch.headerCount', {
                         defaultValue: '{{visible}} of {{total}}',

--- a/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
@@ -341,9 +341,9 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
             {/* ---- Always visible: Header row ---- */}
             <div className="flex items-center justify-between mb-3">
               <div className="flex min-w-0 items-baseline">
-                <h1 className="text-xs uppercase tracking-[0.16em] text-text-muted">
+                <div className="text-xs uppercase tracking-[0.16em] text-text-muted">
                   {t('option:notesSearch.headerLabel', { defaultValue: 'Notes' })}
-                </h1>
+                </div>
                 <span className="ml-2 text-xs uppercase tracking-[0.16em] text-text-subtle">
                   {hasActiveFilters
                     ? t('option:notesSearch.headerCount', {

--- a/apps/packages/ui/src/public/_locales/en/common.json
+++ b/apps/packages/ui/src/public/_locales/en/common.json
@@ -1395,7 +1395,7 @@
     "message": "Go to Media"
   },
   "shortcuts_goToKnowledge": {
-    "message": "Go to Knowledge QA"
+    "message": "Go to Knowledge"
   },
   "shortcuts_goToNotes": {
     "message": "Go to Notes"
@@ -1413,7 +1413,7 @@
     "message": "for commands"
   },
   "commandPalette_goToKnowledge": {
-    "message": "Go to Knowledge QA"
+    "message": "Go to Knowledge"
   },
   "commandPalette_goToPrompts": {
     "message": "Go to Prompts"

--- a/apps/packages/ui/src/routes/__tests__/route-heading-governance.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-heading-governance.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import { PAGES } from "../../../../../tldw-frontend/e2e/smoke/page-inventory"
+import {
+  getRouteHeadingPolicy,
+  getRouteMetadata,
+  normalizeRoutePath,
+  ROUTE_METADATA
+} from "../route-metadata"
+
+const sorted = (values: string[]): string[] => [...values].sort()
+
+describe("route heading governance", () => {
+  it("requires active smoke inventory routes to have an h1 policy or metadata exception", () => {
+    const routesWithoutHeadingPolicy = PAGES
+      .filter((entry) => !entry.skip)
+      .map((entry) => ({
+        path: normalizeRoutePath(entry.path),
+        metadata: getRouteMetadata(entry.path)
+      }))
+      .filter(({ metadata }) => {
+        if (!metadata) return true
+
+        const policy = getRouteHeadingPolicy(metadata)
+
+        return !policy.requiresH1 && !policy.exceptionReason?.trim()
+      })
+      .map(({ path }) => path)
+
+    expect(sorted(routesWithoutHeadingPolicy)).toEqual([])
+  })
+
+  it("requires explicit h1 opt-outs to carry a recovery-friendly reason", () => {
+    const routesWithoutExceptionReasons = ROUTE_METADATA
+      .filter((metadata) => getRouteHeadingPolicy(metadata).requiresH1 === false)
+      .filter((metadata) => !getRouteHeadingPolicy(metadata).exceptionReason?.trim())
+      .map((metadata) => metadata.path)
+
+    expect(sorted(routesWithoutExceptionReasons)).toEqual([])
+  })
+})

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -35,6 +35,7 @@ export type RouteMetadata = {
   path: string
   canonicalPath: string
   label: string
+  commandLabel?: string
   group: RouteGroup
   surface: RouteSurface
   availability: RouteAvailability[]
@@ -45,7 +46,14 @@ export type RouteMetadata = {
   nav: "primary" | "secondary" | "hidden"
   requiresAuth?: boolean
   requiresBackend?: boolean
+  requiresH1?: boolean
+  h1ExceptionReason?: string
   rationale: string
+}
+
+export type RouteHeadingPolicy = {
+  requiresH1: boolean
+  exceptionReason?: string
 }
 
 const webAndExtensionOptions: RouteAvailability[] = ["web", "extension_options"]
@@ -425,6 +433,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     path: "/media",
     canonicalPath: "/media",
     label: "Media Library",
+    commandLabel: "Go to Media",
     group: "media_library",
     surface: "default_self_hosted",
     availability: webAndExtensionOptions,
@@ -1015,6 +1024,7 @@ const registryRoute = ({
   path,
   canonicalPath = path,
   label,
+  commandLabel,
   group,
   surface = "advanced_self_hosted",
   availability = webAndExtensionOptions,
@@ -1025,11 +1035,14 @@ const registryRoute = ({
   nav = "secondary",
   requiresAuth,
   requiresBackend,
+  requiresH1,
+  h1ExceptionReason,
   rationale
 }: RegistryRouteMetadataInput): RouteMetadata => ({
   path,
   canonicalPath,
   label,
+  commandLabel,
   group,
   surface,
   availability,
@@ -1040,6 +1053,8 @@ const registryRoute = ({
   nav,
   requiresAuth,
   requiresBackend,
+  requiresH1,
+  h1ExceptionReason,
   rationale
 })
 
@@ -1164,7 +1179,10 @@ const ROUTE_REGISTRY_METADATA: RouteMetadata[] = [
   settingsRoute(
     "/settings/health",
     "Health Settings",
-    "Health and connection diagnostics are nested under settings."
+    "Health and connection diagnostics are nested under settings.",
+    {
+      commandLabel: "Go to Health & Diagnostics"
+    }
   ),
   settingsRoute(
     "/settings/prompt-studio",
@@ -1730,6 +1748,60 @@ export const getRouteMetadata = (path: string): RouteMetadata | undefined => {
 
 export const getCanonicalRoutePath = (path: string): string | undefined =>
   getRouteMetadata(path)?.canonicalPath
+
+export const getRouteCommandPaletteLabel = (
+  route: RouteMetadata | string
+): string => {
+  const metadata = typeof route === "string" ? getRouteMetadata(route) : route
+
+  return metadata?.commandLabel ?? (metadata ? `Go to ${metadata.label}` : "")
+}
+
+const h1ExceptionSurfaceReasons: Partial<Record<RouteSurface, string>> = {
+  hosted_only: "Hosted-only route can be gated outside self-hosted smoke runs.",
+  extension_sidepanel:
+    "Extension sidepanel route uses a constrained shell instead of the standard page heading contract.",
+  internal_qa_debug:
+    "Internal QA/debug route is not part of normal user-facing page inventory.",
+  legacy_alias:
+    "Legacy alias route delegates ownership to its canonical route.",
+  redirect: "Redirect route delegates ownership to its destination route.",
+  deprecated: "Deprecated route is retained for compatibility and not normal IA."
+}
+
+export const getRouteHeadingPolicy = (
+  route: RouteMetadata | string
+): RouteHeadingPolicy => {
+  const metadata = typeof route === "string" ? getRouteMetadata(route) : route
+
+  if (!metadata) {
+    return {
+      requiresH1: false,
+      exceptionReason: "Route metadata is missing."
+    }
+  }
+
+  if (metadata.requiresH1 === true) {
+    return { requiresH1: true }
+  }
+
+  if (metadata.requiresH1 === false) {
+    return {
+      requiresH1: false,
+      exceptionReason: metadata.h1ExceptionReason ?? metadata.rationale
+    }
+  }
+
+  const exceptionReason = h1ExceptionSurfaceReasons[metadata.surface]
+  if (exceptionReason) {
+    return {
+      requiresH1: false,
+      exceptionReason: metadata.h1ExceptionReason ?? exceptionReason
+    }
+  }
+
+  return { requiresH1: true }
+}
 
 export const isRouteVisibleForSurface = (
   path: string,

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -533,6 +533,9 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     commandPalette: "show",
     nav: "primary",
     requiresBackend: true,
+    requiresH1: false,
+    h1ExceptionReason:
+      "Notes can render user-authored document headings, including h1, inside the editor and preview surface.",
     rationale: "Notes are a primary knowledge capture surface."
   },
   {
@@ -1788,7 +1791,7 @@ export const getRouteHeadingPolicy = (
   if (metadata.requiresH1 === false) {
     return {
       requiresH1: false,
-      exceptionReason: metadata.h1ExceptionReason ?? metadata.rationale
+      exceptionReason: metadata.h1ExceptionReason
     }
   }
 

--- a/apps/tldw-frontend/__tests__/smoke/route-heading-governance.metadata.test.ts
+++ b/apps/tldw-frontend/__tests__/smoke/route-heading-governance.metadata.test.ts
@@ -32,8 +32,8 @@ describe("route heading governance metadata", () => {
 
   it("requires explicit h1 opt-outs to carry a recovery-friendly reason", () => {
     const routesWithoutExceptionReasons = ROUTE_METADATA
-      .filter((metadata) => getRouteHeadingPolicy(metadata).requiresH1 === false)
-      .filter((metadata) => !getRouteHeadingPolicy(metadata).exceptionReason?.trim())
+      .filter((metadata) => metadata.requiresH1 === false)
+      .filter((metadata) => !metadata.h1ExceptionReason?.trim())
       .map((metadata) => metadata.path)
 
     expect(sorted(routesWithoutExceptionReasons)).toEqual([])

--- a/apps/tldw-frontend/__tests__/smoke/route-heading-governance.metadata.test.ts
+++ b/apps/tldw-frontend/__tests__/smoke/route-heading-governance.metadata.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest"
 
-import { PAGES } from "../../../../../tldw-frontend/e2e/smoke/page-inventory"
+import { PAGES } from "../../e2e/smoke/page-inventory"
 import {
   getRouteHeadingPolicy,
   getRouteMetadata,
   normalizeRoutePath,
   ROUTE_METADATA
-} from "../route-metadata"
+} from "../../../packages/ui/src/routes/route-metadata"
 
 const sorted = (values: string[]): string[] => [...values].sort()
 
-describe("route heading governance", () => {
+describe("route heading governance metadata", () => {
   it("requires active smoke inventory routes to have an h1 policy or metadata exception", () => {
     const routesWithoutHeadingPolicy = PAGES
       .filter((entry) => !entry.skip)

--- a/apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, seedAuth, SMOKE_LOAD_TIMEOUT } from './smoke.setup';
+import type { Page } from '@playwright/test';
+import { waitForAppShell, waitForVisualSettle } from '../utils/helpers';
+import { PAGES } from './page-inventory';
+import {
+  getRouteHeadingPolicy,
+  getRouteMetadata,
+} from '../../../packages/ui/src/routes/route-metadata';
+
+const PRIMARY_HEADING_ROUTES = PAGES
+  .filter((entry) => !entry.skip)
+  .map((entry) => ({
+    path: entry.path,
+    metadata: getRouteMetadata(entry.path),
+  }))
+  .filter(({ metadata }) => metadata?.smoke === 'include')
+  .filter(({ metadata }) => metadata?.surface === 'default_self_hosted')
+  .filter(({ metadata }) => metadata?.nav === 'primary')
+  .filter(({ metadata }) => metadata && getRouteHeadingPolicy(metadata).requiresH1)
+  .map(({ path, metadata }) => ({
+    path,
+    label: metadata?.label ?? path,
+  }));
+
+async function installRouteHeadingMocks(page: Page): Promise<void> {
+  await page.route('**/api/v1/health', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'healthy', checks: {} }),
+    });
+  });
+
+  await page.route('**/api/v1/health/live', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'ok' }),
+    });
+  });
+
+  await page.route('**/api/v1/media**', async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname !== '/api/v1/media' && url.pathname !== '/api/v1/media/') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [],
+        pagination: {
+          page: 1,
+          results_per_page: 20,
+          total_items: 0,
+          total_pages: 1,
+        },
+      }),
+    });
+  });
+}
+
+test.describe('route heading governance', () => {
+  for (const entry of PRIMARY_HEADING_ROUTES) {
+    test(`${entry.path} exposes one semantic h1`, async ({ page }) => {
+      await installRouteHeadingMocks(page);
+      await seedAuth(page);
+      await page.goto(entry.path, {
+        waitUntil: 'domcontentloaded',
+        timeout: SMOKE_LOAD_TIMEOUT,
+      });
+      await waitForAppShell(page, SMOKE_LOAD_TIMEOUT);
+      await waitForVisualSettle(page, SMOKE_LOAD_TIMEOUT);
+
+      const headings = page.locator('h1');
+      await expect(
+        headings,
+        `${entry.path} (${entry.label}) must expose exactly one semantic h1`
+      ).toHaveCount(1);
+    });
+  }
+});

--- a/apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/route-heading-governance.spec.ts
@@ -63,6 +63,10 @@ async function installRouteHeadingMocks(page: Page): Promise<void> {
 }
 
 test.describe('route heading governance', () => {
+  test('has at least one primary route requiring h1 governance', () => {
+    expect(PRIMARY_HEADING_ROUTES.length).toBeGreaterThan(0);
+  });
+
   for (const entry of PRIMARY_HEADING_ROUTES) {
     test(`${entry.path} exposes one semantic h1`, async ({ page }) => {
       await installRouteHeadingMocks(page);

--- a/backlog/tasks/task-418.10.2 - Implement-WP12-heading-and-command-target-governance.md
+++ b/backlog/tasks/task-418.10.2 - Implement-WP12-heading-and-command-target-governance.md
@@ -33,10 +33,11 @@ Execute WP12 Task 2 from the WebUI route governance QA plan: add metadata-backed
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Implemented route metadata helpers for command palette labels and h1 policy.
 - Added command target governance Vitest coverage for labels, targets, duplicate labels, and command-palette visibility.
-- Added route heading governance Vitest coverage and browser coverage for primary self-hosted smoke routes.
+- Added frontend-owned route heading governance Vitest coverage and browser coverage for primary self-hosted smoke routes.
 - Changed the existing Notes sidebar title element to the page h1 without visual redesign.
 - Aligned Knowledge command copy and English locale strings with route metadata.
 - Browser QA initially found `/media` and `/notes` heading failures. `/media` was a test harness issue resolved with the same media API mocks used by existing smoke coverage; `/notes` required the semantic h1 fix.
+- Addressed PR review by moving the metadata-only heading test out of `@tldw/ui`, replacing the command label CSS selector with metadata-backed label lookup, and adding direct coverage for the `/settings/health` command-label override.
 - Bandit is not applicable to this frontend-only TypeScript/markdown slice.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 

--- a/backlog/tasks/task-418.10.2 - Implement-WP12-heading-and-command-target-governance.md
+++ b/backlog/tasks/task-418.10.2 - Implement-WP12-heading-and-command-target-governance.md
@@ -1,0 +1,57 @@
+---
+id: TASK-418.10.2
+title: Implement WP12 heading and command target governance
+status: Done
+labels:
+- wp12
+- webui
+- route-governance
+priority: High
+parent_task_id: TASK-418.10
+references:
+- TASK-418.10
+- Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+- https://github.com/rmusser01/tldw_server/pull/1953
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP12 Task 2 from the WebUI route governance QA plan: add metadata-backed heading governance and command palette route-target governance without page-level redesign or backend API changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Route heading governance covers active smoke inventory routes with metadata-backed exceptions for aliases, redirects, hosted-only, sidepanel-only, and internal/debug routes.
+- [x] #2 Command palette route-target tests validate route labels, targets, duplicate labels, and visibility against route metadata.
+- [x] #3 Any required metadata additions stay scoped to governance fields and preserve existing route intent.
+- [x] #4 Focused Vitest and Playwright route-governance checks pass, with unrelated baseline failures documented.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Implemented route metadata helpers for command palette labels and h1 policy.
+- Added command target governance Vitest coverage for labels, targets, duplicate labels, and command-palette visibility.
+- Added route heading governance Vitest coverage and browser coverage for primary self-hosted smoke routes.
+- Changed the existing Notes sidebar title element to the page h1 without visual redesign.
+- Aligned Knowledge command copy and English locale strings with route metadata.
+- Browser QA initially found `/media` and `/notes` heading failures. `/media` was a test harness issue resolved with the same media API mocks used by existing smoke coverage; `/notes` required the semantic h1 fix.
+- Bandit is not applicable to this frontend-only TypeScript/markdown slice.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+WP12 Task 2 route heading and command target governance implemented. Focused Vitest governance/command/notes accessibility tests passed. Browser heading governance passed for 11 primary self-hosted smoke routes. Broad Notes test directory run from apps/tldw-frontend showed unrelated/baseline failures in AI title, contrast CSS path, backlink labels, and inline snapshot setup; not caused by this slice and not used as a gate.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.10.2 - Implement-WP12-heading-and-command-target-governance.md
+++ b/backlog/tasks/task-418.10.2 - Implement-WP12-heading-and-command-target-governance.md
@@ -34,10 +34,11 @@ Execute WP12 Task 2 from the WebUI route governance QA plan: add metadata-backed
 - Implemented route metadata helpers for command palette labels and h1 policy.
 - Added command target governance Vitest coverage for labels, targets, duplicate labels, and command-palette visibility.
 - Added frontend-owned route heading governance Vitest coverage and browser coverage for primary self-hosted smoke routes.
-- Changed the existing Notes sidebar title element to the page h1 without visual redesign.
+- Kept Notes out of strict one-h1 enforcement with a metadata-backed exception because user-authored note content can contain document h1s.
 - Aligned Knowledge command copy and English locale strings with route metadata.
-- Browser QA initially found `/media` and `/notes` heading failures. `/media` was a test harness issue resolved with the same media API mocks used by existing smoke coverage; `/notes` required the semantic h1 fix.
+- Browser QA initially found `/media` and `/notes` heading failures. `/media` was a test harness issue resolved with the same media API mocks used by existing smoke coverage; `/notes` is now excluded from strict one-h1 browser enforcement through a documented metadata exception.
 - Addressed PR review by moving the metadata-only heading test out of `@tldw/ui`, replacing the command label CSS selector with metadata-backed label lookup, and adding direct coverage for the `/settings/health` command-label override.
+- Addressed follow-up review by adding a non-empty browser route guard and enforcing dedicated `h1ExceptionReason` values for explicit h1 opt-outs.
 - Bandit is not applicable to this frontend-only TypeScript/markdown slice.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 


### PR DESCRIPTION
## Summary
- Add route metadata helpers for command palette labels and h1 policy exceptions.
- Add Vitest governance for command targets and frontend-owned route heading policy, plus Playwright coverage for primary self-hosted smoke route h1s.
- Document Notes as an h1-policy exception because user-authored note content can contain h1s; align Knowledge command copy/locales with route metadata.

## Test Plan
- bunx vitest run __tests__/smoke/route-heading-governance.metadata.test.ts ../packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx ../packages/ui/src/components/Common/__tests__/CommandPalette.shortcuts.test.tsx ../packages/ui/src/components/Common/__tests__/CommandPaletteHost.test.tsx ../packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage19.accessibility-skip-links.test.tsx
- bunx playwright test e2e/smoke/route-heading-governance.spec.ts --reporter=line
- git diff --check

## Notes
- Broad Notes test directory run from apps/tldw-frontend showed pre-existing/non-slice failures in AI title, contrast CSS path, backlink labels, and inline snapshot setup; focused touched-scope tests pass.
- Human-authored Change summary is required before merge per the AI-generated PR policy.