### PR TITLE
Migrate TemplateEditor alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2737,27 +2737,5 @@
     "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx before the stable duplicate-id guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx:Alert#antd-alert-templateeditor-type-warning-line-867-18f15ym",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx:Alert#antd-alert-templateeditor-type-warning-line-888-15vs6ip",
-    "path": "src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
   }
 ]

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx
@@ -893,7 +893,8 @@ export const TemplateEditor: React.FC<TemplateEditorProps> = ({
             )}
             action={{
               label: t("watchlists:templates.repairVisualLayout", "Repair layout"),
-              onClick: handleRepairVisualLayout
+              onClick: handleRepairVisualLayout,
+              "data-testid": "template-editor-repair-visual-layout"
             }}
           >
             {t(

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import {
-  Alert,
   Button,
   Checkbox,
   Divider,
@@ -14,6 +13,7 @@ import {
   message
 } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useWatchlistsStore } from "@/store/watchlists"
 import {
   composeWatchlistTemplateSection,
@@ -866,8 +866,7 @@ export const TemplateEditor: React.FC<TemplateEditorProps> = ({
               {hasVersionDrift && (
                 <Alert
                   className="mt-3"
-                  type="warning"
-                  showIcon
+                  variant="warning"
                   title={t("watchlists:templates.unsavedDrift", "Current editor content differs from the loaded version.")}
                 />
               )}
@@ -887,26 +886,21 @@ export const TemplateEditor: React.FC<TemplateEditorProps> = ({
         {activeTab === "visual" && composerNeedsRepair && (
           <Alert
             className="mb-4"
-            type="warning"
-            showIcon
+            variant="warning"
             title={t(
               "watchlists:templates.visualOutOfSyncTitle",
               "Visual layout may be out of sync"
             )}
-            description={t(
+            action={{
+              label: t("watchlists:templates.repairVisualLayout", "Repair layout"),
+              onClick: handleRepairVisualLayout
+            }}
+          >
+            {t(
               "watchlists:templates.visualOutOfSyncDescription",
               "The template was edited in code mode and the visual block layout may need repair."
             )}
-            action={(
-              <Button
-                size="small"
-                onClick={handleRepairVisualLayout}
-                data-testid="template-editor-repair-visual-layout"
-              >
-                {t("watchlists:templates.repairVisualLayout", "Repair layout")}
-              </Button>
-            )}
-          />
+          </Alert>
         )}
 
         <Tabs

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
@@ -337,6 +337,11 @@ describe("TemplateEditor authoring mode contract", () => {
         screen.getByText("Current editor content differs from the loaded version.")
       ).toBeInTheDocument()
     })
+    expect(
+      screen
+        .getByText("Current editor content differs from the loaded version.")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId("template-editor-mode-basic"))
     fireEvent.click(screen.getByTestId("template-editor-mode-advanced"))
@@ -351,6 +356,40 @@ describe("TemplateEditor authoring mode contract", () => {
     expect(
       screen.getByText("Current editor content differs from the loaded version.")
     ).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Current editor content differs from the loaded version.")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+  })
+
+  it("renders visual repair warnings through the design-system Alert primitive", async () => {
+    render(<TemplateEditor open template={null} onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(serviceMocks.fetchWatchlistRuns).toHaveBeenCalled()
+    })
+
+    openEditorTab()
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Start with plain text or Markdown. Advanced users can add Jinja2 tags later."
+      ),
+      {
+        target: { value: "{% macro card(x) %}{{ x }}{% endmacro %}\n{{ card(title) }}" }
+      }
+    )
+    fireEvent.click(screen.getByRole("tab", { name: "Visual" }))
+
+    const repairTitle = await screen.findByText("Visual layout may be out of sync")
+
+    expect(repairTitle.closest('[data-ds-component="Alert"]')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "The template was edited in code mode and the visual block layout may need repair."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Repair layout" })).toBeInTheDocument()
   })
 
   it("applies recipe defaults and autofills name/description in basic create mode", async () => {

--- a/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
@@ -390,6 +390,7 @@ describe("TemplateEditor authoring mode contract", () => {
       )
     ).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Repair layout" })).toBeInTheDocument()
+    expect(screen.getByTestId("template-editor-repair-visual-layout")).toBeInTheDocument()
   })
 
   it("applies recipe defaults and autofills name/description in basic create mode", async () => {

--- a/apps/packages/ui/src/components/ui/primitives/Alert.tsx
+++ b/apps/packages/ui/src/components/ui/primitives/Alert.tsx
@@ -21,6 +21,7 @@ export interface AlertProps {
     loading?: boolean
     disabled?: boolean
     variant?: React.ComponentProps<typeof Button>["variant"]
+    "data-testid"?: string
   }
   /** Secondary action (text link style) */
   secondaryAction?: {
@@ -153,6 +154,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
                   onClick={action.onClick}
                   loading={action.loading}
                   disabled={action.disabled}
+                  data-testid={action["data-testid"]}
                 >
                   {action.label}
                 </Button>

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -3,23 +3,23 @@ id: TASK-45.44.3
 title: 'Migrate design-system product state: Jobs, Scheduler, and Watchlists'
 status: To Do
 assignee: []
-created_date: '2026-05-14 03:19'
-updated_date: '2026-05-24 01:50'
+created_date: 2026-05-14 03:19
+updated_date: 2026-05-24 01:50
 labels:
-  - design-system
-  - webui
-  - extension
-  - product-state
+- design-system
+- webui
+- extension
+- product-state
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1660'
-  - >-
-    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-  - apps/packages/ui/scripts/design-system-product-state-baseline.json
-  - 'https://github.com/rmusser01/tldw_server/pull/2012'
-  - 'https://github.com/rmusser01/tldw_server/pull/2013'
-  - 'https://github.com/rmusser01/tldw_server/pull/2016'
-  - 'https://github.com/rmusser01/tldw_server/pull/2029'
+- https://github.com/rmusser01/tldw_server/issues/1660
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- https://github.com/rmusser01/tldw_server/pull/2012
+- https://github.com/rmusser01/tldw_server/pull/2013
+- https://github.com/rmusser01/tldw_server/pull/2016
+- https://github.com/rmusser01/tldw_server/pull/2029
+- https://github.com/rmusser01/tldw_server/pull/2037
 documentation:
   - |-
     TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the design-system Alert primitive.
@@ -56,6 +56,13 @@ documentation:
       - Jobs/Scheduler/Watchlists exceptions: 20 -> 18
       - AlertsTab target rows: 2 -> 0
     Verification recorded in TASK-45.44.3.10.
+  - |-
+    TASK-45.44.3.11 / PR #2037 migrated TemplateEditor version-drift and visual-repair warning callouts to the design-system Alert primitive.
+    Baseline evidence:
+      - total product-state exceptions: 251 -> 249
+      - Jobs/Scheduler/Watchlists exceptions: 18 -> 16
+      - TemplateEditor target rows: 2 -> 0
+    Verification recorded in TASK-45.44.3.11.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.11 - Migrate-TemplateEditor-warning-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.11 - Migrate-TemplateEditor-warning-alerts-to-design-system-Alert.md
@@ -4,15 +4,21 @@ title: Migrate TemplateEditor warning alerts to design-system Alert
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-24 02:15'
+updated_date: 2026-05-24 02:15
 labels:
-  - design-system
-  - webui
-  - watchlists
-  - product-state
+- design-system
+- webui
+- watchlists
+- product-state
 dependencies: []
 parent_task_id: TASK-45.44.3
 priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/2037
+modified_files:
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx
+- apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
 ---
 
 ## Description
@@ -50,6 +56,7 @@ Continue TASK-45.44.3 by replacing Watchlists TemplateEditor AntD Alert warning 
 - Verification: `git diff --check` passed.
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 with 347 existing diagnostics; no diagnostics mention TemplateEditor, its mode-contract test, the product-state baseline, or this task.
 - Bandit skipped: UI-only TypeScript/JSON/backlog changes; no Python touched.
+- PR: https://github.com/rmusser01/tldw_server/pull/2037
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-45.44.3.11 - Migrate-TemplateEditor-warning-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.11 - Migrate-TemplateEditor-warning-alerts-to-design-system-Alert.md
@@ -3,7 +3,7 @@ id: TASK-45.44.3.11
 title: Migrate TemplateEditor warning alerts to design-system Alert
 status: Done
 assignee: []
-created_date: ''
+created_date: 2026-05-24 02:15
 updated_date: 2026-05-24 02:15
 labels:
 - design-system
@@ -18,6 +18,7 @@ references:
 modified_files:
 - apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/TemplateEditor.tsx
 - apps/packages/ui/src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx
+- apps/packages/ui/src/components/ui/primitives/Alert.tsx
 - apps/packages/ui/scripts/design-system-product-state-baseline.json
 ---
 
@@ -57,6 +58,12 @@ Continue TASK-45.44.3 by replacing Watchlists TemplateEditor AntD Alert warning 
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 with 347 existing diagnostics; no diagnostics mention TemplateEditor, its mode-contract test, the product-state baseline, or this task.
 - Bandit skipped: UI-only TypeScript/JSON/backlog changes; no Python touched.
 - PR: https://github.com/rmusser01/tldw_server/pull/2037
+- Review follow-up: restored the `template-editor-repair-visual-layout` test id by allowing design-system Alert primary actions to forward `data-testid`.
+- Review follow-up: set the Backlog task `created_date` to `2026-05-24 02:15`.
+- Follow-up verification: `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx --reporter=dot` passed 13 tests.
+- Follow-up verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 54 tests.
+- Follow-up verification: `bun run verify:design-system-state` passed with 249 total exceptions and 16 Jobs/Scheduler/Watchlists exceptions.
+- Follow-up TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 with 347 existing diagnostics; no diagnostics mention TemplateEditor, the mode-contract test, Alert.tsx, the baseline, or this task.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-45.44.3.11 - Migrate-TemplateEditor-warning-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.11 - Migrate-TemplateEditor-warning-alerts-to-design-system-Alert.md
@@ -1,0 +1,69 @@
+---
+id: TASK-45.44.3.11
+title: Migrate TemplateEditor warning alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-24 02:15'
+labels:
+  - design-system
+  - webui
+  - watchlists
+  - product-state
+dependencies: []
+parent_task_id: TASK-45.44.3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-45.44.3 by replacing Watchlists TemplateEditor AntD Alert warning callouts with the shared design-system Alert primitive, preserving warning copy and layout, removing migrated baseline exceptions, and recording focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TemplateEditor warning callouts render via design-system Alert.
+- [x] #2 The TemplateEditor Alert baseline exceptions are removed from design-system-product-state-baseline.json.
+- [x] #3 Focused TemplateEditor coverage asserts the design-system Alert marker for the migrated warning paths.
+- [x] #4 Design-system product-state verification passes or records existing unrelated blockers.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect TemplateEditor warning callouts and existing tests, then add focused assertions requiring `[data-ds-component="Alert"]` for both warning paths.
+2. Migrate TemplateEditor Alert usage from AntD props to the design-system Alert primitive while preserving copy and layout.
+3. Remove TemplateEditor Alert exceptions from the product-state baseline and run focused Vitest plus design-system verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- RED: focused TemplateEditor mode-contract test failed because the drift/repair warning content did not have a `[data-ds-component="Alert"]` ancestor.
+- Migrated the TemplateEditor version-drift and visual-repair warnings from AntD Alert props to the shared design-system Alert primitive while preserving warning copy and the repair action.
+- Removed the two TemplateEditor Alert entries from the product-state baseline.
+- Verification: `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx --reporter=dot` passed 13 tests.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 54 tests.
+- Verification: `bun run verify:design-system-state` passed with 249 total exceptions and 16 Jobs/Scheduler/Watchlists exceptions.
+- Verification: TemplateEditor baseline rows are 0 and total baseline rows are 249.
+- Verification: `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 with 347 existing diagnostics; no diagnostics mention TemplateEditor, its mode-contract test, the product-state baseline, or this task.
+- Bandit skipped: UI-only TypeScript/JSON/backlog changes; no Python touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the remaining TemplateEditor warning Alert callouts to the shared design-system Alert primitive, added focused coverage for the migrated warning paths, and removed the two obsolete TemplateEditor product-state baseline exceptions. Focused UI and design-system guard verification passed; the full product-state verifier now reports 249 total baseline exceptions and 16 Jobs/Scheduler/Watchlists exceptions. TypeScript remains blocked by existing unrelated repo-wide diagnostics, with none in this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrates TemplateEditor version-drift and visual-repair warnings from AntD Alert to the shared design-system Alert primitive.
- Adds focused coverage asserting both warning paths render inside `[data-ds-component="Alert"]`.
- Removes the two TemplateEditor Alert entries from the product-state baseline and records tracker evidence.

## Test plan
- `bunx vitest run src/components/Option/Watchlists/TemplatesTab/__tests__/TemplateEditor.mode-contract.test.tsx --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` (expected existing repo-wide failure: 347 diagnostics; none mention this slice)

## Change summary
Human owner should replace this section with their own explanation before merge, per the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated TemplateEditor warning alerts to the design-system `Alert` to standardize callouts and satisfy product-state guard rules. Addressed review feedback by enabling `data-testid` on the `Alert` primary action and expanding tests.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` for version-drift and visual-repair warnings; preserved copy and the "Repair layout" action.
  - Extended design-system `Alert` to forward `data-testid` on the primary action and added tests asserting both warnings render within `[data-ds-component="Alert"]` and that the repair button exposes `data-testid="template-editor-repair-visual-layout"`.
  - Removed two TemplateEditor `Alert` exceptions from `design-system-product-state-baseline.json`.
  - Recorded migration evidence in backlog tracker docs.

<sup>Written for commit d1b3f44442a81c3a407c5824286a5abcf4b39c3c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2037?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

