### PR TITLE
docs: close VN Play session setup task

### DIFF
--- a/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
+++ b/backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-157
 title: Make VN Play session setup usable
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 05:15'
-updated_date: '2026-05-09 06:03'
+updated_date: '2026-05-23 12:38'
 labels:
   - vn-play
   - frontend
@@ -63,6 +63,8 @@ Verification recorded:
 - Bandit: not applicable; touched production code is frontend TypeScript/React only.
 
 PR #1409 review follow-up: verified unresolved review threads, then added regressions and fixes for paginated character loading via /characters/query, bounded VN asset readiness request fan-out, rendering selectors before readiness completes, and duplicate readiness-warning React keys. Verification: red run failed 5 expected tests before fixes; final focused vitest passed 5 files / 26 tests; touched-file ESLint exited 0; git diff --check exited 0; VN Play smoke passed 1 test outside the sandbox after port binding was denied inside the sandbox. Bandit remains not applicable because touched production code is frontend TypeScript/React only.
+
+Closeout review 2026-05-23: confirmed PR #1409 merged into `dev` at merge commit `ad27e6af6fa4511e7d2e27bc96595912fa4db049`. Current `origin/dev` still contains the selector-driven VN Play setup ownership in `NewSessionDialog.tsx`, `lib/api/characters.ts`, `types/characters.ts`, focused `VNPlayWorkspace` coverage, and the selector-based VN Play smoke test. Backlog MCP resolves `TASK-157` to a different duplicate task, so this closeout used the exact VN Play task path.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Change summary
- Marks the exact VN Play TASK-157 Backlog record as Done.
- Adds closeout evidence that PR #1409 merged into dev and that current VN Play files still contain the selector-driven setup implementation and coverage.
- Records the duplicate TASK-157 Backlog MCP resolution issue, which required exact-path editing.

## Verification
- `git diff --check`
- `git diff --name-only` showed only `backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md`
- `rg -n "\[ \]" "backlog/tasks/task-157 - Make-VN-Play-session-setup-usable.md"` exited 1 with no unchecked checklist items
- `gh pr view 1409 --repo rmusser01/tldw_server --json state,mergedAt,mergeCommit,url` confirmed PR #1409 is merged at `ad27e6af6fa4511e7d2e27bc96595912fa4db049`

## Bandit
Skipped: Backlog Markdown metadata only; no Python code changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks VN Play TASK-157 as Done and adds closeout evidence that PR #1409 merged into `dev`, with the selector-driven setup and tests still present. Notes the duplicate MCP resolution and exact-path closeout; documentation-only change to the backlog record.

<sup>Written for commit 161274e2ac7865e6c7ed97ce06411405921e8633. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2005?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

