### PR TITLE
Migrate WritingPlaygroundDiagnosticsPanel alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2629,28 +2629,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-info-l-1cwjvuu",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx:Alert#antd-alert-writingplaygrounddiagnosticspanel-type-warnin-12u64sw",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx:Alert#antd-alert-writingplaygroundmodalhost-type-error-line-22-175t14c",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
-import { Alert, Card, Empty, Tag } from "antd"
+import { Card, Empty, Tag } from "antd"
+import { Alert } from "@/components/ui/primitives"
 import { getDesignSystemState } from "@/design-system"
 import { WritingPlaygroundResponseInspectorCard } from "./WritingPlaygroundResponseInspectorCard"
 import { WritingPlaygroundTokenInspectorCard } from "./WritingPlaygroundTokenInspectorCard"
@@ -39,28 +40,28 @@ export const WritingPlaygroundDiagnosticsPanel: FC<
         </Tag>
         {showOffline ? (
           <Alert
-            type="warning"
-            showIcon
+            variant="warning"
             title={t("option:writingPlayground.offlineTitle", "Server required")}
-            description={t(
+          >
+            {t(
               "option:writingPlayground.offlineBody",
               "Connect to your tldw server to load writing sessions and generate."
             )}
-          />
+          </Alert>
         ) : null}
         {showUnsupported ? (
           <Alert
-            type="info"
-            showIcon
+            variant="info"
             title={t(
               "option:writingPlayground.unavailableTitle",
               "Playground unavailable"
             )}
-            description={t(
+          >
+            {t(
               "option:writingPlayground.unavailableBody",
               "This server does not advertise writing playground support yet."
             )}
-          />
+          </Alert>
         ) : null}
         {!showOffline && !showUnsupported ? (
           hasActiveSession ? (

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-alert.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { WritingPlaygroundDiagnosticsPanel } from "../WritingPlaygroundDiagnosticsPanel"
+import type { WritingPlaygroundDiagnosticsPanelProps } from "../WritingPlaygroundDiagnostics.types"
+
+const t: WritingPlaygroundDiagnosticsPanelProps["t"] = (_key, defaultValue) =>
+  defaultValue
+
+const makeProps = (
+  overrides: Partial<WritingPlaygroundDiagnosticsPanelProps> = {}
+): WritingPlaygroundDiagnosticsPanelProps => ({
+  title: "Diagnostics",
+  t,
+  status: "ready",
+  showOffline: false,
+  showUnsupported: false,
+  hasActiveSession: false,
+  response: {
+    enabled: false,
+    responseInspectorRowsCount: 0,
+    responseLogprobsCount: 0,
+    settingsLogprobsEnabled: false,
+    settingsDisabled: false,
+    responseLogprobRowsCount: 0,
+    responseLogprobTruncated: false,
+    onCopyResponseInspectorJson: vi.fn(),
+    onExportResponseInspectorCsv: vi.fn(),
+    onClearResponseInspector: vi.fn()
+  },
+  token: {
+    enabled: false,
+    tokenizerName: null,
+    serverSupportsTokenCount: false,
+    canCountTokens: false,
+    isCountingTokens: false,
+    onCountTokens: vi.fn(),
+    serverSupportsTokenize: false,
+    canTokenizePreview: false,
+    isTokenizingText: false,
+    onTokenizePreview: vi.fn(),
+    hasTokenCountResult: false,
+    tokenCountValue: null,
+    hasTokenizeResult: false,
+    tokenInspectorError: null,
+    tokenInspectorBusy: false,
+    tokenInspectorUnavailableReason: null,
+    onClearTokenInspector: vi.fn(),
+    tokenPreviewRowsCount: 0,
+    tokenPreviewTotal: 0
+  },
+  wordcloud: {
+    enabled: false,
+    wordcloudStatus: null,
+    wordcloudStatusColor: "default",
+    canGenerateWordcloud: false,
+    isGeneratingWordcloud: false,
+    onGenerateWordcloud: vi.fn(),
+    wordcloudError: null,
+    onClearWordcloud: vi.fn(),
+    wordcloudWords: []
+  },
+  ...overrides
+})
+
+describe("WritingPlaygroundDiagnosticsPanel product-state alerts", () => {
+  it("renders the offline diagnostics state through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundDiagnosticsPanel {...makeProps({ showOffline: true })} />
+    )
+
+    const offlineTitle = screen.getByText("Server required")
+    expect(offlineTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
+  it("renders the unsupported diagnostics state through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundDiagnosticsPanel
+        {...makeProps({ showUnsupported: true })}
+      />
+    )
+
+    const unsupportedTitle = screen.getByText("Playground unavailable")
+    expect(
+      unsupportedTitle.closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -40,6 +40,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created TASK-45.44.12.4 for the narrow Writing slice covering `WritingPlaygroundResponseInspectorCard` response inspector guidance Alert migration. Verification on the slice reduced the product-state baseline from 289 to 288 and `Writing and Review surfaces` from 19 to 18. PR: https://github.com/rmusser01/tldw_server/pull/1966
 - Created TASK-45.44.12.5 for the narrow Writing slice covering `WritingPlaygroundActiveSessionGuard` settings-load Alert migration. Verification on the slice reduced the product-state baseline from 288 to 287 and `Writing and Review surfaces` from 18 to 17. PR: https://github.com/rmusser01/tldw_server/pull/1967
 - Created TASK-45.44.12.6 for the narrow Writing slice covering `WritingPlaygroundTokenInspectorCard` unavailable/error Alert migration. Verification on the slice reduced the product-state baseline from 287 to 285 and `Writing and Review surfaces` from 17 to 15. PR: https://github.com/rmusser01/tldw_server/pull/1971
+- Created TASK-45.44.12.7 for the narrow Writing slice covering `WritingPlaygroundDiagnosticsPanel` offline/unsupported Alert migration. Verification on the slice reduced the product-state baseline from 285 to 283 and `Writing and Review surfaces` from 15 to 13. PR: https://github.com/rmusser01/tldw_server/pull/1972
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.7 - Migrate-WritingPlaygroundDiagnosticsPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.7 - Migrate-WritingPlaygroundDiagnosticsPanel-alerts-to-design-system-Alert.md
@@ -1,0 +1,75 @@
+---
+id: TASK-45.44.12.7
+title: Migrate WritingPlaygroundDiagnosticsPanel alerts to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the diagnostics panel offline and unsupported product-state AntD Alerts to the shared design-system Alert primitive. This reduces the Writing/Review product-state baseline while preserving diagnostics copy and child-card behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The diagnostics offline/server-required state renders through the shared design-system Alert primitive.
+- [x] #2 The diagnostics unsupported/playground-unavailable state renders through the shared design-system Alert primitive.
+- [x] #3 The component keeps existing diagnostics copy, status tag, empty state, and child-card behavior.
+- [x] #4 The `WritingPlaygroundDiagnosticsPanel` AntD Alert exceptions are removed from the product-state baseline.
+- [x] #5 Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add focused failing tests that render the offline and unsupported diagnostics states and assert each alert uses the shared design-system Alert marker.
+- [x] Replace the guarded AntD Alert usages in `WritingPlaygroundDiagnosticsPanel` with the shared design-system Alert primitive while preserving copy and behavior.
+- [x] Remove the migrated `WritingPlaygroundDiagnosticsPanel` Alert rows from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `WritingPlaygroundDiagnosticsPanel.design-system-alert.test.tsx`; red state failed because the AntD Alerts did not provide the `data-ds-component="Alert"` marker.
+- Replaced the diagnostics offline/unsupported AntD `Alert` usages with the shared design-system `Alert` using `variant="warning"` and `variant="info"`. Existing titles, body copy, status tag, empty state, and child-card rendering are unchanged.
+- Removed both `WritingPlaygroundDiagnosticsPanel` Alert baseline rows. Baseline count is now 283 total exceptions, with Writing and Review surfaces at 13.
+- Verification: `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-alert.test.tsx src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx --reporter=dot` passed.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
+- Verification: `bun run verify:design-system-state` passed and reported 283 baseline exceptions / 13 Writing and Review exceptions.
+- Verification: baseline JSON parse and absence check for `src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx` passed.
+- Verification: `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_diagnostics_tsc.log` contains no diagnostics for the touched component or new test.
+- Bandit: skipped because this slice only touches frontend TypeScript/TSX and JSON task metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.7 - Migrate-WritingPlaygroundDiagnosticsPanel-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.7 - Migrate-WritingPlaygroundDiagnosticsPanel-alerts-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.7
 title: Migrate WritingPlaygroundDiagnosticsPanel alerts to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1972
 modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
 - apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-alert.test.tsx
@@ -56,12 +57,13 @@ Migrate the diagnostics panel offline and unsupported product-state AntD Alerts 
 - Verification: `git diff --check` passed.
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_diagnostics_tsc.log` contains no diagnostics for the touched component or new test.
 - Bandit: skipped because this slice only touches frontend TypeScript/TSX and JSON task metadata.
+- PR: https://github.com/rmusser01/tldw_server/pull/1972
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the `WritingPlaygroundDiagnosticsPanel` offline and unsupported states to the shared design-system Alert primitive, added focused marker coverage for both states, and removed the retired product-state baseline exceptions. Verification passed for the focused diagnostics tests, product-state guard test, `verify:design-system-state`, baseline absence check, and `git diff --check`; the slice reduces the product-state baseline to 283 total exceptions and Writing/Review to 13.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -70,6 +72,6 @@ Migrate the diagnostics panel offline and unsupported product-state AntD Alerts 
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the WritingPlaygroundDiagnosticsPanel offline and unsupported alerts from AntD to the shared design-system Alert primitive.
- Adds focused coverage that asserts both diagnostics panel product-state alerts render through the design-system Alert marker.
- Removes the migrated baseline rows, reducing product-state baseline exceptions from 285 to 283 and Writing/Review exceptions from 15 to 13.

## Verification
- `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-alert.test.tsx src/components/Option/WritingPlayground/__tests__/WritingPlaygroundDiagnosticsPanel.design-system-state.test.tsx --reporter=dot` passed.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
- `bun run verify:design-system-state` passed and reported 283 baseline exceptions / 13 Writing and Review exceptions.
- Baseline JSON parse and absence check for `src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx` passed.
- `git diff --check` passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide UI type debt; `/tmp/tldw_writing_diagnostics_tsc.log` has no diagnostics for the touched component or new test.

## Change summary
This is a narrow Writing/Review migration slice. The diagnostics panel offline and unsupported states now use the canonical design-system Alert while preserving existing titles, body copy, status tag, empty state, and child-card behavior. The product-state baseline rows are removed only after focused marker coverage and the product-state guard verifier confirm the migrated exceptions are gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Writing Playground diagnostics alerts from `antd` to the design-system `Alert` to standardize product-state UI. Added focused tests and removed two baseline exceptions (total now 283; Writing/Review 13).

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` for offline and unsupported states (`variant="warning"`/`"info"`), keeping titles and copy.
  - Added tests that assert both alerts render via the design-system marker.
  - Removed the two product-state baseline rows for this component.

<sup>Written for commit 4aeab55052ff3133355ceea4335af7b84c423fcf. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1972?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

