### PR TITLE
Migrate Watchlists visual composer alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2398,39 +2398,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx:Alert#antd-alert-visualcomposerpane-type-error-line-282-1ch7xog",
-    "path": "src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx:Alert#antd-alert-visualcomposerpane-type-info-no-visual-blocks-1k3tlgx",
-    "path": "src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx:Alert#antd-alert-visualcomposerpane-type-warning-line-285-uxz01z",
-    "path": "src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Quiz/tabs/CreateTab.tsx:Alert#antd-alert-createtab-type-info-line-1003-u954tt",
     "path": "src/components/Quiz/tabs/CreateTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx
@@ -203,6 +203,7 @@ export const VisualComposerPane: React.FC<VisualComposerPaneProps> = ({
       {nodes.length === 0 ? (
         <Alert
           variant="info"
+          aria-live="off"
           title="No visual blocks yet"
         >
           Add blocks above to start building this template.

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Alert, Button, Input, Select, Space } from "antd"
+import { Button, Input, Select, Space } from "antd"
 
+import { Alert } from "@/components/ui/primitives/Alert"
 import type { TemplateComposerSectionResult } from "@/services/watchlists"
 
 import {
@@ -201,11 +202,11 @@ export const VisualComposerPane: React.FC<VisualComposerPaneProps> = ({
 
       {nodes.length === 0 ? (
         <Alert
-          type="info"
-          showIcon
+          variant="info"
           title="No visual blocks yet"
-          description="Add blocks above to start building this template."
-        />
+        >
+          Add blocks above to start building this template.
+        </Alert>
       ) : null}
 
       {nodes.map((node) => {
@@ -279,10 +280,10 @@ export const VisualComposerPane: React.FC<VisualComposerPaneProps> = ({
                   Generate section
                 </Button>
                 {state?.error ? (
-                  <Alert type="error" showIcon title={state.error} />
+                  <Alert variant="error" title={state.error} />
                 ) : null}
                 {state?.warnings?.length ? (
-                  <Alert type="warning" showIcon title={state.warnings.join("; ")} />
+                  <Alert variant="warning" title={state.warnings.join("; ")} />
                 ) : null}
               </div>
             ) : null}

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx
@@ -140,10 +140,10 @@ describe("VisualComposerPane section generation", () => {
     )
 
     const emptyTitle = screen.getByText(/No visual blocks yet/)
+    const emptyAlert = emptyTitle.closest('[data-ds-component="Alert"]')
     expect(emptyTitle).toBeInTheDocument()
-    expect(
-      emptyTitle.closest('[data-ds-component="Alert"]')
-    ).not.toBeNull()
+    expect(emptyAlert).not.toBeNull()
+    expect(emptyAlert).toHaveAttribute("aria-live", "off")
     expect(
       screen.getByText("Add blocks above to start building this template.")
     ).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx
@@ -130,4 +130,81 @@ describe("VisualComposerPane section generation", () => {
     const ids = nextAst.nodes.map((node) => node.id)
     expect(new Set(ids).size).toBe(ids.length)
   })
+
+  it("renders the empty composer callout through the design-system Alert primitive", () => {
+    render(
+      <VisualComposerPane
+        ast={{ schema_version: "1.0.0", nodes: [] }}
+        onChange={vi.fn()}
+      />
+    )
+
+    const emptyTitle = screen.getByText(/No visual blocks yet/)
+    expect(emptyTitle).toBeInTheDocument()
+    expect(
+      emptyTitle.closest('[data-ds-component="Alert"]')
+    ).not.toBeNull()
+    expect(
+      screen.getByText("Add blocks above to start building this template.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders generation error and warning callouts through the design-system Alert primitive", async () => {
+    const ast: ComposerAst = {
+      schema_version: "1.0.0",
+      nodes: [
+        {
+          id: "intro-1",
+          type: "IntroSummaryBlock",
+          source: "",
+          config: {
+            prompt: "Write a concise intro."
+          }
+        }
+      ]
+    }
+
+    const onGenerateSection = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Section generation unavailable"))
+      .mockResolvedValueOnce({
+        block_id: "intro-1",
+        content: "Generated introduction paragraph.",
+        warnings: ["Prompt trimmed", "No source summary"],
+        diagnostics: {}
+      })
+
+    render(
+      <VisualComposerPane
+        ast={ast}
+        onChange={vi.fn()}
+        runs={[{ id: 88, label: "Run #88" }]}
+        selectedRunId={88}
+        onSelectedRunIdChange={vi.fn()}
+        onGenerateSection={onGenerateSection}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("visual-generate-intro-1"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Section generation unavailable")).toBeInTheDocument()
+    })
+    expect(
+      screen
+        .getByText("Section generation unavailable")
+        .closest('[data-ds-component="Alert"]')
+    ).not.toBeNull()
+
+    fireEvent.click(screen.getByTestId("visual-generate-intro-1"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Prompt trimmed; No source summary")).toBeInTheDocument()
+    })
+    expect(
+      screen
+        .getByText("Prompt trimmed; No source summary")
+        .closest('[data-ds-component="Alert"]')
+    ).not.toBeNull()
+  })
 })

--- a/backlog/tasks/task-45.44.3.5 - Migrate-VisualComposerPane-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.5 - Migrate-VisualComposerPane-alerts-to-design-system-Alert.md
@@ -12,6 +12,7 @@ priority: medium
 parent_task_id: TASK-45.44.3
 references:
 - https://github.com/rmusser01/tldw_server/issues/1660
+- https://github.com/rmusser01/tldw_server/pull/1975
 - apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx
 - apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -52,12 +53,14 @@ Continue TASK-45.44.3 by replacing Watchlists VisualComposerPane AntD Alert prod
 - Verification: `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline ok')"` -> `baseline ok`.
 - Verification: `git diff --check` -> passed.
 - Bandit: skipped/not applicable; touched code is frontend TS/TSX plus JSON and Backlog task metadata only.
+- PR review follow-up: added a regression assertion for the empty composer Alert `aria-live="off"` opt-out; red run failed with `aria-live="polite"`, then VisualComposerPane passed `aria-live="off"` on the static info Alert and the focused suite passed 4/4.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing diagnostics; no diagnostics mention VisualComposerPane, the focused test, the baseline, or TASK-45.44.3.5.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-VisualComposerPane now uses the shared design-system Alert primitive for its empty composer state and manual section-generation error/warning states. Focused tests cover the migrated callouts, the product-state baseline dropped the three VisualComposerPane Alert exceptions, and verification passed for the focused Watchlists test, product-state guard, design-system verifier, JSON parse, and diff hygiene.
+VisualComposerPane now uses the shared design-system Alert primitive for its empty composer state and manual section-generation error/warning states. The empty composer Alert opts out of live-region announcements with `aria-live="off"` because it is static help text. Focused tests cover the migrated callouts, the product-state baseline dropped the three VisualComposerPane Alert exceptions, and verification passed for the focused Watchlists test, product-state guard, design-system verifier, JSON parse, and diff hygiene.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.3.5 - Migrate-VisualComposerPane-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.5 - Migrate-VisualComposerPane-alerts-to-design-system-Alert.md
@@ -1,0 +1,71 @@
+---
+id: TASK-45.44.3.5
+title: Migrate VisualComposerPane alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+- watchlists
+priority: medium
+parent_task_id: TASK-45.44.3
+references:
+- https://github.com/rmusser01/tldw_server/issues/1660
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/VisualComposerPane.tsx
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-45.44.3 by replacing Watchlists VisualComposerPane AntD Alert product-state callouts with the shared design-system Alert primitive, preserving empty-state, generation error, and generation warning copy while removing migrated baseline exceptions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VisualComposerPane empty-state, section-generation error, and section-generation warning callouts render through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused VisualComposerPane coverage proves the migrated callouts preserve user-facing copy and expose canonical Alert markers.
+- [x] #3 Migrated VisualComposerPane Alert baseline exceptions are removed without introducing new product-state verifier findings.
+- [x] #4 Focused tests, design-system verifier, diff check, and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused VisualComposerPane tests requiring design-system Alert markers around empty/error/warning callouts and observe the expected failure against AntD Alert.
+2. Replace VisualComposerPane AntD Alert imports/usages with the shared Alert primitive while preserving Select/Button/Input behavior.
+3. Remove VisualComposerPane Alert entries from design-system-product-state-baseline.json.
+4. Run focused tests, product-state verifier, git diff --check, and record Bandit as UI-only if no Python changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- TDD red: `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx --maxWorkers=1 --no-file-parallelism` failed on the missing `[data-ds-component="Alert"]` wrapper for the empty/error callouts.
+- Replaced VisualComposerPane AntD Alert usage with `@/components/ui/primitives/Alert`, preserving the empty-state title/body and section-generation error/warning copy.
+- Removed the three migrated VisualComposerPane Alert exceptions from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
+- Verification: `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx --maxWorkers=1 --no-file-parallelism` -> 1 file, 4 tests passed.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism` -> 1 file, 54 tests passed.
+- Verification: `bun run verify:design-system-state` -> passed with 275 baseline exceptions total and Jobs/Scheduler/Watchlists at 24.
+- Verification: `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline ok')"` -> `baseline ok`.
+- Verification: `git diff --check` -> passed.
+- Bandit: skipped/not applicable; touched code is frontend TS/TSX plus JSON and Backlog task metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+VisualComposerPane now uses the shared design-system Alert primitive for its empty composer state and manual section-generation error/warning states. Focused tests cover the migrated callouts, the product-state baseline dropped the three VisualComposerPane Alert exceptions, and verification passed for the focused Watchlists test, product-state guard, design-system verifier, JSON parse, and diff hygiene.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.5 - Migrate-VisualComposerPane-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.5 - Migrate-VisualComposerPane-alerts-to-design-system-Alert.md
@@ -49,12 +49,13 @@ Continue TASK-45.44.3 by replacing Watchlists VisualComposerPane AntD Alert prod
 - Removed the three migrated VisualComposerPane Alert exceptions from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.
 - Verification: `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx --maxWorkers=1 --no-file-parallelism` -> 1 file, 4 tests passed.
 - Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism` -> 1 file, 54 tests passed.
-- Verification: `bun run verify:design-system-state` -> passed with 275 baseline exceptions total and Jobs/Scheduler/Watchlists at 24.
+- Verification: `bun run verify:design-system-state` -> passed with 259 baseline exceptions total and Jobs/Scheduler/Watchlists at 24 after rebasing onto current `origin/dev`.
 - Verification: `node -e "JSON.parse(require('fs').readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log('baseline ok')"` -> `baseline ok`.
 - Verification: `git diff --check` -> passed.
 - Bandit: skipped/not applicable; touched code is frontend TS/TSX plus JSON and Backlog task metadata only.
 - PR review follow-up: added a regression assertion for the empty composer Alert `aria-live="off"` opt-out; red run failed with `aria-live="polite"`, then VisualComposerPane passed `aria-live="off"` on the static info Alert and the focused suite passed 4/4.
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing diagnostics; no diagnostics mention VisualComposerPane, the focused test, the baseline, or TASK-45.44.3.5.
+- Merge conflict follow-up: rebased PR #1975 onto `origin/dev` at 803bbb110 and resolved the baseline conflict by keeping current `dev` entries while removing only the three VisualComposerPane rows; post-rebase baseline parse reported total 259 and targetRows 0.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Replace VisualComposerPane AntD Alert callouts with the shared design-system Alert primitive.
- Add focused Watchlists coverage for empty composer, section-generation error, and section-generation warning Alert states.
- Remove the three migrated VisualComposerPane Alert entries from the product-state baseline and record TASK-45.44.3.5.

## Verification
- bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/VisualComposerPane.section-generation.test.tsx --maxWorkers=1 --no-file-parallelism
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --maxWorkers=1 --no-file-parallelism
- bun run verify:design-system-state
- git diff --check

## Notes
- Bandit skipped: frontend TS/TSX, JSON, and Backlog task metadata only.
- Merge gate: AI-authored PRs still need the requester's human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Watchlists Visual Composer alerts from `antd` to the design-system `Alert` to unify UI, improve accessibility, and clear product-state exceptions. Completes TASK-45.44.3.5 with no user-visible changes to empty, error, or warning callouts.

- **Refactors**
  - Replace `antd` Alert with `@/components/ui/primitives/Alert` in `VisualComposerPane` (use `variant="info|error|warning"`, keep titles; move empty-state message to children; set `aria-live="off"` on the static info callout).
  - Add focused tests to assert design-system `Alert` usage via `[data-ds-component="Alert"]` for empty, error, and warning states; verify empty-state copy and `aria-live="off"`; confirm warnings render joined by "; ".
  - Remove the three migrated entries from `design-system-product-state-baseline.json`.

<sup>Written for commit e9f84d6bb06e321657e3b571513c6184d238e23c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1975?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

