### PR TITLE
Add Research Workspace source status and Jobs tracking

### DIFF
--- a/Docs/superpowers/plans/2026-05-23-research-workspace-source-jobs-plan.md
+++ b/Docs/superpowers/plans/2026-05-23-research-workspace-source-jobs-plan.md
@@ -1,0 +1,29 @@
+## Stage 1: Characterize Source Add Job Contract
+**Goal**: Add focused tests proving workspace source creation enqueues a user-visible, idempotent `media_ingest` Job and preserves source creation when job submission is unavailable.
+**Success Criteria**: Tests fail before implementation because `POST /workspaces/{id}/sources` does not call `JobManager.create_job`.
+**Tests**: `tldw_Server_API/tests/Workspaces/test_workspaces_api.py` focused source endpoint tests.
+**Status**: Complete
+
+## Stage 2: Enqueue Workspace Source Jobs
+**Goal**: Add a narrow helper in the workspace endpoint that submits a `media_ingest/default/workspace_source_ingest` Job after the source row is persisted.
+**Success Criteria**: Job payload contains workspace/source/media identifiers, source metadata, requested lifecycle stages, and a deterministic idempotency key.
+**Tests**: Focused workspace source endpoint tests pass.
+**Status**: Complete
+
+## Stage 3: Verify Projection Integration
+**Goal**: Confirm the existing source status projection recognizes the queued source job via payload keys and keeps no `/workspace-playground` alias behavior.
+**Success Criteria**: Workspace source status tests pass and route search finds no new legacy route alias.
+**Tests**: `test_workspace_source_status_api.py`, route grep.
+**Status**: Complete
+
+## Stage 4: Backend Validation And Security
+**Goal**: Run backend-focused verification, Bandit on touched Python files, and a live backend HTTP smoke test for source add/status.
+**Success Criteria**: Focused tests, Bandit, diff check, and live backend calls complete with recorded output.
+**Tests**: Pytest, Bandit, `git diff --check`, live `uvicorn` + HTTP checks.
+**Status**: Complete
+
+## Stage 5: Review Feedback Hardening
+**Goal**: Address code-review findings around fail-open Jobs dependency construction and source-status job query precision.
+**Success Criteria**: Source creation still persists the source row when Jobs manager construction fails, enqueue failures remain non-destructive, and status projection prioritizes `workspace_source_ingest` Jobs before broad legacy `media_ingest` jobs.
+**Tests**: Focused workspace source endpoint tests, workspace source status tests, full Workspaces suite, Bandit, scoped diff check, live backend HTTP smoke.
+**Status**: Complete

--- a/backlog/completed/task-469 - Address-Research-Workspace-source-Jobs-review-feedback.md
+++ b/backlog/completed/task-469 - Address-Research-Workspace-source-Jobs-review-feedback.md
@@ -1,0 +1,45 @@
+---
+id: TASK-469
+title: Address Research Workspace source Jobs review feedback
+status: Done
+references:
+- backlog/completed/task-469 - Enqueue-Research-Workspace-source-ingestion-Jobs.md
+- Docs/superpowers/plans/2026-05-23-research-workspace-source-jobs-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-05-23-research-workspace-source-jobs-plan.md
+- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+- tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+- tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up to TASK-469. Fix code-review findings for workspace source job enqueueing: source creation must preserve the source row when Jobs dependency construction fails, and status projection should prioritize workspace_source_ingest Jobs so relevant source lifecycle jobs are not buried behind unrelated media_ingest work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed source Jobs review feedback. Added fail-open job manager resolution so source creation still persists when Jobs construction is unavailable, kept enqueue failures non-destructive, and made status projection query workspace_source_ingest Jobs first before broad legacy media_ingest Jobs. Added regression coverage for dependency construction failures and job-list prioritization. Verification: focused review-regression tests passed, full Workspaces suite passed, Bandit on touched production code reported zero findings, scoped diff check passed, and a live backend smoke verified source add/status plus idempotent job creation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/completed/task-469 - Address-Research-Workspace-source-Jobs-review-feedback.md
+++ b/backlog/completed/task-469 - Address-Research-Workspace-source-Jobs-review-feedback.md
@@ -20,6 +20,12 @@ Follow-up to TASK-469. Fix code-review findings for workspace source job enqueue
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] Source creation still succeeds when Jobs manager construction is unavailable.
+- [x] Source creation still persists the source row when non-validation Jobs enqueue failures occur.
+- [x] Jobs validation/quota failures return HTTP 400 instead of a misleading successful enqueue response.
+- [x] Source status queries prioritize `workspace_source_ingest` Jobs before broad legacy `media_ingest` Jobs and choose source matches deterministically.
+- [x] Source status/capability endpoints expose non-sensitive failed-job messages and map ChaChaNotes workspace errors to correct HTTP statuses.
+- [x] Focused regression tests, full Workspaces tests, Bandit on touched production code, diff checks, and live backend smoke verification were recorded.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/completed/task-469 - Enqueue-Research-Workspace-source-ingestion-Jobs.md
+++ b/backlog/completed/task-469 - Enqueue-Research-Workspace-source-ingestion-Jobs.md
@@ -1,0 +1,49 @@
+---
+id: TASK-469
+title: Enqueue Research Workspace source ingestion Jobs
+status: Done
+references:
+- Docs/superpowers/specs/2026-05-23-research-workspace-hard-replacement-roadmap-design.md
+modified_files:
+- Docs/superpowers/plans/2026-05-23-research-workspace-source-jobs-plan.md
+- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+- tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase A backend follow-up for the Research Workspace hard replacement roadmap. When a source is added to a workspace, enqueue an idempotent user-visible Jobs record for ingestion, extraction, chunking, and indexing status so /api/v1/workspaces/{workspace_id}/sources/status has first-class job-backed progress. Preserve no /workspace-playground aliases or redirects.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-23-research-workspace-source-jobs-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Research Workspace source-add job enqueueing. POST /api/v1/workspaces/{workspace_id}/sources now persists the source row, then submits an idempotent media_ingest/default/workspace_source_ingest Job containing workspace/source/media identifiers, source metadata, URL, and requested lifecycle stages. Job enqueue failures are logged and fail open so the source row remains recoverable. Added integration tests for the job contract and fail-open source preservation. Verification: focused workspace endpoint/status tests, the full Workspaces suite, Bandit on touched production code, scoped diff check, route grep, and a live FastAPI backend smoke test on 127.0.0.1:18001.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/completed/task-469 - Enqueue-Research-Workspace-source-ingestion-Jobs.md
+++ b/backlog/completed/task-469 - Enqueue-Research-Workspace-source-ingestion-Jobs.md
@@ -18,6 +18,11 @@ Phase A backend follow-up for the Research Workspace hard replacement roadmap. W
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] `POST /api/v1/workspaces/{workspace_id}/sources` persists a workspace source and enqueues one `media_ingest/default/workspace_source_ingest` Job.
+- [x] Enqueued Jobs include workspace id, workspace source id, media id, source type, title, URL, requested lifecycle stages, owner user id, and a stable idempotency key.
+- [x] Re-adding the same workspace source is idempotent and does not create duplicate Jobs.
+- [x] Runtime Jobs backend failures are logged without deleting the source row, so recovery/status inspection remains possible.
+- [x] Focused Workspaces tests, full Workspaces tests, Bandit on touched production code, diff checks, and live backend smoke verification were recorded.
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -1,9 +1,15 @@
 """Workspace lifecycle CRUD endpoints."""
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, status
+from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     StatusResponse,
     WorkspaceArtifactCreateRequest,
@@ -14,11 +20,13 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceNoteResponse,
     WorkspaceNoteUpdateRequest,
     WorkspacePatchRequest,
+    WorkspaceCapabilitiesResponse,
     WorkspaceResponse,
     WorkspaceSourceCreateRequest,
     WorkspaceSourceReorderRequest,
     WorkspaceSourceResponse,
     WorkspaceSourceSelectionRequest,
+    WorkspaceSourceStatusListResponse,
     WorkspaceSourceUpdateRequest,
     WorkspaceUpsertRequest,
 )
@@ -28,9 +36,24 @@ from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
     WORKSPACES_WRITE_RATE_LIMIT,
 )
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    ConflictError,
+    InputError,
+)
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Workspaces.status_projection import (
+    build_source_status_projection,
+    build_workspace_capability_projection,
+)
 
 router = APIRouter()
+
+WORKSPACE_SOURCE_JOB_DOMAIN = "media_ingest"
+WORKSPACE_SOURCE_JOB_QUEUE = "default"
+WORKSPACE_SOURCE_JOB_TYPE = "workspace_source_ingest"
+WORKSPACE_SOURCE_JOB_STAGES = ["ingestion", "extraction", "chunking", "indexing"]
 
 
 def _ws_to_response(ws: dict) -> WorkspaceResponse:
@@ -107,6 +130,120 @@ def _require_workspace(db: CharactersRAGDB, workspace_id: str) -> dict:
     if not ws:
         raise HTTPException(status_code=404, detail="Workspace not found")
     return ws
