### PR TITLE
Migrate Watchlists report builder alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2706,17 +2706,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx:Alert",
-    "path": "src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/SettingsTab/SettingsTab.tsx:Alert#antd-alert-settingstab-type-info-line-367-m37220",
     "path": "src/components/Option/Watchlists/SettingsTab/SettingsTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
-import { Alert, Button, Checkbox, Drawer, Empty, Input, Select, Spin, Tag, message } from "antd"
+import { Button, Checkbox, Drawer, Empty, Input, Select, Spin, Tag, message } from "antd"
 import { useTranslation } from "react-i18next"
 import {
   createWatchlistOutput,
@@ -15,6 +15,7 @@ import type {
   WatchlistRun,
   WatchlistTemplate
 } from "@/types/watchlists"
+import { Alert } from "@/components/ui"
 import { Badge } from "@/components/ui/primitives/Badge"
 import { READY_STATE_LABEL } from "@/design-system/states"
 
@@ -434,8 +435,7 @@ export const ReportBuilderDrawer: React.FC<ReportBuilderDrawerProps> = ({
             </div>
             {selectedRunId == null && (
               <Alert
-                type="warning"
-                showIcon
+                variant="warning"
                 title={t("watchlists:reports.builder.runRequired", "Select a run to generate a report.")}
               />
             )}
@@ -452,8 +452,7 @@ export const ReportBuilderDrawer: React.FC<ReportBuilderDrawerProps> = ({
                 {preflightWarnings.map((warning) => (
                   <Alert
                     key={warning.code}
-                    type={warning.severity === "blocking" ? "error" : "warning"}
-                    showIcon
+                    variant={warning.severity === "blocking" ? "error" : "warning"}
                     title={warning.label}
                   />
                 ))}

--- a/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
@@ -247,7 +247,8 @@ describe("ReportBuilderDrawer", () => {
       />
     )
 
-    await screen.findByText("Select a run to generate a report.")
+    const runRequiredTitle = await screen.findByText("Select a run to generate a report.")
+    expect(runRequiredTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Generate defensible report" })).toBeDisabled()
 
     expect(uiMocks.messageError).not.toHaveBeenCalled()
@@ -268,7 +269,8 @@ describe("ReportBuilderDrawer", () => {
 
     expect(await screen.findByText("0 queued updates")).toBeInTheDocument()
     expect(screen.getByText("No queued updates found for this run.")).toBeInTheDocument()
-    expect(screen.getByText("No included updates")).toBeInTheDocument()
+    const blockingWarning = screen.getByText("No included updates")
+    expect(blockingWarning.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
   })
 
   it("uses the design-system registry label when report readiness is ready", async () => {

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -41,6 +41,13 @@ documentation:
       - Jobs/Scheduler/Watchlists exceptions: 22 -> 21
       - SourcesBulkImport target rows: 1 -> 0
     Verification recorded in TASK-45.44.3.8.
+  - |-
+    TASK-45.44.3.9 migrated ReportBuilderDrawer run-required and preflight warning notices to the design-system Alert primitive.
+    Baseline evidence:
+      - total product-state exceptions: 256 -> 255
+      - Jobs/Scheduler/Watchlists exceptions: 21 -> 20
+      - ReportBuilderDrawer target rows: 1 -> 0
+    Verification recorded in TASK-45.44.3.9.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.9 - Migrate-ReportBuilderDrawer-alert-to-design-system.md
+++ b/backlog/tasks/task-45.44.3.9 - Migrate-ReportBuilderDrawer-alert-to-design-system.md
@@ -1,0 +1,59 @@
+---
+id: TASK-45.44.3.9
+title: Migrate ReportBuilderDrawer alert to design system
+status: Done
+labels:
+- design-system
+- webui
+- extension
+- product-state
+- watchlists
+priority: medium
+parent_task_id: TASK-45.44.3
+references:
+- https://github.com/rmusser01/tldw_server/issues/1660
+documentation:
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/ReportBuilderDrawer.tsx
+- apps/packages/ui/src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the remaining AntD Alert product-state exception in Watchlists ReportBuilderDrawer to the shared design-system Alert primitive and record before/after baseline evidence for TASK-45.44.3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ReportBuilderDrawer run-required and preflight readiness warnings render through the shared design-system Alert primitive.
+- [x] #2 The ReportBuilderDrawer AntD Alert baseline exception is removed from design-system-product-state-baseline.json.
+- [x] #3 Focused ReportBuilderDrawer coverage and design-system product-state guard pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+RED: `bunx vitest run src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx` failed because the run-required and blocking-warning notices did not have a `data-ds-component="Alert"` ancestor.
+
+GREEN: migrated ReportBuilderDrawer warnings from AntD Alert props to the shared design-system Alert `variant` API and removed the stale baseline entry.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the ReportBuilderDrawer readiness notices from AntD Alert to the shared design-system Alert primitive, added regression assertions for the design-system Alert wrapper, and removed the stale product-state baseline exception. Baseline evidence: total product-state exceptions 256 -> 255; Jobs/Scheduler/Watchlists exceptions 21 -> 20; ReportBuilderDrawer target rows 1 -> 0. Verification: `bunx vitest run src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx` passed (6 tests); `bun run verify:design-system-state` passed with 255 baseline exceptions. Bandit not applicable because the touched implementation scope is TypeScript/TSX plus JSON baseline metadata only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates the Watchlists ReportBuilderDrawer readiness notices from AntD Alert to the shared design-system Alert primitive.
- Adds regression assertions that the run-required and blocking preflight warnings render through the design-system Alert wrapper.
- Removes the stale ReportBuilderDrawer product-state baseline exception and records TASK-45.44.3.9 evidence.

## Verification
- bunx vitest run src/components/Option/Watchlists/OutputsTab/__tests__/ReportBuilderDrawer.test.tsx
- bun run verify:design-system-state
- git diff --check

## Change summary
Human requester must add the merge-gate change summary before merging this AI-authored PR, including what changed and why this implementation choice was used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Watchlists ReportBuilderDrawer alerts from `antd` to the shared design-system Alert to standardize UI and remove the legacy baseline exception. Added tests to ensure run-required and preflight warnings render through the design-system wrapper.

- **Migration**
  - Replaced `antd` Alert with design-system `Alert` using the `variant` prop.
  - Updated tests to assert alerts have a `data-ds-component="Alert"` ancestor.
  - Removed the ReportBuilderDrawer exception from `design-system-product-state-baseline.json`.

<sup>Written for commit 8e089cd03a8e280e2521ebdd3d9b7bb03a7071c7. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2020?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

