### PR TITLE
Migrate OutputsTab alert to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2365,17 +2365,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx:Alert",
-    "path": "src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunsTab.tsx:Alert",
     "path": "src/components/Option/Watchlists/RunsTab/RunsTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
-  Alert,
   Button,
   InputNumber,
   Input,
@@ -26,6 +25,7 @@ import {
   XCircle
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useWatchlistsStore } from "@/store/watchlists"
 import {
   createWatchlistOutput,
@@ -1079,8 +1079,7 @@ export const OutputsTab: React.FC = () => {
 
       {outputsWithDeliveryIssues.length > 0 && (
         <Alert
-          type="warning"
-          showIcon
+          variant="warning"
           data-testid="watchlists-outputs-delivery-issues-banner"
           title={t(
             "watchlists:outputs.deliveryIssuesBannerTitle",
@@ -1090,11 +1089,14 @@ export const OutputsTab: React.FC = () => {
               plural: outputsWithDeliveryIssues.length === 1 ? "" : "s"
             }
           )}
-          description={t(
-            "watchlists:outputs.deliveryIssuesBannerDescription",
-            "Review failed or partial deliveries and open Activity to investigate monitor/run failures."
-          )}
-          action={(
+        >
+          <div className="space-y-2">
+            <p className="m-0">
+              {t(
+                "watchlists:outputs.deliveryIssuesBannerDescription",
+                "Review failed or partial deliveries and open Activity to investigate monitor/run failures."
+              )}
+            </p>
             <Space size={8} wrap>
               <Button
                 size="small"
@@ -1116,8 +1118,8 @@ export const OutputsTab: React.FC = () => {
                 {t("watchlists:outputs.deliveryIssuesOpenRuns", "Open failed runs")}
               </Button>
             </Space>
-          )}
-        />
+          </div>
+        </Alert>
       )}
 
       {isConstrained ? (

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.advanced-filters.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.advanced-filters.test.tsx
@@ -253,7 +253,9 @@ describe("OutputsTab advanced filters disclosure", () => {
 
     render(<OutputsTab />)
 
-    expect(screen.getByTestId("watchlists-outputs-delivery-issues-banner")).toHaveTextContent(
+    const deliveryIssuesBanner = screen.getByTestId("watchlists-outputs-delivery-issues-banner")
+    expect(deliveryIssuesBanner).toHaveAttribute("data-ds-component", "Alert")
+    expect(deliveryIssuesBanner).toHaveTextContent(
       "Delivery issues detected in 1 report."
     )
     expect(screen.getByTestId("outputs-table-rows")).toHaveTextContent("2")

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -18,11 +18,13 @@ references:
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
   - 'https://github.com/rmusser01/tldw_server/pull/2012'
 documentation:
-  - >-
-    TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the
-    design-system Alert primitive. Baseline evidence: total product-state
-    exceptions 259 -> 258; Jobs/Scheduler/Watchlists exceptions 24 -> 23;
-    OutputsTab target rows 1 -> 0. Verification recorded in TASK-45.44.3.6.
+  - |-
+    TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the design-system Alert primitive.
+    Baseline evidence:
+      - total product-state exceptions: 259 -> 258
+      - Jobs/Scheduler/Watchlists exceptions: 24 -> 23
+      - OutputsTab target rows: 1 -> 0
+    Verification recorded in TASK-45.44.3.6.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -4,6 +4,7 @@ title: 'Migrate design-system product state: Jobs, Scheduler, and Watchlists'
 status: To Do
 assignee: []
 created_date: '2026-05-14 03:19'
+updated_date: '2026-05-23 22:17'
 labels:
   - design-system
   - webui
@@ -15,6 +16,13 @@ references:
   - >-
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/2012'
+documentation:
+  - >-
+    TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the
+    design-system Alert primitive. Baseline evidence: total product-state
+    exceptions 259 -> 258; Jobs/Scheduler/Watchlists exceptions 24 -> 23;
+    OutputsTab target rows 1 -> 0. Verification recorded in TASK-45.44.3.6.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.6 - Migrate-OutputsTab-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.6 - Migrate-OutputsTab-alert-to-design-system-Alert.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.3.6
+title: Migrate OutputsTab alert to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-23 22:14'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+  - watchlists
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1660'
+  - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx
+  - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the Watchlists OutputsTab AntD Alert product-state callout with the shared design-system Alert primitive, preserving user-facing copy and removing the migrated baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 OutputsTab delivery-issues banner renders through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused OutputsTab coverage proves the migrated banner preserves copy/actions and exposes the canonical Alert marker.
+- [x] #3 The OutputsTab Alert baseline exception is removed without introducing new product-state verifier findings.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing OutputsTab assertion requiring the delivery-issues banner to render with the design-system Alert marker.
+2. Replace the OutputsTab AntD Alert usage with the shared Alert primitive while preserving copy, warning semantics, and remediation actions.
+3. Remove the migrated OutputsTab Alert entry from design-system-product-state-baseline.json and run focused tests plus design-system verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red/green completed. Added a focused OutputsTab assertion requiring the delivery-issues banner to carry data-ds-component="Alert"; the red run failed because the AntD Alert mock did not expose the marker. Replaced the banner with the shared design-system Alert primitive, preserved the warning title, description, Show failed only and Open failed runs actions, and removed the single OutputsTab baseline exception. Verification: focused OutputsTab advanced-filters test passed 6/6; product-state guard passed 54/54; bun run verify:design-system-state passed with 258 total baseline exceptions and 23 Jobs/Scheduler/Watchlists exceptions; baseline parse reported targetRows 0; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+
+TypeScript: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still exits 2 on 347 existing diagnostics; no diagnostics mention OutputsTab, OutputsTab.advanced-filters, the baseline, or TASK-45.44.3.6.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the OutputsTab delivery-issues banner from AntD Alert to the design-system Alert primitive. Focused coverage now verifies the banner uses data-ds-component="Alert" while preserving the remediation actions, and the product-state baseline no longer contains the OutputsTab Alert exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.6 - Migrate-OutputsTab-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.6 - Migrate-OutputsTab-alert-to-design-system-Alert.md
@@ -3,7 +3,7 @@ id: TASK-45.44.3.6
 title: Migrate OutputsTab alert to design-system Alert
 status: Done
 assignee: []
-created_date: ''
+created_date: '2026-05-23 22:17'
 updated_date: '2026-05-23 22:17'
 labels:
   - design-system
@@ -46,7 +46,7 @@ Replace the Watchlists OutputsTab AntD Alert product-state callout with the shar
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-TDD red/green completed. Added a focused OutputsTab assertion requiring the delivery-issues banner to carry data-ds-component="Alert"; the red run failed because the AntD Alert mock did not expose the marker. Replaced the banner with the shared design-system Alert primitive, preserved the warning title, description, Show failed only and Open failed runs actions, and removed the single OutputsTab baseline exception. Verification: focused OutputsTab advanced-filters test passed 6/6; product-state guard passed 54/54; bun run verify:design-system-state passed with 258 total baseline exceptions and 23 Jobs/Scheduler/Watchlists exceptions; baseline parse reported targetRows 0; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+TDD red/green completed. Added a focused OutputsTab assertion requiring the delivery-issues banner to carry data-ds-component="Alert"; the red run failed because the AntD Alert mock did not expose the marker. Replaced the banner with the shared design-system Alert primitive, preserved the warning title, description, Show failed only and Open failed runs actions, and removed the single OutputsTab baseline exception. Verification: focused OutputsTab advanced-filters test passed 6/6; product-state guard passed 54/54; bun run verify:design-system-state passed with 258 total baseline exceptions and 23 Jobs/Scheduler/Watchlists exceptions; baseline parse reported OutputsTab target rows 1 -> 0; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
 
 TypeScript: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still exits 2 on 347 existing diagnostics; no diagnostics mention OutputsTab, OutputsTab.advanced-filters, the baseline, or TASK-45.44.3.6.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-45.44.3.6 - Migrate-OutputsTab-alert-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.6 - Migrate-OutputsTab-alert-to-design-system-Alert.md
@@ -4,7 +4,7 @@ title: Migrate OutputsTab alert to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-23 22:14'
+updated_date: '2026-05-23 22:17'
 labels:
   - design-system
   - webui
@@ -17,6 +17,7 @@ references:
   - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/OutputsTab.tsx
   - apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/2012'
 parent_task_id: TASK-45.44.3
 priority: medium
 ---


### PR DESCRIPTION
## Summary
- Migrates the Watchlists OutputsTab delivery-issues banner from AntD Alert to the shared design-system Alert primitive.
- Adds focused coverage requiring the banner to expose data-ds-component="Alert" while preserving copy and remediation actions.
- Removes the stale OutputsTab Alert row from the product-state baseline and records TASK-45.44.3.6.

## Verification
- Red: bunx vitest run src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.advanced-filters.test.tsx --reporter=dot failed on missing data-ds-component="Alert"
- Green: bunx vitest run src/components/Option/Watchlists/OutputsTab/__tests__/OutputsTab.advanced-filters.test.tsx --reporter=dot (6/6 passed)
- bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot (54/54 passed)
- bun run verify:design-system-state (258 total baseline exceptions; 23 Jobs/Scheduler/Watchlists exceptions)
- node -e baseline parse check (targetRows 0 for OutputsTab.tsx)
- git diff --check
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false > /tmp/tldw_outputs_tab_alert_tsc.log 2>&1 (still exits 2 on 347 existing diagnostics; no diagnostics mention OutputsTab, OutputsTab.advanced-filters, the baseline, or TASK-45.44.3.6)

## Change summary
This removes one Watchlists product-state exception by replacing the OutputsTab delivery-issues AntD Alert with the canonical design-system Alert. The migration keeps the warning title, description, and both remediation actions in the same branch of the UI, while the existing advanced-filters test now proves the banner is rendered by the shared primitive instead of relying on a shallow AntD mock. The baseline row is removed so the guard reflects the completed migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Watchlists OutputsTab delivery-issues banner from AntD `Alert` to the shared design-system `Alert`, preserving copy and actions. Removed the product-state baseline exception and added focused tests to verify the design-system component.

- **Refactors**
  - Replace AntD `Alert` with design-system `Alert` (`variant="warning"`) in OutputsTab.
  - Render description and actions as children to match the design-system `Alert` API.
  - Update test to assert `data-ds-component="Alert"` and verify banner text.
  - Remove OutputsTab `Alert` entry from `design-system-product-state-baseline.json`.
  - Add `backlog/tasks/task-45.44.3.6` and update the parent task with the PR link and verification notes.

<sup>Written for commit d8e85b1df3bc2752891911e10103ceb1b1fcd0c9. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2012?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

