### PR TITLE
Migrate WritingPlaygroundActiveSessionGuard alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2629,17 +2629,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx:Alert",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-info-l-1cwjvuu",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
@@ -1,5 +1,6 @@
 import type { FC, ReactNode } from "react"
-import { Alert, Empty, Skeleton } from "antd"
+import { Empty, Skeleton } from "antd"
+import { Alert } from "@/components/ui/primitives"
 import type { TranslateFn } from "./WritingPlaygroundDiagnostics.types"
 
 type WritingPlaygroundActiveSessionGuardProps = {
@@ -31,8 +32,7 @@ export const WritingPlaygroundActiveSessionGuard: FC<
   if (hasError) {
     return (
       <Alert
-        type="error"
-        showIcon
+        variant="error"
         title={t(
           "option:writingPlayground.settingsError",
           "Unable to load session settings."

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { WritingPlaygroundActiveSessionGuard } from "../WritingPlaygroundActiveSessionGuard"
+import type { TranslateFn } from "../WritingPlaygroundDiagnostics.types"
+
+const t: TranslateFn = (_key, defaultValue) => defaultValue
+
+describe("WritingPlaygroundActiveSessionGuard product-state alerts", () => {
+  it("renders load failures through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundActiveSessionGuard
+        hasActiveSession
+        isLoading={false}
+        hasError
+        t={t}>
+        <div>ready content</div>
+      </WritingPlaygroundActiveSessionGuard>
+    )
+
+    const errorTitle = screen.getByText("Unable to load session settings.")
+    expect(errorTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -38,6 +38,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created TASK-45.44.12.2 for the narrow Review slice covering `MediaReviewReadingPane` failed-load Alert migration. Verification on the slice reduced the product-state baseline from 291 to 290 and `Writing and Review surfaces` from 21 to 20. PR: https://github.com/rmusser01/tldw_server/pull/1964
 - Created TASK-45.44.12.3 for the narrow Writing slice covering `WritingPlaygroundWordcloudCard` wordcloud error Alert migration. Verification on the slice reduced the product-state baseline from 290 to 289 and `Writing and Review surfaces` from 20 to 19. PR: https://github.com/rmusser01/tldw_server/pull/1965
 - Created TASK-45.44.12.4 for the narrow Writing slice covering `WritingPlaygroundResponseInspectorCard` response inspector guidance Alert migration. Verification on the slice reduced the product-state baseline from 289 to 288 and `Writing and Review surfaces` from 19 to 18. PR: https://github.com/rmusser01/tldw_server/pull/1966
+- Created TASK-45.44.12.5 for the narrow Writing slice covering `WritingPlaygroundActiveSessionGuard` settings-load Alert migration. Verification on the slice reduced the product-state baseline from 288 to 287 and `Writing and Review surfaces` from 18 to 17. PR: https://github.com/rmusser01/tldw_server/pull/1967
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.5 - Migrate-WritingPlaygroundActiveSessionGuard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.5 - Migrate-WritingPlaygroundActiveSessionGuard-alert-to-design-system-Alert.md
@@ -1,0 +1,74 @@
+---
+id: TASK-45.44.12.5
+title: Migrate WritingPlaygroundActiveSessionGuard alert to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the single product-state AntD Alert in `WritingPlaygroundActiveSessionGuard` to the shared design-system Alert primitive. This reduces the Writing/Review product-state baseline while preserving the session-settings load failure copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] The active-session load failure alert renders through the shared design-system Alert primitive.
+- [x] The component keeps the existing session-settings error copy and child/empty/loading behavior.
+- [x] The `WritingPlaygroundActiveSessionGuard` AntD Alert exception is removed from the product-state baseline.
+- [x] Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add a focused failing test that renders the active-session load failure state and asserts the alert uses the shared design-system Alert marker.
+- [x] Replace the guarded AntD Alert usage in `WritingPlaygroundActiveSessionGuard` with the shared design-system Alert primitive while preserving copy and behavior.
+- [x] Remove the migrated `WritingPlaygroundActiveSessionGuard` Alert row from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx`; red state failed because the AntD Alert did not provide the `data-ds-component="Alert"` marker.
+- Replaced the load-failure AntD `Alert` with the shared design-system `Alert` using `variant="error"`. The existing translated title and loading/empty/children branches are unchanged.
+- Removed the `WritingPlaygroundActiveSessionGuard` Alert baseline row. Baseline count is now 287 total exceptions, with Writing and Review surfaces at 17.
+- Verification: `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx --reporter=dot` passed.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
+- Verification: `bun run verify:design-system-state` passed and reported 287 baseline exceptions / 17 Writing and Review exceptions.
+- Verification: baseline JSON parse and absence check for `src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx` passed.
+- Verification: `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_active_session_tsc.log` contains no diagnostics for the touched component or new test.
+- Bandit: skipped because this slice only touches frontend TypeScript/TSX and JSON task metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.5 - Migrate-WritingPlaygroundActiveSessionGuard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.5 - Migrate-WritingPlaygroundActiveSessionGuard-alert-to-design-system-Alert.md
@@ -62,7 +62,7 @@ Migrate the single product-state AntD Alert in `WritingPlaygroundActiveSessionGu
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the `WritingPlaygroundActiveSessionGuard` settings-load error state to the shared design-system Alert primitive, added focused marker coverage, and removed the retired product-state baseline exception. The slice reduces the product-state baseline to 287 total exceptions and Writing/Review to 17.
+Migrated the `WritingPlaygroundActiveSessionGuard` settings-load error state to the shared design-system Alert primitive, added focused marker coverage, and removed the retired product-state baseline exception. Verification passed for the focused guard test, product-state guard test, `verify:design-system-state`, baseline absence check, and `git diff --check`; the slice reduces the product-state baseline to 287 total exceptions and Writing/Review to 17.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.5 - Migrate-WritingPlaygroundActiveSessionGuard-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.5 - Migrate-WritingPlaygroundActiveSessionGuard-alert-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.5
 title: Migrate WritingPlaygroundActiveSessionGuard alert to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1967
 modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
 - apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx
@@ -55,12 +56,13 @@ Migrate the single product-state AntD Alert in `WritingPlaygroundActiveSessionGu
 - Verification: `git diff --check` passed.
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_active_session_tsc.log` contains no diagnostics for the touched component or new test.
 - Bandit: skipped because this slice only touches frontend TypeScript/TSX and JSON task metadata.
+- PR: https://github.com/rmusser01/tldw_server/pull/1967
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the `WritingPlaygroundActiveSessionGuard` settings-load error state to the shared design-system Alert primitive, added focused marker coverage, and removed the retired product-state baseline exception. The slice reduces the product-state baseline to 287 total exceptions and Writing/Review to 17.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -69,6 +71,6 @@ Migrate the single product-state AntD Alert in `WritingPlaygroundActiveSessionGu
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the WritingPlaygroundActiveSessionGuard load-failure alert from AntD to the shared design-system Alert primitive.
- Adds focused coverage that asserts the active-session settings error path renders through the design-system Alert marker.
- Removes the migrated baseline row, reducing product-state baseline exceptions from 288 to 287 and Writing/Review exceptions from 18 to 17.

## Verification
- `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx --reporter=dot` passed.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
- `bun run verify:design-system-state` passed and reported 287 baseline exceptions / 17 Writing and Review exceptions.
- Baseline JSON parse and absence check for `src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx` passed.
- `git diff --check` passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_active_session_tsc.log` has no diagnostics for the touched component or new test.

## Change summary
This is a deliberately narrow Writing/Review migration slice. The error-state branch now uses the canonical design-system Alert while preserving the existing translated copy and leaving the loading, empty, and child-rendering branches untouched. The product-state baseline row is removed only after focused marker coverage and the product-state guard verifier confirm the migrated exception is gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the `WritingPlaygroundActiveSessionGuard` load-failure alert from AntD to the design-system `Alert`, preserving copy and behavior. Completes TASK-45.44.12.5, updates task docs, and removes the related baseline exception (now 287 total; Writing/Review 17).

- **Refactors**
  - Replaced AntD `Alert` with `Alert` from `@/components/ui/primitives` using `variant="error"`.
  - Added `WritingPlaygroundActiveSessionGuard.design-system-alert.test.tsx` asserting the `data-ds-component="Alert"` marker.
  - Removed the guard’s Alert row from `design-system-product-state-baseline.json` and updated TASK-45.44.12/TASK-45.44.12.5 notes.

<sup>Written for commit 653a7ee0bcac5ce0f95eb96b62392140569b2b0e. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1967?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

