### PR TITLE
Close WP12 final route governance gate

### DIFF
--- a/apps/packages/ui/src/components/Review/ViewMediaPage.tsx
+++ b/apps/packages/ui/src/components/Review/ViewMediaPage.tsx
@@ -1104,6 +1104,9 @@ const MediaPageContent: React.FC = () => {
       >
         <div className="flex flex-1 items-center justify-center p-8">
           <div className="max-w-lg w-full">
+            <h1 className="mb-3 px-4 text-center text-base font-semibold text-text">
+              {t('review:mediaPage.mediaInspector', { defaultValue: 'Media Inspector' })}
+            </h1>
             <ResultsList
               results={displayResults}
               selectedId={null}

--- a/apps/tldw-frontend/__tests__/e2e/e2e-auth.test.ts
+++ b/apps/tldw-frontend/__tests__/e2e/e2e-auth.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_E2E_API_KEY,
+  isLocalE2eServerUrl,
+  resolveE2eApiKey,
+  resolveExplicitE2eApiKey,
+} from '../../e2e/utils/e2e-auth';
+
+describe('E2E auth helpers', () => {
+  it('prefers explicit API key environment values', () => {
+    expect(resolveExplicitE2eApiKey({ TLDW_API_KEY: ' primary ' })).toBe('primary');
+    expect(resolveExplicitE2eApiKey({ TLDW_E2E_API_KEY: ' e2e ' })).toBe('e2e');
+    expect(resolveExplicitE2eApiKey({ SINGLE_USER_API_KEY: ' single ' })).toBe('single');
+  });
+
+  it('allows the placeholder key only for local E2E server URLs', () => {
+    expect(resolveE2eApiKey({ serverUrl: 'http://127.0.0.1:8000', env: {} })).toBe(
+      DEFAULT_E2E_API_KEY
+    );
+    expect(resolveE2eApiKey({ serverUrl: 'http://localhost:8000', env: {} })).toBe(
+      DEFAULT_E2E_API_KEY
+    );
+    expect(resolveE2eApiKey({ serverUrl: 'http://[::1]:8000', env: {} })).toBe(
+      DEFAULT_E2E_API_KEY
+    );
+  });
+
+  it('detects localhost variants used by Playwright and dev servers', () => {
+    expect(isLocalE2eServerUrl('http://localhost:8000')).toBe(true);
+    expect(isLocalE2eServerUrl('http://app.localhost:8000')).toBe(true);
+    expect(isLocalE2eServerUrl('http://127.0.0.1:8000')).toBe(true);
+    expect(isLocalE2eServerUrl('http://[::1]:8000')).toBe(true);
+    expect(isLocalE2eServerUrl('https://example.com')).toBe(false);
+  });
+
+  it('fails fast for remote E2E server URLs without an explicit key', () => {
+    expect(() =>
+      resolveE2eApiKey({ serverUrl: 'https://example.com', env: {} })
+    ).toThrow(/Remote E2E server URL/);
+  });
+});

--- a/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+++ b/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
@@ -1,5 +1,4 @@
 import { test as base, expect, Page } from "@playwright/test"
-import { randomUUID } from "node:crypto"
 
 /**
  * Diagnostics data collected during page visits
@@ -81,6 +80,7 @@ export { expect }
 
 const DEFAULT_SMOKE_LOAD_TIMEOUT_MS = 30_000
 const MIN_SMOKE_LOAD_TIMEOUT_MS = 5_000
+const DEFAULT_SMOKE_API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
 
 const resolveSmokeLoadTimeoutMs = (): number => {
   const raw = process.env.TLDW_SMOKE_LOAD_TIMEOUT_MS
@@ -107,7 +107,7 @@ const resolveSmokeApiKey = (): string => {
     return configured.trim()
   }
 
-  return `smoke-${randomUUID()}`
+  return DEFAULT_SMOKE_API_KEY
 }
 
 export const AUTH_CONFIG = {

--- a/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+++ b/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
@@ -1,4 +1,5 @@
 import { test as base, expect, Page } from "@playwright/test"
+import { resolveE2eApiKey } from "../utils/e2e-auth"
 
 /**
  * Diagnostics data collected during page visits
@@ -80,7 +81,7 @@ export { expect }
 
 const DEFAULT_SMOKE_LOAD_TIMEOUT_MS = 30_000
 const MIN_SMOKE_LOAD_TIMEOUT_MS = 5_000
-const DEFAULT_SMOKE_API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
+const DEFAULT_SMOKE_SERVER_URL = "http://127.0.0.1:8000"
 
 const resolveSmokeLoadTimeoutMs = (): number => {
   const raw = process.env.TLDW_SMOKE_LOAD_TIMEOUT_MS
@@ -94,29 +95,20 @@ const resolveSmokeLoadTimeoutMs = (): number => {
 
 export const SMOKE_LOAD_TIMEOUT = resolveSmokeLoadTimeoutMs()
 
+const resolveSmokeServerUrl = (): string =>
+  process.env.TLDW_SERVER_URL ||
+  process.env.TLDW_E2E_SERVER_URL ||
+  process.env.E2E_TEST_BASE_URL ||
+  DEFAULT_SMOKE_SERVER_URL
+
+const SMOKE_SERVER_URL = resolveSmokeServerUrl()
+
 /**
  * Auth configuration for smoke tests
  */
