### PR TITLE
Add Watchlists server-backed output presets

### DIFF
--- a/Docs/superpowers/plans/2026-05-22-watchlists-server-backed-output-presets.md
+++ b/Docs/superpowers/plans/2026-05-22-watchlists-server-backed-output-presets.md
@@ -1,0 +1,251 @@
+# Watchlists Server-Backed Output Presets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]` / `- [x]`) syntax for tracking.
+
+**Goal:** Add durable per-user Watchlists presets for monitor output, delivery, and audio configuration inside `/watchlists`.
+
+**Architecture:** Persist presets in the Watchlists DB as user-scoped records containing a full `output_prefs` JSON object. Expose CRUD plus an apply endpoint that overlays preset-controlled output fields onto a base `output_prefs` object while preserving unknown advanced keys. The WebUI loads presets in `JobFormModal`, lets users save/update/apply/delete them, and never changes monitor cadence, source scope, filters, or dedupe identity when a preset is applied.
+
+**Tech Stack:** FastAPI, Pydantic, `WatchlistsDatabase`, SQLite/PostgreSQL-compatible SQL, React, Ant Design, Vitest, pytest.
+
+---
+
+## File Structure
+
+- Modify `tldw_Server_API/app/core/DB_Management/Watchlists_DB.py`
+  - Add `watchlist_output_presets` schema for SQLite/PostgreSQL.
+  - Add `WatchlistOutputPresetRow` dataclass.
+  - Add CRUD helpers and server-side apply/merge helper.
+- Modify `tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py`
+  - Add output-preset request/response models.
+- Modify `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+  - Add row projection and CRUD/apply routes before `/{watchlist_id}` routes.
+- Modify `tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py`
+  - Add DB coverage for user-scoped presets, default behavior, deletion, validation, and apply merge preservation.
+- Modify `tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py`
+  - Add API coverage for CRUD/apply behavior.
+- Modify `apps/packages/ui/src/types/watchlists.ts`
+  - Add preset DTO/request types.
+- Modify `apps/packages/ui/src/services/watchlists.ts`
+  - Add preset CRUD/apply service calls.
+- Modify `apps/packages/ui/src/services/__tests__/watchlists-items-triage.test.ts`
+  - Add service path/method/body tests.
+- Create `apps/packages/ui/src/components/Option/Watchlists/JobsTab/output-presets.ts`
+  - Add frontend helper for applying preset prefs to a base object and preserving unknown fields.
+- Create `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts`
+  - Add helper tests mirroring backend merge behavior.
+- Modify `apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx`
+  - Load presets, preserve raw output prefs base, and add save/update/apply/delete UI.
+- Modify `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx`
+  - Add modal interaction tests for loading, save, apply, update, delete, and payload preservation.
+
+---
+
+### Task 1: Backend Preset Persistence
+
+**Files:**
+- Modify `tldw_Server_API/app/core/DB_Management/Watchlists_DB.py`
+- Test `tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py`
+
+- [x] **Step 1: Write failing DB tests**
+
+Add tests covering:
+- creating a per-user preset with `name`, `description`, `output_prefs`, `is_default`;
+- listing only the current user's presets;
+- default preset exclusivity for a user;
+- update and delete;
+- apply merge removes known output/audio/delivery fields from the base, applies preset fields, and preserves unknown fields.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py::test_output_presets_are_user_scoped_and_validated tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py::test_output_preset_apply_preserves_unknown_fields -q
+```
+
+Expected: fail because DB methods do not exist.
+
+- [x] **Step 3: Implement persistence**
+
+Add:
+- schema table `watchlist_output_presets`;
+- index `idx_output_presets_user_updated`;
+- unique index `ux_output_presets_user_name`;
+- dataclass `WatchlistOutputPresetRow`;
+- `_normalize_output_preset_name`;
+- `_normalize_output_prefs_payload`;
+- `_check_output_preset_name_available`;
+- `create_output_preset`;
+- `get_output_preset`;
+- `list_output_presets`;
+- `update_output_preset`;
+- `delete_output_preset`;
+- `apply_output_preset`.
+
+- [x] **Step 4: Run DB tests to verify GREEN**
+
+Run the same pytest command. Expected: pass.
+
+---
+
+### Task 2: Backend API
+
+**Files:**
+- Modify `tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py`
+- Modify `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test `tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py`
+
+- [x] **Step 1: Write failing API tests**
+
+Add endpoint tests for:
+- `GET /api/v1/watchlists/job-output-presets`;
+- `POST /api/v1/watchlists/job-output-presets`;
+- `PATCH /api/v1/watchlists/job-output-presets/{preset_id}`;
+- `POST /api/v1/watchlists/job-output-presets/{preset_id}/apply`;
+- `DELETE /api/v1/watchlists/job-output-presets/{preset_id}`;
+- 404 on another user's/nonexistent preset is not exposed.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py::test_output_presets_endpoint_crud_and_apply -q
+```
+
+Expected: fail with 404 or missing schema imports.
+
+- [x] **Step 3: Implement schemas and routes**
+
+Add Pydantic models:
+- `WatchlistOutputPresetCreate`;
+- `WatchlistOutputPresetUpdate`;
+- `WatchlistOutputPreset`;
+- `WatchlistOutputPresetsList`;
+- `WatchlistOutputPresetApplyRequest`;
+- `WatchlistOutputPresetApplyResponse`.
+
+Add API routes under `/watchlists/job-output-presets`.
+
+- [x] **Step 4: Run API tests to verify GREEN**
+
+Run the same pytest command. Expected: pass.
+
+---
+
+### Task 3: Frontend Services and Merge Helper
+
+**Files:**
+- Modify `apps/packages/ui/src/types/watchlists.ts`
+- Modify `apps/packages/ui/src/services/watchlists.ts`
+- Modify `apps/packages/ui/src/services/__tests__/watchlists-items-triage.test.ts`
+- Create `apps/packages/ui/src/components/Option/Watchlists/JobsTab/output-presets.ts`
+- Create `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts`
+
+- [x] **Step 1: Write failing frontend tests**
+
+Add tests for:
+- service paths and methods for preset CRUD/apply;
+- helper apply behavior preserving unknown fields and replacing known output/audio/delivery fields.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun run test -- src/services/__tests__/watchlists-items-triage.test.ts src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail because types/services/helper do not exist.
+
+- [x] **Step 3: Implement types/services/helper**
+
+Add type-safe DTOs and service functions. Keep helper semantics aligned with backend apply:
+- known output fields are replaced by preset values;
+- unknown raw fields remain unless preset explicitly provides the same key.
+
+- [x] **Step 4: Run frontend service/helper tests to verify GREEN**
+
+Run the same Vitest command. Expected: pass.
+
+---
+
+### Task 4: Job Form UI
+
+**Files:**
+- Modify `apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx`
+- Modify `apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx`
+
+- [x] **Step 1: Write failing modal tests**
+
+Add tests for:
+- preset list loads when modal opens;
+- save current setup creates a server preset;
+- apply selected preset changes output/audio/delivery state and preserves unknown output prefs on submit;
+- update selected preset persists current setup;
+- delete selected preset removes it from the list.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun run test -- src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+Expected: fail because modal controls do not exist.
+
+- [x] **Step 3: Implement modal controls**
+
+Add a "Saved output presets" panel near guided presets with:
+- preset selector;
+- preset name input;
+- Apply;
+- Save current setup;
+- Update selected;
+- Delete selected.
+
+Implementation requirements:
+- keep existing guided presets;
+- keep Basic/Advanced behavior;
+- do not touch scope, filters, schedule, source rules, or dedupe settings;
+- show an inline load/apply error state instead of failing silently;
+- preserve advanced/raw output prefs using a raw base state.
+
+- [x] **Step 4: Run modal tests to verify GREEN**
+
+Run the same Vitest command. Expected: pass.
+
+---
+
+### Task 5: Verification and Cleanup
+
+**Files:**
+- Update `backlog/tasks/task-488 - Implement-Watchlists-server-backed-output-delivery-audio-presets.md`
+
+- [x] **Step 1: Run backend focused tests**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py -q
+```
+
+- [x] **Step 2: Run frontend focused tests**
+
+```bash
+bun run test -- src/services/__tests__/watchlists-items-triage.test.ts src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx --maxWorkers=1 --no-file-parallelism
+```
+
+- [x] **Step 3: Run Bandit on touched backend files**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/Watchlists_DB.py tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_output_presets.json
+```
+
+- [x] **Step 4: Update Backlog task**
+
+Record implementation summary, files touched, test results, and any known skips.
+
+- [x] **Step 5: Self-review diff**
+
+Run `git diff --stat` and inspect the diff for route ordering, preservation semantics, and test coverage gaps before final response or PR creation.

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/JobFormModal.tsx
@@ -2,20 +2,26 @@ import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "re
 import { Button, Collapse, Form, Input, InputNumber, Modal, Radio, Select, Switch, Tag, message } from "antd"
 import { useTranslation } from "react-i18next"
 import {
+  applyWatchlistOutputPreset,
+  createWatchlistOutputPreset,
   createWatchlistJob,
+  deleteWatchlistOutputPreset,
   fetchWatchlistGroups,
   fetchJobOutputTemplates,
+  fetchWatchlistOutputPresets,
   fetchWatchlistSources,
   fetchWatchlistTemplates,
   previewWatchlistJob,
   testWatchlistAudioSettings,
-  updateWatchlistJob
+  updateWatchlistJob,
+  updateWatchlistOutputPreset
 } from "@/services/watchlists"
 import type {
   JobOutputPrefs,
   JobPreviewResult,
   JobScope,
   PreviewItem,
+  WatchlistOutputPreset,
   WatchlistFilter,
   WatchlistJob,
   WatchlistJobCreate
@@ -51,6 +57,7 @@ import {
   trackWatchlistsPreventionTelemetry,
   type WatchlistsPreventionRule
 } from "@/utils/watchlists-prevention-telemetry"
+import { applyOutputPresetToPrefs } from "./output-presets"
 
 interface JobFormModalProps {
   open: boolean
@@ -289,6 +296,13 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
   const [timezone, setTimezone] = useState("UTC")
   const [templateOptions, setTemplateOptions] = useState<Array<{ label: string; value: string }>>([])
   const [outputPreset, setOutputPreset] = useState<OutputPresetId | undefined>(undefined)
+  const [outputPrefsBase, setOutputPrefsBase] = useState<JobOutputPrefs>({})
+  const [savedOutputPresets, setSavedOutputPresets] = useState<WatchlistOutputPreset[]>([])
+  const [savedOutputPresetsLoading, setSavedOutputPresetsLoading] = useState(false)
+  const [savedOutputPresetsError, setSavedOutputPresetsError] = useState<string | null>(null)
+  const [selectedOutputPresetId, setSelectedOutputPresetId] = useState<number | undefined>(undefined)
+  const [outputPresetName, setOutputPresetName] = useState("")
+  const [outputPresetBusy, setOutputPresetBusy] = useState<"save" | "update" | "apply" | "delete" | null>(null)
   const [outputTemplateName, setOutputTemplateName] = useState<string | undefined>(undefined)
   const [outputTemplateVersion, setOutputTemplateVersion] = useState<number | null>(null)
   const [outputTemplateFormat, setOutputTemplateFormat] = useState<OutputFormat | undefined>(undefined)
@@ -329,8 +343,14 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
 
   const watchedName = Form.useWatch("name", form)
 
-  const applyOutputPrefsState = (prefs: JobOutputPrefs | null | undefined) => {
+  const applyOutputPrefsState = (
+    prefs: JobOutputPrefs | null | undefined,
+    options?: { updateBase?: boolean }
+  ) => {
     const prefsRecord = isRecord(prefs) ? prefs : {}
+    if (options?.updateBase) {
+      setOutputPrefsBase(cloneRecord(prefsRecord) as JobOutputPrefs)
+    }
     const templateRecord = isRecord(prefsRecord.template) ? prefsRecord.template : {}
     const retentionRecord = isRecord(prefsRecord.retention) ? prefsRecord.retention : {}
     const deliveriesRecord = isRecord(prefsRecord.deliveries) ? prefsRecord.deliveries : {}
@@ -429,15 +449,9 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
   }
 
   const buildOutputPrefs = (
-    options?: { audioVoiceMap?: Record<string, string> | null }
+    options?: { audioVoiceMap?: Record<string, string> | null; forPreset?: boolean }
   ): JobOutputPrefs | undefined => {
-    const basePrefs = (
-      isEditing &&
-      initialValues?.output_prefs &&
-      isRecord(initialValues.output_prefs)
-    )
-      ? cloneRecord(initialValues.output_prefs)
-      : {}
+    const basePrefs = isRecord(outputPrefsBase) ? cloneRecord(outputPrefsBase) : {}
 
     const templatePrefs = isRecord(basePrefs.template) ? { ...basePrefs.template } : {}
     const normalizedTemplateName = outputTemplateName?.trim() || ""
@@ -574,10 +588,9 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
     const existingAutoOutput = isRecord(basePrefs.auto_output)
       ? { ...basePrefs.auto_output }
       : {}
-    const shouldAutoOutput = (
-      hasRecurringSchedule &&
-      createScheduledOutput
-    )
+    const shouldAutoOutput = options?.forPreset
+      ? createScheduledOutput
+      : (hasRecurringSchedule && createScheduledOutput)
     existingAutoOutput.enabled = shouldAutoOutput
     if (shouldAutoOutput) {
       existingAutoOutput.type =
@@ -664,6 +677,194 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
         )
       )
       return undefined
+    }
+  }
+
+  const buildOutputPrefsForPresetSave = (): JobOutputPrefs | null => {
+    if (audioBriefingEnabled && !isValidBackgroundAudioUri(audioBackgroundUri)) {
+      message.error(
+        t(
+          "watchlists:jobs.form.audioBackgroundTrackInvalid",
+          "Background track must start with https://, http://, or file://."
+        )
+      )
+      return null
+    }
+
+    let parsedAudioVoiceMap: Record<string, string> | null = null
+    if (audioBriefingEnabled) {
+      const parsedAudioVoiceMapResult = parseAudioVoiceMapForValidation()
+      if (parsedAudioVoiceMapResult === undefined) return null
+      parsedAudioVoiceMap = parsedAudioVoiceMapResult
+    }
+
+    return buildOutputPrefs({
+      audioVoiceMap: parsedAudioVoiceMap,
+      forPreset: true
+    }) || {}
+  }
+
+  const selectedSavedOutputPreset = savedOutputPresets.find(
+    (preset) => preset.id === selectedOutputPresetId
+  )
+
+  const handleSavedOutputPresetSelect = (presetId: number | undefined) => {
+    setSelectedOutputPresetId(presetId)
+    const preset = savedOutputPresets.find((candidate) => candidate.id === presetId)
+    setOutputPresetName(preset?.name || "")
+  }
+
+  const handleSaveOutputPreset = async () => {
+    const name = outputPresetName.trim()
+    if (!name) {
+      message.error(
+        t("watchlists:jobs.form.outputPresetNameRequired", "Enter a preset name before saving.")
+      )
+      return
+    }
+    const outputPrefs = buildOutputPrefsForPresetSave()
+    if (!outputPrefs) return
+
+    setOutputPresetBusy("save")
+    setSavedOutputPresetsError(null)
+    try {
+      const created = await createWatchlistOutputPreset({
+        name,
+        output_prefs: outputPrefs
+      })
+      setSavedOutputPresets((previous) => [
+        created,
+        ...previous.filter((preset) => preset.id !== created.id)
+      ])
+      setSelectedOutputPresetId(created.id)
+      setOutputPresetName(created.name)
+      message.success(t("watchlists:jobs.form.outputPresetSaved", "Output preset saved"))
+    } catch (err) {
+      const mapped = mapWatchlistsError(err, {
+        t,
+        context: t("watchlists:jobs.form.outputPresetsContext", "output presets"),
+        fallbackMessage: t(
+          "watchlists:jobs.form.outputPresetSaveError",
+          "Could not save output preset."
+        ),
+        operationLabel: t("watchlists:errors.operation.save", "save")
+      })
+      setSavedOutputPresetsError(`${mapped.title} ${mapped.description}`.trim())
+      message.error(mapped.title)
+    } finally {
+      setOutputPresetBusy(null)
+    }
+  }
+
+  const handleUpdateOutputPreset = async () => {
+    if (!selectedSavedOutputPreset) return
+    const name = outputPresetName.trim() || selectedSavedOutputPreset.name
+    const outputPrefs = buildOutputPrefsForPresetSave()
+    if (!outputPrefs) return
+
+    setOutputPresetBusy("update")
+    setSavedOutputPresetsError(null)
+    try {
+      const updated = await updateWatchlistOutputPreset(selectedSavedOutputPreset.id, {
+        name,
+        output_prefs: outputPrefs
+      })
+      setSavedOutputPresets((previous) =>
+        previous.map((preset) => (preset.id === updated.id ? updated : preset))
+      )
+      setOutputPresetName(updated.name)
+      message.success(t("watchlists:jobs.form.outputPresetUpdated", "Output preset updated"))
+    } catch (err) {
+      const mapped = mapWatchlistsError(err, {
+        t,
+        context: t("watchlists:jobs.form.outputPresetsContext", "output presets"),
+        fallbackMessage: t(
+          "watchlists:jobs.form.outputPresetUpdateError",
+          "Could not update output preset."
+        ),
+        operationLabel: t("watchlists:errors.operation.save", "save")
+      })
+      setSavedOutputPresetsError(`${mapped.title} ${mapped.description}`.trim())
+      message.error(mapped.title)
+    } finally {
+      setOutputPresetBusy(null)
+    }
+  }
+
+  const handleApplySavedOutputPreset = async () => {
+    if (!selectedSavedOutputPreset) return
+    setOutputPresetBusy("apply")
+    setSavedOutputPresetsError(null)
+    try {
+      const response = await applyWatchlistOutputPreset(selectedSavedOutputPreset.id, {
+        base_output_prefs: outputPrefsBase
+      })
+      const outputPrefs = response.output_prefs || applyOutputPresetToPrefs({
+        baseOutputPrefs: outputPrefsBase,
+        presetOutputPrefs: selectedSavedOutputPreset.output_prefs
+      })
+      applyOutputPrefsState(outputPrefs, { updateBase: true })
+      setOutputPresetName(selectedSavedOutputPreset.name)
+      message.success(t("watchlists:jobs.form.outputPresetApplied", "Saved preset applied"))
+    } catch (err) {
+      const mapped = mapWatchlistsError(err, {
+        t,
+        context: t("watchlists:jobs.form.outputPresetsContext", "output presets"),
+        fallbackMessage: t(
+          "watchlists:jobs.form.outputPresetApplyError",
+          "Could not apply output preset."
+        ),
+        operationLabel: t("watchlists:errors.operation.apply", "apply")
+      })
+      setSavedOutputPresetsError(`${mapped.title} ${mapped.description}`.trim())
+      message.error(mapped.title)
+    } finally {
+      setOutputPresetBusy(null)
+    }
+  }
+
+  const handleDeleteOutputPreset = async () => {
+    if (!selectedSavedOutputPreset) return
+    const confirmed = await new Promise<boolean>((resolve) => {
+      Modal.confirm({
+        title: t("watchlists:jobs.form.deleteOutputPresetTitle", "Delete output preset?"),
+        content: t(
+          "watchlists:jobs.form.deleteOutputPresetDescription",
+          "This removes {{name}} for future monitors. Existing monitor settings will not change.",
+          { name: selectedSavedOutputPreset.name }
+        ),
+        okText: t("common:delete", "Delete"),
+        okButtonProps: { danger: true },
+        cancelText: t("common:cancel", "Cancel"),
+        onOk: () => resolve(true),
+        onCancel: () => resolve(false)
+      })
+    })
+    if (!confirmed) return
+    setOutputPresetBusy("delete")
+    setSavedOutputPresetsError(null)
+    try {
+      await deleteWatchlistOutputPreset(selectedSavedOutputPreset.id)
+      setSavedOutputPresets((previous) =>
+        previous.filter((preset) => preset.id !== selectedSavedOutputPreset.id)
+      )
+      setSelectedOutputPresetId(undefined)
+      setOutputPresetName("")
+      message.success(t("watchlists:jobs.form.outputPresetDeleted", "Output preset deleted"))
+    } catch (err) {
+      const mapped = mapWatchlistsError(err, {
+        t,
+        context: t("watchlists:jobs.form.outputPresetsContext", "output presets"),
+        fallbackMessage: t(
+          "watchlists:jobs.form.outputPresetDeleteError",
+          "Could not delete output preset."
+        ),
+        operationLabel: t("watchlists:errors.operation.delete", "delete")
+      })
+      setSavedOutputPresetsError(`${mapped.title} ${mapped.description}`.trim())
+      message.error(mapped.title)
+    } finally {
+      setOutputPresetBusy(null)
     }
   }
 
@@ -772,7 +973,9 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
         setSchedule(initialValues.schedule_expr || null)
         setTimezone(initialValues.timezone || "UTC")
         setOutputPreset(undefined)
-        applyOutputPrefsState(initialValues.output_prefs)
+        setSelectedOutputPresetId(undefined)
+        setOutputPresetName("")
+        applyOutputPrefsState(initialValues.output_prefs, { updateBase: true })
       } else {
         form.resetFields()
         form.setFieldsValue({
@@ -793,7 +996,9 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
         setSchedule(null)
         setTimezone("UTC")
         setOutputPreset(undefined)
-        applyOutputPrefsState(null)
+        setSelectedOutputPresetId(undefined)
+        setOutputPresetName("")
+        applyOutputPrefsState(null, { updateBase: true })
       }
     }
   }, [open, initialValues, form])
