### PR TITLE
Migrate WritingPlaygroundTokenInspectorCard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2684,28 +2684,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx:Alert#antd-alert-writingplaygroundtokeninspectorcard-type-erro-i8ourj",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx:Alert#antd-alert-writingplaygroundtokeninspectorcard-type-info-1jtmgd6",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Quiz/tabs/CreateTab.tsx:Alert#antd-alert-createtab-type-info-line-1003-u954tt",
     "path": "src/components/Quiz/tabs/CreateTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
-import { Alert, Button, Tag } from "antd"
+import { Button, Tag } from "antd"
+import { Alert } from "@/components/ui/primitives"
 import type { TokenInspectorCardProps } from "./WritingPlaygroundDiagnostics.types"
 
 export const WritingPlaygroundTokenInspectorCard: FC<TokenInspectorCardProps> = ({
@@ -69,10 +70,10 @@ export const WritingPlaygroundTokenInspectorCard: FC<TokenInspectorCardProps> = 
       ) : null}
     </div>
     {tokenInspectorUnavailableReason ? (
-      <Alert type="info" showIcon message={tokenInspectorUnavailableReason} />
+      <Alert variant="info" title={tokenInspectorUnavailableReason} />
     ) : null}
     {tokenInspectorError ? (
-      <Alert type="error" showIcon message={tokenInspectorError} />
+      <Alert variant="error" title={tokenInspectorError} />
     ) : null}
     <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
       {hasTokenCountResult && tokenCountValue != null ? (

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
@@ -70,7 +70,7 @@ export const WritingPlaygroundTokenInspectorCard: FC<TokenInspectorCardProps> = 
       ) : null}
     </div>
     {tokenInspectorUnavailableReason ? (
-      <Alert variant="info" title={tokenInspectorUnavailableReason} />
+<Alert variant="info" className="mb-2" title={tokenInspectorUnavailableReason} />
     ) : null}
     {tokenInspectorError ? (
       <Alert variant="error" title={tokenInspectorError} />

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
@@ -73,7 +73,7 @@ export const WritingPlaygroundTokenInspectorCard: FC<TokenInspectorCardProps> = 
 <Alert variant="info" className="mb-2" title={tokenInspectorUnavailableReason} />
     ) : null}
     {tokenInspectorError ? (
-      <Alert variant="error" title={tokenInspectorError} />
+<Alert variant="error" className="mb-2" title={tokenInspectorError} />
     ) : null}
     <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
       {hasTokenCountResult && tokenCountValue != null ? (

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundTokenInspectorCard.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundTokenInspectorCard.design-system-alert.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { WritingPlaygroundTokenInspectorCard } from "../WritingPlaygroundTokenInspectorCard"
+import type { TokenInspectorCardProps } from "../WritingPlaygroundDiagnostics.types"
+
+const t: TokenInspectorCardProps["t"] = (_key, defaultValue, options) =>
+  defaultValue.replace(/\{\{(\w+)\}\}/g, (_, key) => String(options?.[key] ?? ""))
+
+const makeProps = (
+  overrides: Partial<TokenInspectorCardProps> = {}
+): TokenInspectorCardProps => ({
+  t,
+  tokenizerName: null,
+  serverSupportsTokenCount: false,
+  canCountTokens: false,
+  isCountingTokens: false,
+  onCountTokens: vi.fn(),
+  serverSupportsTokenize: false,
+  canTokenizePreview: false,
+  isTokenizingText: false,
+  onTokenizePreview: vi.fn(),
+  hasTokenCountResult: false,
+  tokenCountValue: null,
+  hasTokenizeResult: false,
+  tokenInspectorError: null,
+  tokenInspectorBusy: false,
+  tokenInspectorUnavailableReason: null,
+  onClearTokenInspector: vi.fn(),
+  tokenPreviewRowsCount: 0,
+  tokenPreviewTotal: 0,
+  ...overrides
+})
+
+describe("WritingPlaygroundTokenInspectorCard product-state alerts", () => {
+  it("renders unavailable reasons through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundTokenInspectorCard
+        {...makeProps({
+          tokenInspectorUnavailableReason: "Token counting requires a connected server."
+        })}
+      />
+    )
+
+    const unavailableReason = screen.getByText("Token counting requires a connected server.")
+    expect(
+      unavailableReason.closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+  })
+
+  it("renders token inspector errors through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundTokenInspectorCard
+        {...makeProps({
+          tokenInspectorError: "Unable to tokenize this draft."
+        })}
+      />
+    )
+
+    const errorMessage = screen.getByText("Unable to tokenize this draft.")
+    expect(errorMessage.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -39,6 +39,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created TASK-45.44.12.3 for the narrow Writing slice covering `WritingPlaygroundWordcloudCard` wordcloud error Alert migration. Verification on the slice reduced the product-state baseline from 290 to 289 and `Writing and Review surfaces` from 20 to 19. PR: https://github.com/rmusser01/tldw_server/pull/1965
 - Created TASK-45.44.12.4 for the narrow Writing slice covering `WritingPlaygroundResponseInspectorCard` response inspector guidance Alert migration. Verification on the slice reduced the product-state baseline from 289 to 288 and `Writing and Review surfaces` from 19 to 18. PR: https://github.com/rmusser01/tldw_server/pull/1966
 - Created TASK-45.44.12.5 for the narrow Writing slice covering `WritingPlaygroundActiveSessionGuard` settings-load Alert migration. Verification on the slice reduced the product-state baseline from 288 to 287 and `Writing and Review surfaces` from 18 to 17. PR: https://github.com/rmusser01/tldw_server/pull/1967
+- Created TASK-45.44.12.6 for the narrow Writing slice covering `WritingPlaygroundTokenInspectorCard` unavailable/error Alert migration. Verification on the slice reduced the product-state baseline from 287 to 285 and `Writing and Review surfaces` from 17 to 15. PR: https://github.com/rmusser01/tldw_server/pull/1971
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.6 - Migrate-WritingPlaygroundTokenInspectorCard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.6 - Migrate-WritingPlaygroundTokenInspectorCard-alerts-to-design-system-Alert.md
@@ -1,0 +1,75 @@
+---
+id: TASK-45.44.12.6
+title: Migrate WritingPlaygroundTokenInspectorCard alerts to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundTokenInspectorCard.design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the token inspector unavailable/error product-state AntD Alerts to the shared design-system Alert primitive. This reduces the Writing/Review product-state baseline while preserving token inspector status copy and actions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The token inspector unavailable state renders through the shared design-system Alert primitive.
+- [x] #2 The token inspector error state renders through the shared design-system Alert primitive.
+- [x] #3 The component keeps existing token inspector copy, actions, and result tag behavior.
+- [x] #4 The `WritingPlaygroundTokenInspectorCard` AntD Alert exceptions are removed from the product-state baseline.
+- [x] #5 Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add focused failing tests that render the token inspector unavailable and error states and assert each alert uses the shared design-system Alert marker.
+- [x] Replace the guarded AntD Alert usages in `WritingPlaygroundTokenInspectorCard` with the shared design-system Alert primitive while preserving copy and behavior.
+- [x] Remove the migrated `WritingPlaygroundTokenInspectorCard` Alert rows from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `WritingPlaygroundTokenInspectorCard.design-system-alert.test.tsx`; red state failed because the AntD Alerts did not provide the `data-ds-component="Alert"` marker.
+- Replaced the token inspector unavailable/error AntD `Alert` usages with the shared design-system `Alert` using `variant="info"` and `variant="error"`. Existing message text and action/result tag behavior are unchanged.
+- Removed both `WritingPlaygroundTokenInspectorCard` Alert baseline rows. Baseline count is now 285 total exceptions, with Writing and Review surfaces at 15.
+- Verification: `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundTokenInspectorCard.design-system-alert.test.tsx --reporter=dot` passed.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
+- Verification: `bun run verify:design-system-state` passed and reported 285 baseline exceptions / 15 Writing and Review exceptions.
+- Verification: baseline JSON parse and absence check for `src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx` passed.
+- Verification: `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_token_inspector_tsc.log` contains no diagnostics for the touched component or new test.
+- Bandit: skipped because this slice only touches frontend TypeScript/TSX and JSON task metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.6 - Migrate-WritingPlaygroundTokenInspectorCard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.6 - Migrate-WritingPlaygroundTokenInspectorCard-alerts-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.6
 title: Migrate WritingPlaygroundTokenInspectorCard alerts to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1971
 modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx
 - apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundTokenInspectorCard.design-system-alert.test.tsx
@@ -56,12 +57,13 @@ Migrate the token inspector unavailable/error product-state AntD Alerts to the s
 - Verification: `git diff --check` passed.
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_token_inspector_tsc.log` contains no diagnostics for the touched component or new test.
 - Bandit: skipped because this slice only touches frontend TypeScript/TSX and JSON task metadata.
+- PR: https://github.com/rmusser01/tldw_server/pull/1971
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the `WritingPlaygroundTokenInspectorCard` unavailable and error states to the shared design-system Alert primitive, added focused marker coverage for both states, and removed the retired product-state baseline exceptions. Verification passed for the focused token-inspector test, product-state guard test, `verify:design-system-state`, baseline absence check, and `git diff --check`; the slice reduces the product-state baseline to 285 total exceptions and Writing/Review to 15.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -70,6 +72,6 @@ Migrate the token inspector unavailable/error product-state AntD Alerts to the s
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the WritingPlaygroundTokenInspectorCard unavailable and error alerts from AntD to the shared design-system Alert primitive.
- Adds focused coverage that asserts both token-inspector product-state alerts render through the design-system Alert marker.
- Removes the migrated baseline rows, reducing product-state baseline exceptions from 287 to 285 and Writing/Review exceptions from 17 to 15.

## Verification
- `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundTokenInspectorCard.design-system-alert.test.tsx --reporter=dot` passed.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
- `bun run verify:design-system-state` passed and reported 285 baseline exceptions / 15 Writing and Review exceptions.
- Baseline JSON parse and absence check for `src/components/Option/WritingPlayground/WritingPlaygroundTokenInspectorCard.tsx` passed.
- `git diff --check` passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_token_inspector_tsc.log` has no diagnostics for the touched component or new test.

## Change summary
This is a narrow Writing/Review migration slice. The token inspector unavailable and error branches now use the canonical design-system Alert while preserving existing status text, token inspector actions, and result tag behavior. The product-state baseline rows are removed only after focused marker coverage and the product-state guard verifier confirm the migrated exceptions are gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the token inspector alerts in `WritingPlaygroundTokenInspectorCard` from `antd` to the design-system `Alert` for consistent UI and product-state guard compliance. Adds focused tests and removes two baseline exceptions; satisfies TASK-45.44.12.6.

- **Refactors**
  - Swapped `antd` `Alert` for design-system `Alert` with `variant="info" | "error"`, `title`, and `mb-2` spacing; copy and actions unchanged.
  - Added tests asserting both alerts render via the design-system marker.
  - Removed two product-state baseline rows; totals now 285 overall and 15 in Writing/Review.

<sup>Written for commit 0da0ad779ffd043f6c0be6ab06785940e0e341ad. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1971?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

