### PR TITLE
Migrate RunsTab alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2365,17 +2365,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/RunsTab/RunsTab.tsx:Alert",
-    "path": "src/components/Option/Watchlists/RunsTab/RunsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/RunsTab/RunsTab.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx:Alert",
     "path": "src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
-  Alert,
   Button,
   Dropdown,
   Pagination,
@@ -12,6 +11,7 @@ import {
   message
 } from "antd"
 import type { ColumnsType } from "antd/es/table"
+import { Alert } from "@/components/ui/primitives"
 import { ChevronDown, Eye, RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useWatchlistsStore } from "@/store/watchlists"
@@ -1235,51 +1235,37 @@ export const RunsTab: React.FC = () => {
 
       {runsAttention && (
         <Alert
-          type="warning"
-          showIcon
+          variant="warning"
           title={t("watchlists:runs.attention.title", "Reliability attention required")}
-          description={
-            `${runsAttention.description}${runsAttention.hint ? ` ${runsAttention.hint}` : ""}`.trim()
-          }
-          action={(
-            <div className="flex flex-wrap gap-2">
-              {runsAttention.newestFailedRunId != null && (
-                <Button
-                  size="small"
-                  onClick={() => openRunDetail(runsAttention.newestFailedRunId as number)}
-                >
-                  {t("watchlists:runs.attention.viewFailedRun", "View newest failed run")}
-                </Button>
-              )}
-              {runsAttention.failedCount > 0 && runsStatusFilter !== "failed" && (
-                <Button
-                  size="small"
-                  onClick={() => setRunsStatusFilter("failed")}
-                >
-                  {t("watchlists:runs.attention.filterFailed", "Show failed runs")}
-                </Button>
-              )}
-            </div>
-          )}
-        />
+          action={runsAttention.newestFailedRunId != null
+            ? {
+                label: t("watchlists:runs.attention.viewFailedRun", "View newest failed run"),
+                onClick: () => openRunDetail(runsAttention.newestFailedRunId as number)
+              }
+            : undefined}
+          secondaryAction={runsAttention.failedCount > 0 && runsStatusFilter !== "failed"
+            ? {
+                label: t("watchlists:runs.attention.filterFailed", "Show failed runs"),
+                onClick: () => setRunsStatusFilter("failed")
+              }
+            : undefined}
+        >
+          {`${runsAttention.description}${runsAttention.hint ? ` ${runsAttention.hint}` : ""}`.trim()}
+        </Alert>
       )}
 
       {runsLoadError && (
         <Alert
-          type={runsLoadError.severity}
-          showIcon
+          variant={runsLoadError.severity}
           title={runsLoadError.title}
-          description={runsLoadError.description}
-          action={(
-            <Button
-              size="small"
-              onClick={() => void loadRuns()}
-              loading={runsLoading}
-            >
-              {t("watchlists:errors.retry", "Retry")}
-            </Button>
-          )}
-        />
+          action={{
+            label: t("watchlists:errors.retry", "Retry"),
+            onClick: () => void loadRuns(),
+            loading: runsLoading
+          }}
+        >
+          {runsLoadError.description}
+        </Alert>
       )}
 
       {isConstrained ? (

--- a/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunsTab.load-error-retry.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__/RunsTab.load-error-retry.test.tsx
@@ -143,7 +143,9 @@ describe("RunsTab load-error retry", () => {
     render(<RunsTab />)
 
     await waitFor(() => {
-      expect(screen.getByText("Could not load Activity.")).toBeInTheDocument()
+      const loadErrorTitle = screen.getByText("Could not load Activity.")
+      expect(loadErrorTitle).toBeInTheDocument()
+      expect(loadErrorTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
       expect(screen.getByText("Check server connection and try again. Details: Failed to fetch")).toBeInTheDocument()
     })
 
@@ -190,9 +192,9 @@ describe("RunsTab load-error retry", () => {
     render(<RunsTab />)
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Reliability attention required")
-      ).toBeInTheDocument()
+      const attentionTitle = screen.getByText("Reliability attention required")
+      expect(attentionTitle).toBeInTheDocument()
+      expect(attentionTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
       expect(
         screen.getByText(
           "1 failed run and 1 stalled run need review. The source request timed out. Retry, or lower concurrency for this source."

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Jobs, Scheduler, and Watchlists'
 status: To Do
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-23 22:17'
+updated_date: '2026-05-23 22:34'
 labels:
   - design-system
   - webui
@@ -17,6 +17,7 @@ references:
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
   - 'https://github.com/rmusser01/tldw_server/pull/2012'
+  - 'https://github.com/rmusser01/tldw_server/pull/2013'
 documentation:
   - |-
     TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the design-system Alert primitive.
@@ -25,6 +26,13 @@ documentation:
       - Jobs/Scheduler/Watchlists exceptions: 24 -> 23
       - OutputsTab target rows: 1 -> 0
     Verification recorded in TASK-45.44.3.6.
+  - |-
+    TASK-45.44.3.7 / PR #2013 migrated RunsTab load-error and reliability-attention banners to the design-system Alert primitive.
+    Baseline evidence:
+      - total product-state exceptions: 258 -> 257
+      - Jobs/Scheduler/Watchlists exceptions: 23 -> 22
+      - RunsTab target rows: 1 -> 0
+    Verification recorded in TASK-45.44.3.7.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.7 - Migrate-RunsTab-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.7 - Migrate-RunsTab-alerts-to-design-system-Alert.md
@@ -17,6 +17,7 @@ references:
   - apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx
   - apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/2013'
 parent_task_id: TASK-45.44.3
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.7 - Migrate-RunsTab-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.7 - Migrate-RunsTab-alerts-to-design-system-Alert.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.3.7
+title: Migrate RunsTab alerts to design-system Alert
+status: Done
+assignee: []
+created_date: '2026-05-23 22:34'
+updated_date: '2026-05-23 22:34'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+  - watchlists
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1660'
+  - apps/packages/ui/src/components/Option/Watchlists/RunsTab/RunsTab.tsx
+  - apps/packages/ui/src/components/Option/Watchlists/RunsTab/__tests__
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the Watchlists RunsTab AntD Alert product-state callouts with the shared design-system Alert primitive, preserving user-facing copy/actions and removing the migrated baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 RunsTab reliability-attention and load-error banners render through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused RunsTab coverage proves the migrated banners preserve copy/actions and expose the canonical Alert marker.
+- [x] #3 The RunsTab Alert baseline exception is removed without introducing new product-state verifier findings.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing RunsTab assertions requiring the reliability-attention and load-error banners to render with the design-system Alert marker.
+2. Replace the RunsTab AntD Alert usages with the shared Alert primitive while preserving warning/error semantics and remediation actions.
+3. Remove the migrated RunsTab Alert entry from design-system-product-state-baseline.json and run focused tests plus design-system verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red/green completed. Added focused RunsTab assertions requiring both the load-error retry banner and the reliability-attention banner to be wrapped in data-ds-component="Alert"; the red run failed on the missing design-system Alert marker for both banners. Replaced the two RunsTab AntD Alert callouts with the shared design-system Alert primitive, preserved the load-error retry action plus reliability attention view/filter actions, and removed the single RunsTab Alert baseline exception. Verification: focused RunsTab load-error retry test passed 2/2; RunsTab advanced-filters test passed 5/5; product-state guard passed 54/54; bun run verify:design-system-state passed with 257 total baseline exceptions and 22 Jobs/Scheduler/Watchlists exceptions; RunsTab target rows 1 -> 0; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+
+TypeScript: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still exits 2 on 347 existing diagnostics; no diagnostics mention RunsTab.tsx, RunsTab.load-error-retry.test.tsx, the baseline, or TASK-45.44.3.7.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the RunsTab load-error and reliability-attention banners from AntD Alert to the design-system Alert primitive. Focused coverage now verifies both banners use data-ds-component="Alert" while preserving retry, view failed run, and show failed runs actions, and the product-state baseline no longer contains the RunsTab Alert exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Migrates the Watchlists RunsTab load-error and reliability-attention banners from AntD Alert to the shared design-system Alert primitive. The implementation keeps the existing copy and user actions while using the design-system primary/secondary action slots, then removes the now-obsolete RunsTab Alert baseline exception so the product-state guard tracks the reduced debt.

## Verification

- `bunx vitest run src/components/Option/Watchlists/RunsTab/__tests__/RunsTab.load-error-retry.test.tsx --reporter=dot` red: failed on missing `data-ds-component="Alert"` marker before implementation
- `bunx vitest run src/components/Option/Watchlists/RunsTab/__tests__/RunsTab.load-error-retry.test.tsx --reporter=dot` green: 2/2 passed
- `bunx vitest run src/components/Option/Watchlists/RunsTab/__tests__/RunsTab.advanced-filters.test.tsx --reporter=dot` passed 5/5
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 54/54
- `bun run verify:design-system-state` passed; baseline exceptions 257, Jobs/Scheduler/Watchlists 22
- `git diff --check` passed
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing diagnostics; no diagnostics mention RunsTab.tsx, RunsTab.load-error-retry.test.tsx, the baseline, or TASK-45.44.3.7

Bandit skipped because this slice only changes frontend TSX/test/JSON and Backlog markdown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Watchlists RunsTab load-error and reliability-attention banners from `antd` to the design-system `Alert` in `@/components/ui/primitives`, preserving copy and actions. Removes the RunsTab product-state exception and adds focused tests to enforce the design-system marker. Satisfies TASK-45.44.3.7.

- **Refactors**
  - Replaced both RunsTab `Alert` usages with design-system `Alert` (`variant`, `action`, `secondaryAction`) and moved body text into children.
  - Preserved actions: Retry, View newest failed run, Show failed runs.
  - Removed RunsTab `Alert` exception from `design-system-product-state-baseline.json`.
  - Updated tests to assert `data-ds-component="Alert"` is present on both banners.

<sup>Written for commit b893503656309b46f36758847383670478bf3c50. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2013?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