+
+
+def _find_workspace_source(db: CharactersRAGDB, workspace_id: str, source_id: str) -> dict[str, Any] | None:
+    """Return an existing workspace source without requiring a public DB helper."""
+    private_getter = getattr(db, "_get_workspace_source", None)
+    if callable(private_getter):
+        source = private_getter(workspace_id, source_id)
+        return dict(source) if source else None
+    for source in db.list_workspace_sources(workspace_id):
+        if str(source.get("id")) == source_id:
+            return source
+    return None
+
+
+def try_get_workspace_job_manager() -> JobManager | None:
+    """Resolve the Jobs manager for workspace views without blocking workspace reads/writes."""
+    try:
+        return get_job_manager()
+    except Exception as exc:
+        logger.warning("Workspace Jobs manager unavailable: {}", exc)
+        return None
+
+
+def _dedupe_jobs_by_identity(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: list[dict[str, Any]] = []
+    seen: set[Any] = set()
+    for job in jobs:
+        key = job.get("id") or job.get("uuid")
+        if key is None:
+            key = (
+                job.get("domain"),
+                job.get("queue"),
+                job.get("job_type"),
+                job.get("created_at"),
+                str(job.get("payload") or ""),
+            )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(job)
+    return deduped
+
+
+def _safe_list_jobs(jm: JobManager, **kwargs: Any) -> list[dict[str, Any]]:
+    try:
+        return jm.list_jobs(**kwargs)
+    except Exception:
+        return []
+
+
+def _list_recent_media_ingest_jobs(jm: JobManager | None, current_user: User) -> list[dict[str, Any]]:
+    """Return recent media-ingest Jobs for status projection, failing open."""
+    if jm is None:
+        return []
+    workspace_source_jobs = _safe_list_jobs(
+        jm,
+        domain=WORKSPACE_SOURCE_JOB_DOMAIN,
+        queue=WORKSPACE_SOURCE_JOB_QUEUE,
+        owner_user_id=str(current_user.id),
+        job_type=WORKSPACE_SOURCE_JOB_TYPE,
+        limit=500,
+        sort_by="created_at",
+        sort_order="desc",
+    )
+    legacy_media_jobs = _safe_list_jobs(
+        jm,
+        domain=WORKSPACE_SOURCE_JOB_DOMAIN,
+        owner_user_id=str(current_user.id),
+        limit=500,
+        sort_by="created_at",
+        sort_order="desc",
+    )
+    return _dedupe_jobs_by_identity(workspace_source_jobs + legacy_media_jobs)
+
+
+def _enqueue_workspace_source_ingest_job(
+    *,
+    jm: JobManager | None,
+    current_user: User,
+    workspace_id: str,
+    src: dict[str, Any],
+) -> None:
+    """Submit a source lifecycle job after the workspace source row exists."""
+    if jm is None:
+        return
+    source_id = str(src["id"])
+    media_id = int(src["media_id"])
+    payload = {
+        "workspace_id": workspace_id,
+        "workspace_source_id": source_id,
+        "source_id": source_id,
+        "media_id": media_id,
+        "source_type": str(src["source_type"]),
+        "title": str(src["title"]),
+        "url": src.get("url"),
+        "requested_stages": WORKSPACE_SOURCE_JOB_STAGES,
+    }
+    try:
+        jm.create_job(
+            domain=WORKSPACE_SOURCE_JOB_DOMAIN,
+            queue=WORKSPACE_SOURCE_JOB_QUEUE,
+            job_type=WORKSPACE_SOURCE_JOB_TYPE,
+            payload=payload,
+            owner_user_id=str(current_user.id),
+            idempotency_key=f"workspace-source:{workspace_id}:{source_id}:{media_id}",
+            max_retries=3,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Workspace source ingest job enqueue failed for workspace={} source={}: {}",
+            workspace_id,
+            source_id,
+            exc,
+        )
 
 
 # ── Workspace CRUD ──────────────────────────────────────────────
@@ -229,6 +366,66 @@ async def list_sources(
     return [_src_to_response(s) for s in db.list_workspace_sources(workspace_id)]
 
 
+@router.get(
+    "/{workspace_id}/sources/status",
+    response_model=WorkspaceSourceStatusListResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="Get workspace source ingestion and indexing status",
+)
+async def get_sources_status(
+    workspace_id: str,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    jm: JobManager | None = Depends(try_get_workspace_job_manager),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceSourceStatusListResponse:
+    """Return read-computed ingestion, extraction, chunking, and indexing status."""
+    _require_workspace(db, workspace_id)
+    try:
+        sources = db.list_workspace_sources(workspace_id)
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace source status") from exc
+    payload = build_source_status_projection(
+        workspace_id=workspace_id,
+        sources=sources,
+        media_db=media_db,
+        jobs=_list_recent_media_ingest_jobs(jm, current_user),
+    )
+    return WorkspaceSourceStatusListResponse(**payload)
+
+
+@router.get(
+    "/{workspace_id}/capabilities",
+    response_model=WorkspaceCapabilitiesResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="Get workspace capability gates",
+)
+async def get_workspace_capabilities(
+    workspace_id: str,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    jm: JobManager | None = Depends(try_get_workspace_job_manager),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceCapabilitiesResponse:
+    """Return conservative UI capability gates for the workspace model."""
+    workspace = _require_workspace(db, workspace_id)
+    try:
+        sources = db.list_workspace_sources(workspace_id)
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace capabilities") from exc
+    status_payload = build_source_status_projection(
+        workspace_id=workspace_id,
+        sources=sources,
+        media_db=media_db,
+        jobs=_list_recent_media_ingest_jobs(jm, current_user),
+    )
+    payload = build_workspace_capability_projection(
+        workspace=workspace,
+        status_projection=status_payload,
+    )
+    return WorkspaceCapabilitiesResponse(**payload)
+
+
 @router.post(
     "/{workspace_id}/sources",
     response_model=WorkspaceSourceResponse,
@@ -240,11 +437,25 @@ async def add_source(
     workspace_id: str,
     body: WorkspaceSourceCreateRequest,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    jm: JobManager | None = Depends(try_get_workspace_job_manager),
     current_user: User = Depends(get_request_user),
 ) -> WorkspaceSourceResponse:
     """Add a media source to a workspace."""
     _require_workspace(db, workspace_id)
-    src = db.add_workspace_source(workspace_id, body.model_dump())
+    src = _find_workspace_source(db, workspace_id, body.id)
+    if src is None:
+        try:
+            src = db.add_workspace_source(workspace_id, body.model_dump())
+        except (ConflictError, InputError, CharactersRAGDBError):
+            src = _find_workspace_source(db, workspace_id, body.id)
+            if src is None:
+                raise
+    _enqueue_workspace_source_ingest_job(
+        jm=jm,
+        current_user=current_user,
+        workspace_id=workspace_id,
+        src=src,
+    )
     return _src_to_response(src)
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -9,7 +9,6 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
-from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     StatusResponse,
     WorkspaceArtifactCreateRequest,
@@ -133,15 +132,44 @@ def _require_workspace(db: CharactersRAGDB, workspace_id: str) -> dict:
 
 
 def _find_workspace_source(db: CharactersRAGDB, workspace_id: str, source_id: str) -> dict[str, Any] | None:
-    """Return an existing workspace source without requiring a public DB helper."""
-    private_getter = getattr(db, "_get_workspace_source", None)
-    if callable(private_getter):
-        source = private_getter(workspace_id, source_id)
-        return dict(source) if source else None
-    for source in db.list_workspace_sources(workspace_id):
-        if str(source.get("id")) == source_id:
-            return source
+    """Return an existing workspace source using the DB's direct public lookup."""
+    source = db.get_workspace_source(workspace_id, source_id)
+    return dict(source) if source else None
+
+
+def _workspace_access_level(workspace: dict[str, Any], current_user: User) -> str:
+    """Resolve owner/editor/viewer capability scope for the current workspace route."""
+    explicit = _normalize_access_level(workspace.get("access_level"))
+    if explicit is not None:
+        return explicit
+    owner_id = str(workspace.get("owner_user_id") or workspace.get("client_id") or "").strip()
+    if owner_id and owner_id == str(current_user.id):
+        return "owner"
+    # /workspaces is backed by the current user's ChaCha DB. Until shared routes
+    # pass explicit access metadata, absence of a share row means owned access.
+    return "owner"
+
+
+def _normalize_access_level(value: Any) -> str | None:
+    """Map sharing-layer access labels onto capability response labels."""
+    normalized = str(value or "").strip().lower()
+    if normalized in {"owner", "editor", "viewer"}:
+        return normalized
+    if normalized == "full_edit":
+        return "editor"
+    if normalized in {"view_chat", "view_chat_add"}:
+        return "viewer" if normalized == "view_chat" else "editor"
     return None
+
+
+def _map_chacha_error_to_http(exc: Exception, *, default_detail: str) -> HTTPException:
+    """Map ChaChaNotes workspace exceptions to stable HTTP responses."""
+    if isinstance(exc, ConflictError):
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    if isinstance(exc, InputError):
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    logger.error("{}: {}", default_detail, exc)
+    return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=default_detail)
 
 
 def try_get_workspace_job_manager() -> JobManager | None:
@@ -154,10 +182,11 @@ def try_get_workspace_job_manager() -> JobManager | None:
 
 
 def _dedupe_jobs_by_identity(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return jobs with duplicate identity keys removed while preserving order."""
     deduped: list[dict[str, Any]] = []
     seen: set[Any] = set()
     for job in jobs:
-        key = job.get("id") or job.get("uuid")
+        key = job.get("id") if job.get("id") is not None else job.get("uuid")
         if key is None:
             key = (
                 job.get("domain"),
@@ -174,9 +203,11 @@ def _dedupe_jobs_by_identity(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]
 
 
 def _safe_list_jobs(jm: JobManager, **kwargs: Any) -> list[dict[str, Any]]:
+    """List Jobs for status projection without breaking workspace reads."""
     try:
         return jm.list_jobs(**kwargs)
-    except Exception:
+    except Exception as exc:
+        logger.warning("Workspace status job listing failed with filters={}: {}", kwargs, exc)
         return []
 
 
@@ -237,6 +268,8 @@ def _enqueue_workspace_source_ingest_job(
             idempotency_key=f"workspace-source:{workspace_id}:{source_id}:{media_id}",
             max_retries=3,
         )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
         logger.warning(
             "Workspace source ingest job enqueue failed for workspace={} source={}: {}",
@@ -384,7 +417,10 @@ async def get_sources_status(
     try:
         sources = db.list_workspace_sources(workspace_id)
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
-        raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace source status") from exc
+        raise _map_chacha_error_to_http(
+            exc,
+            default_detail="Failed to fetch workspace source status",
+        ) from exc
     payload = build_source_status_projection(
         workspace_id=workspace_id,
         sources=sources,
@@ -412,7 +448,10 @@ async def get_workspace_capabilities(
     try:
         sources = db.list_workspace_sources(workspace_id)
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
-        raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace capabilities") from exc
+        raise _map_chacha_error_to_http(
+            exc,
+            default_detail="Failed to fetch workspace capabilities",
+        ) from exc
     status_payload = build_source_status_projection(
         workspace_id=workspace_id,
         sources=sources,
@@ -420,7 +459,10 @@ async def get_workspace_capabilities(
         jobs=_list_recent_media_ingest_jobs(jm, current_user),
     )
     payload = build_workspace_capability_projection(
-        workspace=workspace,
+        workspace={
+            **workspace,
+            "access_level": _workspace_access_level(workspace, current_user),
+        },
         status_projection=status_payload,
     )
     return WorkspaceCapabilitiesResponse(**payload)

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -116,6 +116,8 @@ WorkspaceCapabilityServiceState = Literal[
 
 
 class WorkspaceSourceReadiness(BaseModel):
+    """Boolean readiness flags for each source capability used by the UI."""
+
     metadata_ready: bool = False
     text_extracted: bool = False
     fts_ready: bool = False
@@ -126,6 +128,8 @@ class WorkspaceSourceReadiness(BaseModel):
 
 
 class WorkspaceSourceJobStatus(BaseModel):
+    """Public, non-sensitive status summary for the matched source ingestion Job."""
+
     id: int | None = None
     uuid: str | None = None
     status: str | None = None
@@ -136,6 +140,8 @@ class WorkspaceSourceJobStatus(BaseModel):
 
 
 class WorkspaceSourceStatusResponse(BaseModel):
+    """Ingestion, extraction, chunking, and indexing status for one workspace source."""
+
     id: str
     workspace_id: str
     media_id: int | None = None
@@ -153,6 +159,8 @@ class WorkspaceSourceStatusResponse(BaseModel):
 
 
 class WorkspaceSourceStatusSummary(BaseModel):
+    """Aggregate counts used to drive workspace-level source readiness UI."""
+
     total: int = 0
     selected: int = 0
     queryable: int = 0
@@ -163,23 +171,31 @@ class WorkspaceSourceStatusSummary(BaseModel):
 
 
 class WorkspaceSourceStatusListResponse(BaseModel):
+    """Source status projection response for all sources in one workspace."""
+
     workspace_id: str
     sources: list[WorkspaceSourceStatusResponse]
     summary: WorkspaceSourceStatusSummary
 
 
 class WorkspaceCapabilityService(BaseModel):
+    """Availability state for a workspace-adjacent service or management surface."""
+
     state: WorkspaceCapabilityServiceState
     reason_code: str | None = None
     management_surface: str | None = None
 
 
 class WorkspaceAllowedAction(BaseModel):
+    """Whether the current principal may perform a workspace action."""
+
     allowed: bool
     reason_code: str | None = None
 
 
 class WorkspaceCapabilitiesResponse(BaseModel):
+    """Capability gates for Research Workspace controls for the current principal."""
+
     workspace_id: str
     workspace_kind: Literal["research_workspace"]
     access_level: Literal["owner", "editor", "viewer"] = "owner"

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -91,6 +91,103 @@ class WorkspaceSourceReorderRequest(BaseModel):
     ordered_ids: list[str]
 
 
+WorkspaceSourceLifecycleState = Literal[
+    "queued",
+    "ingesting",
+    "extracting",
+    "chunking",
+    "indexing",
+    "queryable",
+    "partially_queryable",
+    "failed",
+    "retrying",
+    "missing_media",
+    "blocked_by_permissions",
+]
+
+WorkspaceCapabilityServiceState = Literal[
+    "available",
+    "private",
+    "not_configured",
+    "unknown",
+    "blocked",
+    "degraded",
+]
+
+
+class WorkspaceSourceReadiness(BaseModel):
+    metadata_ready: bool = False
+    text_extracted: bool = False
+    fts_ready: bool = False
+    vector_ready: bool = False
+    citation_ready: bool = False
+    summary_ready: bool = False
+    tool_accessible: bool = False
+
+
+class WorkspaceSourceJobStatus(BaseModel):
+    id: int | None = None
+    uuid: str | None = None
+    status: str | None = None
+    job_type: str | None = None
+    progress_percent: float | None = None
+    progress_message: str | None = None
+    error_message: str | None = None
+
+
+class WorkspaceSourceStatusResponse(BaseModel):
+    id: str
+    workspace_id: str
+    media_id: int | None = None
+    title: str
+    source_type: str
+    url: str | None = None
+    selected: bool = True
+    state: WorkspaceSourceLifecycleState
+    status_reason: str
+    readiness: WorkspaceSourceReadiness
+    progress_percent: float | None = None
+    progress_message: str | None = None
+    job: WorkspaceSourceJobStatus | None = None
+    updated_at: str = ""
+
+
+class WorkspaceSourceStatusSummary(BaseModel):
+    total: int = 0
+    selected: int = 0
+    queryable: int = 0
+    partially_queryable: int = 0
+    processing: int = 0
+    failed: int = 0
+    missing: int = 0
+
+
+class WorkspaceSourceStatusListResponse(BaseModel):
+    workspace_id: str
+    sources: list[WorkspaceSourceStatusResponse]
+    summary: WorkspaceSourceStatusSummary
+
+
+class WorkspaceCapabilityService(BaseModel):
+    state: WorkspaceCapabilityServiceState
+    reason_code: str | None = None
+    management_surface: str | None = None
+
+
+class WorkspaceAllowedAction(BaseModel):
+    allowed: bool
+    reason_code: str | None = None
+
+
+class WorkspaceCapabilitiesResponse(BaseModel):
+    workspace_id: str
+    workspace_kind: Literal["research_workspace"]
+    access_level: Literal["owner", "editor", "viewer"] = "owner"
+    source_summary: WorkspaceSourceStatusSummary
+    workspace_services: dict[str, WorkspaceCapabilityService]
+    allowed_actions: dict[str, WorkspaceAllowedAction]
+
+
 class StatusResponse(BaseModel):
     ok: bool = True
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -21828,9 +21828,19 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             1 if data.get("selected", True) else 0,
             now,
         )
-        with self.transaction() as conn:
-            conn.execute(query, params)
-        return self._get_workspace_source(workspace_id, source_id)  # type: ignore[return-value]
+        try:
+            with self.transaction() as conn:
+                conn.execute(query, params)
+        except sqlite3.IntegrityError as exc:
+            existing = self.get_workspace_source(workspace_id, source_id)
+            if existing is not None:
+                return existing
+            raise ConflictError(  # noqa: TRY003
+                f"Workspace source '{source_id}' already exists.",
+                entity="workspace_sources",
+                entity_id=source_id,
+            ) from exc
+        return self.get_workspace_source(workspace_id, source_id)  # type: ignore[return-value]
 
     def _get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, Any] | None:
         cursor = self.execute_query(
@@ -21839,6 +21849,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         )
         row = cursor.fetchone()
         return dict(row) if row else None
+
+    def get_workspace_source(self, workspace_id: str, source_id: str) -> dict[str, Any] | None:
+        """Return one workspace source by id, or None when it does not exist."""
+        return self._get_workspace_source(workspace_id, source_id)
 
     def list_workspace_sources(self, workspace_id: str) -> list[dict[str, Any]]:
         """List all sources for a workspace ordered by position."""

--- a/tldw_Server_API/app/core/Workspaces/__init__.py
+++ b/tldw_Server_API/app/core/Workspaces/__init__.py
@@ -1,0 +1,1 @@
+"""Workspace domain helpers."""

--- a/tldw_Server_API/app/core/Workspaces/status_projection.py
+++ b/tldw_Server_API/app/core/Workspaces/status_projection.py
@@ -1,0 +1,478 @@
+"""Read-computed status projection for Research Workspace sources."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
+from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
+
+
+_ACTIVE_JOB_STATUSES = frozenset({"queued", "processing", "running", "retrying"})
+_FAILED_JOB_STATUSES = frozenset({"failed", "cancelled", "quarantined"})
+_PROCESSING_STATES = frozenset({"queued", "ingesting", "extracting", "chunking", "indexing", "retrying"})
+_PENDING_REASONS = frozenset({"vector_index_pending", "chunking_pending", "extraction_pending"})
+
+
+def build_source_status_projection(
+    *,
+    workspace_id: str,
+    sources: list[dict[str, Any]],
+    media_db: Any | None = None,
+    jobs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the source status response payload for a workspace.
+
+    The projection is intentionally computed on read for this first contract:
+    workspace membership is stored in ChaChaNotes, text/indexing readiness lives
+    in the Media DB, and in-flight ingestion progress belongs to Jobs.
+    """
+    job_index = _build_job_index(jobs or [])
+    statuses = [
+        _build_source_status(source, media_db=media_db, job_index=job_index)
+        for source in sources
+    ]
+    return {
+        "workspace_id": workspace_id,
+        "sources": statuses,
+        "summary": _summarize_sources(statuses),
+    }
+
+
+def build_workspace_capability_projection(
+    *,
+    workspace: dict[str, Any],
+    status_projection: dict[str, Any],
+) -> dict[str, Any]:
+    """Build conservative capability gates for Research Workspace clients."""
+    summary = dict(status_projection.get("summary") or {})
+    has_queryable_sources = int(summary.get("queryable") or 0) > 0
+
+    return {
+        "workspace_id": workspace["id"],
+        "workspace_kind": "research_workspace",
+        "access_level": "owner",
+        "source_summary": summary,
+        "workspace_services": {
+            "migration": {
+                "state": "available",
+                "reason_code": None,
+                "management_surface": "research_workspace_import",
+            },
+            "sharing": {
+                "state": "private",
+                "reason_code": None,
+                "management_surface": "shared_workspaces",
+            },
+            "mcp": {
+                "state": "not_configured",
+                "reason_code": "no_workspace_mcp_binding",
+                "management_surface": "mcp_hub",
+            },
+            "acp": {
+                "state": "not_configured",
+                "reason_code": "no_workspace_acp_binding",
+                "management_surface": "acp_workspace",
+            },
+            "sandbox": {
+                "state": "not_configured",
+                "reason_code": "no_workspace_sandbox_binding",
+                "management_surface": "sandbox_settings",
+            },
+            "provider": {
+                "state": "unknown",
+                "reason_code": "provider_not_evaluated",
+                "management_surface": "model_settings",
+            },
+        },
+        "allowed_actions": {
+            "add_sources": _allowed(True),
+            "inspect_sources": _allowed(
+                int(summary.get("total") or 0) > 0,
+                "no_sources",
+            ),
+            "ask_grounded_questions": _allowed(
+                has_queryable_sources,
+                "no_queryable_sources",
+            ),
+            "export_workspace": _allowed(True),
+            "manage_tools": _allowed(True),
+            "run_mcp_tools": _allowed(False, "mcp_not_configured"),
+            "use_acp_agents": _allowed(False, "acp_not_configured"),
+            "use_sandbox": _allowed(False, "sandbox_not_configured"),
+        },
+    }
+
+
+def _build_source_status(
+    source: dict[str, Any],
+    *,
+    media_db: Any | None,
+    job_index: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    matched_job = _match_job_for_source(source, job_index)
+    if matched_job and _is_active_job(matched_job):
+        return _status_from_active_job(source, matched_job)
+
+    if matched_job and _is_failed_job(matched_job):
+        return _status_from_failed_job(source, matched_job)
+
+    media_id = _coerce_int(source.get("media_id"))
+    if media_id is None or media_id <= 0:
+        return _base_status(
+            source,
+            state="missing_media",
+            reason="media_id_missing",
+            progress_percent=0.0,
+            progress_message="Workspace source does not have a media item yet.",
+        )
+
+    media = _get_media(media_db, media_id)
+    if media is None:
+        return _base_status(
+            source,
+            state="missing_media",
+            reason="media_not_found",
+            progress_percent=0.0,
+            progress_message="Media item is missing or unavailable.",
+        )
+
+    return _status_from_media(source, media, media_db=media_db, media_id=media_id)
+
+
+def _status_from_media(
+    source: dict[str, Any],
+    media: dict[str, Any],
+    *,
+    media_db: Any | None,
+    media_id: int,
+) -> dict[str, Any]:
+    content = str(media.get("content") or "")
+    text_ready = bool(content.strip())
+    chunking_status = str(media.get("chunking_status") or "").strip().lower()
+    vector_processing = media.get("vector_processing")
+    vector_ready = _is_vector_ready(vector_processing)
+    unvectorized_chunks = _has_unvectorized_chunks(media_db, media_id)
+    vector_failed = _is_vector_failed(vector_processing) or _is_failure_status(chunking_status)
+
+    readiness = {
+        "metadata_ready": True,
+        "text_extracted": text_ready,
+        "fts_ready": text_ready,
+        "vector_ready": vector_ready and not unvectorized_chunks,
+        "citation_ready": text_ready,
+        "summary_ready": bool(media.get("summary") or media.get("analysis") or media.get("analysis_content")),
+        "tool_accessible": True,
+    }
+
+    if not text_ready:
+        return _base_status(
+            source,
+            state="extracting",
+            reason="extraction_pending",
+            readiness=readiness,
+            progress_percent=35.0,
+            progress_message="Text extraction has not completed.",
+        )
+
+    if chunking_status and chunking_status not in {"completed", "complete", "done"} and not vector_failed:
+        return _base_status(
+            source,
+            state="chunking",
+            reason="chunking_pending",
+            readiness=readiness,
+            progress_percent=65.0,
+            progress_message="Text is available while chunking continues.",
+        )
+
+    if readiness["vector_ready"]:
+        return _base_status(
+            source,
+            state="queryable",
+            reason="source_queryable",
+            readiness=readiness,
+            progress_percent=100.0,
+            progress_message="Ready for grounded questions.",
+        )
+
+    if vector_failed:
+        return _base_status(
+            source,
+            state="partially_queryable",
+            reason="vector_index_failed",
+            readiness=readiness,
+            progress_percent=75.0,
+            progress_message="Text search is available, but vector indexing failed.",
+        )
+
+    return _base_status(
+        source,
+        state="partially_queryable",
+        reason="vector_index_pending",
+        readiness=readiness,
+        progress_percent=75.0,
+        progress_message="Text search is available while vector indexing continues.",
+    )
+
+
+def _status_from_active_job(source: dict[str, Any], job: dict[str, Any]) -> dict[str, Any]:
+    state = _state_from_job(job)
+    return _base_status(
+        source,
+        state=state,
+        reason=f"job_{state}",
+        progress_percent=_coerce_float(job.get("progress_percent")),
+        progress_message=job.get("progress_message") or "Ingestion job is running.",
+        job=_job_payload(job),
+    )
+
+
+def _status_from_failed_job(source: dict[str, Any], job: dict[str, Any]) -> dict[str, Any]:
+    return _base_status(
+        source,
+        state="failed",
+        reason="job_failed",
+        progress_percent=_coerce_float(job.get("progress_percent")),
+        progress_message=job.get("error_message") or _job_result_error(job) or "Ingestion job failed.",
+        job=_job_payload(job),
+    )
+
+
+def _base_status(
+    source: dict[str, Any],
+    *,
+    state: str,
+    reason: str,
+    readiness: dict[str, bool] | None = None,
+    progress_percent: float | None = None,
+    progress_message: str | None = None,
+    job: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": source["id"],
+        "workspace_id": source["workspace_id"],
+        "media_id": source.get("media_id"),
+        "title": source.get("title") or "",
+        "source_type": source.get("source_type") or "",
+        "url": source.get("url"),
+        "selected": bool(source.get("selected", True)),
+        "state": state,
+        "status_reason": reason,
+        "readiness": readiness or _empty_readiness(),
+        "progress_percent": progress_percent,
+        "progress_message": progress_message,
+        "job": job,
+        "updated_at": str(source.get("added_at", "")),
+    }
+
+
+def _empty_readiness() -> dict[str, bool]:
+    return {
+        "metadata_ready": False,
+        "text_extracted": False,
+        "fts_ready": False,
+        "vector_ready": False,
+        "citation_ready": False,
+        "summary_ready": False,
+        "tool_accessible": False,
+    }
+
+
+def _summarize_sources(statuses: list[dict[str, Any]]) -> dict[str, int]:
+    summary = {
+        "total": len(statuses),
+        "selected": 0,
+        "queryable": 0,
+        "partially_queryable": 0,
+        "processing": 0,
+        "failed": 0,
+        "missing": 0,
+    }
+    for status in statuses:
+        state = str(status.get("state") or "")
+        reason = str(status.get("status_reason") or "")
+        if status.get("selected"):
+            summary["selected"] += 1
+        if state == "queryable":
+            summary["queryable"] += 1
+        if state == "partially_queryable":
+            summary["partially_queryable"] += 1
+        if state in _PROCESSING_STATES or reason in _PENDING_REASONS:
+            summary["processing"] += 1
+        if state in {"failed", "blocked_by_permissions"}:
+            summary["failed"] += 1
+        if state == "missing_media":
+            summary["missing"] += 1
+    return summary
+
+
+def _get_media(media_db: Any | None, media_id: int) -> dict[str, Any] | None:
+    if media_db is None:
+        return None
+    try:
+        return media_db_api.get_media_by_id(media_db, media_id)
+    except (AttributeError, DatabaseError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _has_unvectorized_chunks(media_db: Any | None, media_id: int) -> bool:
+    if media_db is None:
+        return False
+    try:
+        return media_db_api.has_unvectorized_chunks(media_db, media_id)
+    except (AttributeError, DatabaseError, RuntimeError, TypeError, ValueError):
+        return False
+
+
+def _is_vector_ready(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return int(value) == 1
+    normalized = str(value or "").strip().lower()
+    return normalized in {"1", "true", "ready", "completed", "complete", "done"}
+
+
+def _is_vector_failed(value: Any) -> bool:
+    if isinstance(value, int | float):
+        return int(value) < 0
+    normalized = str(value or "").strip().lower()
+    return any(token in normalized for token in ("error", "failed", "failure"))
+
+
+def _is_failure_status(value: str) -> bool:
+    return any(token in value for token in ("error", "failed", "failure"))
+
+
+def _allowed(allowed: bool, reason_code: str | None = None) -> dict[str, Any]:
+    return {
+        "allowed": allowed,
+        "reason_code": None if allowed else reason_code,
+    }
+
+
+def _build_job_index(jobs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for job in jobs:
+        for key in _job_match_keys(job):
+            existing = index.get(key)
+            if existing is None or _job_sort_value(job) > _job_sort_value(existing):
+                index[key] = job
+    return index
+
+
+def _match_job_for_source(source: dict[str, Any], job_index: dict[str, dict[str, Any]]) -> dict[str, Any] | None:
+    for key in _source_match_keys(source):
+        job = job_index.get(key)
+        if job is not None:
+            return job
+    return None
+
+
+def _source_match_keys(source: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    media_id = _coerce_int(source.get("media_id"))
+    if media_id is not None and media_id > 0:
+        keys.add(f"media:{media_id}")
+    for field in ("id", "url", "title"):
+        raw = source.get(field)
+        if raw:
+            keys.add(f"{field}:{str(raw).strip()}")
+    return keys
+
+
+def _job_match_keys(job: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    payload = _normalize_mapping(job.get("payload"))
+    result = _normalize_mapping(job.get("result"))
+    for container in (payload, result):
+        media_id = _coerce_int(container.get("media_id"))
+        if media_id is not None and media_id > 0:
+            keys.add(f"media:{media_id}")
+    for field in ("source_id", "workspace_source_id"):
+        raw = payload.get(field) or result.get(field)
+        if raw:
+            keys.add(f"id:{str(raw).strip()}")
+    for field in ("source", "url", "input_ref", "original_filename"):
+        raw = payload.get(field) or result.get(field)
+        if raw:
+            keys.add(f"url:{str(raw).strip()}")
+    for field in ("title",):
+        raw = payload.get(field) or result.get(field)
+        if raw:
+            keys.add(f"title:{str(raw).strip()}")
+    return keys
+
+
+def _normalize_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _is_active_job(job: dict[str, Any]) -> bool:
+    return str(job.get("status") or "").strip().lower() in _ACTIVE_JOB_STATUSES
+
+
+def _is_failed_job(job: dict[str, Any]) -> bool:
+    return str(job.get("status") or "").strip().lower() in _FAILED_JOB_STATUSES
+
+
+def _state_from_job(job: dict[str, Any]) -> str:
+    status = str(job.get("status") or "").strip().lower()
+    if status == "queued":
+        return "queued"
+    if status == "retrying":
+        return "retrying"
+    message = str(job.get("progress_message") or "").strip().lower()
+    if "index" in message or "embedding" in message or "vector" in message:
+        return "indexing"
+    if "chunk" in message:
+        return "chunking"
+    if "extract" in message or "transcrib" in message:
+        return "extracting"
+    return "ingesting"
+
+
+def _job_payload(job: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": job.get("id"),
+        "uuid": job.get("uuid"),
+        "status": job.get("status"),
+        "job_type": job.get("job_type"),
+        "progress_percent": _coerce_float(job.get("progress_percent")),
+        "progress_message": job.get("progress_message"),
+        "error_message": job.get("error_message") or _job_result_error(job),
+    }
+
+
+def _job_result_error(job: dict[str, Any]) -> str | None:
+    result = _normalize_mapping(job.get("result"))
+    raw = result.get("error") or result.get("message")
+    return str(raw) if raw else None
+
+
+def _job_sort_value(job: dict[str, Any]) -> tuple[str, int]:
+    created_at = str(job.get("created_at") or "")
+    return created_at, _coerce_int(job.get("id")) or 0
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tldw_Server_API/app/core/Workspaces/status_projection.py
+++ b/tldw_Server_API/app/core/Workspaces/status_projection.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from loguru import logger
+
 from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
 from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
 
@@ -48,11 +50,13 @@ def build_workspace_capability_projection(
     """Build conservative capability gates for Research Workspace clients."""
     summary = dict(status_projection.get("summary") or {})
     has_queryable_sources = int(summary.get("queryable") or 0) > 0
+    access_level = _normalize_access_level(workspace.get("access_level"))
+    can_modify_workspace = access_level in {"owner", "editor"}
 
     return {
         "workspace_id": workspace["id"],
         "workspace_kind": "research_workspace",
-        "access_level": "owner",
+        "access_level": access_level,
         "source_summary": summary,
         "workspace_services": {
             "migration": {
@@ -87,7 +91,7 @@ def build_workspace_capability_projection(
             },
         },
         "allowed_actions": {
-            "add_sources": _allowed(True),
+            "add_sources": _allowed(can_modify_workspace, "insufficient_access"),
             "inspect_sources": _allowed(
                 int(summary.get("total") or 0) > 0,
                 "no_sources",
@@ -96,8 +100,8 @@ def build_workspace_capability_projection(
                 has_queryable_sources,
                 "no_queryable_sources",
             ),
-            "export_workspace": _allowed(True),
-            "manage_tools": _allowed(True),
+            "export_workspace": _allowed(can_modify_workspace, "insufficient_access"),
+            "manage_tools": _allowed(can_modify_workspace, "insufficient_access"),
             "run_mcp_tools": _allowed(False, "mcp_not_configured"),
             "use_acp_agents": _allowed(False, "acp_not_configured"),
             "use_sandbox": _allowed(False, "sandbox_not_configured"),
@@ -149,7 +153,7 @@ def _status_from_media(
     media_id: int,
 ) -> dict[str, Any]:
     content = str(media.get("content") or "")
-    text_ready = bool(content.strip())
+    text_ready = bool(content and not content.isspace())
     chunking_status = str(media.get("chunking_status") or "").strip().lower()
     vector_processing = media.get("vector_processing")
     vector_ready = _is_vector_ready(vector_processing)
@@ -229,12 +233,20 @@ def _status_from_active_job(source: dict[str, Any], job: dict[str, Any]) -> dict
 
 
 def _status_from_failed_job(source: dict[str, Any], job: dict[str, Any]) -> dict[str, Any]:
+    raw_error = job.get("error_message") or _job_result_error(job)
+    if raw_error:
+        logger.warning(
+            "Workspace source ingest job failed for source={} job_id={} error={}",
+            source.get("id"),
+            job.get("id") if job.get("id") is not None else job.get("uuid"),
+            raw_error,
+        )
     return _base_status(
         source,
         state="failed",
         reason="job_failed",
         progress_percent=_coerce_float(job.get("progress_percent")),
-        progress_message=job.get("error_message") or _job_result_error(job) or "Ingestion job failed.",
+        progress_message="Ingestion job failed.",
         job=_job_payload(job),
     )
 
@@ -312,7 +324,8 @@ def _get_media(media_db: Any | None, media_id: int) -> dict[str, Any] | None:
         return None
     try:
         return media_db_api.get_media_by_id(media_db, media_id)
-    except (AttributeError, DatabaseError, RuntimeError, TypeError, ValueError):
+    except (AttributeError, DatabaseError, RuntimeError, TypeError, ValueError) as exc:
+        logger.warning("Workspace source status media lookup failed for media_id={}: {}", media_id, exc)
         return None
 
 
@@ -321,7 +334,8 @@ def _has_unvectorized_chunks(media_db: Any | None, media_id: int) -> bool:
         return False
     try:
         return media_db_api.has_unvectorized_chunks(media_db, media_id)
-    except (AttributeError, DatabaseError, RuntimeError, TypeError, ValueError):
+    except (AttributeError, DatabaseError, RuntimeError, TypeError, ValueError) as exc:
+        logger.warning("Workspace source status chunk lookup failed for media_id={}: {}", media_id, exc)
         return False
 
 
@@ -352,6 +366,20 @@ def _allowed(allowed: bool, reason_code: str | None = None) -> dict[str, Any]:
     }
 
 
+def _normalize_access_level(value: Any) -> str:
+    """Normalize owned/shared workspace access labels for capability gating."""
+    normalized = str(value or "").strip().lower()
+    if normalized in {"owner", "editor", "viewer"}:
+        return normalized
+    if normalized == "full_edit":
+        return "editor"
+    if normalized == "view_chat_add":
+        return "editor"
+    if normalized == "view_chat":
+        return "viewer"
+    return "viewer"
+
+
 def _build_job_index(jobs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     index: dict[str, dict[str, Any]] = {}
     for job in jobs:
@@ -370,15 +398,18 @@ def _match_job_for_source(source: dict[str, Any], job_index: dict[str, dict[str,
     return None
 
 
-def _source_match_keys(source: dict[str, Any]) -> set[str]:
-    keys: set[str] = set()
+def _source_match_keys(source: dict[str, Any]) -> list[str]:
+    keys: list[str] = []
+    raw_id = source.get("id")
+    if raw_id:
+        keys.append(f"id:{str(raw_id).strip()}")
     media_id = _coerce_int(source.get("media_id"))
     if media_id is not None and media_id > 0:
-        keys.add(f"media:{media_id}")
-    for field in ("id", "url", "title"):
+        keys.append(f"media:{media_id}")
+    for field in ("url", "title"):
         raw = source.get(field)
         if raw:
-            keys.add(f"{field}:{str(raw).strip()}")
+            keys.append(f"{field}:{str(raw).strip()}")
     return keys
 
 
@@ -442,6 +473,7 @@ def _state_from_job(job: dict[str, Any]) -> str:
 
 
 def _job_payload(job: dict[str, Any]) -> dict[str, Any]:
+    error_message = None if _is_failed_job(job) else job.get("error_message") or _job_result_error(job)
     return {
         "id": job.get("id"),
         "uuid": job.get("uuid"),
@@ -449,7 +481,7 @@ def _job_payload(job: dict[str, Any]) -> dict[str, Any]:
         "job_type": job.get("job_type"),
         "progress_percent": _coerce_float(job.get("progress_percent")),
         "progress_message": job.get("progress_message"),
-        "error_message": job.get("error_message") or _job_result_error(job),
+        "error_message": error_message,
     }
 
 
@@ -461,7 +493,8 @@ def _job_result_error(job: dict[str, Any]) -> str | None:
 
 def _job_sort_value(job: dict[str, Any]) -> tuple[str, int]:
     created_at = str(job.get("created_at") or "")
-    return created_at, _coerce_int(job.get("id")) or 0
+    job_id = _coerce_int(job.get("id"))
+    return created_at, job_id if job_id is not None else 0
 
 
 def _coerce_int(value: Any) -> int | None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
+from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+class _MediaStatusDB:
+    def __init__(self, rows: dict[int, dict[str, Any]], unvectorized: set[int] | None = None) -> None:
+        self.rows = rows
+        self.unvectorized = unvectorized or set()
+
+    def get_media_by_id(
+        self,
+        media_id: int,
+        *,
+        include_deleted: bool = False,
+        include_trash: bool = False,
+    ) -> dict[str, Any] | None:
+        _ = (include_deleted, include_trash)
+        row = self.rows.get(media_id)
+        return dict(row) if row else None
+
+    def has_unvectorized_chunks(self, media_id: int) -> bool:
+        return media_id in self.unvectorized
+
+
+class _JobManagerDouble:
+    def __init__(self, jobs: list[dict[str, Any]] | None = None) -> None:
+        self.jobs = jobs or []
+
+    def list_jobs(self, **kwargs: Any) -> list[dict[str, Any]]:
+        _ = kwargs
+        return list(self.jobs)
+
+
+@pytest.fixture
+def workspace_status_db(tmp_path):
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    db.upsert_workspace("ws-status", "Source Status")
+    db.add_workspace_source(
+        "ws-status",
+        {
+            "id": "src-ready",
+            "media_id": 1,
+            "title": "Ready paper",
+            "source_type": "pdf",
+            "position": 0,
+            "selected": True,
+        },
+    )
+    db.add_workspace_source(
+        "ws-status",
+        {
+            "id": "src-indexing",
+            "media_id": 2,
+            "title": "Indexing article",
+            "source_type": "web",
+            "position": 1,
+            "selected": True,
+        },
+    )
+    db.add_workspace_source(
+        "ws-status",
+        {
+            "id": "src-missing",
+            "media_id": 99,
+            "title": "Missing upload",
+            "source_type": "docx",
+            "position": 2,
+            "selected": True,
+        },
+    )
+    return db
+
+
+@pytest.fixture
+def workspace_status_app():
+    from tldw_Server_API.app.main import app
+
+    return app
+
+
+async def _allow_rate_limit() -> None:
+    return None
+
+
+async def _user() -> SimpleNamespace:
+    return SimpleNamespace(id=1, username="testuser", email="test@example.com", roles=["admin"], is_admin=True)
+
+
+def _install_overrides(
+    app: Any,
+    db: CharactersRAGDB,
+    media_db: _MediaStatusDB,
+    jobs: list[dict[str, Any]] | None = None,
+) -> None:
+    async def _media_db() -> AsyncGenerator[_MediaStatusDB, None]:
+        yield media_db
+
+    app.dependency_overrides[get_request_user] = _user
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[try_get_media_db_for_user] = _media_db
+    app.dependency_overrides[workspaces_endpoint.try_get_workspace_job_manager] = lambda: _JobManagerDouble(jobs)
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+
+
+def _clear_overrides(app: Any) -> None:
+    app.dependency_overrides.pop(get_request_user, None)
+    app.dependency_overrides.pop(get_chacha_db_for_user, None)
+    app.dependency_overrides.pop(try_get_media_db_for_user, None)
+    app.dependency_overrides.pop(workspaces_endpoint.try_get_workspace_job_manager, None)
+    app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
+def test_workspace_sources_status_reports_readiness_and_missing_media(
+    workspace_status_app,
+    workspace_status_db,
+):
+    media_db = _MediaStatusDB(
+        {
+            1: {
+                "id": 1,
+                "title": "Ready paper",
+                "type": "pdf",
+                "content": "Grounded evidence text.",
+                "chunking_status": "completed",
+                "vector_processing": 1,
+            },
+            2: {
+                "id": 2,
+                "title": "Indexing article",
+                "type": "web",
+                "content": "Extracted but still being indexed.",
+                "chunking_status": "completed",
+                "vector_processing": 0,
+            },
+        },
+        unvectorized={2},
+    )
+    _install_overrides(workspace_status_app, workspace_status_db, media_db)
+    try:
+        with TestClient(workspace_status_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/ws-status/sources/status")
+    finally:
+        _clear_overrides(workspace_status_app)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["workspace_id"] == "ws-status"
+    assert payload["summary"] == {
+        "total": 3,
+        "selected": 3,
+        "queryable": 1,
+        "partially_queryable": 1,
+        "processing": 1,
+        "failed": 0,
+        "missing": 1,
+    }
+
+    sources = {source["id"]: source for source in payload["sources"]}
+    assert sources["src-ready"]["state"] == "queryable"
+    assert sources["src-ready"]["readiness"]["text_extracted"] is True
+    assert sources["src-ready"]["readiness"]["fts_ready"] is True
+    assert sources["src-ready"]["readiness"]["vector_ready"] is True
+    assert sources["src-ready"]["progress_percent"] == 100
+
+    assert sources["src-indexing"]["state"] == "partially_queryable"
+    assert sources["src-indexing"]["readiness"]["fts_ready"] is True
+    assert sources["src-indexing"]["readiness"]["vector_ready"] is False
+    assert sources["src-indexing"]["status_reason"] == "vector_index_pending"
+
+    assert sources["src-missing"]["state"] == "missing_media"
+    assert sources["src-missing"]["readiness"]["text_extracted"] is False
+    assert sources["src-missing"]["status_reason"] == "media_not_found"
+
+
+@pytest.mark.integration
+def test_workspace_capabilities_fail_closed_without_queryable_sources(
+    workspace_status_app,
+    tmp_path,
+):
+    db = CharactersRAGDB(db_path=str(tmp_path / "empty-chacha.db"), client_id="user-1")
+    db.upsert_workspace("ws-empty", "Empty Workspace")
+    _install_overrides(workspace_status_app, db, _MediaStatusDB({}))
+    try:
+        with TestClient(workspace_status_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/ws-empty/capabilities")
+    finally:
+        _clear_overrides(workspace_status_app)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["workspace_id"] == "ws-empty"
+    assert payload["workspace_kind"] == "research_workspace"
+    assert payload["access_level"] == "owner"
+    assert payload["source_summary"]["total"] == 0
+    assert payload["allowed_actions"]["add_sources"]["allowed"] is True
+    assert payload["allowed_actions"]["ask_grounded_questions"] == {
+        "allowed": False,
+        "reason_code": "no_queryable_sources",
+    }
+    assert payload["allowed_actions"]["run_mcp_tools"] == {
+        "allowed": False,
+        "reason_code": "mcp_not_configured",
+    }
+    assert payload["workspace_services"]["mcp"]["management_surface"] == "mcp_hub"
+    assert payload["workspace_services"]["acp"]["state"] == "not_configured"
+    assert payload["workspace_services"]["sandbox"]["state"] == "not_configured"
+
+
+@pytest.mark.integration
+def test_workspace_sources_status_uses_active_media_ingest_job_progress(
+    workspace_status_app,
+    tmp_path,
+):
+    db = CharactersRAGDB(db_path=str(tmp_path / "jobs-chacha.db"), client_id="user-1")
+    db.upsert_workspace("ws-jobs", "Jobs Workspace")
+    db.add_workspace_source(
+        "ws-jobs",
+        {
+            "id": "src-running",
+            "media_id": 7,
+            "title": "Running import",
+            "source_type": "web",
+            "url": "https://example.test/running",
+            "position": 0,
+            "selected": True,
+        },
+    )
+    jobs = [
+        {
+            "id": 42,
+            "uuid": "job-42",
+            "domain": "media_ingest",
+            "job_type": "media_ingest_item",
+            "status": "processing",
+            "payload": {"source": "https://example.test/running"},
+            "result": None,
+            "progress_percent": 82.5,
+            "progress_message": "vector indexing",
+            "created_at": "2026-05-23T12:00:00Z",
+        },
+    ]
+    _install_overrides(workspace_status_app, db, _MediaStatusDB({}), jobs=jobs)
+    try:
+        with TestClient(workspace_status_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/ws-jobs/sources/status")
+    finally:
+        _clear_overrides(workspace_status_app)
+
+    assert response.status_code == 200, response.text
+    source = response.json()["sources"][0]
+    assert source["state"] == "indexing"
+    assert source["progress_percent"] == 82.5
+    assert source["job"]["id"] == 42
+    assert source["job"]["progress_message"] == "vector indexing"
+
+
+def test_recent_media_ingest_jobs_prioritizes_workspace_source_jobs() -> None:
+    class _PrioritizedJobManager:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def list_jobs(self, **kwargs: Any) -> list[dict[str, Any]]:
+            self.calls.append(kwargs)
+            if kwargs.get("job_type") == "workspace_source_ingest":
+                return [
+                    {
+                        "id": 1,
+                        "domain": "media_ingest",
+                        "queue": "default",
+                        "job_type": "workspace_source_ingest",
+                    }
+                ]
+            return [
+                {
+                    "id": 2,
+                    "domain": "media_ingest",
+                    "queue": "default",
+                    "job_type": "media_ingest_item",
+                },
+                {
+                    "id": 1,
+                    "domain": "media_ingest",
+                    "queue": "default",
+                    "job_type": "workspace_source_ingest",
+                },
+            ]
+
+    jm = _PrioritizedJobManager()
+    jobs = workspaces_endpoint._list_recent_media_ingest_jobs(jm, SimpleNamespace(id=1))
+
+    assert [job["id"] for job in jobs] == [1, 2]
+    assert jm.calls[0]["domain"] == "media_ingest"
+    assert jm.calls[0]["queue"] == "default"
+    assert jm.calls[0]["job_type"] == "workspace_source_ingest"
+    assert jm.calls[1]["domain"] == "media_ingest"
+    assert "job_type" not in jm.calls[1]
+
+
+def test_workspace_job_manager_resolver_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_job_manager() -> None:
+        raise RuntimeError("jobs manager unavailable")
+
+    monkeypatch.setattr(workspaces_endpoint, "get_job_manager", _raise_job_manager)
+
+    assert workspaces_endpoint.try_get_workspace_job_manager() is None

--- a/tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -12,7 +13,12 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_use
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
 from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
 from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
+from tldw_Server_API.app.core.Workspaces import status_projection
+from tldw_Server_API.app.core.Workspaces.status_projection import (
+    build_source_status_projection,
+    build_workspace_capability_projection,
+)
 
 
 class _MediaStatusDB:
@@ -45,7 +51,7 @@ class _JobManagerDouble:
 
 
 @pytest.fixture
-def workspace_status_db(tmp_path):
+def workspace_status_db(tmp_path: Path) -> CharactersRAGDB:
     db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
     db.upsert_workspace("ws-status", "Source Status")
     db.add_workspace_source(
@@ -85,7 +91,7 @@ def workspace_status_db(tmp_path):
 
 
 @pytest.fixture
-def workspace_status_app():
+def workspace_status_app() -> Any:
     from tldw_Server_API.app.main import app
 
     return app
@@ -96,12 +102,18 @@ async def _allow_rate_limit() -> None:
 
 
 async def _user() -> SimpleNamespace:
-    return SimpleNamespace(id=1, username="testuser", email="test@example.com", roles=["admin"], is_admin=True)
+    return SimpleNamespace(
+        id=1,
+        username="testuser",
+        email="test@example.com",
+        roles=["admin"],
+        is_admin=True,
+    )
 
 
 def _install_overrides(
     app: Any,
-    db: CharactersRAGDB,
+    db: Any,
     media_db: _MediaStatusDB,
     jobs: list[dict[str, Any]] | None = None,
 ) -> None:
@@ -125,9 +137,9 @@ def _clear_overrides(app: Any) -> None:
 
 @pytest.mark.integration
 def test_workspace_sources_status_reports_readiness_and_missing_media(
-    workspace_status_app,
-    workspace_status_db,
-):
+    workspace_status_app: Any,
+    workspace_status_db: CharactersRAGDB,
+) -> None:
     media_db = _MediaStatusDB(
         {
             1: {
@@ -188,9 +200,9 @@ def test_workspace_sources_status_reports_readiness_and_missing_media(
 
 @pytest.mark.integration
 def test_workspace_capabilities_fail_closed_without_queryable_sources(
-    workspace_status_app,
-    tmp_path,
-):
+    workspace_status_app: Any,
+    tmp_path: Path,
+) -> None:
     db = CharactersRAGDB(db_path=str(tmp_path / "empty-chacha.db"), client_id="user-1")
     db.upsert_workspace("ws-empty", "Empty Workspace")
     _install_overrides(workspace_status_app, db, _MediaStatusDB({}))
@@ -222,9 +234,9 @@ def test_workspace_capabilities_fail_closed_without_queryable_sources(
 
 @pytest.mark.integration
 def test_workspace_sources_status_uses_active_media_ingest_job_progress(
-    workspace_status_app,
-    tmp_path,
-):
+    workspace_status_app: Any,
+    tmp_path: Path,
+) -> None:
     db = CharactersRAGDB(db_path=str(tmp_path / "jobs-chacha.db"), client_id="user-1")
     db.upsert_workspace("ws-jobs", "Jobs Workspace")
     db.add_workspace_source(
@@ -317,3 +329,136 @@ def test_workspace_job_manager_resolver_fails_open(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(workspaces_endpoint, "get_job_manager", _raise_job_manager)
 
     assert workspaces_endpoint.try_get_workspace_job_manager() is None
+
+
+def test_workspace_capabilities_honor_viewer_access_level() -> None:
+    payload = build_workspace_capability_projection(
+        workspace={"id": "ws-viewer", "access_level": "viewer"},
+        status_projection={
+            "summary": {
+                "total": 1,
+                "selected": 1,
+                "queryable": 1,
+                "partially_queryable": 0,
+                "processing": 0,
+                "failed": 0,
+                "missing": 0,
+            }
+        },
+    )
+
+    assert payload["access_level"] == "viewer"
+    assert payload["allowed_actions"]["inspect_sources"]["allowed"] is True
+    assert payload["allowed_actions"]["ask_grounded_questions"]["allowed"] is True
+    assert payload["allowed_actions"]["add_sources"] == {
+        "allowed": False,
+        "reason_code": "insufficient_access",
+    }
+    assert payload["allowed_actions"]["export_workspace"] == {
+        "allowed": False,
+        "reason_code": "insufficient_access",
+    }
+    assert payload["allowed_actions"]["manage_tools"] == {
+        "allowed": False,
+        "reason_code": "insufficient_access",
+    }
+
+
+def test_failed_job_status_does_not_expose_raw_error_text() -> None:
+    payload = build_source_status_projection(
+        workspace_id="ws-errors",
+        sources=[
+            {
+                "id": "src-failed",
+                "workspace_id": "ws-errors",
+                "media_id": 71,
+                "title": "Failed import",
+                "source_type": "pdf",
+                "selected": True,
+            }
+        ],
+        jobs=[
+            {
+                "id": 12,
+                "uuid": "job-12",
+                "status": "failed",
+                "job_type": "workspace_source_ingest",
+                "payload": {"workspace_source_id": "src-failed", "media_id": 71},
+                "result": {"error": "sqlite stack trace with /private/path"},
+                "error_message": "provider secret leaked",
+                "progress_percent": 25,
+                "created_at": "2026-05-23T12:00:00Z",
+            }
+        ],
+    )
+
+    source = payload["sources"][0]
+    assert source["state"] == "failed"
+    assert source["progress_message"] == "Ingestion job failed."
+    assert source["job"]["error_message"] is None
+
+
+def test_source_job_matching_uses_specificity_order() -> None:
+    source = {
+        "id": "src-specific",
+        "workspace_id": "ws-match",
+        "media_id": 88,
+        "title": "Shared Title",
+        "source_type": "web",
+        "url": "https://example.test/shared",
+        "selected": True,
+    }
+
+    assert status_projection._source_match_keys(source) == [
+        "id:src-specific",
+        "media:88",
+        "url:https://example.test/shared",
+        "title:Shared Title",
+    ]
+
+    payload = build_source_status_projection(
+        workspace_id="ws-match",
+        sources=[source],
+        jobs=[
+            {
+                "id": 90,
+                "status": "failed",
+                "job_type": "media_ingest_item",
+                "payload": {"source": "https://example.test/shared"},
+                "created_at": "2026-05-23T13:00:00Z",
+            },
+            {
+                "id": 91,
+                "status": "queued",
+                "job_type": "workspace_source_ingest",
+                "payload": {"workspace_source_id": "src-specific"},
+                "created_at": "2026-05-23T12:00:00Z",
+            },
+        ],
+    )
+
+    assert payload["sources"][0]["state"] == "queued"
+    assert payload["sources"][0]["job"]["id"] == 91
+
+
+@pytest.mark.integration
+def test_workspace_sources_status_maps_chacha_input_errors_to_400(
+    workspace_status_app: Any,
+) -> None:
+    class _InputErrorDB:
+        def get_workspace(self, workspace_id: str) -> dict[str, Any]:
+            return {"id": workspace_id}
+
+        def list_workspace_sources(self, workspace_id: str) -> list[dict[str, Any]]:
+            _ = workspace_id
+            raise InputError("invalid workspace source filter")
+
+    _install_overrides(workspace_status_app, _InputErrorDB(), _MediaStatusDB({}))
+    try:
+        with TestClient(workspace_status_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/ws-error/sources/status")
+    finally:
+        _clear_overrides(workspace_status_app)
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "invalid workspace source filter"

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -1,4 +1,5 @@
 """Tests for workspace CRUD endpoints and scoped chat session isolation."""
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -40,22 +41,28 @@ class _FailingJobManager:
         raise RuntimeError("jobs backend unavailable")
 
 
+class _ValidatingJobManager:
+    def create_job(self, **kwargs: Any) -> dict[str, Any]:
+        _ = kwargs
+        raise ValueError("workspace source ingest quota exceeded")
+
+
 @pytest.fixture
-def db(tmp_path):
+def db(tmp_path: Path) -> CharactersRAGDB:
     d = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
     d.add_character_card({"name": "Test Char"})
     return d
 
 
 @pytest.fixture
-def workspace_fastapi_app():
+def workspace_fastapi_app() -> Any:
     from tldw_Server_API.app.main import app
 
     return app
 
 
 class TestWorkspaceLifecycle:
-    def test_upsert_then_get(self, db):
+    def test_upsert_then_get(self, db: CharactersRAGDB) -> None:
         ws = db.upsert_workspace("ws-1", "My Workspace", study_materials_policy="workspace")
         assert ws["id"] == "ws-1"
         assert ws["study_materials_policy"] == "workspace"
@@ -63,7 +70,7 @@ class TestWorkspaceLifecycle:
         assert fetched["name"] == "My Workspace"
         assert fetched["study_materials_policy"] == "workspace"
 
-    def test_upsert_workspace_updates_existing_policy(self, db):
+    def test_upsert_workspace_updates_existing_policy(self, db: CharactersRAGDB) -> None:
         original = db.upsert_workspace("ws-1", "Original Name", study_materials_policy="general")
         updated = db.upsert_workspace("ws-1", "Renamed Workspace", study_materials_policy="workspace")
         assert updated["id"] == original["id"]
@@ -71,18 +78,18 @@ class TestWorkspaceLifecycle:
         assert updated["study_materials_policy"] == "workspace"
         assert updated["version"] == original["version"] + 1
 
-    def test_patch_workspace_name(self, db):
+    def test_patch_workspace_name(self, db: CharactersRAGDB) -> None:
         db.upsert_workspace("ws-1", "Old")
         ws = db.update_workspace("ws-1", {"name": "New"}, expected_version=1)
         assert ws["name"] == "New"
         assert ws["version"] == 2
 
-    def test_archive_workspace(self, db):
+    def test_archive_workspace(self, db: CharactersRAGDB) -> None:
         db.upsert_workspace("ws-1", "WS")
         ws = db.update_workspace("ws-1", {"archived": True}, expected_version=1)
         assert ws["archived"] in (True, 1)
 
-    def test_delete_workspace_cascade(self, db):
+    def test_delete_workspace_cascade(self, db: CharactersRAGDB) -> None:
         db.upsert_workspace("ws-1", "WS")
         conv_id = db.add_conversation({
             "title": "WS chat", "character_id": 1,
@@ -107,26 +114,57 @@ class TestWorkspaceLifecycle:
         assert quiz["workspace_id"] is None
         assert deck["workspace_id"] is None
 
-    def test_list_workspaces(self, db):
+    def test_list_workspaces(self, db: CharactersRAGDB) -> None:
         for i in range(5):
             db.upsert_workspace(f"ws-{i}", f"WS {i}")
         result = db.list_workspaces()
         assert len(result) == 5
 
-    def test_version_conflict_returns_error(self, db):
+    def test_version_conflict_returns_error(self, db: CharactersRAGDB) -> None:
         db.upsert_workspace("ws-1", "WS")
         db.update_workspace("ws-1", {"name": "V2"}, expected_version=1)
         with pytest.raises((ConflictError, Exception)):
             db.update_workspace("ws-1", {"name": "V3"}, expected_version=1)
 
-    def test_workspace_policy_updates(self, db):
+    def test_workspace_policy_updates(self, db: CharactersRAGDB) -> None:
         db.upsert_workspace("ws-1", "WS")
         ws = db.update_workspace("ws-1", {"study_materials_policy": "workspace"}, expected_version=1)
         assert ws["study_materials_policy"] == "workspace"
 
+    def test_add_workspace_source_returns_existing_row_on_duplicate_insert(
+        self,
+        db: CharactersRAGDB,
+    ) -> None:
+        db.upsert_workspace("ws-duplicate", "Duplicate Source Workspace")
+        created = db.add_workspace_source(
+            "ws-duplicate",
+            {
+                "id": "src-duplicate",
+                "media_id": 21,
+                "title": "First Source",
+                "source_type": "pdf",
+            },
+        )
+
+        duplicate = db.add_workspace_source(
+            "ws-duplicate",
+            {
+                "id": "src-duplicate",
+                "media_id": 21,
+                "title": "First Source",
+                "source_type": "pdf",
+            },
+        )
+
+        assert duplicate == created
+        assert db.get_workspace_source("ws-duplicate", "src-duplicate") == created
+
 
 @pytest.mark.integration
-def test_workspace_api_accepts_and_returns_study_materials_policy(workspace_fastapi_app, db):
+def test_workspace_api_accepts_and_returns_study_materials_policy(
+    workspace_fastapi_app: Any,
+    db: CharactersRAGDB,
+) -> None:
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user, User
     from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
         WORKSPACES_READ_RATE_LIMIT,
@@ -187,7 +225,7 @@ def test_workspace_api_accepts_and_returns_study_materials_policy(workspace_fast
 
 
 class TestScopedChatSessions:
-    def test_workspace_chat_not_visible_in_global_list(self, db):
+    def test_workspace_chat_not_visible_in_global_list(self, db: CharactersRAGDB) -> None:
         db.upsert_workspace("ws-1", "WS")
         db.add_conversation({"title": "Global", "character_id": 1})
         db.add_conversation({
@@ -197,7 +235,7 @@ class TestScopedChatSessions:
         global_results = db.search_conversations(None, scope_type="global")
         assert all(r["scope_type"] == "global" for r in global_results)
 
-    def test_global_chat_not_visible_in_workspace_list(self, db):
+    def test_global_chat_not_visible_in_workspace_list(self, db: CharactersRAGDB) -> None:
         db.upsert_workspace("ws-1", "WS")
         db.add_conversation({"title": "Global", "character_id": 1})
         ws_results = db.search_conversations(None, scope_type="workspace", workspace_id="ws-1")
@@ -205,9 +243,9 @@ class TestScopedChatSessions:
 
 
 @pytest.mark.integration
-def test_delete_workspace_maps_conflict_to_409(workspace_fastapi_app):
+def test_delete_workspace_maps_conflict_to_409(workspace_fastapi_app: Any) -> None:
     class _ConflictDB:
-        def get_workspace(self, workspace_id: str):
+        def get_workspace(self, workspace_id: str) -> dict[str, Any]:
             return {"id": workspace_id, "version": 1}
 
         def delete_workspace(self, workspace_id: str, expected_version: int) -> None:
@@ -232,7 +270,10 @@ def test_delete_workspace_maps_conflict_to_409(workspace_fastapi_app):
 
 
 @pytest.mark.integration
-def test_add_workspace_source_enqueues_idempotent_ingest_job(workspace_fastapi_app, db):
+def test_add_workspace_source_enqueues_idempotent_ingest_job(
+    workspace_fastapi_app: Any,
+    db: CharactersRAGDB,
+) -> None:
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
     async def _allow_rate_limit() -> None:
@@ -305,7 +346,10 @@ def test_add_workspace_source_enqueues_idempotent_ingest_job(workspace_fastapi_a
 
 
 @pytest.mark.integration
-def test_add_workspace_source_preserves_row_when_job_enqueue_fails(workspace_fastapi_app, db):
+def test_add_workspace_source_preserves_row_when_job_enqueue_fails(
+    workspace_fastapi_app: Any,
+    db: CharactersRAGDB,
+) -> None:
     async def _allow_rate_limit() -> None:
         return None
 
@@ -341,10 +385,10 @@ def test_add_workspace_source_preserves_row_when_job_enqueue_fails(workspace_fas
 
 @pytest.mark.integration
 def test_add_workspace_source_preserves_row_when_job_manager_dependency_fails(
-    workspace_fastapi_app,
-    db,
+    workspace_fastapi_app: Any,
+    db: CharactersRAGDB,
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     async def _allow_rate_limit() -> None:
         return None
 
@@ -375,3 +419,51 @@ def test_add_workspace_source_preserves_row_when_job_manager_dependency_fails(
     assert response.status_code == 201, response.text
     assert response.json()["id"] == "src-job-dep-fail"
     assert [src["id"] for src in db.list_workspace_sources("ws-job-dep-fail-api")] == ["src-job-dep-fail"]
+
+
+@pytest.mark.integration
+def test_add_workspace_source_maps_job_validation_failure_to_400(
+    workspace_fastapi_app: Any,
+    db: CharactersRAGDB,
+) -> None:
+    async def _allow_rate_limit() -> None:
+        return None
+
+    db.upsert_workspace("ws-job-validation-api", "Workspace Source Job Validation")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id=10)
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[workspaces_endpoint.try_get_workspace_job_manager] = (
+        lambda: _ValidatingJobManager()
+    )
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/v1/workspaces/ws-job-validation-api/sources",
+                json={
+                    "id": "src-job-validation",
+                    "media_id": 58,
+                    "title": "Validation Source",
+                    "source_type": "pdf",
+                },
+            )
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(workspaces_endpoint.try_get_workspace_job_manager, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "workspace source ingest quota exceeded"
+    assert [src["id"] for src in db.list_workspace_sources("ws-job-validation-api")] == ["src-job-validation"]
+
+
+def test_dedupe_jobs_keeps_id_zero_as_valid_identity() -> None:
+    jobs = workspaces_endpoint._dedupe_jobs_by_identity(
+        [
+            {"id": 0, "uuid": "first"},
+            {"id": 0, "uuid": "second"},
+        ]
+    )
+
+    assert jobs == [{"id": 0, "uuid": "first"}]

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -1,18 +1,43 @@
 """Tests for workspace CRUD endpoints and scoped chat session isolation."""
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
 from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
     WORKSPACES_DELETE_RATE_LIMIT,
+    WORKSPACES_WRITE_RATE_LIMIT,
 )
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     ConflictError,
 )
+
+
+class _CapturingJobManager:
+    def __init__(self) -> None:
+        self.created_jobs: list[dict[str, Any]] = []
+        self.jobs_by_key: dict[str, dict[str, Any]] = {}
+
+    def create_job(self, **kwargs: Any) -> dict[str, Any]:
+        idempotency_key = str(kwargs.get("idempotency_key") or "")
+        if idempotency_key and idempotency_key in self.jobs_by_key:
+            return self.jobs_by_key[idempotency_key]
+        self.created_jobs.append(kwargs)
+        job = {"id": len(self.created_jobs), **kwargs}
+        if idempotency_key:
+            self.jobs_by_key[idempotency_key] = job
+        return job
+
+
+class _FailingJobManager:
+    def create_job(self, **kwargs: Any) -> dict[str, Any]:
+        _ = kwargs
+        raise RuntimeError("jobs backend unavailable")
 
 
 @pytest.fixture
@@ -204,3 +229,149 @@ def test_delete_workspace_maps_conflict_to_409(workspace_fastapi_app):
         workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_DELETE_RATE_LIMIT, None)
 
     assert response.status_code == 409, response.text
+
+
+@pytest.mark.integration
+def test_add_workspace_source_enqueues_idempotent_ingest_job(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=7,
+            username="researcher",
+            email="researcher@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    job_manager = _CapturingJobManager()
+    db.upsert_workspace("ws-job-api", "Workspace Source Jobs")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[workspaces_endpoint.try_get_workspace_job_manager] = lambda: job_manager
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/v1/workspaces/ws-job-api/sources",
+                json={
+                    "id": "src-job-1",
+                    "media_id": 55,
+                    "title": "NotebookLM Migration PDF",
+                    "source_type": "pdf",
+                    "url": "file:///imports/notebooklm.pdf",
+                },
+            )
+            duplicate_response = client.post(
+                "/api/v1/workspaces/ws-job-api/sources",
+                json={
+                    "id": "src-job-1",
+                    "media_id": 55,
+                    "title": "NotebookLM Migration PDF",
+                    "source_type": "pdf",
+                    "url": "file:///imports/notebooklm.pdf",
+                },
+            )
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(workspaces_endpoint.try_get_workspace_job_manager, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+    assert response.status_code == 201, response.text
+    assert duplicate_response.status_code == 201, duplicate_response.text
+    assert duplicate_response.json()["id"] == "src-job-1"
+    assert len(job_manager.created_jobs) == 1
+    job = job_manager.created_jobs[0]
+    assert job["domain"] == "media_ingest"
+    assert job["queue"] == "default"
+    assert job["job_type"] == "workspace_source_ingest"
+    assert job["owner_user_id"] == "7"
+    assert job["idempotency_key"] == "workspace-source:ws-job-api:src-job-1:55"
+    assert job["payload"] == {
+        "workspace_id": "ws-job-api",
+        "workspace_source_id": "src-job-1",
+        "source_id": "src-job-1",
+        "media_id": 55,
+        "source_type": "pdf",
+        "title": "NotebookLM Migration PDF",
+        "url": "file:///imports/notebooklm.pdf",
+        "requested_stages": ["ingestion", "extraction", "chunking", "indexing"],
+    }
+
+
+@pytest.mark.integration
+def test_add_workspace_source_preserves_row_when_job_enqueue_fails(workspace_fastapi_app, db):
+    async def _allow_rate_limit() -> None:
+        return None
+
+    db.upsert_workspace("ws-job-fail-api", "Workspace Source Job Failure")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id=8)
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[workspaces_endpoint.try_get_workspace_job_manager] = (
+        lambda: _FailingJobManager()
+    )
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/v1/workspaces/ws-job-fail-api/sources",
+                json={
+                    "id": "src-job-fail",
+                    "media_id": 56,
+                    "title": "Resilient Source",
+                    "source_type": "web",
+                    "url": "https://example.test/resilient-source",
+                },
+            )
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(workspaces_endpoint.try_get_workspace_job_manager, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+    assert response.status_code == 201, response.text
+    assert response.json()["id"] == "src-job-fail"
+    assert [src["id"] for src in db.list_workspace_sources("ws-job-fail-api")] == ["src-job-fail"]
+
+
+@pytest.mark.integration
+def test_add_workspace_source_preserves_row_when_job_manager_dependency_fails(
+    workspace_fastapi_app,
+    db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def _allow_rate_limit() -> None:
+        return None
+
+    def _raise_job_manager() -> None:
+        raise RuntimeError("jobs manager construction failed")
+
+    db.upsert_workspace("ws-job-dep-fail-api", "Workspace Source Job Dependency Failure")
+    monkeypatch.setattr(workspaces_endpoint, "get_job_manager", _raise_job_manager)
+    workspace_fastapi_app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id=9)
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/v1/workspaces/ws-job-dep-fail-api/sources",
+                json={
+                    "id": "src-job-dep-fail",
+                    "media_id": 57,
+                    "title": "Dependency Resilient Source",
+                    "source_type": "pdf",
+                },
+            )
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+    assert response.status_code == 201, response.text
+    assert response.json()["id"] == "src-job-dep-fail"
+    assert [src["id"] for src in db.list_workspace_sources("ws-job-dep-fail-api")] == ["src-job-dep-fail"]


### PR DESCRIPTION
## Summary
- Adds Research Workspace source status and capability API responses computed from workspace source rows, Media DB readiness, and Jobs progress.
- Enqueues idempotent `workspace_source_ingest` Jobs when workspace sources are added, while preserving source creation if Jobs construction or runtime enqueue is unavailable.
- Tightens PR review feedback: access-aware capability gates, direct source lookup, deterministic job matching, safe failed-job payloads, ChaChaNotes HTTP error mapping, duplicate-source idempotency, schema docstrings, and typed regression tests.

## Validation Checklist
- [x] `git diff --check`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/core/Workspaces tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_pr2018_review_fixes.json`
- [x] Live backend smoke on `127.0.0.1:18001`: health, workspace upsert, source add, source status, capabilities, duplicate source add, and Jobs DB idempotency row count.

## UX Audit Checklist
- [x] Capability payloads now expose `owner`/`editor`/`viewer` access levels instead of hardcoding owner.
- [x] Viewer capability gates can inspect/query ready sources but cannot add sources, export the workspace, or manage tools.
- [x] Failed source-ingestion Jobs return user-safe status copy while logging bounded internal diagnostics.
- [x] Source status matching prefers source-specific workspace Jobs before broad legacy media-ingest Jobs, so users see the most relevant ingestion state.
- [x] No route aliases or redirects were added.

## Risk & Rollback
- Risk: status is still a read-time projection across ChaChaNotes, Media DB, and Jobs. Jobs/media lookup failures intentionally fail open and log diagnostics so the workspace remains readable.
- Risk: `/api/v1/workspaces` defaults missing access metadata to owner because that route is backed by the current user's ChaChaNotes DB; shared workspace routes should pass explicit access metadata when wired in.
- Rollback: revert this PR branch commit sequence. Workspace source rows remain intact because non-validation Jobs enqueue failures do not delete saved sources.

## AI-Generated PR Merge Note
- Human-written Change summary is still required before merge per the repository AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace source status and capability endpoints and enqueues idempotent ingestion jobs when sources are added. This gives clear progress/readiness for ingestion, extraction, chunking, and indexing while keeping source creation resilient if Jobs are down.

- **New Features**
  - GET /api/v1/workspaces/{workspace_id}/sources/status: returns per-source lifecycle state, readiness, progress, and summary using Media DB and Jobs.
  - GET /api/v1/workspaces/{workspace_id}/capabilities: exposes conservative capability gates based on source readiness.
  - POST /api/v1/workspaces/{workspace_id}/sources: persists the source, then submits an idempotent `media_ingest`/`default`/`workspace_source_ingest` job with deterministic key and rich payload.
  - Job lookups prioritize `workspace_source_ingest` over legacy `media_ingest` jobs and dedupe results; Jobs dependency resolution and enqueue failures fail open so source creation always succeeds.

<sup>Written for commit 5e47c2d0b9ae749812ac741309db6d5a6dd56e38. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2018?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->
