### PR TITLE
Migrate WatchlistsPage admin alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -616,28 +616,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Admin/WatchlistsPage.tsx:Alert#antd-alert-watchlistspage-type-error-access-denied-you-d-1m06xt",
-    "path": "src/components/Option/Admin/WatchlistsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/WatchlistsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Admin/WatchlistsPage.tsx:Alert#antd-alert-watchlistspage-type-warning-not-available-wat-n7zudo",
-    "path": "src/components/Option/Admin/WatchlistsPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Admin/WatchlistsPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/AgentTasks/index.tsx:Alert#antd-alert-agenttaskspage-type-warning-line-744-ocj46l",
     "path": "src/components/Option/AgentTasks/index.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Admin/WatchlistsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/WatchlistsPage.tsx
@@ -7,7 +7,6 @@ import {
   Form,
   Tag,
   Space,
-  Alert,
   Popconfirm,
   message
 } from "antd"
@@ -15,6 +14,7 @@ import {
   deriveAdminGuardFromError,
   sanitizeAdminErrorMessage
 } from "./admin-error-utils"
+import { Alert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 
 const WatchlistsPage: React.FC = () => {
@@ -239,10 +239,18 @@ const WatchlistsPage: React.FC = () => {
   // ── Render ──
 
   if (adminGuard === "forbidden") {
-    return <Alert type="error" message="Access Denied" description="You don't have permission to access watchlists administration." showIcon />
+    return (
+      <Alert variant="error" title="Access Denied">
+        You don't have permission to access watchlists administration.
+      </Alert>
+    )
   }
   if (adminGuard === "notFound") {
-    return <Alert type="warning" message="Not Available" description="Watchlists administration is not available on this server." showIcon />
+    return (
+      <Alert variant="warning" title="Not Available">
+        Watchlists administration is not available on this server.
+      </Alert>
+    )
   }
 
   return (

--- a/apps/packages/ui/src/components/Option/Admin/WatchlistsPage.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/WatchlistsPage.tsx
@@ -17,6 +17,11 @@ import {
 import { Alert } from "@/components/ui/primitives"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 
+const pageContainerStyle: React.CSSProperties = {
+  padding: "24px",
+  maxWidth: 1200
+}
+
 const WatchlistsPage: React.FC = () => {
   // Admin guard state
   const [adminGuard, setAdminGuard] = useState<"forbidden" | "notFound" | null>(null)
@@ -240,21 +245,25 @@ const WatchlistsPage: React.FC = () => {
 
   if (adminGuard === "forbidden") {
     return (
-      <Alert variant="error" title="Access Denied">
-        You don't have permission to access watchlists administration.
-      </Alert>
+      <div style={pageContainerStyle}>
+        <Alert variant="error" title="Access Denied">
+          You don't have permission to access watchlists administration.
+        </Alert>
+      </div>
     )
   }
   if (adminGuard === "notFound") {
     return (
-      <Alert variant="warning" title="Not Available">
-        Watchlists administration is not available on this server.
-      </Alert>
+      <div style={pageContainerStyle}>
+        <Alert variant="warning" title="Not Available">
+          Watchlists administration is not available on this server.
+        </Alert>
+      </div>
     )
   }
 
   return (
-    <div style={{ padding: "24px", maxWidth: 1200 }}>
+    <div style={pageContainerStyle}>
       <h2 style={{ marginBottom: 16 }}>Watchlists &amp; Alerts</h2>
 
       {/* Watchlists Card */}

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx
@@ -18,6 +18,16 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: apiMock
 }))
 
+const expectGuardPageContainer = (alert: Element | null) => {
+  expect(alert).toBeInTheDocument()
+
+  const pageContainer = alert?.parentElement
+  expect(pageContainer).toHaveStyle({
+    padding: "24px",
+    maxWidth: "1200px"
+  })
+}
+
 describe("WatchlistsPage admin guard alerts", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -31,8 +41,9 @@ describe("WatchlistsPage admin guard alerts", () => {
     render(<WatchlistsPage />)
 
     const title = await screen.findByText("Access Denied")
+    const alert = title.closest('[data-ds-component="Alert"]')
 
-    expect(title.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expectGuardPageContainer(alert)
     expect(
       screen.getByText(
         "You don't have permission to access watchlists administration."
@@ -46,8 +57,9 @@ describe("WatchlistsPage admin guard alerts", () => {
     render(<WatchlistsPage />)
 
     const title = await screen.findByText("Not Available")
+    const alert = title.closest('[data-ds-component="Alert"]')
 
-    expect(title.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expectGuardPageContainer(alert)
     expect(
       screen.getByText("Watchlists administration is not available on this server.")
     ).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import WatchlistsPage from "../WatchlistsPage"
+
+const apiMock = vi.hoisted(() => ({
+  listWatchlists: vi.fn(),
+  listMonitoringAlerts: vi.fn(),
+  createWatchlist: vi.fn(),
+  deleteWatchlist: vi.fn(),
+  acknowledgeAlert: vi.fn(),
+  dismissAlert: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: apiMock
+}))
+
+describe("WatchlistsPage admin guard alerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMock.listWatchlists.mockResolvedValue([])
+    apiMock.listMonitoringAlerts.mockResolvedValue({ items: [] })
+  })
+
+  it("renders forbidden access guard with the design-system Alert primitive", async () => {
+    apiMock.listWatchlists.mockRejectedValueOnce({ status: 403 })
+
+    render(<WatchlistsPage />)
+
+    const title = await screen.findByText("Access Denied")
+
+    expect(title.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "You don't have permission to access watchlists administration."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("renders unavailable guard with the design-system Alert primitive", async () => {
+    apiMock.listWatchlists.mockRejectedValueOnce({ status: 404 })
+
+    render(<WatchlistsPage />)
+
+    const title = await screen.findByText("Not Available")
+
+    expect(title.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expect(
+      screen.getByText("Watchlists administration is not available on this server.")
+    ).toBeInTheDocument()
+  })
+})

--- a/backlog/tasks/task-45.44.3.9 - Migrate-WatchlistsPage-admin-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.9 - Migrate-WatchlistsPage-admin-guard-alerts-to-design-system-Alert.md
@@ -4,7 +4,7 @@ title: Migrate WatchlistsPage admin guard alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-24 01:05'
+updated_date: '2026-05-24 01:37'
 labels:
   - design-system
   - webui
@@ -52,6 +52,17 @@ Verification:
 - `git diff --check` passed.
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on 347 existing diagnostics; no diagnostics mention WatchlistsPage, WatchlistsPage.admin-guard, the baseline, or TASK-45.44.3.9.
 - Bandit skipped: UI-only TypeScript/test/baseline task; no Python touched.
+
+PR review follow-up:
+- Gemini requested wrapping the forbidden/not-found guard alerts in the same padded max-width container used by the normal admin page render. Verified current code returns bare Alert elements, so the layout feedback applies.
+
+PR review follow-up verification:
+- RED: `bunx vitest run src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx --reporter=dot` failed after adding page-container assertions because guard alerts lacked the shared padded/max-width wrapper.
+- GREEN: `bunx vitest run src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx --reporter=dot` passed, 2 tests.
+- Product-state guard: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed, 54 tests.
+- Verifier: `bun run verify:design-system-state` passed with total baseline exceptions still 254.
+- `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on 347 existing diagnostics; no diagnostics mention WatchlistsPage, WatchlistsPage.admin-guard, the baseline, or TASK-45.44.3.9.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -60,6 +71,8 @@ Verification:
 Migrated the Admin WatchlistsPage forbidden and not-found guard callouts from AntD Alert to the shared design-system Alert primitive, added focused guard-state coverage for both paths, and removed the two WatchlistsPage Alert entries from the product-state baseline. The full design-system verifier passes with total baseline exceptions reduced to 254.
 
 PR: https://github.com/rmusser01/tldw_server/pull/2019
+
+PR review follow-up: wrapped both guard alerts in the same padded/max-width page container used by the normal WatchlistsPage render, and added focused assertions for that layout contract.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.3.9 - Migrate-WatchlistsPage-admin-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.9 - Migrate-WatchlistsPage-admin-guard-alerts-to-design-system-Alert.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.3.9
+title: Migrate WatchlistsPage admin guard alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-24 01:03'
+labels:
+  - design-system
+  - webui
+  - watchlists
+  - product-state
+dependencies: []
+parent_task_id: TASK-45.44.3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the Admin and health expansion product-state migration by replacing the Admin WatchlistsPage AntD admin-guard Alert product-state callouts with the shared design-system Alert primitive, preserving forbidden/not-found copy, removing migrated baseline exceptions, and recording focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WatchlistsPage forbidden and not-found admin guard callouts render via design-system Alert.
+- [x] #2 The WatchlistsPage Alert baseline exceptions are removed from design-system-product-state-baseline.json.
+- [x] #3 Focused component/guard tests assert the design-system Alert marker for both guard states.
+- [x] #4 Design-system product-state verification passes or records existing unrelated blockers.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused guard tests that drive forbidden and not-found API failures and assert the guard copy is inside data-ds-component="Alert".
+2. Migrate WatchlistsPage guard Alert usage from AntD Alert props to the design-system Alert primitive while preserving existing copy and table/form behavior.
+3. Remove WatchlistsPage Alert exceptions from the product-state baseline and run focused Vitest plus design-system verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented with a focused red/green guard test for both admin guard paths.
+
+Verification:
+- RED: `bunx vitest run src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx --reporter=dot` failed before migration because the guard titles were not inside `[data-ds-component="Alert"]`.
+- GREEN: `bunx vitest run src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx --reporter=dot` passed, 2 tests.
+- Product-state guard: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed, 54 tests.
+- Verifier: `bun run verify:design-system-state` passed with total baseline exceptions 254 and WatchlistsPage baseline rows 0.
+- `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on 347 existing diagnostics; no diagnostics mention WatchlistsPage, WatchlistsPage.admin-guard, the baseline, or TASK-45.44.3.9.
+- Bandit skipped: UI-only TypeScript/test/baseline task; no Python touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the Admin WatchlistsPage forbidden and not-found guard callouts from AntD Alert to the shared design-system Alert primitive, added focused guard-state coverage for both paths, and removed the two WatchlistsPage Alert entries from the product-state baseline. The full design-system verifier passes with total baseline exceptions reduced to 254.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.9 - Migrate-WatchlistsPage-admin-guard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.9 - Migrate-WatchlistsPage-admin-guard-alerts-to-design-system-Alert.md
@@ -4,13 +4,15 @@ title: Migrate WatchlistsPage admin guard alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-24 01:03'
+updated_date: '2026-05-24 01:05'
 labels:
   - design-system
   - webui
   - watchlists
   - product-state
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2019'
 parent_task_id: TASK-45.44.3
 priority: medium
 ---
@@ -56,6 +58,8 @@ Verification:
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Migrated the Admin WatchlistsPage forbidden and not-found guard callouts from AntD Alert to the shared design-system Alert primitive, added focused guard-state coverage for both paths, and removed the two WatchlistsPage Alert entries from the product-state baseline. The full design-system verifier passes with total baseline exceptions reduced to 254.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2019
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -3,20 +3,24 @@ id: TASK-45.44.7
 title: 'Migrate design-system product state: Admin and health expansion'
 status: To Do
 assignee: []
-created_date: '2026-05-14 03:19'
+created_date: 2026-05-14 03:19
 labels:
-  - design-system
-  - webui
-  - extension
-  - product-state
+- design-system
+- webui
+- extension
+- product-state
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1664'
-  - >-
-    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/issues/1664
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
 parent_task_id: TASK-45.44
 priority: medium
+documentation:
+- "TASK-45.44.3.9 migrated Admin WatchlistsPage forbidden/not-found guard Alerts to\
+  \ the design-system Alert primitive.\nBaseline evidence:\n  - total product-state\
+  \ exceptions: 256 -> 254\n  - Admin and health expansion exceptions: 41 -> 39\n\
+  \  - WatchlistsPage target rows: 2 -> 0\nVerification recorded in TASK-45.44.3.9."
 ---
 
 ## Description

--- a/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
+++ b/backlog/tasks/task-45.44.7 - Migrate-design-system-product-state-Admin-and-health-expansion.md
@@ -3,24 +3,31 @@ id: TASK-45.44.7
 title: 'Migrate design-system product state: Admin and health expansion'
 status: To Do
 assignee: []
-created_date: 2026-05-14 03:19
+created_date: '2026-05-14 03:19'
+updated_date: '2026-05-24 01:05'
 labels:
-- design-system
-- webui
-- extension
-- product-state
+  - design-system
+  - webui
+  - extension
+  - product-state
 dependencies: []
 references:
-- https://github.com/rmusser01/tldw_server/issues/1664
-- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-- apps/packages/ui/scripts/design-system-product-state-baseline.json
+  - 'https://github.com/rmusser01/tldw_server/issues/1664'
+  - >-
+    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+documentation:
+  - >-
+    TASK-45.44.3.9 / PR #2019 migrated Admin WatchlistsPage forbidden/not-found
+    guard Alerts to the design-system Alert primitive.
+
+    Baseline evidence:
+      - total product-state exceptions: 256 -> 254
+      - Admin and health expansion exceptions: 41 -> 39
+      - WatchlistsPage target rows: 2 -> 0
+    Verification recorded in TASK-45.44.3.9.
 parent_task_id: TASK-45.44
 priority: medium
-documentation:
-- "TASK-45.44.3.9 migrated Admin WatchlistsPage forbidden/not-found guard Alerts to\
-  \ the design-system Alert primitive.\nBaseline evidence:\n  - total product-state\
-  \ exceptions: 256 -> 254\n  - Admin and health expansion exceptions: 41 -> 39\n\
-  \  - WatchlistsPage target rows: 2 -> 0\nVerification recorded in TASK-45.44.3.9."
 ---
 
 ## Description


### PR DESCRIPTION
## Summary
- Migrates Admin WatchlistsPage forbidden/not-found guard alerts from AntD Alert to the shared design-system Alert primitive.
- Adds focused guard-state coverage asserting both guard titles render inside `[data-ds-component="Alert"]`.
- Removes the two WatchlistsPage Alert entries from the product-state baseline and records the Admin/health tracker evidence.

## Test plan
- `bunx vitest run src/components/Option/Admin/__tests__/WatchlistsPage.admin-guard.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` (expected existing repo-wide failure: 347 diagnostics; none mention this slice)

## Change summary
Human owner should replace this section with their own explanation before merge, per the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Admin WatchlistsPage guard alerts from `antd` `Alert` to the design-system `Alert` and wrapped them in the page container for consistent layout and product-state tracking. Added focused tests and removed the two baseline exceptions.

- **Refactors**
  - Replaced `antd` `Alert` with `Alert` from `@/components/ui/primitives`.
  - Preserved guard titles and copy: "Access Denied" and "Not Available".
  - Wrapped guard alerts in the shared page container (24px padding, 1200px max width).
  - Tests assert titles render inside `[data-ds-component="Alert"]` and the container styles.
  - Removed two WatchlistsPage `Alert` entries from the product-state baseline and updated the Admin/health tracker.

<sup>Written for commit ec22f7116f58ecd22efe2582a1f71f87cbd5e28d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2019?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

