### PR TITLE
Add OmniVoice managed sidecar smoke helper

### DIFF
--- a/Docs/STT-TTS/TTS-SETUP-GUIDE.md
+++ b/Docs/STT-TTS/TTS-SETUP-GUIDE.md
@@ -65,6 +65,12 @@ python Helper_Scripts/TTS_Installers/install_tts_omnivoice_sidecar.py \
   --model-path /absolute/path/to/local/OmniVoice/model
 ```
 
+Model path examples:
+
+- Hugging Face cache snapshot: `~/.cache/huggingface/hub/models--k2-fsa--OmniVoice/snapshots/<commit-sha>`
+- Repo-local operator-managed path: `models/omnivoice_sidecar/models/OmniVoice`
+- Any absolute directory containing the local OmniVoice model files
+
 What the installer provisions:
 
 - `models/omnivoice_sidecar/.venv`
@@ -80,11 +86,63 @@ Source checkout behavior:
 Runtime notes:
 
 - The sidecar supervisor reads the configured OmniVoice interpreter path from provider config, so the dedicated `.venv` created by the installer is the runtime that gets launched.
+- If you configure OmniVoice manually, set `extra_params.python_path` to an interpreter that can import `omnivoice`, `torch`, `torchaudio`, `soundfile`, `fastapi`, `uvicorn`, `httpx`, `pydantic`, and `loguru`.
 - Runtime synthesis fails closed if the configured model directory is missing; it does not fetch OmniVoice model assets on demand.
 - Public requests that target OmniVoice and omit `voice` normalize to `auto`.
 - Explicit voices still win over the provider default.
 - Supported request modes are automatic voice selection, voice design via `extra_params.instruct`, and cloning via direct `voice_reference` or stored `custom:<voice_id>` plus `extra_params.reference_text`.
 - The sidecar returns native 24 kHz WAV/PCM; public `response_format` conversion and any resampling happen in the main tldw adapter.
+
+Minimum manual provider config:
+
+```yaml
+providers:
+  omnivoice:
+    enabled: true
+    runtime: "sidecar"
+    model: "omnivoice"
+    sample_rate: 24000
+    max_concurrent_generations: 1
+    extra_params:
+      model_path: "/absolute/path/to/local/OmniVoice/model"
+      python_path: "models/omnivoice_sidecar/.venv/bin/python"
+      runtime_path: "models/omnivoice_sidecar/runtime"
+      scratch_dir: "models/omnivoice_sidecar/runtime/scratch"
+      host: "127.0.0.1"
+      port: 8039
+      autoselect_port: true
+      idle_shutdown_seconds: 900
+```
+
+Verify managed sidecar synthesis:
+
+```bash
+python Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py \
+  --model-path /absolute/path/to/local/OmniVoice/model \
+  --sidecar-python models/omnivoice_sidecar/.venv/bin/python \
+  --output /tmp/omnivoice-sidecar-smoke.wav \
+  --num-step 8 \
+  --speed 1.0
+```
+
+Successful output reports the written WAV path, byte count, 24 kHz sample rate, mono channel count, frame count, duration, RMS, and peak. The helper fails nonzero if the sidecar cannot start, the model cannot load, the output is not parseable WAV, the WAV shape is wrong, or the audio is silent.
+
+The opt-in pytest smoke tests use `OmniVoiceRuntime` directly in the active test interpreter:
+
+```bash
+TLDW_TEST_OMNIVOICE_REAL=1 \
+TLDW_OMNIVOICE_MODEL_PATH=/absolute/path/to/local/OmniVoice/model \
+python -m pytest tldw_Server_API/tests/TTS_NEW/integration/test_omnivoice_real_runtime.py -q
+```
+
+Use those tests only when the active project environment itself has the OmniVoice inference dependencies installed. To verify the intended managed sidecar deployment path, use `smoke_test_omnivoice_sidecar.py` with `--sidecar-python`.
+
+Common OmniVoice failures:
+
+- `ModuleNotFoundError: torchaudio` or `RUNTIME_IMPORT_FAILED`: install OmniVoice and its inference dependencies into the sidecar interpreter passed with `--sidecar-python`.
+- `MODEL_NOT_AVAILABLE` or "model path is not a directory": pass the resolved local model snapshot directory, not the Hugging Face model id.
+- `PermissionError` while checking or binding `127.0.0.1`: run the smoke helper outside restricted sandboxes that block loopback sockets.
+- HTTP timeout during synthesis: rerun with a larger `--timeout`; first model load can be much slower than later requests.
 
 Example request:
 

--- a/Docs/superpowers/plans/2026-05-22-omnivoice-sidecar-smoke-helper-plan.md
+++ b/Docs/superpowers/plans/2026-05-22-omnivoice-sidecar-smoke-helper-plan.md
@@ -1,0 +1,126 @@
+# OmniVoice Sidecar Smoke Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a repo-native helper that verifies the managed OmniVoice sidecar path can produce real non-silent WAV audio, and document how operators configure and run it.
+
+**Architecture:** Keep runtime orchestration on the existing `OmniVoiceSidecarSupervisor` and `OmniVoiceAdapter` path so the helper exercises the same managed sidecar integration as the API. Keep pure helpers importable for unit tests: CLI argument parsing, provider config construction, output path resolution, and WAV validation. Do not add another direct OmniVoice runtime path.
+
+**Tech Stack:** Python argparse, asyncio, stdlib `wave`/`audioop`, existing TTS adapter dataclasses, pytest unit tests, Bandit.
+
+**Backlog:** `TASK-488`
+
+---
+
+## Stage 1: Plan And Test Surface
+**Goal:** Lock the helper scope and add failing tests for behavior that does not require real OmniVoice dependencies.
+**Success Criteria:** Tests fail because `smoke_test_omnivoice_sidecar` does not exist yet or lacks the expected helpers.
+**Tests:** `python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -q`
+**Status:** Complete
+
+### Task 1: Add Failing Unit Tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py`
+- Create later: `Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py`
+
+- [x] **Step 1: Write failing tests for CLI parsing and config construction**
+
+```python
+def test_smoke_helper_builds_sidecar_provider_config(tmp_path):
+    config = build_sidecar_provider_config(...)
+    assert config["extra_params"]["python_path"] == str(sidecar_python)
+```
+
+- [x] **Step 2: Write failing tests for WAV validation**
+
+```python
+def test_smoke_helper_rejects_silent_wav():
+    with pytest.raises(SystemExit, match="silent"):
+        validate_wav_audio(silent_wav_bytes)
+```
+
+- [x] **Step 3: Run the focused tests to verify RED**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -q`
+Expected: FAIL from missing module/helper functions.
+
+---
+
+## Stage 2: Smoke Helper Implementation
+**Goal:** Implement the CLI and importable helpers with no direct model imports.
+**Success Criteria:** Unit tests pass, `--help` works, and the script validates generated audio before reporting success.
+**Tests:** `python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -q`
+**Status:** Complete
+
+### Task 2: Implement Helper Module
+
+**Files:**
+- Create: `Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py`
+- Test: `tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py`
+
+- [x] **Step 1: Implement argument parsing**
+
+Arguments: `--model-path`, `--sidecar-python`, optional `--repo-root`, `--output`, `--text`, `--port`, `--num-step`, `--speed`, `--timeout`.
+
+- [x] **Step 2: Implement config and request construction**
+
+Build provider config with `runtime: "sidecar"`, model path, interpreter path, runtime/scratch paths, loopback host, selected port, and short health/startup timeouts suitable for a smoke test.
+
+- [x] **Step 3: Implement async synthesis path**
+
+Instantiate `OmniVoiceSidecarSupervisor`, attach it to `OmniVoiceAdapter`, generate a non-streaming WAV `TTSRequest`, write the output file, and always shut the supervisor down.
+
+- [x] **Step 4: Implement WAV validation and summary output**
+
+Require parseable WAV bytes, 24 kHz sample rate, mono channel count, nonzero frames, and non-silent PCM samples.
+
+- [x] **Step 5: Run tests to verify GREEN**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -q`
+Expected: PASS.
+
+---
+
+## Stage 3: Documentation And Verification
+**Goal:** Make setup and real-runtime verification discoverable to operators.
+**Success Criteria:** The setup guide includes model-path examples, the sidecar smoke command, expected output, and common failure notes.
+**Tests:** focused tests, helper `--help`, docs grep, Bandit on touched helper.
+**Status:** Complete
+
+### Task 3: Update Setup Guide And Verify
+
+**Files:**
+- Modify: `Docs/STT-TTS/TTS-SETUP-GUIDE.md`
+- Modify: `backlog/tasks/task-487 - Add-OmniVoice-managed-sidecar-smoke-test-helper.md`
+
+- [x] **Step 1: Document OmniVoice setup and verification**
+
+Add model cache examples, sidecar Python guidance, smoke helper command, and notes for `torchaudio`, sandbox loopback restrictions, and the opt-in pytest runtime dependency caveat.
+
+- [x] **Step 2: Run verification**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -q
+python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_installer.py tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_supervisor.py -q
+python Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py --help
+python -m bandit -r Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py -f json -o /tmp/bandit_omnivoice_sidecar_smoke_helper.json
+python -m bandit -r tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -s B101 -f json -o /tmp/bandit_omnivoice_sidecar_smoke_tests.json
+git diff --check
+```
+
+Observed:
+- `test_omnivoice_sidecar_smoke.py`: 10 passed.
+- Adjacent OmniVoice installer/supervisor unit tests: 40 passed.
+- Helper `--help`: exit 0.
+- Bandit helper report: 0 findings.
+- Bandit test report with pytest assertion check skipped (`B101`): 0 findings.
+- `git diff --check`: exit 0.
+- Real managed sidecar smoke run using the local OmniVoice model snapshot and sidecar venv: exit 0, output `/private/tmp/omnivoice-helper-sidecar-smoke-recheck.wav`, 155084 bytes, 24000 Hz mono, 77520 frames, RMS 2284.84, peak 16384. The underlying runtime still emitted a shutdown `resource_tracker` semaphore warning after successful synthesis.
+- After rebasing onto `origin/dev`, repeated the focused test, adjacent OmniVoice tests, helper `--help`, Bandit, `git diff --check`, and real managed sidecar smoke. The post-rebase real smoke wrote `/private/tmp/omnivoice-helper-sidecar-smoke-rebase.wav`, 158924 bytes, 24000 Hz mono, 79440 frames, RMS 2425.56, peak 16384, with the same underlying shutdown `resource_tracker` semaphore warning after successful synthesis.
+
+- [x] **Step 3: Update Backlog and commit**
+
+Record touched files and verification in `TASK-487`, then commit with `feat: add omnivoice sidecar smoke helper`.

--- a/Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py
+++ b/Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py
@@ -10,18 +10,25 @@ from __future__ import annotations
 import argparse
 import asyncio
 import math
+import os
 import sys
 import wave
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Iterator, Optional, Sequence
 
 
 def _bootstrap_repo_root() -> Path:
+    """Find the checkout root and add it to sys.path for direct CLI execution."""
+
     probe = Path(__file__).resolve()
     for candidate in (probe,) + tuple(probe.parents):
-        if (candidate / "pyproject.toml").exists() and (candidate / "tldw_Server_API").is_dir():
+        is_repo_root = (
+            (candidate / "pyproject.toml").exists()
+            and (candidate / "tldw_Server_API").is_dir()
+        )
+        if is_repo_root:
             candidate_str = str(candidate)
             if candidate_str not in sys.path:
                 sys.path.insert(0, candidate_str)
@@ -48,6 +55,7 @@ DEFAULT_TIMEOUT_SECONDS = 180.0
 DEFAULT_HEALTHCHECK_TIMEOUT_SECONDS = 30.0
 DEFAULT_NUM_STEP = 8
 DEFAULT_SPEED = 1.0
+DEFAULT_MAX_ANALYSIS_SECONDS = 10.0
 
 
 @dataclass(frozen=True)
@@ -96,6 +104,8 @@ def resolve_repo_root(start: Optional[Path] = None) -> Path:
 
 
 def _resolve_path(path_value: str | Path, repo_root: Path) -> Path:
+    """Resolve a user path relative to the checkout root."""
+
     candidate = Path(path_value).expanduser()
     if not candidate.is_absolute():
         candidate = repo_root / candidate
@@ -103,6 +113,8 @@ def _resolve_path(path_value: str | Path, repo_root: Path) -> Path:
 
 
 def _resolve_path_preserving_symlink(path_value: str | Path, repo_root: Path) -> Path:
+    """Resolve a user path while preserving the final symlink component."""
+
     candidate = Path(path_value).expanduser()
     if not candidate.is_absolute():
         candidate = repo_root / candidate
@@ -110,32 +122,67 @@ def _resolve_path_preserving_symlink(path_value: str | Path, repo_root: Path) ->
 
 
 def _default_runtime_path(repo_root: Path) -> Path:
+    """Return the default managed sidecar runtime directory."""
+
     return (repo_root / DEFAULT_RUNTIME_BASE / "runtime").resolve(strict=False)
 
 
 def _default_scratch_dir(runtime_path: Path) -> Path:
+    """Return the default sidecar scratch directory."""
+
     return (runtime_path / "scratch").resolve(strict=False)
 
 
 def _default_output_path(runtime_path: Path) -> Path:
+    """Return the default smoke output WAV path."""
+
     return (runtime_path / DEFAULT_OUTPUT_NAME).resolve(strict=False)
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     """Parse CLI arguments for the sidecar smoke test."""
 
-    parser = argparse.ArgumentParser(description="Smoke test real OmniVoice audio through the managed sidecar")
+    parser = argparse.ArgumentParser(
+        description="Smoke test real OmniVoice audio through the managed sidecar",
+    )
     parser.add_argument("--model-path", required=True, help="Local OmniVoice model directory")
-    parser.add_argument("--sidecar-python", required=True, help="Python interpreter from the OmniVoice sidecar venv")
-    parser.add_argument("--repo-root", help="Repository root; defaults to the current script checkout")
+    parser.add_argument(
+        "--sidecar-python",
+        required=True,
+        help="Python interpreter from the OmniVoice sidecar venv",
+    )
+    parser.add_argument(
+        "--repo-root",
+        help="Repository root; defaults to the current script checkout",
+    )
     parser.add_argument("--runtime-path", help="Managed sidecar runtime directory")
     parser.add_argument("--scratch-dir", help="Managed scratch/reference directory")
     parser.add_argument("--output", help="Output WAV file path")
     parser.add_argument("--text", default=DEFAULT_TEXT, help="Text to synthesize")
-    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Starting loopback port for the sidecar")
-    parser.add_argument("--num-step", type=int, default=DEFAULT_NUM_STEP, help="OmniVoice generation num_step")
-    parser.add_argument("--speed", type=float, default=DEFAULT_SPEED, help="OmniVoice generation speed")
-    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Synthesis timeout in seconds")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="Starting loopback port for the sidecar",
+    )
+    parser.add_argument(
+        "--num-step",
+        type=int,
+        default=DEFAULT_NUM_STEP,
+        help="OmniVoice generation num_step",
+    )
+    parser.add_argument(
+        "--speed",
+        type=float,
+        default=DEFAULT_SPEED,
+        help="OmniVoice generation speed",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Synthesis timeout in seconds",
+    )
     return parser.parse_args(argv)
 
 
@@ -179,11 +226,21 @@ def validate_smoke_config(config: OmniVoiceSmokeConfig) -> None:
     if not config.model_path.is_dir():
         raise ValueError(f"OmniVoice model path is not a directory: {config.model_path}")
     if not config.sidecar_python.is_file():
-        raise ValueError(f"OmniVoice sidecar Python interpreter does not exist: {config.sidecar_python}")
+        raise ValueError(
+            f"OmniVoice sidecar Python interpreter does not exist: {config.sidecar_python}",
+        )
+    if not os.access(config.sidecar_python, os.X_OK):
+        raise ValueError(
+            f"OmniVoice sidecar Python interpreter is not executable: {config.sidecar_python}",
+        )
     if config.port <= 0 or config.port > 65535:
         raise ValueError(f"OmniVoice sidecar port must be between 1 and 65535: {config.port}")
     if config.timeout <= 0:
         raise ValueError("OmniVoice sidecar smoke timeout must be positive")
+    if config.speed <= 0:
+        raise ValueError(f"OmniVoice sidecar smoke speed must be positive: {config.speed}")
+    if config.num_step is not None and config.num_step <= 0:
+        raise ValueError(f"OmniVoice sidecar smoke num_step must be positive: {config.num_step}")
     if not config.text.strip():
         raise ValueError("OmniVoice sidecar smoke text must not be empty")
 
@@ -249,7 +306,9 @@ def build_tts_request(
     )
 
 
-def _iter_pcm_samples(frames: bytes, sample_width: int):
+def _iter_pcm_samples(frames: bytes, sample_width: int) -> Iterator[int]:
+    """Yield signed PCM samples from a WAV frame buffer."""
+
     if sample_width == 1:
         for value in frames:
             yield value - 128
@@ -270,11 +329,14 @@ def validate_wav_audio(
     expected_sample_rate: int = DEFAULT_SAMPLE_RATE,
     expected_channels: int = 1,
     min_rms: float = 1.0,
+    max_analysis_seconds: float = DEFAULT_MAX_ANALYSIS_SECONDS,
 ) -> WavAudioSummary:
     """Validate parseable, mono, non-silent WAV audio."""
 
     if not audio_bytes:
         raise ValueError("OmniVoice sidecar returned empty audio")
+    if max_analysis_seconds <= 0:
+        raise ValueError("OmniVoice WAV analysis window must be positive")
 
     try:
         with wave.open(BytesIO(audio_bytes), "rb") as wav_file:
@@ -282,7 +344,11 @@ def validate_wav_audio(
             sample_width = wav_file.getsampwidth()
             sample_rate = wav_file.getframerate()
             frame_count = wav_file.getnframes()
-            frames = wav_file.readframes(frame_count)
+            analysis_frame_count = min(
+                frame_count,
+                max(1, int(sample_rate * max_analysis_seconds)),
+            )
+            frames = wav_file.readframes(analysis_frame_count)
     except (EOFError, wave.Error) as exc:
         raise ValueError("OmniVoice sidecar output is not a parseable WAV file") from exc
 
@@ -336,6 +402,7 @@ async def run_smoke(config: OmniVoiceSmokeConfig) -> WavAudioSummary:
     adapter = OmniVoiceAdapter(provider_config)
     adapter.set_supervisor(supervisor)
 
+    primary_exception: BaseException | None = None
     try:
         initialized = await adapter.initialize()
         if not initialized:
@@ -348,8 +415,22 @@ async def run_smoke(config: OmniVoiceSmokeConfig) -> WavAudioSummary:
         config.output_path.parent.mkdir(parents=True, exist_ok=True)
         config.output_path.write_bytes(audio_bytes)
         return summary
+    except BaseException as exc:
+        primary_exception = exc
+        raise
     finally:
-        await supervisor.shutdown()
+        try:
+            await supervisor.shutdown()
+        except Exception as shutdown_exc:
+            if primary_exception is None:
+                raise RuntimeError(
+                    "Failed to shut down OmniVoice sidecar supervisor",
+                ) from shutdown_exc
+            print(
+                f"Warning: failed to shut down OmniVoice sidecar supervisor after "
+                f"smoke failure: {shutdown_exc}",
+                file=sys.stderr,
+            )
 
 
 def format_summary(config: OmniVoiceSmokeConfig, summary: WavAudioSummary) -> str:

--- a/Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py
+++ b/Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Run a real managed-sidecar OmniVoice TTS smoke test.
+
+The helper intentionally goes through ``OmniVoiceSidecarSupervisor`` and
+``OmniVoiceAdapter`` so operators verify the same managed sidecar path used by
+the API server. It does not import OmniVoice directly in the main interpreter.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import math
+import sys
+import wave
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Optional, Sequence
+
+
+def _bootstrap_repo_root() -> Path:
+    probe = Path(__file__).resolve()
+    for candidate in (probe,) + tuple(probe.parents):
+        if (candidate / "pyproject.toml").exists() and (candidate / "tldw_Server_API").is_dir():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            return candidate
+    raise RuntimeError(f"Unable to resolve repository root from {probe}")
+
+
+_BOOTSTRAPPED_REPO_ROOT = _bootstrap_repo_root()
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest  # noqa: E402
+from tldw_Server_API.app.core.TTS.adapters.omnivoice_adapter import OmniVoiceAdapter  # noqa: E402
+from tldw_Server_API.app.core.TTS.adapters.omnivoice_sidecar_supervisor import (  # noqa: E402
+    OmniVoiceSidecarSupervisor,
+)
+
+
+DEFAULT_TEXT = "Hello from the OmniVoice managed sidecar smoke test."
+DEFAULT_RUNTIME_BASE = Path("models") / "omnivoice_sidecar"
+DEFAULT_OUTPUT_NAME = "omnivoice_sidecar_smoke.wav"
+DEFAULT_SAMPLE_RATE = 24000
+DEFAULT_PORT = 8039
+DEFAULT_PORT_PROBE_MAX = 20
+DEFAULT_TIMEOUT_SECONDS = 180.0
+DEFAULT_HEALTHCHECK_TIMEOUT_SECONDS = 30.0
+DEFAULT_NUM_STEP = 8
+DEFAULT_SPEED = 1.0
+
+
+@dataclass(frozen=True)
+class OmniVoiceSmokeConfig:
+    """Resolved inputs for a managed OmniVoice sidecar smoke test."""
+
+    repo_root: Path
+    model_path: Path
+    sidecar_python: Path
+    runtime_path: Path
+    scratch_dir: Path
+    output_path: Path
+    text: str
+    port: int
+    num_step: Optional[int]
+    speed: float
+    timeout: float
+
+
+@dataclass(frozen=True)
+class WavAudioSummary:
+    """Small quality summary for generated WAV audio."""
+
+    byte_count: int
+    sample_rate: int
+    channels: int
+    sample_width: int
+    frame_count: int
+    duration_seconds: float
+    rms: float
+    peak: int
+
+
+def resolve_repo_root(start: Optional[Path] = None) -> Path:
+    """Resolve the repository root from a path, defaulting to this script."""
+
+    if start is None:
+        return _BOOTSTRAPPED_REPO_ROOT
+
+    probe = start.expanduser().resolve()
+    candidates = (probe,) + tuple(probe.parents)
+    for candidate in candidates:
+        if (candidate / "pyproject.toml").exists() and (candidate / "tldw_Server_API").is_dir():
+            return candidate
+    raise FileNotFoundError(f"Unable to resolve repository root from {probe}")
+
+
+def _resolve_path(path_value: str | Path, repo_root: Path) -> Path:
+    candidate = Path(path_value).expanduser()
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    return candidate.resolve(strict=False)
+
+
+def _resolve_path_preserving_symlink(path_value: str | Path, repo_root: Path) -> Path:
+    candidate = Path(path_value).expanduser()
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    return candidate
+
+
+def _default_runtime_path(repo_root: Path) -> Path:
+    return (repo_root / DEFAULT_RUNTIME_BASE / "runtime").resolve(strict=False)
+
+
+def _default_scratch_dir(runtime_path: Path) -> Path:
+    return (runtime_path / "scratch").resolve(strict=False)
+
+
+def _default_output_path(runtime_path: Path) -> Path:
+    return (runtime_path / DEFAULT_OUTPUT_NAME).resolve(strict=False)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments for the sidecar smoke test."""
+
+    parser = argparse.ArgumentParser(description="Smoke test real OmniVoice audio through the managed sidecar")
+    parser.add_argument("--model-path", required=True, help="Local OmniVoice model directory")
+    parser.add_argument("--sidecar-python", required=True, help="Python interpreter from the OmniVoice sidecar venv")
+    parser.add_argument("--repo-root", help="Repository root; defaults to the current script checkout")
+    parser.add_argument("--runtime-path", help="Managed sidecar runtime directory")
+    parser.add_argument("--scratch-dir", help="Managed scratch/reference directory")
+    parser.add_argument("--output", help="Output WAV file path")
+    parser.add_argument("--text", default=DEFAULT_TEXT, help="Text to synthesize")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Starting loopback port for the sidecar")
+    parser.add_argument("--num-step", type=int, default=DEFAULT_NUM_STEP, help="OmniVoice generation num_step")
+    parser.add_argument("--speed", type=float, default=DEFAULT_SPEED, help="OmniVoice generation speed")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Synthesis timeout in seconds")
+    return parser.parse_args(argv)
+
+
+def build_smoke_config(args: argparse.Namespace) -> OmniVoiceSmokeConfig:
+    """Resolve CLI arguments into a smoke-test config."""
+
+    repo_root = resolve_repo_root(Path(args.repo_root)) if args.repo_root else resolve_repo_root()
+    runtime_path = (
+        _resolve_path(args.runtime_path, repo_root)
+        if args.runtime_path
+        else _default_runtime_path(repo_root)
+    )
+    scratch_dir = (
+        _resolve_path(args.scratch_dir, repo_root)
+        if args.scratch_dir
+        else _default_scratch_dir(runtime_path)
+    )
+    output_path = (
+        _resolve_path(args.output, repo_root)
+        if args.output
+        else _default_output_path(runtime_path)
+    )
+    return OmniVoiceSmokeConfig(
+        repo_root=repo_root,
+        model_path=_resolve_path(args.model_path, repo_root),
+        sidecar_python=_resolve_path_preserving_symlink(args.sidecar_python, repo_root),
+        runtime_path=runtime_path,
+        scratch_dir=scratch_dir,
+        output_path=output_path,
+        text=str(args.text),
+        port=int(args.port),
+        num_step=args.num_step,
+        speed=float(args.speed),
+        timeout=float(args.timeout),
+    )
+
+
+def validate_smoke_config(config: OmniVoiceSmokeConfig) -> None:
+    """Validate operator-provided paths before starting the sidecar."""
+
+    if not config.model_path.is_dir():
+        raise ValueError(f"OmniVoice model path is not a directory: {config.model_path}")
+    if not config.sidecar_python.is_file():
+        raise ValueError(f"OmniVoice sidecar Python interpreter does not exist: {config.sidecar_python}")
+    if config.port <= 0 or config.port > 65535:
+        raise ValueError(f"OmniVoice sidecar port must be between 1 and 65535: {config.port}")
+    if config.timeout <= 0:
+        raise ValueError("OmniVoice sidecar smoke timeout must be positive")
+    if not config.text.strip():
+        raise ValueError("OmniVoice sidecar smoke text must not be empty")
+
+
+def build_sidecar_provider_config(
+    *,
+    model_path: Path,
+    sidecar_python: Path,
+    runtime_path: Path,
+    scratch_dir: Path,
+    port: int,
+    timeout: float,
+) -> dict[str, object]:
+    """Build the provider config consumed by the managed sidecar path."""
+
+    return {
+        "enabled": True,
+        "runtime": "sidecar",
+        "model": "omnivoice",
+        "sample_rate": DEFAULT_SAMPLE_RATE,
+        "timeout": float(timeout),
+        "max_concurrent_generations": 1,
+        "extra_params": {
+            "model_path": str(model_path),
+            "python_path": str(sidecar_python),
+            "runtime_path": str(runtime_path),
+            "scratch_dir": str(scratch_dir),
+            "host": "127.0.0.1",
+            "port": int(port),
+            "autoselect_port": True,
+            "port_probe_max": DEFAULT_PORT_PROBE_MAX,
+            "healthcheck_timeout_seconds": DEFAULT_HEALTHCHECK_TIMEOUT_SECONDS,
+            "healthcheck_interval_seconds": 0.25,
+            "startup_backoff_seconds": 0.0,
+            "idle_shutdown_seconds": 60.0,
+            "warmup_on_startup": False,
+            "resident_mode": False,
+        },
+    }
+
+
+def build_tts_request(
+    *,
+    text: str,
+    num_step: Optional[int],
+    speed: float,
+) -> TTSRequest:
+    """Build the adapter request for the smoke synthesis."""
+
+    extra_params: dict[str, object] = {"language_id": "en"}
+    if num_step is not None:
+        extra_params["num_step"] = int(num_step)
+    return TTSRequest(
+        text=text,
+        voice="auto",
+        language="en",
+        format=AudioFormat.WAV,
+        speed=float(speed),
+        stream=False,
+        provider="omnivoice",
+        model="omnivoice",
+        extra_params=extra_params,
+    )
+
+
+def _iter_pcm_samples(frames: bytes, sample_width: int):
+    if sample_width == 1:
+        for value in frames:
+            yield value - 128
+        return
+
+    if sample_width not in {2, 3, 4}:
+        raise ValueError(f"Output WAV has unsupported sample width: {sample_width} bytes")
+
+    for index in range(0, len(frames), sample_width):
+        sample = frames[index : index + sample_width]
+        if len(sample) == sample_width:
+            yield int.from_bytes(sample, "little", signed=True)
+
+
+def validate_wav_audio(
+    audio_bytes: bytes,
+    *,
+    expected_sample_rate: int = DEFAULT_SAMPLE_RATE,
+    expected_channels: int = 1,
+    min_rms: float = 1.0,
+) -> WavAudioSummary:
+    """Validate parseable, mono, non-silent WAV audio."""
+
+    if not audio_bytes:
+        raise ValueError("OmniVoice sidecar returned empty audio")
+
+    try:
+        with wave.open(BytesIO(audio_bytes), "rb") as wav_file:
+            channels = wav_file.getnchannels()
+            sample_width = wav_file.getsampwidth()
+            sample_rate = wav_file.getframerate()
+            frame_count = wav_file.getnframes()
+            frames = wav_file.readframes(frame_count)
+    except (EOFError, wave.Error) as exc:
+        raise ValueError("OmniVoice sidecar output is not a parseable WAV file") from exc
+
+    if sample_rate != expected_sample_rate:
+        raise ValueError(f"Expected {expected_sample_rate} Hz WAV audio, got {sample_rate} Hz")
+    if channels != expected_channels:
+        raise ValueError(f"Expected mono WAV audio, got {channels} channels")
+    if frame_count <= 0 or not frames:
+        raise ValueError("OmniVoice sidecar returned a WAV file with no frames")
+
+    square_sum = 0
+    sample_count = 0
+    peak = 0
+    for sample in _iter_pcm_samples(frames, sample_width):
+        sample_abs = abs(sample)
+        peak = max(peak, sample_abs)
+        square_sum += sample * sample
+        sample_count += 1
+
+    if sample_count <= 0:
+        raise ValueError("OmniVoice sidecar returned a WAV file with no samples")
+
+    rms = math.sqrt(square_sum / sample_count)
+    if peak <= 0 or rms < min_rms:
+        raise ValueError("OmniVoice sidecar output WAV appears silent")
+
+    return WavAudioSummary(
+        byte_count=len(audio_bytes),
+        sample_rate=sample_rate,
+        channels=channels,
+        sample_width=sample_width,
+        frame_count=frame_count,
+        duration_seconds=frame_count / sample_rate,
+        rms=rms,
+        peak=peak,
+    )
+
+
+async def run_smoke(config: OmniVoiceSmokeConfig) -> WavAudioSummary:
+    """Run synthesis through the managed sidecar and write the verified WAV."""
+
+    provider_config = build_sidecar_provider_config(
+        model_path=config.model_path,
+        sidecar_python=config.sidecar_python,
+        runtime_path=config.runtime_path,
+        scratch_dir=config.scratch_dir,
+        port=config.port,
+        timeout=config.timeout,
+    )
+    supervisor = OmniVoiceSidecarSupervisor(provider_config, repo_root=config.repo_root)
+    adapter = OmniVoiceAdapter(provider_config)
+    adapter.set_supervisor(supervisor)
+
+    try:
+        initialized = await adapter.initialize()
+        if not initialized:
+            raise RuntimeError("OmniVoice adapter did not initialize with the sidecar supervisor")
+
+        request = build_tts_request(text=config.text, num_step=config.num_step, speed=config.speed)
+        response = await adapter.generate(request)
+        audio_bytes = response.audio_data or response.audio_content or b""
+        summary = validate_wav_audio(audio_bytes)
+        config.output_path.parent.mkdir(parents=True, exist_ok=True)
+        config.output_path.write_bytes(audio_bytes)
+        return summary
+    finally:
+        await supervisor.shutdown()
+
+
+def format_summary(config: OmniVoiceSmokeConfig, summary: WavAudioSummary) -> str:
+    """Format the operator-facing success summary."""
+
+    return "\n".join(
+        [
+            "OmniVoice managed sidecar smoke succeeded.",
+            f"Output: {config.output_path}",
+            f"Bytes: {summary.byte_count}",
+            f"Sample rate: {summary.sample_rate} Hz",
+            f"Channels: {summary.channels}",
+            f"Frames: {summary.frame_count}",
+            f"Duration: {summary.duration_seconds:.2f}s",
+            f"RMS: {summary.rms:.2f}",
+            f"Peak: {summary.peak}",
+        ]
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entrypoint."""
+
+    try:
+        config = build_smoke_config(parse_args(argv))
+        validate_smoke_config(config)
+        summary = asyncio.run(run_smoke(config))
+    except SystemExit:
+        raise
+    except Exception as exc:
+        raise SystemExit(f"OmniVoice managed sidecar smoke failed: {exc}") from exc
+
+    print(format_summary(config, summary))
+    return 0
+
+
+__all__ = [
+    "OmniVoiceSmokeConfig",
+    "WavAudioSummary",
+    "build_sidecar_provider_config",
+    "build_smoke_config",
+    "build_tts_request",
+    "format_summary",
+    "main",
+    "parse_args",
+    "resolve_repo_root",
+    "run_smoke",
+    "validate_smoke_config",
+    "validate_wav_audio",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/backlog/tasks/task-488 - Add-OmniVoice-managed-sidecar-smoke-test-helper.md
+++ b/backlog/tasks/task-488 - Add-OmniVoice-managed-sidecar-smoke-test-helper.md
@@ -3,12 +3,12 @@ id: TASK-488
 title: Add OmniVoice managed sidecar smoke test helper
 status: Done
 assignee: []
-created_date: ''
-updated_date: '2026-05-23 01:10'
+created_date: '2026-05-23T01:10:00Z'
+updated_date: '2026-05-23T01:55:00Z'
 labels: []
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/pull/1958'
+  - 'https://github.com/rmusser01/tldw_server/pull/1969'
 documentation:
   - Docs/STT-TTS/TTS-SETUP-GUIDE.md
 ---
@@ -21,6 +21,9 @@ Add a repo-native operator smoke utility for real OmniVoice managed sidecar synt
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Smoke helper exercises the managed OmniVoice sidecar path through OmniVoiceSidecarSupervisor and OmniVoiceAdapter.
+- [x] #2 Smoke helper validates parseable non-silent 24 kHz mono WAV output and records real synthesis evidence.
+- [x] #3 Focused unit tests, adjacent OmniVoice tests, Bandit, helper --help, and diff checks are recorded before completion.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -32,13 +35,13 @@ Docs/superpowers/plans/2026-05-22-omnivoice-sidecar-smoke-helper-plan.md
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented a repo-native OmniVoice managed sidecar smoke helper that exercises OmniVoiceSidecarSupervisor plus OmniVoiceAdapter, preserves sidecar Python symlinks when building config, validates parseable non-silent 24 kHz mono WAV output, and always shuts down the supervisor. Updated the TTS setup guide with model path examples, provider config, smoke command, opt-in pytest caveats, and common failure notes.
+Implemented a repo-native OmniVoice managed sidecar smoke helper that exercises OmniVoiceSidecarSupervisor plus OmniVoiceAdapter, preserves sidecar Python symlinks when building config, validates parseable non-silent 24 kHz mono WAV output, and always shuts down the supervisor. Updated the TTS setup guide with model path examples, provider config, smoke command, opt-in pytest caveats, and common failure notes. Addressed PR #1969 review fixes with typed/docstring cleanup, bounded WAV sample analysis, executable sidecar-python validation, positive speed/num_step validation, shutdown error preservation, and Backlog metadata corrections.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py with focused unit coverage in tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py and documentation updates in Docs/STT-TTS/TTS-SETUP-GUIDE.md. Verification after rebasing onto origin/dev: smoke helper unit suite 10 passed; adjacent OmniVoice installer/supervisor tests 40 passed; helper --help exited 0; git diff --check exited 0; Bandit helper report had 0 findings; Bandit test report had 0 findings with pytest assertion check B101 skipped; real managed sidecar smoke synthesized /private/tmp/omnivoice-helper-sidecar-smoke-rebase.wav as 158924 bytes, 24000 Hz mono, 79440 frames, RMS 2425.56, peak 16384. Known note: the underlying runtime still emits a multiprocessing resource_tracker semaphore warning after successful synthesis.
+Added review fixes for PR #1969 on top of the OmniVoice managed sidecar smoke helper. The helper now validates executable sidecar Python plus positive speed/num_step controls, limits WAV sample analysis to a bounded window, preserves the primary failure if supervisor shutdown also fails, reports shutdown-only failures explicitly, and includes the requested typing/docstring/line-length cleanups. Verification: smoke helper unit suite 16 passed; adjacent OmniVoice installer/supervisor tests 40 passed; helper --help exited 0; py_compile exited 0; git diff --check exited 0; line-length scan found no >100 character lines in touched helper/test files; Bandit helper and test reports had 0 findings; real managed sidecar smoke synthesized /private/tmp/omnivoice-helper-sidecar-smoke-review.wav as 157964 bytes, 24000 Hz mono, 78960 frames, RMS 3922.93, peak 16384. Known note: the underlying runtime still emits a multiprocessing resource_tracker semaphore warning after successful synthesis.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-488 - Add-OmniVoice-managed-sidecar-smoke-test-helper.md
+++ b/backlog/tasks/task-488 - Add-OmniVoice-managed-sidecar-smoke-test-helper.md
@@ -1,0 +1,52 @@
+---
+id: TASK-488
+title: Add OmniVoice managed sidecar smoke test helper
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-23 01:10'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1958'
+documentation:
+  - Docs/STT-TTS/TTS-SETUP-GUIDE.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a repo-native operator smoke utility for real OmniVoice managed sidecar synthesis, with focused tests and TTS setup guide updates documenting model/runtime configuration and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-22-omnivoice-sidecar-smoke-helper-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a repo-native OmniVoice managed sidecar smoke helper that exercises OmniVoiceSidecarSupervisor plus OmniVoiceAdapter, preserves sidecar Python symlinks when building config, validates parseable non-silent 24 kHz mono WAV output, and always shuts down the supervisor. Updated the TTS setup guide with model path examples, provider config, smoke command, opt-in pytest caveats, and common failure notes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py with focused unit coverage in tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py and documentation updates in Docs/STT-TTS/TTS-SETUP-GUIDE.md. Verification after rebasing onto origin/dev: smoke helper unit suite 10 passed; adjacent OmniVoice installer/supervisor tests 40 passed; helper --help exited 0; git diff --check exited 0; Bandit helper report had 0 findings; Bandit test report had 0 findings with pytest assertion check B101 skipped; real managed sidecar smoke synthesized /private/tmp/omnivoice-helper-sidecar-smoke-rebase.wav as 158924 bytes, 24000 Hz mono, 79440 frames, RMS 2425.56, peak 16384. Known note: the underlying runtime still emits a multiprocessing resource_tracker semaphore warning after successful synthesis.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import struct
+import wave
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSResponse
+
+
+def _wav_bytes(samples: list[int], *, sample_rate: int = 24000, channels: int = 1) -> bytes:
+    buffer = BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        frames = b"".join(struct.pack("<h", sample) for sample in samples)
+        if channels > 1:
+            mono_frames = [
+                frames[index : index + 2]
+                for index in range(0, len(frames), 2)
+            ]
+            frames = b"".join(frame * channels for frame in mono_frames)
+        wav_file.writeframes(frames)
+    return buffer.getvalue()
+
+
+@pytest.mark.unit
+def test_smoke_helper_parse_args_accepts_operator_inputs(tmp_path):
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import parse_args
+
+    output_path = tmp_path / "omnivoice.wav"
+
+    args = parse_args(
+        [
+            "--model-path",
+            "/models/OmniVoice",
+            "--sidecar-python",
+            "/runtime/.venv/bin/python",
+            "--output",
+            str(output_path),
+            "--port",
+            "8844",
+            "--num-step",
+            "8",
+            "--speed",
+            "1.25",
+        ]
+    )
+
+    assert args.model_path == "/models/OmniVoice"
+    assert args.sidecar_python == "/runtime/.venv/bin/python"
+    assert args.output == str(output_path)
+    assert args.port == 8844
+    assert args.num_step == 8
+    assert args.speed == pytest.approx(1.25)
+
+
+@pytest.mark.unit
+def test_smoke_helper_builds_provider_config_with_managed_sidecar_paths(tmp_path):
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import build_sidecar_provider_config
+
+    model_path = tmp_path / "models" / "OmniVoice"
+    sidecar_python = tmp_path / "models" / "omnivoice_sidecar" / ".venv" / "bin" / "python"
+    runtime_path = tmp_path / "models" / "omnivoice_sidecar" / "runtime"
+    scratch_dir = runtime_path / "scratch"
+
+    config = build_sidecar_provider_config(
+        model_path=model_path,
+        sidecar_python=sidecar_python,
+        runtime_path=runtime_path,
+        scratch_dir=scratch_dir,
+        port=8844,
+        timeout=123.0,
+    )
+
+    assert config["enabled"] is True
+    assert config["runtime"] == "sidecar"
+    assert config["model"] == "omnivoice"
+    assert config["sample_rate"] == 24000
+    assert config["timeout"] == pytest.approx(123.0)
+    assert config["max_concurrent_generations"] == 1
+
+    extra_params = config["extra_params"]
+    assert extra_params["model_path"] == str(model_path)
+    assert extra_params["python_path"] == str(sidecar_python)
+    assert extra_params["runtime_path"] == str(runtime_path)
+    assert extra_params["scratch_dir"] == str(scratch_dir)
+    assert extra_params["host"] == "127.0.0.1"
+    assert extra_params["port"] == 8844
+    assert extra_params["autoselect_port"] is True
+    assert extra_params["port_probe_max"] >= 1
+
+
+@pytest.mark.unit
+def test_smoke_helper_preserves_sidecar_python_symlink_when_resolving_config(tmp_path):
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import build_smoke_config, parse_args
+
+    repo_root = tmp_path / "repo"
+    (repo_root / "tldw_Server_API").mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text("[project]\nname = \"test\"\n", encoding="utf-8")
+    base_python = tmp_path / "base-python"
+    base_python.write_text("# fake base python\n", encoding="utf-8")
+    sidecar_python = repo_root / "models" / "omnivoice_sidecar" / ".venv" / "bin" / "python"
+    sidecar_python.parent.mkdir(parents=True)
+    sidecar_python.symlink_to(base_python)
+    model_path = repo_root / "models" / "OmniVoice"
+    model_path.mkdir(parents=True)
+
+    args = parse_args(
+        [
+            "--repo-root",
+            str(repo_root),
+            "--model-path",
+            "models/OmniVoice",
+            "--sidecar-python",
+            "models/omnivoice_sidecar/.venv/bin/python",
+        ]
+    )
+
+    config = build_smoke_config(args)
+
+    assert config.sidecar_python == sidecar_python
+    assert config.sidecar_python != base_python.resolve()
+
+
+@pytest.mark.unit
+def test_smoke_helper_builds_non_streaming_wav_request():
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import build_tts_request
+
+    request = build_tts_request(
+        text="Hello from the smoke test.",
+        num_step=8,
+        speed=1.25,
+    )
+
+    assert request.provider == "omnivoice"
+    assert request.model == "omnivoice"
+    assert request.voice == "auto"
+    assert request.format is AudioFormat.WAV
+    assert request.stream is False
+    assert request.speed == pytest.approx(1.25)
+    assert request.extra_params["language_id"] == "en"
+    assert request.extra_params["num_step"] == 8
+
+
+@pytest.mark.unit
+def test_smoke_helper_validates_non_silent_24000_mono_wav():
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import validate_wav_audio
+
+    summary = validate_wav_audio(_wav_bytes([0, 500, -500, 1000, -1000]))
+
+    assert summary.sample_rate == 24000
+    assert summary.channels == 1
+    assert summary.frame_count == 5
+    assert summary.rms > 0
+    assert summary.peak == 1000
+
+
+@pytest.mark.unit
+def test_smoke_helper_rejects_silent_wav():
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import validate_wav_audio
+
+    with pytest.raises(ValueError, match="silent"):
+        validate_wav_audio(_wav_bytes([0, 0, 0, 0]))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("audio_bytes", "message"),
+    [
+        (b"not a wav", "parseable WAV"),
+        (_wav_bytes([1, 2, 3], sample_rate=16000), "24000"),
+        (_wav_bytes([1, 2, 3], channels=2), "mono"),
+    ],
+)
+def test_smoke_helper_rejects_invalid_wav_shape(audio_bytes, message):
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import validate_wav_audio
+
+    with pytest.raises(ValueError, match=message):
+        validate_wav_audio(audio_bytes)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_helper_runs_existing_sidecar_adapter_path_and_shuts_down(tmp_path, monkeypatch):
+    from Helper_Scripts.TTS_Installers import smoke_test_omnivoice_sidecar as smoke
+
+    audio_bytes = _wav_bytes([0, 600, -600, 1200, -1200])
+    supervisor_instances = []
+    adapter_instances = []
+
+    class _FakeSupervisor:
+        def __init__(self, provider_config, repo_root):
+            self.provider_config = provider_config
+            self.repo_root = repo_root
+            self.shutdown_called = False
+            supervisor_instances.append(self)
+
+        async def shutdown(self):
+            self.shutdown_called = True
+
+    class _FakeAdapter:
+        def __init__(self, config):
+            self.config = config
+            self.supervisor = None
+            self.request = None
+            adapter_instances.append(self)
+
+        def set_supervisor(self, supervisor):
+            self.supervisor = supervisor
+
+        async def initialize(self):
+            return True
+
+        async def generate(self, request):
+            self.request = request
+            return TTSResponse(
+                audio_data=audio_bytes,
+                format=AudioFormat.WAV,
+                sample_rate=24000,
+                channels=1,
+                provider="omnivoice",
+                model="omnivoice",
+            )
+
+    monkeypatch.setattr(smoke, "OmniVoiceSidecarSupervisor", _FakeSupervisor, raising=True)
+    monkeypatch.setattr(smoke, "OmniVoiceAdapter", _FakeAdapter, raising=True)
+
+    config = smoke.OmniVoiceSmokeConfig(
+        repo_root=tmp_path,
+        model_path=tmp_path / "models" / "OmniVoice",
+        sidecar_python=tmp_path / "models" / "omnivoice_sidecar" / ".venv" / "bin" / "python",
+        runtime_path=tmp_path / "models" / "omnivoice_sidecar" / "runtime",
+        scratch_dir=tmp_path / "models" / "omnivoice_sidecar" / "runtime" / "scratch",
+        output_path=tmp_path / "smoke.wav",
+        text="Hello from the managed sidecar.",
+        port=8844,
+        num_step=8,
+        speed=1.0,
+        timeout=123.0,
+    )
+
+    summary = await smoke.run_smoke(config)
+
+    assert config.output_path.read_bytes() == audio_bytes
+    assert summary.frame_count == 5
+    assert supervisor_instances[0].shutdown_called is True
+    assert supervisor_instances[0].repo_root == tmp_path
+    assert supervisor_instances[0].provider_config["extra_params"]["python_path"] == str(config.sidecar_python)
+    assert adapter_instances[0].supervisor is supervisor_instances[0]
+    assert adapter_instances[0].request.stream is False
+    assert adapter_instances[0].request.format is AudioFormat.WAV

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py
@@ -4,10 +4,41 @@ import struct
 import wave
 from io import BytesIO
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSResponse
+
+if TYPE_CHECKING:
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import (
+        OmniVoiceSmokeConfig,
+    )
+
+
+def _valid_smoke_config(tmp_path: Path) -> OmniVoiceSmokeConfig:
+    from Helper_Scripts.TTS_Installers import smoke_test_omnivoice_sidecar as smoke
+
+    model_path = tmp_path / "models" / "OmniVoice"
+    model_path.mkdir(parents=True)
+    sidecar_python = tmp_path / "models" / "omnivoice_sidecar" / ".venv" / "bin" / "python"
+    sidecar_python.parent.mkdir(parents=True)
+    sidecar_python.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+    sidecar_python.chmod(0o755)
+
+    return smoke.OmniVoiceSmokeConfig(
+        repo_root=tmp_path,
+        model_path=model_path,
+        sidecar_python=sidecar_python,
+        runtime_path=tmp_path / "models" / "omnivoice_sidecar" / "runtime",
+        scratch_dir=tmp_path / "models" / "omnivoice_sidecar" / "runtime" / "scratch",
+        output_path=tmp_path / "smoke.wav",
+        text="Hello from the managed sidecar.",
+        port=8844,
+        num_step=8,
+        speed=1.0,
+        timeout=123.0,
+    )
 
 
 def _wav_bytes(samples: list[int], *, sample_rate: int = 24000, channels: int = 1) -> bytes:
@@ -60,7 +91,9 @@ def test_smoke_helper_parse_args_accepts_operator_inputs(tmp_path):
 
 @pytest.mark.unit
 def test_smoke_helper_builds_provider_config_with_managed_sidecar_paths(tmp_path):
-    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import build_sidecar_provider_config
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import (
+        build_sidecar_provider_config,
+    )
 
     model_path = tmp_path / "models" / "OmniVoice"
     sidecar_python = tmp_path / "models" / "omnivoice_sidecar" / ".venv" / "bin" / "python"
@@ -96,7 +129,10 @@ def test_smoke_helper_builds_provider_config_with_managed_sidecar_paths(tmp_path
 
 @pytest.mark.unit
 def test_smoke_helper_preserves_sidecar_python_symlink_when_resolving_config(tmp_path):
-    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import build_smoke_config, parse_args
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import (
+        build_smoke_config,
+        parse_args,
+    )
 
     repo_root = tmp_path / "repo"
     (repo_root / "tldw_Server_API").mkdir(parents=True)
@@ -124,6 +160,38 @@ def test_smoke_helper_preserves_sidecar_python_symlink_when_resolving_config(tmp
 
     assert config.sidecar_python == sidecar_python
     assert config.sidecar_python != base_python.resolve()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("speed", 0.0, "OmniVoice sidecar smoke speed"),
+        ("num_step", 0, "OmniVoice sidecar smoke num_step"),
+    ],
+)
+def test_smoke_helper_rejects_invalid_generation_controls(tmp_path, field, value, message):
+    from dataclasses import replace
+
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import validate_smoke_config
+
+    config = replace(_valid_smoke_config(tmp_path), **{field: value})
+
+    with pytest.raises(ValueError, match=message):
+        validate_smoke_config(config)
+
+
+@pytest.mark.unit
+def test_smoke_helper_rejects_non_executable_sidecar_python(tmp_path):
+    from dataclasses import replace
+
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import validate_smoke_config
+
+    config = _valid_smoke_config(tmp_path)
+    config.sidecar_python.chmod(0o644)
+
+    with pytest.raises(ValueError, match="executable"):
+        validate_smoke_config(replace(config, sidecar_python=config.sidecar_python))
 
 
 @pytest.mark.unit
@@ -160,6 +228,20 @@ def test_smoke_helper_validates_non_silent_24000_mono_wav():
 
 
 @pytest.mark.unit
+def test_smoke_helper_limits_wav_sample_analysis_window():
+    from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import validate_wav_audio
+
+    summary = validate_wav_audio(
+        _wav_bytes([1000, 0, 3000, 0], sample_rate=4),
+        expected_sample_rate=4,
+        max_analysis_seconds=0.25,
+    )
+
+    assert summary.frame_count == 4
+    assert summary.peak == 1000
+
+
+@pytest.mark.unit
 def test_smoke_helper_rejects_silent_wav():
     from Helper_Scripts.TTS_Installers.smoke_test_omnivoice_sidecar import validate_wav_audio
 
@@ -185,7 +267,10 @@ def test_smoke_helper_rejects_invalid_wav_shape(audio_bytes, message):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_smoke_helper_runs_existing_sidecar_adapter_path_and_shuts_down(tmp_path, monkeypatch):
+async def test_smoke_helper_runs_existing_sidecar_adapter_path_and_shuts_down(
+    tmp_path,
+    monkeypatch,
+):
     from Helper_Scripts.TTS_Installers import smoke_test_omnivoice_sidecar as smoke
 
     audio_bytes = _wav_bytes([0, 600, -600, 1200, -1200])
@@ -249,7 +334,93 @@ async def test_smoke_helper_runs_existing_sidecar_adapter_path_and_shuts_down(tm
     assert summary.frame_count == 5
     assert supervisor_instances[0].shutdown_called is True
     assert supervisor_instances[0].repo_root == tmp_path
-    assert supervisor_instances[0].provider_config["extra_params"]["python_path"] == str(config.sidecar_python)
+    assert supervisor_instances[0].provider_config["extra_params"]["python_path"] == str(
+        config.sidecar_python,
+    )
     assert adapter_instances[0].supervisor is supervisor_instances[0]
     assert adapter_instances[0].request.stream is False
     assert adapter_instances[0].request.format is AudioFormat.WAV
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_helper_preserves_primary_error_when_shutdown_fails(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from Helper_Scripts.TTS_Installers import smoke_test_omnivoice_sidecar as smoke
+
+    class _FailingShutdownSupervisor:
+        def __init__(self, provider_config, repo_root):
+            pass
+
+        async def shutdown(self):
+            raise RuntimeError("shutdown failed")
+
+    class _FailingAdapter:
+        def __init__(self, config):
+            pass
+
+        def set_supervisor(self, supervisor):
+            pass
+
+        async def initialize(self):
+            raise RuntimeError("primary failed")
+
+    monkeypatch.setattr(
+        smoke,
+        "OmniVoiceSidecarSupervisor",
+        _FailingShutdownSupervisor,
+        raising=True,
+    )
+    monkeypatch.setattr(smoke, "OmniVoiceAdapter", _FailingAdapter, raising=True)
+
+    with pytest.raises(RuntimeError, match="primary failed"):
+        await smoke.run_smoke(_valid_smoke_config(tmp_path))
+
+    assert "shutdown failed" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_helper_reports_shutdown_error_after_success(tmp_path, monkeypatch):
+    from Helper_Scripts.TTS_Installers import smoke_test_omnivoice_sidecar as smoke
+
+    class _FailingShutdownSupervisor:
+        def __init__(self, provider_config, repo_root):
+            pass
+
+        async def shutdown(self):
+            raise RuntimeError("shutdown failed")
+
+    class _SuccessfulAdapter:
+        def __init__(self, config):
+            pass
+
+        def set_supervisor(self, supervisor):
+            pass
+
+        async def initialize(self):
+            return True
+
+        async def generate(self, request):
+            return TTSResponse(
+                audio_data=_wav_bytes([0, 600, -600, 1200, -1200]),
+                format=AudioFormat.WAV,
+                sample_rate=24000,
+                channels=1,
+                provider="omnivoice",
+                model="omnivoice",
+            )
+
+    monkeypatch.setattr(
+        smoke,
+        "OmniVoiceSidecarSupervisor",
+        _FailingShutdownSupervisor,
+        raising=True,
+    )
+    monkeypatch.setattr(smoke, "OmniVoiceAdapter", _SuccessfulAdapter, raising=True)
+
+    with pytest.raises(RuntimeError, match="Failed to shut down OmniVoice sidecar supervisor"):
+        await smoke.run_smoke(_valid_smoke_config(tmp_path))


### PR DESCRIPTION
## Summary

- Add a repo-native OmniVoice managed sidecar smoke helper that exercises `OmniVoiceSidecarSupervisor` plus `OmniVoiceAdapter`.
- Validate generated audio as parseable, non-silent 24 kHz mono WAV before reporting success.
- Document OmniVoice setup, provider config, smoke testing, opt-in runtime test caveats, and common failures in the TTS setup guide.
- Add focused unit coverage for CLI parsing, config construction, symlink-preserving sidecar Python handling, WAV validation, and supervisor shutdown.

## Change summary

This PR was materially authored with AI assistance. Before this PR is merge-ready, the human requester must replace this section with a human-written change summary explaining what changed and why these implementation choices were made.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -q` -> 10 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_installer.py tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_supervisor.py -q` -> 40 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py --help` -> exit 0
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py -f json -o /tmp/bandit_omnivoice_sidecar_smoke_helper_final.json` -> 0 findings
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_sidecar_smoke.py -s B101 -f json -o /tmp/bandit_omnivoice_sidecar_smoke_tests_final.json` -> 0 findings
- `git diff --check` -> clean
- Real sidecar smoke produced `/private/tmp/omnivoice-helper-sidecar-smoke-final.wav`: 152,204 bytes, 24 kHz mono, 76,080 frames, RMS 3657.15, peak 16384

