### PR TITLE
Fix AssistantSelect stale selection mode intent

### DIFF
--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -136,7 +136,7 @@ export const AssistantSelect: React.FC<Props> = ({
   })
   const [open, setOpen] = React.useState(false)
   const [searchText, setSearchText] = React.useState("")
-  const [selectionMode, setSelectionMode] = React.useState<"tracked" | "overlay">(
+  const selectionModeIntentRef = React.useRef<"tracked" | "overlay">(
     selectionModePreference
   )
   const [activeTab, setActiveTab] = React.useState<"character" | "persona">(
@@ -196,6 +196,10 @@ export const AssistantSelect: React.FC<Props> = ({
   }, [selectedAssistant?.kind])
 
   React.useEffect(() => {
+    selectionModeIntentRef.current = selectionModePreference
+  }, [selectionModePreference])
+
+  React.useEffect(() => {
     if (typeof window === "undefined") return
 
     const handleOpen = (event: Event) => {
@@ -209,9 +213,8 @@ export const AssistantSelect: React.FC<Props> = ({
         detail.returnFocusSelector.trim().length > 0
           ? detail.returnFocusSelector.trim()
           : null
-      setSelectionMode(
+      selectionModeIntentRef.current =
         detail?.applyAs === "overlay" ? "overlay" : selectionModePreference
-      )
       setSearchText("")
       setOpen(true)
     }
@@ -438,31 +441,31 @@ export const AssistantSelect: React.FC<Props> = ({
 
   const handleSelect = React.useCallback(
     async (entry: AssistantSelection) => {
-      const activeSelectionMode = selectionMode
+      const nextMode = selectionModeIntentRef.current
       const isTrackedMode =
         effectiveAssistantState.mode === "tracked_character" ||
         effectiveAssistantState.mode === "tracked_persona"
-      if (activeSelectionMode === "overlay" && isTrackedMode) {
+      if (nextMode === "overlay" && isTrackedMode) {
         setOpen(false)
         setSearchText("")
-        setSelectionMode(selectionModePreference)
+        selectionModeIntentRef.current = selectionModePreference
         restoreReturnFocus()
         return
       }
 
       setOpen(false)
       setSearchText("")
-      setSelectionMode(selectionModePreference)
+      selectionModeIntentRef.current = selectionModePreference
       restoreReturnFocus()
       const nextEntry: AssistantSelection = {
         ...entry,
         metadata: {
           ...(entry.metadata ?? {}),
-          selectionMode: activeSelectionMode
+          selectionMode: nextMode
         }
       }
       await setSelectedAssistant(nextEntry)
-      if (activeSelectionMode === "overlay") {
+      if (nextMode === "overlay") {
         let overlaySnapshot = buildAssistantOverlaySnapshotFromSelection(nextEntry)
         try {
           overlaySnapshot = await resolveAssistantOverlaySnapshot(nextEntry)
@@ -488,7 +491,6 @@ export const AssistantSelect: React.FC<Props> = ({
     [
       effectiveAssistantState.mode,
       restoreReturnFocus,
-      selectionMode,
       selectionModePreference,
       setSelectedAssistant,
       updateSettings
@@ -498,11 +500,11 @@ export const AssistantSelect: React.FC<Props> = ({
   const handleOpenChange = React.useCallback((nextOpen: boolean) => {
     setOpen(nextOpen)
     if (nextOpen) {
-      setSelectionMode(selectionModePreference)
+      selectionModeIntentRef.current = selectionModePreference
     }
     if (!nextOpen) {
       setSearchText("")
-      setSelectionMode(selectionModePreference)
+      selectionModeIntentRef.current = selectionModePreference
       restoreReturnFocus()
     }
   }, [restoreReturnFocus, selectionModePreference])
@@ -510,6 +512,7 @@ export const AssistantSelect: React.FC<Props> = ({
   const openActorSettings = React.useCallback(() => {
     setOpen(false)
     setSearchText("")
+    selectionModeIntentRef.current = selectionModePreference
     restoreReturnFocus()
     try {
       if (typeof window !== "undefined") {
@@ -518,7 +521,7 @@ export const AssistantSelect: React.FC<Props> = ({
     } catch {
       // no-op
     }
-  }, [restoreReturnFocus])
+  }, [restoreReturnFocus, selectionModePreference])
 
   const buttonLabel =
     labelOverride ||

--- a/apps/packages/ui/src/components/Common/AssistantSelect.tsx
+++ b/apps/packages/ui/src/components/Common/AssistantSelect.tsx
@@ -214,7 +214,7 @@ export const AssistantSelect: React.FC<Props> = ({
           ? detail.returnFocusSelector.trim()
           : null
       selectionModeIntentRef.current =
-        detail?.applyAs === "overlay" ? "overlay" : selectionModePreference
+        detail?.applyAs ?? selectionModePreference
       setSearchText("")
       setOpen(true)
     }

--- a/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/AssistantSelect.behavior.test.tsx
@@ -146,14 +146,24 @@ const renderAssistantSelect = (
     }
   })
 
-  render(
+  const renderTree = (
+    nextProps: React.ComponentProps<typeof AssistantSelect> = props
+  ) => (
     <QueryClientProvider client={queryClient}>
       <button id="assistant-rail-trigger" type="button">
         Runtime rail trigger
       </button>
-      <AssistantSelect variant="dropdown" {...props} />
+      <AssistantSelect variant="dropdown" {...nextProps} />
     </QueryClientProvider>
   )
+
+  const result = render(renderTree())
+  return {
+    ...result,
+    rerenderAssistantSelect: (
+      nextProps: React.ComponentProps<typeof AssistantSelect>
+    ) => result.rerender(renderTree(nextProps))
+  }
 }
 
 describe("AssistantSelect behavior", () => {
@@ -712,6 +722,42 @@ describe("AssistantSelect behavior", () => {
         })
       )
     })
+  })
+
+  it("uses the latest prop-driven selection mode when choosing after rerender", async () => {
+    const user = userEvent.setup()
+    const { rerenderAssistantSelect } = renderAssistantSelect({
+      selectionModePreference: "overlay",
+      labelOverride: "Apply assistant"
+    })
+
+    await user.click(
+      await screen.findByRole("button", { name: "Apply assistant" })
+    )
+    expect(await screen.findByRole("button", { name: "Alpha" })).toBeInTheDocument()
+
+    rerenderAssistantSelect({
+      selectionModePreference: "tracked",
+      labelOverride: "Apply assistant"
+    })
+    await user.click(await screen.findByRole("tab", { name: "Personas" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Guide Persona" })
+    )
+
+    await waitFor(() => {
+      expect(mocks.setSelectedAssistant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "persona",
+          id: "persona-1",
+          name: "Guide Persona",
+          metadata: expect.objectContaining({
+            selectionMode: "tracked"
+          })
+        })
+      )
+    })
+    expect(mocks.updateSettings).not.toHaveBeenCalled()
   })
 
   it("uses the prop-driven overlay selection path and custom label without requiring an open event", async () => {

--- a/backlog/tasks/task-494 - Fix-AssistantSelect-stale-selection-mode-intent.md
+++ b/backlog/tasks/task-494 - Fix-AssistantSelect-stale-selection-mode-intent.md
@@ -1,0 +1,48 @@
+---
+id: TASK-494
+title: Fix AssistantSelect stale selection mode intent
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-23 19:58'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address post-merge review finding where AssistantSelect.handleSelect can use stale closed-over selectionMode state and persist the wrong overlay/tracked intent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AssistantSelect selection uses a ref-backed current intent instead of closed-over React state after reset operations.
+- [x] #2 Overlay snapshot persistence uses the same resolved intent as selected-assistant metadata.
+- [x] #3 Regression coverage proves rerendered selectionModePreference does not leak stale overlay intent into tracked selections.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED regression failed before implementation with selectedAssistant.metadata.selectionMode=overlay after rerendering selectionModePreference to tracked. Replaced transient selectionMode React state with selectionModeIntentRef. handleSelect now reads one local nextMode and uses it for both selected-assistant metadata and overlay persistence.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed AssistantSelect stale selection intent handling by reading a ref-backed nextMode in handleSelect and using it consistently for metadata and overlay settings writes. Added regression coverage for rerendered selectionModePreference changes before selection.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Keeps AssistantSelect tracked/overlay intent in a ref-backed current value instead of relying on closed-over React state.
- Uses the same resolved intent for selected-assistant metadata and overlay settings persistence.
- Adds a regression for rerendering from overlay to tracked before selection.

## Test Plan
- bunx vitest run src/components/Common/__tests__/AssistantSelect.behavior.test.tsx --testNamePattern "uses the latest prop-driven selection mode"
- bunx vitest run src/components/Common/__tests__/AssistantSelect.behavior.test.tsx src/components/Common/__tests__/AssistantSelect.tabs.test.tsx
- git diff --check

## Change summary
Human-authored summary required before this PR is marked ready for merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale selection mode intent in `AssistantSelect` by tracking the current mode in a ref and applying it during selection. Rerenders and runtime open events now honor the latest `selectionModePreference` and `detail.applyAs` (addresses TASK-494).

- **Bug Fixes**
  - Replace transient state with `selectionModeIntentRef`; keep it in sync on prop changes, open/close, and runtime open via `detail.applyAs`.
  - Use one resolved mode for both selected-assistant metadata and overlay snapshot persistence.
  - Add regression test to ensure a rerender from overlay to tracked writes `selectionMode: "tracked"` and avoids overlay settings writes.

<sup>Written for commit d5d44f6ded111e94161c175976ca07b8d55b8765. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2007?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

