### PR TITLE
Migrate WatchlistSetupWizard alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -2715,27 +2715,5 @@
     "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SettingsTab/SettingsTab.tsx before the stable duplicate-id guard.",
     "replacement": "tldw design-system state primitive",
     "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx:Alert#antd-alert-watchlistsetupwizard-type-info-line-308-1prsq0u",
-    "path": "src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx:Alert#antd-alert-watchlistsetupwizard-type-error-line-472-397y8i",
-    "path": "src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
   }
 ]

--- a/apps/packages/ui/src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react"
-import { Alert, Button, Input, Modal, Switch, Tag } from "antd"
+import { Button, Input, Modal, Switch, Tag } from "antd"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import type {
   WatchlistContainer,
   WatchlistCreate,
@@ -306,14 +307,14 @@ export const WatchlistSetupWizard: React.FC<WatchlistSetupWizardProps> = ({
   const renderCollectionStep = () => (
     <div className="space-y-4">
       <Alert
+        variant="info"
         title={t("watchlists:setupWizard.boundaries.title", "Collection scope first")}
-        description={t(
+      >
+        {t(
           "watchlists:setupWizard.boundaries.alerts",
           "Content-match alerts come later. This setup defines the Watchlist and its initial collection scope."
         )}
-        type="info"
-        showIcon
-      />
+      </Alert>
 
       <label className="block text-sm font-medium" htmlFor="watchlist-setup-source-name">
         {t("watchlists:setupWizard.fields.sourceName", "Source name")}
@@ -469,7 +470,7 @@ export const WatchlistSetupWizard: React.FC<WatchlistSetupWizardProps> = ({
     >
       <div className="space-y-4">
         {validationError ? (
-          <Alert title={validationError} type="error" showIcon />
+          <Alert title={validationError} variant="error" />
         ) : null}
         {renderStep()}
       </div>

--- a/apps/packages/ui/src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx
@@ -168,6 +168,18 @@ describe("WatchlistSetupWizard", () => {
       target: { value: "Healthcare ransomware" }
     })
     clickNext()
+
+    expect(
+      screen
+        .getByText("Collection scope first")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Content-match alerts come later. This setup defines the Watchlist and its initial collection scope."
+      )
+    ).toBeInTheDocument()
+
     clickNext()
 
     expect(screen.getByText("Review Watchlist setup")).toBeInTheDocument()
@@ -290,6 +302,11 @@ describe("WatchlistSetupWizard", () => {
     clickNext()
 
     expect(screen.getByText("Add a Watchlist name.")).toBeInTheDocument()
+    expect(
+      screen
+        .getByText("Add a Watchlist name.")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
     expect(callbacks.onCreateWatchlist).not.toHaveBeenCalled()
   })
 })

--- a/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
+++ b/backlog/tasks/task-45.44.3 - Migrate-design-system-product-state-Jobs-Scheduler-and-Watchlists.md
@@ -20,6 +20,7 @@ references:
 - https://github.com/rmusser01/tldw_server/pull/2016
 - https://github.com/rmusser01/tldw_server/pull/2029
 - https://github.com/rmusser01/tldw_server/pull/2037
+- https://github.com/rmusser01/tldw_server/pull/2039
 documentation:
   - |-
     TASK-45.44.3.6 / PR #2012 migrated OutputsTab delivery-issues Alert to the design-system Alert primitive.
@@ -63,6 +64,13 @@ documentation:
       - Jobs/Scheduler/Watchlists exceptions: 18 -> 16
       - TemplateEditor target rows: 2 -> 0
     Verification recorded in TASK-45.44.3.11.
+  - |-
+    TASK-45.44.3.12 / PR #2039 migrated WatchlistSetupWizard collection-scope guidance and validation error callouts to the design-system Alert primitive.
+    Baseline evidence:
+      - total product-state exceptions: 249 -> 247
+      - Jobs/Scheduler/Watchlists exceptions: 16 -> 14
+      - WatchlistSetupWizard target rows: 2 -> 0
+    Verification recorded in TASK-45.44.3.12.
 parent_task_id: TASK-45.44
 priority: medium
 ---

--- a/backlog/tasks/task-45.44.3.12 - Migrate-WatchlistSetupWizard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.12 - Migrate-WatchlistSetupWizard-alerts-to-design-system-Alert.md
@@ -1,0 +1,76 @@
+---
+id: TASK-45.44.3.12
+title: Migrate WatchlistSetupWizard alerts to design-system Alert
+status: Done
+assignee: []
+created_date: '2026-05-24 02:39'
+updated_date: '2026-05-24 02:39'
+labels:
+  - design-system
+  - webui
+  - watchlists
+  - product-state
+dependencies: []
+parent_task_id: TASK-45.44.3
+priority: medium
+modified_files:
+  - apps/packages/ui/src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx
+  - apps/packages/ui/src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-45.44.3 by replacing Watchlists SetupWizard AntD Alert callouts with the shared design-system Alert primitive, preserving copy and wizard behavior, removing migrated baseline exceptions, and recording focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WatchlistSetupWizard info and error callouts render via design-system Alert.
+- [x] #2 The WatchlistSetupWizard Alert baseline exceptions are removed from design-system-product-state-baseline.json.
+- [x] #3 Focused WatchlistSetupWizard coverage asserts the design-system Alert marker for the migrated callouts.
+- [x] #4 Design-system product-state verification passes or records existing unrelated blockers.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect WatchlistSetupWizard alert callouts and existing tests, then add focused assertions requiring `[data-ds-component="Alert"]` for both migrated callout paths.
+2. Migrate WatchlistSetupWizard Alert usage from AntD props to the design-system Alert primitive while preserving copy and wizard behavior.
+3. Remove WatchlistSetupWizard Alert exceptions from the product-state baseline and run focused Vitest plus design-system verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- RED: focused WatchlistSetupWizard test failed on both new `[data-ds-component="Alert"]` assertions because the collection guidance and validation error still rendered through the AntD Alert mock.
+- Migrated WatchlistSetupWizard collection-scope guidance and validation error callouts from AntD Alert props to the shared design-system Alert primitive while preserving copy and wizard behavior.
+- Removed the two WatchlistSetupWizard Alert entries from the product-state baseline.
+- Verification: `bunx vitest run src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx --reporter=dot` passed 5 tests.
+- Verification: `bunx vitest run src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx src/components/Option/Watchlists/SetupWizard/__tests__/watchlist-setup-model.test.ts --reporter=dot` passed 10 tests across 2 files.
+- Verification: `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 54 tests.
+- Verification: `bun run verify:design-system-state` passed with 247 total exceptions and 14 Jobs/Scheduler/Watchlists exceptions.
+- Verification: WatchlistSetupWizard baseline rows are 0 and total baseline rows are 247.
+- Verification: `git diff --check` passed.
+- TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 with 347 existing diagnostics; no diagnostics mention WatchlistSetupWizard, its tests, the product-state baseline, or this task.
+- Bandit skipped: UI-only TypeScript/JSON/backlog changes; no Python touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the WatchlistSetupWizard collection-scope guidance and validation error callouts to the shared design-system Alert primitive, added focused coverage for both migrated paths, and removed the two obsolete WatchlistSetupWizard product-state baseline exceptions. Focused SetupWizard and design-system guard verification passed; the full product-state verifier now reports 247 total baseline exceptions and 14 Jobs/Scheduler/Watchlists exceptions. TypeScript remains blocked by existing unrelated repo-wide diagnostics, with none in this slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.3.12 - Migrate-WatchlistSetupWizard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.12 - Migrate-WatchlistSetupWizard-alerts-to-design-system-Alert.md
@@ -13,6 +13,8 @@ labels:
 dependencies: []
 parent_task_id: TASK-45.44.3
 priority: medium
+references:
+  - https://github.com/rmusser01/tldw_server/pull/2039
 modified_files:
   - apps/packages/ui/src/components/Option/Watchlists/SetupWizard/WatchlistSetupWizard.tsx
   - apps/packages/ui/src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx
@@ -55,6 +57,7 @@ Continue TASK-45.44.3 by replacing Watchlists SetupWizard AntD Alert callouts wi
 - Verification: `git diff --check` passed.
 - TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` exits 2 with 347 existing diagnostics; no diagnostics mention WatchlistSetupWizard, its tests, the product-state baseline, or this task.
 - Bandit skipped: UI-only TypeScript/JSON/backlog changes; no Python touched.
+- PR: https://github.com/rmusser01/tldw_server/pull/2039
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-45.44.3.12 - Migrate-WatchlistSetupWizard-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.3.12 - Migrate-WatchlistSetupWizard-alerts-to-design-system-Alert.md
@@ -66,8 +66,6 @@ Continue TASK-45.44.3 by replacing Watchlists SetupWizard AntD Alert callouts wi
 Migrated the WatchlistSetupWizard collection-scope guidance and validation error callouts to the shared design-system Alert primitive, added focused coverage for both migrated paths, and removed the two obsolete WatchlistSetupWizard product-state baseline exceptions. Focused SetupWizard and design-system guard verification passed; the full product-state verifier now reports 247 total baseline exceptions and 14 Jobs/Scheduler/Watchlists exceptions. TypeScript remains blocked by existing unrelated repo-wide diagnostics, with none in this slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed


### PR DESCRIPTION
## Summary
- Migrates WatchlistSetupWizard collection-scope guidance and validation error callouts from AntD Alert to the shared design-system Alert primitive.
- Adds focused coverage asserting both migrated callout paths render inside `[data-ds-component="Alert"]`.
- Removes the two WatchlistSetupWizard Alert entries from the product-state baseline and records tracker evidence.

## Test plan
- `bunx vitest run src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx --reporter=dot`
- `bunx vitest run src/components/Option/Watchlists/SetupWizard/__tests__/WatchlistSetupWizard.test.tsx src/components/Option/Watchlists/SetupWizard/__tests__/watchlist-setup-model.test.ts --reporter=dot`
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot`
- `bun run verify:design-system-state`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` (expected existing repo-wide failure: 347 diagnostics; none mention this slice)

## Change summary
Human owner should replace this section with their own explanation before merge, per the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WatchlistSetupWizard alerts from `antd` to the design-system `Alert` for consistent UI and product-state compliance. Added focused tests, removed two baseline exceptions, and updated task docs.

- **Refactors**
  - Replaced `antd` `Alert` with design-system `Alert` from `@/components/ui/primitives` for info and error callouts.
  - Updated tests to assert alerts render inside `[data-ds-component="Alert"]`; recorded verification in `backlog/tasks/task-45.44.3.12` and fixed its final summary marker.
  - Removed two WatchlistSetupWizard `Alert` exceptions from `design-system-product-state-baseline.json`.

<sup>Written for commit c37c7650e37569baabf88d851ad1870cbeefc384. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2039?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

