### PR TITLE
Migrate SourcesBulkImport alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2365,17 +2365,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx:Alert",
-    "path": "src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Quiz/tabs/CreateTab.tsx:Alert#antd-alert-createtab-type-info-line-1003-u954tt",
     "path": "src/components/Quiz/tabs/CreateTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Alert, Button, Modal, Select, Space, Switch, Table, Tag, Upload, message } from "antd"
+import { Button, Modal, Select, Space, Switch, Table, Tag, Upload, message } from "antd"
 import type { RcFile } from "antd/es/upload/interface"
 import { UploadCloud } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { fetchWatchlistSources, importOpml } from "@/services/watchlists"
 import type { SourcesImportResponse, WatchlistGroup, WatchlistTag } from "@/types/watchlists"
 import {
@@ -684,8 +685,7 @@ export const SourcesBulkImport: React.FC<SourcesBulkImportProps> = ({
 
         {existingUrlsLoading && (
           <Alert
-            type="info"
-            showIcon
+            variant="info"
             title={t(
               "watchlists:sources.importPreviewLoadingExisting",
               "Loading existing feeds for duplicate checks..."
@@ -695,10 +695,10 @@ export const SourcesBulkImport: React.FC<SourcesBulkImportProps> = ({
 
         {preflight && (
           <Alert
-            type={preflight.parseError ? "error" : preflight.ready > 0 ? "info" : "warning"}
-            showIcon
+            variant={preflight.parseError ? "error" : preflight.ready > 0 ? "info" : "warning"}
             title={t("watchlists:sources.importPreviewSummaryTitle", "Preflight Summary")}
-            description={preflight.parseError
+          >
+            {preflight.parseError
               ? t(
                   "watchlists:sources.importPreviewParseError",
                   "Could not parse this OPML file. Verify it contains outline nodes with xmlUrl attributes."
@@ -714,22 +714,22 @@ export const SourcesBulkImport: React.FC<SourcesBulkImportProps> = ({
                     missingUrl: preflight.missingUrl
                   }
                 )}
-          />
+          </Alert>
         )}
 
         {renderPreflightPreview()}
 
         {summary && (
           <Alert
-            type={summary.errors > 0 ? "warning" : "success"}
-            showIcon
+            variant={summary.errors > 0 ? "warning" : "success"}
             title={t("watchlists:sources.importSummary", "Import Summary")}
-            description={t(
+          >
+            {t(
               "watchlists:sources.importSummaryDesc",
               "{{created}} created, {{skipped}} skipped, {{errors}} errors",
               summary
             )}
-          />
+          </Alert>
         )}
 
         {renderFailedItems()}

--- a/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesBulkImport.preflight-commit.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesBulkImport.preflight-commit.test.tsx
@@ -240,7 +240,9 @@ describe("SourcesBulkImport preflight and commit", () => {
     fireEvent.change(uploadInput, { target: { files: [file] } })
 
     await waitFor(() => {
-      expect(screen.getByText("Preflight Summary")).toBeInTheDocument()
+      const preflightTitle = screen.getByText("Preflight Summary")
+      expect(preflightTitle).toBeInTheDocument()
+      expect(preflightTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
       expect(screen.getByText(/1 ready, 1 existing duplicates/i)).toBeInTheDocument()
       expect(screen.getByTestId("preflight-table-rows")).toHaveTextContent("2")
     })
@@ -260,6 +262,7 @@ describe("SourcesBulkImport preflight and commit", () => {
       )
       expect(onImported).toHaveBeenCalledTimes(1)
       expect(mocks.messageSuccessMock).toHaveBeenCalledWith("OPML imported")
+      expect(screen.getByText("Import Summary").closest('[data-ds-component="Alert"]')).toBeInTheDocument()
     })
   })
 

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Jobs, Scheduler, and Watchlists'
 status: To Do
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-23 22:34'
+updated_date: '2026-05-24 00:34'
 labels:
   - design-system
   - webui
@@ -18,6 +18,7 @@ references:
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
   - 'https://github.com/rmusser01/tldw_server/pull/2012'
   - 'https://github.com/rmusser01/tldw_server/pull/2013'
+  - 'https://github.com/rmusser01/tldw_server/pull/2016'
 documentation:
   - |-
     TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the design-system Alert primitive.
@@ -33,6 +34,13 @@ documentation:
       - Jobs/Scheduler/Watchlists exceptions: 23 -> 22
       - RunsTab target rows: 1 -> 0
     Verification recorded in TASK-45.44.3.7.
+  - |-
+    TASK-45.44.3.8 / PR #2016 migrated SourcesBulkImport loading, preflight, and import summary banners to the design-system Alert primitive.
+    Baseline evidence:
+      - total product-state exceptions: 257 -> 256
+      - Jobs/Scheduler/Watchlists exceptions: 22 -> 21
+      - SourcesBulkImport target rows: 1 -> 0
+    Verification recorded in TASK-45.44.3.8.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.8 - Migrate-SourcesBulkImport-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.8 - Migrate-SourcesBulkImport-alerts-to-design-system-Alert.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.3.8
+title: Migrate SourcesBulkImport alerts to design-system Alert
+status: Done
+assignee: []
+created_date: '2026-05-24 00:34'
+updated_date: '2026-05-24 00:34'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+  - watchlists
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1660'
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/SourcesTab/SourcesBulkImport.tsx
+  - >-
+    apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesBulkImport.preflight-commit.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the Watchlists SourcesBulkImport AntD Alert product-state callouts with the shared design-system Alert primitive, preserving preflight/commit copy and removing the migrated baseline exception.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SourcesBulkImport preflight/commit banners render through the shared design-system Alert primitive instead of AntD Alert.
+- [x] #2 Focused SourcesBulkImport coverage proves the migrated banners preserve copy and expose the canonical Alert marker.
+- [x] #3 The SourcesBulkImport Alert baseline exception is removed without introducing new product-state verifier findings.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing SourcesBulkImport assertions requiring the preflight/commit banners to render with the design-system Alert marker.
+2. Replace the SourcesBulkImport AntD Alert usages with the shared Alert primitive while preserving warning/error/success semantics and user-facing copy.
+3. Remove the migrated SourcesBulkImport Alert entry from design-system-product-state-baseline.json and run focused tests plus design-system verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD red/green completed. Added focused SourcesBulkImport assertions requiring the preflight summary and import summary banners to be wrapped in data-ds-component="Alert"; the red run failed on the missing design-system Alert marker for the preflight banner. Replaced the SourcesBulkImport AntD Alert callouts with the shared design-system Alert primitive, preserved loading/preflight/import summary copy and info/warning/error/success semantics, and removed the single SourcesBulkImport baseline exception. Verification: focused SourcesBulkImport preflight/commit test passed 5/5; product-state guard passed 54/54; bun run verify:design-system-state passed with 256 total baseline exceptions and 21 Jobs/Scheduler/Watchlists exceptions; SourcesBulkImport target rows 1 -> 0; git diff --check passed. Bandit skipped because this slice touched frontend TSX/test/JSON/Backlog markdown only.
+
+TypeScript: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still exits 2 on 347 existing diagnostics; no diagnostics mention SourcesBulkImport, SourcesBulkImport.preflight-commit, the baseline, or TASK-45.44.3.8.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the SourcesBulkImport loading, preflight, and import summary banners from AntD Alert to the design-system Alert primitive. Focused coverage now verifies the preflight and import summary banners use data-ds-component="Alert", and the product-state baseline no longer contains the SourcesBulkImport Alert exception.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.8 - Migrate-SourcesBulkImport-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.8 - Migrate-SourcesBulkImport-alerts-to-design-system-Alert.md
@@ -19,6 +19,7 @@ references:
   - >-
     apps/packages/ui/src/components/Option/Watchlists/SourcesTab/__tests__/SourcesBulkImport.preflight-commit.test.tsx
   - apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/pull/2016'
 parent_task_id: TASK-45.44.3
 priority: medium
 ---


### PR DESCRIPTION
## Change summary

Migrates the Watchlists SourcesBulkImport loading, preflight, and import summary banners from AntD Alert to the shared design-system Alert primitive. The change keeps the existing copy and status semantics while removing the obsolete SourcesBulkImport Alert baseline exception so the product-state guard reflects the reduced migration debt.

## Verification

- `bunx vitest run src/components/Option/Watchlists/SourcesTab/__tests__/SourcesBulkImport.preflight-commit.test.tsx --reporter=dot` red: failed on missing `data-ds-component="Alert"` marker before implementation
- `bunx vitest run src/components/Option/Watchlists/SourcesTab/__tests__/SourcesBulkImport.preflight-commit.test.tsx --reporter=dot` green: 5/5 passed
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 54/54
- `bun run verify:design-system-state` passed; baseline exceptions 256, Jobs/Scheduler/Watchlists 21
- `git diff --check` passed
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing diagnostics; no diagnostics mention SourcesBulkImport, SourcesBulkImport.preflight-commit, the baseline, or TASK-45.44.3.8

Bandit skipped because this slice only changes frontend TSX/test/JSON and Backlog markdown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Watchlists SourcesBulkImport alerts (loading, preflight, import summary) from `antd` `Alert` to the design-system `Alert`. Aligns UI with the design system and removes the product-state baseline exception (TASK-45.44.3.8).

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert`; mapped `type/showIcon` to `variant` and moved description to children.
  - Updated tests to assert the `data-ds-component="Alert"` marker for preflight and import summary banners.
  - Removed the SourcesBulkImport `Alert` exception from `design-system-product-state-baseline.json` and recorded the PR link in task docs.

<sup>Written for commit 83b4e880f39f06b2bbe6116cdca9ad685db073c1. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2016?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

