### PR TITLE
docs: close stale Persona Visual trackers

### DIFF
--- a/backlog/tasks/task-331 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
+++ b/backlog/tasks/task-331 - Harden-Persona-Visual-import-commit-eligibility-revalidation.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-331
 title: Harden Persona Visual import-commit eligibility revalidation
-status: In Progress
+status: Done
 assignee:
   - codex
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-14 04:05'
+updated_date: '2026-05-23'
 labels:
   - persona
 dependencies: []
@@ -47,8 +47,8 @@ Add a narrow Persona/Buddy visual-pack hardening slice for GitHub #1657. Current
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
 
 ## Implementation Notes
@@ -82,4 +82,12 @@ Verification after review fix: `python -m pytest tldw_Server_API/tests/Persona/t
 Verification after review fix: `git diff --check` passed.
 
 Verification after review fix: `python -m bandit tldw_Server_API/app/core/Persona/visual_portability/commit_eligibility.py tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/api/v1/endpoints/persona.py` reported no issues.
+
+Closeout 2026-05-23: PR #1678 is merged into `dev` at `7f426d80f155b900b999884d829065ee9a27f47e`; no active PR or review blocker remains for this task. The implementation and review-fix verification above satisfy the acceptance criteria. No additional code changes were made in this closeout.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed the Persona Visual import-commit eligibility hardening task. The merged implementation fails closed for non-committable revalidated previews, rejects known commit-ineligible stored preview metadata before queuing, prevents blocked renderer previews from creating draft assets, and includes focused backend tests plus Bandit verification from PR #1678.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
+++ b/backlog/tasks/task-405 - Add-Persona-Visual-starter-asset-production-recipes.md
@@ -1,7 +1,8 @@
 ---
 id: TASK-405
 title: Add Persona Visual starter asset-production recipes
-status: In Progress
+status: Done
+updated_date: '2026-05-23'
 labels:
 - persona
 - visual-packs
@@ -54,6 +55,8 @@ Added immutable `PersonaVisualStarterProductionRecipe` metadata to bundled start
 Updated Persona starter response schemas and docs so the recipe contract is clear to API clients and future authored-asset generation/review flows. Review follow-up aligned the response schema with the catalog validation bounds for non-empty recipe text, bounded recipe item lists, bounded item text, and the required neutral identity consistency review check. Copy-to-draft behavior is unchanged.
 
 Verification: focused Persona Visual starter/API pytest passed 94 tests; py_compile passed for touched backend/schema modules; Bandit JSON report for touched backend/schema modules had zero results; git diff --check passed.
+
+Closeout 2026-05-23: PR #1762 is merged into `dev` at `ebe86408fd5ee7c7ba72971b5f89307b5a00f6e5`; no active PR or review blocker remains for this task. No additional code changes were made in this closeout.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
+++ b/backlog/tasks/task-410 - Design-Persona-Buddy-default-catalog-and-manifest-v2-visual-states.md
@@ -1,7 +1,8 @@
 ---
 id: TASK-410
 title: Design Persona Buddy default catalog and manifest v2 visual states
-status: In Progress
+status: Done
+updated_date: '2026-05-23'
 labels:
 - persona
 - buddy
@@ -23,22 +24,22 @@ references:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Create a repo-backed design spec for the Persona Buddy default visual catalog and user-facing asset creation workflow. The design must capture the approved 9-default catalog structure, the neutral-pose-first asset generation pipeline adapted from Puzzle Attack, and a manifest v2 extension for bounded custom state IDs and per-tool animation variants while preserving the existing Persona Visual pack/runtime contract.
+Create a repo-backed design spec for the Persona Buddy default visual catalog and user-facing asset creation workflow. The design captured the original approved default-catalog structure, the neutral-pose-first asset generation pipeline adapted from Puzzle Attack, and a manifest v2 extension for bounded custom state IDs and per-tool animation variants while preserving the existing Persona Visual pack/runtime contract. TASK-419 later reconciled the catalog wording to the current six-basic/twelve-starter source of truth.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spec documents 9 bundled default buddies across basic, intermediate, and intricate complexity tiers.
-- [ ] #2 Spec defines the neutral identity anchor workflow and distinguishes static talking/reaction sheets from generated animation frames.
-- [ ] #3 Spec defines manifest v2 custom state catalog semantics, bounds, fallback behavior, trigger matching, and compatibility with existing required states.
-- [ ] #4 Spec outlines staged implementation slices for backend validation, MCP/runtime trigger handling, editor UX, starter catalog fixtures, and verification.
-- [ ] #5 Spec references the current Persona Visual pack contract and Puzzle Attack asset-generation process enough for future implementers to work without prior chat context.
+- [x] #1 Spec documents the bundled default Buddy catalog across basic, intermediate, and intricate complexity tiers.
+- [x] #2 Spec defines the neutral identity anchor workflow and distinguishes static talking/reaction sheets from generated animation frames.
+- [x] #3 Spec defines manifest v2 custom state catalog semantics, bounds, fallback behavior, trigger matching, and compatibility with existing required states.
+- [x] #4 Spec outlines staged implementation slices for backend validation, MCP/runtime trigger handling, editor UX, starter catalog fixtures, and verification.
+- [x] #5 Spec references the current Persona Visual pack contract and Puzzle Attack asset-generation process enough for future implementers to work without prior chat context.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Closeout 2026-05-23: PR #1708 merged the design task into `dev` at `e66f1e75ed1d92c7c7187c118fc780a944807ab8`, and TASK-419 / PR #1818 reconciled the later Codex Buddy catalog expansion so the current source of truth is the six-basic/twelve-starter catalog described in issue #1787. The original "9 bundled default buddies" acceptance wording is superseded by the current catalog correction; this design task is closed because the spec, tracker, and reconciliation task now carry the current contract.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -49,10 +50,10 @@ Created the Buddy animation pipeline design spec and GitHub tracker issue #1787 
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-419 - Reconcile-Buddy-default-Codex-compatible-catalog-docs.md
+++ b/backlog/tasks/task-419 - Reconcile-Buddy-default-Codex-compatible-catalog-docs.md
@@ -1,7 +1,8 @@
 ---
 id: TASK-419
 title: Reconcile Buddy default Codex-compatible catalog docs
-status: In Progress
+status: Done
+updated_date: '2026-05-23'
 labels:
 - persona
 - buddy
@@ -54,6 +55,8 @@ Verification:
 - `git diff --name-only` plus `git ls-files --others --exclude-standard` confirmed touched files are docs and Backlog task files only.
 - `rg -n "research-buddy-basic|minimal-helper-basic|three basic|3 basic|nine bundled|nine scaffold|nine default|nine immutable|Simple Buddy|simple tldw draft-pack" Docs backlog -S` now reports only explicit supersession notes and current compatibility wording.
 - Bandit skipped because this is docs/Backlog/GitHub tracker-only.
+
+Closeout 2026-05-23: PR #1818 is merged into `dev` at `89e17c12d37a55ac202a5cf521f746ea2c5ffbbf`; no active PR or review blocker remains for this task. No additional code changes were made in this closeout.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-455 - Implement-Persona-Visual-sectioned-pack-workspace.md
+++ b/backlog/tasks/task-455 - Implement-Persona-Visual-sectioned-pack-workspace.md
@@ -1,7 +1,8 @@
 ---
 id: TASK-455
 title: Implement Persona Visual sectioned pack workspace
-status: In Progress
+status: Done
+updated_date: '2026-05-23'
 labels:
 - persona
 - persona-visual
@@ -52,6 +53,8 @@ Review follow-up:
 - Removed duplicate personal-library heading description text.
 - Hardened the new workspace-section test so unmocked API paths throw instead of rendering a silent error banner.
 - Verification after review fixes: `bunx vitest run src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx -t "workspace sections|management header"` passed with 2 focused tests; `bunx vitest run src/components/PersonaGarden/__tests__/personaVisualManagementSummary.test.ts src/components/PersonaGarden/__tests__/VisualPackEditor.test.tsx` passed with 67 tests; `git diff --check` passed.
+
+Closeout 2026-05-23: PR #1771 is merged into `dev` at `6082a388c56db268dc1129e22db2176287db10a1`; no active PR or review blocker remains for this task. No additional code changes were made in this closeout.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Change summary
- Closes stale Persona Visual/Buddy tracker tasks whose implementation PRs are already merged.
- Marks TASK-331, TASK-405, TASK-410, TASK-419, and TASK-455 as Done and records merge evidence.
- Adds the missing TASK-331 final summary and documents the TASK-410 catalog-count supersession via TASK-419 / PR #1818.

## Verification
- `git diff --check`
- unchecked/stale task marker scan over the five touched task files returned no matches
- `gh pr view 1678`, `gh pr view 1708`, `gh pr view 1762`, `gh pr view 1771`, and PR search for `#1818` confirmed the referenced implementation/docs PRs are merged

## Bandit
Skipped: Markdown/Backlog closeout only; no Python code changed.

## Merge note
Draft pending the project-required human-owned Change summary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes five stale Persona Visual/Buddy tracker tasks now that their implementation PRs are merged, keeping the backlog accurate. Marks TASK-331, TASK-405, TASK-410, TASK-419, and TASK-455 as Done, adds TASK-331’s final summary, and notes TASK-410’s catalog-count wording is superseded by TASK-419/PR #1818.

<sup>Written for commit b65e08d5b53a12f0a405dd5aed2a9758f11eb306. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2011?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

