### PR TITLE
Migrate WritingPlaygroundResponseInspectorCard alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2695,17 +2695,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx:Alert",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx:Alert#antd-alert-writingplaygroundtokeninspectorcard-type-erro-i8ourj",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
-import { Alert, Button, Tag } from "antd"
+import { Button, Tag } from "antd"
+import { Alert } from "@/components/ui/primitives"
 import type { ResponseInspectorCardProps } from "./WritingPlaygroundDiagnostics.types"
 
 export const WritingPlaygroundResponseInspectorCard: FC<
@@ -59,9 +60,8 @@ export const WritingPlaygroundResponseInspectorCard: FC<
     </div>
     {!settingsLogprobsEnabled ? (
       <Alert
-        type="info"
-        showIcon
-        message={t(
+        variant="info"
+        title={t(
           "option:writingPlayground.responseInspectorDisabled",
           "Enable logprobs in generation settings to capture response token scores."
         )}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundResponseInspectorCard.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundResponseInspectorCard.design-system-alert.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { WritingPlaygroundResponseInspectorCard } from "../WritingPlaygroundResponseInspectorCard"
+import type { ResponseInspectorCardProps } from "../WritingPlaygroundDiagnostics.types"
+
+const t: ResponseInspectorCardProps["t"] = (_key, defaultValue, options) =>
+  defaultValue.replace(/\{\{(\w+)\}\}/g, (_, key) => String(options?.[key] ?? ""))
+
+const makeProps = (
+  overrides: Partial<ResponseInspectorCardProps> = {}
+): ResponseInspectorCardProps => ({
+  t,
+  responseInspectorRowsCount: 0,
+  responseLogprobsCount: 0,
+  settingsLogprobsEnabled: false,
+  settingsDisabled: false,
+  responseLogprobRowsCount: 0,
+  responseLogprobTruncated: false,
+  onCopyResponseInspectorJson: vi.fn(),
+  onExportResponseInspectorCsv: vi.fn(),
+  onClearResponseInspector: vi.fn(),
+  ...overrides
+})
+
+describe("WritingPlaygroundResponseInspectorCard product-state alerts", () => {
+  it("renders response inspector guidance through the design-system Alert", () => {
+    render(<WritingPlaygroundResponseInspectorCard {...makeProps()} />)
+
+    const guidance = screen.getByText(
+      "Enable logprobs in generation settings to capture response token scores."
+    )
+    expect(guidance.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -37,6 +37,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created TASK-45.44.12.2 for the narrow Review slice covering `MediaReviewReadingPane` failed-load Alert migration. Verification on the slice reduced the product-state baseline from 291 to 290 and `Writing and Review surfaces` from 21 to 20. PR: https://github.com/rmusser01/tldw_server/pull/1964
 - Created TASK-45.44.12.3 for the narrow Writing slice covering `WritingPlaygroundWordcloudCard` wordcloud error Alert migration. Verification on the slice reduced the product-state baseline from 290 to 289 and `Writing and Review surfaces` from 20 to 19. PR: https://github.com/rmusser01/tldw_server/pull/1965
+- Created TASK-45.44.12.4 for the narrow Writing slice covering `WritingPlaygroundResponseInspectorCard` response inspector guidance Alert migration. Verification on the slice reduced the product-state baseline from 289 to 288 and `Writing and Review surfaces` from 19 to 18. PR: https://github.com/rmusser01/tldw_server/pull/1966
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.4 - Migrate-WritingPlaygroundResponseInspectorCard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.4 - Migrate-WritingPlaygroundResponseInspectorCard-alert-to-design-system-Alert.md
@@ -1,0 +1,75 @@
+---
+id: TASK-45.44.12.4
+title: Migrate WritingPlaygroundResponseInspectorCard alert to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundResponseInspectorCard.design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the single product-state AntD Alert in `WritingPlaygroundResponseInspectorCard` to the shared design-system Alert primitive. This reduces the Writing/Review product-state baseline while preserving the response inspector guidance copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] The response inspector guidance alert renders through the shared design-system Alert primitive.
+- [x] The component keeps the existing guidance copy and response inspector controls.
+- [x] The `WritingPlaygroundResponseInspectorCard` AntD Alert exception is removed from the product-state baseline.
+- [x] Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add a focused failing test that renders the response inspector guidance state and asserts the alert uses the shared design-system Alert marker.
+- [x] Replace the guarded AntD Alert usage in `WritingPlaygroundResponseInspectorCard` with the shared design-system Alert primitive while preserving copy and behavior.
+- [x] Remove the migrated `WritingPlaygroundResponseInspectorCard` Alert row from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `WritingPlaygroundResponseInspectorCard.design-system-alert.test.tsx`. The initial red run failed because the response inspector guidance text was not inside `[data-ds-component="Alert"]`.
+- Replaced the response inspector AntD Alert with the shared `Alert` primitive from `@/components/ui/primitives`, using `variant="info"` and `title={...}` to preserve the visible guidance copy.
+- Removed `antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx:Alert` from the product-state baseline. Baseline count is now 288; `Writing and Review surfaces` is now 18.
+- Verification:
+  - `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundResponseInspectorCard.design-system-alert.test.tsx --reporter=dot` passed.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed with 54 tests.
+  - `node -e 'const data=JSON.parse(require("fs").readFileSync("apps/packages/ui/scripts/design-system-product-state-baseline.json","utf8")); console.log(data.length); if (data.some((entry)=>entry.path==="src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx")) process.exit(1);'` printed `288`.
+  - `bun run verify:design-system-state` passed and reported `Baseline exceptions: 288` and `Writing and Review surfaces: 18`.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI TypeScript debt; no diagnostics mention `WritingPlaygroundResponseInspectorCard` or the new test.
+  - `git diff --check` passed.
+- Bandit skipped: touched implementation is TypeScript/React UI code and JSON/test metadata only, with no Python touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.4 - Migrate-WritingPlaygroundResponseInspectorCard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.4 - Migrate-WritingPlaygroundResponseInspectorCard-alert-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.4
 title: Migrate WritingPlaygroundResponseInspectorCard alert to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1966
 modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundResponseInspectorCard.tsx
 - apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundResponseInspectorCard.design-system-alert.test.tsx
@@ -56,12 +57,13 @@ Migrate the single product-state AntD Alert in `WritingPlaygroundResponseInspect
   - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing repo-wide UI TypeScript debt; no diagnostics mention `WritingPlaygroundResponseInspectorCard` or the new test.
   - `git diff --check` passed.
 - Bandit skipped: touched implementation is TypeScript/React UI code and JSON/test metadata only, with no Python touched.
+- PR: https://github.com/rmusser01/tldw_server/pull/1966
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the `WritingPlaygroundResponseInspectorCard` response inspector guidance alert to the shared design-system Alert primitive, added focused regression coverage for the design-system marker, and removed the migrated baseline exception. PR: https://github.com/rmusser01/tldw_server/pull/1966
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -70,6 +72,6 @@ Migrate the single product-state AntD Alert in `WritingPlaygroundResponseInspect
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the WritingPlaygroundResponseInspectorCard logprobs guidance alert from AntD Alert to the shared design-system Alert primitive.
- Adds focused coverage that asserts the design-system Alert marker around the response inspector guidance copy.
- Removes the migrated WritingPlaygroundResponseInspectorCard row from the product-state baseline, reducing total exceptions from 289 to 288 and Writing/Review from 19 to 18.

## Verification
- bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundResponseInspectorCard.design-system-alert.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- node -e baseline JSON parse and WritingPlaygroundResponseInspectorCard absence check
- bun run verify:design-system-state
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false (fails on existing repo-wide UI TypeScript debt; no diagnostics mention WritingPlaygroundResponseInspectorCard or the new test)
- git diff --check

## Change summary
This PR keeps the migration scoped to one leaf card. The response inspector card already owns the logprobs guidance copy, so the implementation swaps only the rendering primitive and maps the existing message into the design-system Alert title. The baseline row is removed after guard verification confirms the AntD Alert usage is gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the logprobs guidance alert in WritingPlaygroundResponseInspectorCard from `antd` to the design-system `Alert` to standardize UI and remove a product-state exception.

- **Refactors**
  - Replaced `antd` Alert with the design-system `Alert` using variant="info" and mapped title.
  - Added a focused test asserting the guidance text renders within the design-system Alert.
  - Removed the component’s legacy product-state exception (total 289→288; Writing/Review 19→18).
  - Recorded migration metadata and task notes under TASK-45.44.12.4.

<sup>Written for commit 727ea7449ce092a70b7af6b92df5256dfda5bc44. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1966?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

