### PR TITLE
Fix watchlist source clone review flow

### DIFF
--- a/Docs/superpowers/plans/2026-05-22-watchlists-power-user-clone-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-22-watchlists-power-user-clone-implementation-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Verify Existing Clone Surface
+**Goal**: Confirm what clone behavior already exists on `/watchlists` Sources and Monitors, and narrow this slice to the remaining unsafe gap.
+**Success Criteria**: Existing monitor/source clone utilities and UI actions are identified, and the implementation scope avoids duplicating already-merged work.
+**Tests**: Read existing clone utility tests and relevant SourcesTab/JobsTab code paths.
+**Status**: Complete
+
+## Stage 2: Source Clone Review Form
+**Goal**: Change source clone from immediate duplicate creation to a prefilled create form that preserves source rules and assignments while keeping the cloned source inactive by default.
+**Success Criteria**: Clicking clone opens the source form with copied name, URL, type, tags, settings, and hidden group assignment preservation; no create API call is made until the user saves.
+**Tests**: Add a focused SourcesTab clone-flow test that fails before implementation and passes after.
+**Status**: Complete
+
+## Stage 3: Preservation Regression Coverage
+**Goal**: Keep monitor clone behavior covered as a paused copy and source clone payload behavior covered as a reset runtime copy.
+**Success Criteria**: Existing clone utility tests remain passing, and new tab-level behavior coverage protects the source clone handoff.
+**Tests**: Run SourcesTab clone-flow test, source clone utility test, and relevant monitor clone utility test.
+**Status**: Complete
+
+## Stage 4: Verification And Task Finalization
+**Goal**: Verify focused frontend behavior, record results in Backlog, and commit a clean reviewable slice.
+**Success Criteria**: Focused tests pass, diff is reviewed, Backlog task records outcome and any skips, and branch is ready for PR.
+**Tests**: Focused Vitest commands plus `git diff --check`; Bandit skipped if only frontend/markdown files are touched.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourceFormModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { Alert } from "@/components/ui/primitives"
 import { testWatchlistSource, testWatchlistSourceDraft } from "@/services/watchlists"
 import type { JobPreviewResult, SourcePreviewDiagnostics } from "@/types/watchlists"
-import type { WatchlistSource, SourceType } from "@/types/watchlists"
+import type { SourceType } from "@/types/watchlists"
 import { buildWatchlistsModalChrome, useWatchlistsViewport } from "../shared"
 import { mapWatchlistsError } from "../shared/watchlists-error"
 import {
@@ -18,6 +18,17 @@ import {
   restoreFocusToElement
 } from "../shared/focus-management"
 
+type SourceFormMode = "create" | "edit"
+
+type SourceFormInitialValues = {
+  id?: number
+  name: string
+  url: string
+  source_type: SourceType
+  tags?: string[]
+  settings?: Record<string, unknown> | null
+}
+
 interface SourceFormModalProps {
   open: boolean
   onClose: () => void
@@ -28,7 +39,8 @@ interface SourceFormModalProps {
     tags: string[]
     settings?: Record<string, unknown> | null
   }) => Promise<void>
-  initialValues?: WatchlistSource
+  initialValues?: SourceFormInitialValues
+  mode?: SourceFormMode
   existingTags: string[]
   forumsEnabled?: boolean
 }
@@ -155,6 +167,7 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
   onClose,
   onSubmit,
   initialValues,