@@ -843,6 +1048,54 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
       cancelled = true
     }
   }, [open, watchlistId])
+
+  useEffect(() => {
+    if (!open) {
+      setSavedOutputPresets([])
+      setSavedOutputPresetsError(null)
+      setSavedOutputPresetsLoading(false)
+      setSelectedOutputPresetId(undefined)
+      setOutputPresetName("")
+      return
+    }
+    let cancelled = false
+    setSavedOutputPresetsLoading(true)
+    setSavedOutputPresetsError(null)
+
+    fetchWatchlistOutputPresets()
+      .then((result) => {
+        if (cancelled) return
+        const presets = Array.isArray(result.items) ? result.items : []
+        setSavedOutputPresets(presets)
+        setSelectedOutputPresetId((previous) =>
+          previous && presets.some((preset) => preset.id === previous) ? previous : undefined
+        )
+      })
+      .catch((err) => {
+        if (cancelled) return
+        console.error("Failed to load output presets for job form:", err)
+        const mapped = mapWatchlistsError(err, {
+          t,
+          context: t("watchlists:jobs.form.outputPresetsContext", "output presets"),
+          fallbackMessage: t(
+            "watchlists:jobs.form.outputPresetsLoadError",
+            "Could not load saved output presets."
+          ),
+          operationLabel: t("watchlists:errors.operation.load", "load")
+        })
+        setSavedOutputPresets([])
+        setSavedOutputPresetsError(`${mapped.title} ${mapped.description}`.trim())
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSavedOutputPresetsLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, t])
 
   useEffect(() => {
     if (!open || !isEditing || !initialValues?.id) {
@@ -1544,6 +1797,82 @@ export const JobFormModal: React.FC<JobFormModalProps> = ({
       ),
       children: (
         <div className="space-y-4">
+          <div className="rounded-lg border border-border p-3">
+            <div className="mb-3 text-sm font-medium">
+              {t("watchlists:jobs.form.savedOutputPresets", "Saved output presets")}
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_1fr]">
+              <Select
+                allowClear
+                value={selectedOutputPresetId}
+                loading={savedOutputPresetsLoading}
+                onChange={(value) =>
+                  handleSavedOutputPresetSelect(
+                    typeof value === "number" ? value : undefined
+                  )
+                }
+                options={savedOutputPresets.map((preset) => ({
+                  label: preset.name,
+                  value: preset.id
+                }))}
+                placeholder={t("watchlists:jobs.form.savedOutputPresetPlaceholder", "Choose saved preset")}
+                data-testid="job-form-output-preset-select"
+              />
+              <Input
+                value={outputPresetName}
+                onChange={(event) => setOutputPresetName(event.target.value)}
+                placeholder={t("watchlists:jobs.form.outputPresetName", "Preset name")}
+                data-testid="job-form-output-preset-name-input"
+              />
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button
+                onClick={handleApplySavedOutputPreset}
+                disabled={!selectedSavedOutputPreset || outputPresetBusy !== null}
+                loading={outputPresetBusy === "apply"}
+                data-testid="job-form-output-preset-apply-button"
+              >
+                {t("watchlists:jobs.form.applySavedOutputPreset", "Apply saved")}
+              </Button>
+              <Button
+                onClick={handleSaveOutputPreset}
+                disabled={!outputPresetName.trim() || outputPresetBusy !== null}
+                loading={outputPresetBusy === "save"}
+                data-testid="job-form-output-preset-save-button"
+              >
+                {t("watchlists:jobs.form.saveOutputPreset", "Save current setup")}
+              </Button>
+              <Button
+                onClick={handleUpdateOutputPreset}
+                disabled={!selectedSavedOutputPreset || outputPresetBusy !== null}
+                loading={outputPresetBusy === "update"}
+                data-testid="job-form-output-preset-update-button"
+              >
+                {t("watchlists:jobs.form.updateOutputPreset", "Update selected")}
+              </Button>
+              <Button
+                danger
+                onClick={handleDeleteOutputPreset}
+                disabled={!selectedSavedOutputPreset || outputPresetBusy !== null}
+                loading={outputPresetBusy === "delete"}
+                data-testid="job-form-output-preset-delete-button"
+              >
+                {t("watchlists:jobs.form.deleteOutputPreset", "Delete selected")}
+              </Button>
+            </div>
+            <div className="mt-2 text-xs text-text-muted">
+              {t(
+                "watchlists:jobs.form.savedOutputPresetHint",
+                "Presets reuse output, delivery, and audio settings only. Scope, filters, source rules, dedupe, and cadence stay unchanged."
+              )}
+            </div>
+            {savedOutputPresetsError && (
+              <div className="mt-2 text-xs text-danger" data-testid="job-form-output-preset-error">
+                {savedOutputPresetsError}
+              </div>
+            )}
+          </div>
+
           <div className="rounded-lg border border-border p-3">
             <div className="mb-3 text-sm font-medium">
               {t("watchlists:jobs.form.guidedPresets", "Guided presets")}

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx
@@ -7,11 +7,16 @@ import { JobFormModal } from "../JobFormModal"
 import { setViewport } from "../../__tests__/test-utils/viewport"
 
 const servicesMock = vi.hoisted(() => ({
+  applyWatchlistOutputPreset: vi.fn(),
   createWatchlistJob: vi.fn(),
+  createWatchlistOutputPreset: vi.fn(),
+  deleteWatchlistOutputPreset: vi.fn(),
   updateWatchlistJob: vi.fn(),
+  updateWatchlistOutputPreset: vi.fn(),
   fetchWatchlistSources: vi.fn(),
   fetchWatchlistGroups: vi.fn(),
   fetchJobOutputTemplates: vi.fn(),
+  fetchWatchlistOutputPresets: vi.fn(),
   fetchWatchlistTemplates: vi.fn(),
   previewWatchlistJob: vi.fn(),
   testWatchlistAudioSettings: vi.fn()
@@ -65,11 +70,16 @@ vi.mock("react-i18next", () => ({
 }))
 
 vi.mock("@/services/watchlists", () => ({
+  applyWatchlistOutputPreset: (...args: unknown[]) => servicesMock.applyWatchlistOutputPreset(...args),
   createWatchlistJob: (...args: unknown[]) => servicesMock.createWatchlistJob(...args),
+  createWatchlistOutputPreset: (...args: unknown[]) => servicesMock.createWatchlistOutputPreset(...args),
+  deleteWatchlistOutputPreset: (...args: unknown[]) => servicesMock.deleteWatchlistOutputPreset(...args),
   updateWatchlistJob: (...args: unknown[]) => servicesMock.updateWatchlistJob(...args),
+  updateWatchlistOutputPreset: (...args: unknown[]) => servicesMock.updateWatchlistOutputPreset(...args),
   fetchWatchlistSources: (...args: unknown[]) => servicesMock.fetchWatchlistSources(...args),
   fetchWatchlistGroups: (...args: unknown[]) => servicesMock.fetchWatchlistGroups(...args),
   fetchJobOutputTemplates: (...args: unknown[]) => servicesMock.fetchJobOutputTemplates(...args),
+  fetchWatchlistOutputPresets: (...args: unknown[]) => servicesMock.fetchWatchlistOutputPresets(...args),
   fetchWatchlistTemplates: (...args: unknown[]) => servicesMock.fetchWatchlistTemplates(...args),
   previewWatchlistJob: (...args: unknown[]) => servicesMock.previewWatchlistJob(...args),
   testWatchlistAudioSettings: (...args: unknown[]) => servicesMock.testWatchlistAudioSettings(...args)
@@ -204,9 +214,34 @@ describe("JobFormModal live summary", () => {
       items: [],
       total: 0
     })
+    servicesMock.fetchWatchlistOutputPresets.mockResolvedValue({
+      items: []
+    })
     servicesMock.fetchWatchlistTemplates.mockResolvedValue({
       items: []
     })
+    servicesMock.createWatchlistOutputPreset.mockImplementation(async (payload) => ({
+      id: 44,
+      name: payload.name,
+      description: payload.description ?? null,
+      output_prefs: payload.output_prefs,
+      is_default: Boolean(payload.is_default),
+      created_at: "2026-01-15T00:00:00Z",
+      updated_at: "2026-01-15T00:00:00Z"
+    }))
+    servicesMock.updateWatchlistOutputPreset.mockImplementation(async (presetId, payload) => ({
+      id: presetId,
+      name: payload.name ?? "Saved preset",
+      description: payload.description ?? null,
+      output_prefs: payload.output_prefs ?? {},
+      is_default: Boolean(payload.is_default),
+      created_at: "2026-01-15T00:00:00Z",
+      updated_at: "2026-01-16T00:00:00Z"
+    }))
+    servicesMock.applyWatchlistOutputPreset.mockResolvedValue({
+      output_prefs: {}
+    })
+    servicesMock.deleteWatchlistOutputPreset.mockResolvedValue(undefined)
     servicesMock.previewWatchlistJob.mockResolvedValue({
       items: [],
       total: 0,
@@ -489,6 +524,198 @@ describe("JobFormModal live summary", () => {
         })
       })
     )
+  }, 15_000)
+
+  it("saves the current output, delivery, and audio setup as a server-backed preset", async () => {
+    render(<JobFormModal open onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(servicesMock.fetchWatchlistOutputPresets).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByTestId("job-form-mode-advanced"))
+    fireEvent.click(screen.getByText("Output & Delivery"))
+    fireEvent.click(screen.getByTestId("job-form-audio-enabled-switch"))
+    fireEvent.change(screen.getByTestId("job-form-output-preset-name-input"), {
+      target: { value: "Narrated newsletter" }
+    })
+    fireEvent.click(screen.getByTestId("job-form-output-preset-save-button"))
+
+    await waitFor(() => {
+      expect(servicesMock.createWatchlistOutputPreset).toHaveBeenCalledTimes(1)
+    })
+
+    expect(servicesMock.createWatchlistOutputPreset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Narrated newsletter",
+        output_prefs: expect.objectContaining({
+          generate_audio: true,
+          audio_voice: "alloy",
+          audio_speed: 1,
+          target_audio_minutes: 8
+        })
+      })
+    )
+  }, 15_000)
+
+  it("applies server-backed presets without losing unknown output prefs on save", async () => {
+    servicesMock.fetchWatchlistOutputPresets.mockResolvedValueOnce({
+      items: [
+        {
+          id: 12,
+          name: "Podcast preset",
+          description: "Narrated digest",
+          output_prefs: {
+            template: { default_name: "podcast_script", default_format: "md" },
+            generate_audio: true,
+            audio_voice: "nova"
+          },
+          is_default: false,
+          created_at: "2026-01-15T00:00:00Z",
+          updated_at: "2026-01-15T00:00:00Z"
+        }
+      ]
+    })
+    servicesMock.applyWatchlistOutputPreset.mockResolvedValueOnce({
+      output_prefs: {
+        template: {
+          default_name: "podcast_script",
+          default_format: "md",
+          experimental_renderer: "keep"
+        },
+        deliveries: {
+          email: { enabled: true, recipients: ["ops@example.com"] },
+          webhook: { url: "https://hooks.example.com/watchlists" }
+        },
+        generate_audio: true,
+        audio_voice: "nova",
+        raw_advanced: { preserve: true }
+      }
+    })
+    servicesMock.updateWatchlistJob.mockResolvedValueOnce({ id: 78 })
+
+    render(
+      <JobFormModal
+        open
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        initialValues={{
+          id: 78,
+          name: "Existing raw prefs monitor",
+          description: "existing",
+          scope: { sources: [1] },
+          schedule_expr: "0 9 * * *",
+          timezone: "UTC",
+          active: true,
+          output_prefs: {
+            template: { default_name: "old", experimental_renderer: "keep" },
+            deliveries: {
+              webhook: { url: "https://hooks.example.com/watchlists" }
+            },
+            raw_advanced: { preserve: true }
+          },
+          job_filters: null,
+          created_at: "2026-01-15T00:00:00Z"
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(servicesMock.fetchWatchlistOutputPresets).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByTestId("job-form-mode-advanced"))
+    fireEvent.click(screen.getByText("Output & Delivery"))
+    fireEvent.mouseDown(screen.getByTestId("job-form-output-preset-select"))
+    fireEvent.click(await screen.findByText("Podcast preset"))
+    fireEvent.click(screen.getByTestId("job-form-output-preset-apply-button"))
+
+    await waitFor(() => {
+      expect(servicesMock.applyWatchlistOutputPreset).toHaveBeenCalledWith(12, {
+        base_output_prefs: expect.objectContaining({
+          raw_advanced: { preserve: true }
+        })
+      })
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(servicesMock.updateWatchlistJob).toHaveBeenCalledTimes(1)
+    })
+
+    const [, payload] = servicesMock.updateWatchlistJob.mock.calls[0]
+    expect(payload.output_prefs).toEqual(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          default_name: "podcast_script",
+          default_format: "md",
+          experimental_renderer: "keep"
+        }),
+        deliveries: expect.objectContaining({
+          email: expect.objectContaining({
+            enabled: true,
+            recipients: ["ops@example.com"]
+          }),
+          webhook: { url: "https://hooks.example.com/watchlists" }
+        }),
+        generate_audio: true,
+        audio_voice: "nova",
+        raw_advanced: { preserve: true }
+      })
+    )
+  }, 15_000)
+
+  it("updates and deletes selected server-backed output presets", async () => {
+    servicesMock.fetchWatchlistOutputPresets.mockResolvedValueOnce({
+      items: [
+        {
+          id: 34,
+          name: "Reusable newsletter",
+          description: null,
+          output_prefs: { template: { default_name: "newsletter_html" } },
+          is_default: false,
+          created_at: "2026-01-15T00:00:00Z",
+          updated_at: "2026-01-15T00:00:00Z"
+        }
+      ]
+    })
+
+    render(<JobFormModal open onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(servicesMock.fetchWatchlistOutputPresets).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByTestId("job-form-mode-advanced"))
+    fireEvent.click(screen.getByText("Output & Delivery"))
+    fireEvent.mouseDown(screen.getByTestId("job-form-output-preset-select"))
+    fireEvent.click(await screen.findByText("Reusable newsletter"))
+    fireEvent.click(screen.getByTestId("job-form-audio-enabled-switch"))
+    fireEvent.click(screen.getByTestId("job-form-output-preset-update-button"))
+
+    await waitFor(() => {
+      expect(servicesMock.updateWatchlistOutputPreset).toHaveBeenCalledTimes(1)
+    })
+
+    expect(servicesMock.updateWatchlistOutputPreset).toHaveBeenCalledWith(
+      34,
+      expect.objectContaining({
+        name: "Reusable newsletter",
+        output_prefs: expect.objectContaining({ generate_audio: true })
+      })
+    )
+
+    vi.mocked(Modal.confirm).mockClear()
+    fireEvent.click(screen.getByTestId("job-form-output-preset-delete-button"))
+    expect(Modal.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Delete output preset?"
+      })
+    )
+    await waitFor(() => {
+      expect(servicesMock.deleteWatchlistOutputPreset).toHaveBeenCalledWith(34)
+    })
   }, 15_000)
 
   it("sends an explicit disabled auto_output record when scheduled reports are turned off during edit", async () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { applyOutputPresetToPrefs } from "../output-presets"
+
+describe("applyOutputPresetToPrefs", () => {
+  it("replaces known output, delivery, and audio fields while preserving unknown advanced prefs", () => {
+    const applied = applyOutputPresetToPrefs({
+      baseOutputPrefs: {
+        template: {
+          default_name: "old",
+          default_version: 4,
+          experimental_renderer: "keep"
+        },
+        deliveries: {
+          email: { enabled: true, recipients: ["old@example.com"] },
+          webhook: { url: "https://hooks.example.com/watchlists" }
+        },
+        auto_output: {
+          enabled: true,
+          type: "briefing_markdown",
+          custom_flag: "keep"
+        },
+        generate_audio: true,
+        audio_voice: "alloy",
+        target_audio_minutes: 12,
+        raw_advanced: { preserve: true }
+      },
+      presetOutputPrefs: {
+        template: {
+          default_name: "podcast_script",
+          default_format: "md"
+        },
+        deliveries: {
+          chatbook: { enabled: true, title: "Daily Brief" }
+        },
+        generate_audio: false,
+        preset_custom: { copied: true }
+      }
+    })
+
+    expect(applied).toEqual({
+      template: {
+        default_name: "podcast_script",
+        default_format: "md",
+        experimental_renderer: "keep"
+      },
+      deliveries: {
+        chatbook: { enabled: true, title: "Daily Brief" },
+        webhook: { url: "https://hooks.example.com/watchlists" }
+      },
+      auto_output: { custom_flag: "keep" },
+      generate_audio: false,
+      raw_advanced: { preserve: true },
+      preset_custom: { copied: true }
+    })
+  })
+
+  it("removes legacy scalar nested output groups when the preset omits them", () => {
+    const applied = applyOutputPresetToPrefs({
+      baseOutputPrefs: {
+        template: "legacy-template-name",
+        deliveries: "legacy-delivery-target",
+        raw_advanced: { preserve: true }
+      },
+      presetOutputPrefs: {
+        generate_audio: true,
+        audio_voice: "nova"
+      }
+    })
+
+    expect(applied).toEqual({
+      generate_audio: true,
+      audio_voice: "nova",
+      raw_advanced: { preserve: true }
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts
@@ -73,4 +73,20 @@ describe("applyOutputPresetToPrefs", () => {
       raw_advanced: { preserve: true }
     })
   })
+
+  it("deep clones raw advanced values without stringifying non-JSON browser values", () => {
+    const observedAt = new Date("2026-05-23T01:00:00.000Z")
+    const applied = applyOutputPresetToPrefs({
+      baseOutputPrefs: {
+        raw_advanced: { observedAt }
+      },
+      presetOutputPrefs: {
+        generate_audio: false
+      }
+    })
+
+    const rawAdvanced = applied.raw_advanced as { observedAt: Date }
+    expect(rawAdvanced.observedAt).toEqual(observedAt)
+    expect(rawAdvanced.observedAt).not.toBe(observedAt)
+  })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/output-presets.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/output-presets.ts
@@ -20,6 +20,14 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
 const cloneValue = <T>(value: T): T => {
+  if (value === undefined) return undefined as T
+  if (typeof globalThis.structuredClone === "function") {
+    try {
+      return globalThis.structuredClone(value)
+    } catch {
+      // Fall through to JSON-compatible cloning for values structuredClone cannot copy.
+    }
+  }
   try {
     return JSON.parse(JSON.stringify(value)) as T
   } catch {

--- a/apps/packages/ui/src/components/Option/Watchlists/JobsTab/output-presets.ts
+++ b/apps/packages/ui/src/components/Option/Watchlists/JobsTab/output-presets.ts
@@ -1,0 +1,113 @@
+import type { JobOutputPrefs } from "@/types/watchlists"
+
+const TEMPLATE_KEYS = new Set(["default_name", "default_version", "default_format"])
+const RETENTION_KEYS = new Set(["default_seconds", "temporary_seconds"])
+const DELIVERY_CHANNEL_KEYS = new Set(["email", "chatbook"])
+const AUTO_OUTPUT_KEYS = new Set(["enabled", "type", "format", "template_name", "template_version"])
+const TOP_LEVEL_KEYS = new Set([
+  "generate_audio",
+  "audio_voice",
+  "audio_speed",
+  "target_audio_minutes",
+  "background_audio_uri",
+  "voice_map",
+  "retention_days",
+  "template_name",
+  "delivery_config"
+])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const cloneValue = <T>(value: T): T => {
+  try {
+    return JSON.parse(JSON.stringify(value)) as T
+  } catch {
+    return value
+  }
+}
+
+const normalizePrefs = (prefs: JobOutputPrefs | null | undefined): Record<string, unknown> =>
+  isRecord(prefs) ? cloneValue(prefs) : {}
+
+const mergeKnownNestedPrefs = (
+  baseValue: unknown,
+  presetValue: unknown,
+  presetHasKey: boolean,
+  knownKeys: Set<string>
+): unknown | undefined => {
+  if (!presetHasKey) {
+    if (!isRecord(baseValue)) return undefined
+    const preserved = Object.fromEntries(
+      Object.entries(baseValue)
+        .filter(([key]) => !knownKeys.has(key))
+        .map(([key, value]) => [key, cloneValue(value)])
+    )
+    return Object.keys(preserved).length > 0 ? preserved : undefined
+  }
+
+  if (presetValue == null) return undefined
+  if (!isRecord(presetValue)) return cloneValue(presetValue)
+
+  const preserved = isRecord(baseValue)
+    ? Object.fromEntries(
+      Object.entries(baseValue)
+        .filter(([key]) => !knownKeys.has(key))
+        .map(([key, value]) => [key, cloneValue(value)])
+    )
+    : {}
+
+  for (const [key, value] of Object.entries(presetValue)) {
+    preserved[key] = cloneValue(value)
+  }
+  return Object.keys(preserved).length > 0 ? preserved : undefined
+}
+
+export const applyOutputPresetToPrefs = ({
+  baseOutputPrefs,
+  presetOutputPrefs
+}: {
+  baseOutputPrefs?: JobOutputPrefs | null
+  presetOutputPrefs?: JobOutputPrefs | null
+}): JobOutputPrefs => {
+  const base = normalizePrefs(baseOutputPrefs)
+  const preset = normalizePrefs(presetOutputPrefs)
+  const result: Record<string, unknown> = cloneValue(base)
+
+  const nestedSpecs: Array<[string, Set<string>]> = [
+    ["template", TEMPLATE_KEYS],
+    ["retention", RETENTION_KEYS],
+    ["deliveries", DELIVERY_CHANNEL_KEYS],
+    ["auto_output", AUTO_OUTPUT_KEYS]
+  ]
+
+  for (const [key, knownKeys] of nestedSpecs) {
+    const mergedValue = mergeKnownNestedPrefs(
+      base[key],
+      preset[key],
+      Object.prototype.hasOwnProperty.call(preset, key),
+      knownKeys
+    )
+    if (mergedValue === undefined) {
+      delete result[key]
+    } else {
+      result[key] = mergedValue
+    }
+  }
+
+  for (const key of TOP_LEVEL_KEYS) {
+    delete result[key]
+    if (Object.prototype.hasOwnProperty.call(preset, key) && preset[key] != null) {
+      result[key] = cloneValue(preset[key])
+    }
+  }
+
+  const handledKeys = new Set([...nestedSpecs.map(([key]) => key), ...TOP_LEVEL_KEYS])
+  for (const [key, value] of Object.entries(preset)) {
+    if (!handledKeys.has(key)) {
+      result[key] = cloneValue(value)
+    }
+  }
+
+  return result as JobOutputPrefs
+}

--- a/apps/packages/ui/src/services/__tests__/watchlists-items-triage.test.ts
+++ b/apps/packages/ui/src/services/__tests__/watchlists-items-triage.test.ts
@@ -19,11 +19,17 @@ vi.mock("@/services/tts", () => ({
 
 import {
   batchUpdateScrapedItems,
+  applyWatchlistOutputPreset,
+  createWatchlistOutputPreset,
   createWatchlistItemView,
+  deleteWatchlistOutputPreset,
   deleteWatchlistItemView,
   fetchScrapedItems,
   fetchScrapedItemSmartCounts,
+  fetchWatchlistOutputPresets,
   fetchWatchlistItemViews,
+  getWatchlistOutputPreset,
+  updateWatchlistOutputPreset,
   updateWatchlistItemView
 } from "../watchlists"
 
@@ -132,6 +138,75 @@ describe("watchlist item triage service contract", () => {
     await deleteWatchlistItemView(42, 5)
     expect(mocks.bgRequest).toHaveBeenLastCalledWith({
       path: "/api/v1/watchlists/42/item-views/5",
+      method: "DELETE"
+    })
+  })
+
+  it("uses server-backed monitor output preset CRUD and apply routes", async () => {
+    await fetchWatchlistOutputPresets()
+    expect(mocks.bgRequest).toHaveBeenLastCalledWith({
+      path: "/api/v1/watchlists/job-output-presets",
+      method: "GET"
+    })
+
+    await createWatchlistOutputPreset({
+      name: "Daily newsletter",
+      description: "HTML email",
+      output_prefs: {
+        template: { default_name: "newsletter_html", default_format: "html" },
+        generate_audio: true,
+        audio_voice: "nova"
+      },
+      is_default: true
+    })
+    expect(mocks.bgRequest).toHaveBeenLastCalledWith({
+      path: "/api/v1/watchlists/job-output-presets",
+      method: "POST",
+      body: {
+        name: "Daily newsletter",
+        description: "HTML email",
+        output_prefs: {
+          template: { default_name: "newsletter_html", default_format: "html" },
+          generate_audio: true,
+          audio_voice: "nova"
+        },
+        is_default: true
+      }
+    })
+
+    await getWatchlistOutputPreset(7)
+    expect(mocks.bgRequest).toHaveBeenLastCalledWith({
+      path: "/api/v1/watchlists/job-output-presets/7",
+      method: "GET"
+    })
+
+    await updateWatchlistOutputPreset(7, {
+      name: "Executive newsletter",
+      output_prefs: { generate_audio: false }
+    })
+    expect(mocks.bgRequest).toHaveBeenLastCalledWith({
+      path: "/api/v1/watchlists/job-output-presets/7",
+      method: "PATCH",
+      body: {
+        name: "Executive newsletter",
+        output_prefs: { generate_audio: false }
+      }
+    })
+
+    await applyWatchlistOutputPreset(7, {
+      base_output_prefs: { raw_advanced: { preserve: true } }
+    })
+    expect(mocks.bgRequest).toHaveBeenLastCalledWith({
+      path: "/api/v1/watchlists/job-output-presets/7/apply",
+      method: "POST",
+      body: {
+        base_output_prefs: { raw_advanced: { preserve: true } }
+      }
+    })
+
+    await deleteWatchlistOutputPreset(7)
+    expect(mocks.bgRequest).toHaveBeenLastCalledWith({
+      path: "/api/v1/watchlists/job-output-presets/7",
       method: "DELETE"
     })
   })

--- a/apps/packages/ui/src/services/watchlists.ts
+++ b/apps/packages/ui/src/services/watchlists.ts
@@ -51,6 +51,11 @@ import type {
   WatchlistOutput,
   WatchlistOutputCreate,
   WatchlistOutputEvidenceResponse,
+  WatchlistOutputPreset,
+  WatchlistOutputPresetApplyRequest,
+  WatchlistOutputPresetApplyResponse,
+  WatchlistOutputPresetCreate,
+  WatchlistOutputPresetUpdate,
   WatchlistReportReadiness,
   WatchlistRun,
   WatchlistRunAudioStatus,
@@ -868,6 +873,61 @@ export const deleteWatchlistItemView = async (
 ): Promise<void> => {
   return bgRequest<void>({
     path: `/api/v1/watchlists/${watchlistId}/item-views/${viewId}` as any,
+    method: "DELETE"
+  })
+}
+
+export const fetchWatchlistOutputPresets = async (): Promise<{ items: WatchlistOutputPreset[] }> => {
+  return bgRequest<{ items: WatchlistOutputPreset[] }>({
+    path: "/api/v1/watchlists/job-output-presets" as any,
+    method: "GET"
+  })
+}
+
+export const createWatchlistOutputPreset = async (
+  payload: WatchlistOutputPresetCreate
+): Promise<WatchlistOutputPreset> => {
+  return bgRequest<WatchlistOutputPreset>({
+    path: "/api/v1/watchlists/job-output-presets" as any,
+    method: "POST",
+    body: payload
+  })
+}
+
+export const getWatchlistOutputPreset = async (
+  presetId: number
+): Promise<WatchlistOutputPreset> => {
+  return bgRequest<WatchlistOutputPreset>({
+    path: `/api/v1/watchlists/job-output-presets/${presetId}` as any,
+    method: "GET"
+  })
+}
+
+export const updateWatchlistOutputPreset = async (
+  presetId: number,
+  payload: WatchlistOutputPresetUpdate
+): Promise<WatchlistOutputPreset> => {
+  return bgRequest<WatchlistOutputPreset>({
+    path: `/api/v1/watchlists/job-output-presets/${presetId}` as any,
+    method: "PATCH",
+    body: payload
+  })
+}
+
+export const applyWatchlistOutputPreset = async (
+  presetId: number,
+  payload: WatchlistOutputPresetApplyRequest
+): Promise<WatchlistOutputPresetApplyResponse> => {
+  return bgRequest<WatchlistOutputPresetApplyResponse>({
+    path: `/api/v1/watchlists/job-output-presets/${presetId}/apply` as any,
+    method: "POST",
+    body: payload
+  })
+}
+
+export const deleteWatchlistOutputPreset = async (presetId: number): Promise<void> => {
+  return bgRequest<void>({
+    path: `/api/v1/watchlists/job-output-presets/${presetId}` as any,
     method: "DELETE"
   })
 }

--- a/apps/packages/ui/src/types/watchlists.ts
+++ b/apps/packages/ui/src/types/watchlists.ts
@@ -239,7 +239,7 @@ export interface WatchlistOutputPreset {
 }
 
 export interface WatchlistOutputPresetApplyRequest {
-  base_output_prefs?: JobOutputPrefs | null
+  base_output_prefs?: JobOutputPrefs
 }
 
 export interface WatchlistOutputPresetApplyResponse {

--- a/apps/packages/ui/src/types/watchlists.ts
+++ b/apps/packages/ui/src/types/watchlists.ts
@@ -141,7 +141,9 @@ export interface JobScope {
 }
 
 export interface JobOutputPrefs {
+  [key: string]: unknown
   auto_output?: {
+    [key: string]: unknown
     enabled?: boolean
     type?: string
     format?: "md" | "html"
@@ -167,16 +169,20 @@ export interface JobOutputPrefs {
   voice_map?: Record<string, string>
   audio_cast?: WatchlistAudioCast
   retention?: {
+    [key: string]: unknown
     default_seconds?: number
     temporary_seconds?: number
   }
   template?: {
+    [key: string]: unknown
     default_name?: string
     default_format?: "md" | "html"
     default_version?: number
   }
   deliveries?: {
+    [key: string]: unknown
     email?: {
+      [key: string]: unknown
       enabled?: boolean
       recipients?: string[]
       body_format?: "auto" | "text" | "html"
@@ -186,6 +192,7 @@ export interface JobOutputPrefs {
       reply_to?: string
     }
     chatbook?: {
+      [key: string]: unknown
       enabled?: boolean
       title?: string
       description?: string
@@ -205,6 +212,38 @@ export interface JobOutputPrefs {
     email_format?: "auto" | "text" | "html"
     create_chatbook?: boolean
   }
+}
+
+export interface WatchlistOutputPresetCreate {
+  name: string
+  description?: string | null
+  output_prefs: JobOutputPrefs
+  is_default?: boolean
+}
+
+export interface WatchlistOutputPresetUpdate {
+  name?: string
+  description?: string | null
+  output_prefs?: JobOutputPrefs
+  is_default?: boolean
+}
+
+export interface WatchlistOutputPreset {
+  id: number
+  name: string
+  description?: string | null
+  output_prefs: JobOutputPrefs
+  is_default: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface WatchlistOutputPresetApplyRequest {
+  base_output_prefs?: JobOutputPrefs | null
+}
+
+export interface WatchlistOutputPresetApplyResponse {
+  output_prefs: JobOutputPrefs
 }
 
 export interface WatchlistJob {

--- a/backlog/tasks/task-488 - Implement-Watchlists-server-backed-output-delivery-audio-presets.md
+++ b/backlog/tasks/task-488 - Implement-Watchlists-server-backed-output-delivery-audio-presets.md
@@ -1,0 +1,60 @@
+---
+id: TASK-488
+title: Implement Watchlists server-backed output delivery audio presets
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-23 01:18'
+labels:
+  - watchlists
+  - frontend
+  - backend
+  - presets
+  - ux
+dependencies: []
+documentation:
+  - Docs/superpowers/plans/2026-05-22-watchlists-server-backed-output-presets.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement durable per-user Watchlists presets for monitor output, delivery, and audio configuration inside /watchlists, including backend CRUD/apply semantics, frontend service/UI support, preservation of raw advanced output prefs, focused tests, and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend persists per-user Watchlists output presets with CRUD and user isolation.
+- [x] #2 Apply semantics replace known output/delivery/audio fields while preserving unknown advanced output_prefs fields.
+- [x] #3 Frontend /watchlists monitor form can load, save, apply, update, and delete server-backed output presets without changing cadence, scope, filters, source rules, or dedupe settings.
+- [x] #4 Focused backend and frontend tests cover CRUD/apply behavior and raw preference preservation.
+- [x] #5 Verification and Bandit results are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implemented per-user Watchlists output preset persistence in Watchlists DB with SQLite/PostgreSQL schema bootstrap, CRUD helpers, default exclusivity, user scoping, and server-side apply semantics. Added /api/v1/watchlists/job-output-presets CRUD/apply routes and schemas. Added shared UI types/services, a frontend merge helper aligned with backend behavior, and JobFormModal controls to load, save, apply, update, and delete presets inside /watchlists while preserving raw advanced output_prefs and leaving scope, filters, source rules, dedupe, and cadence unchanged. Self-review added regression coverage for legacy scalar nested output prefs and added a confirmation gate before durable preset deletion.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented per-user Watchlists output preset persistence in Watchlists DB with SQLite/PostgreSQL schema bootstrap, CRUD helpers, default exclusivity, user scoping, and server-side apply semantics. Added /api/v1/watchlists/job-output-presets CRUD/apply routes and schemas. Added shared UI types/services, a frontend merge helper aligned with backend behavior, and JobFormModal controls to load, save, apply, update, and delete presets inside /watchlists while preserving raw advanced output_prefs and leaving scope, filters, source rules, dedupe, and cadence unchanged. Self-review added regression coverage for legacy scalar nested output prefs and a confirmation gate before durable preset deletion.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented durable server-backed Watchlists output/delivery/audio presets on codex/watchlists-server-presets. Verification passed: backend Watchlists DB/API pytest suite (15 tests), frontend watchlists preset/service/modal Vitest suite (35 tests), watchlists static guard (3 tests), git diff --check, and Bandit on touched backend files with zero findings in /tmp/bandit_watchlists_output_presets.json.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-488 - Implement-Watchlists-server-backed-output-delivery-audio-presets.md
+++ b/backlog/tasks/task-488 - Implement-Watchlists-server-backed-output-delivery-audio-presets.md
@@ -34,7 +34,11 @@ Implement durable per-user Watchlists presets for monitor output, delivery, and 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Implemented per-user Watchlists output preset persistence in Watchlists DB with SQLite/PostgreSQL schema bootstrap, CRUD helpers, default exclusivity, user scoping, and server-side apply semantics. Added /api/v1/watchlists/job-output-presets CRUD/apply routes and schemas. Added shared UI types/services, a frontend merge helper aligned with backend behavior, and JobFormModal controls to load, save, apply, update, and delete presets inside /watchlists while preserving raw advanced output_prefs and leaving scope, filters, source rules, dedupe, and cadence unchanged. Self-review added regression coverage for legacy scalar nested output prefs and added a confirmation gate before durable preset deletion.
+1. Add per-user Watchlists output preset persistence with user isolation, default handling, and server-side apply semantics that preserve unknown advanced output_prefs fields.
+2. Expose CRUD/apply API routes and typed schemas for saved output, delivery, and audio presets.
+3. Add /watchlists JobFormModal controls for loading, saving, applying, updating, and deleting presets without mutating cadence, scope, filters, source rules, or dedupe settings.
+4. Cover backend CRUD/apply behavior, frontend merge/service/modal behavior, and review-discovered edge cases with focused regression tests.
+5. Record verification, Bandit results, and PR review follow-up notes before closing the task.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -42,13 +46,13 @@ Implemented per-user Watchlists output preset persistence in Watchlists DB with 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented per-user Watchlists output preset persistence in Watchlists DB with SQLite/PostgreSQL schema bootstrap, CRUD helpers, default exclusivity, user scoping, and server-side apply semantics. Added /api/v1/watchlists/job-output-presets CRUD/apply routes and schemas. Added shared UI types/services, a frontend merge helper aligned with backend behavior, and JobFormModal controls to load, save, apply, update, and delete presets inside /watchlists while preserving raw advanced output_prefs and leaving scope, filters, source rules, dedupe, and cadence unchanged. Self-review added regression coverage for legacy scalar nested output prefs and a confirmation gate before durable preset deletion.
 
-PR review follow-up: narrowed output preset row projection error handling to log and re-raise corrupt JSON/non-object prefs instead of silently returning an empty object; mapped DB unique-index races for output preset names back to output_preset_name_exists so API routes continue returning 409; changed the frontend preset clone helper to prefer structuredClone with JSON fallback; added regression tests for all three review items. Verification: backend Watchlists DB/API pytest suite passed with 17 tests; frontend preset/service/modal Vitest suite passed with 36 tests; static guard passed with 3 tests; Bandit wrote /tmp/bandit_watchlists_output_presets_review.json with zero findings; git diff --check passed.
+PR review follow-up: narrowed output preset row projection error handling to log and re-raise corrupt JSON/non-object prefs instead of silently returning an empty object; mapped DB unique-index races for output preset names back to output_preset_name_exists so API routes continue returning 409; changed the frontend preset clone helper to prefer structuredClone with JSON fallback; made apply requests reject explicit null base_output_prefs while still allowing omission; added regression tests for the review items. Verification: backend Watchlists DB/API pytest suite passed with 18 tests; frontend preset/service/modal Vitest suite passed with 36 tests; static guard passed with 3 tests; Bandit wrote /tmp/bandit_watchlists_output_presets_review.json with zero findings; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented durable server-backed Watchlists output/delivery/audio presets on codex/watchlists-server-presets and addressed PR review follow-ups. Verification passed: backend Watchlists DB/API pytest suite (17 tests), frontend watchlists preset/service/modal Vitest suite (36 tests), watchlists static guard (3 tests), git diff --check, and Bandit on touched backend files with zero findings in /tmp/bandit_watchlists_output_presets_review.json.
+Implemented durable server-backed Watchlists output/delivery/audio presets on codex/watchlists-server-presets and addressed PR review follow-ups, including non-null apply request semantics for base_output_prefs. Verification passed: backend Watchlists DB/API pytest suite (18 tests), frontend watchlists preset/service/modal Vitest suite (36 tests), watchlists static guard (3 tests), git diff --check, and Bandit on touched backend files with zero findings in /tmp/bandit_watchlists_output_presets_review.json.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-488 - Implement-Watchlists-server-backed-output-delivery-audio-presets.md
+++ b/backlog/tasks/task-488 - Implement-Watchlists-server-backed-output-delivery-audio-presets.md
@@ -4,7 +4,7 @@ title: Implement Watchlists server-backed output delivery audio presets
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-23 01:18'
+updated_date: '2026-05-23 02:01'
 labels:
   - watchlists
   - frontend
@@ -41,12 +41,14 @@ Implemented per-user Watchlists output preset persistence in Watchlists DB with 
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented per-user Watchlists output preset persistence in Watchlists DB with SQLite/PostgreSQL schema bootstrap, CRUD helpers, default exclusivity, user scoping, and server-side apply semantics. Added /api/v1/watchlists/job-output-presets CRUD/apply routes and schemas. Added shared UI types/services, a frontend merge helper aligned with backend behavior, and JobFormModal controls to load, save, apply, update, and delete presets inside /watchlists while preserving raw advanced output_prefs and leaving scope, filters, source rules, dedupe, and cadence unchanged. Self-review added regression coverage for legacy scalar nested output prefs and a confirmation gate before durable preset deletion.
+
+PR review follow-up: narrowed output preset row projection error handling to log and re-raise corrupt JSON/non-object prefs instead of silently returning an empty object; mapped DB unique-index races for output preset names back to output_preset_name_exists so API routes continue returning 409; changed the frontend preset clone helper to prefer structuredClone with JSON fallback; added regression tests for all three review items. Verification: backend Watchlists DB/API pytest suite passed with 17 tests; frontend preset/service/modal Vitest suite passed with 36 tests; static guard passed with 3 tests; Bandit wrote /tmp/bandit_watchlists_output_presets_review.json with zero findings; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented durable server-backed Watchlists output/delivery/audio presets on codex/watchlists-server-presets. Verification passed: backend Watchlists DB/API pytest suite (15 tests), frontend watchlists preset/service/modal Vitest suite (35 tests), watchlists static guard (3 tests), git diff --check, and Bandit on touched backend files with zero findings in /tmp/bandit_watchlists_output_presets.json.
+Implemented durable server-backed Watchlists output/delivery/audio presets on codex/watchlists-server-presets and addressed PR review follow-ups. Verification passed: backend Watchlists DB/API pytest suite (17 tests), frontend watchlists preset/service/modal Vitest suite (36 tests), watchlists static guard (3 tests), git diff --check, and Bandit on touched backend files with zero findings in /tmp/bandit_watchlists_output_presets_review.json.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -1211,10 +1211,19 @@ def _row_to_output_preset(row) -> WatchlistOutputPreset:
     output_prefs: dict[str, Any] = {}
     try:
         parsed = json.loads(row.output_prefs_json or "{}")
-        if isinstance(parsed, dict):
-            output_prefs = parsed
-    except _WATCHLISTS_NONCRITICAL_EXCEPTIONS:
-        output_prefs = {}
+    except json.JSONDecodeError:
+        logger.opt(exception=True).warning(
+            "Invalid output_prefs_json for watchlist output preset id={}",
+            getattr(row, "id", "unknown"),
+        )
+        raise
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "Invalid non-object output_prefs_json for watchlist output preset id={}",
+            getattr(row, "id", "unknown"),
+        )
+        raise ValueError("output_preset_prefs_invalid")
+    output_prefs = parsed
     return WatchlistOutputPreset(
         id=int(row.id),
         name=row.name,

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -222,6 +222,12 @@ from tldw_Server_API.app.api.v1.schemas.watchlists_schemas import (  # noqa: E40
     WatchlistItemSavedViewCreate,
     WatchlistItemSavedViewsList,
     WatchlistItemSavedViewUpdate,
+    WatchlistOutputPreset,
+    WatchlistOutputPresetApplyRequest,
+    WatchlistOutputPresetApplyResponse,
+    WatchlistOutputPresetCreate,
+    WatchlistOutputPresetsList,
+    WatchlistOutputPresetUpdate,
     WatchlistOnboardingTelemetryIngestRequest,
     WatchlistOnboardingTelemetryIngestResponse,
     WatchlistOnboardingTelemetrySummaryResponse,
@@ -1195,6 +1201,25 @@ def _row_to_item_saved_view(row) -> WatchlistItemSavedView:
         name=row.name,
         filters=filters,
         sort=row.sort,
+        is_default=bool(getattr(row, "is_default", 0)),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _row_to_output_preset(row) -> WatchlistOutputPreset:
+    output_prefs: dict[str, Any] = {}
+    try:
+        parsed = json.loads(row.output_prefs_json or "{}")
+        if isinstance(parsed, dict):
+            output_prefs = parsed
+    except _WATCHLISTS_NONCRITICAL_EXCEPTIONS:
+        output_prefs = {}
+    return WatchlistOutputPreset(
+        id=int(row.id),
+        name=row.name,
+        description=getattr(row, "description", None),
+        output_prefs=output_prefs,
         is_default=bool(getattr(row, "is_default", 0)),
         created_at=row.created_at,
         updated_at=row.updated_at,
@@ -6150,6 +6175,126 @@ async def delete_item_saved_view(
     deleted = db.delete_item_saved_view(view_id=view_id, watchlist_id=watchlist_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="item_saved_view_not_found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+def _output_preset_error_status(exc: ValueError) -> int:
+    detail = str(exc)
+    if detail == "output_preset_name_exists":
+        return status.HTTP_409_CONFLICT
+    return status.HTTP_400_BAD_REQUEST
+
+
+@router.get(
+    "/job-output-presets",
+    response_model=WatchlistOutputPresetsList,
+    summary="List saved monitor output presets",
+)
+async def list_output_presets(
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+):
+    rows = db.list_output_presets()
+    return WatchlistOutputPresetsList(items=[_row_to_output_preset(row) for row in rows])
+
+
+@router.post(
+    "/job-output-presets",
+    response_model=WatchlistOutputPreset,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a saved monitor output preset",
+)
+async def create_output_preset(
+    payload: WatchlistOutputPresetCreate,
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+):
+    try:
+        row = db.create_output_preset(
+            name=payload.name,
+            description=payload.description,
+            output_prefs=payload.output_prefs,
+            is_default=payload.is_default,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=_output_preset_error_status(exc), detail=str(exc)) from exc
+    return _row_to_output_preset(row)
+
+
+@router.get(
+    "/job-output-presets/{preset_id}",
+    response_model=WatchlistOutputPreset,
+    summary="Get a saved monitor output preset",
+)
+async def get_output_preset(
+    preset_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+):
+    try:
+        row = db.get_output_preset(preset_id=preset_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="output_preset_not_found") from None
+    return _row_to_output_preset(row)
+
+
+@router.patch(
+    "/job-output-presets/{preset_id}",
+    response_model=WatchlistOutputPreset,
+    summary="Update a saved monitor output preset",
+)
+async def update_output_preset(
+    payload: WatchlistOutputPresetUpdate,
+    preset_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+):
+    fields = payload.model_dump(exclude_unset=True)
+    try:
+        row = db.update_output_preset(preset_id=preset_id, fields=fields)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="output_preset_not_found") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=_output_preset_error_status(exc), detail=str(exc)) from exc
+    return _row_to_output_preset(row)
+
+
+@router.post(
+    "/job-output-presets/{preset_id}/apply",
+    response_model=WatchlistOutputPresetApplyResponse,
+    summary="Apply a saved monitor output preset to output preferences",
+)
+async def apply_output_preset(
+    payload: WatchlistOutputPresetApplyRequest,
+    preset_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+):
+    try:
+        output_prefs = db.apply_output_preset(
+            preset_id=preset_id,
+            base_output_prefs=payload.base_output_prefs,
+        )
+    except KeyError:
+        raise HTTPException(status_code=404, detail="output_preset_not_found") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=_output_preset_error_status(exc), detail=str(exc)) from exc
+    return WatchlistOutputPresetApplyResponse(output_prefs=output_prefs)
+
+
+@router.delete(
+    "/job-output-presets/{preset_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a saved monitor output preset",
+)
+async def delete_output_preset(
+    preset_id: int = Path(..., ge=1),
+    current_user: User = Depends(get_request_user),
+    db=Depends(get_watchlists_db_for_user),
+):
+    deleted = db.delete_output_preset(preset_id=preset_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="output_preset_not_found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -861,7 +861,7 @@ class WatchlistOutputPresetsList(BaseModel):
 
 
 class WatchlistOutputPresetApplyRequest(BaseModel):
-    base_output_prefs: dict[str, Any] | None = Field(default_factory=dict)
+    base_output_prefs: dict[str, Any] = Field(default_factory=dict)
 
 
 class WatchlistOutputPresetApplyResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -832,6 +832,42 @@ class WatchlistItemSavedViewsList(BaseModel):
     items: list[WatchlistItemSavedView]
 
 
+class WatchlistOutputPresetCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    output_prefs: dict[str, Any] = Field(default_factory=dict)
+    is_default: bool = False
+
+
+class WatchlistOutputPresetUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    output_prefs: dict[str, Any] | None = None
+    is_default: bool | None = None
+
+
+class WatchlistOutputPreset(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    output_prefs: dict[str, Any] = Field(default_factory=dict)
+    is_default: bool = False
+    created_at: str
+    updated_at: str
+
+
+class WatchlistOutputPresetsList(BaseModel):
+    items: list[WatchlistOutputPreset]
+
+
+class WatchlistOutputPresetApplyRequest(BaseModel):
+    base_output_prefs: dict[str, Any] | None = Field(default_factory=dict)
+
+
+class WatchlistOutputPresetApplyResponse(BaseModel):
+    output_prefs: dict[str, Any] = Field(default_factory=dict)
+
+
 class WatchlistReportReadinessWarning(BaseModel):
     code: str
     severity: WatchlistReportReadinessWarningSeverity = "warning"

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -118,6 +118,11 @@ _OUTPUT_PRESET_TOP_LEVEL_KEYS = {
     "template_name",
     "delivery_config",
 }
+_OUTPUT_PRESET_NAME_CONSTRAINT_MARKERS = (
+    "ux_output_presets_user_name",
+    "watchlist_output_presets_user_id_lower_idx",
+    "watchlist_output_presets_user_id_name_key",
+)
 _NESTED_REGEX_QUANTIFIER_RE = re.compile(
     r"\((?:[^()\\]|\\.)*(?:\*|\+|\{\d+(?:,\d*)?\})(?:[^()\\]|\\.)*\)\s*(?:\*|\+|\{\d+(?:,\d*)?\})"
 )
@@ -3368,6 +3373,21 @@ class WatchlistsDatabase:
             return
         raise ValueError("output_preset_name_exists")
 
+    @staticmethod
+    def _is_output_preset_name_constraint_error(exc: _DatabaseError) -> bool:
+        message = str(exc).lower()
+        if any(marker in message for marker in _OUTPUT_PRESET_NAME_CONSTRAINT_MARKERS):
+            return True
+        if "duplicate key value" in message and "watchlist_output_presets" in message:
+            return True
+        return "unique constraint failed" in message and "watchlist_output_presets" in message and "name" in message
+
+    @classmethod
+    def _raise_output_preset_constraint_error(cls, exc: _DatabaseError) -> None:
+        if cls._is_output_preset_name_constraint_error(exc):
+            raise ValueError("output_preset_name_exists") from exc
+        raise exc
+
     def create_output_preset(
         self,
         *,
@@ -3386,22 +3406,25 @@ class WatchlistsDatabase:
                 "UPDATE watchlist_output_presets SET is_default = 0, updated_at = ? WHERE user_id = ?",
                 (now, self.user_id),
             )
-        res = self._execute_insert(
-            """
-            INSERT INTO watchlist_output_presets
-                (user_id, name, description, output_prefs_json, is_default, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                self.user_id,
-                clean_name,
-                clean_description,
-                json.dumps(clean_output_prefs, sort_keys=True),
-                1 if is_default else 0,
-                now,
-                now,
-            ),
-        )
+        try:
+            res = self._execute_insert(
+                """
+                INSERT INTO watchlist_output_presets
+                    (user_id, name, description, output_prefs_json, is_default, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.user_id,
+                    clean_name,
+                    clean_description,
+                    json.dumps(clean_output_prefs, sort_keys=True),
+                    1 if is_default else 0,
+                    now,
+                    now,
+                ),
+            )
+        except _DatabaseError as exc:
+            self._raise_output_preset_constraint_error(exc)
         preset_id = self._extract_lastrowid(res)
         if not preset_id:
             raise RuntimeError("failed_to_create_output_preset")
@@ -3474,14 +3497,17 @@ class WatchlistsDatabase:
         sets.append("updated_at = ?")
         params.append(_utcnow_iso())
         params.extend([int(preset_id), self.user_id])
-        self.backend.execute(
-            f"""
-            UPDATE watchlist_output_presets
-            SET {', '.join(sets)}
-            WHERE id = ? AND user_id = ?
-            """,  # nosec B608
-            tuple(params),
-        )
+        try:
+            self.backend.execute(
+                f"""
+                UPDATE watchlist_output_presets
+                SET {', '.join(sets)}
+                WHERE id = ? AND user_id = ?
+                """,  # nosec B608
+                tuple(params),
+            )
+        except _DatabaseError as exc:
+            self._raise_output_preset_constraint_error(exc)
         return self.get_output_preset(preset_id=int(preset_id))
 
     def delete_output_preset(self, *, preset_id: int) -> bool:

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -29,6 +29,8 @@ Tables (per-user, colocated with Media DB):
                 details_json, created_at)
 - watchlist_item_saved_views(id, user_id, watchlist_id, name, filters_json,
                 sort, is_default, created_at, updated_at)
+- watchlist_output_presets(id, user_id, name, description, output_prefs_json,
+                is_default, created_at, updated_at)
 
 Notes:
 - Backed by DatabaseBackendFactory; default to per-user SQLite Media DB path.
@@ -101,6 +103,21 @@ _VALID_ITEM_SAVED_VIEW_FILTER_KEYS = {
     "smart_filter",
 }
 _VALID_ITEM_SAVED_VIEW_SMART_FILTERS = {"all", "today", "today_unread", "todayUnread", "unread", "reviewed", "queued"}
+_OUTPUT_PRESET_TEMPLATE_KEYS = {"default_name", "default_version", "default_format"}
+_OUTPUT_PRESET_RETENTION_KEYS = {"default_seconds", "temporary_seconds"}
+_OUTPUT_PRESET_DELIVERY_CHANNEL_KEYS = {"email", "chatbook"}
+_OUTPUT_PRESET_AUTO_OUTPUT_KEYS = {"enabled", "type", "format", "template_name", "template_version"}
+_OUTPUT_PRESET_TOP_LEVEL_KEYS = {
+    "generate_audio",
+    "audio_voice",
+    "audio_speed",
+    "target_audio_minutes",
+    "background_audio_uri",
+    "voice_map",
+    "retention_days",
+    "template_name",
+    "delivery_config",
+}
 _NESTED_REGEX_QUANTIFIER_RE = re.compile(
     r"\((?:[^()\\]|\\.)*(?:\*|\+|\{\d+(?:,\d*)?\})(?:[^()\\]|\\.)*\)\s*(?:\*|\+|\{\d+(?:,\d*)?\})"
 )
@@ -291,6 +308,18 @@ class WatchlistItemSavedViewRow:
     name: str
     filters_json: str
     sort: str
+    is_default: int
+    created_at: str
+    updated_at: str
+
+
+@dataclass
+class WatchlistOutputPresetRow:
+    id: int
+    user_id: str
+    name: str
+    description: str | None
+    output_prefs_json: str
     is_default: int
     created_at: str
     updated_at: str
@@ -747,6 +776,21 @@ class WatchlistsDatabase:
             CREATE INDEX IF NOT EXISTS idx_item_saved_views_user_watchlist
                 ON watchlist_item_saved_views(user_id, watchlist_id);
 
+            CREATE TABLE IF NOT EXISTS watchlist_output_presets (
+                id BIGSERIAL PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                output_prefs_json TEXT NOT NULL,
+                is_default INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_output_presets_user_updated
+                ON watchlist_output_presets(user_id, updated_at DESC);
+            CREATE UNIQUE INDEX IF NOT EXISTS ux_output_presets_user_name
+                ON watchlist_output_presets(user_id, LOWER(name));
+
             CREATE TABLE IF NOT EXISTS watchlist_clusters (
                 job_id BIGINT NOT NULL,
                 cluster_id BIGINT NOT NULL,
@@ -1049,6 +1093,21 @@ class WatchlistsDatabase:
             );
             CREATE INDEX IF NOT EXISTS idx_item_saved_views_user_watchlist
                 ON watchlist_item_saved_views(user_id, watchlist_id);
+
+            CREATE TABLE IF NOT EXISTS watchlist_output_presets (
+                id INTEGER PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                output_prefs_json TEXT NOT NULL,
+                is_default INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_output_presets_user_updated
+                ON watchlist_output_presets(user_id, updated_at DESC);
+            CREATE UNIQUE INDEX IF NOT EXISTS ux_output_presets_user_name
+                ON watchlist_output_presets(user_id, LOWER(name));
 
             CREATE TABLE IF NOT EXISTS watchlist_clusters (
                 job_id INTEGER NOT NULL,
@@ -3255,6 +3314,283 @@ class WatchlistsDatabase:
             (int(view_id), self.user_id, int(watchlist_id)),
         )
         return int(getattr(result, "rowcount", 0) or 0) > 0
+
+    @staticmethod
+    def _normalize_output_preset_name(name: str) -> str:
+        value = str(name or "").strip()
+        if not value:
+            raise ValueError("output_preset_name_required")
+        if len(value) > 120:
+            raise ValueError("output_preset_name_too_long")
+        return value
+
+    @staticmethod
+    def _normalize_output_preset_description(description: str | None) -> str | None:
+        if description is None:
+            return None
+        value = str(description).strip()
+        if not value:
+            return None
+        if len(value) > 500:
+            raise ValueError("output_preset_description_too_long")
+        return value
+
+    @staticmethod
+    def _normalize_output_prefs_payload(output_prefs: Any) -> dict[str, Any]:
+        if output_prefs is None:
+            return {}
+        if not isinstance(output_prefs, dict):
+            raise ValueError("output_preset_prefs_invalid")
+        try:
+            serialized = json.dumps(output_prefs, sort_keys=True)
+            parsed = json.loads(serialized)
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ValueError("output_preset_prefs_invalid") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("output_preset_prefs_invalid")
+        return parsed
+
+    def _check_output_preset_name_available(self, *, name: str, exclude_id: int | None = None) -> None:
+        row = self.backend.execute(
+            """
+            SELECT id
+            FROM watchlist_output_presets
+            WHERE user_id = ? AND LOWER(name) = LOWER(?)
+            """,
+            (self.user_id, name),
+        ).first
+        if not row:
+            return
+        existing_id = row.get("id")
+        if existing_id is None:
+            return
+        if exclude_id is not None and int(existing_id) == int(exclude_id):
+            return
+        raise ValueError("output_preset_name_exists")
+
+    def create_output_preset(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        output_prefs: dict[str, Any] | None = None,
+        is_default: bool = False,
+    ) -> WatchlistOutputPresetRow:
+        clean_name = self._normalize_output_preset_name(name)
+        clean_description = self._normalize_output_preset_description(description)
+        clean_output_prefs = self._normalize_output_prefs_payload(output_prefs)
+        self._check_output_preset_name_available(name=clean_name)
+        now = _utcnow_iso()
+        if is_default:
+            self.backend.execute(
+                "UPDATE watchlist_output_presets SET is_default = 0, updated_at = ? WHERE user_id = ?",
+                (now, self.user_id),
+            )
+        res = self._execute_insert(
+            """
+            INSERT INTO watchlist_output_presets
+                (user_id, name, description, output_prefs_json, is_default, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                self.user_id,
+                clean_name,
+                clean_description,
+                json.dumps(clean_output_prefs, sort_keys=True),
+                1 if is_default else 0,
+                now,
+                now,
+            ),
+        )
+        preset_id = self._extract_lastrowid(res)
+        if not preset_id:
+            raise RuntimeError("failed_to_create_output_preset")
+        return self.get_output_preset(preset_id=int(preset_id))
+
+    def get_output_preset(self, *, preset_id: int) -> WatchlistOutputPresetRow:
+        row = self.backend.execute(
+            """
+            SELECT id, user_id, name, description, output_prefs_json, is_default, created_at, updated_at
+            FROM watchlist_output_presets
+            WHERE id = ? AND user_id = ?
+            """,
+            (int(preset_id), self.user_id),
+        ).first
+        if not row:
+            raise KeyError("output_preset_not_found")
+        return WatchlistOutputPresetRow(**row)
+
+    def list_output_presets(self) -> list[WatchlistOutputPresetRow]:
+        rows = self.backend.execute(
+            """
+            SELECT id, user_id, name, description, output_prefs_json, is_default, created_at, updated_at
+            FROM watchlist_output_presets
+            WHERE user_id = ?
+            ORDER BY is_default DESC, updated_at DESC, id DESC
+            """,
+            (self.user_id,),
+        ).rows
+        return [WatchlistOutputPresetRow(**row) for row in rows]
+
+    def update_output_preset(
+        self,
+        *,
+        preset_id: int,
+        fields: dict[str, Any],
+    ) -> WatchlistOutputPresetRow:
+        current = self.get_output_preset(preset_id=int(preset_id))
+        if not fields:
+            return current
+        sets: list[str] = []
+        params: list[Any] = []
+        if "name" in fields and fields["name"] is not None:
+            clean_name = self._normalize_output_preset_name(str(fields["name"]))
+            self._check_output_preset_name_available(name=clean_name, exclude_id=int(preset_id))
+            sets.append("name = ?")
+            params.append(clean_name)
+        if "description" in fields:
+            sets.append("description = ?")
+            params.append(self._normalize_output_preset_description(fields["description"]))
+        if "output_prefs" in fields and fields["output_prefs"] is not None:
+            clean_output_prefs = self._normalize_output_prefs_payload(fields["output_prefs"])
+            sets.append("output_prefs_json = ?")
+            params.append(json.dumps(clean_output_prefs, sort_keys=True))
+        if "is_default" in fields and fields["is_default"] is not None:
+            is_default = bool(fields["is_default"])
+            if is_default:
+                now = _utcnow_iso()
+                self.backend.execute(
+                    """
+                    UPDATE watchlist_output_presets
+                    SET is_default = 0, updated_at = ?
+                    WHERE user_id = ? AND id != ?
+                    """,
+                    (now, self.user_id, int(preset_id)),
+                )
+            sets.append("is_default = ?")
+            params.append(1 if is_default else 0)
+        if not sets:
+            return current
+        sets.append("updated_at = ?")
+        params.append(_utcnow_iso())
+        params.extend([int(preset_id), self.user_id])
+        self.backend.execute(
+            f"""
+            UPDATE watchlist_output_presets
+            SET {', '.join(sets)}
+            WHERE id = ? AND user_id = ?
+            """,  # nosec B608
+            tuple(params),
+        )
+        return self.get_output_preset(preset_id=int(preset_id))
+
+    def delete_output_preset(self, *, preset_id: int) -> bool:
+        result = self.backend.execute(
+            "DELETE FROM watchlist_output_presets WHERE id = ? AND user_id = ?",
+            (int(preset_id), self.user_id),
+        )
+        return int(getattr(result, "rowcount", 0) or 0) > 0
+
+    @staticmethod
+    def _clone_output_prefs_value(value: Any) -> Any:
+        try:
+            return json.loads(json.dumps(value, sort_keys=True))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return value
+
+    @classmethod
+    def _apply_known_nested_output_prefs(
+        cls,
+        *,
+        base_value: Any,
+        preset_value: Any,
+        preset_has_key: bool,
+        known_keys: set[str],
+    ) -> Any | None:
+        if not preset_has_key:
+            if not isinstance(base_value, dict):
+                return None
+            preserved = {
+                key: cls._clone_output_prefs_value(value)
+                for key, value in base_value.items()
+                if key not in known_keys
+            }
+            return preserved or None
+        if preset_value is None:
+            return None
+        if not isinstance(preset_value, dict):
+            return cls._clone_output_prefs_value(preset_value)
+        preserved = (
+            {
+                key: cls._clone_output_prefs_value(value)
+                for key, value in base_value.items()
+                if key not in known_keys
+            }
+            if isinstance(base_value, dict)
+            else {}
+        )
+        for key, value in preset_value.items():
+            preserved[key] = cls._clone_output_prefs_value(value)
+        return preserved or None
+
+    @classmethod
+    def apply_output_prefs_preset(
+        cls,
+        *,
+        base_output_prefs: dict[str, Any] | None,
+        preset_output_prefs: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        base = cls._normalize_output_prefs_payload(base_output_prefs)
+        preset = cls._normalize_output_prefs_payload(preset_output_prefs)
+        result = cls._clone_output_prefs_value(base)
+        if not isinstance(result, dict):
+            result = {}
+
+        nested_specs = {
+            "template": _OUTPUT_PRESET_TEMPLATE_KEYS,
+            "retention": _OUTPUT_PRESET_RETENTION_KEYS,
+            "deliveries": _OUTPUT_PRESET_DELIVERY_CHANNEL_KEYS,
+            "auto_output": _OUTPUT_PRESET_AUTO_OUTPUT_KEYS,
+        }
+        for key, known_keys in nested_specs.items():
+            merged_value = cls._apply_known_nested_output_prefs(
+                base_value=base.get(key),
+                preset_value=preset.get(key),
+                preset_has_key=key in preset,
+                known_keys=known_keys,
+            )
+            if merged_value is None:
+                result.pop(key, None)
+            else:
+                result[key] = merged_value
+
+        for key in _OUTPUT_PRESET_TOP_LEVEL_KEYS:
+            result.pop(key, None)
+            if key in preset and preset[key] is not None:
+                result[key] = cls._clone_output_prefs_value(preset[key])
+
+        handled_keys = set(nested_specs) | _OUTPUT_PRESET_TOP_LEVEL_KEYS
+        for key, value in preset.items():
+            if key not in handled_keys:
+                result[key] = cls._clone_output_prefs_value(value)
+
+        return result
+
+    def apply_output_preset(
+        self,
+        *,
+        preset_id: int,
+        base_output_prefs: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        preset = self.get_output_preset(preset_id=int(preset_id))
+        try:
+            preset_output_prefs = json.loads(preset.output_prefs_json or "{}")
+        except json.JSONDecodeError:
+            preset_output_prefs = {}
+        return self.apply_output_prefs_preset(
+            base_output_prefs=base_output_prefs,
+            preset_output_prefs=preset_output_prefs if isinstance(preset_output_prefs, dict) else {},
+        )
 
     def list_items(
         self,

--- a/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py
@@ -444,6 +444,26 @@ def test_output_presets_endpoint_crud_and_apply(client_with_user):
     assert client.get("/api/v1/watchlists/job-output-presets").json()["items"] == []
 
 
+def test_output_preset_apply_rejects_null_base_output_prefs(client_with_user):
+    client = client_with_user
+
+    created = client.post(
+        "/api/v1/watchlists/job-output-presets",
+        json={
+            "name": "Null apply guard",
+            "output_prefs": {"generate_audio": True},
+        },
+    )
+    assert created.status_code == 201, created.text
+
+    response = client.post(
+        f"/api/v1/watchlists/job-output-presets/{created.json()['id']}/apply",
+        json={"base_output_prefs": None},
+    )
+
+    assert response.status_code == 422
+
+
 def test_output_preset_projection_rejects_corrupt_prefs():
     row = SimpleNamespace(
         id=1,

--- a/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py
@@ -355,3 +355,87 @@ def test_item_saved_views_endpoint_crud_and_validation(client_with_user):
     deleted = client.delete(f"/api/v1/watchlists/{watchlist_id}/item-views/{view['id']}")
     assert deleted.status_code == 204
     assert client.get(f"/api/v1/watchlists/{watchlist_id}/item-views").json()["items"] == []
+
+
+def test_output_presets_endpoint_crud_and_apply(client_with_user):
+    client = client_with_user
+
+    created = client.post(
+        "/api/v1/watchlists/job-output-presets",
+        json={
+            "name": "Daily newsletter",
+            "description": "HTML email plus audio",
+            "output_prefs": {
+                "template": {"default_name": "newsletter_html", "default_format": "html"},
+                "deliveries": {"email": {"enabled": True, "recipients": ["ops@example.com"]}},
+                "generate_audio": True,
+                "audio_voice": "nova",
+            },
+            "is_default": True,
+        },
+    )
+
+    assert created.status_code == 201, created.text
+    preset = created.json()
+    assert preset["name"] == "Daily newsletter"
+    assert preset["description"] == "HTML email plus audio"
+    assert preset["output_prefs"]["audio_voice"] == "nova"
+    assert preset["is_default"] is True
+
+    listed = client.get("/api/v1/watchlists/job-output-presets")
+    assert listed.status_code == 200, listed.text
+    assert [row["id"] for row in listed.json()["items"]] == [preset["id"]]
+
+    applied = client.post(
+        f"/api/v1/watchlists/job-output-presets/{preset['id']}/apply",
+        json={
+            "base_output_prefs": {
+                "template": {"default_name": "old", "experimental_renderer": "keep"},
+                "deliveries": {
+                    "chatbook": {"enabled": True, "title": "Old"},
+                    "webhook": {"url": "https://hooks.example.com/watchlists"},
+                },
+                "generate_audio": False,
+                "raw_advanced": {"preserve": True},
+            }
+        },
+    )
+    assert applied.status_code == 200, applied.text
+    applied_prefs = applied.json()["output_prefs"]
+    assert applied_prefs["template"] == {
+        "default_name": "newsletter_html",
+        "default_format": "html",
+        "experimental_renderer": "keep",
+    }
+    assert applied_prefs["deliveries"] == {
+        "email": {"enabled": True, "recipients": ["ops@example.com"]},
+        "webhook": {"url": "https://hooks.example.com/watchlists"},
+    }
+    assert applied_prefs["audio_voice"] == "nova"
+    assert applied_prefs["raw_advanced"] == {"preserve": True}
+
+    updated = client.patch(
+        f"/api/v1/watchlists/job-output-presets/{preset['id']}",
+        json={
+            "name": "Daily executive newsletter",
+            "description": None,
+            "output_prefs": {"generate_audio": False},
+            "is_default": False,
+        },
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["name"] == "Daily executive newsletter"
+    assert updated.json()["description"] is None
+    assert updated.json()["output_prefs"] == {"generate_audio": False}
+    assert updated.json()["is_default"] is False
+
+    missing = client.post(
+        "/api/v1/watchlists/job-output-presets/999999/apply",
+        json={"base_output_prefs": {}},
+    )
+    assert missing.status_code == 404
+    assert missing.json()["detail"] == "output_preset_not_found"
+
+    deleted = client.delete(f"/api/v1/watchlists/job-output-presets/{preset['id']}")
+    assert deleted.status_code == 204
+    assert client.get("/api/v1/watchlists/job-output-presets").json()["items"] == []

--- a/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import json
 from importlib import import_module
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.endpoints.watchlists import _row_to_output_preset
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
 
@@ -439,3 +442,18 @@ def test_output_presets_endpoint_crud_and_apply(client_with_user):
     deleted = client.delete(f"/api/v1/watchlists/job-output-presets/{preset['id']}")
     assert deleted.status_code == 204
     assert client.get("/api/v1/watchlists/job-output-presets").json()["items"] == []
+
+
+def test_output_preset_projection_rejects_corrupt_prefs():
+    row = SimpleNamespace(
+        id=1,
+        name="Corrupt preset",
+        description=None,
+        output_prefs_json="{not-json",
+        is_default=0,
+        created_at="2026-05-23T00:00:00Z",
+        updated_at="2026-05-23T00:00:00Z",
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        _row_to_output_preset(row)

--- a/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py
@@ -517,3 +517,170 @@ def test_item_saved_views_are_watchlist_scoped_and_validated(tmp_path):
 
     assert db.delete_item_saved_view(view_id=int(view.id), watchlist_id=watchlist_id) is True
     assert db.delete_item_saved_view(view_id=int(view.id), watchlist_id=watchlist_id) is False
+
+
+def test_output_presets_are_user_scoped_and_validated(tmp_path):
+    db = _make_db(tmp_path, user_id=124)
+    other_db = _make_db(tmp_path, user_id=125)
+
+    preset = db.create_output_preset(
+        name="Daily newsletter",
+        description="HTML email with audio",
+        output_prefs={
+            "template": {"default_name": "newsletter_html", "default_format": "html"},
+            "deliveries": {"email": {"enabled": True, "recipients": ["ops@example.com"]}},
+            "generate_audio": True,
+            "audio_voice": "nova",
+        },
+        is_default=True,
+    )
+    other_db.create_output_preset(
+        name="Other user preset",
+        description=None,
+        output_prefs={"template": {"default_name": "other"}},
+    )
+
+    assert preset.name == "Daily newsletter"
+    assert preset.description == "HTML email with audio"
+    assert json.loads(preset.output_prefs_json)["audio_voice"] == "nova"
+    assert int(preset.is_default) == 1
+    assert [row.name for row in db.list_output_presets()] == ["Daily newsletter"]
+    assert [row.name for row in other_db.list_output_presets()] == ["Other user preset"]
+
+    replacement_default = db.create_output_preset(
+        name="Briefing digest",
+        description=None,
+        output_prefs={"template": {"default_name": "briefing_markdown"}},
+        is_default=True,
+    )
+    refreshed_first = db.get_output_preset(preset_id=int(preset.id))
+    assert int(refreshed_first.is_default) == 0
+    assert int(replacement_default.is_default) == 1
+
+    updated = db.update_output_preset(
+        preset_id=int(preset.id),
+        fields={
+            "name": "Daily executive newsletter",
+            "description": "Renamed",
+            "output_prefs": {"generate_audio": False},
+            "is_default": True,
+        },
+    )
+    assert updated.name == "Daily executive newsletter"
+    assert updated.description == "Renamed"
+    assert json.loads(updated.output_prefs_json) == {"generate_audio": False}
+    assert int(updated.is_default) == 1
+    assert int(db.get_output_preset(preset_id=int(replacement_default.id)).is_default) == 0
+
+    with pytest.raises(ValueError, match="output_preset_name_required"):
+        db.create_output_preset(name=" ", description=None, output_prefs={})
+    with pytest.raises(ValueError, match="output_preset_prefs_invalid"):
+        db.create_output_preset(name="Bad prefs", description=None, output_prefs=["not", "a", "dict"])
+    with pytest.raises(ValueError, match="output_preset_name_exists"):
+        db.create_output_preset(
+            name="daily executive newsletter",
+            description=None,
+            output_prefs={},
+        )
+
+    assert db.delete_output_preset(preset_id=int(preset.id)) is True
+    assert db.delete_output_preset(preset_id=int(preset.id)) is False
+
+
+def test_output_preset_apply_preserves_unknown_fields(tmp_path):
+    db = _make_db(tmp_path)
+    preset = db.create_output_preset(
+        name="Podcast briefing",
+        description=None,
+        output_prefs={
+            "template": {"default_name": "podcast_script", "default_format": "md"},
+            "deliveries": {"chatbook": {"enabled": True, "title": "Daily Brief"}},
+            "generate_audio": False,
+            "preset_custom": {"copied": True},
+        },
+    )
+
+    applied = db.apply_output_preset(
+        preset_id=int(preset.id),
+        base_output_prefs={
+            "template": {
+                "default_name": "old",
+                "default_version": 3,
+                "experimental_renderer": "keep",
+            },
+            "deliveries": {
+                "email": {"enabled": True, "recipients": ["old@example.com"]},
+                "webhook": {"url": "https://hooks.example.com/watchlists"},
+            },
+            "auto_output": {"enabled": True, "type": "briefing_markdown", "custom_flag": "keep"},
+            "generate_audio": True,
+            "audio_voice": "alloy",
+            "target_audio_minutes": 12,
+            "raw_advanced": {"preserve": True},
+        },
+    )
+
+    assert applied["template"] == {
+        "default_name": "podcast_script",
+        "default_format": "md",
+        "experimental_renderer": "keep",
+    }
+    assert applied["deliveries"] == {
+        "chatbook": {"enabled": True, "title": "Daily Brief"},
+        "webhook": {"url": "https://hooks.example.com/watchlists"},
+    }
+    assert applied["auto_output"] == {"custom_flag": "keep"}
+    assert applied["generate_audio"] is False
+    assert "audio_voice" not in applied
+    assert "target_audio_minutes" not in applied
+    assert applied["raw_advanced"] == {"preserve": True}
+    assert applied["preset_custom"] == {"copied": True}
+
+
+def test_output_preset_apply_replaces_legacy_nested_values(tmp_path):
+    db = _make_db(tmp_path)
+    preset = db.create_output_preset(
+        name="Structured output",
+        description=None,
+        output_prefs={
+            "template": {"default_name": "newsletter_html", "default_format": "html"},
+            "deliveries": {"email": {"enabled": True, "recipients": ["team@example.com"]}},
+        },
+    )
+
+    applied = db.apply_output_preset(
+        preset_id=int(preset.id),
+        base_output_prefs={
+            "template": "legacy-template-name",
+            "deliveries": "legacy-delivery-target",
+            "raw_advanced": {"preserve": True},
+        },
+    )
+
+    assert applied["template"] == {"default_name": "newsletter_html", "default_format": "html"}
+    assert applied["deliveries"] == {"email": {"enabled": True, "recipients": ["team@example.com"]}}
+    assert applied["raw_advanced"] == {"preserve": True}
+
+
+def test_output_preset_apply_removes_legacy_nested_values_when_preset_omits_group(tmp_path):
+    db = _make_db(tmp_path)
+    preset = db.create_output_preset(
+        name="Audio only",
+        description=None,
+        output_prefs={"generate_audio": True, "audio_voice": "nova"},
+    )
+
+    applied = db.apply_output_preset(
+        preset_id=int(preset.id),
+        base_output_prefs={
+            "template": "legacy-template-name",
+            "deliveries": "legacy-delivery-target",
+            "raw_advanced": {"preserve": True},
+        },
+    )
+
+    assert "template" not in applied
+    assert "deliveries" not in applied
+    assert applied["generate_audio"] is True
+    assert applied["audio_voice"] == "nova"
+    assert applied["raw_advanced"] == {"preserve": True}

--- a/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py
@@ -587,6 +587,34 @@ def test_output_presets_are_user_scoped_and_validated(tmp_path):
     assert db.delete_output_preset(preset_id=int(preset.id)) is False
 
 
+def test_output_preset_unique_constraint_races_map_to_name_exists(tmp_path, monkeypatch):
+    db = _make_db(tmp_path)
+    existing = db.create_output_preset(
+        name="Daily newsletter",
+        description=None,
+        output_prefs={"generate_audio": True},
+    )
+    other = db.create_output_preset(
+        name="Other preset",
+        description=None,
+        output_prefs={"generate_audio": False},
+    )
+    monkeypatch.setattr(db, "_check_output_preset_name_available", lambda **_kwargs: None)
+
+    with pytest.raises(ValueError, match="output_preset_name_exists"):
+        db.create_output_preset(
+            name="daily newsletter",
+            description=None,
+            output_prefs={"generate_audio": False},
+        )
+
+    with pytest.raises(ValueError, match="output_preset_name_exists"):
+        db.update_output_preset(
+            preset_id=int(other.id),
+            fields={"name": str(existing.name).upper()},
+        )
+
+
 def test_output_preset_apply_preserves_unknown_fields(tmp_path):
     db = _make_db(tmp_path)
     preset = db.create_output_preset(


### PR DESCRIPTION
## Summary
- Adds per-user Watchlists output/delivery/audio preset persistence, CRUD, and apply semantics.
- Adds /watchlists Job form controls to load, save, apply, update, and delete presets without changing cadence, scope, filters, source rules, or dedupe.
- Preserves unknown advanced output_prefs while replacing known output/audio/delivery fields, with regression coverage for legacy scalar nested values and delete confirmation.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_db.py tldw_Server_API/tests/Watchlists/test_watchlist_items_triage_api.py -q
- bun run test -- src/services/__tests__/watchlists-items-triage.test.ts src/components/Option/Watchlists/JobsTab/__tests__/output-presets.test.ts src/components/Option/Watchlists/JobsTab/__tests__/JobFormModal.live-summary.test.tsx --maxWorkers=1 --no-file-parallelism
- bun run test -- src/components/Option/Watchlists/__tests__/watchlists-static-guard.typecheck.test.ts --maxWorkers=1 --no-file-parallelism
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/Watchlists_DB.py tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py -f json -o /tmp/bandit_watchlists_output_presets.json
- git diff --check HEAD~1..HEAD

## Notes
- AI-authored PR: per project policy, merge readiness still requires a human-written Change summary from the requester.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-backed, per-user Watchlists output/delivery/audio presets. Users can save, apply, update, and delete presets in the Job form without changing cadence, scope, filters, source rules, or dedupe; unknown advanced `output_prefs` are preserved. Satisfies TASK-488.

- **New Features**
  - Backend: new `watchlist_output_presets` table with CRUD and apply merge; endpoints under `/api/v1/watchlists/job-output-presets` (`GET` list/`GET` one/`POST`/`PATCH`/`DELETE`, plus `POST /{id}/apply`). User-scoped, case-insensitive name uniqueness, and a single default per user.
  - Frontend: `WatchlistOutputPreset*` types and services; a “Saved output presets” area in `JobFormModal` to load, save, apply, update, and delete presets with inline errors and delete confirmation. Server apply merges onto a base; client helper `applyOutputPresetToPrefs` matches backend semantics and preserves legacy scalar groups and unknown keys.

- **Bug Fixes**
  - API returns 409 on duplicate preset names, rejects corrupt/non-object `output_prefs_json` during projection, and returns 422 when `base_output_prefs` is explicitly `null` on apply.
  - Frontend preset merge uses `structuredClone` with JSON fallback to avoid losing non-JSON values; tests cover DB/API CRUD/apply, services, helper merge, and modal interactions.

<sup>Written for commit f39e875746cc9870493e2b4c347c5a8dc7ffd8b4. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1968?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

