### PR TITLE
Migrate WritingPlaygroundWordcloudCard alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2728,17 +2728,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx:Alert",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Quiz/tabs/CreateTab.tsx:Alert#antd-alert-createtab-type-info-line-1003-u954tt",
     "path": "src/components/Quiz/tabs/CreateTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
-import { Alert, Button, Tag } from "antd"
+import { Button, Tag } from "antd"
+import { Alert } from "@/components/ui/primitives"
 import type { WordcloudCardProps } from "./WritingPlaygroundDiagnostics.types"
 
 const MAX_WORDCLOUD_WORDS_TO_DISPLAY = 12
@@ -41,7 +42,7 @@ export const WritingPlaygroundWordcloudCard: FC<WordcloudCardProps> = ({
         </Button>
       ) : null}
     </div>
-    {wordcloudError ? <Alert type="error" showIcon message={wordcloudError} /> : null}
+    {wordcloudError ? <Alert variant="error" title={wordcloudError} /> : null}
     {wordcloudWords.length > 0 ? (
       <div className="max-h-40 overflow-y-auto rounded-md border border-border bg-background px-2 py-1">
         <div className="flex flex-col gap-1 text-xs">

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundWordcloudCard.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundWordcloudCard.design-system-alert.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { WritingPlaygroundWordcloudCard } from "../WritingPlaygroundWordcloudCard"
+import type { WordcloudCardProps } from "../WritingPlaygroundDiagnostics.types"
+
+const t: WordcloudCardProps["t"] = (_key, defaultValue) => defaultValue
+
+const makeProps = (
+  overrides: Partial<WordcloudCardProps> = {}
+): WordcloudCardProps => ({
+  t,
+  wordcloudStatus: null,
+  wordcloudStatusColor: "default",
+  canGenerateWordcloud: true,
+  isGeneratingWordcloud: false,
+  onGenerateWordcloud: vi.fn(),
+  wordcloudError: "Unable to build wordcloud",
+  onClearWordcloud: vi.fn(),
+  wordcloudWords: [],
+  ...overrides
+})
+
+describe("WritingPlaygroundWordcloudCard product-state alerts", () => {
+  it("renders wordcloud errors through the design-system Alert and keeps clear behavior", () => {
+    const onClearWordcloud = vi.fn()
+
+    render(
+      <WritingPlaygroundWordcloudCard
+        {...makeProps({ onClearWordcloud })}
+      />
+    )
+
+    const errorMessage = screen.getByText("Unable to build wordcloud")
+    expect(errorMessage.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }))
+    expect(onClearWordcloud).toHaveBeenCalledTimes(1)
+  })
+})

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -36,6 +36,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created TASK-45.44.12.2 for the narrow Review slice covering `MediaReviewReadingPane` failed-load Alert migration. Verification on the slice reduced the product-state baseline from 291 to 290 and `Writing and Review surfaces` from 21 to 20. PR: https://github.com/rmusser01/tldw_server/pull/1964
+- Created TASK-45.44.12.3 for the narrow Writing slice covering `WritingPlaygroundWordcloudCard` wordcloud error Alert migration. Verification on the slice reduced the product-state baseline from 290 to 289 and `Writing and Review surfaces` from 20 to 19. PR: https://github.com/rmusser01/tldw_server/pull/1965
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.3 - Migrate-WritingPlaygroundWordcloudCard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.3 - Migrate-WritingPlaygroundWordcloudCard-alert-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.3
 title: Migrate WritingPlaygroundWordcloudCard alert to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1965
 modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx
 - apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundWordcloudCard.design-system-alert.test.tsx
@@ -56,12 +57,13 @@ Migrate the single product-state AntD Alert in `WritingPlaygroundWordcloudCard` 
   - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI TypeScript debt; no diagnostics mention `WritingPlaygroundWordcloudCard` or the new test.
   - `git diff --check` passed.
 - Bandit skipped: touched implementation is TypeScript/React UI code and JSON/test metadata only, with no Python touched.
