### PR TITLE
Migrate FlashcardTemplateValueModal alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -77,17 +77,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/components/FlashcardTemplateValueModal.tsx:Alert",
-    "path": "src/components/Flashcards/components/FlashcardTemplateValueModal.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/components/FlashcardTemplateValueModal.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/tabs/ImageOcclusionPanel.tsx:Alert#antd-alert-imageocclusionpanel-type-info-line-230-fgog2f",
     "path": "src/components/Flashcards/tabs/ImageOcclusionPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Alert, Empty, Form, Input, Modal, Select, Spin, Typography } from "antd"
+import { Empty, Form, Input, Modal, Select, Spin, Typography } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import type { FlashcardCreate } from "@/services/flashcards"
 import { useFlashcardTemplatesQuery } from "../hooks"
@@ -143,14 +144,13 @@ export const FlashcardTemplateValueModal: React.FC<FlashcardTemplateValueModalPr
         </div>
       ) : templatesQuery.error ? (
         <Alert
-          type="error"
-          message={t("option:flashcards.templatesLoadError", {
+          variant="error"
+          title={t("option:flashcards.templatesLoadError", {
             defaultValue: "Could not load templates."
           })}
-          description={
-            templatesQuery.error instanceof Error ? templatesQuery.error.message : undefined
-          }
-        />
+        >
+          {templatesQuery.error instanceof Error ? templatesQuery.error.message : undefined}
+        </Alert>
       ) : templates.length === 0 ? (
         <Empty
           description={t("option:flashcards.templatesEmpty", {

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { FlashcardTemplateValueModal } from "../FlashcardTemplateValueModal"
+import { useFlashcardTemplatesQuery } from "../../hooks"
+
+const messageApi = {
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  loading: vi.fn(),
+  open: vi.fn(),
+  destroy: vi.fn()
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      return defaultValueOrOptions?.defaultValue ?? key
+    }
+  })
+}))
+
+vi.mock("@/hooks/useAntdMessage", () => ({
+  useAntdMessage: () => messageApi
+}))
+
+vi.mock("../../hooks", () => ({
+  useFlashcardTemplatesQuery: vi.fn()
+}))
+
+if (!(globalThis as any).ResizeObserver) {
+  ;(globalThis as any).ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+}
+
+describe("FlashcardTemplateValueModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders template load errors with the design-system alert", () => {
+    vi.mocked(useFlashcardTemplatesQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Network offline")
+    } as any)
+
+    render(
+      <FlashcardTemplateValueModal
+        open
+        onClose={vi.fn()}
+        onApply={vi.fn()}
+      />
+    )
+
+    const errorMessage = screen.getByText("Could not load templates.")
+    expect(errorMessage.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expect(errorMessage.closest('[data-ds-component="Alert"]')).toHaveTextContent("Network offline")
+  })
+})

--- a/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
+++ b/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.9
 title: 'Migrate design-system product state: Flashcards, Quiz, and study flows'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-14 03:19'
 labels:
@@ -15,8 +15,15 @@ references:
   - >-
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/2000'
 parent_task_id: TASK-45.44
 priority: medium
+documentation:
+  - >-
+    TASK-45.44.9.7 / PR #2000 migrated FlashcardTemplateValueModal's template-load
+    error Alert to the design-system Alert primitive. Baseline evidence: total product-state
+    exceptions 265 -> 264; Flashcards/Quiz/study-flow exceptions 41 -> 40; FlashcardTemplateValueModal
+    target rows 1 -> 0. Verification recorded in TASK-45.44.9.7.
 ---
 
 ## Description

