### PR TITLE
Add document-first Writing Playground revision workflow

### DIFF
--- a/Docs/superpowers/plans/2026-05-22-writing-playground-document-first-revisions-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-22-writing-playground-document-first-revisions-implementation-plan.md
@@ -1,0 +1,1339 @@
+# Writing Playground Document-First Revisions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a document-first proposed-edit workflow to the shared Writing Playground so users can request creative writing changes, review diffs, and apply or reject safe proposals.
+
+**Architecture:** Keep the feature inside the existing shared `WritingPlayground` surface used by WebUI and extension. Add pure revision utilities, a structured proposal parser/prompt builder, a small persistence bridge into the existing writing session save path, and focused UI components for actions, diffs, and the revision queue. Stage the implementation so plain-text proposals work first; rich editor behavior can honestly fall back to copy/manual apply when preserving rich structure is unsafe.
+
+**Tech Stack:** React, TypeScript, Ant Design, lucide-react, TipTap, TanStack Query, existing `TldwChatService`, existing `/api/v1/writing/*` session persistence, Vitest, Testing Library, Playwright extension smoke tests.
+
+---
+
+## Source Documents
+
+- Design spec: `Docs/superpowers/specs/2026-05-22-writing-playground-document-first-revisions-design.md`
+- Design task: `backlog/tasks/task-443 - Design-document-first-Writing-Playground-revision-workflow.md`
+- Planning task: `backlog/tasks/task-458 - Plan-document-first-Writing-Playground-revision-implementation.md`
+
+## Scope Check
+
+This plan is a single client-first implementation slice. It deliberately avoids:
+
+- backend revision-history APIs
+- full rich-text operational transforms
+- persistent comment threads or annotations
+- a new route or chat-first writing page
+- broad `WritingPlayground/index.tsx` restructuring beyond the local seams needed for this feature
+
+Before executing Task 1, create a Backlog.md implementation task for the code work and record this
+plan path on that task. The planning task is `TASK-458`; do not use it as the implementation task
+once source files are being changed.
+
+## File Structure
+
+Create focused files under the existing Writing Playground directory:
+
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-types.ts`
+  - Shared revision action, operation, preset, target, status, proposal, schema-versioned
+    payload, and apply result types.
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-presets.ts`
+  - Defines inspectable workflow presets, labels, and instruction text.
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-utils.ts`
+  - Pure helpers for word counts, action-aware target resolution, document fingerprints,
+    insertion anchors, destructive-target confirmation, drift detection, retargeting, and
+    plain-text apply plans.
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-prompt-utils.ts`
+  - Builds non-streaming proposed-edit prompts from the document, target, preset, and existing
+    Writing Playground context; validates model responses into proposal drafts or raw/advisory
+    fallbacks.
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingRevisions.ts`
+  - Owns revision queue state, session-payload serialization, proposal create/apply/reject/regenerate state transitions, and delegates text mutation through existing editor/session callbacks.
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/WritingActionBar.tsx`
+  - Compact action controls for Continue, Rewrite, Expand, Tighten, Tone, Outline, Custom, preset
+    selection, target summary, and destructive-target confirmation.
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionDiff.tsx`
+  - Small text diff view for before/after proposal review.
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionQueue.tsx`
+  - Proposal cards with Apply, Reject, Copy, Regenerate, conflict, raw-suggestion, and advisory states.
+
+Modify existing files:
+
+- Modify `apps/packages/ui/src/components/Option/WritingPlayground/hooks/utils.ts`
+  - Add schema-versioned revision payload support to `WritingSessionPayload`.
+  - Add payload helpers for `getRevisionsFromPayload`, `mergeRevisionsIntoPayload`, and a stable revision signature.
+- Modify `apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingSessionManagement.ts`
+  - Track revision payload signatures or expose a narrow payload-patch save helper so proposal-only changes persist and do not overwrite unsaved prompt/settings changes.
+- Modify `apps/packages/ui/src/components/Option/WritingPlayground/index.tsx`
+  - Wire action bar, queue, non-streaming proposal generation, proposal apply, and status bar counts into the existing editor layout.
+- Modify locale files only if the implementation chooses translation keys instead of inline fallback labels:
+  - `apps/packages/ui/src/assets/locale/en/option.json`
+  - `apps/packages/ui/src/public/_locales/en/option.json`
+
+Add focused tests:
+
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts`
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts`
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts`
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx`
+- Create `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx`
+- Modify or add integration coverage near:
+  - `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx`
+  - `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts`
+  - `apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts`
+  - `apps/extension/tests/e2e/writing-playground-mode-parity.spec.ts`
+
+## Implementation Tasks
+
+### Task 1: Add Revision Types And Pure Apply Utilities
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-types.ts`
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-utils.ts`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts`
+
+- [ ] **Step 1: Write failing utility tests**
+
+Cover these cases:
+
+```ts
+import {
+  buildInsertionAnchor,
+  confirmRevisionTarget,
+  countWords,
+  createDocumentFingerprint,
+  findParagraphRange,
+  planRevisionApply,
+  resolveRevisionTarget
+} from "../writing-revision-utils"
+
+describe("writing revision utilities", () => {
+  it("counts words and selected words deterministically", () => {
+    expect(countWords("One two\nthree.")).toBe(3)
+    expect(countWords("   ")).toBe(0)
+  })
+
+  it("resolves the current paragraph around a cursor", () => {
+    const text = "Alpha one.\n\nBeta two.\nBeta three."
+    expect(findParagraphRange(text, 14)).toEqual({ start: 12, end: 33 })
+  })
+
+  it("plans a direct replacement when beforeText still matches", () => {
+    const proposal = makeReplacementProposal({
+      start: 0,
+      end: 5,
+      beforeText: "Alpha",
+      replacementText: "Omega"
+    })
+    expect(planRevisionApply("Alpha beta", proposal)).toEqual({
+      type: "apply",
+      start: 0,
+      end: 5,
+      nextText: "Omega beta"
+    })
+  })
+
+  it("conflicts when replacement target drift is ambiguous", () => {
+    const proposal = makeReplacementProposal({
+      start: 0,
+      end: 5,
+      beforeText: "Alpha",
+      replacementText: "Omega"
+    })
+    expect(planRevisionApply("Intro Alpha beta Alpha", proposal).type).toBe("conflict")
+  })
+
+  it("retargets a zero-length insertion by unique prefix and suffix anchor", () => {
+    const original = "Alpha beta"
+    const anchor = buildInsertionAnchor(original, 5)
+    const proposal = makeInsertionProposal({
+      start: 5,
+      end: 5,
+      beforeText: "",
+      replacementText: " brave",
+      anchor
+    })
+    expect(planRevisionApply("Intro. Alpha beta", proposal)).toMatchObject({
+      type: "retarget"
+    })
+  })
+
+  it("does not treat empty beforeText as a safe insertion match after drift", () => {
+    const proposal = makeInsertionProposal({
+      start: 5,
+      end: 5,
+      beforeText: "",
+      replacementText: " brave",
+      anchor: {
+        documentFingerprint: createDocumentFingerprint("Alpha beta"),
+        prefix: "Alpha",
+        suffix: " beta"
+      }
+    })
+    expect(planRevisionApply("Completely different", proposal).type).toBe("conflict")
+  })
+
+  it("targets the whole document for advisory outline requests", () => {
+    const text = "First paragraph.\n\nSecond paragraph."
+    const target = resolveRevisionTarget({
+      text,
+      action: "outline",
+      operation: "advisory",
+      cursor: 3
+    })
+    expect(target).toMatchObject({
+      mode: "document",
+      start: 0,
+      end: text.length,
+      requiresConfirmation: false
+    })
+  })
+
+  it("requires confirmation before large text-changing document targets", () => {
+    const target = resolveRevisionTarget({
+      text: "First paragraph.\n\nSecond paragraph.",
+      action: "rewrite",
+      operation: "replace",
+      cursor: 3,
+      preferredTargetMode: "document"
+    })
+    expect(target).toMatchObject({
+      mode: "document",
+      requiresConfirmation: true
+    })
+  })
+
+  it("allows apply after a whole-document text-changing target is confirmed", () => {
+    const target = resolveRevisionTarget({
+      text: "First paragraph.\n\nSecond paragraph.",
+      action: "rewrite",
+      operation: "replace",
+      cursor: 3,
+      preferredTargetMode: "document"
+    })
+    const confirmed = confirmRevisionTarget(target)
+    expect(confirmed.requiresConfirmation).toBe(false)
+    expect(confirmed.confirmationReason).toBeUndefined()
+  })
+
+  it("surfaces the resolved target for custom requests before generation", () => {
+    const target = resolveRevisionTarget({
+      text: "First paragraph.\n\nSecond paragraph.",
+      action: "custom",
+      operation: "replace",
+      cursor: 20
+    })
+    expect(target.mode).toBe("paragraph")
+    expect(target.label).toContain("paragraph")
+  })
+})
+```
+
+The helper factories can live inside the test file.
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts
+```
+
+Expected: FAIL because the new utility module does not exist.
+
+- [ ] **Step 3: Implement the types**
+
+Create `writing-revision-types.ts` with:
+
+```ts
+export type WritingRevisionAction =
+  | "continue"
+  | "rewrite"
+  | "expand"
+  | "tighten"
+  | "tone"
+  | "outline"
+  | "custom"
+
+export type WritingRevisionOperation = "insert" | "replace" | "advisory"
+
+export type WritingRevisionPresetId =
+  | "draft_freely"
+  | "polish_prose"
+  | "developmental_edit"
+  | "preserve_voice"
+  | "make_concise"
+  | "expand_sensory_detail"
+
+export type WritingRevisionStatus =
+  | "pending"
+  | "applied"
+  | "rejected"
+  | "conflict"
+  | "raw_suggestion"
+  | "advisory"
+
+export type WritingRevisionAnchor = {
+  documentFingerprint: string
+  prefix: string
+  suffix: string
+}
+
+export type WritingRevisionTarget = {
+  mode: "selection" | "paragraph" | "cursor" | "document"
+  start: number
+  end: number
+  beforeText: string
+  anchor: WritingRevisionAnchor
+  label: string
+  requiresConfirmation: boolean
+  confirmationReason?: string
+}
+
+export type WritingRevisionProposal = {
+  id: string
+  sessionId: string
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  presetId?: WritingRevisionPresetId | null
+  presetInstruction?: string | null
+  instruction: string
+  target: WritingRevisionTarget
+  replacementText?: string
+  rawText?: string
+  rationale?: string
+  title?: string
+  notes?: string[]
+  regeneratedFromId?: string
+  createdAt: string
+  status: WritingRevisionStatus
+}
+
+export type WritingRevisionApplyPlan =
+  | { type: "apply"; start: number; end: number; nextText: string }
+  | { type: "retarget"; start: number; end: number; nextText: string }
+  | { type: "conflict"; reason: string }
+  | { type: "noop"; reason: string }
+
+export type WritingRevisionPayload = {
+  schemaVersion: 1
+  items: WritingRevisionProposal[]
+}
+```
+
+- [ ] **Step 4: Implement pure utility functions**
+
+Create `writing-revision-utils.ts` with:
+
+```ts
+import type {
+  WritingRevisionAction,
+  WritingRevisionAnchor,
+  WritingRevisionApplyPlan,
+  WritingRevisionOperation,
+  WritingRevisionProposal,
+  WritingRevisionTarget
+} from "./writing-revision-types"
+
+const DEFAULT_ANCHOR_WINDOW = 80
+const DEFAULT_LARGE_TARGET_CHARS = 1800
+
+export const countWords = (text: string): number => {
+  const matches = text.trim().match(/\S+/g)
+  return matches ? matches.length : 0
+}
+
+export const createDocumentFingerprint = (text: string): string => {
+  let hash = 2166136261
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16)
+}
+
+export const buildInsertionAnchor = (
+  text: string,
+  offset: number,
+  windowSize = DEFAULT_ANCHOR_WINDOW
+): WritingRevisionAnchor => {
+  const safeOffset = Math.max(0, Math.min(text.length, offset))
+  return {
+    documentFingerprint: createDocumentFingerprint(text),
+    prefix: text.slice(Math.max(0, safeOffset - windowSize), safeOffset),
+    suffix: text.slice(safeOffset, Math.min(text.length, safeOffset + windowSize))
+  }
+}
+
+export const findParagraphRange = (
+  text: string,
+  cursor: number
+): { start: number; end: number } => {
+  const safeCursor = Math.max(0, Math.min(text.length, cursor))
+  const before = text.lastIndexOf("\n\n", safeCursor - 1)
+  const after = text.indexOf("\n\n", safeCursor)
+  return {
+    start: before === -1 ? 0 : before + 2,
+    end: after === -1 ? text.length : after
+  }
+}
+
+const makeRevisionTarget = (input: {
+  text: string
+  mode: WritingRevisionTarget["mode"]
+  start: number
+  end: number
+  operation: WritingRevisionOperation
+  label: string
+  confirmationReason?: string
+}): WritingRevisionTarget => {
+  const start = Math.max(0, Math.min(input.text.length, input.start))
+  const end = Math.max(start, Math.min(input.text.length, input.end))
+  const isTextChanging = input.operation !== "advisory"
+  return {
+    mode: input.mode,
+    start,
+    end,
+    beforeText: input.text.slice(start, end),
+    anchor: buildInsertionAnchor(input.text, start),
+    label: input.label,
+    requiresConfirmation: Boolean(isTextChanging && input.confirmationReason),
+    confirmationReason: isTextChanging ? input.confirmationReason : undefined
+  }
+}
+
+export const confirmRevisionTarget = (
+  target: WritingRevisionTarget
+): WritingRevisionTarget => ({
+  ...target,
+  requiresConfirmation: false,
+  confirmationReason: undefined
+})
+
+export const resolveRevisionTarget = (input: {
+  text: string
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  selection?: { start: number; end: number } | null
+  cursor?: number | null
+  preferredTargetMode?: WritingRevisionTarget["mode"] | null
+  maxAutomaticTargetCharacters?: number
+}): WritingRevisionTarget => {
+  const { text, action, operation, selection } = input
+  const maxAutomaticTargetCharacters =
+    input.maxAutomaticTargetCharacters ?? DEFAULT_LARGE_TARGET_CHARS
+  if (selection && selection.start !== selection.end) {
+    const start = Math.max(0, Math.min(text.length, selection.start))
+    const end = Math.max(start, Math.min(text.length, selection.end))
+    return makeRevisionTarget({
+      text,
+      mode: "selection",
+      start,
+      end,
+      operation,
+      label: "selection"
+    })
+  }
+
+  const cursor = Math.max(0, Math.min(text.length, input.cursor ?? text.length))
+  if (action === "continue") {
+    return makeRevisionTarget({
+      text,
+      mode: "cursor",
+      start: cursor,
+      end: cursor,
+      operation: "insert",
+      label: cursor === text.length ? "document end" : "cursor"
+    })
+  }
+
+  if (action === "outline" || operation === "advisory") {
+    return makeRevisionTarget({
+      text,
+      mode: "document",
+      start: 0,
+      end: text.length,
+      operation: "advisory",
+      label: "whole document"
+    })
+  }
+
+  if (input.preferredTargetMode === "document") {
+    return makeRevisionTarget({
+      text,
+      mode: "document",
+      start: 0,
+      end: text.length,
+      operation,
+      label: "whole document",
+      confirmationReason: "Confirm before applying a whole-document text-changing request."
+    })
+  }
+
+  const paragraph = findParagraphRange(text, cursor)
+  const paragraphLength = paragraph.end - paragraph.start
+  if (paragraphLength > 0 && paragraphLength <= maxAutomaticTargetCharacters) {
+    return makeRevisionTarget({
+      text,
+      mode: "paragraph",
+      start: paragraph.start,
+      end: paragraph.end,
+      operation,
+      label: "current paragraph"
+    })
+  }
+
+  return makeRevisionTarget({
+    text,
+    mode: "document",
+    start: 0,
+    end: text.length,
+    operation,
+    label: "whole document",
+    confirmationReason: "The current paragraph could not be resolved safely."
+  })
+}
+```
+
+Then add `planRevisionApply()` with the exact-target, unique-retarget, insertion-anchor, advisory,
+large-target confirmation, and conflict behavior from the spec. Applying code must refuse
+text-changing proposals whose target still requires confirmation.
+
+- [ ] **Step 5: Run tests to verify utilities pass**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-types.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-utils.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts
+git commit -m "feat: add writing revision utilities"
+```
+
+### Task 2: Add Workflow Presets
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-presets.ts`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts`
+
+- [ ] **Step 1: Write failing preset tests**
+
+Cover:
+
+- all six spec presets exist: Draft freely, Polish prose, Developmental edit, Preserve voice,
+  Make concise, Expand sensory detail
+- each preset has a stable `id`, user-facing `label`, and visible `instruction`
+- preset ids match `WritingRevisionPresetId`
+- preset instructions are not empty and do not silently override the user's custom instruction
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts
+```
+
+Expected: FAIL because the preset module does not exist.
+
+- [ ] **Step 2: Implement visible preset definitions**
+
+Create `writing-revision-presets.ts`:
+
+```ts
+import type { WritingRevisionPresetId } from "./writing-revision-types"
+
+export type WritingRevisionPreset = {
+  id: WritingRevisionPresetId
+  label: string
+  instruction: string
+}
+
+export const WRITING_REVISION_PRESETS: WritingRevisionPreset[] = [
+  {
+    id: "draft_freely",
+    label: "Draft freely",
+    instruction: "Prioritize momentum, vivid continuation, and useful new material."
+  },
+  {
+    id: "polish_prose",
+    label: "Polish prose",
+    instruction: "Improve clarity, rhythm, word choice, and sentence flow without changing intent."
+  },
+  {
+    id: "developmental_edit",
+    label: "Developmental edit",
+    instruction: "Focus on structure, stakes, pacing, continuity, and what the passage needs next."
+  },
+  {
+    id: "preserve_voice",
+    label: "Preserve voice",
+    instruction: "Keep the author's diction, cadence, point of view, and stylistic fingerprints."
+  },
+  {
+    id: "make_concise",
+    label: "Make concise",
+    instruction: "Reduce redundancy and sharpen phrasing while preserving meaning and voice."
+  },
+  {
+    id: "expand_sensory_detail",
+    label: "Expand sensory detail",
+    instruction: "Add concrete sensory detail grounded in the existing scene and tone."
+  }
+]
+
+export const getWritingRevisionPreset = (
+  id?: WritingRevisionPresetId | null
+): WritingRevisionPreset | null =>
+  WRITING_REVISION_PRESETS.find((preset) => preset.id === id) ?? null
+```
+
+- [ ] **Step 3: Run preset tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 2**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-presets.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts
+git commit -m "feat: add writing revision presets"
+```
+
+### Task 3: Add Structured Proposal Prompt And Validation Utilities
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-prompt-utils.ts`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts`
+
+- [ ] **Step 1: Write failing prompt utility tests**
+
+Cover:
+
+- rewrite action creates a text-changing prompt that asks for JSON only
+- outline defaults to advisory operation
+- prompt includes selected preset instruction when present
+- prompt includes existing Writing Playground context: selected template/theme, composed context
+  prompt or context messages, memory block, author note, world info entries, active provider/model,
+  and generation settings summary
+- valid JSON with `replacement` becomes a pending insert or replace proposal
+- valid advisory JSON without replacement becomes advisory
+- malformed JSON becomes `raw_suggestion`
+- streamed or partial-looking JSON is not applyable until complete parsing succeeds
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts
+```
+
+Expected: FAIL because the new module does not exist.
+
+- [ ] **Step 2: Implement prompt and parser utilities**
+
+Create exports shaped like:
+
+```ts
+export const buildRevisionUserPrompt = (input: {
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  instruction: string
+  documentText: string
+  target: WritingRevisionTarget
+  presetInstruction?: string | null
+  writingContext: {
+    selectedTemplateName?: string | null
+    selectedThemeName?: string | null
+    chatMode: boolean
+    contextComposedPrompt?: string | null
+    contextMessages?: Array<{ role: string; content: string }> | null
+    memoryBlock?: unknown
+    authorNote?: unknown
+    worldInfoEntries?: unknown[]
+    provider?: string | null
+    model?: string | null
+    generationSettingsSummary: Record<string, unknown>
+  }
+}): string => {
+  return [
+    "You are helping revise a creative writing document.",
+    "Return only valid JSON. Do not include markdown fences.",
+    `Action: ${input.action}`,
+    `Operation: ${input.operation}`,
+    `Instruction: ${input.instruction}`,
+    input.presetInstruction ? `Workflow preset: ${input.presetInstruction}` : null,
+    `Template: ${input.writingContext.selectedTemplateName || "(none)"}`,
+    `Theme: ${input.writingContext.selectedThemeName || "(none)"}`,
+    `Chat mode: ${input.writingContext.chatMode ? "enabled" : "disabled"}`,
+    `Provider: ${input.writingContext.provider || "(default)"}`,
+    `Model: ${input.writingContext.model || "(unset)"}`,
+    "Generation settings:",
+    JSON.stringify(input.writingContext.generationSettingsSummary),
+    "Composed writing context:",
+    input.writingContext.contextComposedPrompt ||
+      JSON.stringify(input.writingContext.contextMessages ?? []),
+    "Memory / author note / world info:",
+    JSON.stringify({
+      memoryBlock: input.writingContext.memoryBlock,
+      authorNote: input.writingContext.authorNote,
+      worldInfoEntries: input.writingContext.worldInfoEntries ?? []
+    }),
+    "Target text:",
+    input.target.beforeText || "(insertion point)",
+    `Target summary: ${input.target.label}`,
+    "Full document:",
+    input.documentText,
+    "JSON shape:",
+    input.operation === "advisory"
+      ? '{"title":"...","rawText":"...","rationale":"...","notes":["..."]}'
+      : '{"title":"...","replacement":"...","rationale":"...","notes":["..."]}'
+  ].filter(Boolean).join("\n\n")
+}
+```
+
+Implement `parseRevisionModelResponse()` so:
+
+- text-changing proposals require a string `replacement`
+- advisory proposals accept `rawText`, `rationale`, `title`, or `notes`
+- malformed JSON returns a `raw_suggestion` draft with `rawText`
+- parser never marks partial output applyable
+- parser copies `presetId`, `presetInstruction`, target metadata, and model response metadata into
+  the created proposal draft so regeneration can reuse the same context
+
+- [ ] **Step 3: Run tests to verify parser behavior**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 3**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-prompt-utils.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts
+git commit -m "feat: validate writing revision proposals"
+```
+
+### Task 4: Extend Session Payload Persistence For Revision State
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/WritingPlayground/hooks/utils.ts`
+- Modify: `apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingSessionManagement.ts`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts`
+
+- [ ] **Step 1: Write failing persistence tests**
+
+Add tests proving:
+
+- `mergeRevisionsIntoPayload()` preserves prompt/settings and writes `revisions`
+- `mergeRevisionsIntoPayload()` writes `{ schemaVersion: 1, items: [...] }`, not a bare array
+- `getRevisionsFromPayload()` ignores malformed revisions
+- selected workflow preset id persists in session payload and rejects unknown preset ids
+- revision signatures change when proposal status changes
+- clearing all revisions removes or normalizes the payload field
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts
+```
+
+Expected: FAIL for missing revision helpers.
+
+- [ ] **Step 2: Add payload helpers**
+
+In `hooks/utils.ts`:
+
+```ts
+import type {
+  WritingRevisionPresetId,
+  WritingRevisionPayload,
+  WritingRevisionProposal
+} from "../writing-revision-types"
+
+export const WRITING_REVISION_PAYLOAD_SCHEMA_VERSION = 1
+
+export type WritingSessionPayload = Record<string, unknown> & {
+  prompt?: string
+  prompt_rich?: JSONContent
+  revisions?: WritingRevisionPayload
+  revision_preset_id?: WritingRevisionPresetId | null
+  // existing fields...
+}
+
+export const getRevisionsFromPayload = (
+  payload?: Record<string, unknown> | null
+): WritingRevisionProposal[] => {
+  if (!isRecord(payload) || !isRecord(payload.revisions)) return []
+  if (payload.revisions.schemaVersion !== WRITING_REVISION_PAYLOAD_SCHEMA_VERSION) return []
+  if (!Array.isArray(payload.revisions.items)) return []
+  return payload.revisions.items.filter(isWritingRevisionProposal)
+}
+
+export const mergeRevisionsIntoPayload = (
+  payload: Record<string, unknown> | null | undefined,
+  revisions: WritingRevisionProposal[]
+): WritingSessionPayload => {
+  const base = isRecord(payload) ? payload : {}
+  const next: WritingSessionPayload = { ...base }
+  if (revisions.length > 0) {
+    next.revisions = {
+      schemaVersion: WRITING_REVISION_PAYLOAD_SCHEMA_VERSION,
+      items: revisions
+    }
+  } else {
+    delete next.revisions
+  }
+  return next
+}
+
+export const getRevisionPayloadSignature = (
+  payload?: Record<string, unknown> | null
+): string => JSON.stringify(getRevisionsFromPayload(payload))
+
+export const getRevisionPresetIdFromPayload = (
+  payload?: Record<string, unknown> | null
+): WritingRevisionPresetId | null => {
+  const value = isRecord(payload) ? payload.revision_preset_id : null
+  return isWritingRevisionPresetId(value) ? value : null
+}
+```
+
+Keep validation intentionally structural and conservative.
+
+- [ ] **Step 3: Add a safe payload-patch save seam**
+
+In `useWritingSessionManagement.ts`, add a returned helper such as:
+
+```ts
+const applySessionPayloadPatch = React.useCallback(
+  (patcher: (payload: WritingSessionPayload) => WritingSessionPayload) => {
+    if (!activeSessionDetail) return
+    const basePayload =
+      pendingSaveMapRef.current[activeSessionDetail.id] ??
+      mergePayloadIntoSession(
+        activeSessionDetail.payload,
+        editorText,
+        settings,
+        selectedTemplateName,
+        selectedThemeName,
+        chatMode,
+        { promptRich: editorPromptRichRef.current }
+      )
+    const nextPayload = patcher(basePayload)
+    pendingSaveMapRef.current[activeSessionDetail.id] = nextPayload
+    setIsDirty(true)
+    scheduleSave(activeSessionDetail.id, nextPayload)
+  },
+  [
+    activeSessionDetail,
+    chatMode,
+    editorText,
+    scheduleSave,
+    selectedTemplateName,
+    selectedThemeName,
+    settings
+  ]
+)
+```
+
+This helper is required so proposal-only saves merge with pending editor changes instead of stale
+`activeSessionDetail.payload`.
+
+- [ ] **Step 4: Run session payload tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/hooks/utils.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingSessionManagement.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts
+git commit -m "feat: persist writing revision state"
+```
+
+### Task 5: Add Revision State Hook
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingRevisions.ts`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx`
+
+- [ ] **Step 1: Write failing hook tests**
+
+Cover:
+
+- loads revisions from active session payload
+- rejects a proposal without changing text
+- applies a plain replacement through the provided text callback
+- marks conflict without mutating text
+- advisory proposals do not call apply text callback
+- proposal state is passed to `applySessionPayloadPatch`
+- regenerate marks the source proposal rejected, appends a new pending proposal with
+  `regeneratedFromId`, and preserves the source target/instruction/preset
+- rich-editor unsupported apply responses mark the proposal conflict/manual-apply instead of
+  pretending the patch was applied
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx
+```
+
+Expected: FAIL because the hook does not exist.
+
+- [ ] **Step 2: Implement hook state transitions**
+
+The hook should accept dependencies rather than importing global editor state:
+
+```ts
+export function useWritingRevisions(deps: {
+  activeSessionId: string | null
+  activeSessionPayload?: Record<string, unknown> | null
+  editorText: string
+  applyEditorText: (nextText: string) => { applied: true } | { applied: false; reason: string }
+  applySessionPayloadPatch: (patcher: (payload: WritingSessionPayload) => WritingSessionPayload) => void
+}) {
+  // load, update status, persist revisions, apply plans
+}
+```
+
+Keep the hook deterministic and side-effect-light. Do not call the LLM from this hook.
+
+Regeneration is modeled as a callback-driven state transition, not an internal LLM call:
+
+```ts
+const regenerateRevision = async (
+  proposalId: string,
+  createReplacement: (source: WritingRevisionProposal) => Promise<WritingRevisionProposal>
+) => {
+  const source = findProposal(proposalId)
+  if (!source) return
+  const replacement = await createReplacement(source)
+  setRevisions((current) => [
+    ...current.map((proposal) =>
+      proposal.id === source.id ? { ...proposal, status: "rejected" } : proposal
+    ),
+    {
+      ...replacement,
+      regeneratedFromId: source.id,
+      target: source.target,
+      instruction: source.instruction,
+      presetId: source.presetId,
+      presetInstruction: source.presetInstruction,
+      status: "pending"
+    }
+  ])
+}
+```
+
+- [ ] **Step 3: Run hook tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingRevisions.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx
+git commit -m "feat: manage writing revision queue state"
+```
+
+### Task 6: Add Action Bar, Diff, And Queue Components
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/WritingActionBar.tsx`
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionDiff.tsx`
+- Create: `apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionQueue.tsx`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Cover:
+
+- action bar disables actions when generation is unavailable
+- preset selector renders the six workflow presets and shows the selected preset instruction
+- action bar shows the resolved target summary before sending Custom requests
+- action bar requires explicit confirmation before sending whole-document text-changing requests
+- Tone exposes a direction/custom instruction input
+- Outline defaults to advisory copy
+- queue renders pending proposal diff and Apply/Reject/Copy/Regenerate
+- queue hides Apply for advisory proposals
+- conflict state shows copy/manual-apply guidance
+- raw suggestion state shows raw text and Copy only
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx
+```
+
+Expected: FAIL because components do not exist.
+
+- [ ] **Step 2: Implement components with stable dimensions**
+
+Use Ant Design and existing styling conventions. Keep controls dense:
+
+- icon+label buttons for actions where labels matter
+- `Select` or segmented menu for workflow presets; the selected preset instruction must remain
+  visible or inspectable near the controls
+- target summary text from `WritingRevisionTarget.label`
+- confirmation control for `target.requiresConfirmation` before text-changing generation is sent
+- compact custom instruction input
+- `Tag` for status
+- simple text diff based on line or word chunks
+- no nested cards inside cards unless the existing layout forces it
+
+Do not add a new icon library.
+
+- [ ] **Step 3: Run component tests**
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 6**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/WritingActionBar.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionDiff.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionQueue.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx
+git commit -m "feat: add writing revision queue UI"
+```
+
+### Task 7: Wire Plain-Text Proposal Generation Into WritingPlayground
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/WritingPlayground/index.tsx`
+- Modify: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx`
+- Optional modify: `apps/packages/ui/src/assets/locale/en/option.json`
+- Optional modify: `apps/packages/ui/src/public/_locales/en/option.json`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Extend `WritingPlayground.phase1-baseline.test.tsx` with tests that:
+
+- render the action bar when an active session exists
+- click Rewrite with selected text and receive a mocked structured response
+- show a pending proposal instead of immediately mutating editor text
+- click Apply and mutate editor text
+- generate malformed output and show raw suggestion without Apply
+- generate Outline and show advisory proposal without Apply
+- select a workflow preset and verify its visible instruction is included in the proposed-edit prompt
+- verify memory block, author note, world info, selected template/theme, provider/model, and
+  generation settings summary are passed into `buildRevisionUserPrompt`
+- regenerate a proposal and verify the old proposal is rejected while the regenerated proposal is
+  appended with `regeneratedFromId`
+- simulate rich-editor apply unsupported and verify the queue shows copy/manual-apply guidance
+  without mutating rich content
+- confirm a whole-document text-changing target, generate a proposal, and verify Apply is enabled
+  for the confirmed target
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx
+```
+
+Expected: FAIL before integration.
+
+- [ ] **Step 2: Wire hook and components**
+
+In `index.tsx`:
+
+- import `WritingActionBar`, `WritingRevisionQueue`, revision prompt utilities, and `useWritingRevisions`
+- take `applySessionPayloadPatch` from `useWritingSessionManagement`
+- derive current selection from `getCurrentEditorAdapter()`
+- build target with `resolveRevisionTarget()`
+- show `target.label` before Custom generation and block whole-document text-changing generation
+  until `target.requiresConfirmation` is acknowledged
+- acknowledge destructive target confirmation with `confirmRevisionTarget()` before creating the
+  proposal metadata; do not persist confirmed proposals that still carry `requiresConfirmation: true`
+- read the selected workflow preset from `WRITING_REVISION_PRESETS` and pass
+  `presetId`/`presetInstruction` into prompt generation and proposal metadata
+- initialize the selected workflow preset from `getRevisionPresetIdFromPayload()` and persist changes
+  through `applySessionPayloadPatch()` without overwriting pending prompt/settings edits
+- reuse the existing Writing Playground context pipeline:
+  - `contextComposedPrompt` and `contextMessages` from `useWritingContextComposition`
+  - `memoryBlock`, `authorNote`, and `worldInfoEntries`
+  - `selectedTemplateName`, `selectedThemeName`, `chatMode`, `apiProviderOverride`, and
+    `selectedModel`
+  - the same generation settings fields used by the existing Generate path, excluding secrets
+- call `TldwChatService.sendMessage()` for proposed-edit generation, not stream-to-editor generation
+- force proposed-edit calls to complete-response parsing; do not display partial JSON as applyable
+- parse the complete response before adding proposal state
+- wire `regenerateRevision()` by rebuilding the request from the source proposal's action,
+  instruction, target, preset, and current Writing Playground context
+- render the queue below the editor toolbar/content area for the first slice
+
+Do not replace the existing Generate button. This feature adds a reviewable edit path beside the
+existing direct generation path.
+
+- [ ] **Step 3: Preserve rich editor honesty**
+
+When `editorMode === "tiptap"`:
+
+- allow proposal generation from canonical plain text
+- apply only when the active adapter can safely replace plain text
+- otherwise mark or render copy/manual apply guidance
+- do not pretend rich structure is preserved when it is not
+
+- [ ] **Step 4: Run integration tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 7**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/index.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx \
+  apps/packages/ui/src/assets/locale/en/option.json \
+  apps/packages/ui/src/public/_locales/en/option.json
+git commit -m "feat: wire writing revision proposals"
+```
+
+If locale files were not changed, omit them from `git add`.
+
+### Task 8: Add Status Bar Counts And Route/Extension Parity Coverage
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/WritingPlayground/index.tsx`
+- Modify: `apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts`
+- Modify: `apps/extension/tests/e2e/writing-playground-mode-parity.spec.ts`
+
+- [ ] **Step 1: Write failing status and parity assertions**
+
+Add assertions for:
+
+- word count in status bar
+- selected word count when a selection exists and can be observed in component tests
+- pending revisions count
+- route parity still uses shared `WritingPlayground`
+- extension options route can find the revision action bar or queue test id
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx \
+  apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts
+```
+
+Expected: FAIL before status/parity wiring.
+
+- [ ] **Step 2: Implement status counts and stable test ids**
+
+Add stable test ids:
+
+- `writing-revision-action-bar`
+- `writing-revision-queue`
+- `writing-revision-pending-count`
+- `writing-status-word-count`
+- `writing-status-selected-word-count`
+
+Keep status text compact and do not displace save/generation status.
+
+- [ ] **Step 3: Run focused Vitest coverage**
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx \
+  apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run extension smoke if environment is already prepared**
+
+Run:
+
+```bash
+cd apps/extension
+bunx playwright test tests/e2e/writing-playground-mode-parity.spec.ts
+```
+
+Expected: PASS. If the extension build is blocked by known local build noise, record the exact
+failure and keep the Vitest route parity evidence.
+
+- [ ] **Step 5: Commit Task 8**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/WritingPlayground/index.tsx \
+  apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts \
+  apps/extension/tests/e2e/writing-playground-mode-parity.spec.ts
+git commit -m "test: cover writing revision parity"
+```
+
+### Task 9: Final Verification And Handoff
+
+**Files:**
+- Modify if needed: `backlog/tasks/task-458 - Plan-document-first-Writing-Playground-revision-implementation.md`
+
+- [ ] **Step 1: Run focused frontend unit suite**
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run route parity guard**
+
+Run:
+
+```bash
+bunx vitest run apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run extension smoke when available**
+
+Run:
+
+```bash
+cd apps/extension
+bunx playwright test tests/e2e/writing-playground-mode-parity.spec.ts
+```
+
+Expected: PASS, or document environment/build blocker with exact output.
+
+- [ ] **Step 4: Run formatting checks**
+
+Run:
+
+```bash
+git diff --check
+rg -nP "[^\x00-\x7F]" \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-types.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-presets.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-utils.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-prompt-utils.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingRevisions.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/hooks/utils.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingSessionManagement.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/WritingActionBar.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionDiff.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionQueue.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx \
+  apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts \
+  apps/extension/tests/e2e/writing-playground-mode-parity.spec.ts
+```
+
+Expected: no trailing whitespace and no accidental non-ASCII in implementation-owned touched files.
+If locale files are changed, append those exact locale file paths to the `rg` command before running
+it.
+
+- [ ] **Step 5: Record Bandit skip**
+
+Bandit is not required if the implementation remains frontend TypeScript only. If any backend
+Python is touched, run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_writing_revisions.json
+```
+
+Expected: no new findings.
+
+- [ ] **Step 6: Update Backlog task and commit**
+
+Update implementation notes on the implementation task created for the code work, including:
+
+- files touched
+- verification commands and outcomes
+- extension smoke status
+- Bandit skip or results
+
+Commit:
+
+```bash
+git add <touched files> backlog/tasks/<implementation-task-file>.md
+git commit -m "feat: add writing revision workflow"
+```
+
+## Follow-Up Tasks Not In This Plan
+
+- Design persistent comments/annotations.
+- Add backend revision-history APIs if session-payload persistence proves insufficient.
+- Improve TipTap structural patching beyond safe plain-text replacement.
+- Add provider-native structured output support when the selected chat provider exposes it through the existing backend contract.

