### PR TITLE
docs: close Character/Persona product-state tracker

### DIFF
--- a/backlog/tasks/task-45.44.11 - Migrate-design-system-product-state-Character-Persona-and-presentation-surfaces.md
+++ b/backlog/tasks/task-45.44.11 - Migrate-design-system-product-state-Character-Persona-and-presentation-surfaces.md
@@ -3,9 +3,10 @@ id: TASK-45.44.11
 title: >-
   Migrate design-system product state: Character, Persona, and presentation
   surfaces
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-14 03:20'
+updated_date: '2026-05-23'
 labels:
   - design-system
   - webui
@@ -14,6 +15,9 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1668'
+  - 'https://github.com/rmusser01/tldw_server/pull/1709'
+  - 'https://github.com/rmusser01/tldw_server/pull/1759'
+  - 'https://github.com/rmusser01/tldw_server/pull/1832'
   - >-
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -29,17 +33,32 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The linked GitHub issue owns current count and public status.
-- [ ] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
-- [ ] #3 Backlog notes record PR links and before/after count evidence.
+- [x] #1 The linked GitHub issue owns current count and public status.
+- [x] #2 Implementation PR tasks are created under this child when the area is too broad for one PR.
+- [x] #3 Backlog notes record PR links and before/after count evidence.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Created and completed TASK-45.44.11.1 for the Presentation Studio ExtensionStartPanel Ready-label migration. PR: https://github.com/rmusser01/tldw_server/pull/1709. This removed the two ExtensionStartPanel canonical-state-label baseline entries.
+- Created and completed TASK-45.44.11.2 for the Persona Garden AssistantVoiceCard wake-warning Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1759. This removed the AssistantVoiceCard AntD Alert baseline entry and addressed review follow-up by migrating the inherited QuickIngest review-step offline warning.
+- Created and completed TASK-45.44.11.3 for the CharacterDialogs Alert migration. PR: https://github.com/rmusser01/tldw_server/pull/1832. This removed the ten CharacterDialogs AntD Alert baseline entries and recorded touched-file TypeScript cleanup evidence.
+- Closeout 2026-05-23: verified current `apps/packages/ui/scripts/design-system-product-state-baseline.json` has zero rows for the Character/Persona/presentation owned path map (`src/components/Option/Characters`, `src/components/Option/PresentationStudio`, and `src/components/PersonaGarden`). GitHub issue #1668 was refreshed from the original Total 22 baseline debt to Total 0 with PR links for the three completed child slices. Current full `bun run verify:design-system-state` exits 1 on unrelated repo-wide product-state drift outside this owned path map, so this closeout does not claim global verifier cleanliness. Bandit skipped for this closeout because only Backlog markdown is changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed the Character, Persona, and presentation design-system product-state tracker. The area was completed through child tasks TASK-45.44.11.1, TASK-45.44.11.2, and TASK-45.44.11.3, with merged PRs #1709, #1759, and #1832. The current baseline has zero rows for the owned paths and GitHub issue #1668 now records the public zero-count status. No application code changed in this closeout.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Marks `TASK-45.44.11` Done for the Character, Persona, and presentation product-state migration tracker.
- Records completed child slices and merged PRs: #1709, #1759, and #1832.
- Updates GitHub issue #1668 with the current zero-count public status and child PR table.
- Documents that the current full product-state verifier now fails on unrelated repo-wide drift outside this owned path map, so this closeout does not claim global verifier cleanliness.

## Verification
- `jq 'map(select((.file // "") | test("src/components/Option/Characters|src/components/Option/PresentationStudio|src/components/PersonaGarden"))) | length' apps/packages/ui/scripts/design-system-product-state-baseline.json` returned `0`
- `gh issue view 1668 --repo rmusser01/tldw_server --json body,state` confirmed issue #1668 records `Total: 0` and links #1709, #1759, and #1832
- `gh pr view 1709`, `gh pr view 1759`, and `gh pr view 1832` confirmed all three implementation PRs are merged
- `bun run verify:design-system-state` rerun from `apps/packages/ui`; it exits 1 on unrelated repo-wide product-state drift outside the Character/Persona/presentation owned paths
- `git diff --check`
- unchecked/stale task marker scan returned no matches

## Bandit
Skipped: Markdown/Backlog closeout only; no Python code changed.

## Merge note
Draft pending the project-required human-owned Change summary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the Character, Persona, and presentation design-system product-state tracker by marking `TASK-45.44.11` Done, linking merged PRs (#1709, #1759, #1832), and updating GitHub issue #1668 to show zero items for the owned paths. Docs-only update; the global product-state verifier still fails due to unrelated repo-wide drift.

<sup>Written for commit 97790538a453980aff2c2209abfffca028762b1d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2010?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

