### PR TITLE
Migrate Watchlists template preview alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2431,61 +2431,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx:Alert#antd-alert-templatepreviewpane-type-error-line-270-1somb8x",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx:Alert#antd-alert-templatepreviewpane-type-error-line-352-1oorii2",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx:Alert#antd-alert-templatepreviewpane-type-info-line-259-1wp26ge",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx:Alert#antd-alert-templatepreviewpane-type-warning-line-244-5ap8tk",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx:Alert#antd-alert-templatepreviewpane-type-warning-line-289-11rrcz7",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx:Alert#antd-alert-visualcomposerpane-type-error-line-282-1ch7xog",
     "path": "src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from "react"
-import { Alert, Button, Radio, Select, Spin } from "antd"
+import { Button, Radio, Select, Spin } from "antd"
 import DOMPurify from "dompurify"
 import { marked } from "marked"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives/Alert"
 import {
   flowCheckWatchlistTemplateSections,
   previewWatchlistTemplate,
@@ -242,23 +243,22 @@ export const TemplatePreviewPane: React.FC<TemplatePreviewPaneProps> = ({
 
       {mode === "live" && !hasRuns && (
         <Alert
-          type="warning"
-          showIcon
+          variant="warning"
           title={t(
             "watchlists:templates.preview.noRunsTitle",
             "No completed runs available for live preview."
           )}
-          description={t(
+        >
+          {t(
             "watchlists:templates.preview.noRunsDescription",
             "Run a monitor once from Activity, then return here to preview templates with real data."
           )}
-        />
+        </Alert>
       )}
 
       {mode === "live" && hasRuns && !selectedRunId && (
         <Alert
-          type="info"
-          showIcon
+          variant="info"
           title={t(
             "watchlists:templates.preview.selectRunTitle",
             "Select a run to preview the template with real data."
@@ -268,36 +268,32 @@ export const TemplatePreviewPane: React.FC<TemplatePreviewPaneProps> = ({
 
       {error && (
         <Alert
-          type="error"
-          showIcon
+          variant="error"
           title={t("watchlists:templates.preview.renderErrorTitle", "Live preview failed")}
-          description={
+        >
+          <div>
             <div>
-              <div>
-                {t(
-                  "watchlists:templates.preview.renderErrorHint",
-                  "Check template syntax or choose another run, then try live preview again."
-                )}
-              </div>
-              <div className="mt-1 text-xs text-text-muted">{error}</div>
+              {t(
+                "watchlists:templates.preview.renderErrorHint",
+                "Check template syntax or choose another run, then try live preview again."
+              )}
             </div>
-          }
-        />
+            <div className="mt-1 text-xs text-text-muted">{error}</div>
+          </div>
+        </Alert>
       )}
 
       {warnings.length > 0 && (
         <Alert
-          type="warning"
-          showIcon
+          variant="warning"
           title={t("watchlists:templates.preview.renderWarningsTitle", "Render warnings")}
-          description={
-            <ul className="mb-0 pl-4">
-              {warnings.map((warning, index) => (
-                <li key={`${warning}-${index}`}>{warning}</li>
-              ))}
-            </ul>
-          }
-        />
+        >
+          <ul className="mb-0 pl-4">
+            {warnings.map((warning, index) => (
+              <li key={`${warning}-${index}`}>{warning}</li>
+            ))}
+          </ul>
+        </Alert>
       )}
 
       {mode === "static" ? (
@@ -349,7 +345,7 @@ export const TemplatePreviewPane: React.FC<TemplatePreviewPaneProps> = ({
           </Button>
         </div>
 
-        {flowError ? <Alert type="error" showIcon title={flowError} /> : null}
+        {flowError ? <Alert variant="error" title={flowError} /> : null}
 
         {(flowDiff || flowIssues.length > 0) ? (
           <FlowCheckDiffPanel

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.accessibility-baseline.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.accessibility-baseline.test.tsx
@@ -6,6 +6,27 @@ import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { TemplatePreviewPane } from "../TemplatePreviewPane"
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") {
+        return fallbackOrOptions
+      }
+      if (
+        fallbackOrOptions &&
+        typeof fallbackOrOptions === "object" &&
+        typeof fallbackOrOptions.defaultValue === "string"
+      ) {
+        return fallbackOrOptions.defaultValue
+      }
+      return key
+    }
+  })
+}))
+
 vi.mock("antd", () => {
   const RadioButton = ({ value, children, checked, onSelect }: any) => (
     <button
@@ -47,7 +68,7 @@ vi.mock("antd", () => {
     </select>
   )
 
-  const Button = ({ children, onClick, ...rest }: any) => (
+  const Button = ({ children, onClick, loading: _loading, ...rest }: any) => (
     <button type="button" onClick={() => onClick?.()} {...rest}>
       {children}
     </button>

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.live-preview.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.live-preview.test.tsx
@@ -6,7 +6,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { TemplatePreviewPane } from "../TemplatePreviewPane"
 
 const serviceMocks = vi.hoisted(() => ({
-  previewWatchlistTemplate: vi.fn()
+  previewWatchlistTemplate: vi.fn(),
+  flowCheckWatchlistTemplateSections: vi.fn()
 }))
 
 const telemetryMock = vi.hoisted(() => ({
@@ -98,7 +99,7 @@ vi.mock("antd", async () => {
   )
 
   const Spin = () => <div data-testid="template-preview-loading">Loading</div>
-  const Button = ({ children, onClick, ...rest }: any) => (
+  const Button = ({ children, onClick, loading: _loading, ...rest }: any) => (
     <button type="button" onClick={() => onClick?.()} {...rest}>
       {children}
     </button>
@@ -117,7 +118,9 @@ vi.mock("antd", async () => {
 })
 
 vi.mock("@/services/watchlists", () => ({
-  previewWatchlistTemplate: (...args: unknown[]) => serviceMocks.previewWatchlistTemplate(...args)
+  previewWatchlistTemplate: (...args: unknown[]) => serviceMocks.previewWatchlistTemplate(...args),
+  flowCheckWatchlistTemplateSections: (...args: unknown[]) =>
+    serviceMocks.flowCheckWatchlistTemplateSections(...args)
 }))
 
 vi.mock("@/utils/watchlists-prevention-telemetry", () => ({
@@ -132,6 +135,12 @@ describe("TemplatePreviewPane preview clarity", () => {
       rendered: "# Preview",
       context_keys: ["items"],
       warnings: []
+    })
+    serviceMocks.flowCheckWatchlistTemplateSections.mockResolvedValue({
+      issues: [],
+      diff: "",
+      sections: [],
+      mode: "suggest_only"
     })
   })
 
@@ -165,6 +174,11 @@ describe("TemplatePreviewPane preview clarity", () => {
       "Live preview renders with data from a completed run to validate loops, variables, and conditionals."
     )
     expect(screen.getByText("Select a run to preview the template with real data.")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Select a run to preview the template with real data.")
+        .closest('[data-ds-component="Alert"]')
+    ).not.toBeNull()
   })
 
   it("renders live preview warnings when server render returns warning metadata", async () => {
@@ -197,6 +211,7 @@ describe("TemplatePreviewPane preview clarity", () => {
     }, { timeout: 2000 })
 
     expect(screen.getByText("Render warnings")).toBeInTheDocument()
+    expect(screen.getByText("Render warnings").closest('[data-ds-component="Alert"]')).not.toBeNull()
     expect(screen.getByText("Missing item.summary")).toBeInTheDocument()
     expect(screen.getByText("Unknown group key")).toBeInTheDocument()
     expect(screen.getByText("Live output")).toBeInTheDocument()
@@ -218,6 +233,11 @@ describe("TemplatePreviewPane preview clarity", () => {
     fireEvent.click(screen.getByRole("radio", { name: "Live (render with run data)" }))
 
     expect(screen.getByText("No completed runs available for live preview.")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("No completed runs available for live preview.")
+        .closest('[data-ds-component="Alert"]')
+    ).not.toBeNull()
     expect(
       screen.getByText(
         "Run a monitor once from Activity, then return here to preview templates with real data."
@@ -251,6 +271,7 @@ describe("TemplatePreviewPane preview clarity", () => {
     }, { timeout: 2000 })
 
     expect(screen.getByText("Live preview failed")).toBeInTheDocument()
+    expect(screen.getByText("Live preview failed").closest('[data-ds-component="Alert"]')).not.toBeNull()
     expect(
       screen.getByText("Check template syntax or choose another run, then try live preview again.")
     ).toBeInTheDocument()
@@ -268,5 +289,35 @@ describe("TemplatePreviewPane preview clarity", () => {
         run_id: 33
       })
     )
+  })
+
+  it("renders flow-check failures through the design-system Alert primitive", async () => {
+    serviceMocks.flowCheckWatchlistTemplateSections.mockRejectedValueOnce(
+      new Error("Flow-check service unavailable")
+    )
+
+    render(
+      <TemplatePreviewPane
+        content="# Heading"
+        format="md"
+        runs={[{ id: 44, label: "Run #44" }]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("radio", { name: "Live (render with run data)" }))
+    fireEvent.change(screen.getByTestId("template-preview-run-select"), {
+      target: { value: "44" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run flow-check" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Flow-check service unavailable")).toBeInTheDocument()
+    })
+
+    expect(
+      screen
+        .getByText("Flow-check service unavailable")
+        .closest('[data-ds-component="Alert"]')
+    ).not.toBeNull()
   })
 })

--- a/backlog/tasks/task-45.44.3.4 - Migrate-TemplatePreviewPane-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.4 - Migrate-TemplatePreviewPane-alerts-to-design-system-Alert.md
@@ -1,0 +1,68 @@
+---
+id: TASK-45.44.3.4
+title: Migrate TemplatePreviewPane alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+- watchlists
+priority: medium
+parent_task_id: TASK-45.44.3
+references:
+- https://github.com/rmusser01/tldw_server/issues/1660
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplatePreviewPane.tsx
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.live-preview.test.tsx
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.accessibility-baseline.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-45.44.3 by replacing Watchlists TemplatePreviewPane AntD Alert product-state callouts with the shared design-system Alert primitive, preserving preview error/info/warning copy and controls, removing migrated baseline exceptions, and recording focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TemplatePreviewPane warning, info, preview error, and flow error callouts render through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused TemplatePreviewPane coverage proves the migrated callouts preserve user-facing copy and expose canonical Alert markers.
+- [x] #3 Migrated TemplatePreviewPane Alert baseline exceptions are removed without introducing new product-state verifier findings.
+- [x] #4 Focused tests, design-system verifier, locale/JSON hygiene where relevant, diff check, and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add or extend focused TemplatePreviewPane tests that require design-system Alert markers around warning/info/error callouts. 2. Replace TemplatePreviewPane AntD Alert imports/usages with the shared Alert primitive while preserving titles, descriptions, icons, loading, and preview controls. 3. Remove TemplatePreviewPane Alert entries from design-system-product-state-baseline.json. 4. Run focused tests, product-state verifier, git diff --check, and record Bandit as UI-only if no Python changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added focused TemplatePreviewPane regression coverage requiring the live-preview setup, no-runs, render-warning, render-error, and flow-error callouts to sit inside `[data-ds-component="Alert"]`.
+- Replaced TemplatePreviewPane AntD Alert usage with `@/components/ui/primitives/Alert`, preserving warning/info/error copy and flow-check controls.
+- Removed the five migrated TemplatePreviewPane Alert exceptions from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
+- Verification: `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.live-preview.test.tsx src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.accessibility-baseline.test.tsx --maxWorkers=1 --no-file-parallelism` -> 2 files, 6 tests passed.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism` -> 1 file, 54 tests passed.
+- Verification: `bun run verify:design-system-state` -> passed with 280 baseline exceptions total and Jobs/Scheduler/Watchlists at 27.
+- Verification: `git diff --check` -> passed.
+- Bandit: skipped/not applicable; touched code is frontend TS/TSX plus JSON and Backlog task metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+TemplatePreviewPane now uses the shared design-system Alert primitive for its preview/setup/error flow states. Focused tests cover the migrated callouts, the product-state baseline dropped the five TemplatePreviewPane Alert exceptions, and verification passed for the focused Watchlists tests, product-state guard, design-system verifier, and diff hygiene.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replace TemplatePreviewPane AntD Alert callouts with the shared design-system Alert primitive.
- Add focused Watchlists coverage for preview setup, no-runs, warning, error, and flow-check Alert states.
- Remove the five migrated TemplatePreviewPane Alert entries from the product-state baseline and record TASK-45.44.3.4.

## Verification
- bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.live-preview.test.tsx src/components/Option/Watchlists/TemplatesTab/__tests__/TemplatePreviewPane.accessibility-baseline.test.tsx --maxWorkers=1 --no-file-parallelism
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism
- bun run verify:design-system-state
- git diff --check

## Notes
- Bandit skipped: frontend TS/TSX, JSON, and Backlog task metadata only.
- Merge gate: AI-authored PRs still need the requester's human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Watchlists TemplatePreviewPane alerts from `antd` to the design-system `Alert` to standardize callouts and markers. Cleans up five product-state baseline exceptions and adds focused tests for live preview states, aligning with TASK-45.44.3.4.

- **Refactors**
  - Replace `antd` Alert with `@/components/ui/primitives/Alert` for no-runs, select-run, render warnings, render error, and flow-check error states.
  - Remove five related entries from `design-system-product-state-baseline.json`.
  - Update tests to assert `[data-ds-component="Alert"]` and cover flow-check failures.

<sup>Written for commit c3ab9acd27164ce78024b4c2f1f839ed133c3e5d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1973?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

