### PR TITLE
Close stale VN backlog tasks

### DIFF
--- a/backlog/tasks/task-278 - Add-VN-scripted-generation-WebUI-inspector.md
+++ b/backlog/tasks/task-278 - Add-VN-scripted-generation-WebUI-inspector.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-278
 title: Add VN scripted generation WebUI inspector
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-12 01:04'
+updated_date: '2026-05-23 17:49'
 labels:
   - vn-play
   - webui
@@ -62,3 +63,8 @@ Implement the WebUI consumer for the backend-owned scripted VN generation API fr
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added a session-scoped VN scripted generation inspector for the WebUI. It consumes backend-owned generation history/debug/action APIs, renders only public generation output by default, supports confirm/cancel/regenerate/activate commands with idempotency keys, and gates moderation-blocked raw debug reveal behind an explicit confirmation path. Focused API and workspace tests cover endpoint wiring, rendering, backend action controls, and guarded debug reveal behavior.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
+## Closeout Notes
+<!-- SECTION:CLOSEOUT:BEGIN -->
+Closed after verifying PR #1584 merged into `dev` on 2026-05-12 at merge commit `482e73c8ed082d01d7797b80269fdae9487bbda3`. The task already recorded completed acceptance criteria, completed Definition of Done items, implementation notes, verification evidence, and final summary; this closeout only corrects the stale Backlog status.
+<!-- SECTION:CLOSEOUT:END -->

--- a/backlog/tasks/task-283 - Polish-VN-Play-runtime-playback-surface.md
+++ b/backlog/tasks/task-283 - Polish-VN-Play-runtime-playback-surface.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-283
 title: Polish VN Play runtime playback surface
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-12 02:17'
+updated_date: '2026-05-23 17:49'
 labels:
   - vn-play
   - webui
@@ -12,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1587'
   - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1590'
 documentation:
   - Docs/API/VN.md
 priority: medium
@@ -63,3 +65,8 @@ Implement GitHub issue #1587: improve the main VN Play WebUI runtime playback su
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Polished the VN Play runtime playback surface by rendering backend-provided visual metadata/fallbacks in `SceneStage`, labeling generated choices from backend metadata in `ChoicePanel`, and adding workspace coverage to keep normal play usable while the generation inspector remains a separate audit/debug route. The implementation keeps prompt generation, asset resolution, branch semantics, moderation, and debug state owned by the backend.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
+## Closeout Notes
+<!-- SECTION:CLOSEOUT:BEGIN -->
+Closed after verifying PR #1590 merged into `dev` on 2026-05-12 at merge commit `8869efda98aa9997ac43dd61e3fec0807c89bc90`. The task already recorded completed acceptance criteria, completed Definition of Done items, implementation notes, verification evidence, and final summary; this closeout only corrects the stale Backlog status and adds the merged PR reference.
+<!-- SECTION:CLOSEOUT:END -->

--- a/backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md
+++ b/backlog/tasks/task-284 - Add-VN-Play-branch-timeline-and-restore-UX.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-284
 title: Add VN Play branch timeline and restore UX
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-12 03:03'
-updated_date: '2026-05-12 03:04'
+updated_date: '2026-05-23 17:49'
 labels:
   - vn-play
   - webui
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1592'
   - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1595'
 documentation:
   - Docs/API-related/VN_PLAY_API.md
 priority: medium
@@ -88,3 +89,9 @@ Added backend-owned VN Play branch navigation support to the frontend: typed bra
 
 Branch restore controls now call the guarded backend restore endpoint with scene-version and idempotency protection, update the selected session from the restore response, and surface stale/in-progress restore conflicts as recoverable play-state messages. Documentation now notes that custom frontends should use the backend branch-navigation read model rather than deriving branch state from raw events.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
+## Closeout Notes
+
+<!-- SECTION:CLOSEOUT:BEGIN -->
+Closed after verifying PR #1595 merged into `dev` on 2026-05-12 at merge commit `2137cbba0ef4dff1c14270bfd402084f49268ead`. The task already recorded completed acceptance criteria, completed Definition of Done items, implementation notes, verification evidence, and final summary; this closeout only corrects the stale Backlog status and adds the merged PR reference.
+<!-- SECTION:CLOSEOUT:END -->

--- a/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
+++ b/backlog/tasks/task-333 - Add-VN-script-graph-and-outline-inspector.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-333
 title: Add VN script graph and outline inspector
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-14 04:15'
-updated_date: '2026-05-14 05:10'
+updated_date: '2026-05-23 17:49'
 labels:
   - vn
   - frontend
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/1680'
   - 'https://github.com/rmusser01/tldw_server/issues/1391'
+  - 'https://github.com/rmusser01/tldw_server/pull/1681'
 priority: high
 ---
 
@@ -60,6 +61,12 @@ Implement GitHub issue #1680: add a WebUI consumer for the backend-owned VN scri
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added the VN script graph inspector WebUI slice for issue #1680. The frontend now has typed graph API helpers, a capability-gated read-only graph panel for saved drafts and unsaved draft previews, per-version graph inspection from published version cards, focused coverage for the new graph flows, and custom-frontend documentation for graph-inspector usage and staleness keys.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
+## Closeout Notes
+
+<!-- SECTION:CLOSEOUT:BEGIN -->
+Closed after verifying PR #1681 merged into `dev` on 2026-05-14 at merge commit `a1b7047d01c900dd6ea3ed71284f5281c9c2127e`. The task already recorded completed acceptance criteria, completed Definition of Done items, implementation notes, verification evidence, and final summary; this closeout only corrects the stale Backlog status and adds the merged PR reference.
+<!-- SECTION:CLOSEOUT:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->


### PR DESCRIPTION
## Summary
- Mark stale completed VN tasks TASK-278, TASK-283, TASK-284, and TASK-333 as Done.
- Add closeout notes with merge evidence for PRs #1584, #1590, #1595, and #1681.
- Add missing merged PR references where the task metadata did not already include them.

## Verification
- gh pr view 1584/1590/1595/1681 confirmed each PR is MERGED into dev with recorded merge commits.
- git merge-base --is-ancestor passed for all four referenced merge commits against this branch HEAD.
- git diff --check passed.
- git diff --cached --check passed before commit.
- rg guard over touched task files found no stale In Progress status or unchecked boxes.
- Local VN-title backlog status sweep found no remaining To Do or In Progress VN-title tasks after the closeout edits.
- Bandit skipped: Backlog markdown-only closeout, no Python touched.

## Merge note
AI-authored draft PR. Human requester still needs to provide the required Change summary before merge if this repository gate applies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked stale VN tasks TASK-278, TASK-283, TASK-284, and TASK-333 as Done and added closeout notes with merged PR links (#1584, #1590, #1595, #1681). Backlog markdown only; aligns VN backlog with actual state and ties each task to merge evidence.

<sup>Written for commit 33ee3efe94f00538a94146ee00834b3641d8d86b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2017?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