+- PR: https://github.com/rmusser01/tldw_server/pull/1965
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the `WritingPlaygroundWordcloudCard` wordcloud error alert to the shared design-system Alert primitive, added focused regression coverage for the design-system marker and Clear behavior, and removed the migrated baseline exception. PR: https://github.com/rmusser01/tldw_server/pull/1965
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -70,6 +72,6 @@ Migrate the single product-state AntD Alert in `WritingPlaygroundWordcloudCard` 
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.3 - Migrate-WritingPlaygroundWordcloudCard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.3 - Migrate-WritingPlaygroundWordcloudCard-alert-to-design-system-Alert.md
@@ -1,0 +1,75 @@
+---
+id: TASK-45.44.12.3
+title: Migrate WritingPlaygroundWordcloudCard alert to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundWordcloudCard.design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the single product-state AntD Alert in `WritingPlaygroundWordcloudCard` to the shared design-system Alert primitive. This reduces the Writing/Review product-state baseline while preserving the wordcloud error copy and existing generate/clear controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] The wordcloud error alert renders through the shared design-system Alert primitive.
+- [x] The component keeps the existing wordcloud error copy and generate/clear behavior.
+- [x] The `WritingPlaygroundWordcloudCard` AntD Alert exception is removed from the product-state baseline.
+- [x] Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add a focused failing test that renders the wordcloud error state and asserts the error alert uses the shared design-system Alert marker.
+- [x] Replace the guarded AntD Alert usage in `WritingPlaygroundWordcloudCard` with the shared design-system Alert primitive while preserving copy and behavior.
+- [x] Remove the migrated `WritingPlaygroundWordcloudCard` Alert row from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `WritingPlaygroundWordcloudCard.design-system-alert.test.tsx`. The initial red run failed because the wordcloud error text was not inside `[data-ds-component="Alert"]`.
+- Replaced the wordcloud AntD Alert with the shared `Alert` primitive from `@/components/ui/primitives`, using `variant="error"` and `title={wordcloudError}` to preserve the visible copy.
+- Removed `antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx:Alert` from the product-state baseline. Baseline count is now 289; `Writing and Review surfaces` is now 19.
+- Verification:
+  - `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundWordcloudCard.design-system-alert.test.tsx --reporter=dot` passed.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed with 54 tests.
+  - `node -e 'const data=JSON.parse(require("fs").readFileSync("apps/packages/ui/scripts/design-system-product-state-baseline.json","utf8")); console.log(data.length); if (data.some((entry)=>entry.path==="src/components/Option/WritingPlayground/WritingPlaygroundWordcloudCard.tsx")) process.exit(1);'` printed `289`.
+  - `bun run verify:design-system-state` passed and reported `Baseline exceptions: 289` and `Writing and Review surfaces: 19`.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI TypeScript debt; no diagnostics mention `WritingPlaygroundWordcloudCard` or the new test.
+  - `git diff --check` passed.
+- Bandit skipped: touched implementation is TypeScript/React UI code and JSON/test metadata only, with no Python touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the WritingPlaygroundWordcloudCard wordcloud error alert from AntD Alert to the shared design-system Alert primitive.
- Adds focused coverage that asserts the design-system Alert marker and existing Clear behavior.
- Removes the migrated WritingPlaygroundWordcloudCard row from the product-state baseline, reducing total exceptions from 290 to 289 and Writing/Review from 20 to 19.

## Verification
- bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundWordcloudCard.design-system-alert.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- node -e baseline JSON parse and WritingPlaygroundWordcloudCard absence check
- bun run verify:design-system-state
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false (fails on existing repo-wide UI TypeScript debt; no diagnostics mention WritingPlaygroundWordcloudCard or the new test)
- git diff --check

## Change summary
This PR keeps the migration scoped to one leaf card. The wordcloud card already owns the error message and clear action, so the implementation only swaps the rendering primitive and maps the existing error message to the design-system Alert title. The baseline row is removed after guard verification confirms the migrated AntD Alert usage is gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the WritingPlaygroundWordcloudCard wordcloud error alert to the design-system `Alert` for consistent UI and guard compliance. Removes a legacy product-state exception.

- **Migration**
  - Replaced `antd` `Alert` with design-system `Alert` from `@/components/ui/primitives` using `variant="error"` and `title={wordcloudError}`.
  - Added a focused test that asserts `[data-ds-component="Alert"]` and preserves the Clear action.
  - Removed the component’s baseline exception (now 289 total; Writing/Review 19) and recorded the migration in `TASK-45.44.12.3`.

<sup>Written for commit 82035149212ea2d8de5143e63247816bbec72e2c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1965?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

