### PR TITLE
Close first-time model readiness setup task

### DIFF
--- a/backlog/tasks/task-426 - Design-first-time-model-readiness-setup-flow.md
+++ b/backlog/tasks/task-426 - Design-first-time-model-readiness-setup-flow.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-426
 title: Design first-time model readiness setup flow
-status: In Progress
+status: Done
 labels:
 - design
 - setup
@@ -39,15 +39,15 @@ Design-only task. Spec captures the approved first-time model readiness setup ar
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md as a design-only spec for first-time model readiness setup. The spec records the approved unified readiness wizard direction, native WebUI backed by setup APIs, curated profiles, explicit Provision now gating, lane readiness semantics, permission boundaries, error handling, and test strategy. A follow-up critique pass hardened the design by making restart/admin/remote-blocked states overlays instead of lane statuses, treating TTS as secondary metadata inside the speech lane, requiring WebUI fallback when the backend local setup guard blocks native first-run setup, requiring pollable provisioning instead of long-held HTTP requests, clarifying secret handling, and gating trusted custom HF models behind advanced acknowledgement. Verification: rg found no TODO/TBD/FIXME markers; git diff checks passed for touched docs/task metadata. Bandit skipped because this task changes documentation/task metadata only.
+Created Docs/superpowers/specs/2026-05-18-first-time-model-readiness-setup-design.md as a design-only spec for first-time model readiness setup. The spec records the approved unified readiness wizard direction, native WebUI backed by setup APIs, curated profiles, explicit Provision now gating, lane readiness semantics, permission boundaries, error handling, and test strategy. A follow-up critique pass hardened the design by making restart/admin/remote-blocked states overlays instead of lane statuses, treating TTS as secondary metadata inside the speech lane, requiring WebUI fallback when the backend local setup guard blocks native first-run setup, requiring pollable provisioning instead of long-held HTTP requests, clarifying secret handling, and gating trusted custom HF models behind advanced acknowledgement. Verification: rg found no unfinished-work markers; git diff checks passed for touched docs/task metadata. Bandit skipped because this task changes documentation/task metadata only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
Backlog-only closeout for TASK-426.\n\nChanges:\n- Mark TASK-426 as Done.\n- Check the Definition of Done items based on the existing final summary and verification evidence.\n- Reword the marker-scan evidence to avoid self-referential TODO/TBD/FIXME matches.\n\nVerification:\n- git diff --check\n- rg unfinished-work marker scan over the spec and task file found no matches\n- targeted rg scan found no open status or unchecked DoD boxes in TASK-426\n- ASCII/trailing-whitespace scan passed for the task file\n\nBandit is not applicable because this PR changes only Markdown Backlog metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closeout for TASK-426: mark the first-time model readiness design task as Done, check all Definition of Done items, and reword the verification note to use “unfinished-work” markers to avoid TODO/TBD/FIXME false positives.
Documentation-only change to the task markdown; scans and whitespace checks pass, with no open items or unchecked boxes remaining.

<sup>Written for commit bf26bc02281205336328a104a246cff5909afd25. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/1999?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

