### PR TITLE
Migrate ConnectionWebModal feedback states to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2596,39 +2596,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx:Empty#antd-empty-connectionwebmodal-add-characters-or-world-in-13nhe96",
-    "path": "src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx:Empty#antd-empty-connectionwebmodal-select-a-project-first-lin-1lvl2ch",
-    "path": "src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Empty",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Empty product-state UI in src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx:Spin",
-    "path": "src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Spin",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Spin product-state UI in src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx:Alert#antd-alert-writingplaygroundmodalhost-type-error-line-22-175t14c",
     "path": "src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/ConnectionWebModal.design-system-feedback.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/ConnectionWebModal.design-system-feedback.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+type QueryResult = {
+  data?: unknown
+  isLoading?: boolean
+}
+
+const mockState = vi.hoisted(() => ({
+  activeProjectId: null as string | null,
+  queryResults: [] as QueryResult[],
+}))
+
+vi.mock("@/store/writing-playground", () => ({
+  useWritingPlaygroundStore: () => ({
+    activeProjectId: mockState.activeProjectId,
+  }),
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(
+    () =>
+      mockState.queryResults.shift() ?? {
+        data: undefined,
+        isLoading: false,
+      },
+  ),
+}))
+
+import { ConnectionWebModal } from "../modals/ConnectionWebModal"
+
+const CLOSED_HANDLER = vi.fn()
+
+const setQueryResults = (results: QueryResult[]) => {
+  mockState.queryResults = results
+}
+
+const renderModal = () => {
+  render(<ConnectionWebModal open onClose={CLOSED_HANDLER} />)
+}
+
+describe("ConnectionWebModal design-system feedback states", () => {
+  beforeEach(() => {
+    CLOSED_HANDLER.mockReset()
+    mockState.activeProjectId = null
+    setQueryResults([])
+  })
+
+  it("renders the project-required state through EmptyState", () => {
+    renderModal()
+
+    expect(screen.getByText("Select a project first")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Select a project first")
+        .closest('[data-ds-component="EmptyState"]'),
+    ).toBeInTheDocument()
+  })
+
+  it("renders the loading branch through LoadingState", () => {
+    mockState.activeProjectId = "project-1"
+    setQueryResults([
+      { data: undefined, isLoading: true },
+      { data: undefined, isLoading: false },
+      { data: undefined, isLoading: false },
+    ])
+
+    renderModal()
+
+    expect(
+      document.body.querySelector('[data-ds-component="LoadingState"]'),
+    ).toBeInTheDocument()
+  })
+
+  it("renders the no-data state through EmptyState", () => {
+    mockState.activeProjectId = "project-1"
+    setQueryResults([
+      { data: { characters: [] }, isLoading: false },
+      { data: { relationships: [] }, isLoading: false },
+      { data: { items: [] }, isLoading: false },
+    ])
+
+    renderModal()
+
+    expect(
+      screen.getByText("Add characters or world info to visualize connections"),
+    ).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Add characters or world info to visualize connections")
+        .closest('[data-ds-component="EmptyState"]'),
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { Button, Empty, Modal, Spin } from "antd"
+import { Button, Modal } from "antd"
 import { ZoomIn, ZoomOut, Maximize2 } from "lucide-react"
 import cytoscape, {
   type Core,
@@ -9,6 +9,8 @@ import cytoscape, {
   type StylesheetJson,
 } from "cytoscape"
 import dagre from "cytoscape-dagre"
+import { EmptyState } from "@/components/ui/feedback/EmptyState"
+import { LoadingState } from "@/components/ui/feedback/LoadingState"
 import { useWritingPlaygroundStore } from "@/store/writing-playground"
 import {
   listManuscriptCharacters,
@@ -215,13 +217,23 @@ export function ConnectionWebModal({ open, onClose }: ConnectionWebModalProps) {
   return (
     <Modal title="Connection Web" open={open} onCancel={onClose} footer={null} width={900}>
       {!activeProjectId ? (
-        <Empty description="Select a project first" />
+        <EmptyState
+          variant="inline"
+          size="md"
+          title="Select a project first"
+          className="py-10"
+        />
       ) : isLoading ? (
         <div className="h-[520px] flex items-center justify-center">
-          <Spin />
+          <LoadingState mode="spinner" size="md" />
         </div>
       ) : !hasData ? (
-        <Empty description="Add characters or world info to visualize connections" />
+        <EmptyState
+          variant="inline"
+          size="md"
+          title="Add characters or world info to visualize connections"
+          className="py-10"
+        />
       ) : (
         <>
           <div className="flex items-center gap-2 mb-2">

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -41,6 +41,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created TASK-45.44.12.5 for the narrow Writing slice covering `WritingPlaygroundActiveSessionGuard` settings-load Alert migration. Verification on the slice reduced the product-state baseline from 288 to 287 and `Writing and Review surfaces` from 18 to 17. PR: https://github.com/rmusser01/tldw_server/pull/1967
 - Created TASK-45.44.12.6 for the narrow Writing slice covering `WritingPlaygroundTokenInspectorCard` unavailable/error Alert migration. Verification on the slice reduced the product-state baseline from 287 to 285 and `Writing and Review surfaces` from 17 to 15. PR: https://github.com/rmusser01/tldw_server/pull/1971
 - Created TASK-45.44.12.7 for the narrow Writing slice covering `WritingPlaygroundDiagnosticsPanel` offline/unsupported Alert migration. Verification on the slice reduced the product-state baseline from 285 to 283 and `Writing and Review surfaces` from 15 to 13. PR: https://github.com/rmusser01/tldw_server/pull/1972
+- Created TASK-45.44.12.8 for the narrow Writing slice covering `ConnectionWebModal` project-required/no-data Empty and loading Spin migration. Verification on the slice reduced the product-state baseline from 283 to 280 and `Writing and Review surfaces` from 13 to 10. PR: https://github.com/rmusser01/tldw_server/pull/1974
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.8 - Migrate-ConnectionWebModal-empty-and-loading-states-to-design-system-feedback.md
+++ b/backlog/tasks/task-45.44.12.8 - Migrate-ConnectionWebModal-empty-and-loading-states-to-design-system-feedback.md
@@ -1,0 +1,78 @@
+---
+id: TASK-45.44.12.8
+title: Migrate ConnectionWebModal empty and loading states to design-system feedback
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/ConnectionWebModal.design-system-feedback.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the Connection Web modal project-required, no-data, and loading product-state AntD feedback to shared design-system feedback primitives. This reduces the Writing/Review product-state baseline while preserving modal behavior and copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The project-required empty state renders through the shared design-system EmptyState primitive.
+- [x] #2 The no-data empty state renders through the shared design-system EmptyState primitive.
+- [x] #3 The loading branch renders through the shared design-system LoadingState primitive.
+- [x] #4 The modal keeps existing copy, query gating, and graph branch behavior.
+- [x] #5 The `ConnectionWebModal` AntD Empty/Spin exceptions are removed from the product-state baseline.
+- [x] #6 Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add focused failing tests that render the project-required, loading, and no-data states and assert each uses the shared design-system feedback marker.
+- [x] Replace the AntD Empty/Spin usages in `ConnectionWebModal` with shared design-system EmptyState/LoadingState primitives while preserving copy and layout.
+- [x] Remove the migrated `ConnectionWebModal` rows from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `ConnectionWebModal.design-system-feedback.test.tsx` with three product-state checks for project-required, loading, and no-data modal branches.
+- Red check before implementation: `bunx vitest run src/components/Option/WritingPlayground/__tests__/ConnectionWebModal.design-system-feedback.test.tsx --reporter=dot` failed all three marker assertions because the component still rendered AntD `Empty`/`Spin`.
+- Migrated the two AntD `Empty` branches to `EmptyState` and the AntD `Spin` branch to `LoadingState`, preserving the existing visible copy and conditional branches.
+- Removed the three `ConnectionWebModal` product-state baseline rows; baseline total is now 280 and Writing/Review baseline count is now 10.
+- Verification:
+  - `bunx vitest run src/components/Option/WritingPlayground/__tests__/ConnectionWebModal.design-system-feedback.test.tsx --reporter=dot` passed, 3 tests.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed, 54 tests.
+  - `bun run verify:design-system-state` passed with `Baseline exceptions: 280` and `Writing and Review surfaces: 10`.
+  - Baseline parse/absence check passed and confirmed no `ConnectionWebModal` baseline entries remain.
+  - `git diff --check` passed.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exited 2 on existing repo-wide TypeScript debt; `/tmp/tldw_writing_connection_web_tsc.log` has no diagnostics for `ConnectionWebModal` or the new design-system feedback test.
+- Bandit not run: touched implementation is UI TypeScript/TSX and JSON/task metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.8 - Migrate-ConnectionWebModal-empty-and-loading-states-to-design-system-feedback.md
+++ b/backlog/tasks/task-45.44.12.8 - Migrate-ConnectionWebModal-empty-and-loading-states-to-design-system-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.8
 title: Migrate ConnectionWebModal empty and loading states to design-system feedback
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1974
 modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/modals/ConnectionWebModal.tsx
 - apps/packages/ui/src/components/Option/WritingPlayground/__tests__/ConnectionWebModal.design-system-feedback.test.tsx
@@ -64,7 +65,9 @@ Migrate the Connection Web modal project-required, no-data, and loading product-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR: https://github.com/rmusser01/tldw_server/pull/1974
 
+Migrated `ConnectionWebModal` project-required, loading, and no-data feedback branches to shared design-system `EmptyState`/`LoadingState` primitives. Added focused marker coverage and removed the three migrated product-state baseline rows, bringing the product-state baseline to 280 and Writing/Review to 10.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -73,6 +76,6 @@ Migrate the Connection Web modal project-required, no-data, and loading product-
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the ConnectionWebModal project-required/no-data empty states and loading branch from AntD feedback to shared design-system EmptyState/LoadingState primitives.
- Adds focused coverage that asserts those modal states render through design-system feedback markers.
- Removes the migrated baseline rows, reducing product-state baseline exceptions from 283 to 280 and Writing/Review exceptions from 13 to 10.

## Verification
- `bunx vitest run src/components/Option/WritingPlayground/__tests__/ConnectionWebModal.design-system-feedback.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- Baseline parse/absence check for `ConnectionWebModal`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 on existing repo-wide TypeScript debt; no diagnostics for touched files.

## Change summary
This is a narrow Writing/Review migration slice. The Connection Web modal project-required, loading, and no-data branches now use canonical design-system feedback primitives while preserving visible copy, query gating, and graph branch behavior. Baseline rows are removed only after focused marker coverage and guard verifier confirm the migrated exceptions are gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `ConnectionWebModal` project-required, loading, and no-data feedback from `antd` to design-system `EmptyState`/`LoadingState`. Added focused tests and removed three product-state baseline exceptions (283→280; Writing/Review 13→10).

- **Refactors**
  - Replaced `antd` `Empty`/`Spin` with `EmptyState`/`LoadingState` without changing copy or logic.
  - Added tests asserting design-system markers for project-required, loading, and no-data.
  - Removed `ConnectionWebModal` entries from `design-system-product-state-baseline.json`.

<sup>Written for commit f08843862ab455e933b6d2ea4a6b05214629be07. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1974?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

