### PR TITLE
Migrate WritingPlayground shell alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2464,7 +2464,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-1852-1jqib81",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-1853-1jgipj2",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2475,7 +2475,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-2107-aevhs3",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1631-pxp5j4",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",
@@ -2486,51 +2486,7 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-error-line-2269-1h1rbna",
-    "path": "src/components/Option/WritingPlayground/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1630-q7or83",
-    "path": "src/components/Option/WritingPlayground/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1666-1vabedw",
-    "path": "src/components/Option/WritingPlayground/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-2228-zpj6ix",
-    "path": "src/components/Option/WritingPlayground/index.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/WritingPlayground/index.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-warning-line-2223-l0pc9y",
+    "id": "antd-product-state-import:src/components/Option/WritingPlayground/index.tsx:Alert#antd-alert-writingplayground-type-info-line-1667-1vkb02v",
     "path": "src/components/Option/WritingPlayground/index.tsx",
     "rule": "antd-product-state-import",
     "subject": "Alert",

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.shell-design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.shell-design-system-alert.test.tsx
@@ -1,0 +1,300 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+type QueryResult = {
+  data?: unknown
+  error?: unknown
+  isLoading?: boolean
+  isFetching?: boolean
+}
+
+const mockState = vi.hoisted(() => ({
+  storageValues: new Map<string, unknown>(),
+  queryResults: new Map<string, QueryResult>(),
+  serverOnline: true,
+  serverCapabilities: { hasChat: true },
+  registryReadyLabel: "Registry Ready",
+  resolveApiProviderForModel: vi.fn(async () => null as string | null),
+  streamCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>,
+  sendCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>,
+}))
+
+const queryKeyId = (queryKey: unknown): string => {
+  const key = Array.isArray(queryKey) ? queryKey[0] : queryKey
+  if (key === "writing-session" && Array.isArray(queryKey)) {
+    return `writing-session:${String(queryKey[1] || "")}`
+  }
+  return String(key)
+}
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: unknown }) => {
+    const result = mockState.queryResults.get(queryKeyId(queryKey)) ?? {}
+    return {
+      data: result.data,
+      isLoading: result.isLoading ?? false,
+      isFetching: result.isFetching ?? false,
+      error: result.error ?? null,
+    }
+  },
+  useMutation: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+    setQueryData: vi.fn(),
+  }),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string },
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) return fallbackOrOptions.defaultValue
+      return key
+    },
+  }),
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: <T,>(key: string, initial?: T) =>
+    React.useState<T | undefined>(() =>
+      mockState.storageValues.has(key)
+        ? (mockState.storageValues.get(key) as T)
+        : initial,
+    ),
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => mockState.serverOnline,
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: mockState.serverCapabilities,
+    loading: false,
+    refresh: async () => {},
+  }),
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+  return {
+    ...actual,
+    READY_STATE_LABEL: mockState.registryReadyLabel,
+  }
+})
+
+vi.mock("@/utils/resolve-api-provider", () => ({
+  AUTO_MODEL_ID: "auto",
+  resolveApiProviderForModel: mockState.resolveApiProviderForModel,
+}))
+
+vi.mock("@/components/Common/MarkdownPreview", () => ({
+  MarkdownPreview: ({ content }: { content: string }) => <div>{content}</div>,
+}))
+
+vi.mock("@/services/tldw/TldwChat", () => ({
+  TldwChatService: class TldwChatServiceMock {
+    cancelStream() {}
+    async *streamMessage(
+      messages: unknown[],
+      options: Record<string, unknown>,
+    ) {
+      mockState.streamCalls.push({ messages, options })
+      yield "mocked stream token"
+    }
+    async sendMessage(messages: unknown[], options: Record<string, unknown>) {
+      mockState.sendCalls.push({ messages, options })
+      return "mocked completion"
+    }
+  },
+}))
+
+vi.mock("@/services/writing-playground", () => ({
+  cloneWritingSession: vi.fn(),
+  createWritingSession: vi.fn(),
+  createWritingTemplate: vi.fn(),
+  createWritingTheme: vi.fn(),
+  createWritingWordcloud: vi.fn(),
+  countWritingTokens: vi.fn(),
+  deleteWritingSession: vi.fn(),
+  deleteWritingTemplate: vi.fn(),
+  deleteWritingTheme: vi.fn(),
+  exportWritingSnapshot: vi.fn(),
+  getWritingCapabilities: vi.fn(),
+  getWritingDefaults: vi.fn(),
+  getWritingSession: vi.fn(),
+  getWritingWordcloud: vi.fn(),
+  importWritingSnapshot: vi.fn(),
+  listWritingSessions: vi.fn(),
+  listWritingTemplates: vi.fn(),
+  listWritingThemes: vi.fn(),
+  tokenizeWritingText: vi.fn(),
+  updateWritingSession: vi.fn(),
+  updateWritingTemplate: vi.fn(),
+  updateWritingTheme: vi.fn(),
+}))
+
+import { WritingPlayground } from "../index"
+import { useWritingPlaygroundStore } from "@/store/writing-playground"
+
+const DEFAULT_WRITING_CAPABILITIES = {
+  server: {
+    sessions: true,
+    templates: true,
+    themes: true,
+    defaults_catalog: false,
+    snapshots: false,
+    tokenize: true,
+    token_count: true,
+  },
+  requested: {
+    provider: "openai",
+    tokenizer_available: true,
+    tokenizer: "mock-tokenizer",
+    tokenizer_kind: "mock",
+    tokenizer_source: "mock",
+    detokenize_available: true,
+    features: {
+      logprobs: true,
+    },
+    supported_fields: ["top_logprobs"],
+    extra_body_compat: {
+      effective: true,
+      source: "mock",
+      notes: "mock",
+    },
+  },
+}
+
+const seedDefaultQueries = () => {
+  mockState.queryResults.set("writing-capabilities", {
+    data: DEFAULT_WRITING_CAPABILITIES,
+  })
+  mockState.queryResults.set("writing-defaults", {
+    data: { templates: [], themes: [] },
+  })
+  mockState.queryResults.set("writing-sessions", {
+    data: {
+      sessions: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    },
+  })
+  mockState.queryResults.set("writing-templates", {
+    data: {
+      templates: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    },
+  })
+  mockState.queryResults.set("writing-themes", {
+    data: {
+      themes: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    },
+  })
+  mockState.queryResults.set("writing-session:", { data: null })
+}
+
+const seedActiveSession = () => {
+  useWritingPlaygroundStore.setState({
+    activeSessionId: "session-auto",
+    activeSessionName: "Auto Session",
+  })
+  mockState.queryResults.set("writing-sessions", {
+    data: {
+      sessions: [
+        {
+          id: "session-auto",
+          name: "Auto Session",
+          last_modified: "2026-03-16T12:00:00Z",
+          version: 1,
+        },
+      ],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    },
+  })
+}
+
+describe("WritingPlayground shell product-state alerts", () => {
+  beforeEach(() => {
+    mockState.storageValues.clear()
+    mockState.queryResults.clear()
+    mockState.serverOnline = true
+    mockState.serverCapabilities = { hasChat: true }
+    mockState.resolveApiProviderForModel.mockReset()
+    mockState.resolveApiProviderForModel.mockResolvedValue(null)
+    mockState.streamCalls.length = 0
+    mockState.sendCalls.length = 0
+    seedDefaultQueries()
+
+    useWritingPlaygroundStore.setState({
+      activeSessionId: null,
+      activeSessionName: null,
+    })
+  })
+
+  it("renders the offline shell state through the design-system Alert", () => {
+    mockState.serverOnline = false
+
+    render(<WritingPlayground />)
+
+    const offlineTitle = screen.getByText("Server required")
+    expect(offlineTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
+  it("renders the unsupported shell state through the design-system Alert", () => {
+    mockState.queryResults.set("writing-capabilities", {
+      data: {
+        ...DEFAULT_WRITING_CAPABILITIES,
+        server: { ...DEFAULT_WRITING_CAPABILITIES.server, sessions: false },
+      },
+    })
+
+    render(<WritingPlayground />)
+
+    const unsupportedTitle = screen.getByText("Playground unavailable")
+    expect(
+      unsupportedTitle.closest('[data-ds-component="Alert"]'),
+    ).toBeInTheDocument()
+  })
+
+  it("renders the sessions-load error through the design-system Alert", () => {
+    mockState.queryResults.set("writing-sessions", {
+      data: undefined,
+      error: new Error("Session list unavailable"),
+    })
+
+    render(<WritingPlayground />)
+
+    const sessionsError = screen.getByText("Unable to load sessions.")
+    expect(sessionsError.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+
+  it("renders the active-session editor error through the design-system Alert", () => {
+    seedActiveSession()
+    mockState.queryResults.set("writing-session:session-auto", {
+      data: undefined,
+      error: new Error("Session detail unavailable"),
+    })
+
+    render(<WritingPlayground />)
+
+    const editorError = screen.getByText("Unable to load this session.")
+    expect(editorError.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -48,6 +48,7 @@ import { useServerOnline } from "@/hooks/useServerOnline"
 import { READY_STATE_LABEL } from "@/design-system"
 import { formatRelativeTime } from "@/utils/dateFormatters"
 import { MarkdownPreview } from "@/components/Common/MarkdownPreview"
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { TldwChatService } from "@/services/tldw/TldwChat"
 import {
   getWritingCapabilities,
@@ -2104,7 +2105,10 @@ export const WritingPlayground = () => {
           <ManuscriptTreePanel isOnline={isOnline} />
         ) : (
         sessionsLoading ? (<Skeleton active />) : sessionsError ? (
-          <Alert type="error" showIcon title={t("option:writingPlayground.sessionsError", "Unable to load sessions.")} />
+          <DesignSystemAlert
+            variant="error"
+            title={t("option:writingPlayground.sessionsError", "Unable to load sessions.")}
+          />
         ) : sortedSessions.length === 0 ? (
           <Empty description={t("option:writingPlayground.sessionsEmpty", "Create your first session to start writing.")} />
         ) : (
@@ -2220,12 +2224,22 @@ export const WritingPlayground = () => {
       {activeThemeCss ? <style>{activeThemeCss}</style> : null}
       {showOffline && (
         <div className="p-4">
-          <Alert type="warning" showIcon title={t("option:writingPlayground.offlineTitle", "Server required")} description={t("option:writingPlayground.offlineBody", "Connect to your tldw server to load writing sessions and generate.")} />
+          <DesignSystemAlert
+            variant="warning"
+            title={t("option:writingPlayground.offlineTitle", "Server required")}
+          >
+            {t("option:writingPlayground.offlineBody", "Connect to your tldw server to load writing sessions and generate.")}
+          </DesignSystemAlert>
         </div>
       )}
       {showUnsupported && (
         <div className="p-4">
-          <Alert type="info" showIcon title={t("option:writingPlayground.unavailableTitle", "Playground unavailable")} description={t("option:writingPlayground.unavailableBody", "This server does not advertise writing playground support yet.")} />
+          <DesignSystemAlert
+            variant="info"
+            title={t("option:writingPlayground.unavailableTitle", "Playground unavailable")}
+          >
+            {t("option:writingPlayground.unavailableBody", "This server does not advertise writing playground support yet.")}
+          </DesignSystemAlert>
         </div>
       )}
       {!showOffline && !showUnsupported && (
@@ -2266,7 +2280,10 @@ export const WritingPlayground = () => {
               <WritingPlaygroundEditorPanel>
               {activeSession ? (
                 activeSessionLoading ? (<Skeleton active />) : activeSessionError ? (
-                  <Alert type="error" showIcon title={t("option:writingPlayground.editorError", "Unable to load this session.")} />
+                  <DesignSystemAlert
+                    variant="error"
+                    title={t("option:writingPlayground.editorError", "Unable to load this session.")}
+                  />
                 ) : (
                   <div className="flex flex-col gap-3">
                     <div className="flex flex-wrap items-center gap-2">

--- a/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
+++ b/backlog/tasks/task-45.44.12 - Migrate-design-system-product-state-Writing-and-Review-surfaces.md
@@ -29,7 +29,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 <!-- AC:BEGIN -->
 - [ ] #1 The linked GitHub issue owns current count and public status.
 - [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
-- [ ] #3 Backlog notes record PR links and before/after count evidence.
+- [x] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -43,6 +43,7 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - Created TASK-45.44.12.7 for the narrow Writing slice covering `WritingPlaygroundDiagnosticsPanel` offline/unsupported Alert migration. Verification on the slice reduced the product-state baseline from 285 to 283 and `Writing and Review surfaces` from 15 to 13. PR: https://github.com/rmusser01/tldw_server/pull/1972
 - Created TASK-45.44.12.8 for the narrow Writing slice covering `ConnectionWebModal` project-required/no-data Empty and loading Spin migration. Verification on the slice reduced the product-state baseline from 283 to 280 and `Writing and Review surfaces` from 13 to 10. PR: https://github.com/rmusser01/tldw_server/pull/1974
 - Created TASK-45.44.12.9 for the narrow Writing slice covering `WritingPlaygroundModalHost` extra_body/template/theme error Alert migration. Verification on the slice reduced the product-state baseline from 275 to 272 and `Writing and Review surfaces` from 10 to 7. PR: https://github.com/rmusser01/tldw_server/pull/1976
+- Created TASK-45.44.12.10 for the narrow Writing slice covering `WritingPlayground` shell/session/editor Alert migration. Verification on the slice reduced the product-state baseline from 272 to 268 and `Writing and Review surfaces` from 7 to 3. PR: https://github.com/rmusser01/tldw_server/pull/1979
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.12.10 - Migrate-WritingPlayground-shell-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.10 - Migrate-WritingPlayground-shell-alerts-to-design-system-Alert.md
@@ -1,0 +1,77 @@
+---
+id: TASK-45.44.12.10
+title: Migrate WritingPlayground shell alerts to design-system Alert
+status: In Progress
+labels:
+- design-system
+- webui
+- product-state
+- writing
+priority: medium
+parent_task_id: TASK-45.44.12
+references:
+- apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- Docs/Design/tldw_web_design_system_contract.md
+modified_files:
+- apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.shell-design-system-alert.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the WritingPlayground shell/session/editor product-state AntD Alert usages to the shared design-system Alert primitive. This narrows the remaining Writing/Review product-state baseline while leaving advanced settings alerts for a follow-up slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The offline shell state renders through the shared design-system Alert primitive.
+- [x] #2 The unsupported shell state renders through the shared design-system Alert primitive.
+- [x] #3 The sessions-load error state renders through the shared design-system Alert primitive.
+- [x] #4 The active editor session-load error state renders through the shared design-system Alert primitive.
+- [x] #5 The four migrated WritingPlayground shell/session/editor Alert exceptions are removed from the product-state baseline while advanced settings Alert exceptions remain for a follow-up slice.
+- [x] #6 Focused tests and design-system guard verification are recorded in this task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- [x] Add focused failing tests that render offline, unsupported, sessions-load error, and active-session editor error branches and assert each uses the shared design-system Alert marker.
+- [x] Replace only those WritingPlayground shell/session/editor AntD Alert usages with the shared design-system Alert primitive while preserving copy and branch behavior.
+- [x] Remove the four migrated WritingPlayground baseline rows from the product-state baseline, leaving the three advanced settings rows in place.
+- [x] Run focused tests, product-state guard/unit verifier checks, baseline JSON parse, TypeScript check, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added focused test coverage for the four targeted WritingPlayground shell/session/editor product states: offline shell, unsupported shell, sessions-load error, and active-session editor error.
+- Confirmed the red check before implementation: the focused Vitest file failed all four design-system marker assertions while the branches still rendered AntD `Alert`.
+- Migrated only the four targeted WritingPlayground shell/session/editor alerts to the shared design-system `Alert` primitive. The three advanced-settings AntD alerts remain as the follow-up slice.
+- Removed the four migrated product-state baseline rows and refreshed the three remaining advanced-settings baseline IDs after the import shifted line numbers. Baseline now reports 268 total exceptions and 3 Writing/Review exceptions.
+- Verification: `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlayground.shell-design-system-alert.test.tsx --reporter=dot` passed, with existing AntD Drawer deprecation warnings only.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed.
+- Verification: `bun run verify:design-system-state` passed, reporting `Baseline exceptions: 268` and `Writing and Review surfaces: 3`.
+- Verification: baseline JSON parse/remaining check passed with exactly 3 `WritingPlayground/index.tsx` rows.
+- Verification: `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exited 2 on existing repo-wide TypeScript debt; `/tmp/tldw_writing_shell_tsc.log` has 314 lines and `rg` found no diagnostics for the touched files.
+- Bandit skipped: this slice touches UI TypeScript/TSX, product-state baseline JSON, and Backlog metadata only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.12.10 - Migrate-WritingPlayground-shell-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.12.10 - Migrate-WritingPlayground-shell-alerts-to-design-system-Alert.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.12.10
 title: Migrate WritingPlayground shell alerts to design-system Alert
-status: In Progress
+status: Done
 labels:
 - design-system
 - webui
@@ -63,7 +63,7 @@ Migrate the WritingPlayground shell/session/editor product-state AntD Alert usag
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the four targeted `WritingPlayground` shell/session/editor product-state alerts to the shared design-system `Alert` primitive and added focused coverage for each branch. Removed the four migrated product-state baseline exceptions while preserving the three advanced-settings exceptions for a follow-up slice. PR: https://github.com/rmusser01/tldw_server/pull/1979
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -72,6 +72,6 @@ Migrate the WritingPlayground shell/session/editor product-state AntD Alert usag
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the WritingPlayground offline, unsupported, session-list error, and active-session editor error branches from AntD `Alert` to the shared design-system `Alert` primitive.
- Adds focused coverage that asserts those four shell/session/editor states render through design-system `Alert` markers.
- Removes the four migrated baseline rows, reducing product-state baseline exceptions from 272 to 268 and Writing/Review exceptions from 7 to 3. The remaining three WritingPlayground rows are advanced-settings alerts and are left for a follow-up slice.

## Verification
- `bunx vitest run src/components/Option/WritingPlayground/__tests__/WritingPlayground.shell-design-system-alert.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- Baseline parse/remaining check for `WritingPlayground/index.tsx`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 on existing repo-wide TypeScript debt; no diagnostics for touched files.

## Change summary
This is a narrow Writing/Review migration slice. The WritingPlayground shell and session error states now render through the canonical design-system Alert primitive while preserving existing copy and branch behavior. The baseline rows are removed only for the four migrated shell/session/editor alerts; the three advanced-settings alerts remain baselined for a follow-up PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WritingPlayground shell and session error alerts from AntD to the design system `Alert` to unify UI and product-state markers. Adds focused tests and removes four baseline exceptions, reducing totals from 272 to 268.

- **Refactors**
  - Replaced four AntD `Alert` instances (offline, unsupported, sessions-list error, active-session editor error) with design system `Alert`; copy and logic unchanged.
  - Added focused tests to assert the design system `Alert` renders for those states.
  - Removed the four corresponding baseline exceptions and refreshed remaining IDs; advanced-settings alerts remain for a follow-up.

<sup>Written for commit 22a996c2566d63d09079cf684d143f350c6a71fa. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1979?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