--- a/Docs/superpowers/specs/2026-05-22-writing-playground-document-first-revisions-design.md
+++ b/Docs/superpowers/specs/2026-05-22-writing-playground-document-first-revisions-design.md
@@ -1,0 +1,598 @@
+# Writing Playground Document-First Revisions Design
+
+Date: 2026-05-22
+Backlog: TASK-443
+Status: Approved for planning; design hardening review applied
+
+## Purpose
+
+The Writing Playground should become a document-first creative drafting workspace for fiction,
+essays, scripts, blog posts, and other long-form writing. The current page already has a large
+set of writing controls, but the core loop still behaves mostly like prompt generation into an
+editor plus separate analysis panels. The approved direction is to make AI assistance feel like
+reviewable document work:
+
+1. Write in the document.
+2. Ask the assistant for a concrete change.
+3. Review a proposed edit.
+4. Apply, reject, copy, or regenerate it.
+
+Comments and annotations are valuable, but they are a later phase. The first slice should make
+proposed text changes trustworthy before adding persistent marginal commentary.
+
+## Current Evidence
+
+The design is grounded in the current shared WebUI and extension surface:
+
+- WebUI route wrapper: `apps/packages/ui/src/routes/option-writing-playground.tsx`.
+- Next page wrapper: `apps/tldw-frontend/pages/writing-playground.tsx`.
+- Extension route wrapper: `apps/tldw-frontend/extension/routes/option-writing-playground.tsx`.
+- Extension registry path: `apps/tldw-frontend/extension/routes/route-registry.tsx`.
+- Shared component root: `apps/packages/ui/src/components/Option/WritingPlayground/index.tsx`.
+- Existing shell/sidebar component: `apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundShell.tsx`.
+- Existing editor panel: `apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundEditorPanel.tsx`.
+- Existing inspector tabs: `apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundInspectorPanel.tsx`.
+- Existing rich editor: `apps/packages/ui/src/components/Option/WritingPlayground/WritingTipTapEditor.tsx`.
+- Existing writing store: `apps/packages/ui/src/store/writing-playground.tsx`.
+- Existing service layer: `apps/packages/ui/src/services/writing-playground.ts`.
+- Prior PRD: `apps/extension/docs/Product/WIP/Writing-Playground-PRD.md`.
+
+The current Writing Playground already includes:
+
+- session and manuscript navigation
+- plain and rich editor modes
+- edit, preview, and split editor views
+- generation, stop, undo, redo, search, replace, and read-aloud actions
+- sampling, context, setup, analysis, characters, research, agent, and feedback tabs
+- writing capabilities gating
+- server-backed sessions, templates, themes, and snapshots where supported
+- WebUI and extension parity tests around route and writing mode behavior
+
+This means the improvement should extend the existing shared component tree instead of creating a
+new route or separate extension-only experience.
+
+## Product Direction
+
+### Primary User Goal
+
+The user wants help drafting and revising long-form creative work while staying in control of the
+document. The page should support broad creative writing, not only manuscript fiction.
+
+Examples:
+
+- continue this essay in the same voice
+- rewrite this passage to be less generic
+- expand this paragraph with sensory detail
+- tighten this scene without losing tone
+- turn this rough outline into a blog post section
+- make this script beat more conversational
+- revise this selected section for clarity
+
+### Product Model
+
+The editor is the primary workspace. AI actions are document operations, not just chat messages.
+
+The assistant can still use the existing context, model, template, character, research, and
+analysis infrastructure, but the visible output of common creative-writing actions should be a
+reviewable proposal against the current document.
+
+### Non-Goals
+
+- Do not build a separate Writing page.
+- Do not replace the existing `WritingPlayground` route with a chat-first clone.
+- Do not implement Google Docs style collaboration.
+- Do not require full rich-text operational transforms in the first slice.
+- Do not add persistent annotations or comment threads in the first slice.
+- Do not remove existing power-user controls for sampling, context, templates, themes, tokens, or
+  manuscript tools.
+- Do not introduce backend revision-history APIs until the client workflow proves useful.
+
+## Approaches Considered
+
+### 1. Document-first revision workflow
+
+Keep the editor as the center of gravity. Add compact writing actions and a revision queue that
+shows proposed edits with diffs and apply or reject controls.
+
+Strengths:
+
+- fits broad long-form creative writing
+- uses the existing shared route and editor infrastructure
+- makes AI changes reviewable instead of silently mutating the document
+- keeps comments and annotations as a clean later extension
+
+Weaknesses:
+
+- requires careful range handling and drift detection
+- needs a proposal response contract around a probabilistic model output
+
+### 2. Chat-led writing assistant
+
+Make conversation the main control surface, with the document beside it like a side-by-side chat
+and document tool.
+
+Strengths:
+
+- resembles the reference image closely
+- makes tool calls and reasoning visible
+- could reuse chat-style interaction patterns
+
+Weaknesses:
+
+- risks making writing feel like chatting around a document instead of writing in it
+- can bury the draft behind assistant transcript noise
+- duplicates capabilities that already belong in the Writing Playground
+
+### 3. Mode-based writing studio
+
+Add explicit modes such as Draft, Revise, Structure, Research, and Polish, each with tailored
+controls and panels.
+
+Strengths:
+
+- powerful mental model for advanced users
+- can organize the existing broad feature set
+
+Weaknesses:
+
+- too broad for the first slice
+- risks more navigation and mode confusion before the edit loop is validated
+
+## Recommended Approach
+
+Use approach 1: document-first revision workflow.
+
+The first implementation plan should extend the existing shared `WritingPlayground` with a small
+AI action bar, a proposed-edit generation adapter, a revision queue, and conflict-safe apply logic.
+The feature should work in both WebUI and extension routes because both consume the shared UI
+component.
+
+## Target UX
+
+### Editor-First Layout
+
+The default visible state should feel like a serious writing desk:
+
+- The editor and current document are central.
+- Sessions and manuscript navigation stay available on the left.
+- Sampling, context, setup, analysis, characters, research, agent, and feedback stay available in
+  the inspector, but should not be required for the basic drafting loop.
+- The editor should remain useful when the inspector is closed.
+
+### AI Action Bar
+
+Add a compact action bar near the editor. Initial actions:
+
+- Continue
+- Rewrite
+- Expand
+- Tighten
+- Tone
+- Outline
+- Custom
+
+Tone should prompt for a requested direction such as warmer, sharper, more formal, more playful,
+or preserve voice. Outline should produce a structured outline or next-section plan by default,
+not replace the draft unless the user explicitly asks to apply outline text.
+
+Targeting rules:
+
+- If text is selected, target the selection.
+- If no text is selected, Continue targets the insertion point or end of the draft.
+- If no text is selected, Rewrite, Expand, Tighten, and Tone target the current paragraph when
+  the editor can resolve it.
+- If the current paragraph cannot be resolved, fall back to whole-document targeting only after
+  clear user confirmation for destructive or large edits.
+- Outline can target the whole document by default.
+- Custom should show the resolved target before the request is sent.
+
+The action bar should not expose all prompt engineering details. It should translate a writing
+intent into a structured request while still honoring the existing model, template, context, and
+generation settings.
+
+Important boundary: the first implementation should distinguish text-changing actions from
+planning or advisory actions. Continue, Rewrite, Expand, Tighten, Tone, and Custom can create
+replacement or insertion proposals. Outline should default to a non-mutating advisory proposal
+unless the user explicitly asks to insert or replace text with the outline.
+
+### Revision Queue
+
+Add a queue for AI proposals. It can live below the editor at first or inside a new inspector tab
+named `Revisions`. The implementation plan should choose the least disruptive placement based on
+current layout constraints.
+
+Each proposal should show:
+
+- action type
+- operation type
+- instruction
+- target summary
+- short rationale when available
+- before and after preview
+- diff view
+- status: pending, applied, rejected, conflict, raw suggestion, or advisory
+- actions: Apply, Reject, Copy, Regenerate
+
+Applied proposals should remain visible briefly enough to support user confidence and undo. The
+existing generation undo stack can remain the first undo mechanism if it can cover applied proposal
+changes safely.
+
+Advisory proposals should not show Apply unless the user converts them into an insertion or
+replacement request. This prevents Outline or critique-like actions from being treated as document
+patches by accident.
+
+### Document-Aware Status
+
+Improve the status bar around writing state:
+
+- word count
+- selected word count when text is selected
+- save state
+- active model
+- pending revisions count
+- generation state
+
+Token counts, logprobs, word clouds, and tokenizer details belong in Analysis, not the default
+writing status line.
+
+### Workflow Presets
+
+Add a small set of creative-writing presets that shape instructions:
+
+- Draft freely
+- Polish prose
+- Developmental edit
+- Preserve voice
+- Make concise
+- Expand sensory detail
+
+These presets should map to visible instruction text or templates. They should not become hidden
+magic settings that the user cannot inspect or override.
+
+## Architecture
+
+### Component Boundaries
+
+The implementation should add small, testable units instead of growing the already large
+`WritingPlayground/index.tsx`.
+
+Suggested units:
+
+- `WritingActionBar`: renders actions, custom instruction input, and targeting summary.
+- `writing-revision-types.ts`: defines proposal, target, status, and action types.
+- `writing-revision-utils.ts`: range resolution, word counts, drift checks, and apply planning.
+- `writing-revision-prompt-utils.ts`: builds structured prompts for proposed edits.
+- `WritingRevisionQueue`: renders proposal cards and queue actions.
+- `WritingRevisionDiff`: renders before/after and inline or block-level text diff.
+- `useWritingRevisions`: owns local proposal state, session-payload sync, and apply/reject handlers.
+
+The existing `WritingPlayground` root should orchestrate these units but not own all internal
+logic directly.
+
+### Draft Editor
+
+The current plain and rich editor modes remain. The editor adapter introduced by earlier Writing
+work should be the boundary for selection and range behavior:
+
+- get selected text
+- get selected range
+- focus editor
+- set selection
+- apply replacement where safe
+
+Plain text remains the canonical generation and diff input. Rich editor mode can initially derive
+plain text for proposals and apply text replacements when the target still matches.
+
+### Generation Adapter
+
+The proposed-edit flow should wrap the existing chat-completions service rather than introduce a
+new provider path.
+
+Request inputs:
+
+- full document text
+- target range and target text
+- action type
+- user instruction
+- writing preset if selected
+- active model and provider state
+- existing context, template, world info, author note, and memory settings
+
+Expected model output:
+
+```json
+{
+  "title": "Short proposal title",
+  "replacement": "The proposed replacement text",
+  "rationale": "Brief reason for the change",
+  "notes": ["Optional concise notes"]
+}
+```
+
+For text-changing proposals, `title` and `notes` are optional display fields. The proposal can be
+valid with only `replacement` and an optional `rationale`; missing display fields should not block
+the user from reviewing the proposed text. Advisory and raw-suggestion proposals may use `rawText`,
+`rationale`, `title`, and `notes` without a `replacement`. The first implementation can request
+JSON through prompt discipline and client validation. If the server later exposes structured output
+support for the selected provider, the adapter can use it behind the same client boundary.
+
+Proposal generation should not stream partial edits into the editor. For structured proposed-edit
+requests, default to non-streaming generation, or accumulate the stream invisibly and validate only
+after the complete response is available. Partial JSON or partial replacement text must never
+appear as an applyable proposal.
+
+### Proposal Shape
+
+Client-side proposal shape:
+
+```ts
+type WritingRevisionProposal = {
+  id: string
+  sessionId: string
+  action: "continue" | "rewrite" | "expand" | "tighten" | "tone" | "outline" | "custom"
+  operation: "insert" | "replace" | "advisory"
+  instruction: string
+  target: {
+    mode: "selection" | "paragraph" | "cursor" | "document"
+    start: number
+    end: number
+    beforeText: string
+    anchor: {
+      documentFingerprint: string
+      prefix: string
+      suffix: string
+    }
+  }
+  replacementText?: string
+  rawText?: string
+  rationale?: string
+  title?: string
+  notes?: string[]
+  regeneratedFromId?: string
+  createdAt: string
+  status: "pending" | "applied" | "rejected" | "conflict" | "raw_suggestion" | "advisory"
+}
+```
+
+Continue can use a zero-length target at the cursor or document end. The queue should still render
+it as an insertion proposal. Because zero-length targets cannot rely on `beforeText` matching, the
+proposal must store an insertion anchor:
+
+- `documentFingerprint`: a stable hash or equivalent fingerprint of the document text at proposal
+  creation time
+- `prefix`: a bounded text window before the insertion point
+- `suffix`: a bounded text window after the insertion point
+
+The first implementation can compute the fingerprint client-side from the canonical plain text. It
+does not need a backend document-version API.
+
+Replacement and insertion proposals require `replacementText`. Advisory and raw-suggestion
+proposals can omit `replacementText` and instead use `rawText`, `rationale`, `title`, and `notes`
+for display-only review.
+
+### Persistence
+
+Initial persistence should be session-payload based:
+
+- Store pending, applied, rejected, conflict, and raw-suggestion proposals in the active writing
+  session payload under a schema-versioned revisions field.
+- The canonical document remains the existing prompt/editor text.
+- Applying a proposal updates the canonical document through the same dirty-state and autosave path
+  as direct edits.
+- Proposal history can be pruned by count or age in the client if payload size becomes an issue.
+
+This avoids a new backend revision-history API in the first slice while preserving refresh safety.
+
+The implementation must not assume the current dirty-state helper already tracks proposal-only
+changes. Today the Writing session save path primarily compares prompt, rich prompt, settings,
+template, theme, and chat-mode state. The revision feature needs one of these explicit save
+contracts:
+
+- extend the session dirty baseline and save helper to include the schema-versioned revisions
+  payload, or
+- add a narrow proposal-save helper that merges revisions with the latest pending editor payload and
+  uses the same expected-version conflict handling.
+
+Either way, proposal-only changes must persist, and proposal saves must not overwrite unsaved prompt
+or settings edits by merging against a stale `activeSessionDetail.payload`.
+
+## Data Flow
+
+1. User writes or selects text in the editor.
+2. User chooses an action or enters a custom instruction.
+3. The UI resolves a target:
+   - selection
+   - current paragraph
+   - cursor insertion
+   - whole document
+4. The UI builds a proposed-edit request from the document, target, action, instruction, selected
+   model, and existing writing context.
+5. The adapter sends the request through the existing chat-completions path.
+6. The client validates the response into a `WritingRevisionProposal`.
+7. The queue renders the proposal and diff.
+8. Apply checks that the current target still matches `beforeText`, or validates the insertion
+   anchor for zero-length targets.
+9. If the target matches and the proposal operation is `replace` or `insert`, apply replaces or
+   inserts text and marks the proposal applied.
+10. If the target drifted, mark the proposal conflict and offer copy or manual apply.
+11. If the proposal operation is `advisory`, do not mutate the document; allow copy or a follow-up
+    request that turns it into an insertion or replacement proposal.
+12. Reject marks the proposal rejected without changing the document.
+13. Regenerate creates a replacement proposal linked by `regeneratedFromId`, instruction, and
+    target.
+
+## Error Handling
+
+### Model Output Cannot Be Parsed
+
+If the model response is not valid structured output, create a `raw_suggestion` proposal. Show the
+raw text, allow copy, and do not offer automatic apply unless a safe replacement can be derived.
+
+### Target Drift
+
+Before applying, compare the current document slice at the saved range with `beforeText`.
+
+- If it matches, apply.
+- If it does not match, attempt a conservative exact-text search for `beforeText`.
+- If there is exactly one match, offer to retarget before apply.
+- If there are zero or multiple matches, mark conflict and offer copy/manual apply.
+
+Never silently overwrite text when the target has drifted.
+
+### Insertion Anchor Drift
+
+Continue and other insertion proposals have `start === end` and `beforeText === ""`, so they need
+separate validation:
+
+- If the current document fingerprint is unchanged, apply at the saved insertion offset.
+- If the fingerprint changed, search for the saved `prefix` and `suffix` as a local insertion
+  anchor.
+- If the prefix and suffix identify exactly one insertion point, offer to retarget before apply.
+- If the anchor cannot be found or is ambiguous, mark conflict and offer copy/manual apply.
+
+Never treat an empty `beforeText` match as sufficient validation for insertion proposals.
+
+### Missing Selection
+
+If an action expects a selected passage but none exists:
+
+- use current paragraph when available
+- otherwise show a target confirmation state before whole-document edits
+
+### Rich Editor Apply Limitation
+
+If rich editor mode cannot safely apply a range replacement while preserving structure, the proposal
+should degrade to copy/manual apply. This is acceptable for the first slice; correctness is more
+important than pretending rich-text patching is solved.
+
+### Backend Or Model Unavailable
+
+Reuse existing offline, unsupported, and model-missing states. The action bar should disable
+generation actions with the same reasons as the existing Generate button.
+
+## Testing Strategy
+
+Unit coverage:
+
+- range resolution for selected text, cursor insertion, current paragraph, and whole document
+- word-count and selected-word-count helpers
+- proposal response validation
+- non-streaming or complete-response validation for structured proposed edits
+- raw-suggestion fallback
+- advisory proposal behavior
+- exact-match apply
+- zero-length insertion anchor validation
+- drift conflict
+- unique exact-text retargeting
+- unique insertion-anchor retargeting
+- ambiguous exact-text retargeting
+- ambiguous insertion-anchor retargeting
+- session-payload serialization and pruning
+
+Component coverage:
+
+- action bar renders disabled/enabled states correctly
+- action selection creates a pending proposal
+- revision queue renders pending, applied, rejected, conflict, raw-suggestion, and advisory states
+- Apply and Reject update UI state
+- advisory proposals do not render Apply until converted into a text-changing request
+- conflict state does not mutate editor text
+
+Integration and parity coverage:
+
+- WebUI route still renders `/writing-playground`.
+- Extension route still renders `#/writing-playground`.
+- Plain editor proposal apply works.
+- Rich editor proposal generation works and either applies safely or falls back honestly.
+- Responsive layouts remain usable with the revision queue visible.
+
+Manual/browser verification:
+
+- create a session
+- draft a short passage
+- select a paragraph
+- request Rewrite or Tighten
+- inspect diff
+- reject one proposal
+- apply one proposal
+- edit the target before applying and confirm conflict handling
+- verify the same core flow in the extension options route
+
+Bandit:
+
+- Not applicable for a documentation-only design task.
+- If a later implementation touches backend Python, run Bandit on touched backend paths.
+
+## Rollout Plan
+
+### Stage 1: Client Proposal Loop
+
+Add action bar, proposal generation adapter, queue state, diff preview, and conflict-safe apply for
+plain text.
+
+Success criteria:
+
+- user can generate a proposed edit
+- user can apply or reject it
+- target drift is detected
+- proposal state survives session refresh through payload persistence
+
+Stage 1 should be planned as small implementation commits rather than one large patch:
+
+1. revision types and pure utilities
+2. proposal validation and prompt-building utilities
+3. plain-text apply/conflict tests
+4. action bar and queue UI
+5. session-payload persistence integration
+6. WebUI/extension parity and responsive verification
+
+### Stage 2: Rich Editor And Layout Hardening
+
+Improve TipTap range handling and decide whether the queue belongs below the editor, in the
+inspector, or in a responsive hybrid layout.
+
+Success criteria:
+
+- rich editor mode does not misrepresent unsupported apply operations
+- queue remains usable on WebUI desktop, narrow WebUI, and extension options layout
+
+### Stage 3: Presets And Writing Status
+
+Add creative-writing presets and document-aware status bar improvements.
+
+Success criteria:
+
+- presets produce inspectable instructions
+- status bar reports writing-focused state without displacing analysis tools
+
+### Stage 4: Comment And Annotation Design
+
+Design comments/annotations after the proposed-edit workflow is stable.
+
+Candidate actions:
+
+- explain why
+- mark weak spots
+- flag inconsistency
+- reader reaction
+- style note
+
+This stage should reuse revision targets and proposal metadata but should not be included in the
+first implementation plan unless explicitly re-scoped.
+
+## Open Questions For Implementation Planning
+
+- Should the first queue placement be below the editor or in a new inspector `Revisions` tab?
+- How many proposals should be persisted per session before pruning?
+- Should Regenerate replace the existing pending proposal or append a linked alternative?
+- Should whole-document edits require confirmation every time or only for destructive actions?
+- How much of the existing `WritingPlayground/index.tsx` should be extracted before adding the new
+  units?
+
+## Definition Of Done For This Design
+
+- Spec captures the document-first creative drafting workflow.
+- Spec preserves WebUI and extension shared-surface parity.
+- Spec defines proposed edits, revision queue, data flow, conflict handling, and testing.
+- Spec scopes comments and annotations to a later phase.
+- Spec review loop has no blocking findings.

