### PR TITLE
Migrate AlertsTab alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2662,28 +2662,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx:Alert#antd-alert-alertstab-type-info-line-344-19bm1rx",
-    "path": "src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx:Alert#antd-alert-alertstab-type-error-line-355-10h3sox",
-    "path": "src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/Watchlists/SettingsTab/SettingsTab.tsx:Alert#antd-alert-settingstab-type-info-line-367-m37220",
     "path": "src/components/Option/Watchlists/SettingsTab/SettingsTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx
@@ -143,6 +143,7 @@ export const AlertsTab: React.FC = () => {
   const [rulesLoading, setRulesLoading] = useState(false)
   const [alertsLoading, setAlertsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [retryError, setRetryError] = useState<string | null>(null)
   const [ruleFormOpen, setRuleFormOpen] = useState(false)
   const [ruleSaving, setRuleSaving] = useState(false)
   const [ruleForm, setRuleForm] = useState<RuleFormState>(DEFAULT_RULE_FORM)
@@ -159,21 +160,23 @@ export const AlertsTab: React.FC = () => {
   const debouncedSearchText = useDebouncedValue(searchText, ALERTS_FILTER_DEBOUNCE_MS)
 
   const loadRules = useCallback(async () => {
-    if (selectedWatchlistId == null) return
+    if (selectedWatchlistId == null) return true
     setRulesLoading(true)
     setError(null)
     try {
       const response = await fetchWatchlistContentAlertRules(selectedWatchlistId, { page: 1, size: 100 })
       setRules(Array.isArray(response.items) ? response.items : [])
+      return true
     } catch {
       setError(t("watchlists:alerts.loadRulesError", "Failed to load content alert rules"))
+      return false
     } finally {
       setRulesLoading(false)
     }
   }, [selectedWatchlistId, t])
 
   const loadAlerts = useCallback(async () => {
-    if (selectedWatchlistId == null) return
+    if (selectedWatchlistId == null) return true
     setAlertsLoading(true)
     setError(null)
     try {
@@ -188,12 +191,27 @@ export const AlertsTab: React.FC = () => {
       })
       setAlerts(Array.isArray(response.items) ? response.items : [])
       setAlertsTotal(Number(response.total || 0))
+      return true
     } catch {
       setError(t("watchlists:alerts.loadAlertsError", "Failed to load content alerts"))
+      return false
     } finally {
       setAlertsLoading(false)
     }
   }, [alertsPage, debouncedSearchText, debouncedSourceFilterText, ruleFilter, selectedWatchlistId, severityFilter, statusFilter, t])
+
+  const retryFailedLoads = useCallback(() => {
+    if (error) setRetryError(error)
+    void Promise.all([
+      loadRules(),
+      loadAlerts()
+    ]).then(([rulesLoaded, alertsLoaded]) => {
+      if (rulesLoaded && alertsLoaded) {
+        setError(null)
+      }
+      setRetryError(null)
+    })
+  }, [error, loadAlerts, loadRules])
 
   useEffect(() => {
     void loadRules()
@@ -340,6 +358,8 @@ export const AlertsTab: React.FC = () => {
     )
   }
 
+  const visibleError = error ?? retryError
+
   return (
     <div className="space-y-4" data-testid="watchlists-alerts-tab">
       <Alert
@@ -352,16 +372,14 @@ export const AlertsTab: React.FC = () => {
         )}
       </Alert>
 
-      {error && (
+      {visibleError && (
         <Alert
           variant="error"
-          title={error}
+          title={visibleError}
           action={{
             label: t("common:refresh", "Refresh"),
-            onClick: () => {
-              void loadRules()
-              void loadAlerts()
-            }
+            loading: rulesLoading || alertsLoading,
+            onClick: retryFailedLoads
           }}
         />
       )}

--- a/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/AlertsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
-import { Alert, Button, Empty, Input, Modal, Pagination, Select, Switch, Tag, Tooltip, message } from "antd"
+import { Button, Empty, Input, Modal, Pagination, Select, Switch, Tag, Tooltip, message } from "antd"
 import {
   BellRing,
   CheckCircle2,
@@ -19,6 +19,7 @@ import {
   updateWatchlistContentAlert,
   updateWatchlistContentAlertRule
 } from "@/services/watchlists"
+import { Alert } from "@/components/ui/primitives"
 import { useWatchlistsStore } from "@/store/watchlists"
 import type {
   WatchlistContentAlert,
@@ -342,25 +343,26 @@ export const AlertsTab: React.FC = () => {
   return (
     <div className="space-y-4" data-testid="watchlists-alerts-tab">
       <Alert
-        type="info"
-        showIcon
+        variant="info"
         title={t("watchlists:alerts.healthBoundary", "Run failures and source problems are health issues, not content alerts.")}
-        description={t(
+      >
+        {t(
           "watchlists:alerts.boundaryDescription",
           "Use content alert rules for newly collected items that match a descriptor, keyword, classification, entity, IOC, CVE, or source constraint."
         )}
-      />
+      </Alert>
 
       {error && (
         <Alert
-          type="error"
-          showIcon
+          variant="error"
           title={error}
-          action={(
-            <Button size="small" onClick={() => { void loadRules(); void loadAlerts() }}>
-              {t("common:refresh", "Refresh")}
-            </Button>
-          )}
+          action={{
+            label: t("common:refresh", "Refresh"),
+            onClick: () => {
+              void loadRules()
+              void loadAlerts()
+            }
+          }}
         />
       )}
 

--- a/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/__tests__/AlertsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/__tests__/AlertsTab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react"
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
@@ -153,7 +153,10 @@ describe("AlertsTab", () => {
     expect(screen.getByText("CVE-2026-9999 active exploitation observed")).toBeInTheDocument()
     expect(screen.getByText("Active exploitation is affecting healthcare providers.")).toBeInTheDocument()
     expect(screen.getByText("Advisory feed")).toBeInTheDocument()
-    expect(screen.getByText("Run failures and source problems are health issues, not content alerts.")).toBeInTheDocument()
+    const boundaryTitle = screen.getByText(
+      "Run failures and source problems are health issues, not content alerts."
+    )
+    expect(boundaryTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Mark read" }))
 
@@ -170,5 +173,19 @@ describe("AlertsTab", () => {
 
     expect(screen.getByText("Name and pattern are required")).toBeInTheDocument()
     expect(mocks.createRule).not.toHaveBeenCalled()
+  })
+
+  it("renders load errors with the design-system Alert primitive", async () => {
+    mocks.fetchAlerts.mockRejectedValue(new Error("offline"))
+
+    render(<AlertsTab />)
+
+    const errorTitle = await screen.findByText("Failed to load content alerts")
+    const errorAlert = errorTitle.closest('[data-ds-component="Alert"]')
+
+    expect(errorAlert).toBeInTheDocument()
+    expect(
+      within(errorAlert as HTMLElement).getByRole("button", { name: "Refresh" })
+    ).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/__tests__/AlertsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/AlertsTab/__tests__/AlertsTab.test.tsx
@@ -188,4 +188,31 @@ describe("AlertsTab", () => {
       within(errorAlert as HTMLElement).getByRole("button", { name: "Refresh" })
     ).toBeInTheDocument()
   })
+
+  it("marks the load-error refresh action busy while retrying", async () => {
+    mocks.fetchAlerts.mockRejectedValue(new Error("offline"))
+
+    render(<AlertsTab />)
+
+    const errorTitle = await screen.findByText("Failed to load content alerts")
+    const errorAlert = errorTitle.closest('[data-ds-component="Alert"]') as HTMLElement
+    const refreshButton = within(errorAlert).getByRole("button", { name: "Refresh" })
+    const pendingRules = new Promise(() => {})
+    const pendingAlerts = new Promise(() => {})
+
+    mocks.fetchRules.mockImplementation(() => pendingRules)
+    mocks.fetchAlerts.mockImplementation(() => pendingAlerts)
+
+    fireEvent.click(refreshButton)
+
+    await waitFor(() => {
+      const retryingAlert = screen
+        .getByText("Failed to load content alerts")
+        .closest('[data-ds-component="Alert"]') as HTMLElement
+      const retryingButton = within(retryingAlert).getByRole("button", { name: "Refresh" })
+
+      expect(retryingButton).toHaveAttribute("aria-busy", "true")
+      expect(retryingButton).toBeDisabled()
+    })
+  })
 })

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -4,7 +4,7 @@ title: 'Migrate design-system product state: Jobs, Scheduler, and Watchlists'
 status: To Do
 assignee: []
 created_date: '2026-05-14 03:19'
-updated_date: '2026-05-24 00:34'
+updated_date: '2026-05-24 01:50'
 labels:
   - design-system
   - webui
@@ -19,6 +19,7 @@ references:
   - 'https://github.com/rmusser01/tldw_server/pull/2012'
   - 'https://github.com/rmusser01/tldw_server/pull/2013'
   - 'https://github.com/rmusser01/tldw_server/pull/2016'
+  - 'https://github.com/rmusser01/tldw_server/pull/2029'
 documentation:
   - |-
     TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the design-system Alert primitive.
@@ -48,6 +49,13 @@ documentation:
       - Jobs/Scheduler/Watchlists exceptions: 21 -> 20
       - ReportBuilderDrawer target rows: 1 -> 0
     Verification recorded in TASK-45.44.3.9.
+  - |-
+    TASK-45.44.3.10 / PR #2029 migrated AlertsTab boundary guidance and load-error callouts to the design-system Alert primitive.
+    Baseline evidence:
+      - total product-state exceptions: 253 -> 251
+      - Jobs/Scheduler/Watchlists exceptions: 20 -> 18
+      - AlertsTab target rows: 2 -> 0
+    Verification recorded in TASK-45.44.3.10.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.10 - Migrate-AlertsTab-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.10 - Migrate-AlertsTab-alerts-to-design-system-Alert.md
@@ -4,13 +4,15 @@ title: Migrate AlertsTab alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-24 01:48'
+updated_date: '2026-05-24 01:50'
 labels:
   - design-system
   - webui
   - watchlists
   - product-state
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2029'
 parent_task_id: TASK-45.44.3
 priority: medium
 ---
@@ -46,6 +48,8 @@ Continue TASK-45.44.3 by replacing Watchlists AlertsTab AntD Alert product-state
 - Verification: bunx vitest run src/components/Option/Watchlists/AlertsTab/__tests__/AlertsTab.test.tsx --reporter=dot passed 3 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 54 tests; bun run verify:design-system-state passed with 251 total exceptions and 18 Jobs/Scheduler/Watchlists exceptions; AlertsTab baseline rows are 0; git diff --check passed.
 - TypeScript: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still exits 2 with 347 existing diagnostics; no diagnostics mention AlertsTab, the AlertsTab test, the baseline file, or this task record.
 - Bandit skipped because this slice only touches TypeScript/React test files, JSON baseline metadata, and Backlog task markdown.
+
+- PR: https://github.com/rmusser01/tldw_server/pull/2029
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-45.44.3.10 - Migrate-AlertsTab-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.10 - Migrate-AlertsTab-alerts-to-design-system-Alert.md
@@ -1,0 +1,67 @@
+---
+id: TASK-45.44.3.10
+title: Migrate AlertsTab alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-24 01:48'
+labels:
+  - design-system
+  - webui
+  - watchlists
+  - product-state
+dependencies: []
+parent_task_id: TASK-45.44.3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-45.44.3 by replacing Watchlists AlertsTab AntD Alert product-state callouts with the shared design-system Alert primitive, preserving boundary guidance/error copy and retry behavior, removing migrated baseline exceptions, and recording focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AlertsTab boundary guidance and load-error callouts render via design-system Alert.
+- [x] #2 The AlertsTab Alert baseline exceptions are removed from design-system-product-state-baseline.json.
+- [x] #3 Focused AlertsTab coverage asserts the design-system Alert marker for the boundary and error paths.
+- [x] #4 Design-system product-state verification passes or records existing unrelated blockers.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extend focused AlertsTab tests to assert boundary guidance and load-error callouts render inside `[data-ds-component="Alert"]`, watching the assertions fail while AlertsTab still uses AntD Alert.
+2. Migrate AlertsTab Alert usage from AntD props to the design-system Alert primitive while preserving copy and refresh behavior.
+3. Remove AlertsTab Alert exceptions from the product-state baseline and run focused Vitest plus design-system verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added RED coverage in AlertsTab.test.tsx for boundary guidance and load-error callouts requiring the design-system Alert marker; focused test failed while the component still rendered the AntD Alert mock.
+- Migrated AlertsTab boundary guidance to Alert variant="info" and load-error messaging to Alert variant="error" with the existing refresh action preserved.
+- Removed the two AlertsTab Alert entries from design-system-product-state-baseline.json.
+- Verification: bunx vitest run src/components/Option/Watchlists/AlertsTab/__tests__/AlertsTab.test.tsx --reporter=dot passed 3 tests; bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot passed 54 tests; bun run verify:design-system-state passed with 251 total exceptions and 18 Jobs/Scheduler/Watchlists exceptions; AlertsTab baseline rows are 0; git diff --check passed.
+- TypeScript: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still exits 2 with 347 existing diagnostics; no diagnostics mention AlertsTab, the AlertsTab test, the baseline file, or this task record.
+- Bandit skipped because this slice only touches TypeScript/React test files, JSON baseline metadata, and Backlog task markdown.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the AlertsTab boundary guidance and load-error callouts from AntD Alert to the shared design-system Alert primitive, preserved the refresh behavior, added focused design-system marker coverage, and removed the two AlertsTab baseline exceptions. Focused Vitest, product-state guard, design-system verifier, and whitespace checks passed; TypeScript remains blocked by existing unrelated repo-wide diagnostics with no touched-file matches; Bandit was skipped for this UI-only slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.10 - Migrate-AlertsTab-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.10 - Migrate-AlertsTab-alerts-to-design-system-Alert.md
@@ -4,7 +4,7 @@ title: Migrate AlertsTab alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-24 01:50'
+updated_date: '2026-05-24 02:00'
 labels:
   - design-system
   - webui
@@ -50,14 +50,15 @@ Continue TASK-45.44.3 by replacing Watchlists AlertsTab AntD Alert product-state
 - Bandit skipped because this slice only touches TypeScript/React test files, JSON baseline metadata, and Backlog task markdown.
 
 - PR: https://github.com/rmusser01/tldw_server/pull/2029
+
+- PR review follow-up: removed the duplicate FINAL_SUMMARY end marker, added a focused retry loading assertion, and kept the load-error Alert visible with a busy Refresh action while retry requests are pending.
+- Review verification: focused AlertsTab Vitest passed 4 tests; product-state guard passed 54 tests; verify:design-system-state passed with 251 total exceptions and 18 Jobs/Scheduler/Watchlists exceptions; git diff --check passed; TypeScript still exits 2 with 347 existing diagnostics and no touched-file matches.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the AlertsTab boundary guidance and load-error callouts from AntD Alert to the shared design-system Alert primitive, preserved the refresh behavior, added focused design-system marker coverage, and removed the two AlertsTab baseline exceptions. Focused Vitest, product-state guard, design-system verifier, and whitespace checks passed; TypeScript remains blocked by existing unrelated repo-wide diagnostics with no touched-file matches; Bandit was skipped for this UI-only slice.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Migrated the AlertsTab boundary guidance and load-error callouts from AntD Alert to the shared design-system Alert primitive, preserved retry behavior, added focused design-system marker and retry-busy coverage, removed the two AlertsTab baseline exceptions, and addressed PR review feedback by removing the duplicate task marker. Focused Vitest, product-state guard, design-system verifier, and whitespace checks passed; TypeScript remains blocked by existing unrelated repo-wide diagnostics with no touched-file matches; Bandit was skipped for this UI-only slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Migrates AlertsTab boundary guidance and load-error callouts from AntD Alert to the shared design-system Alert primitive.
- Adds focused coverage asserting both callouts render inside `[data-ds-component="Alert"]`.
- Removes the two AlertsTab Alert entries from the product-state baseline and records tracker evidence.

## Test plan
- `bunx vitest run src/components/Option/Watchlists/AlertsTab/__tests__/AlertsTab.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 with the existing 347 repo-wide diagnostics; no diagnostics mention AlertsTab, its test, the baseline file, or this task record.

## Change summary
Human owner should replace this section with their own explanation before merge, per the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated AlertsTab callouts from `antd` `Alert` to the design-system `Alert` to standardize UI and remove legacy product-state exceptions. Improves retry UX by keeping the error visible and showing a busy Refresh state.

- **Refactors**
  - Replaced AntD `Alert` with design-system `Alert` (`variant="info" | "error"`, `action` with loading).
  - Improved retry flow: error persists during retry; Refresh is disabled and aria-busy while pending.
  - Removed two AlertsTab `Alert` exceptions from `design-system-product-state-baseline.json` (total 253 -> 251; Jobs/Scheduler/Watchlists 20 -> 18) and updated tests to assert the DS marker and busy Refresh.

<sup>Written for commit 81fef32efaa97746c656da223f4c79d283337fa2. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2029?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