## Known notes

- The underlying OmniVoice runtime still emits a multiprocessing `resource_tracker` semaphore warning after successful synthesis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI smoke test for the managed OmniVoice sidecar that generates and validates real 24 kHz mono, non-silent WAV through `OmniVoiceSidecarSupervisor` and `OmniVoiceAdapter`. Updates the TTS setup guide and tightens validations and shutdown handling; implements TASK-488.

- **New Features**
  - Added `Helper_Scripts/TTS_Installers/smoke_test_omnivoice_sidecar.py` to launch the managed sidecar, synthesize text, validate 24 kHz mono WAV, preserve symlinked `--sidecar-python`, and always shut the supervisor down.
  - Added unit tests for CLI parsing, provider config, symlink-preserving interpreter resolution, WAV validation, and supervisor shutdown.
  - Expanded `Docs/STT-TTS/TTS-SETUP-GUIDE.md` with model-path examples, a minimal provider config, the smoke command, opt-in pytest caveats, and common failure notes.

- **Bug Fixes**
  - Enforced executable `--sidecar-python`, positive `--speed`/`--num-step`, and bounded WAV analysis; improved error messages for non-parseable, non-mono, wrong-rate, or silent WAV.
  - Preserved primary errors when shutdown also fails and raised explicit errors on shutdown-only failures; minor typing/docstring cleanups.

<sup>Written for commit 715e69496021eb0de98ab7ee9667f0bafc121e46. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1969?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