--- a/backlog/tasks/task-45.44.9.7 - Migrate-FlashcardTemplateValueModal-load-error-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.7 - Migrate-FlashcardTemplateValueModal-load-error-to-design-system-Alert.md
@@ -1,0 +1,66 @@
+---
+id: TASK-45.44.9.7
+title: Migrate FlashcardTemplateValueModal load error to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+- flashcards
+priority: medium
+parent_task_id: TASK-45.44.9
+references:
+- https://github.com/rmusser01/tldw_server/issues/1666
+- apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.templates.test.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+modified_files:
+- apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the FlashcardTemplateValueModal template-load error callout off AntD Alert and onto the canonical design-system Alert while preserving modal behavior and copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FlashcardTemplateValueModal template-load error callout renders the design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused Flashcards coverage proves the error text remains visible and wrapped in the canonical design-system marker.
+- [x] #3 Design-system product-state verifier passes with the stale FlashcardTemplateValueModal Alert baseline entry removed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing focused FlashcardCreateDrawer template-modal test assertion requiring the load-error callout to render with the design-system Alert marker.
+2. Replace the FlashcardTemplateValueModal AntD Alert usage with the canonical design-system Alert primitive while preserving error title and description copy.
+3. Remove the FlashcardTemplateValueModal Alert entry from the product-state baseline and run focused tests plus the design-system verifier.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+TDD red/green completed. Added a focused FlashcardTemplateValueModal load-error test requiring the error title to be wrapped by the canonical data-ds-component Alert marker; the first focused run failed because the existing AntD Alert had no design-system marker. Replaced only the modal template-load error callout with the shared design-system Alert primitive while preserving title and error-message copy, then removed the stale FlashcardTemplateValueModal Alert baseline entry.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the FlashcardTemplateValueModal template-load error callout from AntD Alert to the design-system Alert primitive. Focused coverage now verifies the load-error text renders in the canonical Alert wrapper, and the product-state baseline no longer contains the FlashcardTemplateValueModal Alert exception. Verification: red focused modal test failed on the missing design-system marker; green focused modal test passed 1/1; existing FlashcardCreateDrawer template-flow suite passed 8/8; product-state guard passed 54/54; bun run verify:design-system-state passed with 264 allowed legacy exceptions and 40 remaining Flashcards/Quiz/study-flow exceptions; baseline JSON parse reported targetRows 0; git diff --check passed. TypeScript still exits 2 on 330 existing diagnostics, with no diagnostics for FlashcardTemplateValueModal, the new modal test, the baseline, or TASK-45.44.9.7. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.9.7 - Migrate-FlashcardTemplateValueModal-load-error-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.7 - Migrate-FlashcardTemplateValueModal-load-error-to-design-system-Alert.md
@@ -16,6 +16,7 @@ references:
 - apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.templates.test.tsx
 - apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/2000
 modified_files:
 - apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
 - apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx


### PR DESCRIPTION
## Summary
- Migrates the FlashcardTemplateValueModal template-load error callout from AntD Alert to the shared design-system Alert primitive.
- Adds focused modal coverage requiring the load-error text to render inside the canonical data-ds-component="Alert" wrapper.
- Removes the stale FlashcardTemplateValueModal Alert row from the product-state baseline and records TASK-45.44.9.7.

## Verification
- bunx vitest run src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx --reporter=dot
- bunx vitest run src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.templates.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); console.log(JSON.stringify({total:data.length,targetRows:data.filter(e=>e.path==='src/components/Flashcards/components/FlashcardTemplateValueModal.tsx').length},null,2));"
- git diff --check origin/dev
- git diff --cached --check
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false > /tmp/tldw_flashcard_template_value_tsc.log 2>&1 (still exits 2 on 330 existing diagnostics; no diagnostics mention FlashcardTemplateValueModal, the new modal test, the baseline, or TASK-45.44.9.7)

## Change summary
This narrows one remaining Flashcards product-state exception by replacing the modal's load-error AntD Alert with the canonical design-system primitive, preserving the existing error title and optional error-message body. The focused test is direct to the modal so the design-system contract is covered without coupling the assertion to the broader drawer workflow, while the existing drawer template-flow suite still protects the integration path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the `FlashcardTemplateValueModal` load-error callout from AntD to the design-system `Alert` to standardize UI and remove a product-state exception. Adds a focused test to ensure the error renders inside the canonical `[data-ds-component="Alert"]` wrapper. Satisfies TASK-45.44.9.7.

- **Refactors**
  - Replace AntD `Alert` with design-system `Alert` in `FlashcardTemplateValueModal`, keeping the same error title and optional message.
  - Add a focused modal test that asserts the design-system `Alert` wrapper and error text.
  - Remove the stale `FlashcardTemplateValueModal` `Alert` entry from `design-system-product-state-baseline.json`.
  - Update tasks: mark `TASK-45.44.9` In Progress and record this PR link and verification in `TASK-45.44.9.7`.

<sup>Written for commit 9fd44b3b9cd5c0d799257957915110912c281fd4. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2000?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

