### PR TITLE
test: govern sidepanel and hosted route visibility

### DIFF
--- a/apps/packages/ui/src/routes/__tests__/option-route-visibility.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/option-route-visibility.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
@@ -17,6 +18,14 @@ import {
 } from "./route-registry-ast-helpers"
 
 const testDir = path.dirname(fileURLToPath(import.meta.url))
+const optionRouteVisibilitySourcePath = path.resolve(
+  testDir,
+  "../option-route-visibility.ts"
+)
+const optionRouteVisibilitySource = readFileSync(
+  optionRouteVisibilitySourcePath,
+  "utf8"
+)
 const routeRegistry = readFirstExistingSource(
   [path.resolve(testDir, "../route-registry.tsx")],
   "shared route-registry.tsx"
@@ -26,7 +35,7 @@ const optionRegistryPaths = extractRoutePathsFromRouteObjects(
   routeRegistry.source,
   routeRegistry.path,
   { kind: "options" }
-).filter((routePath) => !routePath.includes(":") && !routePath.includes("*"))
+)
 
 const sorted = (values: string[]) => [...values].sort()
 
@@ -39,6 +48,11 @@ describe("hosted option route visibility", () => {
     expect(sorted(metadataVisiblePaths)).toEqual(
       sorted(Array.from(HOSTED_VISIBLE_OPTION_PATHS))
     )
+  })
+
+  it("keeps production hosted visibility independent from the full route metadata registry", () => {
+    expect(optionRouteVisibilitySource).not.toMatch(/route-metadata/)
+    expect(optionRouteVisibilitySource).not.toMatch(/ROUTE_METADATA/)
   })
 
   it("does not expose internal, redirect, or deprecated routes in hosted mode", () => {
@@ -69,7 +83,7 @@ describe("hosted option route visibility", () => {
 
       const metadata = getRouteMetadata(routePath)
 
-      return !metadata?.rationale.trim()
+      return !metadata?.rationale?.trim()
     })
 
     expect(hiddenRoutesWithoutReason).toEqual([])

--- a/apps/packages/ui/src/routes/__tests__/option-route-visibility.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/option-route-visibility.test.ts
@@ -1,10 +1,84 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
-import { isHostedVisibleOptionPath } from "../option-route-visibility"
+import {
+  HOSTED_VISIBLE_OPTION_PATHS,
+  isHostedVisibleOptionPath
+} from "../option-route-visibility"
+import {
+  getRouteMetadata,
+  normalizeRoutePath,
+  ROUTE_METADATA
+} from "../route-metadata"
+import {
+  extractRoutePathsFromRouteObjects,
+  readFirstExistingSource
+} from "./route-registry-ast-helpers"
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const routeRegistry = readFirstExistingSource(
+  [path.resolve(testDir, "../route-registry.tsx")],
+  "shared route-registry.tsx"
+)
+
+const optionRegistryPaths = extractRoutePathsFromRouteObjects(
+  routeRegistry.source,
+  routeRegistry.path,
+  { kind: "options" }
+).filter((routePath) => !routePath.includes(":") && !routePath.includes("*"))
+
+const sorted = (values: string[]) => [...values].sort()
 
 describe("hosted option route visibility", () => {
+  it("derives hosted-visible option paths from route metadata", () => {
+    const metadataVisiblePaths = ROUTE_METADATA.filter(
+      (metadata) => metadata.hostedOptionVisibility === "visible"
+    ).map((metadata) => normalizeRoutePath(metadata.path))
+
+    expect(sorted(metadataVisiblePaths)).toEqual(
+      sorted(Array.from(HOSTED_VISIBLE_OPTION_PATHS))
+    )
+  })
+
+  it("does not expose internal, redirect, or deprecated routes in hosted mode", () => {
+    const invalidHostedRoutes = Array.from(HOSTED_VISIBLE_OPTION_PATHS).filter(
+      (routePath) => {
+        const metadata = getRouteMetadata(routePath)
+
+        return (
+          !metadata ||
+          [
+            "internal_qa_debug",
+            "legacy_alias",
+            "redirect",
+            "deprecated"
+          ].includes(metadata.surface)
+        )
+      }
+    )
+
+    expect(invalidHostedRoutes).toEqual([])
+  })
+
+  it("keeps hosted-hidden option routes backed by an explicit metadata reason", () => {
+    const hiddenRoutesWithoutReason = optionRegistryPaths.filter((routePath) => {
+      if (isHostedVisibleOptionPath(routePath)) {
+        return false
+      }
+
+      const metadata = getRouteMetadata(routePath)
+
+      return !metadata?.rationale.trim()
+    })
+
+    expect(hiddenRoutesWithoutReason).toEqual([])
+  })
+
   it("keeps audio explainer routes visible in hosted mode", () => {
     expect(isHostedVisibleOptionPath("/tts")).toBe(true)
     expect(isHostedVisibleOptionPath("/stt")).toBe(true)
+    expect(getRouteMetadata("/tts")?.hostedOptionVisibility).toBe("visible")
+    expect(getRouteMetadata("/stt")?.hostedOptionVisibility).toBe("visible")
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/route-governance.sidepanel-availability.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-governance.sidepanel-availability.test.ts
@@ -1,0 +1,124 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+import {
+  getRouteMetadata,
+  normalizeRoutePath,
+  ROUTE_METADATA
+} from "../route-metadata"
+import {
+  extractRoutePathsFromRouteObjects,
+  readFirstExistingSource,
+  uniqueSorted
+} from "./route-registry-ast-helpers"
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+
+const sharedSidepanelRegistry = readFirstExistingSource(
+  [path.resolve(testDir, "../sidepanel-route-registry.tsx")],
+  "shared sidepanel-route-registry.tsx"
+)
+
+const extensionSidepanelRegistry = readFirstExistingSource(
+  [
+    path.resolve(
+      testDir,
+      "../../../../../tldw-frontend/extension/routes/sidepanel-route-registry.tsx"
+    )
+  ],
+  "extension sidepanel-route-registry.tsx"
+)
+
+const extensionUnifiedRegistry = readFirstExistingSource(
+  [
+    path.resolve(
+      testDir,
+      "../../../../../tldw-frontend/extension/routes/route-registry.tsx"
+    )
+  ],
+  "extension route-registry.tsx"
+)
+
+const extractSidepanelPaths = (source: string, fileName: string) =>
+  extractRoutePathsFromRouteObjects(source, fileName, { kind: "sidepanel" }).map(
+    normalizeRoutePath
+  )
+
+const sharedSidepanelPaths = extractSidepanelPaths(
+  sharedSidepanelRegistry.source,
+  sharedSidepanelRegistry.path
+)
+
+const extensionSidepanelPaths = uniqueSorted([
+  ...extractSidepanelPaths(
+    extensionSidepanelRegistry.source,
+    extensionSidepanelRegistry.path
+  ),
+  ...extractSidepanelPaths(
+    extensionUnifiedRegistry.source,
+    extensionUnifiedRegistry.path
+  )
+])
+
+const sidepanelRegistryPaths = uniqueSorted([
+  ...sharedSidepanelPaths,
+  ...extensionSidepanelPaths
+])
+
+const metadataSidepanelPaths = uniqueSorted(
+  ROUTE_METADATA.filter((metadata) =>
+    metadata.availability.includes("extension_sidepanel")
+  ).map((metadata) => normalizeRoutePath(metadata.path))
+)
+
+describe("route governance sidepanel availability", () => {
+  it("registers every metadata-declared sidepanel route in a sidepanel registry", () => {
+    const missingRegistryRoutes = metadataSidepanelPaths.filter(
+      (routePath) => !sidepanelRegistryPaths.includes(routePath)
+    )
+
+    expect(missingRegistryRoutes).toEqual([])
+  })
+
+  it("marks every shared or extension sidepanel registry route as sidepanel-available metadata", () => {
+    const missingMetadataAvailability = sidepanelRegistryPaths.filter(
+      (routePath) =>
+        !getRouteMetadata(routePath)?.availability.includes("extension_sidepanel")
+    )
+
+    expect(missingMetadataAvailability).toEqual([])
+  })
+
+  it("keeps core handoff routes available in the sidepanel registry union", () => {
+    const expectedHandoffRoutes = [
+      "/chat",
+      "/clipper",
+      "/companion",
+      "/flashcards",
+      "/persona"
+    ]
+
+    for (const routePath of expectedHandoffRoutes) {
+      expect(sidepanelRegistryPaths, routePath).toContain(routePath)
+      expect(getRouteMetadata(routePath)?.availability, routePath).toContain(
+        "extension_sidepanel"
+      )
+    }
+  })
+
+  it("keeps internal sidepanel QA routes out of default navigation", () => {
+    const exposedDebugRoutes = sidepanelRegistryPaths.filter((routePath) => {
+      const metadata = getRouteMetadata(routePath)
+
+      return (
+        metadata?.surface === "internal_qa_debug" &&
+        (metadata.nav !== "hidden" ||
+          metadata.commandPalette !== "hide" ||
+          metadata.smoke === "include")
+      )
+    })
+
+    expect(exposedDebugRoutes).toEqual([])
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/route-governance.sidepanel-availability.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-governance.sidepanel-availability.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   extractRoutePathsFromRouteObjects,
   readFirstExistingSource,
+  readOptionalFirstExistingSource,
   uniqueSorted
 } from "./route-registry-ast-helpers"
 
@@ -20,24 +21,30 @@ const sharedSidepanelRegistry = readFirstExistingSource(
   "shared sidepanel-route-registry.tsx"
 )
 
-const extensionSidepanelRegistry = readFirstExistingSource(
+const extensionSidepanelRegistry = readOptionalFirstExistingSource(
   [
     path.resolve(
       testDir,
       "../../../../../tldw-frontend/extension/routes/sidepanel-route-registry.tsx"
+    ),
+    path.resolve(
+      testDir,
+      "../../../../../../apps/tldw-frontend/extension/routes/sidepanel-route-registry.tsx"
     )
-  ],
-  "extension sidepanel-route-registry.tsx"
+  ]
 )
 
-const extensionUnifiedRegistry = readFirstExistingSource(
+const extensionUnifiedRegistry = readOptionalFirstExistingSource(
   [
     path.resolve(
       testDir,
       "../../../../../tldw-frontend/extension/routes/route-registry.tsx"
+    ),
+    path.resolve(
+      testDir,
+      "../../../../../../apps/tldw-frontend/extension/routes/route-registry.tsx"
     )
-  ],
-  "extension route-registry.tsx"
+  ]
 )
 
 const extractSidepanelPaths = (source: string, fileName: string) =>
@@ -51,14 +58,18 @@ const sharedSidepanelPaths = extractSidepanelPaths(
 )
 
 const extensionSidepanelPaths = uniqueSorted([
-  ...extractSidepanelPaths(
-    extensionSidepanelRegistry.source,
-    extensionSidepanelRegistry.path
-  ),
-  ...extractSidepanelPaths(
-    extensionUnifiedRegistry.source,
-    extensionUnifiedRegistry.path
-  )
+  ...(extensionSidepanelRegistry
+    ? extractSidepanelPaths(
+        extensionSidepanelRegistry.source,
+        extensionSidepanelRegistry.path
+      )
+    : []),
+  ...(extensionUnifiedRegistry
+    ? extractSidepanelPaths(
+        extensionUnifiedRegistry.source,
+        extensionUnifiedRegistry.path
+      )
+    : [])
 ])
 
 const sidepanelRegistryPaths = uniqueSorted([
@@ -84,7 +95,9 @@ describe("route governance sidepanel availability", () => {
   it("marks every shared or extension sidepanel registry route as sidepanel-available metadata", () => {
     const missingMetadataAvailability = sidepanelRegistryPaths.filter(
       (routePath) =>
-        !getRouteMetadata(routePath)?.availability.includes("extension_sidepanel")
+        !getRouteMetadata(routePath)?.availability?.includes(
+          "extension_sidepanel"
+        )
     )
 
     expect(missingMetadataAvailability).toEqual([])
@@ -120,5 +133,21 @@ describe("route governance sidepanel availability", () => {
     })
 
     expect(exposedDebugRoutes).toEqual([])
+  })
+})
+
+const describeExtensionRegistries =
+  extensionSidepanelPaths.length > 0 ? describe : describe.skip
+
+describeExtensionRegistries("extension sidepanel registry availability", () => {
+  it("marks every extension sidepanel registry route as sidepanel-available metadata when extension sources exist", () => {
+    const missingMetadataAvailability = extensionSidepanelPaths.filter(
+      (routePath) =>
+        !getRouteMetadata(routePath)?.availability?.includes(
+          "extension_sidepanel"
+        )
+    )
+
+    expect(missingMetadataAvailability).toEqual([])
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/route-registry-ast-helpers.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry-ast-helpers.ts
@@ -43,6 +43,21 @@ export const readFirstExistingSource = (
   }
 }
 
+export const readOptionalFirstExistingSource = (
+  candidates: string[]
+): RouteRegistrySource | undefined => {
+  const sourcePath = candidates.find((candidate) => existsSync(candidate))
+
+  if (!sourcePath) {
+    return undefined
+  }
+
+  return {
+    path: sourcePath,
+    source: readFileSync(sourcePath, "utf8")
+  }
+}
+
 export const getPropertyNameText = (
   name: ts.PropertyName
 ): string | undefined => {

--- a/apps/packages/ui/src/routes/__tests__/route-registry.companion.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.companion.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import { getRouteMetadata } from "../route-metadata"
 
 const optionRouteRegistryPathCandidates = [
   "src/routes/route-registry.tsx",
@@ -31,6 +32,9 @@ const sidepanelRouteRegistrySource = readFileSync(sidepanelRouteRegistryPath, "u
 describe("sidepanel route registry companion parity", () => {
   it("registers a dedicated companion sidepanel route", () => {
     expect(sidepanelRouteRegistrySource).toMatch(/path:\s*"\/companion"/)
+    expect(getRouteMetadata("/companion")?.availability).toContain(
+      "extension_sidepanel"
+    )
   })
 
   it("registers the companion conversation route in both option and sidepanel shells", () => {
@@ -40,5 +44,8 @@ describe("sidepanel route registry companion parity", () => {
       sidepanelRouteRegistrySource.match(/path:\s*"\/companion\/conversation"/g) ?? []
     expect(optionMatches).toHaveLength(1)
     expect(sidepanelMatches).toHaveLength(1)
+    expect(getRouteMetadata("/companion/conversation")?.availability).toContain(
+      "extension_sidepanel"
+    )
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/route-registry.persona.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.persona.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import { getRouteMetadata } from "../route-metadata"
 
 const routeRegistryPathCandidates = [
   "src/routes/sidepanel-route-registry.tsx",
@@ -22,10 +23,17 @@ const routeRegistrySource = readFileSync(routeRegistryPath, "utf8")
 describe("sidepanel route registry persona parity", () => {
   it("registers a dedicated persona sidepanel route", () => {
     expect(routeRegistrySource).toMatch(/path:\s*"\/persona"/)
+    expect(getRouteMetadata("/persona")?.availability).toContain(
+      "extension_sidepanel"
+    )
   })
 
   it("keeps persona and coding-agent routes separate", () => {
     expect(routeRegistrySource).toMatch(/path:\s*"\/agent"/)
     expect(routeRegistrySource).toMatch(/path:\s*"\/persona"/)
+    expect(getRouteMetadata("/agent")).toMatchObject({
+      canonicalPath: "/agents",
+      surface: "extension_sidepanel"
+    })
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import { getRouteMetadata } from "../route-metadata"
 
 const routeRegistryPathCandidates = [
   "src/routes/sidepanel-route-registry.tsx",
@@ -23,10 +24,14 @@ describe("sidepanel route registry chat parity", () => {
   it("registers a dedicated sidepanel chat route", () => {
     expect(routeRegistrySource).toMatch(/path:\s*"\/chat"/)
     expect(routeRegistrySource).toContain("SidepanelChat")
+    expect(getRouteMetadata("/chat")?.availability).toContain(
+      "extension_sidepanel"
+    )
   })
 
   it("keeps the sidepanel home resolver on the root route", () => {
     expect(routeRegistrySource).toMatch(/path:\s*"\/"/)
     expect(routeRegistrySource).toContain("SidepanelHomeResolver")
+    expect(getRouteMetadata("/")?.availability).toContain("extension_sidepanel")
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-clipper.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-clipper.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import { getRouteMetadata } from "../route-metadata"
 
 const routeRegistryPathCandidates = [
   "src/routes/sidepanel-route-registry.tsx",
@@ -23,5 +24,12 @@ describe("sidepanel route registry clipper parity", () => {
   it("registers a dedicated sidepanel clipper route", () => {
     expect(routeRegistrySource).toMatch(/path:\s*"\/clipper"/)
     expect(routeRegistrySource).toContain("SidepanelClipper")
+    expect(getRouteMetadata("/clipper")).toMatchObject({
+      surface: "extension_sidepanel",
+      nav: "hidden"
+    })
+    expect(getRouteMetadata("/clipper")?.availability).toEqual([
+      "extension_sidepanel"
+    ])
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import { getRouteMetadata } from "../route-metadata"
 import { STUDY_SAFETY_SPECIALIZED_ROUTE_JOBS } from "../study-safety-specialized-route-jobs"
 
 const registryPathCandidates = [
@@ -34,6 +35,9 @@ describe("sidepanel flashcards route registration", () => {
   it("registers a /flashcards route in the sidepanel registry", () => {
     expect(registrySource).toMatch(/path:\s*"\/flashcards"/)
     expect(registrySource).toContain("SidepanelFlashcards")
+    expect(getRouteMetadata("/flashcards")?.availability).toContain(
+      "extension_sidepanel"
+    )
   })
 
   it("keeps flashcards as the only Task 11B sidepanel route", () => {

--- a/apps/packages/ui/src/routes/option-route-visibility.ts
+++ b/apps/packages/ui/src/routes/option-route-visibility.ts
@@ -1,10 +1,10 @@
-import { normalizeRoutePath, ROUTE_METADATA } from "./route-metadata"
+import {
+  HOSTED_VISIBLE_OPTION_PATHS,
+  HOSTED_VISIBLE_OPTION_PATHS_LIST
+} from "./route-hosted-visibility"
+import { normalizeRoutePath } from "./route-path-normalization"
 
-export const HOSTED_VISIBLE_OPTION_PATHS = new Set(
-  ROUTE_METADATA.filter(
-    (metadata) => metadata.hostedOptionVisibility === "visible"
-  ).map((metadata) => normalizeRoutePath(metadata.path))
-)
+export { HOSTED_VISIBLE_OPTION_PATHS, HOSTED_VISIBLE_OPTION_PATHS_LIST }
 
 export const isHostedVisibleOptionPath = (path: string) =>
   HOSTED_VISIBLE_OPTION_PATHS.has(normalizeRoutePath(path))

--- a/apps/packages/ui/src/routes/option-route-visibility.ts
+++ b/apps/packages/ui/src/routes/option-route-visibility.ts
@@ -1,16 +1,10 @@
-import { CHAT_WORKSPACE_PATH, RESEARCH_STUDIO_PATH } from "./route-paths"
+import { normalizeRoutePath, ROUTE_METADATA } from "./route-metadata"
 
-export const HOSTED_VISIBLE_OPTION_PATHS = new Set([
-  "/",
-  "/chat",
-  CHAT_WORKSPACE_PATH,
-  "/media",
-  "/knowledge",
-  "/collections",
-  RESEARCH_STUDIO_PATH,
-  "/stt",
-  "/tts"
-])
+export const HOSTED_VISIBLE_OPTION_PATHS = new Set(
+  ROUTE_METADATA.filter(
+    (metadata) => metadata.hostedOptionVisibility === "visible"
+  ).map((metadata) => normalizeRoutePath(metadata.path))
+)
 
 export const isHostedVisibleOptionPath = (path: string) =>
-  HOSTED_VISIBLE_OPTION_PATHS.has(path)
+  HOSTED_VISIBLE_OPTION_PATHS.has(normalizeRoutePath(path))

--- a/apps/packages/ui/src/routes/route-hosted-visibility.ts
+++ b/apps/packages/ui/src/routes/route-hosted-visibility.ts
@@ -1,0 +1,21 @@
+import {
+  CHAT_WORKSPACE_PATH,
+  RESEARCH_STUDIO_PATH
+} from "./route-paths"
+import { normalizeRoutePath } from "./route-path-normalization"
+
+export const HOSTED_VISIBLE_OPTION_PATHS_LIST = [
+  "/",
+  "/chat",
+  CHAT_WORKSPACE_PATH,
+  "/media",
+  "/knowledge",
+  "/collections",
+  RESEARCH_STUDIO_PATH,
+  "/stt",
+  "/tts"
+] as const
+
+export const HOSTED_VISIBLE_OPTION_PATHS = new Set(
+  HOSTED_VISIBLE_OPTION_PATHS_LIST.map((path) => normalizeRoutePath(path))
+)

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -31,6 +31,8 @@ export type RouteAvailability =
   | "extension_options"
   | "extension_sidepanel"
 
+export type HostedOptionVisibility = "visible"
+
 export type RouteMetadata = {
   path: string
   canonicalPath: string
@@ -43,6 +45,7 @@ export type RouteMetadata = {
   redirectsTo?: string
   smoke: "include" | "exclude" | "manual"
   commandPalette: "show" | "hide" | "alias_only"
+  hostedOptionVisibility?: HostedOptionVisibility
   nav: "primary" | "secondary" | "hidden"
   requiresAuth?: boolean
   requiresBackend?: boolean
@@ -69,6 +72,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: [...webAndExtensionOptions, "extension_sidepanel"],
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "primary",
     requiresBackend: true,
     rationale: "Default entry route for self-hosted WebUI and extension shells."
@@ -195,6 +199,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: [...webAndExtensionOptions, "extension_sidepanel"],
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "primary",
     requiresBackend: true,
     rationale: "Primary assistant conversation route across WebUI and extension sidepanel."
@@ -297,6 +302,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: webAndExtensionOptions,
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "secondary",
     requiresBackend: true,
     rationale: "Workspace-style chat is available for users who need denser working context."
@@ -310,6 +316,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: webAndExtensionOptions,
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "primary",
     requiresBackend: true,
     rationale: "Primary knowledge and RAG route for self-hosted users."
@@ -439,6 +446,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: webAndExtensionOptions,
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "primary",
     requiresBackend: true,
     rationale: "Primary route for ingested media review and management."
@@ -505,6 +513,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: webAndExtensionOptions,
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "secondary",
     requiresBackend: true,
     rationale: "Collection organization is a common media-library workflow."
@@ -782,6 +791,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: webAndExtensionOptions,
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "secondary",
     requiresBackend: true,
     rationale: "STT remains a direct task route inside the broader speech workflow."
@@ -795,6 +805,7 @@ const AUDITED_ROUTE_METADATA: RouteMetadata[] = [
     availability: webAndExtensionOptions,
     smoke: "include",
     commandPalette: "show",
+    hostedOptionVisibility: "visible",
     nav: "secondary",
     requiresBackend: true,
     rationale: "TTS remains a direct task route inside the broader speech workflow."
@@ -1035,6 +1046,7 @@ const registryRoute = ({
   redirectsTo,
   smoke = "include",
   commandPalette = "show",
+  hostedOptionVisibility,
   nav = "secondary",
   requiresAuth,
   requiresBackend,
@@ -1053,6 +1065,7 @@ const registryRoute = ({
   redirectsTo,
   smoke,
   commandPalette,
+  hostedOptionVisibility,
   nav,
   requiresAuth,
   requiresBackend,
@@ -1690,6 +1703,7 @@ const ROUTE_REGISTRY_METADATA: RouteMetadata[] = [
     group: "workspace",
     surface: "advanced_self_hosted",
     availability: webAndExtensionOptions,
+    hostedOptionVisibility: "visible",
     requiresBackend: true,
     rationale: "Research Studio is the canonical route for workspace playground behavior in the shared router."
   }),

--- a/apps/packages/ui/src/routes/route-metadata.ts
+++ b/apps/packages/ui/src/routes/route-metadata.ts
@@ -1,3 +1,5 @@
+import { normalizeRoutePath } from "./route-path-normalization"
+
 export type RouteSurface =
   | "default_self_hosted"
   | "advanced_self_hosted"
@@ -1728,20 +1730,7 @@ export const ROUTE_METADATA: RouteMetadata[] = [
   ...ROUTE_REGISTRY_METADATA
 ]
 
-export const normalizeRoutePath = (path: string): string => {
-  const trimmed = path.trim()
-  if (!trimmed) {
-    return "/"
-  }
-
-  const withoutHash = trimmed.split("#", 1)[0]
-  const withoutQuery = withoutHash.split("?", 1)[0] || "/"
-  if (withoutQuery === "/") {
-    return withoutQuery
-  }
-
-  return withoutQuery.replace(/\/+$/, "")
-}
+export { normalizeRoutePath }
 
 const routeMetadataByPath = new Map<string, RouteMetadata>()
 const routeMetadataByAlias = new Map<string, RouteMetadata>()

--- a/apps/packages/ui/src/routes/route-path-normalization.ts
+++ b/apps/packages/ui/src/routes/route-path-normalization.ts
@@ -1,0 +1,14 @@
+export const normalizeRoutePath = (path: string): string => {
+  const trimmed = path.trim()
+  if (!trimmed) {
+    return "/"
+  }
+
+  const withoutHash = trimmed.split("#", 1)[0]
+  const withoutQuery = withoutHash.split("?", 1)[0] || "/"
+  if (withoutQuery === "/") {
+    return withoutQuery
+  }
+
+  return withoutQuery.replace(/\/+$/, "")
+}

--- a/backlog/tasks/task-418.10.3 - Implement-WP12-sidepanel-availability-and-hosted-visibility-governance.md
+++ b/backlog/tasks/task-418.10.3 - Implement-WP12-sidepanel-availability-and-hosted-visibility-governance.md
@@ -1,0 +1,63 @@
+---
+id: TASK-418.10.3
+title: Implement WP12 sidepanel availability and hosted visibility governance
+status: Done
+labels:
+- wp12
+- webui
+- extension
+- route-governance
+priority: High
+ordinal: 3
+parent_task_id: TASK-418.10
+references:
+- TASK-418.10
+- Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+- https://github.com/rmusser01/tldw_server/pull/1960
+modified_files:
+- apps/packages/ui/src/routes/__tests__/route-governance.sidepanel-availability.test.ts
+- apps/packages/ui/src/routes/__tests__/option-route-visibility.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-chat.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-clipper.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.persona.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry.companion.test.ts
+- apps/packages/ui/src/routes/option-route-visibility.ts
+- apps/packages/ui/src/routes/route-metadata.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP12 Task 3 from the WebUI route governance QA plan: add sidepanel availability and hosted visibility governance against route metadata without page-level redesign or backend API changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Sidepanel governance tests verify metadata availability matches shared and extension sidepanel registries.
+- [ ] #2 Hosted visibility tests verify hosted-visible and hosted-hidden routes are metadata-owned, non-internal, and explicitly reasoned.
+- [ ] #3 Existing chat, clipper, flashcards, persona, and companion sidepanel handoff coverage remains intact.
+- [ ] #4 Focused sidepanel and hosted visibility Vitest checks pass, with unrelated baseline failures documented.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented WP12 Task 3 sidepanel and hosted visibility governance. Added metadata-backed hosted option visibility, derived hosted visible paths from route metadata, added sidepanel registry union governance across shared and extension registries, and tightened existing chat, clipper, flashcards, persona, and companion sidepanel handoff tests with metadata availability assertions. Focused route governance Vitest suite passed after rebase onto `origin/dev` with 11 files and 40 tests. `git diff --check` passed. Broad `bunx tsc --noEmit` remains blocked by package-wide baseline TypeScript errors outside this slice; the default heap also OOMs without `NODE_OPTIONS=--max-old-space-size=8192`. Bandit is not applicable because this slice changed TypeScript and Backlog Markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.10.3 - Implement-WP12-sidepanel-availability-and-hosted-visibility-governance.md
+++ b/backlog/tasks/task-418.10.3 - Implement-WP12-sidepanel-availability-and-hosted-visibility-governance.md
@@ -22,7 +22,10 @@ modified_files:
 - apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
 - apps/packages/ui/src/routes/__tests__/route-registry.persona.test.ts
 - apps/packages/ui/src/routes/__tests__/route-registry.companion.test.ts
+- apps/packages/ui/src/routes/__tests__/route-registry-ast-helpers.ts
 - apps/packages/ui/src/routes/option-route-visibility.ts
+- apps/packages/ui/src/routes/route-hosted-visibility.ts
+- apps/packages/ui/src/routes/route-path-normalization.ts
 - apps/packages/ui/src/routes/route-metadata.ts
 ---
 
@@ -49,7 +52,7 @@ Execute WP12 Task 3 from the WebUI route governance QA plan: add sidepanel avail
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented WP12 Task 3 sidepanel and hosted visibility governance. Added metadata-backed hosted option visibility, derived hosted visible paths from route metadata, added sidepanel registry union governance across shared and extension registries, and tightened existing chat, clipper, flashcards, persona, and companion sidepanel handoff tests with metadata availability assertions. Focused route governance Vitest suite passed after rebase onto `origin/dev` with 11 files and 40 tests. `git diff --check` passed. Broad `bunx tsc --noEmit` remains blocked by package-wide baseline TypeScript errors outside this slice; the default heap also OOMs without `NODE_OPTIONS=--max-old-space-size=8192`. Bandit is not applicable because this slice changed TypeScript and Backlog Markdown only.
+Implemented WP12 Task 3 sidepanel and hosted visibility governance. Added metadata-backed hosted option visibility, sidepanel registry union governance across shared and extension registries, and metadata assertions for chat, clipper, flashcards, persona, and companion sidepanel handoff tests. PR #1963 review follow-up moved the production hosted allowlist into lightweight route-hosted-visibility and route-path-normalization modules so option-route-visibility no longer imports the full route metadata registry, included dynamic option routes in hosted-hidden governance, added safer optional metadata checks, and made extension source lookups conditional when extension sources are absent. Focused route governance Vitest suite passed after review fixes with 42 tests. git diff --check passed. Broad bunx tsc --noEmit remains blocked by package-wide baseline TypeScript errors outside this slice; the default heap also OOMs before diagnostics. Bandit is not applicable because this slice changed TypeScript and Backlog Markdown only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Add WP12 Task 3 sidepanel availability governance across shared and extension sidepanel registries.
- Move hosted option visible-route policy onto route metadata and derive `HOSTED_VISIBLE_OPTION_PATHS` from metadata.
- Tighten existing chat, clipper, flashcards, persona, and companion sidepanel handoff tests with metadata availability assertions.

## Verification
- `bunx vitest run src/routes/__tests__/option-route-visibility.test.ts src/routes/__tests__/research-studio-route-alias.test.tsx src/routes/__tests__/route-governance.sidepanel-availability.test.ts src/routes/__tests__/route-registry.sidepanel-availability.test.ts src/routes/__tests__/route-governance.metadata-coverage.test.ts src/routes/__tests__/route-registry.visibility.test.ts src/routes/__tests__/route-registry.sidepanel-chat.test.ts src/routes/__tests__/route-registry.sidepanel-clipper.test.ts src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts src/routes/__tests__/route-registry.persona.test.ts src/routes/__tests__/route-registry.companion.test.ts` - 40 passed
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit` - blocked by existing package-wide TypeScript baseline failures outside this slice; default heap OOMs before diagnostics

## Merge note
- Repo policy requires a human-owned Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements WP12 Task 3 by enforcing sidepanel availability across shared and optional extension registries and moving hosted option visibility to a metadata-owned policy with a lightweight production allowlist. Keeps core handoff routes sidepanel-available and requires explicit rationales for hosted-hidden paths while blocking internal/redirect/deprecated routes.

- **Refactors**
  - Added `hostedOptionVisibility` to route metadata; tests derive `HOSTED_VISIBLE_OPTION_PATHS` from metadata and verify audio routes. Moved the production allowlist to `route-hosted-visibility` with `route-path-normalization`; `option-route-visibility` no longer imports `ROUTE_METADATA`.
  - Added governance tests to keep sidepanel registries and metadata in sync across shared and, when present, extension/unified registries; assert core handoff paths are registered and internal QA routes stay out of default nav.
  - Strengthened chat, clipper, flashcards, persona, and companion tests with metadata assertions (e.g., `availability: extension_sidepanel`, clipper `nav: hidden`, persona vs agent canonical path).
  - Introduced `readOptionalFirstExistingSource` and extracted `normalizeRoutePath` for safer path checks.

<sup>Written for commit 7fb4170916f1e6712b6c9bd6bb9fe4bf75b9f271. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1963?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

