### PR TITLE
Migrate WritingPlaygroundModalHost alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2541,39 +2541,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx:Alert#antd-alert-writingplaygroundmodalhost-type-error-line-22-175t14c",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx:Alert#antd-alert-writingplaygroundmodalhost-type-error-line-31-1jyrk",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx:Alert#antd-alert-writingplaygroundmodalhost-type-error-line-55-t7t6f2",
-    "path": "src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Quiz/tabs/CreateTab.tsx:Alert#antd-alert-createtab-type-info-line-1003-u954tt",
     "path": "src/components/Quiz/tabs/CreateTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import {
-  Alert,
   Button,
   Checkbox,
   Empty,
@@ -11,6 +10,7 @@ import {
   Tag,
 } from "antd"
 import type { TFunction } from "i18next"
+import { Alert } from "@/components/ui/primitives"
 import type { WritingTemplateResponse, WritingThemeResponse } from "@/services/writing-playground"
 
 type WritingPlaygroundModalHostProps = {
@@ -225,7 +225,9 @@ export const WritingPlaygroundModalHost = ({
               "Provide a JSON object to merge advanced provider-specific parameters."
             )}
           </span>
-          {extraBodyJsonError ? <Alert type="error" showIcon message={extraBodyJsonError} /> : null}
+          {extraBodyJsonError ? (
+            <Alert variant="error" title={extraBodyJsonError} />
+          ) : null}
           <Input.TextArea
             value={extraBodyJsonDraft}
             rows={14}
@@ -316,8 +318,7 @@ export const WritingPlaygroundModalHost = ({
                 <Skeleton active />
               ) : templatesError ? (
                 <Alert
-                  type="error"
-                  showIcon
+                  variant="error"
                   title={t("option:writingPlayground.templateError", "Unable to load templates.")}
                 />
               ) : templates.length === 0 ? (
@@ -552,8 +553,7 @@ export const WritingPlaygroundModalHost = ({
                 <Skeleton active />
               ) : themesError ? (
                 <Alert
-                  type="error"
-                  showIcon
+                  variant="error"
                   title={t("option:writingPlayground.themeError", "Unable to load themes.")}
                 />
               ) : themes.length === 0 ? (

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundModalHost.design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundModalHost.design-system-alert.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { WritingPlaygroundModalHost } from "../WritingPlaygroundModalHost"
+import type {
+  WritingTemplateResponse,
+  WritingThemeResponse,
+} from "@/services/writing-playground"
+
+type ModalHostProps = React.ComponentProps<typeof WritingPlaygroundModalHost>
+
+const t = ((_key: string, defaultValue?: string) =>
+  defaultValue ?? _key) as ModalHostProps["t"]
+
+const makeProps = (overrides: Partial<ModalHostProps> = {}): ModalHostProps => ({
+  t,
+  settingsDisabled: false,
+  supportsAdvancedCompat: true,
+  extraBodyJsonModalOpen: false,
+  setExtraBodyJsonModalOpen: vi.fn(),
+  extraBodyJsonError: null,
+  setExtraBodyJsonError: vi.fn(),
+  extraBodyJsonDraft: "{}",
+  setExtraBodyJsonDraft: vi.fn(),
+  applyExtraBodyJsonDraft: vi.fn(),
+  contextPreviewModalOpen: false,
+  setContextPreviewModalOpen: vi.fn(),
+  handleCopyContextPreview: vi.fn(async () => {}),
+  handleExportContextPreview: vi.fn(),
+  contextPreviewJson: "{}",
+  templatesModalOpen: false,
+  setTemplatesModalOpen: vi.fn(),
+  templatesLoading: false,
+  templatesError: null,
+  templates: [],
+  editingTemplate: null,
+  templateImporting: false,
+  templateRestoringDefaults: false,
+  handleTemplateNew: vi.fn(),
+  handleTemplateDuplicate: vi.fn(),
+  templateDuplicateDisabled: true,
+  templateFileInputRef: { current: null },
+  templateExportDisabled: true,
+  exportTemplate: vi.fn((_template: WritingTemplateResponse) => {}),
+  templateRestoreDefaultsDisabled: true,
+  handleTemplateRestoreDefaults: vi.fn(async () => {}),
+  templateForm: {
+    name: "",
+    systemPrefix: "",
+    systemSuffix: "",
+    userPrefix: "",
+    userSuffix: "",
+    assistantPrefix: "",
+    assistantSuffix: "",
+    fimTemplate: "",
+    isDefault: false,
+  },
+  templateFormDisabled: false,
+  updateTemplateForm: vi.fn(),
+  handleTemplateSelect: vi.fn(),
+  templateSaveLoading: false,
+  templateSaveDisabled: true,
+  handleTemplateSave: vi.fn(),
+  templateDeleteDisabled: true,
+  deleteTemplateMutation: { isPending: false },
+  confirmDeleteTemplate: vi.fn(),
+  handleTemplateImport: vi.fn(),
+  themesModalOpen: false,
+  setThemesModalOpen: vi.fn(),
+  themesLoading: false,
+  themesError: null,
+  themes: [],
+  editingTheme: null,
+  themeImporting: false,
+  themeRestoringDefaults: false,
+  handleThemeNew: vi.fn(),
+  handleThemeDuplicate: vi.fn(),
+  themeDuplicateDisabled: true,
+  themeFileInputRef: { current: null },
+  themeExportDisabled: true,
+  exportTheme: vi.fn((_theme: WritingThemeResponse) => {}),
+  themeRestoreDefaultsDisabled: true,
+  handleThemeRestoreDefaults: vi.fn(async () => {}),
+  themeForm: {
+    name: "",
+    className: "",
+    css: "",
+    order: 0,
+    isDefault: false,
+  },
+  themeFormDisabled: false,
+  updateThemeForm: vi.fn(),
+  handleThemeSelect: vi.fn(),
+  themeSaveLoading: false,
+  themeSaveDisabled: true,
+  handleThemeSave: vi.fn(),
+  themeDeleteDisabled: true,
+  deleteThemeMutation: { isPending: false },
+  confirmDeleteTheme: vi.fn(),
+  handleThemeImport: vi.fn(),
+  createModalOpen: false,
+  setCreateModalOpen: vi.fn(),
+  createSessionMutation: {
+    isPending: false,
+    mutate: vi.fn(),
+  },
+  canCreateSession: false,
+  newSessionName: "",
+  setNewSessionName: vi.fn(),
+  renameModalOpen: false,
+  setRenameModalOpen: vi.fn(),
+  renameTarget: null,
+  renameSessionMutation: {
+    isPending: false,
+    mutate: vi.fn(),
+  },
+  canRenameSession: false,
+  renameSessionName: "",
+  setRenameSessionName: vi.fn(),
+  ...overrides,
+})
+
+describe("WritingPlaygroundModalHost product-state alerts", () => {
+  it("renders the extra_body JSON error through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundModalHost
+        {...makeProps({
+          extraBodyJsonModalOpen: true,
+          extraBodyJsonError: "Invalid JSON payload",
+        })}
+      />
+    )
+
+    const errorMessage = screen.getByText("Invalid JSON payload")
+    expect(errorMessage.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
+  it("renders the template-load error through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundModalHost
+        {...makeProps({
+          templatesModalOpen: true,
+          templatesError: new Error("Template service failed"),
+        })}
+      />
+    )
+
+    const errorTitle = screen.getByText("Unable to load templates.")
+    expect(errorTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
+  it("renders the theme-load error through the design-system Alert", () => {
+    render(
+      <WritingPlaygroundModalHost
+        {...makeProps({
+          themesModalOpen: true,
+          themesError: new Error("Theme service failed"),
+        })}
+      />
+    )
+
+    const errorTitle = screen.getByText("Unable to load themes.")
+    expect(errorTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -42,6 +42,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created TASK-45.44.12.6 for the narrow Writing slice covering `WritingPlaygroundTokenInspectorCard` unavailable/error Alert migration. Verification on the slice reduced the product-state baseline from 287 to 285 and `Writing and Review surfaces` from 17 to 15. PR: https://github.com/rmusser01/tldw_server/pull/1971
 - Created TASK-45.44.12.7 for the narrow Writing slice covering `WritingPlaygroundDiagnosticsPanel` offline/unsupported Alert migration. Verification on the slice reduced the product-state baseline from 285 to 283 and `Writing and Review surfaces` from 15 to 13. PR: https://github.com/rmusser01/tldw_server/pull/1972
 - Created TASK-45.44.12.8 for the narrow Writing slice covering `ConnectionWebModal` project-required/no-data Empty and loading Spin migration. Verification on the slice reduced the product-state baseline from 283 to 280 and `Writing and Review surfaces` from 13 to 10. PR: https://github.com/rmusser01/tldw_server/pull/1974
+- Created TASK-45.44.12.9 for the narrow Writing slice covering `WritingPlaygroundModalHost` extra_body/template/theme error Alert migration. Verification on the slice reduced the product-state baseline from 275 to 272 and `Writing and Review surfaces` from 10 to 7. PR: https://github.com/rmusser01/tldw_server/pull/1976
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.9 - Migrate-WritingPlaygroundModalHost-alert-states-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.9 - Migrate-WritingPlaygroundModalHost-alert-states-to-design-system-Alert.md
@@ -1,0 +1,78 @@
+---
+id: TASK-45.44.12.9
+title: Migrate WritingPlaygroundModalHost alert states to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundModalHost.design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate WritingPlaygroundModalHost error product-state AntD Alert usages to the shared design-system Alert primitive. This reduces the Writing/Review product-state baseline while preserving modal copy and layout.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The extra_body JSON error state renders through the shared design-system Alert primitive.
+- [x] #2 The template-load error state renders through the shared design-system Alert primitive.
+- [x] #3 The theme-load error state renders through the shared design-system Alert primitive.
+- [x] #4 The modal host keeps existing copy, modal behavior, and non-alert list states unchanged.
+- [x] #5 The WritingPlaygroundModalHost AntD Alert exceptions are removed from the product-state baseline.
+- [x] #6 Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add focused failing tests that render the extra_body JSON, template-load, and theme-load error branches and assert each uses the shared design-system Alert marker.
+- [x] Replace AntD Alert usages in WritingPlaygroundModalHost with the shared design-system Alert primitive while preserving copy and layout.
+- [x] Remove the migrated WritingPlaygroundModalHost rows from the product-state baseline.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `WritingPlaygroundModalHost.design-system-alert.test.tsx` with focused coverage for extra_body JSON, template-load, and theme-load error branches.
+- Red check before implementation: `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundModalHost.design-system-alert.test.tsx --reporter=dot` failed all three marker assertions because the component still rendered AntD `Alert`.
+- Migrated the three modal-host AntD `Alert` usages to the shared design-system `Alert` primitive while preserving visible error copy and existing modal/list branch behavior.
+- Removed the three `WritingPlaygroundModalHost` product-state baseline rows; baseline total is now 272 and Writing/Review baseline count is now 7.
+- Verification:
+  - `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundModalHost.design-system-alert.test.tsx --reporter=dot` passed, 3 tests.
+  - `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed, 54 tests.
+  - `bun run verify:design-system-state` passed with `Baseline exceptions: 272` and `Writing and Review surfaces: 7`.
+  - Baseline parse/absence check passed and confirmed no `WritingPlaygroundModalHost` baseline entries remain.
+  - `git diff --check` passed.
+  - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exited 2 on existing repo-wide TypeScript debt; `/tmp/tldw_writing_modalhost_tsc.log` has no diagnostics for `WritingPlaygroundModalHost` or the new design-system Alert test after tightening the test `t` shim.
+- Bandit not run: touched implementation is UI TypeScript/TSX and JSON/task metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.9 - Migrate-WritingPlaygroundModalHost-alert-states-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.9 - Migrate-WritingPlaygroundModalHost-alert-states-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.9
 title: Migrate WritingPlaygroundModalHost alert states to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -13,6 +13,7 @@ references:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 - Docs/Design/tldw_web_design_system_contract.md
+- https://github.com/rmusser01/tldw_server/pull/1976
 modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundModalHost.tsx
 - apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlaygroundModalHost.design-system-alert.test.tsx
@@ -64,7 +65,9 @@ Migrate WritingPlaygroundModalHost error product-state AntD Alert usages to the 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR: https://github.com/rmusser01/tldw_server/pull/1976
 
+Migrated `WritingPlaygroundModalHost` extra_body JSON, template-load, and theme-load error states to the shared design-system `Alert` primitive. Added focused marker coverage and removed the three migrated product-state baseline rows, bringing the product-state baseline to 272 and Writing/Review to 7.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -73,6 +76,6 @@ Migrate WritingPlaygroundModalHost error product-state AntD Alert usages to the 
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the three WritingPlaygroundModalHost error branches from AntD `Alert` to the shared design-system `Alert` primitive.
- Adds focused coverage for the extra_body JSON error, template-load error, and theme-load error branches.
- Removes the migrated baseline rows, reducing product-state baseline exceptions from 275 to 272 and Writing/Review exceptions from 10 to 7.

## Verification
- `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlaygroundModalHost.design-system-alert.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- Baseline parse/absence check for `WritingPlaygroundModalHost`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 on existing repo-wide TypeScript debt; no diagnostics for touched files.

## Change summary
This is a narrow Writing/Review migration slice. The modal host now renders its extra_body JSON, template-load, and theme-load error states through the canonical design-system Alert primitive while preserving existing copy and modal branch behavior. The baseline rows were removed after focused marker coverage and the product-state verifier confirmed the migrated exceptions are gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WritingPlaygroundModalHost error alerts from `antd` to the design-system `Alert` to standardize UI and remove legacy product-state exceptions. Aligns with TASK-45.44.12.9 acceptance criteria.

- **Refactors**
  - Replaced `antd` `Alert` with `Alert` from `@/components/ui/primitives` for extra body JSON, template-load, and theme-load errors.
  - Preserved copy and behavior; used `variant="error"` and `title`.
  - Added focused tests to assert the design-system alert marker; recorded verification in TASK-45.44.12.9 docs.
  - Removed three baseline exceptions; Writing/Review count now 7.

<sup>Written for commit eb7207f9cf2021b1984fa475f69119895db02403. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1976?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

