### PR TITLE
Migrate DocumentWorkspaceErrorBoundary to design-system EmptyState

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -33,17 +33,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx:Result",
-    "path": "src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Result",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Result product-state UI in src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardDocumentRow.tsx:Alert#antd-alert-flashcarddocumentrow-type-error-line-414-o4coyq",
     "path": "src/components/Flashcards/components/FlashcardDocumentRow.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Button, Result } from "antd"
 import { AlertTriangle, RefreshCw } from "lucide-react"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
 
 interface ErrorBoundaryState {
   hasError: boolean
@@ -68,13 +68,16 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ onRetry, error }) => {
 
   return (
     <div className="flex h-full items-center justify-center bg-bg p-8">
-      <Result
-        icon={<AlertTriangle className="mx-auto h-16 w-16 text-warning" />}
+      <EmptyState
+        variant="card"
+        size="lg"
+        icon={AlertTriangle}
+        iconClassName="text-warning"
         title={t(
           "option:documentWorkspace.errorTitle",
           "Something went wrong"
         )}
-        subTitle={
+        description={
           <div className="space-y-2">
             <p className="text-text-secondary">
               {t(
@@ -100,15 +103,11 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ onRetry, error }) => {
             )}
           </div>
         }
-        extra={
-          <Button
-            type="primary"
-            icon={<RefreshCw className="h-4 w-4" />}
-            onClick={onRetry}
-          >
-            {t("common:tryAgain", "Try again")}
-          </Button>
-        }
+        primaryAction={{
+          label: t("common:tryAgain", "Try again"),
+          icon: <RefreshCw className="h-4 w-4" />,
+          onClick: onRetry
+        }}
       />
     </div>
   )

--- a/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentWorkspaceErrorBoundary.design-system.test.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentWorkspaceErrorBoundary.design-system.test.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DocumentWorkspaceErrorBoundary } from "../DocumentWorkspaceErrorBoundary"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue || _key
+  })
+}))
+
+const MaybeThrow: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error("Document pane crashed")
+  }
+
+  return <div>Workspace recovered</div>
+}
+
+const suppressExpectedWindowError = (expectedMessage: string): (() => void) => {
+  const handler = (event: ErrorEvent) => {
+    const message =
+      event.error instanceof Error
+        ? event.error.message
+        : typeof event.message === "string"
+          ? event.message
+          : ""
+
+    if (message.includes(expectedMessage)) {
+      event.preventDefault()
+    }
+  }
+
+  window.addEventListener("error", handler)
+  return () => window.removeEventListener("error", handler)
+}
+
+describe("DocumentWorkspaceErrorBoundary design-system fallback", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+  let restoreWindowError: () => void
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    restoreWindowError = suppressExpectedWindowError("Document pane crashed")
+  })
+
+  afterEach(() => {
+    cleanup()
+    restoreWindowError()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("renders the default recovery fallback through the design-system EmptyState", () => {
+    let shouldThrow = true
+
+    const { container, rerender } = render(
+      <DocumentWorkspaceErrorBoundary>
+        <MaybeThrow shouldThrow={shouldThrow} />
+      </DocumentWorkspaceErrorBoundary>
+    )
+
+    const title = screen.getByText("Something went wrong")
+    const emptyState = title.closest('[data-ds-component="EmptyState"]')
+    expect(emptyState).not.toBeNull()
+    expect(emptyState?.querySelector("svg")).toHaveClass("text-warning")
+    expect(
+      screen.getByText("An error occurred while loading the document workspace.")
+    ).toBeInTheDocument()
+
+    shouldThrow = false
+    rerender(
+      <DocumentWorkspaceErrorBoundary>
+        <MaybeThrow shouldThrow={shouldThrow} />
+      </DocumentWorkspaceErrorBoundary>
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }))
+
+    expect(screen.getByText("Workspace recovered")).toBeInTheDocument()
+    expect(container.querySelector('[data-ds-component="EmptyState"]')).toBeNull()
+  })
+})

--- a/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
+++ b/backlog/tasks/task-45.44.10 - Migrate-design-system-product-state-Document-and-Workspace-surfaces.md
@@ -40,6 +40,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created and completed TASK-45.44.10.3 for the next narrow Document/Workspace slice: DocumentWorkspacePage loading/health Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1955. Verifier evidence after the slice reduces total baseline exceptions from 296 to 294 and Document/Workspace exceptions from 5 to 3.
 - Created and completed TASK-45.44.10.4 to fix the merged PdfDocument design-system Alert translation binding discovered by the TypeScript check. PR: https://github.com/rmusser01/tldw_server/pull/1955.
 - Created and completed TASK-45.44.10.5 for the next narrow Document/Workspace slice: ReferencesTab server-unavailable/error EmptyState migration. PR: https://github.com/rmusser01/tldw_server/pull/1959. Verifier evidence after the slice reduces total baseline exceptions from 294 to 292 and Document/Workspace exceptions from 3 to 1.
