### PR TITLE
Record prototype final signoff evidence

### DIFF
--- a/Docs/Operations/Prototype_Workspaces_Release_Readiness.md
+++ b/Docs/Operations/Prototype_Workspaces_Release_Readiness.md
@@ -8,6 +8,8 @@ Parent tracker: https://github.com/rmusser01/tldw_server/issues/1440
 
 Risk Gate 8: https://github.com/rmusser01/tldw_server/issues/1461
 
+Final signoff follow-up: https://github.com/rmusser01/tldw_server/issues/1977
+
 ## Backend Verification Matrix
 
 | Area | Evidence | Status |
@@ -32,7 +34,7 @@ Risk Gate 8: https://github.com/rmusser01/tldw_server/issues/1461
 | Contract fixture states | Frozen Risk Gate 4 states remain available to frontend tests | Covered by `contract-states.json` and docs-contract tests. |
 | Owner review UI | Pending, terminal, validation, conflict, and failure states render distinctly | Covered by `PrototypeWorkspaceOwnerView` tests and Gate 8 frontend verification. |
 | Owner action gating | Review actions are disabled when state/backend semantics would reject them | Covered by `PrototypeWorkspaceOwnerView` tests and Gate 8 frontend verification. |
-| Browser-observed UX | Final manual browser pass for owner and collaborator flows | Remaining Gate 8 evidence item. |
+| Browser-observed UX | Final browser pass for owner and collaborator flows against the real WebUI route with API-shaped Playwright stubs | Complete; see 2026-05-23 signoff evidence. |
 
 ## Gate 8 CI Smoke Path
 
@@ -48,6 +50,37 @@ The first Gate 8 smoke test must exercise this path without external runtime ser
 8. Owner approval with a passing publish validator returns `status = "promoted"` and advances canonical state.
 
 The negative smoke path must verify revoked and expired prototype share links fail without confirming whether the token, workspace, or actor exists.
+
+## 2026-05-23 Final Browser Signoff Evidence
+
+Browser evidence was captured against the local Next WebUI at `http://127.0.0.1:18027` using the real `/share/{token}` and `/prototype-workspaces` pages with Playwright network stubs for the prototype APIs. Screenshots were written to `/private/tmp/prototype-final-signoff-1977/`.
+
+During the first probe, `/share/proto-token` rendered the prototype public handoff, but `/prototype-workspaces` resolved to the WebUI 404 because the shared route had no Next page shim. This was fixed with `apps/tldw-frontend/pages/prototype-workspaces.tsx` and guarded by `apps/tldw-frontend/__tests__/navigation/prototype-workspaces-route.test.tsx`.
+
+The full browser pass then observed:
+
+- Owner empty/create route: `owner-empty.png`, `owner-created.png`.
+- Owner private-link creation: `owner-share-link.png` with `/share/proto-token`.
+- Owner promotion review: `owner-review-pending.png`.
+- Owner validation failure handling: `owner-validation-failed.png`.
+- Owner promotion success handling: `owner-promoted.png`.
+- Public share handoff: `collaborator-public-share.png` to `/prototype-workspaces?share_token=proto-token`.
+- Collaborator link exchange and session creation: `collaborator-link-handoff.png`, `collaborator-link-exchanged.png`, `collaborator-session-started.png`.
+- Collaborator promotion submission: `collaborator-promotion-submitted.png`.
+
+The collaborator pass also verified that the UI remains on the collaborator session surface after token-bearing route cleanup. This is guarded by `PrototypeWorkspacePage.test.tsx` so `/prototype-workspaces?workspace=...` does not fall back to the owner view when the collaborator session is already stored.
+
+## 2026-05-23 Private-Link And Session-Token Signoff
+
+| Invariant | Evidence | Signoff |
+| --- | --- | --- |
+| Prototype token ownership | `create_token` calls `_get_owned_prototype_workspace()` for `prototype_workspace` resources before `ShareTokenService.generate_token()`. | Pass. Non-owners cannot mint prototype links for another owner's workspace. |
+| Revocation | `ShareTokenService.validate_token()` rejects revoked tokens; public exchange returns `link_unavailable`; repo/session/service paths reject revoked shared actors, sessions, and preview handles. | Pass. Covered by link-exchange, endpoint, service, and preview broker tests. |
+| Expiration | Share-token expiry, session-token `exp`, shared actor expiry, active-session lookup, and preview grant expiry are all checked before use. | Pass. Expired links and actors fail without confirming resource existence. |
+| Resume-cookie flags | `public_prototype_session_exchange()` sets `prototype_shared_actor` with `HttpOnly`, `SameSite=Lax`, and `secure=_request_is_secure(request)`, where `_request_is_secure()` honors `X-Forwarded-Proto: https` before falling back to request scheme. | Pass. Secure-cookie behavior matches proxy-aware HTTPS detection. |
+| Non-enumerating errors | Public prototype exchange maps missing, revoked, expired, exhausted, missing-workspace, and owner-mismatch cases to stable `invalid_or_unavailable_link` / `link_unavailable` responses. | Pass. Covered by focused link-exchange tests and the Gate 8 negative smoke path. |
+| Preview grants | `PrototypePreviewBroker` issues opaque handles, signs short-lived grants, persists active scope handles, renews only still-authorized handles, and invalidates grants when sessions/shared actors are revoked or expired. | Pass. Covered by preview broker and endpoint renewal tests. |
+| Promotion authority | Promotion submission validates the session token workspace, branch session, shared actor, snapshot ownership, and active actor/session state; review is limited to workspace owner or designated promoters. | Pass. Covered by endpoint and promotion service tests. |
 
 ## Verification Log
 