+  mode,
   existingTags,
   forumsEnabled = false
 }) => {
@@ -169,7 +182,8 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
   const wasOpenRef = useRef(false)
   const { isConstrained } = useWatchlistsViewport()
 
-  const isEditing = !!initialValues
+  const formMode = mode ?? (typeof initialValues?.id === "number" ? "edit" : "create")
+  const isEditing = formMode === "edit"
   const testSourceId = typeof initialValues?.id === "number" ? initialValues.id : null
   const modalChrome = buildWatchlistsModalChrome(isConstrained, 500)
   const diagnosticsLines = buildDiagnosticsLines(testResult?.diagnostics, t)
@@ -197,7 +211,7 @@ export const SourceFormModal: React.FC<SourceFormModalProps> = ({
           name: initialValues.name,
           url: initialValues.url,
           source_type: initialValues.source_type,
-          tags: initialValues.tags,
+          tags: initialValues.tags || [],
           ...sourceSettingsToFormValues(initialValues.settings)
         })
       } else {

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesTab.tsx
@@ -47,7 +47,13 @@ import {
   restoreWatchlistSource,
   updateWatchlistSource
 } from "@/services/watchlists"
-import type { SourceSeenStats, WatchlistJob, WatchlistSource, SourceType } from "@/types/watchlists"
+import type {
+  SourceSeenStats,
+  WatchlistJob,
+  WatchlistSource,
+  WatchlistSourceCreate,
+  SourceType
+} from "@/types/watchlists"
 import { formatRelativeTime } from "@/utils/dateFormatters"
 import { SourceFormModal } from "./SourceFormModal"
 import { GroupsTree } from "./GroupsTree"
@@ -181,8 +187,7 @@ export const SourcesTab: React.FC = () => {
   )
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([])
   const [bulkWorking, setBulkWorking] = useState(false)
-  const cloningSourceIdsRef = useRef<Set<number>>(new Set())
-  const [cloningSourceIds, setCloningSourceIds] = useState<Set<number>>(() => new Set())
+  const [sourceCloneDraft, setSourceCloneDraft] = useState<WatchlistSourceCreate | null>(null)
   const [bulkMoveTargetValue, setBulkMoveTargetValue] = useState<BulkMoveTargetValue>(null)
   const [checkingSourceIds, setCheckingSourceIds] = useState<number[]>([])
   const [importOpen, setImportOpen] = useState(false)
@@ -1112,6 +1117,21 @@ export const SourcesTab: React.FC = () => {
     })
   }, [])
 