-const resolveSmokeApiKey = (): string => {
-  const configured =
-    process.env.TLDW_API_KEY ||
-    process.env.TLDW_E2E_API_KEY ||
-    process.env.SINGLE_USER_API_KEY
-
-  if (configured?.trim()) {
-    return configured.trim()
-  }
-
-  return DEFAULT_SMOKE_API_KEY
-}
-
 export const AUTH_CONFIG = {
-  serverUrl:
-    process.env.TLDW_SERVER_URL ||
-    process.env.TLDW_E2E_SERVER_URL ||
-    process.env.E2E_TEST_BASE_URL ||
-    "http://127.0.0.1:8000",
-  apiKey: resolveSmokeApiKey(),
+  serverUrl: SMOKE_SERVER_URL,
+  apiKey: resolveE2eApiKey({ serverUrl: SMOKE_SERVER_URL }),
   allowOffline: process.env.TLDW_E2E_ALLOW_OFFLINE !== "0"
 }
 

--- a/apps/tldw-frontend/e2e/utils/e2e-auth.ts
+++ b/apps/tldw-frontend/e2e/utils/e2e-auth.ts
@@ -1,0 +1,61 @@
+// Non-secret placeholder used by local single-user E2E server fixtures only.
+export const DEFAULT_E2E_API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY";
+
+const EXPLICIT_API_KEY_ENV_KEYS = [
+  "TLDW_API_KEY",
+  "TLDW_E2E_API_KEY",
+  "SINGLE_USER_API_KEY",
+] as const;
+
+type E2eAuthEnvironment = Partial<
+  Record<(typeof EXPLICIT_API_KEY_ENV_KEYS)[number], string | undefined>
+>;
+
+export const resolveExplicitE2eApiKey = (
+  env: E2eAuthEnvironment = process.env
+): string | undefined => {
+  for (const key of EXPLICIT_API_KEY_ENV_KEYS) {
+    const value = env[key];
+    if (value?.trim()) return value.trim();
+  }
+  return undefined;
+};
+
+export const isLocalE2eServerUrl = (serverUrl: string): boolean => {
+  try {
+    const { hostname, protocol } = new URL(serverUrl);
+    if (protocol === "file:") return true;
+    const normalizedHost = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return (
+      normalizedHost === "localhost" ||
+      normalizedHost.endsWith(".localhost") ||
+      normalizedHost === "127.0.0.1" ||
+      normalizedHost === "::1" ||
+      normalizedHost === "0.0.0.0"
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const resolveE2eApiKey = ({
+  serverUrl,
+  env = process.env,
+}: {
+  serverUrl: string;
+  env?: E2eAuthEnvironment;
+}): string => {
+  const explicitApiKey = resolveExplicitE2eApiKey(env);
+  if (explicitApiKey) return explicitApiKey;
+
+  if (!isLocalE2eServerUrl(serverUrl)) {
+    throw new Error(
+      [
+        `Remote E2E server URL "${serverUrl}" is configured without an explicit API key.`,
+        `Set ${EXPLICIT_API_KEY_ENV_KEYS.join(", ")} before running against non-local servers.`,
+      ].join(" ")
+    );
+  }
+
+  return DEFAULT_E2E_API_KEY;
+};

--- a/apps/tldw-frontend/e2e/utils/helpers.ts
+++ b/apps/tldw-frontend/e2e/utils/helpers.ts
@@ -2,13 +2,20 @@
  * Common test helpers for E2E tests
  */
 import { expect, type Locator, type Page, type Route } from '@playwright/test';
+import { resolveE2eApiKey } from './e2e-auth';
+
+const E2E_SERVER_URL =
+  process.env.TLDW_SERVER_URL ||
+  process.env.TLDW_E2E_SERVER_URL ||
+  process.env.E2E_TEST_BASE_URL ||
+  'http://127.0.0.1:8000';
 
 /**
  * Environment configuration for tests
  */
 export const TEST_CONFIG = {
-  serverUrl: process.env.TLDW_SERVER_URL || 'http://127.0.0.1:8000',
-  apiKey: process.env.TLDW_API_KEY || 'THIS-IS-A-SECURE-KEY-123-FAKE-KEY',
+  serverUrl: E2E_SERVER_URL,
+  apiKey: resolveE2eApiKey({ serverUrl: E2E_SERVER_URL }),
   webUrl: process.env.TLDW_WEB_URL || 'http://localhost:8080',
   allowOffline: process.env.TLDW_E2E_ALLOW_OFFLINE !== '0',
 };

--- a/backlog/tasks/task-418.10.7 - Close-WP12-final-route-governance-gate.md
+++ b/backlog/tasks/task-418.10.7 - Close-WP12-final-route-governance-gate.md
@@ -1,0 +1,83 @@
+---
+id: TASK-418.10.7
+title: Close WP12 final route governance gate
+status: Done
+labels:
+- wp12
+- webui
+- route-governance
+- e2e
+- closeout
+priority: High
+ordinal: 7
+parent_task_id: TASK-418.10
+references:
+- TASK-418.10
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+- apps/tldw-frontend/e2e/smoke/route-evidence-protocol.md
+modified_files:
+- apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+- apps/packages/ui/src/components/Review/ViewMediaPage.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute WP12 Task 7 from the WebUI route governance QA plan: run the final all-pages, Stage 4, route-governance, and route metadata gates; triage every failure into a fixed regression, explicit route-owned reason, or follow-up task; and record the final coverage matrix closure without broad UX redesign or unrelated cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All-pages hard gate is run and every failure is resolved or tied to a route metadata reason and follow-up task.
+- [x] #2 Stage 4 Axe gate is run and passes or any blocker is documented with route-owned follow-up.
+- [x] #3 Route governance gate is run and passes or any blocker is documented with route-owned follow-up.
+- [x] #4 Route metadata unit tests are run and pass or any blocker is documented with route-owned follow-up.
+- [x] #5 Backlog final summary records findings closed, route rows changed, tests run, browser evidence paths, known skips, deferred backend dependencies, and any route rows intentionally left open.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Initial all-pages hard gate failed because smoke auth defaulted to a random API key, producing hard-gate 401 console errors from notifications/persona endpoints. Updated the smoke default to the existing E2E API key used by shared helpers.
+
+Stage 4 then exposed a real `/media` empty-library semantic heading gap: the normal split view had `Media Inspector` as `h1`, but the true empty-library branch rendered no `h1`. Added the same compact route heading to that empty branch.
+
+No backend APIs changed. Bandit was not run because the touched files are TypeScript/TSX frontend and Playwright smoke code only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed WP12 final governance gate in this worktree.
+
+Findings closed: all-pages hard gate auth default mismatch fixed; `/media` empty-library `h1` gap fixed.
+
+Route rows changed: none.
+
+Tests run:
+- `bunx playwright test e2e/smoke/stage4-responsive-landmarks.spec.ts --reporter=line --grep "/media has one route heading" --workers=1` => 1 passed
+- `bun run e2e:smoke:stage4` => 29 passed, 1 skipped
+- `bun run e2e:smoke:route-governance` => 18 passed
+- `bunx vitest run ../packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts ../packages/ui/src/routes/__tests__/route-governance.sidepanel-availability.test.ts ../packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx` => 3 files / 15 tests passed
+- `bun run e2e:smoke:all-pages:gate` => 123 passed
+- `git diff --check` => passed
+
+Browser evidence: Playwright chromium runs from `apps/tldw-frontend`; no separate screenshot artifacts captured.
+
+Known skips: Stage 4 reported 1 existing skipped test.
+
+Deferred backend dependencies: none.
+
+Route rows intentionally left open: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-418.10.8 - Address-PR-1986-smoke-auth-review-comments.md
+++ b/backlog/tasks/task-418.10.8 - Address-PR-1986-smoke-auth-review-comments.md
@@ -1,0 +1,74 @@
+---
+id: TASK-418.10.8
+title: Address PR 1986 smoke auth review comments
+status: Done
+labels:
+- wp12
+- webui
+- route-governance
+- review-comments
+priority: High
+parent_task_id: TASK-418.10
+references:
+- https://github.com/rmusser01/tldw_server/pull/1986
+- TASK-418.10.7
+documentation:
+- Docs/superpowers/plans/2026-05-17-webui-route-governance-qa-implementation-plan.md
+modified_files:
+- apps/tldw-frontend/e2e/utils/e2e-auth.ts
+- apps/tldw-frontend/__tests__/e2e/e2e-auth.test.ts
+- apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+- apps/tldw-frontend/e2e/utils/helpers.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address review comments on PR #1986 about the smoke-test API key fallback: centralize the local E2E placeholder, fail fast for remote server URLs without an explicit key, update evidence, and keep the WP12 final governance fix scoped to frontend smoke/governance code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Smoke and shared E2E helpers use one auth fallback resolver.
+- [x] #2 Local E2E placeholder fallback is documented as non-secret and limited to local server URLs.
+- [x] #3 Non-local E2E server URLs fail fast without an explicit API key.
+- [x] #4 Focused coverage and affected smoke gates are run and recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Addressed PR #1986 review feedback by extracting E2E auth fallback handling into a single shared helper. The default E2E key remains only as a documented non-secret local placeholder, and remote/non-local server URLs now fail fast unless `TLDW_API_KEY`, `TLDW_E2E_API_KEY`, or `SINGLE_USER_API_KEY` is explicitly provided.
+
+Updated smoke setup and shared E2E helpers to use the same resolver. Added Vitest coverage for explicit env precedence, local fallback, localhost detection, and remote fail-fast behavior.
+
+Bandit was not run because the touched files are TypeScript/TSX frontend/E2E code only.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR #1986 review comments addressed. Qodo/Gemini hardcoded-key feedback was handled by centralizing the placeholder in `apps/tldw-frontend/e2e/utils/e2e-auth.ts`, documenting it as a non-secret local E2E fixture value, and guarding against accidental use with non-local server URLs. The duplicated fallback in `smoke.setup.ts` and `helpers.ts` was removed.
+
+Tests run:
+- `bunx vitest run __tests__/e2e/e2e-auth.test.ts` => 1 file / 4 tests passed
+- `bunx playwright test e2e/smoke/all-pages.spec.ts --reporter=line --grep "Smoke Tests - All Pages.*Home" --workers=1` => 1 passed
+- `bun run e2e:smoke:stage4` => 29 passed, 1 skipped
+- `bun run e2e:smoke:route-governance` => 18 passed
+- `bun run e2e:smoke:all-pages:gate` => 123 passed
+- `git diff --check` => passed
+
+Known skips: existing Stage 4 single skipped test.
+
+Deferred backend dependencies: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Centralize E2E smoke auth resolution so `smoke.setup.ts` and shared E2E helpers use the same local-only placeholder behavior.
- Fail fast when a non-local E2E server URL is configured without an explicit `TLDW_API_KEY`, `TLDW_E2E_API_KEY`, or `SINGLE_USER_API_KEY`.
- Add the existing `Media Inspector` route heading to the `/media` empty-library branch, matching the normal media layout and satisfying responsive heading governance.
- Record WP12 Task 7 and PR review follow-up evidence in Backlog.md.

## Validation

- [x] Tests added or updated
- [x] Unit tests pass
- [x] Integration / E2E smoke tests pass
- [x] Documentation or Backlog record updated
- [x] No backend API changes
- [x] Bandit considered; skipped because touched files are TypeScript/TSX frontend/E2E files only

## Verification

- `bunx vitest run __tests__/e2e/e2e-auth.test.ts` => 1 file / 4 tests passed
- `bunx playwright test e2e/smoke/all-pages.spec.ts --reporter=line --grep "Smoke Tests - All Pages.*Home" --workers=1` => 1 passed
- `bunx playwright test e2e/smoke/stage4-responsive-landmarks.spec.ts --reporter=line --grep "/media has one route heading" --workers=1` => 1 passed
- `bun run e2e:smoke:stage4` => 29 passed, 1 skipped
- `bun run e2e:smoke:route-governance` => 18 passed
- `bunx vitest run ../packages/ui/src/routes/__tests__/route-governance.metadata-coverage.test.ts ../packages/ui/src/routes/__tests__/route-governance.sidepanel-availability.test.ts ../packages/ui/src/components/Common/__tests__/CommandPalette.route-targets.test.tsx` => 3 files / 15 tests passed
- `bun run e2e:smoke:all-pages:gate` => 123 passed
- `git diff --check` => passed

## Risk & Rollback

Risk level: Low.

Primary risk is E2E configuration behavior: remote/non-local smoke runs without an explicit API key now fail early instead of falling back to the local placeholder. That is intentional and matches the review feedback.

Rollback plan: revert this PR or revert commits `de96ee21f` and `bef7fd37c` to restore the previous smoke auth and `/media` heading behavior.

## AI-Generated PR Note

Per the repository merge gate, a human-authored `Change summary` explaining what changed and why is still required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the WP12 Task 7 final route-governance gate by centralizing E2E smoke auth with a local-only placeholder key and adding the missing `/media` route heading. This removes 401 console noise, enforces safe auth defaults, and completes responsive heading coverage so Stage 4 and route-governance gates pass.

- **Bug Fixes**
  - E2E/Smoke auth now uses a shared resolver: prefers explicit env keys, only allows the default placeholder for local servers, and fails fast for remote URLs without a key.
  - Added the “Media Inspector” h1 to the `/media` empty-library branch to match the normal media layout and satisfy heading governance.

<sup>Written for commit de96ee21f32f0dacf7432b846146ad6812164b0c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1986?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->
