### PR TITLE
Migrate MediaReviewReadingPane alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2970,17 +2970,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Review/MediaReviewReadingPane.tsx:Alert",
-    "path": "src/components/Review/MediaReviewReadingPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Review/MediaReviewReadingPane.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/StudySuggestions/StudySuggestionsPanel.tsx:Alert",
     "path": "src/components/StudySuggestions/StudySuggestionsPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
+++ b/apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { Button, Tag, Tooltip, Radio, Select, Dropdown, Switch, Spin, Skeleton, Empty, Typography, Alert } from "antd"
+import { Button, Tag, Tooltip, Radio, Select, Dropdown, Switch, Spin, Skeleton, Empty, Typography } from "antd"
 import { CopyIcon, HelpCircle, Settings2, ChevronLeft, ChevronRight, Layers, LayoutGrid, Focus, Rows3, Check, MessageSquare } from "lucide-react"
 import { ChevronDown, ChevronUp } from "lucide-react"
 import type { VirtualItem } from "@tanstack/react-virtual"
+import { Alert } from "@/components/ui/primitives"
 import { clearSetting } from "@/services/settings/registry"
 import {
   MEDIA_REVIEW_SELECTION_SETTING,
@@ -294,15 +295,13 @@ export const MediaReviewReadingPane: React.FC<MediaReviewReadingPaneProps> = ({ 
 
         {hasFailed && (
           <Alert
-            type="error"
-            showIcon
+            variant="error"
             className="mt-3"
             title={t('mediaPage.loadFailed', 'Failed to load content')}
-            action={
-              <Button size="small" onClick={() => retryFetch(d.id)}>
-                {t('mediaPage.retry', 'Retry')}
-              </Button>
-            }
+            action={{
+              label: t('mediaPage.retry', 'Retry'),
+              onClick: () => retryFetch(d.id)
+            }}
           />
         )}
 

--- a/apps/packages/ui/src/components/Review/__tests__/MediaReviewReadingPane.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/MediaReviewReadingPane.design-system-alert.test.tsx
@@ -1,0 +1,198 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { MediaReviewReadingPane } from "../MediaReviewReadingPane"
+import type { MediaDetail, MediaReviewActions, MediaReviewState } from "../media-review-types"
+
+vi.mock("@/components/Review/ContentRenderer", () => ({
+  ContentRenderer: ({ content }: { content: string }) => (
+    <div data-testid="mock-content-renderer">{content}</div>
+  )
+}))
+
+vi.mock("@/components/Review/InContentSearch", () => ({
+  InContentSearch: () => null
+}))
+
+vi.mock("@/components/Review/SectionNavigator", () => ({
+  SectionNavigator: () => null
+}))
+
+vi.mock("@/components/Review/ComparisonSplit", () => ({
+  ComparisonSplit: () => null
+}))
+
+vi.mock("@/services/settings/registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/settings/registry")>()),
+  clearSetting: vi.fn()
+}))
+
+const interpolate = (template: string, opts?: Record<string, unknown>) =>
+  template.replace(/\{\{(\w+)\}\}/g, (_, key) => String(opts?.[key] ?? ""))
+
+const t = (
+  key: string,
+  defaultValueOrOpts?: string | Record<string, unknown>,
+  opts?: Record<string, unknown>
+) => {
+  if (typeof defaultValueOrOpts === "string") {
+    return interpolate(defaultValueOrOpts, opts)
+  }
+  if (typeof defaultValueOrOpts?.defaultValue === "string") {
+    return interpolate(defaultValueOrOpts.defaultValue, defaultValueOrOpts)
+  }
+  return key
+}
+
+const makeVirtualizer = () => ({
+  getTotalSize: () => 240,
+  getVirtualItems: () => [
+    {
+      index: 0,
+      key: 0,
+      start: 0,
+      size: 240,
+      end: 240
+    }
+  ],
+  measureElement: vi.fn()
+})
+
+const makeDetail = (): MediaDetail => ({
+  id: 42,
+  title: "Failed media",
+  type: "video",
+  created_at: "2026-05-01T00:00:00Z",
+  content: "Transcript body"
+})
+
+const makeState = (): MediaReviewState => {
+  const detail = makeDetail()
+  const viewerVirtualizer = makeVirtualizer()
+  const stackVirtualizer = makeVirtualizer()
+
+  return {
+    t,
+    message: {
+      info: vi.fn(),
+      warning: vi.fn(),
+      success: vi.fn(),
+      error: vi.fn()
+    },
+    selectedIds: [detail.id],
+    setSelectedIds: vi.fn(),
+    focusedId: detail.id,
+    setFocusedId: vi.fn(),
+    previewedId: null,
+    setPreviewedId: vi.fn(),
+    previewedDetail: null,
+    previewIndex: -1,
+    details: { [detail.id]: detail },
+    setDetails: vi.fn(),
+    detailLoading: {},
+    setDetailLoading: vi.fn(),
+    failedIds: new Set([detail.id]),
+    setFailedIds: vi.fn(),
+    viewMode: "spread",
+    viewModeState: "spread",
+    setViewModeState: vi.fn(),
+    setViewMode: vi.fn(),
+    viewerItems: [detail],
+    focusedDetail: detail,
+    focusIndex: 0,
+    allResults: [detail],
+    viewerRef: React.createRef<HTMLDivElement>(),
+    viewerParentRef: React.createRef<HTMLDivElement>(),
+    stackParentRef: React.createRef<HTMLDivElement>(),
+    cardRefs: { current: {} },
+    viewerVirtualizer,
+    stackVirtualizer,
+    helpDismissed: true,
+    helpDismissedLoading: false,
+    setHelpDismissed: vi.fn(),
+    helpModalOpen: false,
+    setHelpModalOpen: vi.fn(),
+    isMobileViewport: false,
+    orientation: "vertical",
+    setOrientation: vi.fn(),
+    hideTranscriptTimings: true,
+    setHideTranscriptTimings: vi.fn(),
+    shouldHideTranscriptTimings: false,
+    contentExpandedIds: new Set(),
+    setContentExpandedIds: vi.fn(),
+    analysisExpandedIds: new Set(),
+    setAnalysisExpandedIds: vi.fn(),
+    showEmptyAnalysisIds: new Set(),
+    setShowEmptyAnalysisIds: vi.fn(),
+    copiedIds: new Set(),
+    setCopiedIds: vi.fn(),
+    autoViewMode: false,
+    autoViewModeSetting: false,
+    setAutoViewModeSetting: vi.fn(),
+    autoModeInlineNotice: null,
+    setAutoModeInlineNotice: vi.fn(),
+    manualViewModePinned: false,
+    setManualViewModePinned: vi.fn(),
+    collapseOthers: false,
+    setCollapseOthers: vi.fn(),
+    selectedItemsDrawerOpen: false,
+    setSelectedItemsDrawerOpen: vi.fn(),
+    openAllLimit: 25,
+    hasTranscriptTimingContentInViewer: false,
+    cardCls: "rounded border border-border bg-surface p-3",
+    setQuery: vi.fn(),
+    setTypes: vi.fn(),
+    setKeywordTokens: vi.fn()
+  } as unknown as MediaReviewState
+}
+
+const makeActions = (retryFetch = vi.fn()): MediaReviewActions =>
+  ({
+    previewItem: vi.fn(),
+    toggleSelect: vi.fn(),
+    ensureDetail: vi.fn(),
+    retryFetch,
+    removeFromSelection: vi.fn(),
+    clearSelectionWithGuard: vi.fn(),
+    addVisibleToSelection: vi.fn(),
+    replaceSelectionWithVisible: vi.fn(),
+    goRelative: vi.fn(),
+    scrollToCard: vi.fn(),
+    runContentFiltering: vi.fn(),
+    cancelContentFiltering: vi.fn(),
+    mapMediaItems: vi.fn(),
+    loadKeywordSuggestions: vi.fn(),
+    handleBatchAddTags: vi.fn(),
+    handleBatchMoveToTrash: vi.fn(),
+    handleBatchExport: vi.fn(),
+    handleBatchReprocess: vi.fn(),
+    handleCompareContent: vi.fn(),
+    handleChatAboutSelection: vi.fn(),
+    expandAllContent: vi.fn(),
+    collapseAllContent: vi.fn(),
+    expandAllAnalysis: vi.fn(),
+    collapseAllAnalysis: vi.fn(),
+    getSelectedNumericIds: vi.fn(),
+    openTrashFromBatch: vi.fn(),
+    confirmBatchTrash: vi.fn(),
+    resolveDetailForCompare: vi.fn()
+  }) as unknown as MediaReviewActions
+
+describe("MediaReviewReadingPane product-state alerts", () => {
+  it("renders failed content through the design-system Alert and keeps retry behavior", () => {
+    const retryFetch = vi.fn()
+
+    render(
+      <MediaReviewReadingPane
+        state={makeState()}
+        actions={makeActions(retryFetch)}
+      />
+    )
+
+    const failedTitle = screen.getByText("Failed to load content")
+    expect(failedTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    expect(retryFetch).toHaveBeenCalledWith(42)
+  })
+})

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12
 title: 'Migrate design-system product state: Writing and Review surfaces'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:20'
 labels:
@@ -28,9 +28,15 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 The linked GitHub issue owns current count and public status.
-- [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
+- [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
 - [ ] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Created TASK-45.44.12.2 for the narrow Review slice covering `MediaReviewReadingPane` failed-load Alert migration. Verification on the slice reduced the product-state baseline from 291 to 290 and `Writing and Review surfaces` from 21 to 20.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -35,7 +35,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-- Created TASK-45.44.12.2 for the narrow Review slice covering `MediaReviewReadingPane` failed-load Alert migration. Verification on the slice reduced the product-state baseline from 291 to 290 and `Writing and Review surfaces` from 21 to 20.
+- Created TASK-45.44.12.2 for the narrow Review slice covering `MediaReviewReadingPane` failed-load Alert migration. Verification on the slice reduced the product-state baseline from 291 to 290 and `Writing and Review surfaces` from 21 to 20. PR: https://github.com/rmusser01/tldw_server/pull/1964
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.2 - Migrate-MediaReviewReadingPane-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.2 - Migrate-MediaReviewReadingPane-alert-to-design-system-Alert.md
@@ -1,0 +1,75 @@
+---
+id: TASK-45.44.12.2
+title: Migrate MediaReviewReadingPane alert to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- review
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
+- apps/packages/ui/src/components/Review/__tests__/MediaReviewReadingPane.design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the single product-state AntD Alert in `MediaReviewReadingPane` to the shared design-system Alert primitive. This clears the remaining Review-area product-state baseline entry while preserving the failed-content retry affordance.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] The failed-content alert in `MediaReviewReadingPane` renders through the shared design-system Alert primitive.
+- [x] The alert keeps the existing failed-load copy and retry action behavior.
+- [x] The `MediaReviewReadingPane` AntD Alert exception is removed from the product-state baseline.
+- [x] Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add a focused failing test that renders the `MediaReviewReadingPane` failed-load state and asserts the error alert uses the shared design-system Alert marker.
+- [x] Replace the guarded AntD Alert usage in `MediaReviewReadingPane` with the shared design-system Alert primitive while preserving copy and action behavior.
+- [x] Remove the migrated `MediaReviewReadingPane` Alert row from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `MediaReviewReadingPane.design-system-alert.test.tsx`. The initial red run failed because the failed-load text was not inside `[data-ds-component="Alert"]`.
+- Replaced the failed-load AntD Alert with the shared `Alert` primitive from `@/components/ui/primitives`, using `variant="error"` and the primitive action API to preserve the Retry callback.
+- Removed `antd-product-state-import:src/components/Review/MediaReviewReadingPane.tsx:Alert` from the product-state baseline. Baseline count is now 290; `Writing and Review surfaces` is now 20.
+- Verification:
+  - `bunx vitest run src/components/Review/__tests__/MediaReviewReadingPane.design-system-alert.test.tsx --reporter=dot` passed.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed with 54 tests.
+  - `node -e 'const data=JSON.parse(require("fs").readFileSync("apps/packages/ui/scripts/design-system-product-state-baseline.json","utf8")); console.log(data.length); if (data.some((entry)=>entry.path==="src/components/Review/MediaReviewReadingPane.tsx")) process.exit(1);'` printed `290`.
+  - `bun run verify:design-system-state` passed and reported `Baseline exceptions: 290` and `Writing and Review surfaces: 20`.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI TypeScript debt; no diagnostics mention `MediaReviewReadingPane` or the new test.
+  - `git diff --check` passed.
+- Bandit skipped: touched implementation is TypeScript/React UI code and JSON/test metadata only, with no Python touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.2 - Migrate-MediaReviewReadingPane-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.2 - Migrate-MediaReviewReadingPane-alert-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.2
 title: Migrate MediaReviewReadingPane alert to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1964
 modified_files:
 - apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
 - apps/packages/ui/src/components/Review/__tests__/MediaReviewReadingPane.design-system-alert.test.tsx
@@ -56,12 +57,13 @@ Migrate the single product-state AntD Alert in `MediaReviewReadingPane` to the s
   - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI TypeScript debt; no diagnostics mention `MediaReviewReadingPane` or the new test.
   - `git diff --check` passed.
 - Bandit skipped: touched implementation is TypeScript/React UI code and JSON/test metadata only, with no Python touched.
+- PR: https://github.com/rmusser01/tldw_server/pull/1964
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the `MediaReviewReadingPane` failed-content alert to the shared design-system Alert primitive, added focused regression coverage for the design-system marker and Retry behavior, and removed the remaining Review baseline exception. PR: https://github.com/rmusser01/tldw_server/pull/1964
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -70,6 +72,6 @@ Migrate the single product-state AntD Alert in `MediaReviewReadingPane` to the s
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the MediaReviewReadingPane failed-content alert from AntD Alert to the shared design-system Alert primitive.
- Adds focused coverage that asserts the design-system Alert marker and retry callback behavior.
- Removes the migrated Review alert row from the product-state baseline, reducing total exceptions from 291 to 290 and Writing/Review from 21 to 20.

## Verification
- bunx vitest run src/components/Review/__tests__/MediaReviewReadingPane.design-system-alert.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- node -e baseline JSON parse and MediaReviewReadingPane absence check
- bun run verify:design-system-state
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false (fails on existing repo-wide UI TypeScript debt; no diagnostics mention MediaReviewReadingPane or the new test)
- git diff --check

## Change summary
This PR keeps the migration slice intentionally narrow: the reading pane already owns the failed-content retry state, so the implementation swaps only the rendering primitive and uses the design-system Alert action API to preserve the existing retry callback. The baseline row is removed only after guard verification confirms the migrated usage no longer appears.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the MediaReviewReadingPane failed-content alert from `antd` to the design-system `Alert`, preserving the retry action. Adds a focused test, removes one product-state exception, and records backlog task metadata for this migration slice.

- **Refactors**
  - Replaced `antd` `Alert` with `Alert` from `@/components/ui/primitives` using `variant="error"` and the `action` API.
  - Added `MediaReviewReadingPane.design-system-alert.test.tsx` to assert the design-system marker and retry callback.
  - Removed the baseline exception for this alert (total exceptions 291 → 290; Writing/Review 21 → 20).

<sup>Written for commit a67f2d938f0ae98b9088bc2280e394606acdf8e0. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1964?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

