### PR TITLE
Close llama.cpp managed runtime roadmap task

### DIFF
--- a/Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
@@ -1,11 +1,29 @@
 # llama.cpp Managed Runtime Roadmap Design
 
-Status: Draft
+Status: Closed for staged implementation tracking
 Date: 2026-05-16
 Owner: Core/WebUI maintainers
 Scope: Multi-instance llama.cpp management, local model import/register workflows, durable instance profiles, supervisor behavior, and model-family/mmproj support
 Tracking: TASK-397
 Reference: https://github.com/m94301/llama-studio
+
+## Closeout Status - 2026-05-23
+
+This roadmap is no longer a draft. It was used as the governing design for the
+staged managed-runtime work recorded under `TASK-397.1`, `TASK-397.2`,
+`TASK-397.5`, `TASK-397.6`, `TASK-397.7`, `TASK-397.8`, `TASK-407`, `TASK-418`,
+`TASK-418.14`, `TASK-418.15`, `TASK-418.16`, `TASK-419`, and `TASK-423`.
+
+The implementation chain delivered the core backend-owned runtime posture this
+design called for: durable profiles, a process runner, multi-profile
+supervisor, default-profile V1 compatibility, local asset inventory, mmproj and
+model-family metadata, Admin UI assets/runtime/profile panels, startup/shutdown
+reconciliation, API compatibility hardening, documentation, and E2E smoke
+coverage.
+
+Remote model downloads, curated catalogs, and broader acquisition workflows
+remain intentionally deferred to separate acquisition/import tasks rather than
+being part of this closed roadmap-design task.
 
 ## Summary
 

--- a/backlog/tasks/task-397 - Design-llama.cpp-managed-runtime-roadmap.md
+++ b/backlog/tasks/task-397 - Design-llama.cpp-managed-runtime-roadmap.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-397
 title: Design llama.cpp managed runtime roadmap
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-16 01:20'
-updated_date: '2026-05-16 01:29'
+updated_date: '2026-05-23 11:28'
 labels:
   - llamacpp
   - design
@@ -14,9 +14,12 @@ dependencies: []
 references:
   - 'https://github.com/m94301/llama-studio'
 documentation:
-  - Docs/superpowers/specs/2026-05-15-llamacpp-server-management-webui-design.md
-  - >-
-    Docs/superpowers/plans/2026-05-15-llamacpp-server-management-webui-implementation-plan.md
+  - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+  - Docs/superpowers/plans/2026-05-16-llamacpp-managed-runtime-stage1-implementation-plan.md
+  - Docs/superpowers/plans/2026-05-17-llamacpp-managed-runtime-implementation-plan.md
+modified_files:
+  - Docs/superpowers/specs/2026-05-16-llamacpp-managed-runtime-roadmap-design.md
+  - backlog/tasks/task-397 - Design-llama.cpp-managed-runtime-roadmap.md
 priority: medium
 ---
 
@@ -45,14 +48,27 @@ Local consistency review completed: checked the spec for the requested compatibi
 Bandit not run for this task because the current change is documentation/backlog only and touches no Python code.
 
 Spec critique pass completed before implementation planning. Added design clarifications for backend-owned persistence vs config.txt, admin-only/deployment-global scope, multi-user provider-wiring constraints, asset identity and symlink allowlist handling, explicit port policy, default-profile migration behavior, per-profile lifecycle locking, shutdown/orphan behavior, reserved mode flags, local folder import semantics, and extra E2E coverage for duplicate ports and V1 wrapper behavior.
+
+2026-05-23 closeout review:
+- Re-reviewed the roadmap spec against all acceptance criteria and current `origin/dev`.
+- Updated the spec status from draft to closed for staged implementation tracking.
+- Confirmed follow-on planning and implementation evidence exists through `TASK-397.1`, `TASK-397.2`, `TASK-397.5`, `TASK-397.6`, `TASK-397.7`, `TASK-397.8`, `TASK-407`, `TASK-418`, `TASK-418.14`, `TASK-418.15`, `TASK-418.16`, `TASK-419`, and `TASK-423`.
+- Confirmed current code contains the expected backend/runtime/WebUI ownership points: profile store, process runner, supervisor service, runtime reconciler startup/shutdown hooks, Admin assets/runtime/profile panels, llama.cpp runtime API tests, and rollout E2E smoke coverage.
+- Backlog note: this repository contains a duplicate `TASK-397` ID, so MCP `task_view` resolves `TASK-397` to an unrelated Sync task. This llama.cpp task was updated by exact file path to avoid modifying the wrong record.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed the llama.cpp managed runtime roadmap design task. The approved spec covers the requested roadmap architecture, default-profile V1 compatibility, local-first asset/profile/runtime supervision model, model-family and mmproj support, UX workflow, testing strategy, and explicit remote-download deferral. Follow-on work has already carried the roadmap through staged planning, Stage 1 runtime/profile APIs, asset inventory, model-family/mmproj metadata, Admin UI capability/profile surfaces, runtime reconciliation, validation/API hardening, rollout docs, and E2E smoke coverage. Verification for this closeout used exact-path Backlog review because of the duplicate `TASK-397` ID, current-code ownership `rg` checks, unfinished-marker checks, and `git diff --check`; Bandit is not applicable because only Markdown/Backlog metadata changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
Summary: closes the llama.cpp managed runtime roadmap design task by updating the roadmap spec status from draft to closed for staged implementation tracking; records the completed implementation chain and duplicate TASK-397 Backlog ID caveat; marks the exact llama.cpp TASK-397 record Done with DoD/final summary. Verification: git diff --check; rg checks for TASK-397 status/DoD and unfinished markers; current-code ownership rg checks for profile store, process runner, supervisor, runtime reconciler, Admin panels, runtime tests, and E2E smoke coverage. Bandit skipped because only Markdown/Backlog metadata changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the llama.cpp managed runtime roadmap spec as Closed and sets `TASK-397` to Done with a final summary and Definition of Done. Adds closeout notes and links to the staged implementation chain; no code changes (docs/backlog only).

<sup>Written for commit b14ea33555f47ee56b079bc7399e741cc8531182. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2003?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