+- Created and completed TASK-45.44.10.6 for the final current Document/Workspace slice: DocumentWorkspaceErrorBoundary Result migration. PR: https://github.com/rmusser01/tldw_server/pull/1961. Verifier evidence after the slice reduces total baseline exceptions from 292 to 291 and removes the Document/Workspace product-area bucket.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.10.6 - Migrate-DocumentWorkspaceErrorBoundary-result-to-design-system-state.md
+++ b/backlog/tasks/task-45.44.10.6 - Migrate-DocumentWorkspaceErrorBoundary-result-to-design-system-state.md
@@ -1,0 +1,77 @@
+---
+id: TASK-45.44.10.6
+title: Migrate DocumentWorkspaceErrorBoundary result to design-system state
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- document-workspace
+priority: medium
+parent_task_id: TASK-45.44.10
+references:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx
+- apps/packages/ui/src/components/DocumentWorkspace/__tests__/DocumentWorkspaceErrorBoundary.design-system.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Document and Workspace product-state design-system migration by replacing the final AntD Result product-state surface in DocumentWorkspaceErrorBoundary with the shared design-system EmptyState primitive. Keep scope limited to the error-boundary fallback, focused tests, and removal of the matching baseline entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 DocumentWorkspaceErrorBoundary no longer imports or renders AntD Result for the default recovery fallback.
+- [x] #2 The default recovery fallback renders through the shared design-system EmptyState primitive.
+- [x] #3 The fallback preserves title, description, development error details, warning icon tone, and Try again behavior.
+- [x] #4 The matching DocumentWorkspaceErrorBoundary product-state baseline row is removed without introducing unbaselined findings.
+- [x] #5 Focused error-boundary tests and product-state verifier checks are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing test that trips DocumentWorkspaceErrorBoundary and asserts the fallback renders through a design-system product-state primitive instead of AntD Result.
+2. Replace the AntD Result fallback with the shared design-system EmptyState primitive while preserving title, description, development details, warning icon tone, and retry action.
+3. Remove the migrated DocumentWorkspaceErrorBoundary Result row from the product-state baseline.
+4. Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red test evidence: `bunx vitest run src/components/DocumentWorkspace/__tests__/DocumentWorkspaceErrorBoundary.design-system.test.tsx --reporter=dot` failed on missing `data-ds-component="EmptyState"` for the default fallback before the component migration.
+- Migrated only the default DocumentWorkspaceErrorBoundary fallback from AntD Result to the shared design-system EmptyState primitive. The custom `fallback` prop path remains unchanged.
+- Removed one baseline row for `DocumentWorkspaceErrorBoundary.tsx`, targeting the final current Document/Workspace product-state baseline exception.
+- Verification:
+  - `bunx vitest run src/components/DocumentWorkspace/__tests__/DocumentWorkspaceErrorBoundary.design-system.test.tsx --reporter=dot` passed: 1 test.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed: 54 tests.
+  - `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline json ok')"` passed.
+  - `bun run verify:design-system-state` passed with 291 baseline exceptions total and no remaining Document/Workspace product-area bucket.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI type debt outside the touched DocumentWorkspaceErrorBoundary files; `/tmp/tldw_doc_workspace_error_boundary_tsc.log` contains no `DocumentWorkspaceErrorBoundary` or `ErrorBoundary.design-system` matches.
+  - `git diff --check` passed.
+- Bandit is not applicable to this UI-only TypeScript/React slice; no Python files were touched.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.10.6 - Migrate-DocumentWorkspaceErrorBoundary-result-to-design-system-state.md
+++ b/backlog/tasks/task-45.44.10.6 - Migrate-DocumentWorkspaceErrorBoundary-result-to-design-system-state.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.10.6
 title: Migrate DocumentWorkspaceErrorBoundary result to design-system state
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -10,6 +10,7 @@ labels:
 priority: medium
 parent_task_id: TASK-45.44.10
 references:
+- https://github.com/rmusser01/tldw_server/pull/1961
 - apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspaceErrorBoundary.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
@@ -63,15 +64,16 @@ Continue the Document and Workspace product-state design-system migration by rep
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the DocumentWorkspaceErrorBoundary default recovery fallback from AntD Result to the shared design-system EmptyState primitive, added focused regression coverage for the fallback and Try again path, and removed the final current Document/Workspace product-state baseline entry. PR: https://github.com/rmusser01/tldw_server/pull/1961.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
Summary
- Replace the DocumentWorkspaceErrorBoundary default AntD Result fallback with design-system EmptyState.
- Add focused regression coverage for the recovery fallback and Try again path.
- Remove the final Document/Workspace product-state baseline row, reducing total exceptions 292 to 291 and the Document/Workspace bucket to zero.

Verification
- bunx vitest run src/components/DocumentWorkspace/__tests__/DocumentWorkspaceErrorBoundary.design-system.test.tsx --reporter=dot passed: 1 test.
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed: 54 tests.
- node baseline JSON parse passed.
- bun run verify:design-system-state passed with 291 total baseline exceptions and no Document/Workspace product-area bucket.
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still fails on existing repo-wide UI TypeScript debt outside the touched DocumentWorkspaceErrorBoundary files; the captured log had no DocumentWorkspaceErrorBoundary or ErrorBoundary.design-system matches.
- git diff --check passed.

Change summary
This closes the last current Document/Workspace product-state baseline exception by moving the error-boundary recovery UI onto the same EmptyState primitive used by the rest of the migration. The change keeps the existing recovery copy, warning icon tone, development details, and retry behavior while removing AntD Result from this fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the DocumentWorkspaceErrorBoundary fallback from `antd` Result with the design-system `EmptyState` to unify product-state UI and close the last Document/Workspace baseline exception. Added a focused recovery test; copy, warning icon, and retry behavior remain the same.

- **Refactors**
  - Swapped the fallback to design-system `EmptyState` and removed `antd` `Result`.
  - Removed the matching baseline row (292 → 291), added `DocumentWorkspaceErrorBoundary.design-system.test.tsx`, and recorded TASK-45.44.10.6 in the backlog.

<sup>Written for commit 17bf3270e310e6e00edaf7d2793d896edded102b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1961?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

