### PR TITLE
docs: close Chat/Playground product-state tracker

### DIFF
--- a/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
+++ b/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-45.44.1
 title: 'Migrate design-system product state: Chat and Playground'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-14 03:18'
-updated_date: '2026-05-14 06:35'
+updated_date: '2026-05-23'
 labels:
   - design-system
   - webui
@@ -13,6 +13,7 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1658'
+  - 'https://github.com/rmusser01/tldw_server/pull/1683'
   - >-
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -28,9 +29,9 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The linked GitHub issue owns current count and public status.
-- [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
-- [ ] #3 Backlog notes record PR links and before/after count evidence.
+- [x] #1 The linked GitHub issue owns current count and public status.
+- [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
+- [x] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,14 +50,22 @@ Migrated Chat and Playground target labels. Target guard findings are now zero a
 PR #1683 opened against dev and issue #1658 body updated with current count 0 and PR link. Before this slice: 2 Chat/Playground baseline exceptions. After this slice: 0 Chat/Playground baseline exceptions. No narrower implementation PR task was needed because the area contained only the two target canonical-state-label findings.
 
 PR #1683 review fixes: added defensive optional state-label access for the reviewed getDesignSystemState call sites. After rebasing onto current dev, WorkspaceACPHistoryModal uses the shared design-system Alert primitive instead of AntD Alert. Full bun run verify:design-system-state now exits 0.
+
+Closeout 2026-05-23: verified GitHub issue #1658 records current Chat/Playground baseline debt as Total 0, `antd-product-state-import` 0, and `canonical-state-label` 0, refreshed by PR #1683. PR #1683 is merged into `dev` at `e4663b9b6cb06730ef901ccb44fac930ad1a8fec`. Current `apps/packages/ui/scripts/design-system-product-state-baseline.json` has zero rows for the Chat/Playground owned path map (`src/components/Option/Playground`, `src/components/Common/Playground`, `src/components/Sidepanel/Chat`, and `src/routes/sidepanel-chat.tsx`). Follow-up child TASK-45.44.1.1 closed the later unbaselined Playground Ready labels. Current full `bun run verify:design-system-state` was rerun after repairing the local UI dependency symlink and exits 1 on unrelated repo-wide product-state drift outside the Chat/Playground owned paths, so this closeout does not claim the global verifier is currently clean. Bandit skipped for this closeout because only Backlog markdown is changed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed the Chat and Playground design-system product-state tracker. The product area was migrated through PR #1683, the public issue #1658 records zero current baseline debt for the owned paths, the local baseline file has zero Chat/Playground rows, and the later Playground Ready-label follow-up is already closed under TASK-45.44.1.1. No application code changed in this closeout.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
+++ b/backlog/tasks/task-45.44.1 - Migrate-design-system-product-state-Chat-and-Playground.md
@@ -51,7 +51,13 @@ PR #1683 opened against dev and issue #1658 body updated with current count 0 an
 
 PR #1683 review fixes: added defensive optional state-label access for the reviewed getDesignSystemState call sites. After rebasing onto current dev, WorkspaceACPHistoryModal uses the shared design-system Alert primitive instead of AntD Alert. Full bun run verify:design-system-state now exits 0.
 
-Closeout 2026-05-23: verified GitHub issue #1658 records current Chat/Playground baseline debt as Total 0, `antd-product-state-import` 0, and `canonical-state-label` 0, refreshed by PR #1683. PR #1683 is merged into `dev` at `e4663b9b6cb06730ef901ccb44fac930ad1a8fec`. Current `apps/packages/ui/scripts/design-system-product-state-baseline.json` has zero rows for the Chat/Playground owned path map (`src/components/Option/Playground`, `src/components/Common/Playground`, `src/components/Sidepanel/Chat`, and `src/routes/sidepanel-chat.tsx`). Follow-up child TASK-45.44.1.1 closed the later unbaselined Playground Ready labels. Current full `bun run verify:design-system-state` was rerun after repairing the local UI dependency symlink and exits 1 on unrelated repo-wide product-state drift outside the Chat/Playground owned paths, so this closeout does not claim the global verifier is currently clean. Bandit skipped for this closeout because only Backlog markdown is changed.
+Closeout 2026-05-23:
+- Verified GitHub issue #1658 records current Chat/Playground baseline debt as Total 0, `antd-product-state-import` 0, and `canonical-state-label` 0, refreshed by PR #1683.
+- PR #1683 is merged into `dev` at `e4663b9b6cb06730ef901ccb44fac930ad1a8fec`.
+- Current `apps/packages/ui/scripts/design-system-product-state-baseline.json` has zero rows for the Chat/Playground owned path map (`src/components/Option/Playground`, `src/components/Common/Playground`, `src/components/Sidepanel/Chat`, and `src/routes/sidepanel-chat.tsx`).
+- Follow-up child TASK-45.44.1.1 closed the later unbaselined Playground Ready labels.
+- Current full `bun run verify:design-system-state` was rerun after repairing the local UI dependency symlink and exits 1 on unrelated repo-wide product-state drift outside the Chat/Playground owned paths; this closeout does not claim global verifier cleanliness.
+- Bandit skipped for this closeout because only Backlog markdown is changed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Change summary
- Marks `TASK-45.44.1` Done for the Chat/Playground design-system product-state migration tracker.
- Records PR #1683 merge evidence, issue #1658 public count evidence, and the current zero-row Chat/Playground baseline check.
- Documents that the current full product-state verifier now fails on unrelated repo-wide drift outside the Chat/Playground owned paths, so this closeout does not claim global verifier cleanliness.

## Verification
- `jq '[.[] | select((.file // "") | test("src/components/Option/Playground|src/components/Common/Playground|src/components/Sidepanel/Chat|src/routes/sidepanel-chat.tsx"))] | length' apps/packages/ui/scripts/design-system-product-state-baseline.json` returned `0`
- `gh issue view 1658 --repo rmusser01/tldw_server --json body,state` confirmed issue #1658 records Total 0, `antd-product-state-import` 0, and `canonical-state-label` 0 for Chat/Playground
- `gh pr view 1683 --repo rmusser01/tldw_server --json state,mergedAt,mergeCommit` confirmed PR #1683 merged at `e4663b9b6cb06730ef901ccb44fac930ad1a8fec`
- `bun run verify:design-system-state` rerun from `apps/packages/ui`; it exits 1 on unrelated repo-wide product-state drift outside Chat/Playground owned paths
- `git diff --check`
- unchecked/stale task marker scan returned no matches

## Bandit
Skipped: Markdown/Backlog closeout only; no Python code changed.

## Merge note
Draft pending the project-required human-owned Change summary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the Chat/Playground design-system product-state tracker by marking `TASK-45.44.1` Done and confirming baseline debt is 0 (PR #1683 merged, issue #1658 updated, `apps/packages/ui/scripts/design-system-product-state-baseline.json` shows no Chat/Playground rows); follow-up `TASK-45.44.1.1` closed the later Ready labels. Full `verify:design-system-state` still fails due to unrelated repo drift; docs-only change.

<sup>Written for commit 0d7cd2e98edb36ee4b93a8bdff46328d88ebfe9f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2009?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