@@ -67,8 +100,28 @@ The negative smoke path must verify revoked and expired prototype share links fa
 - Review follow-up: `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/tests/PrototypeWorkspaces/test_release_readiness_smoke.py -s B101 -f json -o /tmp/bandit_prototype_gate8_review.json`
   - GREEN: `results: []`; `B101` skipped because the touched backend Python path is a pytest file where `assert` is expected.
 
+2026-05-23:
+
+- `bun install --frozen-lockfile` from `apps/`
+  - GREEN: workspace dependencies hydrated from the existing lockfile.
+- Initial Playwright route probe via `/private/tmp/prototype-signoff-probe.mjs`
+  - RED: `/prototype-workspaces` returned the WebUI 404 while `/share/proto-token` rendered the prototype handoff.
+- `bunx vitest run __tests__/navigation/prototype-workspaces-route.test.tsx --maxWorkers=1 --no-file-parallelism` from `apps/tldw-frontend/`
+  - RED before adding the page shim; GREEN after adding `pages/prototype-workspaces.tsx`: `1 passed`.
+- `bunx vitest run src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx --maxWorkers=1 --no-file-parallelism` from `apps/packages/ui/`
+  - RED before preserving stored collaborator context after token cleanup; GREEN after the page-state fix: `6 passed`.
+- `bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism` from `apps/packages/ui/`
+  - GREEN: `5 passed (5)`, `31 passed (31)`.
+- Full Playwright signoff flow via `/private/tmp/prototype-signoff-flow.mjs`
+  - GREEN: owner create/share/review/failure/success and collaborator public-share/link-exchange/session/promotion states observed; screenshots written to `/private/tmp/prototype-final-signoff-1977/`.
+- `../../.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_release_readiness_smoke.py tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py -q`
+  - GREEN: `5 passed, 5 warnings`.
+- `git diff --check`
+  - GREEN: no output.
+- `../../.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/sharing.py tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/core/Sharing/share_token_service.py tldw_Server_API/app/core/Prototype_Workspaces/access.py tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py -f json -o /tmp/bandit_prototype_security_review_1977.json`
+  - GREEN: `results: []`.
+
 ## Remaining Risks For Gate 8
 
-- Browser-observed UX evidence still needs to be captured against the local frontend route.
-- Final security review should confirm private-link/session-token flows against the latest merged code.
-- If production deployment requires operator dashboards instead of documented log/status-field workflows, that should be filed as a follow-up rather than folded into this smoke-coverage slice.
+- No production-blocking browser UX or private-link/session-token security issues remain from #1977.
+- Operator dashboards beyond documented log/status-field workflows remain a possible future enhancement, not a Gate 8 blocker.

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
@@ -16,6 +16,12 @@ export const PrototypeWorkspacePage = () => {
   const activeWorkspaceId = usePrototypeWorkspaceStore(
     (state) => state.activeWorkspaceId
   )
+  const collaboratorSessionId = usePrototypeWorkspaceStore(
+    (state) => state.collaboratorSessionId
+  )
+  const collaboratorSessionToken = usePrototypeWorkspaceStore(
+    (state) => state.collaboratorSessionToken
+  )
   const setActiveWorkspaceId = usePrototypeWorkspaceStore(
     (state) => state.setActiveWorkspaceId
   )
@@ -47,7 +53,12 @@ export const PrototypeWorkspacePage = () => {
     }
   }, [sessionToken, shareToken, setCollaboratorEntry])
 