+  const handleOpenNewSourceForm = useCallback(() => {
+    setSourceCloneDraft(null)
+    openSourceForm()
+  }, [openSourceForm])
+
+  const handleOpenExistingSourceForm = useCallback((sourceId: number) => {
+    setSourceCloneDraft(null)
+    openSourceForm(sourceId)
+  }, [openSourceForm])
+
+  const handleCloseSourceForm = useCallback(() => {
+    setSourceCloneDraft(null)
+    closeSourceForm()
+  }, [closeSourceForm])
+
   // Handle form submit
   const handleFormSubmit = async (
     values: {
@@ -1130,12 +1150,27 @@ export const SourcesTab: React.FC = () => {
       } else {
         const created = await createWatchlistSource({
           ...values,
-          watchlist_id: selectedWatchlistId ?? undefined
+          ...(sourceCloneDraft
+            ? {
+                active: false,
+                group_ids: sourceCloneDraft.group_ids,
+                watchlist_id: sourceCloneDraft.watchlist_id ?? selectedWatchlistId ?? undefined
+              }
+            : {
+                watchlist_id: selectedWatchlistId ?? undefined
+              })
         })
         addSource(created)
-        message.success(t("watchlists:sources.created", "Source created"))
+        message.success(
+          sourceCloneDraft
+            ? t(
+                "watchlists:sources.cloneSuccess",
+                "Feed cloned as an inactive copy. Review and enable it when ready."
+              )
+            : t("watchlists:sources.created", "Source created")
+        )
       }
-      closeSourceForm()
+      handleCloseSourceForm()
       loadTags() // Refresh tags in case new ones were added
     } catch (err) {
       console.error("Failed to save source:", err)
@@ -1166,54 +1201,17 @@ export const SourcesTab: React.FC = () => {
     }
   }
 
-  const startCloningSource = useCallback((sourceId: number) => {
-    if (cloningSourceIdsRef.current.has(sourceId)) {
-      return false
-    }
-    const next = new Set(cloningSourceIdsRef.current)
-    next.add(sourceId)
-    cloningSourceIdsRef.current = next
-    setCloningSourceIds(next)
-    return true
-  }, [])
-
-  const finishCloningSource = useCallback((sourceId: number) => {
-    if (!cloningSourceIdsRef.current.has(sourceId)) {
-      return
-    }
-    const next = new Set(cloningSourceIdsRef.current)
-    next.delete(sourceId)
-    cloningSourceIdsRef.current = next
-    setCloningSourceIds(next)
-  }, [])
-
-  const handleCloneSource = async (source: WatchlistSource) => {
-    if (!startCloningSource(source.id)) return
-    try {
-      const cloned = await createWatchlistSource(
-        buildClonedWatchlistSourcePayload(source, selectedWatchlistId)
-      )
-      addSource(cloned)
-      message.success(
-        t(
-          "watchlists:sources.cloneSuccess",
-          "Feed cloned as an inactive copy. Review and enable it when ready."
-        )
-      )
-      void loadSources()
-      void loadTags()
-    } catch (err) {
-      console.error("Failed to clone source:", err)
-      message.error(t("watchlists:sources.cloneError", "Failed to clone feed"))
-    } finally {
-      finishCloningSource(source.id)
-    }
+  const handleCloneSource = (source: WatchlistSource) => {
+    setSourceCloneDraft(buildClonedWatchlistSourcePayload(source, selectedWatchlistId))
+    openSourceForm()
   }
 
   // Get source for editing
   const editingSource = sourceFormEditId
     ? sources.find((s) => s.id === sourceFormEditId)
     : undefined
+  const sourceFormInitialValues = editingSource ?? sourceCloneDraft ?? undefined
+  const sourceFormMode = sourceFormEditId ? "edit" : "create"
 
   // Table columns
   const tagsColumn: ColumnsType<WatchlistSource>[number] = {
@@ -1412,7 +1410,7 @@ export const SourcesTab: React.FC = () => {
               size="small"
               aria-label={t("common:edit", "Edit")}
               icon={<Edit2 className="h-4 w-4" />}
-              onClick={() => openSourceForm(record.id)}
+              onClick={() => handleOpenExistingSourceForm(record.id)}
             />
           </Tooltip>
           <Tooltip title={t("watchlists:sources.seenInfo", "Source Health & Dedup Stats")}>
@@ -1430,7 +1428,6 @@ export const SourcesTab: React.FC = () => {
               size="small"
               aria-label={t("watchlists:sources.cloneFeedAria", "Clone {{name}}", { name: record.name })}
               icon={<Copy className="h-4 w-4" />}
-              loading={cloningSourceIds.has(record.id)}
               onClick={() => handleCloneSource(record)}
             />
           </Tooltip>
@@ -1587,7 +1584,6 @@ export const SourcesTab: React.FC = () => {
                   size="small"
                   aria-label={t("watchlists:sources.cloneFeedAria", "Clone {{name}}", { name: source.name })}
                   icon={<Copy className="h-4 w-4" />}
-                  loading={cloningSourceIds.has(source.id)}
                   onClick={() => handleCloneSource(source)}
                 />
                 <Button
@@ -1595,7 +1591,7 @@ export const SourcesTab: React.FC = () => {
                   size="small"
                   aria-label={t("watchlists:sources.editSourceAria", "Edit {{name}}", { name: source.name })}
                   icon={<Edit2 className="h-4 w-4" />}
-                  onClick={() => openSourceForm(source.id)}
+                  onClick={() => handleOpenExistingSourceForm(source.id)}
                 />
                 <Button
                   type="text"
@@ -1705,7 +1701,7 @@ export const SourcesTab: React.FC = () => {
           <Button
             type="primary"
             icon={<Plus className="h-4 w-4" />}
-            onClick={() => openSourceForm()}
+            onClick={handleOpenNewSourceForm}
           >
             {t("watchlists:sources.addSource", "Add Source")}
           </Button>
@@ -1823,7 +1819,7 @@ export const SourcesTab: React.FC = () => {
               <Space>
                 <Button
                   icon={<Plus className="h-4 w-4" />}
-                  onClick={() => openSourceForm()}
+                  onClick={handleOpenNewSourceForm}
                 >
                   {t("watchlists:sources.addSource", "Add Source")}
                 </Button>
@@ -1900,9 +1896,10 @@ export const SourcesTab: React.FC = () => {
 
       <SourceFormModal
         open={sourceFormOpen}
-        onClose={closeSourceForm}
+        onClose={handleCloseSourceForm}
         onSubmit={handleFormSubmit}
-        initialValues={editingSource}
+        initialValues={sourceFormInitialValues}
+        mode={sourceFormMode}
         existingTags={(Array.isArray(tags) ? tags : []).map((t) => t.name)}
         forumsEnabled={Boolean(settings?.forums_enabled)}
       />

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx
@@ -273,6 +273,100 @@ describe("SourceFormModal test-source preflight", () => {
     })
   })
 
+  it("submits cloned draft initial values with create semantics", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    formApi.validateFields.mockResolvedValue({
+      name: "Saved Feed copy",
+      url: "https://copy.example.com/feed.xml",
+      source_type: "site",
+      tags: ["news", "daily"],
+      scrape_item_selector: "css:article",
+      scrape_link_selector: ".//a/@href",
+      scrape_title_selector: "css:h2",
+      scrape_summary_selector: "",
+      scrape_content_selector: "",
+      scrape_date_selector: "",
+      scrape_guid_selector: "css:[data-guid]",
+      scrape_limit: 5,
+      source_top_n: 3,
+      discover_method: "links",
+      skip_article_fetch: true
+    })
+
+    render(
+      <SourceFormModal
+        open
+        mode="create"
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+        initialValues={{
+          name: "Saved Feed copy",
+          url: "https://example.com/feed.xml",
+          source_type: "site",
+          tags: ["news", "daily"],
+          settings: {
+            retain_unowned_rule: "preserve",
+            scrape_rules: {
+              item_selector: "css:article",
+              link_xpath: ".//a/@href",
+              guid_xpath: "css:[data-guid]",
+              limit: 5,
+              skip_article_fetch: true
+            },
+            top_n: 3,
+            discover_method: "links"
+          }
+        }}
+        existingTags={[]}
+      />
+    )
+
+    expect(screen.getByRole("heading", { name: "Add Source" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(formApi.setFieldsValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Saved Feed copy",
+          url: "https://example.com/feed.xml",
+          source_type: "site",
+          tags: ["news", "daily"],
+          scrape_item_selector: "css:article",
+          scrape_link_selector: ".//a/@href",
+          scrape_guid_selector: "css:[data-guid]",
+          scrape_limit: 5,
+          source_top_n: 3,
+          discover_method: "links",
+          skip_article_fetch: true
+        })
+      )
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: "Saved Feed copy",
+        url: "https://copy.example.com/feed.xml",
+        source_type: "site",
+        tags: ["news", "daily"],
+        settings: {
+          retain_unowned_rule: "preserve",
+          scrape_rules: {
+            item_selector: "css:article",
+            link_xpath: ".//a/@href",
+            title_selector: "css:h2",
+            guid_xpath: "css:[data-guid]",
+            limit: 5,
+            skip_article_fetch: true
+          },
+          top_n: 3,
+          discover_method: "links"
+        }
+      })
+    })
+  })
+
   it("renders optional source validation diagnostics from preview", async () => {
     formApi.validateFields.mockResolvedValue({
       url: "https://example.com/news",

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.advanced-details.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.advanced-details.test.tsx
@@ -15,6 +15,8 @@ type SourceRecord = {
   active: boolean
   tags: string[]
   group_ids?: number[]
+  watchlist_ids?: number[]
+  settings?: Record<string, unknown> | null
   status: string
   created_at: string
   updated_at: string
@@ -33,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   deleteWatchlistSourceMock: vi.fn(),
   restoreWatchlistSourceMock: vi.fn(),
   updateWatchlistSourceMock: vi.fn(),
+  sourceFormModalProps: { current: null as any },
   showUndoNotificationMock: vi.fn(),
   tMock: (key: string, defaultValue?: unknown, options?: Record<string, unknown>) => {
     if (typeof defaultValue !== "string") return key
@@ -173,7 +176,33 @@ vi.mock("@/store/watchlists", () => ({
 }))
 
 vi.mock("../SourceFormModal", () => ({
-  SourceFormModal: () => null
+  SourceFormModal: (props: any) => {
+    mocks.sourceFormModalProps.current = props
+    if (!props.open) return null
+    const initialValues = props.initialValues || {}
+    return (
+      <div data-testid="source-form-modal">
+        <div data-testid="source-form-mode">{props.mode || ""}</div>
+        <div data-testid="source-form-name">{initialValues.name || ""}</div>
+        <div data-testid="source-form-url">{initialValues.url || ""}</div>
+        <button
+          type="button"
+          data-testid="source-form-submit"
+          onClick={() =>
+            props.onSubmit({
+              name: initialValues.name,
+              url: "https://copy.example.com/feed.xml",
+              source_type: initialValues.source_type,
+              tags: initialValues.tags,
+              settings: initialValues.settings
+            })
+          }
+        >
+          submit
+        </button>
+      </div>
+    )
+  }
 }))
 
 vi.mock("../GroupsTree", () => ({
@@ -196,6 +225,11 @@ const buildSource = (id: number): SourceRecord => ({
   active: true,
   tags: ["tech", "ai"],
   group_ids: [7],
+  watchlist_ids: [3],
+  settings: {
+    fetch_mode: "rss",
+    dedupe_identity: ["canonical_url", "title"]
+  },
   status: "healthy",
   created_at: "2026-02-20T00:00:00Z",
   updated_at: "2026-02-20T00:00:00Z",
@@ -214,6 +248,7 @@ const baseState = (overrides: Record<string, unknown> = {}) => ({
   groupsLoading: false,
   selectedGroupId: null,
   selectedTagName: null,
+  selectedWatchlistId: 42,
   sourceFormOpen: false,
   sourceFormEditId: null,
   setSources: vi.fn(),
@@ -227,8 +262,20 @@ const baseState = (overrides: Record<string, unknown> = {}) => ({
   setActiveTab: vi.fn(),
   setSelectedGroupId: vi.fn(),
   setSelectedTagName: vi.fn(),
-  openSourceForm: vi.fn(),
-  closeSourceForm: vi.fn(),
+  openSourceForm: vi.fn((editId?: number | null) => {
+    mocks.storeStateRef.current = {
+      ...mocks.storeStateRef.current,
+      sourceFormOpen: true,
+      sourceFormEditId: editId ?? null
+    }
+  }),
+  closeSourceForm: vi.fn(() => {
+    mocks.storeStateRef.current = {
+      ...mocks.storeStateRef.current,
+      sourceFormOpen: false,
+      sourceFormEditId: null
+    }
+  }),
   addSource: vi.fn(),
   updateSourceInList: vi.fn(),
   removeSource: vi.fn(),
@@ -353,5 +400,56 @@ describe("SourcesTab advanced details disclosure", () => {
       expect(mocks.fetchWatchlistSourcesMock).toHaveBeenCalledTimes(2)
     })
     expect(mocks.exportOpmlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("opens cloned feeds in the source form before creating so duplicate URLs can be edited", async () => {
+    const source = {
+      ...buildSource(101),
+      group_ids: [7, 8],
+      watchlist_ids: [11],
+      settings: {
+        fetch: { user_agent: "tldw-test" },
+        extraction: { title_selector: "h1" },
+        dedupe: { identity: ["canonical_url", "title"] }
+      }
+    }
+    mocks.storeStateRef.current = baseState({
+      sources: [source],
+      sourcesTotal: 1,
+      selectedWatchlistId: 42
+    })
+    mocks.fetchWatchlistSourcesMock.mockResolvedValue({
+      items: [source],
+      total: 1,
+      page: 1,
+      size: 20,
+      has_more: false
+    })
+
+    render(<SourcesTab />)
+
+    fireEvent.click(await screen.findByRole("button", { name: "Clone Feed 101" }))
+
+    expect(mocks.createWatchlistSourceMock).not.toHaveBeenCalled()
+    expect(mocks.storeStateRef.current.openSourceForm).toHaveBeenCalledWith()
+    expect(await screen.findByTestId("source-form-modal")).toBeInTheDocument()
+    expect(screen.getByTestId("source-form-mode")).toHaveTextContent("create")
+    expect(screen.getByTestId("source-form-name")).toHaveTextContent("Feed 101 copy")
+    expect(screen.getByTestId("source-form-url")).toHaveTextContent("https://example.com/feed-101.xml")
+
+    fireEvent.click(screen.getByTestId("source-form-submit"))
+
+    await waitFor(() => {
+      expect(mocks.createWatchlistSourceMock).toHaveBeenCalledWith({
+        name: "Feed 101 copy",
+        url: "https://copy.example.com/feed.xml",
+        source_type: "rss",
+        active: false,
+        tags: ["tech", "ai"],
+        settings: source.settings,
+        group_ids: [7, 8],
+        watchlist_id: 42
+      })
+    })
   })
 })

--- a/backlog/tasks/task-487 - Implement-Watchlists-power-user-clone-workflow.md
+++ b/backlog/tasks/task-487 - Implement-Watchlists-power-user-clone-workflow.md
@@ -1,0 +1,63 @@
+---
+id: TASK-487
+title: Implement Watchlists power-user clone workflow
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-23 00:13'
+labels:
+  - watchlists
+  - power-user
+  - frontend
+  - ux
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-20-watchlists-demo-remediation-implementation-plan.md
+  - >-
+    Docs/superpowers/plans/2026-05-22-watchlists-power-user-clone-implementation-plan.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next Watchlists power-user follow-up: clone monitor and clone source-rule workflows with preservation smoke coverage, while preserving existing news/OSINT/CTI advanced flows and avoiding new backend batch APIs unless required.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Source clone action is available from /watchlists Sources and opens the existing source form with copied settings/tags/group/extraction/dedupe-style configuration, while resetting runtime/status/seen state and inactive-by-default safety.
+- [x] #2 Focused preservation tests cover clone behavior and critical existing advanced watchlists workflows are not regressed.
+- [x] #3 No backend batch APIs are added for this slice unless frontend composition is unsafe or impossible.
+- [x] #4 Focused frontend tests and relevant verification are run and recorded.
+- [x] #5 Monitor clone action remains available from /watchlists Monitors as an inactive/paused copy, with preservation covered by existing clone utility tests.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Adjusted after code inspection: monitor clone and source clone actions already exist on origin/dev. Monitor clone creates a paused copy and will stay as-is unless tests reveal regression. The unsafe gap is source clone immediately POSTing a duplicate URL, which can fail before the user can edit it. This slice changes source clone to open a prefilled create form, preserves copied source rules/group assignment on save, and covers the behavior with focused frontend tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation changed source clone from immediate create API call to a create-mode SourceFormModal draft. The cloned draft preserves name suffix, URL/type/tags/settings/group_ids/watchlist_id and applies active:false on save. Existing monitor clone behavior remains direct paused-copy creation and is covered by clone utility tests. No backend APIs were added.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed source clone review-form flow and preservation coverage. Addressed code review by rebasing onto latest dev to remove unrelated route-governance/design-system files from the PR diff and by adding real SourceFormModal clone-draft create-mode submit coverage. Verification: focused Watchlists Vitest suite passed; git diff --check passed. Full UI tsc was attempted with an increased heap and failed on existing repo-wide baseline errors outside this Watchlists slice. Bandit skipped because only frontend/markdown/backlog files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
Source cloning now opens the existing source form as a copied draft instead of immediately creating a duplicate source. This keeps the clone workflow usable when the copied URL needs to be edited before save, while preserving copied tags, source settings, group assignment, watchlist scope, and inactive-by-default safety. Monitor cloning remains the existing paused-copy flow and is covered by the clone utility tests.

## Why
The previous source clone action submitted the copied source immediately with the original URL. If the backend rejects duplicate source URLs, users hit an error before they can edit the copied URL. Routing clone through the source form keeps the workflow inside `/watchlists` and gives users a review/edit step before creation.

## Test Plan
- [x] `./node_modules/.bin/vitest run src/components/Option/Watchlists/SourcesTab/__tests__/SourcesTab.advanced-details.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/clone-utils.test.ts src/components/Option/Watchlists/JobsTab/__tests__/clone-utils.test.ts src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.test-source.test.tsx src/components/Option/Watchlists/SourcesTab/__tests__/SourceFormModal.forum-help.test.tsx src/components/Option/Watchlists/__tests__/watchlists-static-guard.typecheck.test.ts --maxWorkers=1 --no-file-parallelism`
- [x] `git diff --check`
- [ ] Full UI TypeScript: attempted `node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit --pretty false`; failed on existing repo-wide baseline errors outside this Watchlists slice.

## Backlog
- TASK-487

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloning a watchlist source now opens a prefilled create form instead of creating a duplicate right away. Users can edit the URL first, avoid duplicate-URL errors, and stay in /watchlists.

- **Bug Fixes**
  - Clone opens the create-mode form with copied name, URL, type, tags, settings, and preserves group_ids and watchlist scope; saving creates an inactive copy.
  - `SourceFormModal` now supports explicit create/edit modes with narrowed initial values; mode is inferred if not provided.
  - Added focused tests for the draft-based clone flow and create-mode submit; monitor cloning remains unchanged (paused copy) and is still covered by utility tests.
  - Success toast clarifies that cloned feeds are inactive by default; docs/backlog updated to close TASK-487.

<sup>Written for commit bbcf5599ddd77afee961fe2f46dc372e59ac1d13. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1962?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

