### PR TITLE
Migrate Flashcards ExportPanel preview alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -99,17 +99,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx:Alert",
-    "path": "src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx:Alert#antd-alert-generatepanel-type-error-line-522-1gz2kd2",
     "path": "src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import { useQuery } from "@tanstack/react-query"
-import { Alert, Button, Form, Input, Select, Switch, Typography } from "antd"
+import { Button, Form, Input, Select, Switch, Typography } from "antd"
 import { useTranslation } from "react-i18next"
 
+import { Alert } from "@/components/ui/primitives"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { exportFlashcards, exportFlashcardsFile, listFlashcards } from "@/services/flashcards"
 
@@ -290,13 +291,13 @@ export const ExportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
         </>
       )}
       <Alert
-        type="info"
-        showIcon
+        variant="info"
         data-testid="flashcards-export-preview"
         title={t("option:flashcards.exportPreviewTitle", {
           defaultValue: "Export preview"
         })}
-        description={t("option:flashcards.exportPreviewDescription", {
+      >
+        {t("option:flashcards.exportPreviewDescription", {
           defaultValue:
             "{{count}} cards from {{deck}}. Tag filter: {{tag}}. Query filter: {{query}}.",
           count: exportPreviewCountQuery.data ?? 0,
@@ -308,7 +309,7 @@ export const ExportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
             normalizedExportQuery ||
             t("option:flashcards.noneLabel", { defaultValue: "none" })
         })}
-      />
+      </Alert>
       <Button
         type="primary"
         onClick={handleExport}

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -815,6 +815,10 @@ describe("ImportExportTab import result details", () => {
         "42 cards from Biology"
       )
     })
+    expect(screen.getByTestId("flashcards-export-preview")).toHaveAttribute(
+      "data-ds-component",
+      "Alert"
+    )
     const exportPreviewQuery = useQueryMock.mock.calls
       .map(([options]) => options as any)
       .findLast((options) => options.queryKey?.[0] === "flashcards:export-preview-count")

--- a/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
+++ b/backlog/tasks/task-45.44.9 - Migrate-design-system-product-state-Flashcards-Quiz-and-study-flows.md
@@ -16,6 +16,7 @@ references:
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
   - 'https://github.com/rmusser01/tldw_server/pull/2000'
+  - 'https://github.com/rmusser01/tldw_server/pull/2002'
 parent_task_id: TASK-45.44
 priority: medium
 documentation:
@@ -24,6 +25,11 @@ documentation:
     error Alert to the design-system Alert primitive. Baseline evidence: total product-state
     exceptions 265 -> 264; Flashcards/Quiz/study-flow exceptions 41 -> 40; FlashcardTemplateValueModal
     target rows 1 -> 0. Verification recorded in TASK-45.44.9.7.
+  - >-
+    TASK-45.44.9.8 / PR #2002 migrated the Flashcards ExportPanel export-preview Alert
+    to the design-system Alert primitive. Baseline evidence: total product-state exceptions
+    264 -> 263; Flashcards/Quiz/study-flow exceptions 40 -> 39; ExportPanel target rows
+    1 -> 0. Verification recorded in TASK-45.44.9.8.
 ---
 
 ## Description

--- a/backlog/tasks/task-45.44.9.8 - Migrate-Flashcards-ExportPanel-preview-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.8 - Migrate-Flashcards-ExportPanel-preview-alert-to-design-system-Alert.md
@@ -15,6 +15,7 @@ references:
 - apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx
 - apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/2002
 modified_files:
 - apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx
 - apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx

--- a/backlog/tasks/task-45.44.9.8 - Migrate-Flashcards-ExportPanel-preview-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.9.8 - Migrate-Flashcards-ExportPanel-preview-alert-to-design-system-Alert.md
@@ -1,0 +1,65 @@
+---
+id: TASK-45.44.9.8
+title: Migrate Flashcards ExportPanel preview alert to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+- flashcards
+priority: medium
+parent_task_id: TASK-45.44.9
+references:
+- https://github.com/rmusser01/tldw_server/issues/1666
+- apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+modified_files:
+- apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the Flashcards Import/Export export-preview callout off AntD Alert and onto the canonical design-system Alert while preserving preview copy and export behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ExportPanel preview callout renders the design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused ImportExportTab export coverage proves the preview copy remains visible and wrapped in the canonical design-system marker.
+- [x] #3 Design-system product-state verifier passes with the stale ExportPanel Alert baseline entry removed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing focused ImportExportTab export-preview assertion requiring the preview callout to render with the design-system Alert marker.
+2. Replace the ExportPanel AntD Alert preview usage with the canonical design-system Alert primitive while preserving title, description, data-testid, and export behavior.
+3. Remove the ExportPanel Alert entry from the product-state baseline and run focused tests plus the design-system verifier.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+TDD red/green completed. Added a focused ImportExportTab export-preview assertion requiring the existing preview callout to carry the canonical data-ds-component Alert marker; the red run failed because the AntD Alert preview lacked that marker. Replaced only the export preview callout with the shared design-system Alert primitive while preserving title, preview description interpolation, data-testid, and export behavior, then removed the stale ExportPanel Alert baseline entry.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the Flashcards Import/Export export preview callout from AntD Alert to the design-system Alert primitive. Focused export coverage now verifies the preview copy remains visible and the preview root carries data-ds-component="Alert", and the product-state baseline no longer contains the ExportPanel Alert exception. Verification: red ImportExportTab import-results test failed on the missing design-system marker; green ImportExportTab import-results suite passed 22/22; product-state guard passed 54/54; bun run verify:design-system-state passed with 263 allowed legacy exceptions and 39 remaining Flashcards/Quiz/study-flow exceptions; baseline JSON parse reported targetRows 0; git diff --check passed. TypeScript still exits 2 on 330 existing diagnostics, with no diagnostics for ExportPanel, ImportExportTab.import-results, the baseline, or TASK-45.44.9.8. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the Flashcards Import/Export export-preview callout from AntD Alert to the shared design-system Alert primitive.
- Extends focused ImportExportTab export coverage so the preview copy must render on the canonical data-ds-component="Alert" root.
- Removes the stale ExportPanel Alert row from the product-state baseline and records TASK-45.44.9.8.

## Verification
- bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx --reporter=dot
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot
- bun run verify:design-system-state
- node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('apps/packages/ui/scripts/design-system-product-state-baseline.json','utf8')); const focus=data.filter(e=>/^(src\/components\/Flashcards\/|src\/components\/Quiz\/|src\/components\/StudySuggestions\/)/.test(e.path)); console.log(JSON.stringify({total:data.length,focus:focus.length,targetRows:data.filter(e=>e.path==='src/components/Flashcards/tabs/ImportExport/ExportPanel.tsx').length},null,2));"
- git diff --check origin/dev
- git diff --cached --check
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false > /tmp/tldw_flashcards_export_panel_tsc.log 2>&1 (still exits 2 on 330 existing diagnostics; no diagnostics mention ExportPanel, ImportExportTab.import-results, the baseline, or TASK-45.44.9.8)

## Change summary
This removes one Flashcards product-state exception by replacing the export preview's AntD Alert with the canonical design-system Alert, preserving the preview title, interpolated description, data-testid, and export flow behavior. The existing export-options test already exercised this UI, so the PR tightens that coverage with a design-system marker assertion instead of adding a separate shallow test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Flashcards ExportPanel export preview from `antd` Alert to the design-system Alert to standardize UI and remove a product-state exception. Satisfies TASK-45.44.9.8 and records the PR link in the task docs.

- **Refactors**
  - Replaced preview `antd` Alert with design-system Alert; kept title, copy, and `data-testid`.
  - Tightened test to assert `data-ds-component="Alert"` on the preview root.
  - Removed the ExportPanel Alert entry from the design-system product-state baseline.

<sup>Written for commit 4195f81a1ef3812f334111ac204275f0bf5373eb. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2002?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