-  const isCollaboratorEntry = Boolean(sessionToken || shareToken)
+  const hasStoredCollaboratorEntry = Boolean(
+    workspaceId && (collaboratorSessionId || collaboratorSessionToken)
+  )
+  const isCollaboratorEntry = Boolean(
+    sessionToken || shareToken || hasStoredCollaboratorEntry
+  )
   const resolvedWorkspaceId = isCollaboratorEntry
     ? workspaceId ?? null
     : workspaceId ?? activeWorkspaceId

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
@@ -16,6 +16,9 @@ export const PrototypeWorkspacePage = () => {
   const activeWorkspaceId = usePrototypeWorkspaceStore(
     (state) => state.activeWorkspaceId
   )
+  const collaboratorWorkspaceId = usePrototypeWorkspaceStore(
+    (state) => state.collaboratorWorkspaceId
+  )
   const collaboratorSessionId = usePrototypeWorkspaceStore(
     (state) => state.collaboratorSessionId
   )
@@ -54,7 +57,9 @@ export const PrototypeWorkspacePage = () => {
   }, [sessionToken, shareToken, setCollaboratorEntry])
 
   const hasStoredCollaboratorEntry = Boolean(
-    workspaceId && (collaboratorSessionId || collaboratorSessionToken)
+    workspaceId &&
+      collaboratorWorkspaceId === workspaceId &&
+      (collaboratorSessionId || collaboratorSessionToken)
   )
   const isCollaboratorEntry = Boolean(
     sessionToken || shareToken || hasStoredCollaboratorEntry

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
@@ -172,6 +172,7 @@ export const PrototypeWorkspaceSessionView = ({
       return
     }
     setCollaboratorEntry({
+      collaboratorWorkspaceId: null,
       collaboratorSessionId: null,
       collaboratorSessionToken: sessionToken ?? null,
       collaboratorShareToken: shareToken ?? null,
@@ -195,6 +196,7 @@ export const PrototypeWorkspaceSessionView = ({
       password: password || undefined
     })
     setCollaboratorEntry({
+      collaboratorWorkspaceId: null,
       collaboratorSessionToken: result.session_token,
       collaboratorShareToken: shareToken,
       sharedActorId: result.shared_actor_id
@@ -210,6 +212,7 @@ export const PrototypeWorkspaceSessionView = ({
     })
     setActiveWorkspaceId(result.prototype_workspace_id)
     setCollaboratorEntry({
+      collaboratorWorkspaceId: result.prototype_workspace_id,
       collaboratorSessionId: result.prototype_session_id,
       collaboratorSessionToken: effectiveSessionToken,
       collaboratorShareToken: shareToken,

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
@@ -150,6 +150,28 @@ describe("PrototypeWorkspacePage", () => {
     ).toHaveTextContent("Workspace:none Session:none Share:share-token-1")
   })
 
+  it("keeps the collaborator session view after token-bearing routes are cleaned up", () => {
+    usePrototypeWorkspaceStore.getState().setCollaboratorEntry({
+      collaboratorSessionId: "pss_collab",
+      collaboratorSessionToken: "session-token-1",
+      collaboratorShareToken: "share-token-1",
+      sharedActorId: "psa_collab"
+    })
+    searchParamsState.value = new URLSearchParams({
+      workspace: "pw_collab"
+    })
+
+    render(<PrototypeWorkspacePage />)
+
+    expect(hookState.usePrototypeWorkspace).toHaveBeenCalledWith(null)
+    expect(
+      screen.getByTestId("prototype-workspace-session-view")
+    ).toHaveTextContent("Workspace:pw_collab Session:none Share:none")
+    expect(
+      screen.queryByTestId("prototype-workspace-owner-view")
+    ).not.toBeInTheDocument()
+  })
+
   it("passes prototype share passwords from navigation state into collaborator entry", () => {
     searchParamsState.value = new URLSearchParams({
       share_token: "share-token-1"

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
@@ -66,6 +66,7 @@ vi.mock("../PrototypeWorkspaceSessionView", () => ({
 
 describe("PrototypeWorkspacePage", () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     searchParamsState.value = new URLSearchParams()
     locationState.value = null
     usePrototypeWorkspaceStore.getState().reset()
@@ -152,6 +153,7 @@ describe("PrototypeWorkspacePage", () => {
 
   it("keeps the collaborator session view after token-bearing routes are cleaned up", () => {
     usePrototypeWorkspaceStore.getState().setCollaboratorEntry({
+      collaboratorWorkspaceId: "pw_collab",
       collaboratorSessionId: "pss_collab",
       collaboratorSessionToken: "session-token-1",
       collaboratorShareToken: "share-token-1",
@@ -169,6 +171,37 @@ describe("PrototypeWorkspacePage", () => {
     ).toHaveTextContent("Workspace:pw_collab Session:none Share:none")
     expect(
       screen.queryByTestId("prototype-workspace-owner-view")
+    ).not.toBeInTheDocument()
+  })
+
+  it("ignores stale stored collaborator sessions for a different owner workspace", () => {
+    usePrototypeWorkspaceStore.getState().setCollaboratorEntry({
+      collaboratorWorkspaceId: "pw_previous_collab",
+      collaboratorSessionId: "pss_stale",
+      collaboratorSessionToken: "session-token-stale",
+      collaboratorShareToken: "share-token-stale",
+      sharedActorId: "psa_stale"
+    })
+    searchParamsState.value = new URLSearchParams({
+      workspace: "pw_owner"
+    })
+    hookState.usePrototypeWorkspace.mockReturnValue({
+      data: {
+        id: "pw_owner",
+        viewer_role: "owner",
+        sessions: [],
+        snapshots: []
+      }
+    })
+
+    render(<PrototypeWorkspacePage />)
+
+    expect(hookState.usePrototypeWorkspace).toHaveBeenCalledWith("pw_owner")
+    expect(
+      screen.getByTestId("prototype-workspace-owner-view")
+    ).toHaveTextContent("Owner:pw_owner")
+    expect(
+      screen.queryByTestId("prototype-workspace-session-view")
     ).not.toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx
@@ -134,6 +134,12 @@ describe("PrototypeWorkspaceSessionView", () => {
         session_token: "session-token-1"
       })
     })
+    expect(usePrototypeWorkspaceStore.getState()).toMatchObject({
+      collaboratorWorkspaceId: "pw_collab",
+      collaboratorSessionId: "pss_collab",
+      collaboratorSessionToken: "session-token-1",
+      collaboratorShareToken: "share-token-1"
+    })
     expect(routerState.navigate).toHaveBeenCalledWith(
       "/prototype-workspaces?workspace=pw_collab",
       { replace: true }

--- a/apps/packages/ui/src/store/prototype-workspace.ts
+++ b/apps/packages/ui/src/store/prototype-workspace.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from "zustand/traditional"
 type PrototypeWorkspaceStoreState = {
   activeWorkspaceId: string | null
   ownerSessionId: string | null
+  collaboratorWorkspaceId: string | null
   collaboratorSessionId: string | null
   collaboratorSessionToken: string | null
   collaboratorShareToken: string | null
@@ -11,6 +12,7 @@ type PrototypeWorkspaceStoreState = {
   setActiveWorkspaceId: (workspaceId: string | null) => void
   setOwnerSessionId: (sessionId: string | null) => void
   setCollaboratorEntry: (entry: {
+    collaboratorWorkspaceId?: string | null
     collaboratorSessionId?: string | null
     collaboratorSessionToken?: string | null
     collaboratorShareToken?: string | null
@@ -23,6 +25,7 @@ type PrototypeWorkspaceStoreState = {
 const initialState = {
   activeWorkspaceId: null,
   ownerSessionId: null,
+  collaboratorWorkspaceId: null,
   collaboratorSessionId: null,
   collaboratorSessionToken: null,
   collaboratorShareToken: null,
@@ -37,6 +40,10 @@ export const usePrototypeWorkspaceStore =
     setOwnerSessionId: (ownerSessionId) => set({ ownerSessionId }),
     setCollaboratorEntry: (entry) =>
       set({
+        collaboratorWorkspaceId:
+          entry.collaboratorWorkspaceId !== undefined
+            ? entry.collaboratorWorkspaceId
+            : initialState.collaboratorWorkspaceId,
         collaboratorSessionId:
           entry.collaboratorSessionId !== undefined
             ? entry.collaboratorSessionId

--- a/apps/tldw-frontend/__tests__/e2e/stage4-axe-visual-settle.guard.test.ts
+++ b/apps/tldw-frontend/__tests__/e2e/stage4-axe-visual-settle.guard.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const readStage4AxeSource = () =>
+  readFileSync(
+    path.join(process.cwd(), "e2e/smoke/stage4-axe-high-risk-routes.spec.ts"),
+    "utf8"
+  )
+
+describe("Stage 4 Axe visual settle contract", () => {
+  it("waits for visual settle immediately before Axe analysis", () => {
+    const source = readStage4AxeSource()
+
+    expect(source).toContain("waitForVisualSettle")
+    expect(source).toMatch(
+      /await waitForVisualSettle\(page, LOAD_TIMEOUT\)[\s\S]*?const results = await new AxeBuilder\(\{ page \}\)/
+    )
+    expect(source).not.toContain('waitForLoadState("networkidle"')
+    expect(source).not.toContain("waitForTimeout(250)")
+  })
+})

--- a/apps/tldw-frontend/__tests__/navigation/prototype-workspaces-route.test.tsx
+++ b/apps/tldw-frontend/__tests__/navigation/prototype-workspaces-route.test.tsx
@@ -1,0 +1,20 @@
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const testFileDirectory = dirname(fileURLToPath(import.meta.url))
+const pagePath = resolve(testFileDirectory, "../../pages/prototype-workspaces.tsx")
+
+describe("web prototype workspaces page route", () => {
+  it("exposes a Next.js page shim for prototype workspaces", () => {
+    expect(existsSync(pagePath)).toBe(true)
+
+    const source = readFileSync(pagePath, "utf8")
+
+    expect(source).toMatch(
+      /dynamic\(\(\) => import\("@\/routes\/option-prototype-workspaces"\)/
+    )
+    expect(source).toMatch(/ssr:\s*false/)
+  })
+})

--- a/apps/tldw-frontend/e2e/smoke/stage4-axe-high-risk-routes.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage4-axe-high-risk-routes.spec.ts
@@ -140,11 +140,7 @@ async function waitForRouteToSettle(
     } catch {}
   }
 
-  try {
-    await page.waitForLoadState('networkidle', { timeout: 1_500 });
-  } catch {}
-
-  await page.waitForTimeout(250);
+  await waitForVisualSettle(page, LOAD_TIMEOUT);
 }
 
 async function analyzeA11yWithRetry(

--- a/apps/tldw-frontend/pages/prototype-workspaces.tsx
+++ b/apps/tldw-frontend/pages/prototype-workspaces.tsx
@@ -1,0 +1,5 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-prototype-workspaces"), {
+  ssr: false
+})

--- a/backlog/tasks/task-489 - Prototype-workspace-final-browser-UX-and-private-link-security-signoff.md
+++ b/backlog/tasks/task-489 - Prototype-workspace-final-browser-UX-and-private-link-security-signoff.md
@@ -1,0 +1,56 @@
+---
+id: TASK-489
+title: Prototype workspace final browser UX and private-link security signoff
+status: Done
+labels:
+- prototype-workspaces
+- release-readiness
+- security
+- ux
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/issues/1977
+- https://github.com/rmusser01/tldw_server/issues/1440
+documentation:
+- Docs/Operations/Prototype_Workspaces_Release_Readiness.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Browser-observed owner flow evidence is recorded for workspace creation, share-link creation, promotion review, validation failure handling, and successful promotion where practical.
+- [x] #2 Browser-observed collaborator flow evidence is recorded for public-share handoff, session handling, branch session creation, candidate save, and promotion submission where practical.
+- [x] #3 Private-link/session-token security review is recorded against latest merged code for ownership, revocation, expiration, resume-cookie flags, non-enumerating errors, preview grants, and promotion authority.
+- [x] #4 Any blockers are filed or explicitly recorded as none found.
+- [x] #5 Verification results and final summary are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Browser pass found and fixed a WebUI routing blocker: `/share/{token}` could hand off to `/prototype-workspaces`, but the WebUI lacked a Next page shim for that path.
+- Added `apps/tldw-frontend/pages/prototype-workspaces.tsx` and a page-shim contract test.
+- Added a collaborator route-state regression so token cleanup after branch-session creation preserves the collaborator session surface instead of falling back to owner view.
+- Recorded private-link/session-token signoff in `Docs/Operations/Prototype_Workspaces_Release_Readiness.md` for ownership, revocation, expiration, resume-cookie flags, non-enumerating errors, preview grants, and promotion authority.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Final #1977 signoff evidence is recorded. Browser-observed owner and collaborator flows passed against the real WebUI route with API-shaped Playwright stubs, screenshots were captured under `/private/tmp/prototype-final-signoff-1977/`, the missing `/prototype-workspaces` page shim was fixed, collaborator route-state cleanup was hardened, and no production-blocking private-link/session-token security issues remain from this review.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Evidence recorded in release-readiness docs and/or issue
+- [x] #3 Security review completed
+- [x] #4 Tests or manual/browser verification recorded
+- [x] #5 Known blockers documented
+- [x] #6 Final summary added
+<!-- DOD:END -->

--- a/backlog/tasks/task-490 - Address-prototype-signoff-PR-review-feedback-for-stale-collaborator-sessions.md
+++ b/backlog/tasks/task-490 - Address-prototype-signoff-PR-review-feedback-for-stale-collaborator-sessions.md
@@ -1,0 +1,47 @@
+---
+id: TASK-490
+title: Address prototype signoff PR review feedback for stale collaborator sessions
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-23 04:23'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix PR #1980 review feedback: stored collaborator session state must not force collaborator view for a different workspace owner URL. Track implementation, verification, and PR follow-up.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Owner workspace URLs render the owner view when only stale stored collaborator data exists for another workspace.
+- [x] #2 Stored collaborator session context is scoped to the workspace created by the collaborator branch session after token cleanup.
+- [x] #3 Focused tests and verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1980 review feedback by scoping stored collaborator session state to a collaboratorWorkspaceId. PrototypeWorkspacePage now only treats stored collaborator data as collaborator entry context when it matches the workspace in the URL, preventing stale collaborator sessions from forcing owner workspaces into collaborator view. Added regressions for stale-session owner fallback and collaborator branch session workspace scoping. Verification: route shim vitest 1 passed; focused prototype UI vitest 32 passed; prototype docs/readiness pytest 5 passed; git diff --check passed; Bandit backend security scope returned no errors/results. UI package tsc was attempted with increased heap and failed on existing repo-wide baseline errors outside the touched prototype workspace files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-491 - Address-Stage-4-Axe-visual-settle-review-feedback.md
+++ b/backlog/tasks/task-491 - Address-Stage-4-Axe-visual-settle-review-feedback.md
@@ -1,0 +1,47 @@
+---
+id: TASK-491
+title: Address Stage 4 Axe visual settle review feedback
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-23 04:36
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix PR review feedback: Stage 4 high-risk Axe scans should use waitForVisualSettle before AxeBuilder.analyze and reduce fixed sleep reliance in the scan path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Stage 4 Axe high-risk scans call waitForVisualSettle before AxeBuilder.analyze.
+- [x] #2 Stage 4 Axe high-risk scans no longer use direct networkidle waits or the fixed 250ms sleep in route-settle flow.
+- [x] #3 Focused guard tests and diff checks are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated Stage 4 Axe high-risk route scanning to use waitForVisualSettle(page, LOAD_TIMEOUT) before AxeBuilder.analyze and replaced the direct networkidle plus fixed 250ms route-settle delay with the visual-settle helper. Removed the unused duplicate Axe retry helper so the guarded retry path is the active scan path. Added a focused Vitest guard to prevent future drift. Verification: new guard was red before the fix and passes after; Stage 4 Axe helper plus visual-settle guard passed (5 tests); existing e2e harness Stage 4 smoke-slice guard passed by name; git diff --check passed. Bandit skipped because only TypeScript test/e2e files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-492 - Resolve-prototype-final-signoff-PR-merge-conflict.md
+++ b/backlog/tasks/task-492 - Resolve-prototype-final-signoff-PR-merge-conflict.md
@@ -1,0 +1,47 @@
+---
+id: TASK-492
+title: Resolve prototype final signoff PR merge conflict
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-23 05:43
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve PR #1980 merge conflicts against latest dev, preserve prototype signoff/review fixes, rerun focused verification, and push the updated PR branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased onto latest origin/dev.
+- [x] #2 Stage 4 Axe merge conflict is resolved without conflict markers and preserves waitForVisualSettle before Axe analysis.
+- [x] #3 Focused verification and security checks are recorded before pushing.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #1980 merge conflict by rebasing codex/prototype-final-signoff-1977 onto origin/dev (807f91acf). The only conflict was in apps/tldw-frontend/e2e/smoke/stage4-axe-high-risk-routes.spec.ts; resolution kept the latest dev formatting and route metadata while preserving waitForVisualSettle before AxeBuilder.analyze and removing the old direct networkidle/fixed 250ms route-settle path. Verification after rebase: Stage 4 Axe helper plus visual-settle guard 5 passed; Stage 4 smoke-slice readiness guard 1 passed; prototype route shim 1 passed; focused prototype UI suite 32 passed; prototype docs/readiness pytest 5 passed; git diff --check passed; Bandit backend security scope returned no errors/results.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds the missing Next.js page shim for `/prototype-workspaces`, which the public prototype share handoff already targets.
- Preserves collaborator session context after token-bearing routes are cleaned up, so branch-session collaborators stay on the collaborator surface.
- Scopes stored collaborator session state to the matching workspace, preventing stale sessions from forcing owner workspace URLs into collaborator view.
- Moves Stage 4 high-risk Axe scans onto `waitForVisualSettle` before analysis and removes the fixed 250ms/networkidle settle dependency from that scan path.
- Records #1977 browser signoff evidence and private-link/session-token security review in the release-readiness doc and Backlog task.

## Verification
- `bunx vitest run __tests__/navigation/prototype-workspaces-route.test.tsx --maxWorkers=1 --no-file-parallelism`
- `bunx vitest run src/components/Option/__tests__/PublicShare.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceOwnerView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspaceSessionView.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/hooks/__tests__/usePrototypeWorkspaces.test.tsx --maxWorkers=1 --no-file-parallelism`
- `../../.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_release_readiness_smoke.py tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_docs_contract.py -q`
- `git diff --cached --check`
- `../../.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/sharing.py tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/core/Sharing/share_token_service.py tldw_Server_API/app/core/Prototype_Workspaces/access.py tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py -f json -o /tmp/bandit_prototype_security_review_1980_comments.json`
- `/private/tmp/prototype-signoff-flow.mjs` against local Next WebUI with API-shaped Playwright stubs.
- `bunx vitest run __tests__/e2e/stage4-axe-visual-settle.guard.test.ts --maxWorkers=1 --no-file-parallelism`
- `bunx vitest run __tests__/e2e-harness-readiness.guard.test.ts -t "keeps the next smoke harness slice off direct networkidle waits" --maxWorkers=1 --no-file-parallelism`
- `bunx vitest run __tests__/e2e/stage4-axe-high-risk-routes.helpers.test.ts __tests__/e2e/stage4-axe-visual-settle.guard.test.ts --maxWorkers=1 --no-file-parallelism`

## Verification Notes
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` was attempted for `apps/packages/ui`; it fails on existing repo-wide baseline TypeScript errors outside the touched prototype workspace files.

## PR Template Checklist Status
- UX audit checklist: Applies. Final owner/collaborator browser signoff evidence is recorded in `Docs/Operations/Prototype_Workspaces_Release_Readiness.md`.
- Security checklist: Applies. Private-link and session-token ownership, revocation, expiration, non-enumerating error, preview-grant, and promotion-authority checks are recorded in `Docs/Operations/Prototype_Workspaces_Release_Readiness.md`.
- Human-authored change summary: Required before merge. The placeholder below must be replaced by the human maintainer.

## Linked Issues
- Closes #1977
- Supports #1440

## Change Summary
Human maintainer must replace this section before merge with their own summary of what changed and why these implementation choices were made, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.