--- a/apps/extension/tests/e2e/writing-playground-mode-parity.spec.ts
+++ b/apps/extension/tests/e2e/writing-playground-mode-parity.spec.ts
@@ -214,6 +214,10 @@ test.describe("Writing Playground mode parity", () => {
     try {
       await createUniqueSessionForTest(page, "E2E Writing Mode")
 
+      await expect(page.getByTestId("writing-revision-action-bar")).toBeVisible()
+      await expect(page.getByTestId("writing-revision-queue")).toBeVisible()
+      await expect(page.getByTestId("writing-status-word-count")).toBeVisible()
+
       const modeSwitch = page.getByTestId("writing-workspace-mode-switch")
       const draftRadio = modeSwitch.getByRole("radio", { name: /^Draft$/i })
       const manageRadio = modeSwitch.getByRole("radio", { name: /^Manage$/i })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingActionBar.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingActionBar.tsx
@@ -1,0 +1,287 @@
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { Alert, Button, Checkbox, Input, Segmented, Space, Tag, Typography } from "antd"
+import {
+  ArrowRight,
+  FileText,
+  ListTree,
+  Minimize2,
+  PenLine,
+  RefreshCw,
+  SlidersHorizontal
+} from "lucide-react"
+import { WRITING_REVISION_PRESETS, getWritingRevisionPreset } from "./writing-revision-presets"
+import type {
+  WritingRevisionAction,
+  WritingRevisionOperation,
+  WritingRevisionPresetId,
+  WritingRevisionTarget
+} from "./writing-revision-types"
+
+const { Text } = Typography
+
+export type WritingActionBarRequest = {
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  presetId: WritingRevisionPresetId
+  presetInstruction: string
+  instruction: string
+  target: WritingRevisionTarget
+}
+
+export type WritingActionBarProps = {
+  generationAvailable: boolean
+  target: WritingRevisionTarget
+  selectedPresetId?: WritingRevisionPresetId
+  isGenerating?: boolean
+  onPresetChange?: (presetId: WritingRevisionPresetId) => void
+  onRequest: (request: WritingActionBarRequest) => void
+}
+
+const TEXT_CHANGING_ACTIONS = new Set<WritingRevisionAction>([
+  "continue",
+  "rewrite",
+  "expand",
+  "tighten",
+  "tone",
+  "custom"
+])
+
+const ACTION_LABELS: Array<{
+  action: WritingRevisionAction
+  label: string
+  icon: React.ReactNode
+}> = [
+  { action: "continue", label: "Continue", icon: <ArrowRight size={14} /> },
+  { action: "rewrite", label: "Rewrite", icon: <RefreshCw size={14} /> },
+  { action: "expand", label: "Expand", icon: <FileText size={14} /> },
+  { action: "tighten", label: "Tighten", icon: <Minimize2 size={14} /> },
+  { action: "tone", label: "Tone", icon: <SlidersHorizontal size={14} /> },
+  { action: "outline", label: "Outline", icon: <ListTree size={14} /> },
+  { action: "custom", label: "Custom", icon: <PenLine size={14} /> }
+]
+
+const DEFAULT_INSTRUCTIONS: Record<WritingRevisionAction, string> = {
+  continue: "Continue from the current cursor position.",
+  rewrite: "Rewrite the target while preserving intent.",
+  expand: "Expand the target with useful detail.",
+  tighten: "Tighten the target and remove redundancy.",
+  tone: "Adjust the tone using the requested direction.",
+  outline: "Provide an advisory outline for improving the current draft.",
+  custom: "Follow the custom instruction for the selected target."
+}
+
+const getOperationForAction = (
+  action: WritingRevisionAction
+): WritingRevisionOperation => {
+  if (action === "continue") return "insert"
+  if (action === "outline") return "advisory"
+  return "replace"
+}
+
+const getTargetIdentity = (target: WritingRevisionTarget): string =>
+  [
+    target.mode,
+    target.start,
+    target.end,
+    target.beforeText,
+    target.anchor.documentFingerprint
+  ].join("|")
+
+export function WritingActionBar({
+  generationAvailable,
+  target,
+  selectedPresetId,
+  isGenerating = false,
+  onPresetChange,
+  onRequest
+}: WritingActionBarProps) {
+  const [internalPresetId, setInternalPresetId] =
+    useState<WritingRevisionPresetId>("polish_prose")
+  const [activeInputAction, setActiveInputAction] =
+    useState<WritingRevisionAction | null>(null)
+  const [customInstruction, setCustomInstruction] = useState("")
+  const [toneDirection, setToneDirection] = useState("")
+  const [confirmed, setConfirmed] = useState(false)
+  const [confirmationWarning, setConfirmationWarning] = useState(false)
+  const customInputRef = useRef<{
+    resizableTextArea?: { textArea?: HTMLTextAreaElement | null }
+  } | null>(null)
+  const toneInputRef = useRef<{ input?: HTMLInputElement | null } | null>(null)
+
+  const activePresetId = selectedPresetId ?? internalPresetId
+  const selectedPreset = useMemo(
+    () => getWritingRevisionPreset(activePresetId) ?? WRITING_REVISION_PRESETS[0],
+    [activePresetId]
+  )
+  const targetIdentity = useMemo(() => getTargetIdentity(target), [target])
+
+  useEffect(() => {
+    setConfirmed(false)
+    setConfirmationWarning(false)
+  }, [targetIdentity])
+
+  const disabled = !generationAvailable || isGenerating
+
+  const sendRequest = (action: WritingRevisionAction, explicitInstruction?: string) => {
+    const operation = getOperationForAction(action)
+    const requiresConfirmation =
+      target.requiresConfirmation &&
+      operation !== "insert" &&
+      TEXT_CHANGING_ACTIONS.has(action)
+
+    if (requiresConfirmation && !confirmed) {
+      setConfirmationWarning(true)
+      return
+    }
+
+    setConfirmationWarning(false)
+    onRequest({
+      action,
+      operation,
+      presetId: selectedPreset.id,
+      presetInstruction: selectedPreset.instruction,
+      instruction:
+        explicitInstruction?.trim() ||
+        (action === "outline"
+          ? DEFAULT_INSTRUCTIONS.outline
+          : DEFAULT_INSTRUCTIONS[action]),
+      target
+    })
+  }
+
+  const handleAction = (action: WritingRevisionAction) => {
+    if (disabled) return
+    if (action === "custom" || action === "tone") {
+      setActiveInputAction(action)
+      return
+    }
+    sendRequest(action)
+  }
+
+  const sendCustom = () =>
+    sendRequest(
+      "custom",
+      customInputRef.current?.resizableTextArea?.textArea?.value ??
+        customInstruction
+    )
+  const sendTone = () =>
+    sendRequest("tone", toneInputRef.current?.input?.value ?? toneDirection)
+
+  return (
+    <section
+      data-testid="writing-revision-action-bar"
+      className="flex flex-col gap-2 rounded border border-gray-200 p-2"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <Tag color={generationAvailable ? "green" : "default"}>
+          {generationAvailable ? "Ready" : "Generation unavailable"}
+        </Tag>
+        <Text type="secondary" className="text-xs">
+          Target:
+        </Text>
+        <Text type="secondary" className="text-xs">
+          {target.label}
+        </Text>
+      </div>
+
+      <Segmented
+        size="small"
+        value={activePresetId}
+        onChange={(value) => {
+          const nextPresetId = value as WritingRevisionPresetId
+          setInternalPresetId(nextPresetId)
+          onPresetChange?.(nextPresetId)
+        }}
+        options={WRITING_REVISION_PRESETS.map((preset) => ({
+          label: preset.label,
+          value: preset.id
+        }))}
+      />
+      <Text type="secondary" className="text-xs">
+        {selectedPreset.instruction}
+      </Text>
+
+      {target.requiresConfirmation ? (
+        <div className="flex flex-col gap-1">
+          <Checkbox
+            checked={confirmed}
+            onChange={(event) => setConfirmed(event.target.checked)}
+            aria-label="Confirm whole-document text change"
+          >
+            Confirm whole-document text change
+          </Checkbox>
+          <Text type="secondary" className="text-xs">
+            {target.confirmationReason ??
+              "Confirm before sending a broad text-changing request."}
+          </Text>
+        </div>
+      ) : null}
+
+      {confirmationWarning ? (
+        <Alert
+          type="warning"
+          title={
+            target.confirmationReason ??
+            "Confirm before sending a broad text-changing request."
+          }
+        />
+      ) : null}
+
+      <Space wrap size={[6, 6]}>
+        {ACTION_LABELS.map(({ action, label, icon }) => (
+          <Button
+            key={action}
+            size="small"
+            icon={icon}
+            disabled={disabled}
+            loading={isGenerating}
+            onClick={() => handleAction(action)}
+          >
+            {label}
+          </Button>
+        ))}
+      </Space>
+
+      {activeInputAction === "custom" ? (
+        <div className="flex flex-col gap-2">
+          <Input.TextArea
+            ref={customInputRef}
+            aria-label="Custom instruction"
+            value={customInstruction}
+            onChange={(event) => setCustomInstruction(event.target.value)}
+            rows={2}
+            placeholder="Describe the revision you want."
+          />
+          <Button
+            size="small"
+            type="primary"
+            disabled={disabled}
+            onClick={sendCustom}
+          >
+            Send Custom
+          </Button>
+        </div>
+      ) : null}
+
+      {activeInputAction === "tone" ? (
+        <div className="flex flex-col gap-2">
+          <Input
+            ref={toneInputRef}
+            aria-label="Tone direction"
+            value={toneDirection}
+            onChange={(event) => setToneDirection(event.target.value)}
+            placeholder="warmer, sharper, more formal..."
+          />
+          <Button
+            size="small"
+            type="primary"
+            disabled={disabled}
+            onClick={sendTone}
+          >
+            Send Tone
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionDiff.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionDiff.tsx
@@ -1,0 +1,80 @@
+import React from "react"
+import { Typography } from "antd"
+
+const { Text } = Typography
+
+export type WritingRevisionDiffProps = {
+  beforeText: string
+  afterText: string
+}
+
+const splitWords = (text: string): string[] => text.match(/\S+|\s+/g) ?? []
+
+const findSharedPrefix = (before: string[], after: string[]): number => {
+  let index = 0
+  while (index < before.length && index < after.length && before[index] === after[index]) {
+    index += 1
+  }
+  return index
+}
+
+const findSharedSuffix = (
+  before: string[],
+  after: string[],
+  prefixLength: number
+): number => {
+  let count = 0
+  while (
+    count + prefixLength < before.length &&
+    count + prefixLength < after.length &&
+    before[before.length - 1 - count] === after[after.length - 1 - count]
+  ) {
+    count += 1
+  }
+  return count
+}
+
+export function WritingRevisionDiff({
+  beforeText,
+  afterText
+}: WritingRevisionDiffProps) {
+  const beforeChunks = splitWords(beforeText)
+  const afterChunks = splitWords(afterText)
+  const prefixLength = findSharedPrefix(beforeChunks, afterChunks)
+  const suffixLength = findSharedSuffix(beforeChunks, afterChunks, prefixLength)
+  const beforeChanged = beforeChunks.slice(
+    prefixLength,
+    beforeChunks.length - suffixLength
+  )
+  const afterChanged = afterChunks.slice(
+    prefixLength,
+    afterChunks.length - suffixLength
+  )
+
+  return (
+    <div className="grid gap-2 md:grid-cols-2" data-testid="writing-revision-diff">
+      <div className="min-h-20 rounded border border-red-100 bg-red-50 p-2">
+        <Text strong className="block text-xs">
+          Before
+        </Text>
+        <pre className="m-0 whitespace-pre-wrap text-xs">{beforeText}</pre>
+        {beforeChanged.length > 0 ? (
+          <Text type="danger" className="text-xs">
+            Changed: {beforeChanged.join("")}
+          </Text>
+        ) : null}
+      </div>
+      <div className="min-h-20 rounded border border-green-100 bg-green-50 p-2">
+        <Text strong className="block text-xs">
+          After
+        </Text>
+        <pre className="m-0 whitespace-pre-wrap text-xs">{afterText}</pre>
+        {afterChanged.length > 0 ? (
+          <Text type="success" className="text-xs">
+            Changed: {afterChanged.join("")}
+          </Text>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionQueue.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingRevisionQueue.tsx
@@ -1,0 +1,156 @@
+import React from "react"
+import { Button, Empty, Space, Tag, Typography } from "antd"
+import { Check, Copy, RefreshCw, X } from "lucide-react"
+import { WritingRevisionDiff } from "./WritingRevisionDiff"
+import type { WritingRevisionProposal, WritingRevisionStatus } from "./writing-revision-types"
+
+const { Text, Paragraph } = Typography
+
+export type WritingRevisionQueueProps = {
+  proposals: WritingRevisionProposal[]
+  onApply: (proposal: WritingRevisionProposal) => void
+  onReject: (proposal: WritingRevisionProposal) => void
+  onCopy: (proposal: WritingRevisionProposal) => void
+  onRegenerate: (proposal: WritingRevisionProposal) => void
+}
+
+const STATUS_COLORS: Record<WritingRevisionStatus, string> = {
+  pending: "blue",
+  applied: "green",
+  rejected: "default",
+  conflict: "red",
+  raw_suggestion: "gold",
+  advisory: "purple"
+}
+
+const formatAction = (action: string): string =>
+  action.replace(/_/g, " ").replace(/^\w/, (letter) => letter.toUpperCase())
+
+const showApply = (proposal: WritingRevisionProposal): boolean =>
+  proposal.status === "pending" && proposal.operation !== "advisory"
+
+const showStandardActions = (proposal: WritingRevisionProposal): boolean =>
+  proposal.status !== "raw_suggestion"
+
+function ProposalBody({ proposal }: { proposal: WritingRevisionProposal }) {
+  if (proposal.status === "raw_suggestion") {
+    return (
+      <pre className="m-0 whitespace-pre-wrap rounded border border-gray-200 bg-gray-50 p-2 text-xs">
+        {proposal.rawText ?? proposal.replacementText ?? ""}
+      </pre>
+    )
+  }
+
+  if (proposal.operation === "advisory") {
+    return (
+      <Paragraph className="!mb-0 whitespace-pre-wrap text-sm">
+        {proposal.rawText ?? proposal.replacementText ?? proposal.rationale}
+      </Paragraph>
+    )
+  }
+
+  return (
+    <WritingRevisionDiff
+      beforeText={proposal.target.beforeText}
+      afterText={proposal.replacementText ?? ""}
+    />
+  )
+}
+
+export function WritingRevisionQueue({
+  proposals,
+  onApply,
+  onReject,
+  onCopy,
+  onRegenerate
+}: WritingRevisionQueueProps) {
+  return (
+    <section
+      data-testid="writing-revision-queue"
+      className="flex flex-col gap-2 rounded border border-gray-200 p-2"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <Text strong>Revision queue</Text>
+        <Tag>{proposals.length}</Tag>
+      </div>
+
+      {proposals.length === 0 ? (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No revision proposals" />
+      ) : null}
+
+      {proposals.map((proposal) => (
+        <article
+          key={proposal.id}
+          data-testid="writing-revision-proposal"
+          data-proposal-id={proposal.id}
+          data-regenerated-from-id={proposal.regeneratedFromId ?? undefined}
+          className="flex flex-col gap-2 rounded border border-gray-100 p-2"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <Text strong className="text-sm">
+              {proposal.title ?? formatAction(proposal.action)}
+            </Text>
+            <Tag color={STATUS_COLORS[proposal.status]}>{proposal.status}</Tag>
+            <Text type="secondary" className="text-xs">
+              {proposal.target.label}
+            </Text>
+          </div>
+
+          <ProposalBody proposal={proposal} />
+
+          {proposal.rationale && proposal.operation !== "advisory" ? (
+            <Text type="secondary" className="text-xs">
+              {proposal.rationale}
+            </Text>
+          ) : null}
+
+          {proposal.status === "conflict" ? (
+            <Text type="danger" className="text-xs">
+              Copy the suggestion and apply it manually.
+            </Text>
+          ) : null}
+
+          {proposal.notes?.length ? (
+            <div className="flex flex-col gap-1">
+              {proposal.notes.map((note) => (
+                <Text key={note} type="secondary" className="text-xs">
+                  {note}
+                </Text>
+              ))}
+            </div>
+          ) : null}
+
+          <Space wrap size={[6, 6]}>
+            {showApply(proposal) ? (
+              <Button
+                size="small"
+                type="primary"
+                icon={<Check size={14} />}
+                onClick={() => onApply(proposal)}
+              >
+                Apply
+              </Button>
+            ) : null}
+            <Button size="small" icon={<Copy size={14} />} onClick={() => onCopy(proposal)}>
+              Copy
+            </Button>
+            {showStandardActions(proposal) ? (
+              <>
+                <Button size="small" icon={<X size={14} />} onClick={() => onReject(proposal)}>
+                  Reject
+                </Button>
+                <Button
+                  size="small"
+                  icon={<RefreshCw size={14} />}
+                  onClick={() => onRegenerate(proposal)}
+                >
+                  Regenerate
+                </Button>
+              </>
+            ) : null}
+          </Space>
+        </article>
+      ))}
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingTipTapEditor.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingTipTapEditor.tsx
@@ -9,13 +9,16 @@ import { AIAnnotationExtension } from "./extensions/AIAnnotationExtension"
 import { tipTapJsonToPlainText } from "./writing-tiptap-utils"
 import {
   createTipTapEditorAdapter,
-  type WritingEditorAdapter
+  getTipTapSelection,
+  type WritingEditorAdapter,
+  type WritingEditorSelection
 } from "./writing-editor-adapter"
 
 export type WritingTipTapEditorProps = {
   content: JSONContent | null
   onContentChange: (json: JSONContent, plainText: string) => void
   onAdapterReady?: (adapter: WritingEditorAdapter | null) => void
+  onSelectionChange?: (selection: WritingEditorSelection) => void
   editable?: boolean
   placeholder?: string
   className?: string
@@ -25,6 +28,7 @@ export function WritingTipTapEditor({
   content,
   onContentChange,
   onAdapterReady,
+  onSelectionChange,
   editable = true,
   placeholder = "Start writing...",
   className,
@@ -52,11 +56,19 @@ export function WritingTipTapEditor({
     [onContentChange],
   )
 
+  const handleSelectionUpdate = useCallback(
+    ({ editor }: { editor: Editor }) => {
+      onSelectionChange?.(getTipTapSelection(editor))
+    },
+    [onSelectionChange],
+  )
+
   const editor = useEditor({
     extensions,
     content: content || { type: "doc", content: [{ type: "paragraph" }] },
     editable,
     onUpdate: handleUpdate,
+    onSelectionUpdate: handleSelectionUpdate,
   })
 
   const adapter = useMemo(

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx
@@ -1,0 +1,307 @@
+import React from "react"
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import { JSDOM } from "jsdom"
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest"
+import { WritingActionBar } from "../WritingActionBar"
+import { WRITING_REVISION_PRESETS } from "../writing-revision-presets"
+import type {
+  WritingRevisionAction,
+  WritingRevisionTarget
+} from "../writing-revision-types"
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>")
+const requestAnimationFrame = (callback: FrameRequestCallback) =>
+  dom.window.setTimeout(() => callback(Date.now()), 0)
+const cancelAnimationFrame = (id: number) => {
+  dom.window.clearTimeout(id)
+}
+
+Object.defineProperties(globalThis, {
+  window: { value: dom.window, configurable: true },
+  document: { value: dom.window.document, configurable: true },
+  navigator: { value: dom.window.navigator, configurable: true },
+  HTMLElement: { value: dom.window.HTMLElement, configurable: true },
+  SVGElement: { value: dom.window.SVGElement, configurable: true },
+  Element: { value: dom.window.Element, configurable: true },
+  ShadowRoot: { value: dom.window.ShadowRoot, configurable: true },
+  Node: { value: dom.window.Node, configurable: true },
+  MutationObserver: {
+    value: dom.window.MutationObserver,
+    configurable: true
+  },
+  requestAnimationFrame: {
+    value: requestAnimationFrame,
+    configurable: true
+  },
+  cancelAnimationFrame: {
+    value: cancelAnimationFrame,
+    configurable: true
+  },
+  ResizeObserver: {
+    value: class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+    configurable: true
+  },
+  getComputedStyle: {
+    value: dom.window.getComputedStyle.bind(dom.window),
+    configurable: true
+  }
+})
+
+Object.assign(dom.window, {
+  requestAnimationFrame,
+  cancelAnimationFrame
+})
+
+afterAll(() => {
+  dom.window.close()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const selectionTarget: WritingRevisionTarget = {
+  mode: "selection",
+  start: 0,
+  end: 16,
+  beforeText: "The old sentence",
+  anchor: {
+    documentFingerprint: "fingerprint-1",
+    prefix: "",
+    suffix: ""
+  },
+  label: "Selection: 16 chars",
+  requiresConfirmation: false
+}
+
+const documentTarget: WritingRevisionTarget = {
+  ...selectionTarget,
+  mode: "document",
+  start: 0,
+  end: 1200,
+  beforeText: "Whole document",
+  label: "Whole document: 1,200 chars",
+  requiresConfirmation: true,
+  confirmationReason: "This will rewrite the full draft."
+}
+
+describe("WritingActionBar", () => {
+  it("disables actions when generation is unavailable", () => {
+    const onRequest = vi.fn()
+
+    const view = render(
+      <WritingActionBar
+        generationAvailable={false}
+        target={selectionTarget}
+        onRequest={onRequest}
+      />
+    )
+
+    fireEvent.click(view.getByRole("button", { name: /rewrite/i }))
+
+    expect(onRequest).not.toHaveBeenCalled()
+    expect(
+      (view.getByRole("button", { name: /rewrite/i }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true)
+    expect(
+      view.getByRole("button", { name: /rewrite/i }).querySelector("svg")
+    ).toBeTruthy()
+    expect(view.getByText(/generation unavailable/i)).toBeTruthy()
+  })
+
+  it("renders the six workflow presets and shows the selected preset instruction", () => {
+    const view = render(
+      <WritingActionBar
+        generationAvailable
+        target={selectionTarget}
+        onRequest={vi.fn()}
+      />
+    )
+
+    for (const preset of WRITING_REVISION_PRESETS) {
+      expect(view.getByText(preset.label)).toBeTruthy()
+    }
+
+    fireEvent.click(view.getByRole("radio", { name: /make concise/i }))
+
+    expect(
+      view.getByText(WRITING_REVISION_PRESETS[4].instruction)
+    ).toBeTruthy()
+  })
+
+  it("can be controlled by a persisted workflow preset", () => {
+    const onPresetChange = vi.fn()
+
+    const view = render(
+      <WritingActionBar
+        generationAvailable
+        target={selectionTarget}
+        selectedPresetId="preserve_voice"
+        onPresetChange={onPresetChange}
+        onRequest={vi.fn()}
+      />
+    )
+
+    expect(
+      view.getByText(
+        "Keep the author's diction, cadence, point of view, and stylistic fingerprints."
+      )
+    ).toBeTruthy()
+
+    fireEvent.click(view.getByRole("radio", { name: /make concise/i }))
+
+    expect(onPresetChange).toHaveBeenCalledWith("make_concise")
+  })
+
+  it("shows the resolved target summary before sending Custom requests", () => {
+    const onRequest = vi.fn()
+
+    const view = render(
+      <WritingActionBar
+        generationAvailable
+        target={selectionTarget}
+        onRequest={onRequest}
+      />
+    )
+
+    expect(view.getByText("Selection: 16 chars")).toBeTruthy()
+
+    fireEvent.click(view.getByRole("button", { name: /custom/i }))
+    fireEvent.change(view.getByRole("textbox", { name: /custom instruction/i }), {
+      target: { value: "Make this more direct." }
+    })
+    fireEvent.click(view.getByRole("button", { name: /send custom/i }))
+
+    expect(onRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "custom",
+        instruction: "Make this more direct.",
+        target: selectionTarget
+      })
+    )
+  })
+
+  it("requires explicit confirmation before sending whole-document text-changing requests", () => {
+    const onRequest = vi.fn()
+
+    const view = render(
+      <WritingActionBar
+        generationAvailable
+        target={documentTarget}
+        onRequest={onRequest}
+      />
+    )
+
+    fireEvent.click(view.getByRole("button", { name: /rewrite/i }))
+    expect(onRequest).not.toHaveBeenCalled()
+    expect(view.getAllByText(/this will rewrite the full draft/i).length).toBe(2)
+
+    fireEvent.click(
+      view.getByLabelText(/confirm whole-document text change/i)
+    )
+    fireEvent.click(view.getByRole("button", { name: /rewrite/i }))
+
+    expect(onRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "rewrite",
+        target: documentTarget
+      })
+    )
+  })
+
+  it("requires fresh confirmation when the broad target changes", () => {
+    const onRequest = vi.fn()
+    const nextDocumentTarget: WritingRevisionTarget = {
+      ...documentTarget,
+      start: 20,
+      end: 1400,
+      beforeText: "Different full document",
+      anchor: {
+        ...documentTarget.anchor,
+        documentFingerprint: "fingerprint-2"
+      }
+    }
+
+    const view = render(
+      <WritingActionBar
+        generationAvailable
+        target={documentTarget}
+        onRequest={onRequest}
+      />
+    )
+
+    fireEvent.click(
+      view.getByLabelText(/confirm whole-document text change/i)
+    )
+    fireEvent.click(view.getByRole("button", { name: /rewrite/i }))
+    expect(onRequest).toHaveBeenCalledTimes(1)
+
+    view.rerender(
+      <WritingActionBar
+        generationAvailable
+        target={nextDocumentTarget}
+        onRequest={onRequest}
+      />
+    )
+
+    fireEvent.click(view.getByRole("button", { name: /rewrite/i }))
+    expect(onRequest).toHaveBeenCalledTimes(1)
+    expect(view.getAllByText(/this will rewrite the full draft/i).length).toBe(2)
+  })
+
+  it("exposes a direction/custom instruction input for Tone", () => {
+    const onRequest = vi.fn()
+
+    const view = render(
+      <WritingActionBar
+        generationAvailable
+        target={selectionTarget}
+        onRequest={onRequest}
+      />
+    )
+
+    fireEvent.click(view.getByRole("button", { name: /tone/i }))
+    const toneInput = view.getByRole("textbox", { name: /tone direction/i })
+    fireEvent.change(toneInput, {
+      target: { value: "warmer and more confident" }
+    })
+    fireEvent.input(toneInput, {
+      target: { value: "warmer and more confident" }
+    })
+    fireEvent.click(view.getByRole("button", { name: /send tone/i }))
+
+    expect(onRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "tone" satisfies WritingRevisionAction,
+        instruction: "warmer and more confident"
+      })
+    )
+  })
+
+  it("defaults Outline to advisory copy", () => {
+    const onRequest = vi.fn()
+
+    const view = render(
+      <WritingActionBar
+        generationAvailable
+        target={selectionTarget}
+        onRequest={onRequest}
+      />
+    )
+
+    fireEvent.click(view.getByRole("button", { name: /outline/i }))
+
+    expect(onRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "outline",
+        operation: "advisory",
+        instruction: expect.stringMatching(/outline/i)
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.inspector-tabs.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.inspector-tabs.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 vi.mock("@tanstack/react-query", () => {
+  const serializeQueryKey = (key: unknown) =>
+    JSON.stringify(Array.isArray(key) ? key : [key])
   const writingCaps = {
     server: {
       sessions: true,
@@ -24,29 +26,36 @@ vi.mock("@tanstack/react-query", () => {
     }
   }
 
-  const resolveQueryData = (queryKey: unknown): unknown => {
-    const key = Array.isArray(queryKey) ? queryKey[0] : queryKey
-    switch (key) {
-      case "writing-capabilities":
-        return writingCaps
-      case "writing-defaults":
-        return { templates: [], themes: [] }
-      case "writing-sessions":
-        return { sessions: [], total: 0, limit: 200, offset: 0 }
-      case "writing-templates":
-        return { templates: [], total: 0, limit: 200, offset: 0 }
-      case "writing-themes":
-        return { themes: [], total: 0, limit: 200, offset: 0 }
-      case "writing-session":
-        return null
-      default:
-        return undefined
-    }
-  }
+  const queryResults = new Map<string, unknown>([
+    [serializeQueryKey(["writing-capabilities"]), writingCaps],
+    [serializeQueryKey(["writing-defaults"]), { templates: [], themes: [] }],
+    [
+      serializeQueryKey(["writing-sessions"]),
+      { sessions: [], total: 0, limit: 200, offset: 0 }
+    ],
+    [
+      serializeQueryKey(["writing-templates"]),
+      { templates: [], total: 0, limit: 200, offset: 0 }
+    ],
+    [
+      serializeQueryKey(["writing-themes"]),
+      { themes: [], total: 0, limit: 200, offset: 0 }
+    ],
+    [serializeQueryKey(["writing-session", null]), null]
+  ])
 
   return {
-    useQuery: ({ queryKey }: { queryKey: unknown }) => ({
-      data: resolveQueryData(queryKey),
+    useQuery: ({
+      queryKey,
+      enabled = true
+    }: {
+      queryKey: unknown
+      enabled?: boolean
+    }) => ({
+      data:
+        enabled === false
+          ? undefined
+          : queryResults.get(serializeQueryKey(queryKey)),
       isLoading: false,
       isFetching: false,
       error: null

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx
@@ -1,29 +1,48 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react"
+import { useQuery } from "@tanstack/react-query"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockState = vi.hoisted(() => ({
   storageValues: new Map<string, unknown>(),
   queryData: new Map<string, unknown>(),
+  queryKey: (queryKey: unknown) =>
+    JSON.stringify(Array.isArray(queryKey) ? queryKey : [queryKey]),
   resolveApiProviderForModel: vi.fn(async () => null as string | null),
   streamCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>,
-  sendCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>
+  sendCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>,
+  sendResponses: [] as Array<string | Promise<string>>
 }))
+
+type MockQueryResult = {
+  data: unknown
+  isLoading: boolean
+  isFetching: boolean
+  error: unknown
+}
 
 vi.mock("@tanstack/react-query", () => {
   const resolveQueryData = (queryKey: unknown): unknown => {
-    const key = Array.isArray(queryKey) ? queryKey[0] : queryKey
-    if (key === "writing-session" && Array.isArray(queryKey)) {
-      return mockState.queryData.get(
-        `writing-session:${String(queryKey[1] || "")}`
-      )
-    }
-    return mockState.queryData.get(String(key))
+    return mockState.queryData.get(mockState.queryKey(queryKey))
   }
 
   return {
-    useQuery: ({ queryKey }: { queryKey: unknown }) => ({
-      data: resolveQueryData(queryKey),
+    useQuery: ({
+      queryKey,
+      enabled = true
+    }: {
+      queryKey: unknown
+      enabled?: boolean
+    }) => ({
+      data: enabled === false ? undefined : resolveQueryData(queryKey),
       isLoading: false,
       isFetching: false,
       error: null
@@ -97,7 +116,7 @@ vi.mock("@/services/tldw/TldwChat", () => ({
     }
     async sendMessage(messages: unknown[], options: Record<string, unknown>) {
       mockState.sendCalls.push({ messages, options })
-      return "mocked completion"
+      return await (mockState.sendResponses.shift() ?? "mocked completion")
     }
   }
 }))
@@ -127,7 +146,86 @@ vi.mock("@/services/writing-playground", () => ({
   updateWritingTheme: vi.fn()
 }))
 
+vi.mock("../WritingTipTapEditor", () => ({
+  WritingTipTapEditor: ({
+    content,
+    onAdapterReady,
+    onSelectionChange,
+    onContentChange,
+    placeholder
+  }: {
+    content?: {
+      type?: string
+      text?: string
+      content?: Array<{
+        type?: string
+        text?: string
+        content?: Array<{ type?: string; text?: string }>
+      }>
+    } | null
+    onAdapterReady: (adapter: {
+      getSelection: () => { start: number; end: number }
+      setSelection: (selection: { start: number; end: number }) => void
+      getSelectedText: (currentValue: string) => string
+      focus: () => void
+    }) => void
+    onSelectionChange?: (selection: { start: number; end: number }) => void
+    onContentChange: (json: Record<string, unknown>, plain: string) => void
+    placeholder?: string
+  }) => {
+    const [selection, setSelection] = React.useState({ start: 0, end: 0 })
+    const [value, setValue] = React.useState("")
+
+    React.useEffect(() => {
+      const text =
+        content?.content
+          ?.map((node) =>
+            node.text ??
+            node.content?.map((child) => child.text ?? "").join("") ??
+            ""
+          )
+          .join("\n") ?? ""
+      setValue(text)
+    }, [content])
+
+    React.useEffect(() => {
+      onAdapterReady({
+        getSelection: () => selection,
+        setSelection,
+        getSelectedText: (currentValue: string) =>
+          currentValue.slice(selection.start, selection.end),
+        focus: () => {}
+      })
+    }, [onAdapterReady, selection])
+
+    return (
+      <textarea
+        aria-label="Mock rich editor"
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => {
+          setValue(event.target.value)
+          onContentChange({ type: "doc" }, event.target.value)
+        }}
+        onSelect={(event) => {
+          const node = event.currentTarget
+          setSelection({
+            start: node.selectionStart,
+            end: node.selectionEnd
+          })
+          onSelectionChange?.({
+            start: node.selectionStart,
+            end: node.selectionEnd
+          })
+        }}
+      />
+    )
+  }
+}))
+
 import { WritingPlayground } from "../index"
+import { WRITING_REVISION_PRESETS } from "../writing-revision-presets"
+import { useStoreChatModelSettings } from "@/store/model"
 import { useWritingPlaygroundStore } from "@/store/writing-playground"
 
 const DEFAULT_WRITING_CAPABILITIES = {
@@ -159,12 +257,28 @@ const DEFAULT_WRITING_CAPABILITIES = {
   }
 }
 
-const seedWritingSession = () => {
+const structuredReplacement = (replacement: string, title = "Rewrite selection") =>
+  JSON.stringify({
+    title,
+    replacement,
+    rationale: "Clearer and more direct."
+  })
+
+const structuredAdvice = (rawText: string, title = "Outline advice") =>
+  JSON.stringify({
+    title,
+    rawText,
+    rationale: "This is an advisory planning pass."
+  })
+
+const seedWritingSession = (
+  payloadOverrides: Record<string, unknown> = {}
+) => {
   useWritingPlaygroundStore.setState({
     activeSessionId: "session-auto",
     activeSessionName: "Auto Session"
   })
-  mockState.queryData.set("writing-sessions", {
+  mockState.queryData.set(mockState.queryKey(["writing-sessions"]), {
     sessions: [
       {
         id: "session-auto",
@@ -177,24 +291,49 @@ const seedWritingSession = () => {
     limit: 200,
     offset: 0
   })
-  mockState.queryData.set("writing-session:session-auto", {
-    id: "session-auto",
-    name: "Auto Session",
-    payload: {
-      prompt: "Seed prompt",
-      settings: {},
-      template_name: null,
-      theme_name: null,
-      chat_mode: false
-    },
-    schema_version: 1,
-    version_parent_id: null,
-    created_at: "2026-03-16T12:00:00Z",
-    last_modified: "2026-03-16T12:00:00Z",
-    deleted: false,
-    client_id: "test-client",
-    version: 1
-  })
+  mockState.queryData.set(
+    mockState.queryKey(["writing-session", "session-auto"]),
+    {
+      id: "session-auto",
+      name: "Auto Session",
+      payload: {
+        prompt: "Seed prompt",
+        settings: {},
+        template_name: null,
+        theme_name: null,
+        chat_mode: false,
+        ...payloadOverrides
+      },
+      schema_version: 1,
+      version_parent_id: null,
+      created_at: "2026-03-16T12:00:00Z",
+      last_modified: "2026-03-16T12:00:00Z",
+      deleted: false,
+      client_id: "test-client",
+      version: 1
+    }
+  )
+}
+
+const getEditor = () =>
+  screen.getByPlaceholderText("Start writing your prompt...") as HTMLTextAreaElement
+
+const selectEditorText = (editor: HTMLTextAreaElement, selectedText: string) => {
+  const start = editor.value.indexOf(selectedText)
+  expect(start).toBeGreaterThanOrEqual(0)
+  editor.focus()
+  editor.setSelectionRange(start, start + selectedText.length)
+  fireEvent.select(editor)
+}
+
+const latestRevisionPrompt = () => {
+  const lastCall = mockState.sendCalls.at(-1)
+  expect(lastCall).toBeTruthy()
+  const userMessage = (lastCall?.messages as Array<{ content?: unknown }>).find(
+    (message) => typeof message.content === "string"
+  )
+  expect(userMessage?.content).toEqual(expect.any(String))
+  return userMessage?.content as string
 }
 
 beforeEach(() => {
@@ -204,36 +343,88 @@ beforeEach(() => {
   mockState.resolveApiProviderForModel.mockResolvedValue(null)
   mockState.streamCalls.length = 0
   mockState.sendCalls.length = 0
+  mockState.sendResponses.length = 0
 
-  mockState.queryData.set("writing-capabilities", DEFAULT_WRITING_CAPABILITIES)
-  mockState.queryData.set("writing-defaults", { templates: [], themes: [] })
-  mockState.queryData.set("writing-sessions", {
+  mockState.queryData.set(
+    mockState.queryKey(["writing-capabilities"]),
+    DEFAULT_WRITING_CAPABILITIES
+  )
+  mockState.queryData.set(
+    mockState.queryKey(["writing-defaults"]),
+    { templates: [], themes: [] }
+  )
+  mockState.queryData.set(mockState.queryKey(["writing-sessions"]), {
     sessions: [],
     total: 0,
     limit: 200,
     offset: 0
   })
-  mockState.queryData.set("writing-templates", {
+  mockState.queryData.set(mockState.queryKey(["writing-templates"]), {
     templates: [],
     total: 0,
     limit: 200,
     offset: 0
   })
-  mockState.queryData.set("writing-themes", {
+  mockState.queryData.set(mockState.queryKey(["writing-themes"]), {
     themes: [],
     total: 0,
     limit: 200,
     offset: 0
   })
-  mockState.queryData.set("writing-session:", null)
+  mockState.queryData.set(mockState.queryKey(["writing-session", null]), null)
 
   useWritingPlaygroundStore.setState({
     activeSessionId: null,
-    activeSessionName: null
+    activeSessionName: null,
+    editorMode: "plain"
   })
+  useStoreChatModelSettings.getState().reset()
+})
+
+afterEach(() => {
+  cleanup()
 })
 
 describe("WritingPlayground phase1 baseline", () => {
+  it("test mock returns empty query state when a query is disabled", () => {
+    const result = useQuery({
+      queryKey: ["writing-capabilities"],
+      queryFn: vi.fn(),
+      enabled: false
+    } as never) as MockQueryResult
+
+    expect(result).toEqual({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: null
+    })
+  })
+
+  it("test mock distinguishes full array query keys", () => {
+    mockState.queryData.clear()
+    mockState.queryData.set(
+      mockState.queryKey(["writing-capabilities"]),
+      { source: "base" }
+    )
+    mockState.queryData.set(
+      mockState.queryKey(["writing-capabilities", "requested", "model-a", ""]),
+      { source: "requested" }
+    )
+
+    const baseResult = useQuery({
+      queryKey: ["writing-capabilities"],
+      queryFn: vi.fn()
+    } as never) as { data: unknown }
+    const requestedResult = useQuery({
+      queryKey: ["writing-capabilities", "requested", "model-a", ""],
+      queryFn: vi.fn()
+    } as never) as { data: unknown }
+
+    expect(baseResult.data).toEqual({ source: "base" })
+    expect(requestedResult.data).toEqual({ source: "requested" })
+  })
+
   it("renders key empty-state landmarks without crashing", () => {
     render(<WritingPlayground />)
 
@@ -316,5 +507,514 @@ describe("WritingPlayground phase1 baseline", () => {
         })
       ])
     )
+  })
+
+  it("renders the writing revision action bar when an active session exists", () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    seedWritingSession({ prompt: "Draft text." })
+
+    render(<WritingPlayground />)
+
+    expect(screen.getByTestId("writing-revision-action-bar")).toBeInTheDocument()
+    expect(screen.getByTestId("writing-revision-queue")).toBeInTheDocument()
+  })
+
+  it("shows document and selected word counts in the status bar", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    seedWritingSession({ prompt: "One two three four." })
+
+    render(<WritingPlayground />)
+
+    expect(screen.getByTestId("writing-status-word-count")).toHaveTextContent(
+      "4 words"
+    )
+    expect(screen.queryByTestId("writing-status-selected-word-count")).toBeNull()
+
+    selectEditorText(getEditor(), "One two")
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("writing-status-selected-word-count")
+      ).toHaveTextContent("2 selected")
+    })
+  })
+
+  it("initializes the workflow preset from the active session payload", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("Voice-preserved line."))
+    const preserveVoice = WRITING_REVISION_PRESETS.find(
+      (preset) => preset.id === "preserve_voice"
+    )
+    expect(preserveVoice).toBeTruthy()
+    seedWritingSession({
+      prompt: "Keep this voice.",
+      revision_preset_id: "preserve_voice"
+    })
+
+    render(<WritingPlayground />)
+
+    expect(screen.getByText(preserveVoice!.instruction)).toBeInTheDocument()
+    selectEditorText(getEditor(), "Keep this voice.")
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(mockState.sendCalls).toHaveLength(1)
+    })
+    expect(latestRevisionPrompt()).toContain(preserveVoice!.instruction)
+  })
+
+  it("creates a pending Rewrite proposal for selected text and applies it without mutating early", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("The sharper sentence."))
+    seedWritingSession({ prompt: "Intro. The old sentence. Outro." })
+
+    render(<WritingPlayground />)
+    const editor = getEditor()
+    selectEditorText(editor, "The old sentence.")
+
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("The sharper sentence.")).toBeInTheDocument()
+    })
+    expect(editor.value).toBe("Intro. The old sentence. Outro.")
+    expect(mockState.streamCalls).toHaveLength(0)
+    expect(mockState.sendCalls).toHaveLength(1)
+    expect(screen.getByTestId("writing-revision-pending-count")).toHaveTextContent(
+      "1 pending"
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }))
+
+    await waitFor(() => {
+      expect(editor.value).toBe("Intro. The sharper sentence. Outro.")
+    })
+  })
+
+  it("continues from the selected text end and applies an insertion", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement(" continued"))
+    seedWritingSession({ prompt: "Intro sentence. Outro." })
+
+    render(<WritingPlayground />)
+    const editor = getEditor()
+    selectEditorText(editor, "sentence")
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+    await waitFor(() => {
+      expect(mockState.sendCalls).toHaveLength(1)
+    })
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }))
+
+    await waitFor(() => {
+      expect(editor.value).toBe("Intro sentence continued. Outro.")
+    })
+  })
+
+  it("does not require broad-target confirmation for Continue", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("Opening "))
+    seedWritingSession({
+      prompt: "Long paragraph ".repeat(120)
+    })
+
+    render(<WritingPlayground />)
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+    await waitFor(() => {
+      expect(mockState.sendCalls).toHaveLength(1)
+    })
+    expect(latestRevisionPrompt()).toContain("Operation: insert")
+  })
+
+  it("refreshes the action-bar target when text is selected after a broad target renders", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("Specific rewrite."))
+    seedWritingSession({
+      prompt: `${"Long paragraph ".repeat(180)}target phrase.`
+    })
+
+    render(<WritingPlayground />)
+    expect(
+      screen.getByLabelText(/confirm whole-document text change/i)
+    ).toBeInTheDocument()
+
+    selectEditorText(getEditor(), "target phrase.")
+
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText(/confirm whole-document text change/i)
+      ).toBeNull()
+    })
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Specific rewrite.")).toBeInTheDocument()
+    })
+    expect(latestRevisionPrompt()).toContain("Target summary: selection")
+  })
+
+  it("refreshes the rich-editor action-bar target when rich text is selected", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("Rich specific rewrite."))
+    useWritingPlaygroundStore.setState({ editorMode: "tiptap" })
+    seedWritingSession({
+      prompt: `${"Long paragraph ".repeat(180)}target phrase.`
+    })
+
+    render(<WritingPlayground />)
+    fireEvent.click(screen.getByRole("radio", { name: "Rich" }))
+    const richEditor = await screen.findByLabelText("Mock rich editor") as HTMLTextAreaElement
+    expect(
+      screen.getByLabelText(/confirm whole-document text change/i)
+    ).toBeInTheDocument()
+
+    selectEditorText(richEditor, "target phrase.")
+
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText(/confirm whole-document text change/i)
+      ).toBeNull()
+    })
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Rich specific rewrite.")).toBeInTheDocument()
+    })
+    expect(latestRevisionPrompt()).toContain("Target summary: selection")
+  })
+
+  it("keeps the topbar Generate control non-cancelable during revision proposal requests", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    let resolveResponse: (value: string) => void = () => {}
+    mockState.sendResponses.push(
+      new Promise<string>((resolve) => {
+        resolveResponse = resolve
+      })
+    )
+    seedWritingSession({
+      prompt: "Rewrite this line.",
+      settings: { token_streaming: true }
+    })
+
+    render(<WritingPlayground />)
+    selectEditorText(getEditor(), "Rewrite this line.")
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(mockState.sendCalls).toHaveLength(1)
+    })
+    const generateButton = screen.getByTestId("writing-topbar-generate")
+    expect(generateButton).toHaveTextContent("Generate")
+    expect(generateButton).toBeDisabled()
+
+    await act(async () => {
+      resolveResponse(structuredReplacement("Resolved rewrite."))
+    })
+    await waitFor(() => {
+      expect(screen.getByText("Resolved rewrite.")).toBeInTheDocument()
+    })
+  })
+
+  it("blocks session switching while a revision proposal request is pending", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    let resolveResponse: (value: string) => void = () => {}
+    mockState.sendResponses.push(
+      new Promise<string>((resolve) => {
+        resolveResponse = resolve
+      })
+    )
+    seedWritingSession({ prompt: "Rewrite this line." })
+    mockState.queryData.set(mockState.queryKey(["writing-sessions"]), {
+      sessions: [
+        {
+          id: "session-auto",
+          name: "Auto Session",
+          last_modified: "2026-03-16T12:00:00Z",
+          version: 1
+        },
+        {
+          id: "session-other",
+          name: "Other Session",
+          last_modified: "2026-03-16T12:05:00Z",
+          version: 1
+        }
+      ],
+      total: 2,
+      limit: 200,
+      offset: 0
+    })
+    mockState.queryData.set(
+      mockState.queryKey(["writing-session", "session-other"]),
+      {
+        id: "session-other",
+        name: "Other Session",
+        payload: {
+          prompt: "Other draft.",
+          settings: {},
+          template_name: null,
+          theme_name: null,
+          chat_mode: false
+        },
+        schema_version: 1,
+        version_parent_id: null,
+        created_at: "2026-03-16T12:00:00Z",
+        last_modified: "2026-03-16T12:05:00Z",
+        deleted: false,
+        client_id: "test-client",
+        version: 1
+      }
+    )
+
+    render(<WritingPlayground />)
+    selectEditorText(getEditor(), "Rewrite this line.")
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(mockState.sendCalls).toHaveLength(1)
+    })
+    fireEvent.click(screen.getByRole("button", { name: /Other Session/i }))
+
+    expect(useWritingPlaygroundStore.getState().activeSessionId).toBe(
+      "session-auto"
+    )
+    expect(getEditor()).toHaveValue("Rewrite this line.")
+
+    await act(async () => {
+      resolveResponse(structuredReplacement("Resolved rewrite."))
+    })
+    await waitFor(() => {
+      expect(screen.getByText("Resolved rewrite.")).toBeInTheDocument()
+    })
+  })
+
+  it("shows malformed model output as a raw suggestion without Apply", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push("not structured json")
+    seedWritingSession({ prompt: "Rewrite this line." })
+
+    render(<WritingPlayground />)
+    const editor = getEditor()
+    selectEditorText(editor, "Rewrite this line.")
+
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("not structured json")).toBeInTheDocument()
+    })
+    const queue = screen.getByTestId("writing-revision-queue")
+    expect(within(queue).queryByRole("button", { name: /apply/i })).toBeNull()
+  })
+
+  it("creates Outline as an advisory proposal without Apply", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredAdvice("Add a midpoint reversal."))
+    seedWritingSession({ prompt: "Act one opens quietly." })
+
+    render(<WritingPlayground />)
+    fireEvent.click(screen.getByRole("button", { name: /outline/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Add a midpoint reversal.")).toBeInTheDocument()
+    })
+    const queue = screen.getByTestId("writing-revision-queue")
+    expect(within(queue).queryByRole("button", { name: /apply/i })).toBeNull()
+  })
+
+  it("includes the selected workflow preset instruction in the proposed-edit prompt", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("Concise line."))
+    seedWritingSession({ prompt: "This line could use fewer extra words." })
+
+    render(<WritingPlayground />)
+    const makeConcise = WRITING_REVISION_PRESETS.find(
+      (preset) => preset.id === "make_concise"
+    )
+    expect(makeConcise).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("radio", { name: /make concise/i }))
+    selectEditorText(getEditor(), "This line could use fewer extra words.")
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(mockState.sendCalls).toHaveLength(1)
+    })
+    expect(latestRevisionPrompt()).toContain(makeConcise!.instruction)
+  })
+
+  it("passes writing context, routing, and generation settings into the proposed-edit prompt", async () => {
+    mockState.storageValues.set("selectedModel", "context-model")
+    useStoreChatModelSettings.getState().setApiProvider("anthropic")
+    mockState.sendResponses.push(structuredReplacement("Context-aware rewrite."))
+    seedWritingSession({
+      prompt: "Original line.",
+      template_name: "Story template",
+      theme_name: "Noir theme",
+      chat_mode: false,
+      settings: {
+        temperature: 0.42,
+        top_p: 0.88,
+        top_k: 11,
+        token_streaming: true,
+        max_tokens: 333,
+        presence_penalty: 0.2,
+        frequency_penalty: 0.1,
+        seed: 1234,
+        stop: ["END"],
+        advanced_extra_body: {
+          safe_key: "kept",
+          api_key: "do-not-leak",
+          banned_tokens: ["cliche"]
+        },
+        memory_block: {
+          enabled: true,
+          prefix: "Memory:",
+          text: "The lighthouse is important.",
+          suffix: ""
+        },
+        author_note: {
+          enabled: true,
+          prefix: "Author:",
+          text: "Keep the narrator restrained.",
+          suffix: "",
+          insertion_depth: 2
+        },
+        world_info: {
+          enabled: true,
+          search_range: 2000,
+          prefix: "",
+          suffix: "",
+          entries: [
+            {
+              id: "wi-1",
+              keys: ["lighthouse"],
+              content: "The lighthouse marks the old border.",
+              enabled: true
+            }
+          ]
+        },
+        context_order:
+          "{memPrefix}{memText}{memSuffix}{wiPrefix}{wiText}{wiSuffix}{prompt}",
+        context_length: 4096,
+        author_note_depth_mode: "insertion",
+        logprobs: true,
+        top_logprobs: 3,
+        use_basic_stopping_mode: false,
+        basic_stopping_mode_type: "max_tokens"
+      }
+    })
+
+    render(<WritingPlayground />)
+    selectEditorText(getEditor(), "Original line.")
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(mockState.sendCalls).toHaveLength(1)
+    })
+    const prompt = latestRevisionPrompt()
+    expect(prompt).toContain("The lighthouse is important.")
+    expect(prompt).toContain("Keep the narrator restrained.")
+    expect(prompt).toContain("The lighthouse marks the old border.")
+    expect(prompt).toContain("Template: Story template")
+    expect(prompt).toContain("Theme: Noir theme")
+    expect(prompt).toContain("Provider: anthropic")
+    expect(prompt).toContain("Model: context-model")
+    expect(prompt).toContain('"temperature":0.42')
+    expect(prompt).toContain('"topP":0.88')
+    expect(prompt).toContain('"maxTokens":333')
+    expect(prompt).toContain('"safe_key":"kept"')
+    expect(prompt).not.toContain("do-not-leak")
+    expect(mockState.sendCalls[0]?.options).toMatchObject({
+      model: "context-model",
+      temperature: 0.42,
+      maxTokens: 333,
+      extraBody: {
+        safe_key: "kept",
+        banned_tokens: ["cliche"]
+      }
+    })
+  })
+
+  it("regenerates by rejecting the old proposal and appending a regenerated proposal", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(
+      structuredReplacement("First replacement.", "First proposal"),
+      structuredReplacement("Second replacement.", "Second proposal")
+    )
+    seedWritingSession({ prompt: "Replace this sentence." })
+
+    render(<WritingPlayground />)
+    selectEditorText(getEditor(), "Replace this sentence.")
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("First replacement.")).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole("button", { name: /regenerate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Second replacement.")).toBeInTheDocument()
+    })
+    const queue = screen.getByTestId("writing-revision-queue")
+    expect(within(queue).getByText("rejected")).toBeInTheDocument()
+    expect(within(queue).getAllByText("pending")).toHaveLength(1)
+    expect(screen.getByText(/regenerated from/i)).toBeInTheDocument()
+    const proposals = within(queue).getAllByTestId("writing-revision-proposal")
+    expect(proposals).toHaveLength(2)
+    expect(proposals[1]).toHaveAttribute(
+      "data-regenerated-from-id",
+      proposals[0].getAttribute("data-proposal-id")
+    )
+  })
+
+  it("shows manual-apply guidance for rich editor apply without mutating content", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("Rich replacement."))
+    useWritingPlaygroundStore.setState({ editorMode: "tiptap" })
+    seedWritingSession({ prompt: "Rich original." })
+
+    render(<WritingPlayground />)
+    fireEvent.click(screen.getByRole("radio", { name: "Rich" }))
+    const richEditor = await screen.findByLabelText("Mock rich editor")
+    expect(richEditor).toHaveValue("Rich original.")
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Rich replacement.")).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/copy the suggestion and apply it manually/i)
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByText(/rich editor/i)).toBeInTheDocument()
+    expect(richEditor).toHaveValue("Rich original.")
+  })
+
+  it("allows confirmed whole-document text-changing targets to create applyable proposals", async () => {
+    mockState.storageValues.set("selectedModel", "mock-model")
+    mockState.sendResponses.push(structuredReplacement("Whole document rewrite."))
+    seedWritingSession({
+      prompt: `${"Long paragraph ".repeat(180)}\n\nSecond paragraph.`
+    })
+
+    render(<WritingPlayground />)
+    const editor = getEditor()
+    editor.focus()
+    editor.setSelectionRange(0, 0)
+    fireEvent.select(editor)
+    fireEvent.click(
+      await screen.findByLabelText(/confirm whole-document text change/i)
+    )
+    fireEvent.click(screen.getByRole("button", { name: /rewrite/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Whole document rewrite.")).toBeInTheDocument()
+    })
+    const queue = screen.getByTestId("writing-revision-queue")
+    expect(within(queue).getByRole("button", { name: /apply/i })).toBeEnabled()
+    expect(latestRevisionPrompt()).toContain("Target summary: whole document")
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.shell-design-system-alert.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.shell-design-system-alert.test.tsx
@@ -20,17 +20,31 @@ const mockState = vi.hoisted(() => ({
   sendCalls: [] as Array<{ messages: unknown[]; options: Record<string, unknown> }>,
 }))
 
-const queryKeyId = (queryKey: unknown): string => {
-  const key = Array.isArray(queryKey) ? queryKey[0] : queryKey
-  if (key === "writing-session" && Array.isArray(queryKey)) {
-    return `writing-session:${String(queryKey[1] || "")}`
-  }
-  return String(key)
+const serializeQueryKey = (queryKey: unknown): string =>
+  JSON.stringify(Array.isArray(queryKey) ? queryKey : [queryKey])
+
+const setQueryResult = (queryKey: unknown, result: QueryResult) => {
+  mockState.queryResults.set(serializeQueryKey(queryKey), result)
 }
 
 vi.mock("@tanstack/react-query", () => ({
-  useQuery: ({ queryKey }: { queryKey: unknown }) => {
-    const result = mockState.queryResults.get(queryKeyId(queryKey)) ?? {}
+  useQuery: ({
+    queryKey,
+    enabled = true,
+  }: {
+    queryKey: unknown
+    enabled?: boolean
+  }) => {
+    if (enabled === false) {
+      return {
+        data: undefined,
+        isLoading: false,
+        isFetching: false,
+        error: null,
+      }
+    }
+
+    const result = mockState.queryResults.get(serializeQueryKey(queryKey)) ?? {}
     return {
       data: result.data,
       isLoading: result.isLoading ?? false,
@@ -175,13 +189,13 @@ const DEFAULT_WRITING_CAPABILITIES = {
 }
 
 const seedDefaultQueries = () => {
-  mockState.queryResults.set("writing-capabilities", {
+  setQueryResult(["writing-capabilities"], {
     data: DEFAULT_WRITING_CAPABILITIES,
   })
-  mockState.queryResults.set("writing-defaults", {
+  setQueryResult(["writing-defaults"], {
     data: { templates: [], themes: [] },
   })
-  mockState.queryResults.set("writing-sessions", {
+  setQueryResult(["writing-sessions"], {
     data: {
       sessions: [],
       total: 0,
@@ -189,7 +203,7 @@ const seedDefaultQueries = () => {
       offset: 0,
     },
   })
-  mockState.queryResults.set("writing-templates", {
+  setQueryResult(["writing-templates"], {
     data: {
       templates: [],
       total: 0,
@@ -197,7 +211,7 @@ const seedDefaultQueries = () => {
       offset: 0,
     },
   })
-  mockState.queryResults.set("writing-themes", {
+  setQueryResult(["writing-themes"], {
     data: {
       themes: [],
       total: 0,
@@ -205,7 +219,7 @@ const seedDefaultQueries = () => {
       offset: 0,
     },
   })
-  mockState.queryResults.set("writing-session:", { data: null })
+  setQueryResult(["writing-session", null], { data: null })
 }
 
 const seedActiveSession = () => {
@@ -213,7 +227,7 @@ const seedActiveSession = () => {
     activeSessionId: "session-auto",
     activeSessionName: "Auto Session",
   })
-  mockState.queryResults.set("writing-sessions", {
+  setQueryResult(["writing-sessions"], {
     data: {
       sessions: [
         {
@@ -258,7 +272,7 @@ describe("WritingPlayground shell product-state alerts", () => {
   })
 
   it("renders the unsupported shell state through the design-system Alert", () => {
-    mockState.queryResults.set("writing-capabilities", {
+    setQueryResult(["writing-capabilities"], {
       data: {
         ...DEFAULT_WRITING_CAPABILITIES,
         server: { ...DEFAULT_WRITING_CAPABILITIES.server, sessions: false },
@@ -274,7 +288,7 @@ describe("WritingPlayground shell product-state alerts", () => {
   })
 
   it("renders the sessions-load error through the design-system Alert", () => {
-    mockState.queryResults.set("writing-sessions", {
+    setQueryResult(["writing-sessions"], {
       data: undefined,
       error: new Error("Session list unavailable"),
     })
@@ -287,7 +301,7 @@ describe("WritingPlayground shell product-state alerts", () => {
 
   it("renders the active-session editor error through the design-system Alert", () => {
     seedActiveSession()
-    mockState.queryResults.set("writing-session:session-auto", {
+    setQueryResult(["writing-session", "session-auto"], {
       data: undefined,
       error: new Error("Session detail unavailable"),
     })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx
@@ -1,0 +1,189 @@
+import React from "react"
+import { cleanup, fireEvent, render, within } from "@testing-library/react"
+import { JSDOM } from "jsdom"
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest"
+import { WritingRevisionQueue } from "../WritingRevisionQueue"
+import type { WritingRevisionProposal } from "../writing-revision-types"
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>")
+const requestAnimationFrame = (callback: FrameRequestCallback) =>
+  dom.window.setTimeout(() => callback(Date.now()), 0)
+const cancelAnimationFrame = (id: number) => {
+  dom.window.clearTimeout(id)
+}
+
+Object.defineProperties(globalThis, {
+  window: { value: dom.window, configurable: true },
+  document: { value: dom.window.document, configurable: true },
+  navigator: { value: dom.window.navigator, configurable: true },
+  HTMLElement: { value: dom.window.HTMLElement, configurable: true },
+  SVGElement: { value: dom.window.SVGElement, configurable: true },
+  Element: { value: dom.window.Element, configurable: true },
+  ShadowRoot: { value: dom.window.ShadowRoot, configurable: true },
+  Node: { value: dom.window.Node, configurable: true },
+  MutationObserver: {
+    value: dom.window.MutationObserver,
+    configurable: true
+  },
+  requestAnimationFrame: {
+    value: requestAnimationFrame,
+    configurable: true
+  },
+  cancelAnimationFrame: {
+    value: cancelAnimationFrame,
+    configurable: true
+  },
+  getComputedStyle: {
+    value: dom.window.getComputedStyle.bind(dom.window),
+    configurable: true
+  }
+})
+
+Object.assign(dom.window, {
+  requestAnimationFrame,
+  cancelAnimationFrame
+})
+
+afterAll(() => {
+  dom.window.close()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const target: WritingRevisionProposal["target"] = {
+  mode: "selection",
+  start: 0,
+  end: 11,
+  beforeText: "Old wording",
+  anchor: {
+    documentFingerprint: "fingerprint-1",
+    prefix: "",
+    suffix: ""
+  },
+  label: "Selection: 11 chars",
+  requiresConfirmation: false
+}
+
+const buildProposal = (
+  overrides: Partial<WritingRevisionProposal> = {}
+): WritingRevisionProposal => ({
+  id: "revision-1",
+  sessionId: "session-1",
+  action: "rewrite",
+  operation: "replace",
+  presetId: "polish_prose",
+  presetInstruction: "Improve flow.",
+  instruction: "Rewrite this.",
+  target,
+  replacementText: "New wording",
+  rationale: "Clearer.",
+  title: "Rewrite selection",
+  createdAt: "2026-05-22T12:00:00.000Z",
+  status: "pending",
+  ...overrides
+})
+
+describe("WritingRevisionQueue", () => {
+  it("renders pending proposal diff and Apply/Reject/Copy/Regenerate", () => {
+    const view = render(
+      <WritingRevisionQueue
+        proposals={[buildProposal()]}
+        onApply={vi.fn()}
+        onReject={vi.fn()}
+        onCopy={vi.fn()}
+        onRegenerate={vi.fn()}
+      />
+    )
+
+    const queue = view.getByTestId("writing-revision-queue")
+    expect(within(queue).getByText("Old wording")).toBeTruthy()
+    expect(within(queue).getByText("New wording")).toBeTruthy()
+    expect(within(queue).getByRole("button", { name: /apply/i })).toBeTruthy()
+    expect(within(queue).getByRole("button", { name: /reject/i })).toBeTruthy()
+    expect(within(queue).getByRole("button", { name: /copy/i })).toBeTruthy()
+    expect(
+      within(queue).getByRole("button", { name: /regenerate/i })
+    ).toBeTruthy()
+    expect(
+      within(queue).getByRole("button", { name: /apply/i }).querySelector("svg")
+    ).toBeTruthy()
+    expect(
+      within(queue).getByRole("button", { name: /copy/i }).querySelector("svg")
+    ).toBeTruthy()
+  })
+
+  it("hides Apply for advisory proposals", () => {
+    const view = render(
+      <WritingRevisionQueue
+        proposals={[
+          buildProposal({
+            operation: "advisory",
+            status: "advisory",
+            replacementText: undefined,
+            rawText: "Consider strengthening the stakes."
+          })
+        ]}
+        onApply={vi.fn()}
+        onReject={vi.fn()}
+        onCopy={vi.fn()}
+        onRegenerate={vi.fn()}
+      />
+    )
+
+    expect(view.queryByRole("button", { name: /apply/i })).not.toBeTruthy()
+    expect(view.getByText("Consider strengthening the stakes.")).toBeTruthy()
+  })
+
+  it("shows copy/manual-apply guidance for conflict state", () => {
+    const view = render(
+      <WritingRevisionQueue
+        proposals={[
+          buildProposal({
+            status: "conflict",
+            notes: ["Anchor moved after the draft changed."]
+          })
+        ]}
+        onApply={vi.fn()}
+        onReject={vi.fn()}
+        onCopy={vi.fn()}
+        onRegenerate={vi.fn()}
+      />
+    )
+
+    expect(view.getByText(/copy the suggestion and apply it manually/i)).toBeTruthy()
+    expect(view.getByText("Anchor moved after the draft changed.")).toBeTruthy()
+  })
+
+  it("shows raw text and Copy only for raw suggestion state", () => {
+    const onCopy = vi.fn()
+
+    const view = render(
+      <WritingRevisionQueue
+        proposals={[
+          buildProposal({
+            status: "raw_suggestion",
+            operation: "advisory",
+            replacementText: undefined,
+            rawText: "Raw model output"
+          })
+        ]}
+        onApply={vi.fn()}
+        onReject={vi.fn()}
+        onCopy={onCopy}
+        onRegenerate={vi.fn()}
+      />
+    )
+
+    expect(view.getByText("Raw model output")).toBeTruthy()
+    expect(view.getByRole("button", { name: /copy/i })).toBeTruthy()
+    expect(view.queryByRole("button", { name: /apply/i })).not.toBeTruthy()
+    expect(view.queryByRole("button", { name: /reject/i })).not.toBeTruthy()
+    expect(view.queryByRole("button", { name: /regenerate/i })).not.toBeTruthy()
+
+    fireEvent.click(view.getByRole("button", { name: /copy/i }))
+
+    expect(onCopy).toHaveBeenCalledWith(expect.objectContaining({ id: "revision-1" }))
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import type { JSONContent } from "@tiptap/react"
-import { render, waitFor } from "@testing-library/react"
+import { act, render, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { WritingTipTapEditor } from "../WritingTipTapEditor"
+import type { WritingEditorAdapter } from "../writing-editor-adapter"
 
 const FIRST_DOC: JSONContent = {
   type: "doc",
@@ -37,6 +38,53 @@ describe("WritingTipTapEditor external sync", () => {
 
     await waitFor(() => {
       expect(container.textContent).toContain("Second draft")
+    })
+  })
+
+  it("maps selections to plain-text offsets after paragraph boundaries", async () => {
+    const adapterRef: { current: WritingEditorAdapter | null } = {
+      current: null
+    }
+    const selectionChanges: Array<{ start: number; end: number }> = []
+
+    render(
+      <WritingTipTapEditor
+        content={{
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Alpha" }]
+            },
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Beta" }]
+            }
+          ]
+        }}
+        onContentChange={vi.fn()}
+        onAdapterReady={(adapter) => {
+          adapterRef.current = adapter
+        }}
+        onSelectionChange={(selection) => {
+          selectionChanges.push(selection)
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(adapterRef.current).not.toBeNull()
+    })
+
+    act(() => {
+      adapterRef.current?.setSelection({ start: 6, end: 10 })
+    })
+
+    await waitFor(() => {
+      expect(adapterRef.current?.getSelectedText("Alpha\nBeta")).toBe("Beta")
+    })
+    await waitFor(() => {
+      expect(selectionChanges.at(-1)).toEqual({ start: 6, end: 10 })
     })
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx
@@ -1,0 +1,417 @@
+import { act, renderHook } from "@testing-library/react"
+import { JSDOM } from "jsdom"
+import { afterAll, describe, expect, it, vi } from "vitest"
+import { useWritingRevisions } from "../hooks/useWritingRevisions"
+import type { WritingSessionPayload } from "../hooks/utils"
+import { mergeRevisionsIntoPayload } from "../hooks/utils"
+import type { WritingRevisionProposal } from "../writing-revision-types"
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>")
+
+Object.defineProperties(globalThis, {
+  window: { value: dom.window, configurable: true },
+  document: { value: dom.window.document, configurable: true },
+  navigator: { value: dom.window.navigator, configurable: true },
+  HTMLElement: { value: dom.window.HTMLElement, configurable: true },
+  MutationObserver: {
+    value: dom.window.MutationObserver,
+    configurable: true
+  },
+  Node: { value: dom.window.Node, configurable: true }
+})
+
+afterAll(() => {
+  dom.window.close()
+})
+
+const target: WritingRevisionProposal["target"] = {
+  mode: "selection",
+  start: 0,
+  end: 5,
+  beforeText: "Alpha",
+  anchor: {
+    documentFingerprint: "fingerprint-1",
+    prefix: "",
+    suffix: " beta"
+  },
+  label: "selection",
+  requiresConfirmation: false
+}
+
+const buildRevision = (
+  overrides: Partial<WritingRevisionProposal> = {}
+): WritingRevisionProposal => ({
+  id: "revision-1",
+  sessionId: "session-1",
+  action: "rewrite",
+  operation: "replace",
+  presetId: "polish_prose",
+  presetInstruction: "Polish without changing meaning.",
+  instruction: "Make this clearer.",
+  target,
+  replacementText: "Omega",
+  createdAt: "2026-05-22T12:00:00.000Z",
+  status: "pending",
+  ...overrides
+})
+
+const setup = (
+  overrides: Partial<Parameters<typeof useWritingRevisions>[0]> = {}
+) => {
+  const applyEditorText = vi.fn(() => ({ applied: true as const }))
+  const applySessionPayloadPatch = vi.fn()
+
+  const result = renderHook(
+    (props: Parameters<typeof useWritingRevisions>[0]) =>
+      useWritingRevisions(props),
+    {
+      initialProps: {
+        activeSessionId: "session-1",
+        activeSessionPayload: null,
+        editorText: "Alpha beta",
+        applyEditorText,
+        applySessionPayloadPatch,
+        ...overrides
+      }
+    }
+  )
+
+  return {
+    ...result,
+    applyEditorText,
+    applySessionPayloadPatch
+  }
+}
+
+const latestPersistedRevisions = (
+  applySessionPayloadPatch: ReturnType<typeof vi.fn>
+): WritingRevisionProposal[] => {
+  const patcher = applySessionPayloadPatch.mock.calls.at(-1)?.[0] as
+    | ((payload: WritingSessionPayload) => WritingSessionPayload)
+    | undefined
+
+  if (!patcher) return []
+  return patcher({ prompt: "Existing draft" }).revisions?.items ?? []
+}
+
+const createDeferred = <T,>() => {
+  let resolve: (value: T) => void
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver
+  })
+  return {
+    promise,
+    resolve: resolve!
+  }
+}
+
+describe("useWritingRevisions", () => {
+  it("loads revisions from the active session payload", () => {
+    const revision = buildRevision()
+    const payload = mergeRevisionsIntoPayload({ prompt: "Alpha beta" }, [revision])
+
+    const { result, rerender } = setup({
+      activeSessionId: "session-1",
+      activeSessionPayload: payload
+    })
+
+    expect(result.current.revisions).toEqual([revision])
+
+    const nextRevision = buildRevision({ id: "revision-2" })
+    rerender({
+      activeSessionId: "session-2",
+      activeSessionPayload: mergeRevisionsIntoPayload({}, [nextRevision]),
+      editorText: "Alpha beta",
+      applyEditorText: vi.fn(() => ({ applied: true as const })),
+      applySessionPayloadPatch: vi.fn()
+    })
+
+    expect(result.current.revisions).toEqual([nextRevision])
+  })
+
+  it("rejects a proposal without changing text", () => {
+    const revision = buildRevision()
+    const { result, applyEditorText, applySessionPayloadPatch } = setup()
+
+    act(() => {
+      result.current.addRevision(revision)
+      result.current.rejectRevision(revision.id)
+    })
+
+    expect(applyEditorText).not.toHaveBeenCalled()
+    expect(result.current.revisions[0]).toMatchObject({ status: "rejected" })
+    expect(latestPersistedRevisions(applySessionPayloadPatch)[0]).toMatchObject({
+      status: "rejected"
+    })
+  })
+
+  it("applies a plain replacement through the provided text callback", () => {
+    const revision = buildRevision()
+    const { result, applyEditorText, applySessionPayloadPatch } = setup()
+
+    act(() => {
+      result.current.addRevision(revision)
+      result.current.applyRevision(revision.id)
+    })
+
+    expect(applyEditorText).toHaveBeenCalledWith("Omega beta")
+    expect(result.current.revisions[0]).toMatchObject({ status: "applied" })
+    expect(latestPersistedRevisions(applySessionPayloadPatch)[0]).toMatchObject({
+      status: "applied"
+    })
+  })
+
+  it("marks conflict without mutating text", () => {
+    const revision = buildRevision({
+      target: {
+        ...target,
+        start: 0,
+        end: 5,
+        beforeText: "Alpha"
+      }
+    })
+    const { result, applyEditorText, applySessionPayloadPatch } = setup({
+      editorText: "Intro Alpha beta Alpha"
+    })
+
+    act(() => {
+      result.current.addRevision(revision)
+      result.current.applyRevision(revision.id)
+    })
+
+    expect(applyEditorText).not.toHaveBeenCalled()
+    expect(result.current.revisions[0]).toMatchObject({ status: "conflict" })
+    expect(latestPersistedRevisions(applySessionPayloadPatch)[0]).toMatchObject({
+      status: "conflict"
+    })
+  })
+
+  it("does not call the text callback for advisory proposals", () => {
+    const revision = buildRevision({
+      operation: "advisory",
+      replacementText: undefined,
+      rawText: "Consider making the stakes clearer."
+    })
+    const { result, applyEditorText } = setup()
+
+    act(() => {
+      result.current.addRevision(revision)
+      result.current.applyRevision(revision.id)
+    })
+
+    expect(applyEditorText).not.toHaveBeenCalled()
+    expect(result.current.revisions[0]).toMatchObject({ status: "advisory" })
+  })
+
+  it("passes proposal state to applySessionPayloadPatch", () => {
+    const revision = buildRevision()
+    const { result, applySessionPayloadPatch } = setup()
+
+    act(() => {
+      result.current.addRevision(revision)
+      result.current.rejectRevision(revision.id)
+    })
+
+    const patcher = applySessionPayloadPatch.mock.calls.at(-1)?.[0] as (
+      payload: WritingSessionPayload
+    ) => WritingSessionPayload
+    const patched = patcher({ prompt: "Existing draft" })
+
+    expect(patched.prompt).toBe("Existing draft")
+    expect(patched.revisions?.items).toEqual([
+      expect.objectContaining({ id: revision.id, status: "rejected" })
+    ])
+  })
+
+  it("regenerates by rejecting the source and appending a pending replacement", async () => {
+    const source = buildRevision({
+      id: "source",
+      presetId: "preserve_voice",
+      presetInstruction: "Preserve voice.",
+      instruction: "Keep the rhythm."
+    })
+    const replacement = buildRevision({
+      id: "replacement",
+      target: {
+        ...target,
+        beforeText: "Different"
+      },
+      instruction: "Different instruction",
+      presetId: "make_concise",
+      presetInstruction: "Different preset.",
+      status: "applied"
+    })
+    const createReplacement = vi.fn(async () => replacement)
+    const { result, applySessionPayloadPatch } = setup()
+
+    await act(async () => {
+      result.current.addRevision(source)
+      await result.current.regenerateRevision(source.id, createReplacement)
+    })
+
+    expect(createReplacement).toHaveBeenCalledWith(source)
+    expect(result.current.revisions).toEqual([
+      expect.objectContaining({ id: source.id, status: "rejected" }),
+      expect.objectContaining({
+        id: replacement.id,
+        regeneratedFromId: source.id,
+        target: source.target,
+        instruction: source.instruction,
+        presetId: source.presetId,
+        presetInstruction: source.presetInstruction,
+        status: "pending"
+      })
+    ])
+    expect(latestPersistedRevisions(applySessionPayloadPatch)).toHaveLength(2)
+  })
+
+  it("keeps a pending regeneration after a same-payload save echo", async () => {
+    const source = buildRevision({ id: "source" })
+    const replacement = buildRevision({ id: "replacement" })
+    const deferred = createDeferred<WritingRevisionProposal>()
+    const createReplacement = vi.fn(() => deferred.promise)
+    const payload = mergeRevisionsIntoPayload({}, [source])
+    const { result, rerender, applyEditorText, applySessionPayloadPatch } = setup({
+      activeSessionPayload: payload
+    })
+
+    await act(async () => {
+      void result.current.regenerateRevision(source.id, createReplacement)
+      await Promise.resolve()
+    })
+
+    rerender({
+      activeSessionId: "session-1",
+      activeSessionPayload: mergeRevisionsIntoPayload({}, [{ ...source }]),
+      editorText: "Alpha beta",
+      applyEditorText,
+      applySessionPayloadPatch
+    })
+
+    await act(async () => {
+      deferred.resolve(replacement)
+      await deferred.promise
+    })
+
+    expect(result.current.revisions).toEqual([
+      expect.objectContaining({ id: source.id, status: "rejected" }),
+      expect.objectContaining({
+        id: replacement.id,
+        regeneratedFromId: source.id,
+        status: "pending"
+      })
+    ])
+    expect(latestPersistedRevisions(applySessionPayloadPatch)).toHaveLength(2)
+  })
+
+  it("ignores a pending regeneration when the active session changes before completion", async () => {
+    const source = buildRevision({ id: "source" })
+    const replacement = buildRevision({
+      id: "replacement",
+      sessionId: "session-1"
+    })
+    const nextSessionRevision = buildRevision({
+      id: "next-session",
+      sessionId: "session-2"
+    })
+    const deferred = createDeferred<WritingRevisionProposal>()
+    const createReplacement = vi.fn(() => deferred.promise)
+    const applyEditorText = vi.fn(() => ({ applied: true as const }))
+    const applySessionPayloadPatch = vi.fn()
+    const nextSessionPayloadPatch = vi.fn()
+    const { result, rerender } = setup({
+      applyEditorText,
+      applySessionPayloadPatch
+    })
+
+    await act(async () => {
+      result.current.addRevision(source)
+    })
+    const callsBeforeRegenerationCompletes =
+      applySessionPayloadPatch.mock.calls.length
+
+    await act(async () => {
+      void result.current.regenerateRevision(source.id, createReplacement)
+      await Promise.resolve()
+    })
+
+    rerender({
+      activeSessionId: "session-2",
+      activeSessionPayload: mergeRevisionsIntoPayload({}, [nextSessionRevision]),
+      editorText: "Session two text",
+      applyEditorText,
+      applySessionPayloadPatch: nextSessionPayloadPatch
+    })
+
+    await act(async () => {
+      deferred.resolve(replacement)
+      await deferred.promise
+    })
+
+    expect(result.current.revisions).toEqual([nextSessionRevision])
+    expect(applySessionPayloadPatch).toHaveBeenCalledTimes(
+      callsBeforeRegenerationCompletes
+    )
+    expect(nextSessionPayloadPatch).not.toHaveBeenCalled()
+  })
+
+  it("ignores a pending regeneration when the source is no longer pending", async () => {
+    const source = buildRevision({ id: "source" })
+    const replacement = buildRevision({ id: "replacement" })
+    const deferred = createDeferred<WritingRevisionProposal>()
+    const createReplacement = vi.fn(() => deferred.promise)
+    const { result, applySessionPayloadPatch } = setup()
+
+    await act(async () => {
+      result.current.addRevision(source)
+    })
+
+    await act(async () => {
+      void result.current.regenerateRevision(source.id, createReplacement)
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      result.current.rejectRevision(source.id)
+    })
+    const callsBeforeRegenerationCompletes =
+      applySessionPayloadPatch.mock.calls.length
+
+    await act(async () => {
+      deferred.resolve(replacement)
+      await deferred.promise
+    })
+
+    expect(result.current.revisions).toEqual([
+      expect.objectContaining({ id: source.id, status: "rejected" })
+    ])
+    expect(latestPersistedRevisions(applySessionPayloadPatch)).toEqual([
+      expect.objectContaining({ id: source.id, status: "rejected" })
+    ])
+    expect(applySessionPayloadPatch).toHaveBeenCalledTimes(
+      callsBeforeRegenerationCompletes
+    )
+  })
+
+  it("marks unsupported rich-editor apply responses as conflict for manual apply", () => {
+    const revision = buildRevision()
+    const applyEditorText = vi.fn(() => ({
+      applied: false as const,
+      reason: "Rich editor patching is not supported."
+    }))
+    const { result } = setup({ applyEditorText })
+
+    act(() => {
+      result.current.addRevision(revision)
+      result.current.applyRevision(revision.id)
+    })
+
+    expect(applyEditorText).toHaveBeenCalledWith("Omega beta")
+    expect(result.current.revisions[0]).toMatchObject({
+      status: "conflict",
+      notes: expect.arrayContaining([
+        expect.stringContaining("Rich editor patching is not supported.")
+      ])
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts
@@ -1,0 +1,69 @@
+import { Editor } from "@tiptap/core"
+import StarterKit from "@tiptap/starter-kit"
+import { describe, expect, it } from "vitest"
+import { SceneBreakExtension } from "../extensions/SceneBreakExtension"
+import { createTipTapEditorAdapter } from "../writing-editor-adapter"
+import { tipTapJsonToPlainText } from "../writing-tiptap-utils"
+
+describe("writing editor adapter", () => {
+  it("sets TipTap selections using plain-text offsets after paragraph breaks", () => {
+    const editor = new Editor({
+      extensions: [StarterKit],
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Alpha" }]
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Beta" }]
+          }
+        ]
+      }
+    })
+    const adapter = createTipTapEditorAdapter(editor)
+
+    adapter?.setSelection({ start: 6, end: 10 })
+
+    const { from, to } = editor.state.selection
+    expect(editor.state.doc.textBetween(from, to, "\n", "\n")).toBe("Beta")
+    expect(adapter?.getSelection()).toEqual({ start: 6, end: 10 })
+
+    editor.destroy()
+  })
+
+  it("maps TipTap selections against serialized scene breaks", () => {
+    const editor = new Editor({
+      extensions: [StarterKit, SceneBreakExtension],
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Alpha" }]
+          },
+          { type: "sceneBreak" },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Beta" }]
+          }
+        ]
+      }
+    })
+    const adapter = createTipTapEditorAdapter(editor)
+    const plainText = tipTapJsonToPlainText(editor.getJSON())
+    const start = plainText.indexOf("Beta")
+
+    expect(plainText).toBe("Alpha\n\n***\nBeta")
+
+    adapter?.setSelection({ start, end: start + "Beta".length })
+
+    const { from, to } = editor.state.selection
+    expect(editor.state.doc.textBetween(from, to, "\n", "\n")).toBe("Beta")
+    expect(adapter?.getSelection()).toEqual({ start, end: start + 4 })
+
+    editor.destroy()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import type { WritingRevisionPresetId } from "../writing-revision-types"
+import {
+  getWritingRevisionPreset,
+  WRITING_REVISION_PRESETS
+} from "../writing-revision-presets"
+
+const EXPECTED_PRESETS: Array<{
+  id: WritingRevisionPresetId
+  label: string
+  instruction: string
+}> = [
+  {
+    id: "draft_freely",
+    label: "Draft freely",
+    instruction: "Prioritize momentum, vivid continuation, and useful new material."
+  },
+  {
+    id: "polish_prose",
+    label: "Polish prose",
+    instruction: "Improve clarity, rhythm, word choice, and sentence flow without changing intent."
+  },
+  {
+    id: "developmental_edit",
+    label: "Developmental edit",
+    instruction: "Focus on structure, stakes, pacing, continuity, and what the passage needs next."
+  },
+  {
+    id: "preserve_voice",
+    label: "Preserve voice",
+    instruction: "Keep the author's diction, cadence, point of view, and stylistic fingerprints."
+  },
+  {
+    id: "make_concise",
+    label: "Make concise",
+    instruction: "Reduce redundancy and sharpen phrasing while preserving meaning and voice."
+  },
+  {
+    id: "expand_sensory_detail",
+    label: "Expand sensory detail",
+    instruction: "Add concrete sensory detail grounded in the existing scene and tone."
+  }
+]
+
+describe("writing revision presets", () => {
+  it("defines the six spec presets with stable ids and visible copy", () => {
+    expect(WRITING_REVISION_PRESETS).toEqual(EXPECTED_PRESETS)
+  })
+
+  it("keeps preset ids assignable to WritingRevisionPresetId", () => {
+    const presetIds: WritingRevisionPresetId[] = WRITING_REVISION_PRESETS.map(
+      (preset) => preset.id
+    )
+
+    expect(presetIds).toEqual(EXPECTED_PRESETS.map((preset) => preset.id))
+  })
+
+  it("exposes non-empty user-facing labels and instructions", () => {
+    WRITING_REVISION_PRESETS.forEach((preset) => {
+      expect(preset.label.trim()).toBe(preset.label)
+      expect(preset.label).not.toBe("")
+      expect(preset.instruction.trim()).toBe(preset.instruction)
+      expect(preset.instruction).not.toBe("")
+    })
+  })
+
+  it("resolves presets by id without inventing a custom-instruction default", () => {
+    EXPECTED_PRESETS.forEach((preset) => {
+      expect(getWritingRevisionPreset(preset.id)).toEqual(preset)
+    })
+
+    const customInstruction = "Keep the ending ambiguous."
+    expect(getWritingRevisionPreset(null)?.instruction ?? customInstruction).toBe(
+      customInstruction
+    )
+    expect(getWritingRevisionPreset(undefined)).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest"
+import type {
+  WritingRevisionOperation,
+  WritingRevisionTarget
+} from "../writing-revision-types"
+import {
+  buildRevisionUserPrompt,
+  parseRevisionModelResponse
+} from "../writing-revision-prompt-utils"
+
+const target: WritingRevisionTarget = {
+  mode: "paragraph",
+  start: 6,
+  end: 19,
+  beforeText: "the old line.",
+  anchor: {
+    documentFingerprint: "fingerprint-1",
+    prefix: "Once ",
+    suffix: "\nThen"
+  },
+  label: "current paragraph",
+  requiresConfirmation: false
+}
+
+const buildPrompt = (
+  overrides: Partial<Parameters<typeof buildRevisionUserPrompt>[0]> = {}
+) =>
+  buildRevisionUserPrompt({
+    action: "rewrite",
+    operation: "replace",
+    instruction: "Make the paragraph more vivid.",
+    documentText: "Once the old line.\nThen the scene changed.",
+    target,
+    writingContext: {
+      chatMode: false,
+      generationSettingsSummary: {}
+    },
+    ...overrides
+  })
+
+const parseResponse = (
+  overrides: Partial<Parameters<typeof parseRevisionModelResponse>[0]> = {}
+) =>
+  parseRevisionModelResponse({
+    responseText: '{"title":"Cleaner line","replacement":"the new line.","rationale":"Sharper image.","notes":["Keep tense."]}',
+    sessionId: "session-1",
+    action: "rewrite",
+    operation: "replace",
+    instruction: "Make the paragraph more vivid.",
+    target,
+    createdAt: "2026-05-22T10:00:00.000Z",
+    id: "proposal-1",
+    ...overrides
+  })
+
+describe("writing revision prompt utilities", () => {
+  it("creates a text-changing rewrite prompt that asks for JSON only", () => {
+    const prompt = buildPrompt()
+
+    expect(prompt).toContain(
+      "Return only valid JSON. Do not include markdown fences."
+    )
+    expect(prompt).toContain("Action: rewrite")
+    expect(prompt).toContain("Operation: replace")
+    expect(prompt).toContain("Instruction: Make the paragraph more vivid.")
+    expect(prompt).toContain('"replacement":"..."')
+    expect(prompt).not.toContain('"rawText":"..."')
+  })
+
+  it("uses the advisory JSON shape for outline requests", () => {
+    const prompt = buildPrompt({
+      action: "outline",
+      operation: "advisory",
+      instruction: "Outline the next scene.",
+      target: {
+        ...target,
+        mode: "document",
+        start: 0,
+        end: 41,
+        beforeText: "Once the old line.\nThen the scene changed.",
+        label: "whole document"
+      }
+    })
+
+    expect(prompt).toContain("Action: outline")
+    expect(prompt).toContain("Operation: advisory")
+    expect(prompt).toContain('"rawText":"..."')
+    expect(prompt).not.toContain('"replacement":"..."')
+  })
+
+  it("includes the preset instruction and existing Writing Playground context", () => {
+    const prompt = buildPrompt({
+      presetInstruction:
+        "Improve clarity without changing the author's point of view.",
+      writingContext: {
+        selectedTemplateName: "Novel chapter",
+        selectedThemeName: "Noir",
+        chatMode: true,
+        contextComposedPrompt: "Earlier context: rain at the train station.",
+        memoryBlock: { facts: ["Mara distrusts the conductor."] },
+        authorNote: { note: "Keep the voice restrained." },
+        worldInfoEntries: [{ key: "city", content: "Glass harbor" }],
+        provider: "openai",
+        model: "gpt-4.1",
+        generationSettingsSummary: {
+          temperature: 0.7,
+          max_tokens: 400
+        }
+      }
+    })
+
+    expect(prompt).toContain(
+      "Workflow preset: Improve clarity without changing the author's point of view."
+    )
+    expect(prompt).toContain("Template: Novel chapter")
+    expect(prompt).toContain("Theme: Noir")
+    expect(prompt).toContain("Chat mode: enabled")
+    expect(prompt).toContain("Provider: openai")
+    expect(prompt).toContain("Model: gpt-4.1")
+    expect(prompt).toContain('"temperature":0.7')
+    expect(prompt).toContain('"max_tokens":400')
+    expect(prompt).toContain("Earlier context: rain at the train station.")
+    expect(prompt).toContain("Mara distrusts the conductor.")
+    expect(prompt).toContain("Keep the voice restrained.")
+    expect(prompt).toContain("Glass harbor")
+  })
+
+  it("falls back to context messages when no composed prompt is present", () => {
+    const prompt = buildPrompt({
+      writingContext: {
+        selectedTemplateName: null,
+        selectedThemeName: null,
+        chatMode: false,
+        contextComposedPrompt: "",
+        contextMessages: [
+          { role: "system", content: "Write in close third person." },
+          { role: "user", content: "The last scene ended at the docks." }
+        ],
+        provider: null,
+        model: null,
+        generationSettingsSummary: {}
+      }
+    })
+
+    expect(prompt).toContain("Template: (none)")
+    expect(prompt).toContain("Theme: (none)")
+    expect(prompt).toContain("Provider: (default)")
+    expect(prompt).toContain("Model: (unset)")
+    expect(prompt).toContain("Write in close third person.")
+    expect(prompt).toContain("The last scene ended at the docks.")
+  })
+
+  it.each<WritingRevisionOperation>(["insert", "replace"])(
+    "turns valid %s JSON with replacement into a pending proposal",
+    (operation) => {
+      const proposal = parseResponse({
+        operation,
+        presetId: "polish_prose",
+        presetInstruction: "Improve clarity and rhythm."
+      })
+
+      expect(proposal).toEqual({
+        id: "proposal-1",
+        sessionId: "session-1",
+        action: "rewrite",
+        operation,
+        presetId: "polish_prose",
+        presetInstruction: "Improve clarity and rhythm.",
+        instruction: "Make the paragraph more vivid.",
+        target,
+        replacementText: "the new line.",
+        rationale: "Sharper image.",
+        title: "Cleaner line",
+        notes: ["Keep tense."],
+        createdAt: "2026-05-22T10:00:00.000Z",
+        status: "pending"
+      })
+    }
+  )
+
+  it("turns valid advisory JSON without replacement into an advisory proposal", () => {
+    const proposal = parseResponse({
+      responseText:
+        '{"title":"Next beats","rawText":"1. Raise the stakes.\\n2. Reveal the letter.","rationale":"This keeps the outline non-mutating.","notes":["Use as guidance."]}',
+      action: "outline",
+      operation: "advisory",
+      instruction: "Outline the next scene.",
+      presetId: null,
+      presetInstruction: null
+    })
+
+    expect(proposal).toMatchObject({
+      action: "outline",
+      operation: "advisory",
+      presetId: null,
+      presetInstruction: null,
+      instruction: "Outline the next scene.",
+      rawText: "1. Raise the stakes.\n2. Reveal the letter.",
+      rationale: "This keeps the outline non-mutating.",
+      title: "Next beats",
+      notes: ["Use as guidance."],
+      status: "advisory"
+    })
+    expect(proposal).not.toHaveProperty("replacementText")
+  })
+
+  it("keeps text-changing JSON without a string replacement as a raw suggestion", () => {
+    const proposal = parseResponse({
+      responseText:
+        '{"title":"No edit","rawText":"The model only gave advice.","rationale":"Missing replacement."}'
+    })
+
+    expect(proposal).toMatchObject({
+      title: "No edit",
+      rawText: "The model only gave advice.",
+      rationale: "Missing replacement.",
+      status: "raw_suggestion"
+    })
+    expect(proposal).not.toHaveProperty("replacementText")
+  })
+
+  it("turns malformed JSON into a raw suggestion", () => {
+    const proposal = parseResponse({
+      responseText: "Use a sharper verb and shorten the sentence."
+    })
+
+    expect(proposal).toMatchObject({
+      rawText: "Use a sharper verb and shorten the sentence.",
+      status: "raw_suggestion"
+    })
+    expect(proposal).not.toHaveProperty("replacementText")
+  })
+
+  it("does not make streamed partial JSON applyable until complete parsing succeeds", () => {
+    const partial = parseResponse({
+      responseText: '{"title":"Partial","replacement":"the new'
+    })
+
+    expect(partial).toMatchObject({
+      rawText: '{"title":"Partial","replacement":"the new',
+      status: "raw_suggestion"
+    })
+    expect(partial).not.toHaveProperty("replacementText")
+
+    const complete = parseResponse({
+      responseText: '{"title":"Complete","replacement":"the new line."}'
+    })
+
+    expect(complete).toMatchObject({
+      title: "Complete",
+      replacementText: "the new line.",
+      status: "pending"
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildInsertionAnchor,
+  confirmRevisionTarget,
+  countWords,
+  createDocumentFingerprint,
+  findParagraphRange,
+  planRevisionApply,
+  resolveRevisionTarget
+} from "../writing-revision-utils"
+
+const makeReplacementProposal = ({
+  start,
+  end,
+  beforeText,
+  replacementText,
+  documentText = beforeText
+}: {
+  start: number
+  end: number
+  beforeText: string
+  replacementText?: string
+  documentText?: string
+}) => ({
+  id: "revision-1",
+  sessionId: "session-1",
+  action: "rewrite" as const,
+  operation: "replace" as const,
+  instruction: "Rewrite this text.",
+  target: {
+    mode: "paragraph" as const,
+    start,
+    end,
+    beforeText,
+    anchor: buildInsertionAnchor(documentText, start),
+    label: "current paragraph",
+    requiresConfirmation: false
+  },
+  ...(typeof replacementText === "string" ? { replacementText } : {}),
+  createdAt: "2026-05-22T00:00:00.000Z",
+  status: "pending" as const
+})
+
+const makeInsertionProposal = ({
+  start,
+  end,
+  beforeText,
+  replacementText,
+  anchor
+}: {
+  start: number
+  end: number
+  beforeText: string
+  replacementText: string
+  anchor: ReturnType<typeof buildInsertionAnchor>
+}) => ({
+  id: "revision-2",
+  sessionId: "session-1",
+  action: "continue" as const,
+  operation: "insert" as const,
+  instruction: "Continue this text.",
+  target: {
+    mode: "cursor" as const,
+    start,
+    end,
+    beforeText,
+    anchor,
+    label: "cursor",
+    requiresConfirmation: false
+  },
+  replacementText,
+  createdAt: "2026-05-22T00:00:00.000Z",
+  status: "pending" as const
+})
+
+describe("writing revision utilities", () => {
+  it("counts words and selected words deterministically", () => {
+    expect(countWords("One two\nthree.")).toBe(3)
+    expect(countWords("   ")).toBe(0)
+  })
+
+  it("resolves the current paragraph around a cursor", () => {
+    const text = "Alpha one.\n\nBeta two.\nBeta three."
+    expect(findParagraphRange(text, 14)).toEqual({ start: 12, end: 33 })
+  })
+
+  it("resolves Continue as cursor insertion even when text is selected", () => {
+    const target = resolveRevisionTarget({
+      text: "Alpha beta gamma",
+      action: "continue",
+      operation: "insert",
+      selection: { start: 0, end: 5 },
+      cursor: 5
+    })
+
+    expect(target).toMatchObject({
+      mode: "cursor",
+      start: 5,
+      end: 5,
+      beforeText: "",
+      requiresConfirmation: false
+    })
+  })
+
+  it("resolves leading blank paragraphs to the first content paragraph", () => {
+    expect(findParagraphRange("\n\nAlpha", 0)).toEqual({ start: 2, end: 7 })
+  })
+
+  it("keeps a cursor at paragraph end on the preceding paragraph", () => {
+    expect(findParagraphRange("Alpha\n\nBeta", 5)).toEqual({
+      start: 0,
+      end: 5
+    })
+  })
+
+  it("keeps a cursor inside a paragraph delimiter on the preceding paragraph", () => {
+    expect(findParagraphRange("Alpha\n\nBeta", 6)).toEqual({
+      start: 0,
+      end: 5
+    })
+  })
+
+  it("plans a direct replacement when beforeText still matches", () => {
+    const proposal = makeReplacementProposal({
+      start: 0,
+      end: 5,
+      beforeText: "Alpha",
+      replacementText: "Omega",
+      documentText: "Alpha beta"
+    })
+    expect(planRevisionApply("Alpha beta", proposal)).toEqual({
+      type: "apply",
+      start: 0,
+      end: 5,
+      nextText: "Omega beta"
+    })
+  })
+
+  it("noops when a replacement proposal has no replacement text", () => {
+    const proposal = makeReplacementProposal({
+      start: 0,
+      end: 5,
+      beforeText: "Alpha",
+      documentText: "Alpha beta"
+    })
+    expect(planRevisionApply("Alpha beta", proposal)).toMatchObject({
+      type: "noop"
+    })
+  })
+
+  it("conflicts when replacement target drift is ambiguous", () => {
+    const proposal = makeReplacementProposal({
+      start: 0,
+      end: 5,
+      beforeText: "Alpha",
+      replacementText: "Omega",
+      documentText: "Alpha beta"
+    })
+    expect(planRevisionApply("Intro Alpha beta Alpha", proposal).type).toBe(
+      "conflict"
+    )
+  })
+
+  it("retargets a zero-length insertion by unique prefix and suffix anchor", () => {
+    const original = "Alpha beta"
+    const anchor = buildInsertionAnchor(original, 5)
+    const proposal = makeInsertionProposal({
+      start: 5,
+      end: 5,
+      beforeText: "",
+      replacementText: " brave",
+      anchor
+    })
+    expect(planRevisionApply("Intro. Alpha beta", proposal)).toEqual({
+      type: "retarget",
+      start: 12,
+      end: 12,
+      nextText: "Intro. Alpha brave beta"
+    })
+  })
+
+  it("conflicts when an insert proposal has a non-zero target", () => {
+    const proposal = makeInsertionProposal({
+      start: 0,
+      end: 5,
+      beforeText: "Alpha",
+      replacementText: " brave",
+      anchor: buildInsertionAnchor("Alpha beta", 0)
+    })
+    expect(planRevisionApply("Alpha beta", proposal)).toMatchObject({
+      type: "conflict",
+      reason: expect.stringContaining("Insert")
+    })
+  })
+
+  it("does not treat empty beforeText as a safe insertion match after drift", () => {
+    const proposal = makeInsertionProposal({
+      start: 5,
+      end: 5,
+      beforeText: "",
+      replacementText: " brave",
+      anchor: {
+        documentFingerprint: createDocumentFingerprint("Alpha beta"),
+        prefix: "Alpha",
+        suffix: " beta"
+      }
+    })
+    expect(planRevisionApply("Completely different", proposal).type).toBe(
+      "conflict"
+    )
+  })
+
+  it("targets the whole document for advisory outline requests", () => {
+    const text = "First paragraph.\n\nSecond paragraph."
+    const target = resolveRevisionTarget({
+      text,
+      action: "outline",
+      operation: "advisory",
+      cursor: 3
+    })
+    expect(target).toMatchObject({
+      mode: "document",
+      start: 0,
+      end: text.length,
+      requiresConfirmation: false
+    })
+  })
+
+  it("conflicts when a text-changing target still requires confirmation", () => {
+    const text = "First paragraph.\n\nSecond paragraph."
+    const target = resolveRevisionTarget({
+      text,
+      action: "rewrite",
+      operation: "replace",
+      cursor: 3,
+      preferredTargetMode: "document"
+    })
+    const proposal = {
+      ...makeReplacementProposal({
+        start: target.start,
+        end: target.end,
+        beforeText: target.beforeText,
+        replacementText: "Updated document.",
+        documentText: text
+      }),
+      target
+    }
+    expect(planRevisionApply(text, proposal)).toMatchObject({
+      type: "conflict"
+    })
+  })
+
+  it("requires confirmation before large text-changing document targets", () => {
+    const target = resolveRevisionTarget({
+      text: "First paragraph.\n\nSecond paragraph.",
+      action: "rewrite",
+      operation: "replace",
+      cursor: 3,
+      preferredTargetMode: "document"
+    })
+    expect(target).toMatchObject({
+      mode: "document",
+      requiresConfirmation: true
+    })
+  })
+
+  it("allows apply after a whole-document text-changing target is confirmed", () => {
+    const target = resolveRevisionTarget({
+      text: "First paragraph.\n\nSecond paragraph.",
+      action: "rewrite",
+      operation: "replace",
+      cursor: 3,
+      preferredTargetMode: "document"
+    })
+    const confirmed = confirmRevisionTarget(target)
+    expect(confirmed.requiresConfirmation).toBe(false)
+    expect(confirmed.confirmationReason).toBeUndefined()
+  })
+
+  it("surfaces the resolved target for custom requests before generation", () => {
+    const target = resolveRevisionTarget({
+      text: "First paragraph.\n\nSecond paragraph.",
+      action: "custom",
+      operation: "replace",
+      cursor: 20
+    })
+    expect(target.mode).toBe("paragraph")
+    expect(target.label).toContain("paragraph")
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts
@@ -2,9 +2,16 @@ import type { JSONContent } from "@tiptap/react"
 import { describe, expect, it } from "vitest"
 import {
   DEFAULT_SETTINGS,
+  getRevisionPayloadSignature,
+  getRevisionPresetIdFromPayload,
+  getRevisionsFromPayload,
   getPromptRichFromPayload,
-  mergePayloadIntoSession
+  mergePendingPayloadIntoSession,
+  mergeRevisionsIntoPayload,
+  mergePayloadIntoSession,
+  shouldClearPendingSessionSave
 } from "../hooks/utils"
+import type { WritingRevisionProposal } from "../writing-revision-types"
 
 const RICH_DOC: JSONContent = {
   type: "doc",
@@ -15,6 +22,35 @@ const RICH_DOC: JSONContent = {
     }
   ]
 }
+
+const buildRevision = (
+  overrides: Partial<WritingRevisionProposal> = {}
+): WritingRevisionProposal => ({
+  id: "revision-1",
+  sessionId: "session-1",
+  action: "rewrite",
+  operation: "replace",
+  presetId: "polish_prose",
+  presetInstruction: "Polish without changing meaning.",
+  instruction: "Make this clearer.",
+  target: {
+    mode: "selection",
+    start: 0,
+    end: 11,
+    beforeText: "Hello world",
+    anchor: {
+      documentFingerprint: "fingerprint-1",
+      prefix: "",
+      suffix: ""
+    },
+    label: "Selection",
+    requiresConfirmation: false
+  },
+  replacementText: "Hello there",
+  createdAt: "2026-05-22T12:00:00.000Z",
+  status: "pending",
+  ...overrides
+})
 
 describe("writing session payload utils", () => {
   it("stores prompt_rich when rich content is supplied", () => {
@@ -43,5 +79,194 @@ describe("writing session payload utils", () => {
 
   it("returns null for malformed prompt_rich payloads", () => {
     expect(getPromptRichFromPayload({ prompt_rich: "bad" })).toBeNull()
+  })
+
+  it("preserves prompt and settings when merging revisions into the payload", () => {
+    const revision = buildRevision()
+    const payload = mergeRevisionsIntoPayload(
+      {
+        prompt: "Existing draft",
+        settings: DEFAULT_SETTINGS,
+        template_name: "story",
+        chat_mode: false
+      },
+      [revision]
+    )
+
+    expect(payload.prompt).toBe("Existing draft")
+    expect(payload.settings).toBe(DEFAULT_SETTINGS)
+    expect(payload.revisions?.items).toEqual([revision])
+  })
+
+  it("stores revisions as a schema-versioned object instead of a bare array", () => {
+    const revision = buildRevision()
+    const payload = mergeRevisionsIntoPayload({}, [revision])
+
+    expect(payload.revisions).toEqual({
+      schemaVersion: 1,
+      items: [revision]
+    })
+    expect(Array.isArray(payload.revisions)).toBe(false)
+  })
+
+  it("ignores malformed revisions in session payloads", () => {
+    const revision = buildRevision()
+
+    expect(getRevisionsFromPayload({ revisions: [revision] })).toEqual([])
+    expect(
+      getRevisionsFromPayload({
+        revisions: { schemaVersion: 2, items: [revision] }
+      })
+    ).toEqual([])
+    expect(
+      getRevisionsFromPayload({
+        revisions: { schemaVersion: 1, items: "bad" }
+      })
+    ).toEqual([])
+    expect(
+      getRevisionsFromPayload({
+        revisions: {
+          schemaVersion: 1,
+          items: [revision, { ...revision, target: null }]
+        }
+      })
+    ).toEqual([revision])
+  })
+
+  it("ignores revisions with malformed target offsets", () => {
+    const target = buildRevision().target
+    const malformedTargets = [
+      { ...target, start: -1, end: 11 },
+      { ...target, start: 0.5, end: 11 },
+      { ...target, start: 0, end: 10.5 },
+      { ...target, start: 11, end: 0 }
+    ]
+
+    for (const malformedTarget of malformedTargets) {
+      expect(
+        getRevisionsFromPayload({
+          revisions: {
+            schemaVersion: 1,
+            items: [buildRevision({ target: malformedTarget })]
+          }
+        })
+      ).toEqual([])
+    }
+  })
+
+  it("preserves a known revision workflow preset id and rejects unknown ids", () => {
+    const payload = mergePayloadIntoSession(
+      { revision_preset_id: "preserve_voice" },
+      "Draft",
+      DEFAULT_SETTINGS,
+      null,
+      null,
+      false
+    )
+
+    expect(getRevisionPresetIdFromPayload(payload)).toBe("preserve_voice")
+    expect(
+      getRevisionPresetIdFromPayload({ revision_preset_id: "unknown_preset" })
+    ).toBeNull()
+  })
+
+  it("changes revision payload signatures when proposal status changes", () => {
+    const pendingSignature = getRevisionPayloadSignature({
+      revisions: { schemaVersion: 1, items: [buildRevision({ status: "pending" })] }
+    })
+    const appliedSignature = getRevisionPayloadSignature({
+      revisions: { schemaVersion: 1, items: [buildRevision({ status: "applied" })] }
+    })
+
+    expect(pendingSignature).not.toBe(appliedSignature)
+  })
+
+  it("removes the revisions field when all revisions are cleared", () => {
+    const payload = mergeRevisionsIntoPayload(
+      {
+        prompt: "Existing draft",
+        revisions: { schemaVersion: 1, items: [buildRevision()] }
+      },
+      []
+    )
+
+    expect(payload.prompt).toBe("Existing draft")
+    expect(payload).not.toHaveProperty("revisions")
+    expect(getRevisionsFromPayload(payload)).toEqual([])
+  })
+
+  it("uses pending payload state when merging prompt edits into a session payload", () => {
+    const revision = buildRevision()
+    const activePayload = {
+      prompt: "Server draft",
+      settings: DEFAULT_SETTINGS,
+      template_name: null,
+      theme_name: null,
+      chat_mode: false
+    }
+    const pendingPayload = mergeRevisionsIntoPayload(activePayload, [revision])
+
+    const payload = mergePendingPayloadIntoSession(
+      activePayload,
+      pendingPayload,
+      "Typed draft",
+      DEFAULT_SETTINGS,
+      null,
+      null,
+      false,
+      { promptRich: null }
+    )
+
+    expect(payload.prompt).toBe("Typed draft")
+    expect(payload.revisions?.items).toEqual([revision])
+  })
+
+  it("does not clear a revision-only pending payload when editor fields are clean", () => {
+    const activePayload = {
+      prompt: "Server draft",
+      settings: DEFAULT_SETTINGS,
+      template_name: null,
+      theme_name: null,
+      chat_mode: false
+    }
+    const pendingPayload = mergeRevisionsIntoPayload(activePayload, [buildRevision()])
+    const nextPayload = mergePendingPayloadIntoSession(
+      activePayload,
+      pendingPayload,
+      "Server draft",
+      DEFAULT_SETTINGS,
+      null,
+      null,
+      false
+    )
+
+    expect(
+      shouldClearPendingSessionSave(activePayload, nextPayload, false)
+    ).toBe(false)
+  })
+
+  it("does not clear a preset-id-only pending payload unless the preset id matches", () => {
+    const activePayload = {
+      prompt: "Server draft",
+      settings: DEFAULT_SETTINGS,
+      template_name: null,
+      theme_name: null,
+      chat_mode: false
+    }
+    const pendingPresetPayload = {
+      ...activePayload,
+      revision_preset_id: "preserve_voice"
+    }
+    const savedPresetPayload = {
+      ...activePayload,
+      revision_preset_id: "preserve_voice"
+    }
+
+    expect(
+      shouldClearPendingSessionSave(activePayload, pendingPresetPayload, false)
+    ).toBe(false)
+    expect(
+      shouldClearPendingSessionSave(savedPresetPayload, pendingPresetPayload, false)
+    ).toBe(true)
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingRevisions.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingRevisions.ts
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { planRevisionApply } from "../writing-revision-utils"
+import type { WritingRevisionProposal } from "../writing-revision-types"
+import {
+  getRevisionsFromPayload,
+  getRevisionPayloadSignature,
+  mergeRevisionsIntoPayload,
+  type WritingSessionPayload
+} from "./utils"
+
+type ApplyEditorTextResult =
+  | { applied: true }
+  | { applied: false; reason: string }
+
+type UseWritingRevisionsDeps = {
+  activeSessionId: string | null
+  activeSessionPayload?: Record<string, unknown> | null
+  editorText: string
+  applyEditorText: (nextText: string) => ApplyEditorTextResult
+  applySessionPayloadPatch: (
+    patcher: (payload: WritingSessionPayload) => WritingSessionPayload
+  ) => void
+}
+
+const appendNote = (
+  proposal: WritingRevisionProposal,
+  note: string
+): WritingRevisionProposal => ({
+  ...proposal,
+  notes: [...(proposal.notes ?? []), note]
+})
+
+export function useWritingRevisions(deps: UseWritingRevisionsDeps) {
+  const {
+    activeSessionId,
+    activeSessionPayload,
+    editorText,
+    applyEditorText,
+    applySessionPayloadPatch
+  } = deps
+  const [revisions, setRevisions] = useState<WritingRevisionProposal[]>(() =>
+    getRevisionsFromPayload(activeSessionPayload)
+  )
+  const revisionsRef = useRef(revisions)
+  const activeSessionIdRef = useRef(activeSessionId)
+  const loadedSessionIdRef = useRef(activeSessionId)
+  const revisionPayloadSignatureRef = useRef(
+    getRevisionPayloadSignature(activeSessionPayload)
+  )
+  const revisionListVersionRef = useRef(0)
+
+  activeSessionIdRef.current = activeSessionId
+
+  useEffect(() => {
+    revisionsRef.current = revisions
+  }, [revisions])
+
+  useEffect(() => {
+    const nextRevisions = getRevisionsFromPayload(activeSessionPayload)
+    const nextSignature = getRevisionPayloadSignature(activeSessionPayload)
+    if (
+      loadedSessionIdRef.current === activeSessionId &&
+      revisionPayloadSignatureRef.current === nextSignature
+    ) {
+      return
+    }
+
+    loadedSessionIdRef.current = activeSessionId
+    revisionPayloadSignatureRef.current = nextSignature
+    revisionListVersionRef.current += 1
+    revisionsRef.current = nextRevisions
+    setRevisions(nextRevisions)
+  }, [activeSessionId, activeSessionPayload])
+
+  const persistRevisions = useCallback(
+    (nextRevisions: WritingRevisionProposal[]) => {
+      applySessionPayloadPatch((payload) =>
+        mergeRevisionsIntoPayload(payload, nextRevisions)
+      )
+    },
+    [applySessionPayloadPatch]
+  )
+
+  const updateRevisions = useCallback(
+    (
+      updater: (
+        current: WritingRevisionProposal[]
+      ) => WritingRevisionProposal[]
+    ) => {
+      const nextRevisions = updater(revisionsRef.current)
+      revisionListVersionRef.current += 1
+      revisionPayloadSignatureRef.current = JSON.stringify(nextRevisions)
+      revisionsRef.current = nextRevisions
+      setRevisions(nextRevisions)
+      persistRevisions(nextRevisions)
+    },
+    [persistRevisions]
+  )
+
+  const addRevision = useCallback(
+    (proposal: WritingRevisionProposal) => {
+      updateRevisions((current) => [...current, proposal])
+    },
+    [updateRevisions]
+  )
+
+  const rejectRevision = useCallback(
+    (proposalId: string) => {
+      updateRevisions((current) =>
+        current.map((proposal) =>
+          proposal.id === proposalId
+            ? { ...proposal, status: "rejected" }
+            : proposal
+        )
+      )
+    },
+    [updateRevisions]
+  )
+
+  const applyRevision = useCallback(
+    (proposalId: string) => {
+      const proposal = revisionsRef.current.find(
+        (revision) => revision.id === proposalId
+      )
+      if (!proposal) return
+
+      const plan = planRevisionApply(editorText, proposal)
+      if (plan.type === "apply" || plan.type === "retarget") {
+        const result = applyEditorText(plan.nextText)
+        updateRevisions((current) =>
+          current.map((revision) => {
+            if (revision.id !== proposalId) return revision
+            if (result.applied) {
+              return { ...revision, status: "applied" }
+            }
+            return appendNote(
+              { ...revision, status: "conflict" },
+              `Manual apply required: ${result.reason}`
+            )
+          })
+        )
+        return
+      }
+
+      if (plan.type === "noop" && proposal.operation === "advisory") {
+        updateRevisions((current) =>
+          current.map((revision) =>
+            revision.id === proposalId
+              ? { ...revision, status: "advisory" }
+              : revision
+          )
+        )
+        return
+      }
+
+      updateRevisions((current) =>
+        current.map((revision) =>
+          revision.id === proposalId
+            ? appendNote({ ...revision, status: "conflict" }, plan.reason)
+            : revision
+        )
+      )
+    },
+    [applyEditorText, editorText, updateRevisions]
+  )
+
+  const regenerateRevision = useCallback(
+    async (
+      proposalId: string,
+      createReplacement: (
+        source: WritingRevisionProposal
+      ) => Promise<WritingRevisionProposal>
+    ) => {
+      const source = revisionsRef.current.find(
+        (proposal) => proposal.id === proposalId
+      )
+      if (!source) return
+
+      const regenerationSessionId = activeSessionIdRef.current
+      const regenerationVersion = revisionListVersionRef.current
+      const replacement = await createReplacement(source)
+      if (activeSessionIdRef.current !== regenerationSessionId) return
+
+      const currentSource = revisionsRef.current.find(
+        (proposal) => proposal.id === source.id
+      )
+      if (
+        revisionListVersionRef.current !== regenerationVersion ||
+        currentSource !== source ||
+        currentSource.sessionId !== regenerationSessionId ||
+        currentSource.status !== "pending"
+      ) {
+        return
+      }
+
+      updateRevisions((current) => [
+        ...current.map((proposal) =>
+          proposal.id === source.id
+            ? { ...proposal, status: "rejected" }
+            : proposal
+        ),
+        {
+          ...replacement,
+          regeneratedFromId: source.id,
+          target: source.target,
+          instruction: source.instruction,
+          presetId: source.presetId,
+          presetInstruction: source.presetInstruction,
+          status: "pending"
+        }
+      ])
+    },
+    [updateRevisions]
+  )
+
+  return {
+    revisions,
+    addRevision,
+    rejectRevision,
+    applyRevision,
+    regenerateRevision
+  }
+}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingSessionManagement.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useWritingSessionManagement.ts
@@ -31,9 +31,10 @@ import {
   getTemplateNameFromPayload,
   getThemeNameFromPayload,
   isVersionConflictError,
-  mergePayloadIntoSession,
+  mergePendingPayloadIntoSession,
   normalizeStringArrayValue,
   SAVE_DEBOUNCE_MS,
+  shouldClearPendingSessionSave,
   type PendingSave,
   type SessionUsageMap,
   type WritingSessionPayload,
@@ -686,6 +687,35 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
   }, [])
 
   // --- Prompt/settings change helpers ---
+  const applySessionPayloadPatch = React.useCallback(
+    (patcher: (payload: WritingSessionPayload) => WritingSessionPayload) => {
+      if (!activeSessionDetail) return
+      const basePayload = mergePendingPayloadIntoSession(
+        activeSessionDetail.payload,
+        pendingSaveMapRef.current[activeSessionDetail.id],
+        editorText,
+        settings,
+        selectedTemplateName,
+        selectedThemeName,
+        chatMode,
+        { promptRich: editorPromptRichRef.current }
+      )
+      const nextPayload = patcher(basePayload)
+      pendingSaveMapRef.current[activeSessionDetail.id] = nextPayload
+      setIsDirty(true)
+      scheduleSave(activeSessionDetail.id, nextPayload)
+    },
+    [
+      activeSessionDetail,
+      chatMode,
+      editorText,
+      scheduleSave,
+      selectedTemplateName,
+      selectedThemeName,
+      settings
+    ]
+  )
+
   const applyPromptValue = React.useCallback(
     (
       nextValue: string,
@@ -698,8 +728,9 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
       setEditorText(nextValue)
       editorPromptRichRef.current = promptRich
       if (!activeSessionDetail) return selection
-      const nextPayload = mergePayloadIntoSession(
+      const nextPayload = mergePendingPayloadIntoSession(
         activeSessionDetail.payload,
+        pendingSaveMapRef.current[activeSessionDetail.id],
         nextValue,
         settings,
         selectedTemplateName,
@@ -716,8 +747,13 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
         selectedThemeName,
         chatMode
       )
-      setIsDirty(isDirtyNext)
-      if (!isDirtyNext) {
+      const shouldClearPendingSave = shouldClearPendingSessionSave(
+        activeSessionDetail.payload,
+        nextPayload,
+        isDirtyNext
+      )
+      setIsDirty(!shouldClearPendingSave)
+      if (shouldClearPendingSave) {
         clearPendingSave(activeSessionDetail.id)
       } else {
         scheduleSave(activeSessionDetail.id, nextPayload)
@@ -746,8 +782,9 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
       if (typeof nextStopInput === "string") {
         setStopStringsInput(nextStopInput)
       }
-      const nextPayload = mergePayloadIntoSession(
+      const nextPayload = mergePendingPayloadIntoSession(
         activeSessionDetail.payload,
+        pendingSaveMapRef.current[activeSessionDetail.id],
         editorText,
         nextSettings,
         selectedTemplateName,
@@ -764,8 +801,13 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
         selectedThemeName,
         chatMode
       )
-      setIsDirty(isDirtyNext)
-      if (!isDirtyNext) {
+      const shouldClearPendingSave = shouldClearPendingSessionSave(
+        activeSessionDetail.payload,
+        nextPayload,
+        isDirtyNext
+      )
+      setIsDirty(!shouldClearPendingSave)
+      if (shouldClearPendingSave) {
         clearPendingSave(activeSessionDetail.id)
         return
       }
@@ -795,8 +837,9 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
     (nextTemplateName: string | null) => {
       setSelectedTemplateName(nextTemplateName)
       if (!activeSessionDetail) return
-      const nextPayload = mergePayloadIntoSession(
+      const nextPayload = mergePendingPayloadIntoSession(
         activeSessionDetail.payload,
+        pendingSaveMapRef.current[activeSessionDetail.id],
         editorText,
         settings,
         nextTemplateName,
@@ -813,8 +856,13 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
         selectedThemeName,
         chatMode
       )
-      setIsDirty(isDirtyNext)
-      if (!isDirtyNext) {
+      const shouldClearPendingSave = shouldClearPendingSessionSave(
+        activeSessionDetail.payload,
+        nextPayload,
+        isDirtyNext
+      )
+      setIsDirty(!shouldClearPendingSave)
+      if (shouldClearPendingSave) {
         clearPendingSave(activeSessionDetail.id)
         return
       }
@@ -836,8 +884,9 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
     (nextThemeName: string | null) => {
       setSelectedThemeName(nextThemeName)
       if (!activeSessionDetail) return
-      const nextPayload = mergePayloadIntoSession(
+      const nextPayload = mergePendingPayloadIntoSession(
         activeSessionDetail.payload,
+        pendingSaveMapRef.current[activeSessionDetail.id],
         editorText,
         settings,
         selectedTemplateName,
@@ -854,8 +903,13 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
         nextThemeName,
         chatMode
       )
-      setIsDirty(isDirtyNext)
-      if (!isDirtyNext) {
+      const shouldClearPendingSave = shouldClearPendingSessionSave(
+        activeSessionDetail.payload,
+        nextPayload,
+        isDirtyNext
+      )
+      setIsDirty(!shouldClearPendingSave)
+      if (shouldClearPendingSave) {
         clearPendingSave(activeSessionDetail.id)
         return
       }
@@ -877,8 +931,9 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
     (nextChatMode: boolean) => {
       setChatMode(nextChatMode)
       if (!activeSessionDetail) return
-      const nextPayload = mergePayloadIntoSession(
+      const nextPayload = mergePendingPayloadIntoSession(
         activeSessionDetail.payload,
+        pendingSaveMapRef.current[activeSessionDetail.id],
         editorText,
         settings,
         selectedTemplateName,
@@ -895,8 +950,13 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
         selectedThemeName,
         nextChatMode
       )
-      setIsDirty(isDirtyNext)
-      if (!isDirtyNext) {
+      const shouldClearPendingSave = shouldClearPendingSessionSave(
+        activeSessionDetail.payload,
+        nextPayload,
+        isDirtyNext
+      )
+      setIsDirty(!shouldClearPendingSave)
+      if (shouldClearPendingSave) {
         clearPendingSave(activeSessionDetail.id)
         return
       }
@@ -966,6 +1026,7 @@ export function useWritingSessionManagement(deps: UseWritingSessionManagementDep
     handleTemplateChange,
     handleThemeChange,
     handleChatModeChange,
+    applySessionPayloadPatch,
     scheduleSave,
     clearPendingSave,
     computeDirty,

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/utils.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/utils.ts
@@ -16,6 +16,14 @@ import {
   type WritingWorldInfoEntry,
   type WritingWorldInfoSettings
 } from "../writing-context-utils"
+import type {
+  WritingRevisionAction,
+  WritingRevisionOperation,
+  WritingRevisionPayload,
+  WritingRevisionPresetId,
+  WritingRevisionProposal,
+  WritingRevisionStatus
+} from "../writing-revision-types"
 import type { BasicStoppingModeType } from "../writing-stop-mode-utils"
 
 // ---------------------------------------------------------------------------
@@ -32,6 +40,8 @@ export type SessionUsageMap = Record<string, SessionUsage>
 export type WritingSessionPayload = Record<string, unknown> & {
   prompt?: string
   prompt_rich?: JSONContent
+  revisions?: WritingRevisionPayload
+  revision_preset_id?: WritingRevisionPresetId | null
   settings?: WritingSessionSettings
   template_name?: string | null
   templateName?: string | null
@@ -143,6 +153,7 @@ export type NonToolMessage = Extract<ChatMessage, { role: NonToolRole }>
 // ---------------------------------------------------------------------------
 
 export const WRITING_SPEECH_PREFS_STORAGE_KEY = "writing:speech-preferences"
+export const WRITING_REVISION_PAYLOAD_SCHEMA_VERSION = 1
 export const SAVE_DEBOUNCE_MS = 800
 export const MAX_MATCHES = 500
 export const MAX_CHUNKS = 80
@@ -154,6 +165,47 @@ export const WORDCLOUD_POLL_DELAY_MS = 600
 
 export const PREDICT_PLACEHOLDER = "{predict}"
 export const FILL_PLACEHOLDER = "{fill}"
+
+const WRITING_REVISION_PRESET_IDS: readonly WritingRevisionPresetId[] = [
+  "draft_freely",
+  "polish_prose",
+  "developmental_edit",
+  "preserve_voice",
+  "make_concise",
+  "expand_sensory_detail"
+]
+
+const WRITING_REVISION_ACTIONS: readonly WritingRevisionAction[] = [
+  "continue",
+  "rewrite",
+  "expand",
+  "tighten",
+  "tone",
+  "outline",
+  "custom"
+]
+
+const WRITING_REVISION_OPERATIONS: readonly WritingRevisionOperation[] = [
+  "insert",
+  "replace",
+  "advisory"
+]
+
+const WRITING_REVISION_STATUSES: readonly WritingRevisionStatus[] = [
+  "pending",
+  "applied",
+  "rejected",
+  "conflict",
+  "raw_suggestion",
+  "advisory"
+]
+
+const WRITING_REVISION_TARGET_MODES = [
+  "selection",
+  "paragraph",
+  "cursor",
+  "document"
+] as const
 
 export const PREDICT_SYSTEM_PROMPT =
   "Continue the text from the prompt. Respond with only the continuation."
@@ -322,6 +374,78 @@ export const cloneDefaultSettings = (): WritingSessionSettings => ({
 
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isOneOf = <T extends string>(
+  value: unknown,
+  allowed: readonly T[]
+): value is T => typeof value === "string" && allowed.includes(value as T)
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string"
+
+const isOptionalNullableString = (
+  value: unknown
+): value is string | null | undefined =>
+  value == null || typeof value === "string"
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string")
+
+const isWritingRevisionPresetId = (
+  value: unknown
+): value is WritingRevisionPresetId =>
+  isOneOf(value, WRITING_REVISION_PRESET_IDS)
+
+const isWritingRevisionAnchor = (
+  value: unknown
+): value is WritingRevisionProposal["target"]["anchor"] =>
+  isRecord(value) &&
+  typeof value.documentFingerprint === "string" &&
+  typeof value.prefix === "string" &&
+  typeof value.suffix === "string"
+
+const isWritingRevisionTarget = (
+  value: unknown
+): value is WritingRevisionProposal["target"] =>
+  isRecord(value) &&
+  isOneOf(value.mode, WRITING_REVISION_TARGET_MODES) &&
+  typeof value.start === "number" &&
+  Number.isFinite(value.start) &&
+  Number.isInteger(value.start) &&
+  value.start >= 0 &&
+  typeof value.end === "number" &&
+  Number.isFinite(value.end) &&
+  Number.isInteger(value.end) &&
+  value.end >= value.start &&
+  typeof value.beforeText === "string" &&
+  isWritingRevisionAnchor(value.anchor) &&
+  typeof value.label === "string" &&
+  typeof value.requiresConfirmation === "boolean" &&
+  isOptionalString(value.confirmationReason)
+
+const isWritingRevisionProposal = (
+  value: unknown
+): value is WritingRevisionProposal => {
+  if (!isRecord(value)) return false
+  if (typeof value.id !== "string") return false
+  if (typeof value.sessionId !== "string") return false
+  if (!isOneOf(value.action, WRITING_REVISION_ACTIONS)) return false
+  if (!isOneOf(value.operation, WRITING_REVISION_OPERATIONS)) return false
+  if (!isOptionalNullableString(value.presetInstruction)) return false
+  if (value.presetId != null && !isWritingRevisionPresetId(value.presetId)) {
+    return false
+  }
+  if (typeof value.instruction !== "string") return false
+  if (!isWritingRevisionTarget(value.target)) return false
+  if (!isOptionalString(value.replacementText)) return false
+  if (!isOptionalString(value.rawText)) return false
+  if (!isOptionalString(value.rationale)) return false
+  if (!isOptionalString(value.title)) return false
+  if (value.notes !== undefined && !isStringArray(value.notes)) return false
+  if (!isOptionalString(value.regeneratedFromId)) return false
+  if (typeof value.createdAt !== "string") return false
+  return isOneOf(value.status, WRITING_REVISION_STATUSES)
+}
 
 export const buildRegex = (
   pattern: string,
@@ -990,6 +1114,47 @@ export const getChatModeFromPayload = (
   return Boolean(raw)
 }
 
+export const getRevisionsFromPayload = (
+  payload?: Record<string, unknown> | null
+): WritingRevisionProposal[] => {
+  if (!isRecord(payload) || !isRecord(payload.revisions)) return []
+  if (
+    payload.revisions.schemaVersion !== WRITING_REVISION_PAYLOAD_SCHEMA_VERSION
+  ) {
+    return []
+  }
+  if (!Array.isArray(payload.revisions.items)) return []
+  return payload.revisions.items.filter(isWritingRevisionProposal)
+}
+
+export const mergeRevisionsIntoPayload = (
+  payload: Record<string, unknown> | null | undefined,
+  revisions: WritingRevisionProposal[]
+): WritingSessionPayload => {
+  const base = isRecord(payload) ? payload : {}
+  const next: WritingSessionPayload = { ...base }
+  if (revisions.length > 0) {
+    next.revisions = {
+      schemaVersion: WRITING_REVISION_PAYLOAD_SCHEMA_VERSION,
+      items: revisions
+    }
+  } else {
+    delete next.revisions
+  }
+  return next
+}
+
+export const getRevisionPayloadSignature = (
+  payload?: Record<string, unknown> | null
+): string => JSON.stringify(getRevisionsFromPayload(payload))
+
+export const getRevisionPresetIdFromPayload = (
+  payload?: Record<string, unknown> | null
+): WritingRevisionPresetId | null => {
+  const value = isRecord(payload) ? payload.revision_preset_id : null
+  return isWritingRevisionPresetId(value) ? value : null
+}
+
 export const mergePayloadIntoSession = (
   payload: Record<string, unknown> | null | undefined,
   prompt: string,
@@ -1016,6 +1181,42 @@ export const mergePayloadIntoSession = (
     }
   }
   return next
+}
+
+export const mergePendingPayloadIntoSession = (
+  payload: Record<string, unknown> | null | undefined,
+  pendingPayload: Record<string, unknown> | null | undefined,
+  prompt: string,
+  settings: WritingSessionSettings,
+  templateName: string | null,
+  themeName: string | null,
+  chatMode: boolean,
+  options?: { promptRich?: JSONContent | null }
+): WritingSessionPayload =>
+  mergePayloadIntoSession(
+    isRecord(pendingPayload) ? pendingPayload : payload,
+    prompt,
+    settings,
+    templateName,
+    themeName,
+    chatMode,
+    options
+  )
+
+export const shouldClearPendingSessionSave = (
+  savedPayload: Record<string, unknown> | null | undefined,
+  pendingPayload: Record<string, unknown> | null | undefined,
+  hasCurrentFieldChanges: boolean
+): boolean => {
+  if (hasCurrentFieldChanges) return false
+  if (!isRecord(pendingPayload)) return true
+  return (
+    getRevisionPayloadSignature(savedPayload) === getRevisionPayloadSignature(
+      pendingPayload
+    ) &&
+    getRevisionPresetIdFromPayload(savedPayload) ===
+      getRevisionPresetIdFromPayload(pendingPayload)
+  )
 }
 
 export const areSettingsEqual = (

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -104,6 +104,31 @@ import { WritingAnalysisModalHost } from "./WritingAnalysisModalHost"
 import { WritingPlaygroundDiagnosticsPanel } from "./WritingPlaygroundDiagnosticsPanel"
 import { WritingWorldInfoImportControls } from "./WritingWorldInfoImportControls"
 import {
+  WritingActionBar,
+  type WritingActionBarRequest
+} from "./WritingActionBar"
+import { WritingRevisionQueue } from "./WritingRevisionQueue"
+import {
+  WRITING_REVISION_PRESETS,
+  getWritingRevisionPreset
+} from "./writing-revision-presets"
+import {
+  buildRevisionUserPrompt,
+  parseRevisionModelResponse
+} from "./writing-revision-prompt-utils"
+import {
+  confirmRevisionTarget,
+  countWords,
+  resolveRevisionTarget
+} from "./writing-revision-utils"
+import type {
+  WritingRevisionAction,
+  WritingRevisionOperation,
+  WritingRevisionPresetId,
+  WritingRevisionProposal,
+  WritingRevisionTarget
+} from "./writing-revision-types"
+import {
   buildSpeechVoiceOptions,
   clampSpeechRate,
   resolvePauseResumeAction,
@@ -131,6 +156,7 @@ import {
   useWritingImportExport,
   useWritingFeedback
 } from "./hooks"
+import { useWritingRevisions } from "./hooks/useWritingRevisions"
 import {
   ADVANCED_NUMBER_PARAMS,
   buildChatMessages,
@@ -152,14 +178,30 @@ import {
   resolveGenerationPlan,
   applyFimTemplate,
   getPromptRichFromPayload,
+  getRevisionPresetIdFromPayload,
   WRITING_SPEECH_PREFS_STORAGE_KEY,
   type EditorViewMode,
   type GenerationHistoryEntry,
   type LastGenerationContext,
+  type NonToolMessage,
   type SessionUsageMap
 } from "./hooks/utils"
 
 const { Paragraph } = Typography
+
+const SECRET_FIELD_PATTERN =
+  /(api[_-]?key|authorization|auth[_-]?token|secret|password|token)/i
+
+const sanitizeRevisionValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sanitizeRevisionValue)
+  if (!value || typeof value !== "object") return value
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !SECRET_FIELD_PATTERN.test(key))
+      .map(([key, entryValue]) => [key, sanitizeRevisionValue(entryValue)])
+  )
+}
 
 const LazyWritingPlaygroundModalHost = React.lazy(() =>
   import("./WritingPlaygroundModalHost").then((module) => ({
@@ -218,6 +260,7 @@ export const WritingPlayground = () => {
   const [useRegex, setUseRegex] = React.useState(false)
   const [activeMatchIndex, setActiveMatchIndex] = React.useState(0)
   const [isGenerating, setIsGenerating] = React.useState(false)
+  const [isRevisionGenerating, setIsRevisionGenerating] = React.useState(false)
   const [canUndoGeneration, setCanUndoGeneration] = React.useState(false)
   const [canRedoGeneration, setCanRedoGeneration] = React.useState(false)
   const [isSpeaking, setIsSpeaking] = React.useState(false)
@@ -236,6 +279,12 @@ export const WritingPlayground = () => {
   const [extraBodyJsonModalOpen, setExtraBodyJsonModalOpen] = React.useState(false)
   const [extraBodyJsonDraft, setExtraBodyJsonDraft] = React.useState("{}")
   const [extraBodyJsonError, setExtraBodyJsonError] = React.useState<string | null>(null)
+  const [selectedRevisionPresetId, setSelectedRevisionPresetId] =
+    React.useState<WritingRevisionPresetId>(
+      WRITING_REVISION_PRESETS[0]?.id ?? "polish_prose"
+    )
+  const [revisionSelection, setRevisionSelection] =
+    React.useState<WritingEditorSelection | null>(null)
 
   // --- Refs (local only) ---
   const generationServiceRef = React.useRef(new TldwChatService())
@@ -269,6 +318,7 @@ export const WritingPlayground = () => {
   const hasServerDefaultsCatalog = Boolean(writingCaps?.server?.defaults_catalog)
   const hasSnapshots = Boolean(writingCaps?.server?.snapshots)
   const hasChat = capabilities?.hasChat !== false
+  const isWritingRequestBusy = isGenerating || isRevisionGenerating
 
   // =====================================================================
   // Hook 1: Session Management
@@ -277,7 +327,7 @@ export const WritingPlayground = () => {
     isOnline, hasWriting, activeSessionId, activeSessionName,
     setActiveSessionId, setActiveSessionName, sessionUsageMap, setSessionUsageMap,
     selectedModel, setSelectedModel, apiProviderOverride, setApiProvider,
-    isGenerating, t
+    isGenerating: isWritingRequestBusy, t
   })
   const {
     sessions, sessionsLoading, sessionsFetching, sessionsError,
@@ -307,6 +357,7 @@ export const WritingPlayground = () => {
     handleSelectSession, openRenameModal,
     applyPromptValue, updateSetting,
     handleTemplateChange, handleThemeChange, handleChatModeChange,
+    applySessionPayloadPatch,
     canCreateSession, canRenameSession
   } = sessionMgmt
 
@@ -332,12 +383,28 @@ export const WritingPlayground = () => {
     [textareaEditorAdapter]
   )
 
+  const updateRevisionSelection = React.useCallback(
+    (selection: WritingEditorSelection | null) => {
+      setRevisionSelection((current) => {
+        if (
+          current?.start === selection?.start &&
+          current?.end === selection?.end
+        ) {
+          return current
+        }
+        return selection
+      })
+    },
+    []
+  )
+
   const setActiveEditorAdapter = React.useCallback(
     (adapter: WritingEditorAdapter | null) => {
       activeEditorAdapterRef.current = adapter
       applyPendingEditorSelection(adapter)
+      updateRevisionSelection(adapter?.getSelection() ?? null)
     },
-    [applyPendingEditorSelection]
+    [applyPendingEditorSelection, updateRevisionSelection]
   )
 
   // Sync TipTap content when editorText changes from an external source (e.g. session load, undo/redo, generate)
@@ -372,7 +439,21 @@ export const WritingPlayground = () => {
     applyPendingEditorSelection(activeEditorAdapterRef.current)
   }, [applyPendingEditorSelection, editorMode, editorView])
 
-  const settingsDisabled = isGenerating || !activeSessionDetail
+  const settingsDisabled =
+    isGenerating || isRevisionGenerating || !activeSessionDetail
+
+  React.useEffect(() => {
+    const persistedPresetId = getRevisionPresetIdFromPayload(
+      activeSessionDetail?.payload
+    )
+    setSelectedRevisionPresetId(
+      persistedPresetId ?? WRITING_REVISION_PRESETS[0]?.id ?? "polish_prose"
+    )
+  }, [activeSessionDetail?.id, activeSessionDetail?.payload])
+
+  React.useEffect(() => {
+    setRevisionSelection(null)
+  }, [activeSessionDetail?.id, editorMode])
 
   // =====================================================================
   // Hook 2: Template Library
@@ -604,7 +685,7 @@ export const WritingPlayground = () => {
   // =====================================================================
   const handleGenerate = React.useCallback(
     async (overrideText?: string) => {
-    if (isGenerating) return
+    if (isGenerating || isRevisionGenerating) return
     if (!activeSessionDetail) {
       message.info(
         t("option:writingPlayground.selectSession", "Select a session to begin.")
@@ -803,6 +884,7 @@ export const WritingPlayground = () => {
       effectiveTemplate,
       hasChat,
       isGenerating,
+      isRevisionGenerating,
       isOnline,
       selectedModel,
       settings,
@@ -988,6 +1070,12 @@ export const WritingPlayground = () => {
     [applyPendingEditorSelection, editorView, getCurrentEditorAdapter]
   )
 
+  const refreshRevisionSelection = React.useCallback(() => {
+    const selection = getCurrentEditorAdapter()?.getSelection() ?? null
+    updateRevisionSelection(selection)
+    return selection
+  }, [getCurrentEditorAdapter, updateRevisionSelection])
+
   const syncScroll = React.useCallback((source: "editor" | "preview") => {
     if (editorView !== "split") return
     if (isSyncingScrollRef.current) return
@@ -1125,6 +1213,393 @@ export const WritingPlayground = () => {
     [activeSessionDetail, applyPromptValue]
   )
 
+  const applyRevisionEditorText = React.useCallback(
+    (nextText: string): { applied: true } | { applied: false; reason: string } => {
+      if (editorMode === "tiptap") {
+        return {
+          applied: false,
+          reason:
+            "Rich editor manual apply is required because plain-text replacement does not preserve rich structure."
+        }
+      }
+      applyHistoryText(nextText)
+      pushGenerationHistory(editorText, nextText)
+      return { applied: true }
+    },
+    [applyHistoryText, editorMode, editorText, pushGenerationHistory]
+  )
+
+  const revisionState = useWritingRevisions({
+    activeSessionId,
+    activeSessionPayload: activeSessionDetail?.payload,
+    editorText,
+    applyEditorText: applyRevisionEditorText,
+    applySessionPayloadPatch
+  })
+
+  const buildRevisionGenerationSettingsSummary = React.useCallback(
+    (): Record<string, unknown> => ({
+      temperature: settings.temperature,
+      topP: settings.top_p,
+      topK: settings.top_k,
+      maxTokens: settings.max_tokens,
+      presencePenalty: settings.presence_penalty,
+      frequencyPenalty: settings.frequency_penalty,
+      seed: settings.seed,
+      stop: settings.stop,
+      logprobs: settings.logprobs,
+      topLogprobs: settings.top_logprobs,
+      tokenStreaming: false,
+      useBasicStoppingMode: settings.use_basic_stopping_mode,
+      basicStoppingModeType: settings.basic_stopping_mode_type,
+      contextLength: settings.context_length,
+      authorNoteDepthMode: settings.author_note_depth_mode,
+      advancedExtraBody: sanitizeRevisionValue(settings.advanced_extra_body)
+    }),
+    [settings]
+  )
+
+  const buildRevisionContext = React.useCallback(
+    (documentText: string) => {
+      const contextSettings = {
+        memory_block: settings.memory_block,
+        author_note: settings.author_note,
+        world_info: settings.world_info,
+        context_order: settings.context_order,
+        context_length: settings.context_length,
+        author_note_depth_mode: settings.author_note_depth_mode
+      }
+      return {
+        selectedTemplateName,
+        selectedThemeName,
+        chatMode,
+        contextComposedPrompt: chatMode
+          ? null
+          : composeContextPrompt(documentText, contextSettings),
+        contextMessages: chatMode
+          ? buildContextSystemMessages(documentText, contextSettings)
+          : null,
+        memoryBlock,
+        authorNote,
+        worldInfoEntries,
+        provider: apiProviderOverride ?? null,
+        model: selectedModel ?? null,
+        generationSettingsSummary: buildRevisionGenerationSettingsSummary()
+      }
+    },
+    [
+      apiProviderOverride,
+      authorNote,
+      buildRevisionGenerationSettingsSummary,
+      chatMode,
+      memoryBlock,
+      selectedModel,
+      selectedTemplateName,
+      selectedThemeName,
+      settings,
+      worldInfoEntries
+    ]
+  )
+
+  const buildRevisionRequestOptions = React.useCallback(() => {
+    const stopStrings = resolveGenerationStopStrings({
+      useBasicMode: settings.use_basic_stopping_mode,
+      basicModeType: settings.basic_stopping_mode_type,
+      customStopStrings: settings.stop
+    })
+    const genAdvancedExtraBody =
+      supportsAdvancedCompat
+        ? settings.advanced_extra_body
+        : {}
+    return {
+      model: selectedModel,
+      temperature: settings.temperature,
+      maxTokens: settings.max_tokens,
+      topP: settings.top_p,
+      frequencyPenalty: settings.frequency_penalty,
+      presencePenalty: settings.presence_penalty,
+      logprobs: false,
+      topLogprobs: undefined,
+      systemPrompt:
+        "Return only the requested JSON object for the writing revision.",
+      extraBody: buildExtraBodyPayload({
+        top_k: settings.top_k,
+        seed: settings.seed,
+        stop: stopStrings,
+        advanced_extra_body: genAdvancedExtraBody
+      })
+    }
+  }, [selectedModel, settings, supportsAdvancedCompat])
+
+  const persistRevisionPreset = React.useCallback(
+    (presetId: WritingRevisionPresetId | null | undefined) => {
+      if (!presetId) return
+      setSelectedRevisionPresetId(presetId)
+      applySessionPayloadPatch((payload) => ({
+        ...payload,
+        revision_preset_id: presetId
+      }))
+    },
+    [applySessionPayloadPatch]
+  )
+
+  const createRevisionProposal = React.useCallback(
+    async (input: {
+      action: WritingRevisionAction
+      operation: WritingRevisionOperation
+      instruction: string
+      target: WritingRevisionTarget
+      presetId?: WritingRevisionPresetId | null
+      presetInstruction?: string | null
+    }): Promise<WritingRevisionProposal | null> => {
+      if (!activeSessionDetail) {
+        message.info(
+          t("option:writingPlayground.selectSession", "Select a session to begin.")
+        )
+        return null
+      }
+      if (!isOnline || !hasChat) {
+        message.error(
+          t("option:writingPlayground.generateUnavailable", "Chat completions unavailable.")
+        )
+        return null
+      }
+      if (!selectedModel) {
+        message.info(
+          t("option:writingPlayground.modelMissing", "Select a model in Settings to generate.")
+        )
+        return null
+      }
+
+      const userPrompt = buildRevisionUserPrompt({
+        action: input.action,
+        operation: input.operation,
+        instruction: input.instruction,
+        documentText: editorText,
+        target: input.target,
+        presetInstruction: input.presetInstruction,
+        writingContext: buildRevisionContext(editorText)
+      })
+      const messages: NonToolMessage[] = [
+        {
+          role: "user",
+          content: userPrompt
+        }
+      ]
+      const responseText = await generationServiceRef.current.sendMessage(
+        messages,
+        buildRevisionRequestOptions()
+      )
+      return parseRevisionModelResponse({
+        responseText,
+        sessionId: activeSessionDetail.id,
+        action: input.action,
+        operation: input.operation,
+        instruction: input.instruction,
+        target: input.target,
+        presetId: input.presetId,
+        presetInstruction: input.presetInstruction
+      })
+    },
+    [
+      activeSessionDetail,
+      buildRevisionContext,
+      buildRevisionRequestOptions,
+      editorText,
+      hasChat,
+      isOnline,
+      selectedModel,
+      t
+    ]
+  )
+
+  const resolveFreshRevisionTarget = React.useCallback(
+    (request: WritingActionBarRequest): WritingRevisionTarget | null => {
+      const adapterSelection = refreshRevisionSelection()
+      const freshTarget = resolveRevisionTarget({
+        text: editorText,
+        action: request.action,
+        operation: request.operation,
+        selection: adapterSelection,
+        cursor: adapterSelection?.end ?? editorText.length,
+        preferredTargetMode:
+          request.target.requiresConfirmation &&
+          request.target.mode === "document"
+            ? "document"
+            : null
+      })
+
+      if (!freshTarget.requiresConfirmation) return freshTarget
+      if (
+        request.target.requiresConfirmation &&
+        request.target.mode === freshTarget.mode
+      ) {
+        return confirmRevisionTarget(freshTarget)
+      }
+
+      message.warning(
+        freshTarget.confirmationReason ??
+          t(
+            "option:writingPlayground.revisionConfirmBroadTarget",
+            "Confirm before applying a broad text-changing request."
+          )
+      )
+      return null
+    },
+    [editorText, refreshRevisionSelection, t]
+  )
+
+  const handleRevisionRequest = React.useCallback(
+    async (request: WritingActionBarRequest) => {
+      if (isGenerating || isRevisionGenerating) return
+      const target = resolveFreshRevisionTarget(request)
+      if (!target) return
+
+      persistRevisionPreset(request.presetId)
+      setIsRevisionGenerating(true)
+      try {
+        const proposal = await createRevisionProposal({
+          action: request.action,
+          operation: request.operation,
+          instruction: request.instruction,
+          target,
+          presetId: request.presetId,
+          presetInstruction: request.presetInstruction
+        })
+        if (proposal) {
+          revisionState.addRevision(proposal)
+        }
+      } catch (error) {
+        const detail =
+          error instanceof Error
+            ? error.message
+            : t("option:error", "Error")
+        message.error(
+          t("option:writingPlayground.generateError", "Generation failed: {{detail}}", { detail })
+        )
+      } finally {
+        setIsRevisionGenerating(false)
+      }
+    },
+    [
+      createRevisionProposal,
+      isGenerating,
+      isRevisionGenerating,
+      persistRevisionPreset,
+      resolveFreshRevisionTarget,
+      revisionState,
+      t
+    ]
+  )
+
+  const handleRegenerateRevision = React.useCallback(
+    async (proposal: WritingRevisionProposal) => {
+      if (isGenerating || isRevisionGenerating) return
+      setIsRevisionGenerating(true)
+      try {
+        await revisionState.regenerateRevision(proposal.id, async (source) => {
+          const preset =
+            getWritingRevisionPreset(source.presetId) ??
+            getWritingRevisionPreset(selectedRevisionPresetId)
+          const replacement = await createRevisionProposal({
+            action: source.action,
+            operation: source.operation,
+            instruction: source.instruction,
+            target: source.target.requiresConfirmation
+              ? confirmRevisionTarget(source.target)
+              : source.target,
+            presetId: source.presetId ?? preset?.id ?? null,
+            presetInstruction:
+              source.presetInstruction ?? preset?.instruction ?? null
+          })
+          if (!replacement) {
+            throw new Error("Revision regeneration did not return a proposal.")
+          }
+          return {
+            ...replacement,
+            notes: [
+              ...(replacement.notes ?? []),
+              `Regenerated from ${source.id}`
+            ]
+          }
+        })
+      } catch (error) {
+        const detail =
+          error instanceof Error
+            ? error.message
+            : t("option:error", "Error")
+        message.error(
+          t("option:writingPlayground.generateError", "Generation failed: {{detail}}", { detail })
+        )
+      } finally {
+        setIsRevisionGenerating(false)
+      }
+    },
+    [
+      createRevisionProposal,
+      isGenerating,
+      isRevisionGenerating,
+      revisionState,
+      selectedRevisionPresetId,
+      t
+    ]
+  )
+
+  const displayedRevisionTarget = React.useMemo(
+    () =>
+      resolveRevisionTarget({
+        text: editorText,
+        action: "rewrite",
+        operation: "replace",
+        selection: revisionSelection,
+        cursor: revisionSelection?.end ?? 0
+      }),
+    [editorText, revisionSelection]
+  )
+  const writingWordCount = React.useMemo(
+    () => countWords(editorText),
+    [editorText]
+  )
+  const selectedWordCount = React.useMemo(() => {
+    if (!revisionSelection || revisionSelection.start === revisionSelection.end) {
+      return 0
+    }
+    return countWords(
+      editorText.slice(revisionSelection.start, revisionSelection.end)
+    )
+  }, [editorText, revisionSelection])
+  const pendingRevisionCount = React.useMemo(
+    () =>
+      revisionState.revisions.filter((proposal) => proposal.status === "pending")
+        .length,
+    [revisionState.revisions]
+  )
+
+  const handleCopyRevision = React.useCallback(
+    async (proposal: WritingRevisionProposal) => {
+      const copyText =
+        proposal.replacementText ??
+        proposal.rawText ??
+        proposal.rationale ??
+        ""
+      if (!copyText) return
+      try {
+        await navigator.clipboard?.writeText(copyText)
+        message.success(
+          t("option:writingPlayground.revisionCopySuccess", "Revision copied.")
+        )
+      } catch {
+        message.info(
+          t(
+            "option:writingPlayground.revisionCopyManual",
+            "Copy the suggestion from the revision queue."
+          )
+        )
+      }
+    },
+    [t]
+  )
+
   const handleUndoGeneration = React.useCallback(() => {
     if (isGenerating) return
     const entry = generationUndoRef.current.pop()
@@ -1178,6 +1653,7 @@ export const WritingPlayground = () => {
     handleCancelGeneration,
     handleGenerate,
     isGenerating,
+    isRevisionGenerating,
     settings.token_streaming
   ])
 
@@ -1403,9 +1879,12 @@ export const WritingPlayground = () => {
     Boolean(activeSessionDetail) &&
     Boolean(selectedModel) &&
     hasChat &&
-    !isGenerating
+    !isGenerating &&
+    !isRevisionGenerating
   const generateDisabledReason = React.useMemo(() => {
     if (isGenerating) return null
+    if (isRevisionGenerating)
+      return t("option:writingPlayground.disabledRevisionBusy", "Revision request in progress")
     if (!activeSessionDetail)
       return t("option:writingPlayground.disabledNoSession", "Select a session first")
     if (!selectedModel)
@@ -1415,7 +1894,15 @@ export const WritingPlayground = () => {
     if (!hasChat)
       return t("option:writingPlayground.disabledNoChat", "Chat completions unavailable")
     return null
-  }, [activeSessionDetail, hasChat, isGenerating, isOnline, selectedModel, t])
+  }, [
+    activeSessionDetail,
+    hasChat,
+    isGenerating,
+    isOnline,
+    isRevisionGenerating,
+    selectedModel,
+    t
+  ])
 
   const saveStatusLabel = React.useMemo(() => {
     if (!activeSessionId) return null
@@ -2264,7 +2751,7 @@ export const WritingPlayground = () => {
                 icon={isGenerating ? <Square className="h-3.5 w-3.5" /> : <Zap className="h-3.5 w-3.5" />}
                 onClick={() => { if (isGenerating && settings.token_streaming) { handleCancelGeneration() } else { void handleGenerate() } }}
                 loading={isGenerating && !settings.token_streaming}
-                disabled={isGenerating ? !settings.token_streaming : !canGenerate}
+                disabled={isGenerating ? !settings.token_streaming : !canGenerate || isRevisionGenerating}
                 data-testid="writing-topbar-generate">
                 {isGenerating ? t("option:writingPlayground.stopAction", "Stop") : t("option:writingPlayground.generateAction", "Generate")}
               </Button>
@@ -2341,6 +2828,16 @@ export const WritingPlayground = () => {
                       </Dropdown>
                       <Button size="small" icon={searchOpen ? <X className="h-3.5 w-3.5" /> : <Search className="h-3.5 w-3.5" />} onClick={() => setSearchOpen((open) => !open)} title={searchOpen ? t("option:writingPlayground.searchClose", "Close search") : t("option:writingPlayground.searchToggle", "Find")} />
                     </div>
+                    <WritingActionBar
+                      generationAvailable={canGenerate && !isRevisionGenerating}
+                      target={displayedRevisionTarget}
+                      selectedPresetId={selectedRevisionPresetId}
+                      isGenerating={isRevisionGenerating}
+                      onPresetChange={persistRevisionPreset}
+                      onRequest={(request) => {
+                        void handleRevisionRequest(request)
+                      }}
+                    />
                     {searchOpen && (
                       <div className="rounded-md border border-border bg-surface p-3">
                         <div className="flex flex-col gap-3">
@@ -2381,6 +2878,7 @@ export const WritingPlayground = () => {
                           onAdapterReady={(adapter) => {
                             setActiveEditorAdapter(adapter)
                           }}
+                          onSelectionChange={updateRevisionSelection}
                           editable={!isGenerating}
                           placeholder={t("option:writingPlayground.editorPlaceholder", "Start writing your prompt...")}
                           className={cn("flex-1 transition-all", isGenerating && "ring-2 ring-primary/50 ring-offset-1 animate-pulse rounded-md")}
@@ -2389,7 +2887,7 @@ export const WritingPlayground = () => {
                     ) : (
                       <Dropdown menu={{ items: editorMenuItems }} trigger={["contextMenu"]}>
                         <div className={cn("flex-1 transition-all", isGenerating && "ring-2 ring-primary/50 ring-offset-1 animate-pulse rounded-md")}>
-                            <Input.TextArea ref={editorRef} value={editorText} onChange={handlePromptChange} onScroll={() => syncScroll("editor")} placeholder={t("option:writingPlayground.editorPlaceholder", "Start writing your prompt...")} autoSize={{ minRows: 12 }} disabled={isGenerating} className="!resize-y" />
+                            <Input.TextArea ref={editorRef} value={editorText} onChange={handlePromptChange} onClick={refreshRevisionSelection} onKeyUp={refreshRevisionSelection} onSelect={refreshRevisionSelection} onScroll={() => syncScroll("editor")} placeholder={t("option:writingPlayground.editorPlaceholder", "Start writing your prompt...")} autoSize={{ minRows: 12 }} disabled={isGenerating} className="!resize-y" />
                         </div>
                       </Dropdown>
                     )
@@ -2414,6 +2912,7 @@ export const WritingPlayground = () => {
                                 onAdapterReady={(adapter) => {
                                   setActiveEditorAdapter(adapter)
                                 }}
+                                onSelectionChange={updateRevisionSelection}
                                 editable={!isGenerating}
                                 placeholder={t("option:writingPlayground.editorPlaceholder", "Start writing your prompt...")}
                                 className={cn("flex-1 transition-all", isGenerating && "ring-2 ring-primary/50 ring-offset-1 animate-pulse rounded-md")}
@@ -2422,7 +2921,7 @@ export const WritingPlayground = () => {
                           ) : (
                             <Dropdown menu={{ items: editorMenuItems }} trigger={["contextMenu"]}>
                               <div>
-                                <Input.TextArea ref={editorRef} value={editorText} onChange={handlePromptChange} onScroll={() => syncScroll("editor")} placeholder={t("option:writingPlayground.editorPlaceholder", "Start writing your prompt...")} autoSize={{ minRows: 12 }} disabled={isGenerating} className="!resize-y" />
+                                <Input.TextArea ref={editorRef} value={editorText} onChange={handlePromptChange} onClick={refreshRevisionSelection} onKeyUp={refreshRevisionSelection} onSelect={refreshRevisionSelection} onScroll={() => syncScroll("editor")} placeholder={t("option:writingPlayground.editorPlaceholder", "Start writing your prompt...")} autoSize={{ minRows: 12 }} disabled={isGenerating} className="!resize-y" />
                               </div>
                             </Dropdown>
                           )}
@@ -2432,6 +2931,21 @@ export const WritingPlayground = () => {
                         </div>
                       </div>
                     )}
+                    <WritingRevisionQueue
+                      proposals={revisionState.revisions}
+                      onApply={(proposal) =>
+                        revisionState.applyRevision(proposal.id)
+                      }
+                      onReject={(proposal) =>
+                        revisionState.rejectRevision(proposal.id)
+                      }
+                      onCopy={(proposal) => {
+                        void handleCopyRevision(proposal)
+                      }}
+                      onRegenerate={(proposal) => {
+                        void handleRegenerateRevision(proposal)
+                      }}
+                    />
                     {responseLogprobs.length > 0 ? (
                       <div className="rounded-md border border-border bg-surface p-3">
                         <div className="flex flex-wrap items-center justify-between gap-2">
@@ -2493,6 +3007,33 @@ export const WritingPlayground = () => {
               </WritingPlaygroundEditorPanel>
             </div>
             <div data-testid="writing-playground-statusbar" className="flex items-center gap-3 px-4 py-1.5 border-t border-border bg-surface text-xs text-text-muted flex-shrink-0">
+              <span data-testid="writing-status-word-count">
+                {t(
+                  "option:writingPlayground.wordCountLabel",
+                  writingWordCount === 1
+                    ? `${writingWordCount} word`
+                    : `${writingWordCount} words`,
+                  { count: writingWordCount }
+                )}
+              </span>
+              {selectedWordCount > 0 ? (
+                <span data-testid="writing-status-selected-word-count">
+                  {t(
+                    "option:writingPlayground.selectedWordCountLabel",
+                    `${selectedWordCount} selected`,
+                    { count: selectedWordCount }
+                  )}
+                </span>
+              ) : null}
+              {pendingRevisionCount > 0 ? (
+                <span data-testid="writing-revision-pending-count">
+                  {t(
+                    "option:writingPlayground.pendingRevisionCountLabel",
+                    `${pendingRevisionCount} pending`,
+                    { count: pendingRevisionCount }
+                  )}
+                </span>
+              ) : null}
               {generationTokenCount > 0 && (<span>{t("option:writingPlayground.generationTokensLabel", "{{count}} tokens", { count: generationTokenCount })}</span>)}
               {generationTokensPerSec > 0 && (<span>{t("option:writingPlayground.generationRateLabel", "{{rate}} tok/s", { rate: generationTokensPerSec >= 10 ? generationTokensPerSec.toFixed(1) : generationTokensPerSec.toFixed(2) })}</span>)}
               {isGenerating && generationElapsed > 0 && (<span>{generationElapsed}s</span>)}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
@@ -1,6 +1,7 @@
 import type { TextAreaRef } from "antd/es/input/TextArea"
 import type { Editor } from "@tiptap/react"
 import type { RefObject } from "react"
+import { tipTapJsonToPlainText } from "./writing-tiptap-utils"
 
 export type WritingEditorSelection = {
   start: number
@@ -36,6 +37,15 @@ const normalizeUnboundedSelection = (
   const end = Math.max(0, Math.floor(selection.end))
 
   return start <= end ? { start, end } : { start: end, end: start }
+}
+
+const TIPTAP_SCENE_BREAK_TEXT = "\n***\n"
+
+type TipTapNode = Editor["state"]["doc"]
+
+type TipTapPositionOffsetPoint = {
+  position: number
+  offset: number
 }
 
 const resolveTextareaNode = (
@@ -76,12 +86,128 @@ export const createTextareaEditorAdapter = (
   focus: () => resolveTextareaNode(textareaRef)?.focus(),
 })
 
-const getTipTapSelection = (editor: Editor): WritingEditorSelection => {
+const getTipTapPlainText = (editor: Editor): string =>
+  tipTapJsonToPlainText(editor.getJSON())
+
+const pushTipTapMappingPoint = (
+  points: TipTapPositionOffsetPoint[],
+  position: number,
+  offset: number,
+) => {
+  points.push({ position, offset })
+}
+
+const appendTipTapNodeMappings = (
+  node: TipTapNode,
+  position: number,
+  offset: number,
+  points: TipTapPositionOffsetPoint[],
+): number => {
+  pushTipTapMappingPoint(points, position, offset)
+
+  if (node.isText) {
+    const textLength = node.text?.length ?? 0
+    for (let index = 1; index <= textLength; index += 1) {
+      pushTipTapMappingPoint(points, position + index, offset + index)
+    }
+    return offset + textLength
+  }
+
+  if (node.type.name === "hardBreak") {
+    const nextOffset = offset + 1
+    pushTipTapMappingPoint(points, position + node.nodeSize, nextOffset)
+    return nextOffset
+  }
+
+  if (node.type.name === "sceneBreak") {
+    const nextOffset = offset + TIPTAP_SCENE_BREAK_TEXT.length
+    pushTipTapMappingPoint(points, position + node.nodeSize, nextOffset)
+    return nextOffset
+  }
+
+  if (node.isLeaf) {
+    pushTipTapMappingPoint(points, position + node.nodeSize, offset)
+    return offset
+  }
+
+  let nextOffset = offset
+  node.forEach((childNode, childOffset) => {
+    nextOffset = appendTipTapNodeMappings(
+      childNode,
+      position + 1 + childOffset,
+      nextOffset,
+      points,
+    )
+  })
+
+  pushTipTapMappingPoint(points, position + node.nodeSize - 1, nextOffset)
+
+  if (node.type.name === "paragraph" || node.type.name === "heading") {
+    nextOffset += 1
+  }
+
+  pushTipTapMappingPoint(points, position + node.nodeSize, nextOffset)
+  return nextOffset
+}
+
+const getTipTapPositionOffsetPoints = (
+  editor: Editor,
+): TipTapPositionOffsetPoint[] => {
+  const points: TipTapPositionOffsetPoint[] = [{ position: 0, offset: 0 }]
+  let offset = 0
+
+  editor.state.doc.forEach((childNode, childOffset) => {
+    offset = appendTipTapNodeMappings(childNode, childOffset, offset, points)
+  })
+
+  return points.sort((a, b) => a.position - b.position || a.offset - b.offset)
+}
+
+const getPlainTextOffsetAtTipTapPosition = (
+  editor: Editor,
+  position: number,
+): number => {
+  const doc = editor.state.doc
+  const resolvedPosition = clampIndex(position, doc.content.size)
+  const plainTextLength = getTipTapPlainText(editor).length
+  const points = getTipTapPositionOffsetPoints(editor)
+  let offset = 0
+
+  for (const point of points) {
+    if (point.position > resolvedPosition) break
+    offset = point.offset
+  }
+
+  return clampIndex(offset, plainTextLength)
+}
+
+const getTipTapPositionAtPlainTextOffset = (
+  editor: Editor,
+  offset: number,
+): number => {
+  const doc = editor.state.doc
+  const plainTextLength = getTipTapPlainText(editor).length
+  const targetOffset = clampIndex(offset, plainTextLength)
+  const points = getTipTapPositionOffsetPoints(editor)
+  let candidatePosition = points[0]?.position ?? 0
+
+  for (const point of points) {
+    const currentOffset = clampIndex(point.offset, plainTextLength)
+    if (currentOffset > targetOffset) {
+      return candidatePosition
+    }
+    candidatePosition = point.position
+  }
+
+  return clampIndex(candidatePosition, doc.content.size)
+}
+
+export const getTipTapSelection = (editor: Editor): WritingEditorSelection => {
   const { from, to } = editor.state.selection
 
   return {
-    start: Math.max(0, from - 1),
-    end: Math.max(0, to - 1),
+    start: getPlainTextOffsetAtTipTapPosition(editor, from),
+    end: getPlainTextOffsetAtTipTapPosition(editor, to),
   }
 }
 
@@ -93,11 +219,14 @@ export const createTipTapEditorAdapter = (
   return {
     getSelection: () => getTipTapSelection(editor),
     setSelection: (selection) => {
-      const normalized = normalizeUnboundedSelection(selection)
+      const normalized = normalizeSelection(
+        normalizeUnboundedSelection(selection),
+        getTipTapPlainText(editor).length,
+      )
 
       editor.commands.setTextSelection({
-        from: normalized.start + 1,
-        to: normalized.end + 1,
+        from: getTipTapPositionAtPlainTextOffset(editor, normalized.start),
+        to: getTipTapPositionAtPlainTextOffset(editor, normalized.end),
       })
     },
     getSelectedText: (currentValue) => {

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-presets.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-presets.ts
@@ -1,0 +1,45 @@
+import type { WritingRevisionPresetId } from "./writing-revision-types"
+
+export type WritingRevisionPreset = {
+  id: WritingRevisionPresetId
+  label: string
+  instruction: string
+}
+
+export const WRITING_REVISION_PRESETS: WritingRevisionPreset[] = [
+  {
+    id: "draft_freely",
+    label: "Draft freely",
+    instruction: "Prioritize momentum, vivid continuation, and useful new material."
+  },
+  {
+    id: "polish_prose",
+    label: "Polish prose",
+    instruction: "Improve clarity, rhythm, word choice, and sentence flow without changing intent."
+  },
+  {
+    id: "developmental_edit",
+    label: "Developmental edit",
+    instruction: "Focus on structure, stakes, pacing, continuity, and what the passage needs next."
+  },
+  {
+    id: "preserve_voice",
+    label: "Preserve voice",
+    instruction: "Keep the author's diction, cadence, point of view, and stylistic fingerprints."
+  },
+  {
+    id: "make_concise",
+    label: "Make concise",
+    instruction: "Reduce redundancy and sharpen phrasing while preserving meaning and voice."
+  },
+  {
+    id: "expand_sensory_detail",
+    label: "Expand sensory detail",
+    instruction: "Add concrete sensory detail grounded in the existing scene and tone."
+  }
+]
+
+export const getWritingRevisionPreset = (
+  id?: WritingRevisionPresetId | null
+): WritingRevisionPreset | null =>
+  WRITING_REVISION_PRESETS.find((preset) => preset.id === id) ?? null

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-prompt-utils.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-prompt-utils.ts
@@ -1,0 +1,207 @@
+import type {
+  WritingRevisionAction,
+  WritingRevisionOperation,
+  WritingRevisionPresetId,
+  WritingRevisionProposal,
+  WritingRevisionTarget
+} from "./writing-revision-types"
+
+type WritingRevisionPromptContext = {
+  selectedTemplateName?: string | null
+  selectedThemeName?: string | null
+  chatMode: boolean
+  contextComposedPrompt?: string | null
+  contextMessages?: Array<{ role: string; content: string }> | null
+  memoryBlock?: unknown
+  authorNote?: unknown
+  worldInfoEntries?: unknown[]
+  provider?: string | null
+  model?: string | null
+  generationSettingsSummary: Record<string, unknown>
+}
+
+type BuildRevisionUserPromptInput = {
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  instruction: string
+  documentText: string
+  target: WritingRevisionTarget
+  presetInstruction?: string | null
+  writingContext: WritingRevisionPromptContext
+}
+
+type ParseRevisionModelResponseInput = {
+  responseText: string
+  sessionId: string
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  instruction: string
+  target: WritingRevisionTarget
+  presetId?: WritingRevisionPresetId | null
+  presetInstruction?: string | null
+  createdAt?: string
+  id?: string
+}
+
+type ParsedRevisionResponse = {
+  title?: string
+  replacement?: string
+  rawText?: string
+  rationale?: string
+  notes?: string[]
+}
+
+const createRevisionProposalId = () =>
+  globalThis.crypto?.randomUUID?.() ??
+  `revision-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+const getString = (value: unknown) =>
+  typeof value === "string" ? value : undefined
+
+const getNotes = (value: unknown) =>
+  Array.isArray(value)
+    ? value.filter((note): note is string => typeof note === "string")
+    : undefined
+
+const parseJsonObject = (responseText: string): Record<string, unknown> | null => {
+  try {
+    const parsed = JSON.parse(responseText.trim())
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+const normalizeParsedResponse = (
+  response: Record<string, unknown>
+): ParsedRevisionResponse => ({
+  title: getString(response.title),
+  replacement: getString(response.replacement),
+  rawText: getString(response.rawText),
+  rationale: getString(response.rationale),
+  notes: getNotes(response.notes)
+})
+
+const hasAdvisoryContent = (response: ParsedRevisionResponse) =>
+  response.title !== undefined ||
+  response.rawText !== undefined ||
+  response.rationale !== undefined ||
+  response.notes !== undefined
+
+const createBaseProposal = (
+  input: ParseRevisionModelResponseInput
+): WritingRevisionProposal => {
+  const proposal: WritingRevisionProposal = {
+    id: input.id ?? createRevisionProposalId(),
+    sessionId: input.sessionId,
+    action: input.action,
+    operation: input.operation,
+    instruction: input.instruction,
+    target: input.target,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    status: "raw_suggestion"
+  }
+
+  if (input.presetId !== undefined) {
+    proposal.presetId = input.presetId
+  }
+  if (input.presetInstruction !== undefined) {
+    proposal.presetInstruction = input.presetInstruction
+  }
+
+  return proposal
+}
+
+const copyParsedDisplayFields = (
+  proposal: WritingRevisionProposal,
+  response: ParsedRevisionResponse
+) => {
+  if (response.title !== undefined) {
+    proposal.title = response.title
+  }
+  if (response.rationale !== undefined) {
+    proposal.rationale = response.rationale
+  }
+  if (response.notes !== undefined) {
+    proposal.notes = response.notes
+  }
+  if (response.rawText !== undefined) {
+    proposal.rawText = response.rawText
+  }
+}
+
+export const buildRevisionUserPrompt = (
+  input: BuildRevisionUserPromptInput
+): string => {
+  return [
+    "You are helping revise a creative writing document.",
+    "Return only valid JSON. Do not include markdown fences.",
+    `Action: ${input.action}`,
+    `Operation: ${input.operation}`,
+    `Instruction: ${input.instruction}`,
+    input.presetInstruction ? `Workflow preset: ${input.presetInstruction}` : null,
+    `Template: ${input.writingContext.selectedTemplateName || "(none)"}`,
+    `Theme: ${input.writingContext.selectedThemeName || "(none)"}`,
+    `Chat mode: ${input.writingContext.chatMode ? "enabled" : "disabled"}`,
+    `Provider: ${input.writingContext.provider || "(default)"}`,
+    `Model: ${input.writingContext.model || "(unset)"}`,
+    "Generation settings:",
+    JSON.stringify(input.writingContext.generationSettingsSummary),
+    "Composed writing context:",
+    input.writingContext.contextComposedPrompt ||
+      JSON.stringify(input.writingContext.contextMessages ?? []),
+    "Memory / author note / world info:",
+    JSON.stringify({
+      memoryBlock: input.writingContext.memoryBlock,
+      authorNote: input.writingContext.authorNote,
+      worldInfoEntries: input.writingContext.worldInfoEntries ?? []
+    }),
+    "Target text:",
+    input.target.beforeText || "(insertion point)",
+    `Target summary: ${input.target.label}`,
+    "Full document:",
+    input.documentText,
+    "JSON shape:",
+    input.operation === "advisory"
+      ? '{"title":"...","rawText":"...","rationale":"...","notes":["..."]}'
+      : '{"title":"...","replacement":"...","rationale":"...","notes":["..."]}'
+  ]
+    .filter(Boolean)
+    .join("\n\n")
+}
+
+export const parseRevisionModelResponse = (
+  input: ParseRevisionModelResponseInput
+): WritingRevisionProposal => {
+  const proposal = createBaseProposal(input)
+  const parsedJson = parseJsonObject(input.responseText)
+
+  if (!parsedJson) {
+    proposal.rawText = input.responseText
+    return proposal
+  }
+
+  const parsed = normalizeParsedResponse(parsedJson)
+  copyParsedDisplayFields(proposal, parsed)
+
+  if (input.operation === "advisory") {
+    if (hasAdvisoryContent(parsed)) {
+      proposal.status = "advisory"
+      return proposal
+    }
+
+    proposal.rawText = input.responseText
+    return proposal
+  }
+
+  if (parsed.replacement !== undefined) {
+    proposal.replacementText = parsed.replacement
+    proposal.status = "pending"
+    return proposal
+  }
+
+  proposal.rawText = parsed.rawText ?? input.responseText
+  return proposal
+}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-types.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-types.ts
@@ -1,0 +1,73 @@
+export type WritingRevisionAction =
+  | "continue"
+  | "rewrite"
+  | "expand"
+  | "tighten"
+  | "tone"
+  | "outline"
+  | "custom"
+
+export type WritingRevisionOperation = "insert" | "replace" | "advisory"
+
+export type WritingRevisionPresetId =
+  | "draft_freely"
+  | "polish_prose"
+  | "developmental_edit"
+  | "preserve_voice"
+  | "make_concise"
+  | "expand_sensory_detail"
+
+export type WritingRevisionStatus =
+  | "pending"
+  | "applied"
+  | "rejected"
+  | "conflict"
+  | "raw_suggestion"
+  | "advisory"
+
+export type WritingRevisionAnchor = {
+  documentFingerprint: string
+  prefix: string
+  suffix: string
+}
+
+export type WritingRevisionTarget = {
+  mode: "selection" | "paragraph" | "cursor" | "document"
+  start: number
+  end: number
+  beforeText: string
+  anchor: WritingRevisionAnchor
+  label: string
+  requiresConfirmation: boolean
+  confirmationReason?: string
+}
+
+export type WritingRevisionProposal = {
+  id: string
+  sessionId: string
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  presetId?: WritingRevisionPresetId | null
+  presetInstruction?: string | null
+  instruction: string
+  target: WritingRevisionTarget
+  replacementText?: string
+  rawText?: string
+  rationale?: string
+  title?: string
+  notes?: string[]
+  regeneratedFromId?: string
+  createdAt: string
+  status: WritingRevisionStatus
+}
+
+export type WritingRevisionApplyPlan =
+  | { type: "apply"; start: number; end: number; nextText: string }
+  | { type: "retarget"; start: number; end: number; nextText: string }
+  | { type: "conflict"; reason: string }
+  | { type: "noop"; reason: string }
+
+export type WritingRevisionPayload = {
+  schemaVersion: 1
+  items: WritingRevisionProposal[]
+}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-utils.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-revision-utils.ts
@@ -1,0 +1,335 @@
+import type {
+  WritingRevisionAction,
+  WritingRevisionAnchor,
+  WritingRevisionApplyPlan,
+  WritingRevisionOperation,
+  WritingRevisionProposal,
+  WritingRevisionTarget
+} from "./writing-revision-types"
+
+const DEFAULT_ANCHOR_WINDOW = 80
+const DEFAULT_LARGE_TARGET_CHARS = 1800
+
+const clampIndex = (value: number, length: number): number => {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(length, Math.floor(value)))
+}
+
+const replaceRange = (
+  text: string,
+  start: number,
+  end: number,
+  replacementText: string
+): string => text.slice(0, start) + replacementText + text.slice(end)
+
+const findExactMatches = (
+  text: string,
+  searchText: string
+): Array<{ start: number; end: number }> => {
+  if (searchText.length === 0) return []
+
+  const matches: Array<{ start: number; end: number }> = []
+  let offset = 0
+  while (offset <= text.length) {
+    const foundAt = text.indexOf(searchText, offset)
+    if (foundAt === -1) break
+    matches.push({ start: foundAt, end: foundAt + searchText.length })
+    offset = foundAt + 1
+  }
+  return matches
+}
+
+const findInsertionAnchorOffsets = (
+  text: string,
+  anchor: WritingRevisionAnchor
+): number[] => {
+  const offsets: number[] = []
+  for (let offset = 0; offset <= text.length; offset += 1) {
+    const prefixStart = offset - anchor.prefix.length
+    if (prefixStart < 0) continue
+    if (text.slice(prefixStart, offset) !== anchor.prefix) continue
+    if (text.slice(offset, offset + anchor.suffix.length) !== anchor.suffix) {
+      continue
+    }
+    offsets.push(offset)
+  }
+  return offsets
+}
+
+export const countWords = (text: string): number => {
+  const matches = text.trim().match(/\S+/g)
+  return matches ? matches.length : 0
+}
+
+export const createDocumentFingerprint = (text: string): string => {
+  let hash = 2166136261
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16)
+}
+
+export const buildInsertionAnchor = (
+  text: string,
+  offset: number,
+  windowSize = DEFAULT_ANCHOR_WINDOW
+): WritingRevisionAnchor => {
+  const safeOffset = clampIndex(offset, text.length)
+  const safeWindowSize = Math.max(0, Math.floor(windowSize))
+  return {
+    documentFingerprint: createDocumentFingerprint(text),
+    prefix: text.slice(Math.max(0, safeOffset - safeWindowSize), safeOffset),
+    suffix: text.slice(
+      safeOffset,
+      Math.min(text.length, safeOffset + safeWindowSize)
+    )
+  }
+}
+
+export const findParagraphRange = (
+  text: string,
+  cursor: number
+): { start: number; end: number } => {
+  const safeCursor = clampIndex(cursor, text.length)
+  const paragraphCursor =
+    safeCursor === 0 && text.startsWith("\n\n")
+      ? clampIndex(safeCursor + 2, text.length)
+      : safeCursor > 0 && text.slice(safeCursor - 1, safeCursor + 1) === "\n\n"
+        ? safeCursor - 1
+      : safeCursor
+  const before =
+    paragraphCursor === 0 ? -1 : text.lastIndexOf("\n\n", paragraphCursor - 1)
+  const after = text.indexOf("\n\n", paragraphCursor)
+  return {
+    start: before === -1 ? 0 : before + 2,
+    end: after === -1 ? text.length : after
+  }
+}
+
+const makeRevisionTarget = (input: {
+  text: string
+  mode: WritingRevisionTarget["mode"]
+  start: number
+  end: number
+  operation: WritingRevisionOperation
+  label: string
+  confirmationReason?: string
+}): WritingRevisionTarget => {
+  const normalizedStart = clampIndex(input.start, input.text.length)
+  const normalizedEnd = clampIndex(input.end, input.text.length)
+  const start = Math.min(normalizedStart, normalizedEnd)
+  const end = Math.max(normalizedStart, normalizedEnd)
+  const isTextChanging = input.operation !== "advisory"
+  return {
+    mode: input.mode,
+    start,
+    end,
+    beforeText: input.text.slice(start, end),
+    anchor: buildInsertionAnchor(input.text, start),
+    label: input.label,
+    requiresConfirmation: Boolean(isTextChanging && input.confirmationReason),
+    confirmationReason: isTextChanging ? input.confirmationReason : undefined
+  }
+}
+
+export const confirmRevisionTarget = (
+  target: WritingRevisionTarget
+): WritingRevisionTarget => ({
+  ...target,
+  requiresConfirmation: false,
+  confirmationReason: undefined
+})
+
+export const resolveRevisionTarget = (input: {
+  text: string
+  action: WritingRevisionAction
+  operation: WritingRevisionOperation
+  selection?: { start: number; end: number } | null
+  cursor?: number | null
+  preferredTargetMode?: WritingRevisionTarget["mode"] | null
+  maxAutomaticTargetCharacters?: number
+}): WritingRevisionTarget => {
+  const { text, action, operation, selection } = input
+  const maxAutomaticTargetCharacters =
+    input.maxAutomaticTargetCharacters ?? DEFAULT_LARGE_TARGET_CHARS
+  const cursor = clampIndex(
+    input.cursor ?? selection?.end ?? text.length,
+    text.length
+  )
+  if (action === "continue") {
+    return makeRevisionTarget({
+      text,
+      mode: "cursor",
+      start: cursor,
+      end: cursor,
+      operation: "insert",
+      label: cursor === text.length ? "document end" : "cursor"
+    })
+  }
+
+  if (selection && selection.start !== selection.end) {
+    return makeRevisionTarget({
+      text,
+      mode: "selection",
+      start: selection.start,
+      end: selection.end,
+      operation,
+      label: "selection"
+    })
+  }
+
+  if (action === "outline" || operation === "advisory") {
+    return makeRevisionTarget({
+      text,
+      mode: "document",
+      start: 0,
+      end: text.length,
+      operation: "advisory",
+      label: "whole document"
+    })
+  }
+
+  if (input.preferredTargetMode === "document") {
+    return makeRevisionTarget({
+      text,
+      mode: "document",
+      start: 0,
+      end: text.length,
+      operation,
+      label: "whole document",
+      confirmationReason:
+        "Confirm before applying a whole-document text-changing request."
+    })
+  }
+
+  const paragraph = findParagraphRange(text, cursor)
+  const paragraphLength = paragraph.end - paragraph.start
+  if (paragraphLength > 0 && paragraphLength <= maxAutomaticTargetCharacters) {
+    return makeRevisionTarget({
+      text,
+      mode: "paragraph",
+      start: paragraph.start,
+      end: paragraph.end,
+      operation,
+      label: "current paragraph"
+    })
+  }
+
+  return makeRevisionTarget({
+    text,
+    mode: "document",
+    start: 0,
+    end: text.length,
+    operation,
+    label: "whole document",
+    confirmationReason: "The current paragraph could not be resolved safely."
+  })
+}
+
+export const planRevisionApply = (
+  text: string,
+  proposal: WritingRevisionProposal
+): WritingRevisionApplyPlan => {
+  if (proposal.operation === "advisory") {
+    return { type: "noop", reason: "Advisory revisions do not mutate text." }
+  }
+
+  if (proposal.target.requiresConfirmation) {
+    return {
+      type: "conflict",
+      reason: "Confirm the revision target before applying text changes."
+    }
+  }
+
+  const replacementText = proposal.replacementText
+  if (typeof replacementText !== "string") {
+    return {
+      type: "noop",
+      reason: "Text-changing revisions require replacement text."
+    }
+  }
+
+  const start = clampIndex(proposal.target.start, text.length)
+  const end = clampIndex(proposal.target.end, text.length)
+  const normalizedStart = Math.min(start, end)
+  const normalizedEnd = Math.max(start, end)
+  const beforeText = proposal.target.beforeText
+
+  if (
+    proposal.operation === "insert" &&
+    normalizedStart === normalizedEnd &&
+    beforeText === ""
+  ) {
+    if (
+      createDocumentFingerprint(text) === proposal.target.anchor.documentFingerprint
+    ) {
+      return {
+        type: "apply",
+        start: normalizedStart,
+        end: normalizedEnd,
+        nextText: replaceRange(
+          text,
+          normalizedStart,
+          normalizedEnd,
+          replacementText
+        )
+      }
+    }
+
+    const offsets = findInsertionAnchorOffsets(text, proposal.target.anchor)
+    if (offsets.length === 1) {
+      const nextStart = offsets[0]
+      return {
+        type: "retarget",
+        start: nextStart,
+        end: nextStart,
+        nextText: replaceRange(text, nextStart, nextStart, replacementText)
+      }
+    }
+
+    return {
+      type: "conflict",
+      reason: "The insertion anchor no longer identifies a unique target."
+    }
+  }
+
+  if (proposal.operation === "insert") {
+    return {
+      type: "conflict",
+      reason: "Insert revisions require a zero-length target."
+    }
+  }
+
+  if (beforeText.length === 0) {
+    return {
+      type: "conflict",
+      reason: "Empty target text cannot validate a replacement."
+    }
+  }
+
+  if (text.slice(normalizedStart, normalizedEnd) === beforeText) {
+    return {
+      type: "apply",
+      start: normalizedStart,
+      end: normalizedEnd,
+      nextText: replaceRange(text, normalizedStart, normalizedEnd, replacementText)
+    }
+  }
+
+  const matches = findExactMatches(text, beforeText)
+  if (matches.length === 1) {
+    const [match] = matches
+    return {
+      type: "retarget",
+      start: match.start,
+      end: match.end,
+      nextText: replaceRange(text, match.start, match.end, replacementText)
+    }
+  }
+
+  return {
+    type: "conflict",
+    reason: "The revision target no longer matches uniquely."
+  }
+}

--- a/apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts
+++ b/apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts
@@ -12,10 +12,22 @@ describe("writing playground route parity", () => {
       path.resolve(__dirname, "../routes/option-writing-playground.tsx"),
       "utf8"
     )
+    const sharedWritingPlayground = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        "../../../packages/ui/src/components/Option/WritingPlayground/index.tsx"
+      ),
+      "utf8"
+    )
 
     expect(webRoute).toContain('data-testid="writing-playground-route-shell"')
     expect(extRoute).toContain('PageShell className="py-6" maxWidthClassName="max-w-7xl"')
     expect(webRoute).toContain("<WritingPlayground />")
     expect(extRoute).toContain("<WritingPlayground />")
+    expect(sharedWritingPlayground).toContain("<WritingActionBar")
+    expect(sharedWritingPlayground).toContain("<WritingRevisionQueue")
+    expect(sharedWritingPlayground).toContain('data-testid="writing-revision-pending-count"')
+    expect(sharedWritingPlayground).toContain('data-testid="writing-status-word-count"')
+    expect(sharedWritingPlayground).toContain('data-testid="writing-status-selected-word-count"')
   })
 })

--- a/backlog/tasks/task-493 - Rebase-PR-1985-onto-dev-and-address-review-comments.md
+++ b/backlog/tasks/task-493 - Rebase-PR-1985-onto-dev-and-address-review-comments.md
@@ -1,0 +1,51 @@
+---
+id: TASK-493
+title: Rebase PR 1985 onto dev and address review comments
+status: Done
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/1985
+modified_files:
+- Docs/superpowers/plans/2026-05-22-writing-playground-document-first-revisions-implementation-plan.md
+- Docs/superpowers/specs/2026-05-22-writing-playground-document-first-revisions-design.md
+- apps/extension/tests/e2e/writing-playground-mode-parity.spec.ts
+- apps/packages/ui/src/components/Option/WritingPlayground
+- apps/tldw-frontend/extension/__tests__/writing-playground-route-parity.guard.test.ts
+- backlog/tasks/task-493 - Rebase-PR-1985-onto-dev-and-address-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track PR maintenance for codex/chat-sidebar-tools-first: rebase onto latest origin/dev, clean up PR base/diff, evaluate active GitHub review comments, apply valid fixes, verify, and update/comment on the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] PR branch is rebuilt on latest `origin/dev` with only the intended Writing Playground revision workflow scope.
+- [x] Active PR review comments are evaluated; stale comments from the old `main`-targeted diff are made obsolete by retargeting to `dev`.
+- [x] The valid `useQuery` mock review issue is fixed in the dev-preserved WritingPlayground shell alert test.
+- [x] Focused WritingPlayground and extension route parity tests pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebuilt the PR contents from `origin/dev` using a scoped writing-only patch instead of replaying 175 historical stacked commits. Excluded old Backlog task files from the original branch because their IDs now collide with unrelated tasks on `dev`; this follow-up is tracked under `TASK-493`. Fixed the WritingPlayground shell design-system alert test `useQuery` mock to honor `enabled=false` and key query results by a stable full query-key serialization.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased/reconstructed PR 1985 on latest origin/dev with a scoped Writing Playground revision workflow diff, preserved dev's design-system alert work, fixed the still-valid useQuery mock review issue, and verified with focused shared UI and extension parity tests. Bandit is not applicable because the touched scope is frontend TypeScript/TSX plus docs/backlog, with no Python files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds the Writing Playground proposed-edit revision workflow with reviewable apply/reject/copy/regenerate states, workflow presets, and persisted revision payload state.
- Wires the shared WebUI/extension Writing Playground surface with route parity coverage and status/count affordances.
- Hardens final-review edge cases for Continue targeting, same-payload regeneration echoes, advanced request extra body preservation, and rich-editor TipTap selection mapping.

## Test Plan
- [x] cd apps/packages/ui && bunx vitest run src/components/Option/WritingPlayground/__tests__/writing-revision-utils.test.ts src/components/Option/WritingPlayground/__tests__/writing-revision-presets.test.ts src/components/Option/WritingPlayground/__tests__/writing-revision-prompt-utils.test.ts src/components/Option/WritingPlayground/__tests__/writing-session-payload-utils.test.ts src/components/Option/WritingPlayground/__tests__/useWritingRevisions.test.tsx src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx src/components/Option/WritingPlayground/__tests__/WritingActionBar.test.tsx src/components/Option/WritingPlayground/__tests__/WritingRevisionQueue.test.tsx src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx --maxWorkers=1 --no-file-parallelism
- [x] cd apps/tldw-frontend/extension && bunx vitest run __tests__/writing-playground-route-parity.guard.test.ts --maxWorkers=1 --no-file-parallelism
- [x] git diff --check over touched paths
- [x] ASCII scan over touched paths

## Known Blockers
- Extension Playwright smoke remains blocked by an existing WXT production build stall. Focused shared UI tests and the extension route parity guard are the verified extension evidence for this PR.

## Human Change Summary Required Before Merge
Per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`, a human maintainer/requester must replace this section with a human-written Change summary explaining what changed and why these implementation choices were made before this PR is merge-ready.