### PR TITLE
docs: close main chat cockpit gap task

### DIFF
--- a/Docs/superpowers/specs/2026-05-12-main-chat-cockpit-controls-gap-design.md
+++ b/Docs/superpowers/specs/2026-05-12-main-chat-cockpit-controls-gap-design.md
@@ -1,5 +1,11 @@
 # Main /chat True Cockpit Controls Gap Design
 
+## Closeout Status - 2026-05-23
+
+This gap design is closed as the originating specification for the main WebUI `/chat` cockpit work. It stayed scoped to the main `/chat` route, excluded browser-extension sidepanel/sidebar work, separated parity gaps from true cockpit-control completion, and defined the component plus real-server verification bar.
+
+The work continued through the first-slice plan and implementation, the mature rail completion design, the P-series completion tracker, and merge certification. PR #1582 merged into `dev` at `ef1390857fee0e322f26756f7f1da48115373272`. Later post-merge UX maturity planning is tracked in `Docs/superpowers/specs/2026-05-15-main-chat-cockpit-maturity-roadmap-design.md`; do not treat this historical gap spec as the active backlog for additional `/chat` cockpit enhancements.
+
 ## Scope
 
 This spec covers only the main WebUI `/chat` page, routed through `apps/tldw-frontend/pages/chat/index.tsx` into the shared `Playground` surface. It explicitly excludes the browser-extension sidepanel, sidepanel sidebar, settings pages, onboarding, character library pages, backend API design, MCP Hub, evaluations, media ingestion, and repo-wide architecture unless a point directly affects the main `/chat` user experience.

--- a/backlog/tasks/task-288 - Specify-main-chat-true-cockpit-control-gaps.md
+++ b/backlog/tasks/task-288 - Specify-main-chat-true-cockpit-control-gaps.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-288
 title: Specify main /chat true cockpit control gaps
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-12 04:21'
-updated_date: '2026-05-12 04:34'
+updated_date: '2026-05-23 12:47'
 labels:
   - webui
   - chat
@@ -16,6 +16,12 @@ dependencies:
   - TASK-280
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/1582'
+documentation:
+  - Docs/superpowers/specs/2026-05-12-main-chat-cockpit-controls-gap-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-13-main-chat-cockpit-rail-completion-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-16-main-chat-cockpit-merge-certification.md
 priority: high
 ---
 
@@ -27,11 +33,11 @@ Create a design/spec artifact for the main WebUI /chat page that defines the mis
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spec states the target is the main /chat page only and excludes sidepanel/sidebar work.
-- [ ] #2 Spec distinguishes existing /chat functionality parity from true cockpit-control design gaps.
-- [ ] #3 Spec identifies missing or incomplete cockpit controls with evidence from current files/components where possible.
-- [ ] #4 Spec defines practical test coverage needed for true cockpit controls and old /chat workflow parity.
-- [ ] #5 Spec does not implement code changes or propose unrelated product features.
+- [x] #1 Spec states the target is the main /chat page only and excludes sidepanel/sidebar work.
+- [x] #2 Spec distinguishes existing /chat functionality parity from true cockpit-control design gaps.
+- [x] #3 Spec identifies missing or incomplete cockpit controls with evidence from current files/components where possible.
+- [x] #4 Spec defines practical test coverage needed for true cockpit controls and old /chat workflow parity.
+- [x] #5 Spec does not implement code changes or propose unrelated product features.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -42,14 +48,22 @@ Created design spec at Docs/superpowers/specs/2026-05-12-main-chat-cockpit-contr
 Design review pass found and addressed three spec risks: real-server requirements could be misread as allowing mocked browser data, cockpit scope was too broad for one implementation pass, and open questions lacked default decisions. The spec now adds a shared control contract, a narrow first implementation slice, explicit no page.route/synthetic payload language for merge-critical Playwright coverage, interim degraded-health classification, and default answers for persistence/runtime/submit-test scope.
 
 Clarified the spec is only the first implementation slice toward the longer-term main /chat cockpit target. Added a First Slice Boundary section with explicit in-scope and out-of-scope lists, renamed broader items to Cockpit Maturity Backlog, and added a boundary warning not to implement later cockpit-maturity items without explicit user approval.
