### PR TITLE
Close media read-along design and plan metadata

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
@@ -20,6 +20,26 @@
 
 This plan covers one reviewable subsystem: read-along behavior inside the shared `ContentViewer` path. It deliberately excludes backend API work, new TTS providers, persistent server-side audio cache, word-level timing, and a page-level read-aloud player.
 
+## Plan Hardening Review - 2026-05-23
+
+Status: this plan has already been executed. The implementation is recorded in `TASK-417`, and post-PR review fixes are recorded in `TASK-425` for PR #1835. Do not treat the unchecked task-step checkboxes below as current backlog work; they are preserved as the original execution script. The authoritative completion evidence is the completed `TASK-417`/`TASK-425` records plus the final verification checklist in this file.
+
+Current-code ownership check passed:
+
+- `apps/packages/ui/src/components/Media/read-along/` contains the planned segmentation, cache, DOM, selection, session, popover, transport, and focused test modules.
+- `ContentViewer` imports and wires `useContentSelectionActions`, `useMediaReadAlongSession`, `MediaReadAlongPopover`, and `MediaReadAlongTransport`.
+- `useContentViewerModals` exposes explicit `captureAnnotationSelection` while retaining `handleCaptureAnnotationSelection` as a compatibility wrapper.
+- `useTranscriptDisplay` and `ContentViewer` expose `data-read-along-segment-id` / `data-read-along-active` markers for plain and transcript rendering.
+- `tts-provider` exposes `TtsSynthesizeOptions.signal`; `tldw`, OpenAI, and ElevenLabs synthesis paths accept abort signals where their helpers support it, while the browser provider remains a no-cache SpeechSynthesis path.
+- Dexie schema/types include `mediaReadAlongAudioCache` with the media read-along audio cache entry type.
+- Route guards verify WebUI and extension media routes stay on the shared `ViewMediaPage` path and do not duplicate read-along implementation in extension route files.
+
+Risk review passed:
+
+- Annotation selection mediation, full-content versus rendered-window behavior, abort/stale suppression, cache privacy/quota behavior, browser TTS, embedded media pause, markdown/html fallback, route parity, and accessibility all map to focused tests or recorded browser verification.
+- No stale file ownership paths were found in this plan.
+- Future read-along changes should use new focused Backlog tasks rather than re-executing this historical plan.
+
 ## File Structure
 
 Create this directory:

--- a/backlog/tasks/task-415 - Design-media-viewer-read-along-TTS-interaction.md
+++ b/backlog/tasks/task-415 - Design-media-viewer-read-along-TTS-interaction.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-415
 title: Design media viewer read-along TTS interaction
-status: In Progress
+status: Done
 labels:
 - design
 - webui
@@ -10,6 +10,9 @@ labels:
 - media
 modified_files:
 - Docs/superpowers/specs/2026-05-17-media-viewer-read-along-tts-design.md
+- Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md
+- backlog/tasks/task-415 - Design-media-viewer-read-along-TTS-interaction.md
+- backlog/tasks/task-416 - Plan-media-viewer-read-along-TTS-implementation.md
 ---
 
 ## Description
@@ -20,10 +23,10 @@ Create a design spec for selection-initiated read-along functionality in the sha
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spec documents the approved selection-first interaction model.
-- [ ] #2 Spec anchors the design to shared ContentViewer/WebUI/extension paths and existing TTS services.
-- [ ] #3 Spec covers hybrid transcript-line/sentence segmentation, range expansion actions, active highlighting, chunked lookahead, browser-local cache, error handling, and v1 exclusions.
-- [ ] #4 Spec includes testing and staged rollout guidance.
+- [x] #1 Spec documents the approved selection-first interaction model.
+- [x] #2 Spec anchors the design to shared ContentViewer/WebUI/extension paths and existing TTS services.
+- [x] #3 Spec covers hybrid transcript-line/sentence segmentation, range expansion actions, active highlighting, chunked lookahead, browser-local cache, error handling, and v1 exclusions.
+- [x] #4 Spec includes testing and staged rollout guidance.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -45,26 +48,33 @@ Verification:
 - Marker scan found no unfinished-work markers in the spec or task after the critique patch.
 - git diff --check passed for the spec and task files.
 - Bandit is not applicable because this change is docs/task tracking only.
+
+2026-05-23 closeout review:
+- Re-reviewed the design spec against all acceptance criteria and current `origin/dev`.
+- Re-hardened the implementation plan at Docs/superpowers/plans/2026-05-17-media-viewer-read-along-tts-implementation-plan.md with a status note showing the plan has already been executed by TASK-417 and post-PR review fixes were recorded in TASK-425.
+- Confirmed current code ownership for shared `ContentViewer` integration, mediated annotation/read-along selection, read-along modules, TTS provider abort support, Dexie cache schema, and WebUI/extension route parity.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+The design spec remains the authoritative v1 product contract. No spec changes were required during the closeout pass because the existing document already covers the selection-first entry model, shared UI ownership, existing TTS reuse, segmentation/highlighting/lookahead/cache/error behavior, v1 exclusions, staged rollout, and testing guidance.
 
+Backlog note: this repository currently has duplicate `TASK-416` IDs, so MCP task lookup resolves `TASK-416` to an unrelated chat task. The media read-along plan file was updated directly by path to avoid modifying the wrong task.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Closed the media viewer read-along TTS design task. The approved spec documents the selection-first interaction model, anchors the work to shared `ContentViewer`/WebUI/extension surfaces and existing TTS services, covers hybrid transcript/sentence segmentation, range expansion actions, active highlighting, chunked lookahead, browser-local cache, error handling, and v1 exclusions, and includes staged rollout plus testing guidance. The implementation plan was re-reviewed and updated with current execution status: implementation landed through TASK-417 and PR review feedback through TASK-425. Verification for this closeout used current-code ownership `rg` checks, Backlog evidence review, unfinished-marker checks, and `git diff --check`; Bandit is not applicable because only Markdown/Backlog metadata changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-416 - Plan-media-viewer-read-along-TTS-implementation.md
+++ b/backlog/tasks/task-416 - Plan-media-viewer-read-along-TTS-implementation.md
@@ -60,7 +60,10 @@ Verification:
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+2026-05-23 plan-hardening review:
+- Re-reviewed the implementation plan against current `origin/dev` after the read-along implementation and PR review fixes had already landed.
+- Confirmed the planned shared UI ownership, read-along module layout, `ContentViewer` wiring, annotation selection mediation, TTS provider abort surface, Dexie cache table, route parity guard, and focused test surfaces all exist in current code.
+- Updated the plan with an execution-status note so future workers do not mistake the preserved unchecked task-step checklist for remaining backlog work.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
Summary: closes TASK-415 after validating the existing media read-along design spec; hardens the read-along implementation plan with current execution status from TASK-417 and TASK-425; records duplicate TASK-416 Backlog ID caveat so future workers do not update the wrong task. Verification: git diff --check; rg checks for TASK-415 status/DoD and unfinished markers; current-code ownership rg checks for ContentViewer/read-along/TTS/Dexie/route parity evidence. Bandit skipped because only Markdown/Backlog metadata changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes `TASK-415` by validating the media read‑along TTS design and marking AC/DoD complete, and hardens the `2026-05-17` implementation plan with an execution-status note (implemented in `TASK-417`, fixes in `TASK-425`). Confirms shared `ContentViewer` wiring, read‑along modules, Dexie cache table, TTS abort support, and WebUI/extension route parity; records a duplicate `TASK-416` ID caveat to avoid edits to the wrong task.

<sup>Written for commit b8d75625c92484f3bc2086ce90702a2ebad3dd01. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2001?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