+
+Closeout review 2026-05-23: verified the design artifact at `Docs/superpowers/specs/2026-05-12-main-chat-cockpit-controls-gap-design.md` already satisfies the task acceptance criteria: it scopes to `apps/tldw-frontend/pages/chat/index.tsx` -> `apps/packages/ui/src/routes/option-chat.tsx` -> `Playground`, excludes browser-extension sidepanel/sidebar work, separates merge-blocking parity from true cockpit-control completion, names file/component evidence, and defines component plus real-server Playwright coverage. PR #1582 is merged into `dev` at `ef1390857fee0e322f26756f7f1da48115373272`; downstream TASK-290, TASK-291, TASK-295, TASK-319, TASK-390, and `Docs/superpowers/specs/2026-05-16-main-chat-cockpit-merge-certification.md` record the implementation, certification, and post-merge roadmap that followed from this spec. Bandit skipped for this closeout because only Markdown spec/task files changed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed the main `/chat` cockpit-control gap specification task. The original spec is scoped to the main WebUI `/chat` page, excludes sidepanel/sidebar work, separates parity gaps from cockpit maturity, identifies missing controls with concrete file/component evidence, and defines practical component plus real-server verification coverage. No application code was changed in this closeout; the design has already fed the merged PR #1582 implementation and later maturity roadmap.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-288 - Specify-main-chat-true-cockpit-control-gaps.md
+++ b/backlog/tasks/task-288 - Specify-main-chat-true-cockpit-control-gaps.md
@@ -18,10 +18,9 @@ references:
   - 'https://github.com/rmusser01/tldw_server/pull/1582'
 documentation:
   - Docs/superpowers/specs/2026-05-12-main-chat-cockpit-controls-gap-design.md
-  - >-
-    Docs/superpowers/specs/2026-05-13-main-chat-cockpit-rail-completion-design.md
-  - >-
-    Docs/superpowers/specs/2026-05-16-main-chat-cockpit-merge-certification.md
+  - Docs/superpowers/specs/2026-05-13-main-chat-cockpit-rail-completion-design.md
+  - Docs/superpowers/specs/2026-05-15-main-chat-cockpit-maturity-roadmap-design.md
+  - Docs/superpowers/specs/2026-05-16-main-chat-cockpit-merge-certification.md
 priority: high
 ---
 


### PR DESCRIPTION
## Change summary
- Marks TASK-288 as Done and checks its acceptance criteria/Definition of Done.
- Adds closeout evidence that the original main `/chat` cockpit gap spec scoped to the WebUI chat page, excluded sidepanel/sidebar work, separated parity from cockpit maturity, named concrete file/component evidence, and defined real-server verification coverage.
- Adds a short closeout status to the original gap spec so future work follows the later post-merge maturity roadmap instead of reopening the historical PR #1582 gap artifact.

## Verification
- `git diff --check`
- `rg -n "\[ \]" "backlog/tasks/task-288 - Specify-main-chat-true-cockpit-control-gaps.md" Docs/superpowers/specs/2026-05-12-main-chat-cockpit-controls-gap-design.md` exited 1 with no unchecked checklist items
- `gh pr view 1582 --repo rmusser01/tldw_server --json state,mergedAt,mergeCommit,url` confirmed PR #1582 is merged at `ef1390857fee0e322f26756f7f1da48115373272`

## Bandit
Skipped: Markdown spec/task closeout only; no Python code changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the main `/chat` cockpit-controls gap by marking `TASK-288` Done and adding a 2026‑05‑23 Closeout Status to the spec; no app code changed. The spec reaffirms scope (main `/chat` only; excludes sidepanel/sidebar), separates parity from true cockpit maturity, cites concrete component/file evidence with real‑server verification, and links to merged PR #1582 plus the rail completion, merge certification, and maturity roadmap docs.

<sup>Written for commit 152d8f5959099f09ae72f7bad33518f2fe86ae96. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2006?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

