### PR TITLE
Fix sync v2 review follow-ups

### DIFF
--- a/Docs/API/Sync_V2_M2.md
+++ b/Docs/API/Sync_V2_M2.md
@@ -62,6 +62,18 @@ capabilities response:
 If `blob_transfer.supported` is false, clients must treat the server as M1 for
 binary content and may still restore `attachment.ref` metadata.
 
+Production deployments keep M2 blob transfer disabled unless explicitly enabled.
+The server factory reads these environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SYNC_V2_ENABLE_BLOB_TRANSFER` | `false` | Enables blob upload/download capabilities when truthy (`1`, `true`, `yes`, `on`). |
+| `SYNC_V2_BLOB_STORE_PATH` | shared user DB root `_sync_v2_blobs` | Local filesystem root for committed blobs and staged upload chunks. |
+| `SYNC_V2_MAX_BLOB_BYTES` | `max_attachment_bytes` | Optional maximum logical blob size. |
+| `SYNC_V2_MAX_CHUNK_BYTES` | `4194304` | Maximum raw upload/download chunk size. |
+| `SYNC_V2_MAX_ACTIVE_BLOB_UPLOADS` | `8` | Maximum active upload sessions counted by quota. |
+| `SYNC_V2_USER_BLOB_QUOTA_BYTES` | unset | Optional per-user blob quota. |
+
 ## Upload Flow
 
 The primary M2 upload path is resumable:

--- a/Docs/Design/2026-05-23-chatbook-sync-v2-roadmap-prd-design.md
+++ b/Docs/Design/2026-05-23-chatbook-sync-v2-roadmap-prd-design.md
@@ -1,0 +1,14 @@
+# Chatbook Sync v2 Roadmap PRD
+
+This design-doc path is retained for discovery from the repository's
+`Docs/Design` index.
+
+The canonical Sync v2 roadmap PRD is maintained at:
+
+- `Docs/superpowers/specs/2026-05-23-chatbook-sync-v2-roadmap-prd-design.md`
+
+The implementation plans are maintained at:
+
+- `Docs/superpowers/plans/2026-05-23-chatbook-sync-v2-m1-implementation-plan.md`
+- `Docs/superpowers/plans/2026-05-23-chatbook-sync-v2-m2-implementation-plan.md`
+- `Docs/superpowers/plans/2026-05-23-chatbook-sync-v2-m3-implementation-plan.md`

--- a/Docs/superpowers/plans/2026-05-23-sync-v2-pr2030-review-fixes-plan.md
+++ b/Docs/superpowers/plans/2026-05-23-sync-v2-pr2030-review-fixes-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Verify Review Findings
+**Goal**: Confirm each requested code review finding against the rebased Sync v2 branch.
+**Success Criteria**: Critical and Important findings are classified as valid fixes or explicit pushback.
+**Tests**: Read-only inspection of the referenced implementation paths.
+**Status**: Complete
+
+## Stage 2: Patch Contract And Restore Safety
+**Goal**: Align public push/pull request shape with the M1 contract and make restore preview complete beyond the scan page size.
+**Success Criteria**: Contract aliases are accepted without breaking existing clients, and restore preview no longer silently truncates domains.
+**Tests**: Focused endpoint/model and restore preview regression tests.
+**Status**: Complete
+
+## Stage 3: Patch Blob And Workspace Safety
+**Goal**: Add production blob-transfer configuration, bounded chunk reads, retry-safe blob completion, dataset-scoped workspace blob reads, and conservative workspace retention blockers.
+**Success Criteria**: Blob upload/download and retention semantics avoid data loss or unauthorized omissions.
+**Tests**: Focused blob endpoint, factory, workspace blob, and retention regression tests.
+**Status**: Complete
+
+## Stage 4: Verify And Publish
+**Goal**: Run targeted Sync tests and Bandit, update Backlog, commit, and push the PR branch.
+**Success Criteria**: Verification output is recorded and PR branch contains the review fixes.
+**Tests**: `python -m pytest tldw_Server_API/tests/Sync` and Bandit over touched Sync v2 production paths.
+**Status**: Complete

--- a/backlog/tasks/task-497 - Address-Sync-v2-requested-code-review-findings.md
+++ b/backlog/tasks/task-497 - Address-Sync-v2-requested-code-review-findings.md
@@ -37,6 +37,11 @@ Track fixes for the requested code review on PR #2030 after rebase onto latest d
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- Restore preview scans all accepted envelopes needed for selected datasets/domains rather than stopping at the default pull window.
+- Sync v2 push/pull accepts the locked API contract aliases for `limit`, `include_same_device_echoes`, `base_server_cursor`, and `options.stop_on_conflict` while compatibility-only aliases stay hidden from generated schemas.
+- M2 blob transfer can be enabled by environment configuration, chunk reads enforce configured limits before buffering, and blob completion preserves staged chunks when database completion fails.
+- Workspace blob storage is dataset-scoped, retention compaction refuses unsafe workspace compaction until acknowledgment scope is explicit, and workspace blob access requires sync authorization.
+- Focused regression tests, the full Sync test suite, `git diff --check`, and Bandit are recorded for the touched production scope.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -57,15 +62,15 @@ Track fixes for the requested code review on PR #2030 after rebase onto latest d
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed requested PR #2030 code review findings and added regression coverage. Follow-up draft PR: https://github.com/rmusser01/tldw_server/pull/2043. Verification passed after rebase: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync` => 424 passed, 6 warnings; `git diff --check` => clean; Bandit on touched production Sync/API paths => 0 findings, results at `/tmp/bandit_sync_v2_review_fixes_pr2030.json`.
+Addressed requested PR #2030 code review findings and added regression coverage. Follow-up draft PR: https://github.com/rmusser01/tldw_server/pull/2043. Verification passed after rebase: `python -m pytest tldw_Server_API/tests/Sync` => 424 passed, 6 warnings; `git diff --check` => clean; Bandit on touched production Sync/API paths => 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-497 - Address-Sync-v2-requested-code-review-findings.md
+++ b/backlog/tasks/task-497 - Address-Sync-v2-requested-code-review-findings.md
@@ -1,0 +1,70 @@
+---
+id: TASK-497
+title: Address Sync v2 requested code review findings
+status: Done
+labels:
+- sync-v2
+- code-review
+priority: high
+references:
+- 'PR #2030'
+- Review agent 019e57d2-7eb7-7ea0-811a-8940f3abfaca
+modified_files:
+- Docs/API/Sync_V2_M2.md
+- Docs/Design/2026-05-23-chatbook-sync-v2-roadmap-prd-design.md
+- Docs/superpowers/plans/2026-05-23-sync-v2-pr2030-review-fixes-plan.md
+- tldw_Server_API/app/api/v1/endpoints/sync.py
+- tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+- tldw_Server_API/app/core/Sync/v2/blob_store.py
+- tldw_Server_API/app/core/Sync/v2/factory.py
+- tldw_Server_API/app/core/Sync/v2/service.py
+- tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
+- tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+- tldw_Server_API/tests/Sync/test_sync_v2_factory.py
+- tldw_Server_API/tests/Sync/test_sync_v2_models.py
+- tldw_Server_API/tests/Sync/test_sync_v2_notes_materializer.py
+- tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
+- tldw_Server_API/tests/Sync/test_sync_v2_retention.py
+- tldw_Server_API/tests/Sync/test_sync_v2_workspace_blobs.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track fixes for the requested code review on PR #2030 after rebase onto latest dev. Scope covers restore preview completeness, API contract alignment, blob upload size/enablement behavior, workspace blob access/retention semantics, and blob completion retry safety.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify each reviewer finding against the current code and classify true fixes vs pushback.
+2. Apply focused fixes with tests for restore completeness/API aliases/blob config and upload safety/workspace semantics.
+3. Run targeted Sync tests and Bandit on touched production scope.
+4. Commit and push review fixes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed requested PR #2030 code review findings and added regression coverage. Verification passed: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync` => 424 passed, 6 warnings; `git diff --check` => clean; Bandit on touched production Sync/API paths => 0 findings, results at `/tmp/bandit_sync_v2_review_fixes_pr2030.json`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-497 - Address-Sync-v2-requested-code-review-findings.md
+++ b/backlog/tasks/task-497 - Address-Sync-v2-requested-code-review-findings.md
@@ -9,6 +9,7 @@ priority: high
 references:
 - 'PR #2030'
 - Review agent 019e57d2-7eb7-7ea0-811a-8940f3abfaca
+- 'PR #2043 https://github.com/rmusser01/tldw_server/pull/2043'
 modified_files:
 - Docs/API/Sync_V2_M2.md
 - Docs/Design/2026-05-23-chatbook-sync-v2-roadmap-prd-design.md
@@ -56,7 +57,7 @@ Track fixes for the requested code review on PR #2030 after rebase onto latest d
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed requested PR #2030 code review findings and added regression coverage. Verification passed: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync` => 424 passed, 6 warnings; `git diff --check` => clean; Bandit on touched production Sync/API paths => 0 findings, results at `/tmp/bandit_sync_v2_review_fixes_pr2030.json`.
+Addressed requested PR #2030 code review findings and added regression coverage. Follow-up draft PR: https://github.com/rmusser01/tldw_server/pull/2043. Verification passed after rebase: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync` => 424 passed, 6 warnings; `git diff --check` => clean; Bandit on touched production Sync/API paths => 0 findings, results at `/tmp/bandit_sync_v2_review_fixes_pr2030.json`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-498 - Address-PR-2043-temp-blob-commit-collision-review.md
+++ b/backlog/tasks/task-498 - Address-PR-2043-temp-blob-commit-collision-review.md
@@ -22,6 +22,10 @@ Fix the PR #2043 review finding where LocalSyncBlobStore.commit_upload uses a de
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- Same-payload commits from distinct upload IDs use distinct temporary paths under the final blob directory.
+- The final blob key remains content-addressed and identical for identical payloads, and committed bytes read back unchanged.
+- Unique temporary files are atomically replaced into the final location and cleanup keeps the existing error handling behavior.
+- The focused regression test, blob-store test file, full Sync suite, `git diff --check`, and Bandit verification are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,15 +46,15 @@ Fix the PR #2043 review finding where LocalSyncBlobStore.commit_upload uses a de
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Resolved the PR #2043 Qodo reliability finding by changing LocalSyncBlobStore.commit_upload to use a unique temporary file per upload attempt in the final blob directory before atomic replace. Added a regression test proving same-payload uploads use distinct commit temp paths. Verification: targeted regression first failed on the old deterministic path, then passed after the fix; `python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py` => 5 passed; `python -m pytest tldw_Server_API/tests/Sync` => 425 passed, 6 warnings; `git diff --check` => clean; Bandit on blob_store.py => 0 findings at `/tmp/bandit_sync_v2_blob_store_pr2043.json`.
+Resolved the PR #2043 Qodo reliability finding by changing LocalSyncBlobStore.commit_upload to use a unique temporary file per upload attempt in the final blob directory before atomic replace. Added a regression test proving same-payload uploads use distinct commit temp paths. Verification: targeted regression first failed on the old deterministic path, then passed after the fix; `python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py` => 5 passed; `python -m pytest tldw_Server_API/tests/Sync` => 425 passed, 6 warnings; `git diff --check` => clean; Bandit on `tldw_Server_API/app/core/Sync/v2/blob_store.py` => 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-498 - Address-PR-2043-temp-blob-commit-collision-review.md
+++ b/backlog/tasks/task-498 - Address-PR-2043-temp-blob-commit-collision-review.md
@@ -1,0 +1,56 @@
+---
+id: TASK-498
+title: Address PR 2043 temp blob commit collision review
+status: Done
+labels:
+- sync-v2
+- code-review
+priority: high
+references:
+- 'PR #2043'
+- Qodo review thread https://github.com/rmusser01/tldw_server/pull/2043#discussion_r3293879128
+modified_files:
+- tldw_Server_API/app/core/Sync/v2/blob_store.py
+- tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the PR #2043 review finding where LocalSyncBlobStore.commit_upload uses a deterministic temp file path for content-addressed blobs, allowing concurrent commits of the same payload hash to collide in the shared blob root.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a regression test that demonstrates deterministic temp-path collision during concurrent/same-hash blob commits.
+2. Change LocalSyncBlobStore.commit_upload to use a per-upload unique temporary file in the final blob directory before atomic replace.
+3. Run focused blob-store tests, Sync tests, git diff checks, and Bandit on touched production code.
+4. Push fix and reply to the PR review thread.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved the PR #2043 Qodo reliability finding by changing LocalSyncBlobStore.commit_upload to use a unique temporary file per upload attempt in the final blob directory before atomic replace. Added a regression test proving same-payload uploads use distinct commit temp paths. Verification: targeted regression first failed on the old deterministic path, then passed after the fix; `python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py` => 5 passed; `python -m pytest tldw_Server_API/tests/Sync` => 425 passed, 6 warnings; `git diff --check` => clean; Bandit on blob_store.py => 0 findings at `/tmp/bandit_sync_v2_blob_store_pr2043.json`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-499 - Address-PR-2043-CodeRabbit-comments-and-CI-failures.md
+++ b/backlog/tasks/task-499 - Address-PR-2043-CodeRabbit-comments-and-CI-failures.md
@@ -1,0 +1,69 @@
+---
+id: TASK-499
+title: Address PR 2043 CodeRabbit comments and CI failures
+status: Done
+labels:
+- sync-v2
+- code-review
+- ci
+priority: high
+references:
+- 'PR #2043'
+- CodeRabbit review on commit 12ef11800
+- GitHub Actions run 26351693801
+modified_files:
+- backlog/tasks/task-497 - Address-sync-v2-requested-code-review-findings.md
+- backlog/tasks/task-498 - Address-PR-2043-temp-blob-commit-collision-review.md
+- tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+- tldw_Server_API/app/core/Sync/v2/factory.py
+- tldw_Server_API/app/core/Sync/v2/service.py
+- tldw_Server_API/tests/Sync/test_sync_v2_factory.py
+- tldw_Server_API/tests/Sync/test_sync_v2_models.py
+- tldw_Server_API/tests/Sync/test_sync_v2_service.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track follow-up fixes for PR #2043 CodeRabbit review comments and failing Full Suite CI jobs after the blob temp collision fix.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- PR #2043 CodeRabbit task-record comments are addressed by adding Acceptance Criteria, checking completed DoD items, and removing machine-local absolute paths from completed Backlog final summaries.
+- Sync v2 numeric environment settings fail fast with `ValueError` when explicitly configured to non-integer or non-positive values.
+- Blob upload completion logs cleanup failures without raising a secondary `NameError`.
+- `SyncPushOptions` is included in the public sync v2 schema export list.
+- Focused regression tests, full Sync test suite, `git diff --check`, and Bandit are recorded before resolving review threads.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect failing Full Suite job logs and classify failures.
+2. Verify each CodeRabbit comment against current code and fix valid issues with minimal edits.
+3. Add or update focused tests for behavior changes, then run focused and Sync verification.
+4. Commit, push, and resolve/reply to PR review threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the PR #2043 CodeRabbit comments by adding missing Backlog Acceptance Criteria and DoD completion state, replacing machine-local paths in completed task summaries, making explicit invalid Sync v2 numeric env configuration fail fast, importing the service logger used by blob cleanup warning paths, and exporting `SyncPushOptions`. Added focused regressions for the behavior changes. Verification: focused red-green tests first failed on the old behavior and then passed; `python -m pytest tldw_Server_API/tests/Sync` => 435 passed, 6 warnings; `git diff --check` => clean; Bandit on touched production files => 0 findings. CI note: GitHub Actions run 26351693801 was still in progress when inspected; the displayed failed Full Suite jobs were cancelled matrix jobs with logs unavailable until run completion, not actionable failure logs.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -202,6 +202,14 @@ def _safe_sync_v2_http_error(exc: Exception, **context: object) -> HTTPException
                     "message": "Sync attachment exceeds the server size limit.",
                 },
             )
+        if "blob chunk exceeds" in lowered:
+            return HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail={
+                    "error_code": "sync_blob_chunk_too_large",
+                    "message": "Sync blob chunk exceeds the server size limit.",
+                },
+            )
         if "quota" in lowered:
             return HTTPException(
                 status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -269,6 +277,32 @@ def _safe_sync_v2_http_error(exc: Exception, **context: object) -> HTTPException
             "message": "Internal server error while processing sync request.",
         },
     )
+
+
+async def _read_limited_sync_blob_chunk(raw_request: Request, *, max_bytes: int) -> bytes:
+    """Read a raw blob chunk without unbounded request-body buffering."""
+
+    if max_bytes < 1:
+        raise SyncStoreError("Sync blob chunk exceeds the server size limit")
+    content_length = raw_request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_size = int(content_length)
+        except ValueError as exc:
+            raise SyncStoreError("Sync blob chunk size is invalid") from exc
+        if declared_size > max_bytes:
+            raise SyncStoreError("Sync blob chunk exceeds the server size limit")
+
+    chunks: list[bytes] = []
+    total_size = 0
+    async for chunk in raw_request.stream():
+        if not chunk:
+            continue
+        total_size += len(chunk)
+        if total_size > max_bytes:
+            raise SyncStoreError("Sync blob chunk exceeds the server size limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _parse_sync_key_rotation_commit_request(
@@ -1148,6 +1182,8 @@ def push_sync_v2_envelopes(
             dataset_id=request.dataset_id,
             device_id=request.device_id,
             envelopes=[_core_envelope_from_api(envelope) for envelope in request.envelopes],
+            base_server_cursor=request.base_server_cursor,
+            stop_on_conflict=request.options.stop_on_conflict,
         )
     except Exception as exc:
         raise _safe_sync_v2_http_error(
@@ -1176,11 +1212,19 @@ def pull_sync_v2_envelopes(
     device_id: str,
     cursor: str | None = None,
     domains: list[SyncDomain] | None = Query(None, alias="domain"),
-    page_size: int | None = Query(None, ge=1),
-    include_own_changes: bool = False,
+    limit: int | None = Query(None, ge=1),
+    include_same_device_echoes: bool | None = Query(None),
+    page_size: int | None = Query(None, ge=1, include_in_schema=False),
+    include_own_changes: bool | None = Query(None, include_in_schema=False),
     user: User = Depends(get_request_user),
     service: SyncV2Service = Depends(get_sync_v2_service),
 ):
+    effective_page_size = limit if limit is not None else page_size
+    effective_include_own_changes = (
+        include_same_device_echoes
+        if include_same_device_echoes is not None
+        else bool(include_own_changes)
+    )
     try:
         result = service.pull(
             user_id=_sync_user_id(user),
@@ -1188,8 +1232,8 @@ def pull_sync_v2_envelopes(
             device_id=device_id,
             cursor=cursor,
             domains=domains,
-            page_size=page_size,
-            include_own_changes=include_own_changes,
+            page_size=effective_page_size,
+            include_own_changes=effective_include_own_changes,
         )
     except Exception as exc:
         raise _safe_sync_v2_http_error(
@@ -1198,6 +1242,8 @@ def pull_sync_v2_envelopes(
             dataset_id=dataset_id,
             device_id=device_id,
             cursor=cursor,
+            limit=limit,
+            page_size=page_size,
         ) from exc
     return SyncPullResponse(
         dataset_id=result.dataset_id,
@@ -1481,8 +1527,11 @@ async def upload_sync_v2_blob_chunk(
     user: User = Depends(get_request_user),
     service: SyncV2Service = Depends(get_sync_v2_service),
 ):
-    payload = await raw_request.body()
     try:
+        payload = await _read_limited_sync_blob_chunk(
+            raw_request,
+            max_bytes=service.settings.max_chunk_bytes,
+        )
         chunk = await asyncio.to_thread(
             service.upload_blob_chunk,
             user_id=_sync_user_id(user),

--- a/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
@@ -1278,17 +1278,28 @@ class SyncV2Envelope(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
 
+class SyncPushOptions(BaseModel):
+    """Client push behavior flags from the locked Sync v2 M1 contract."""
+
+    stop_on_conflict: bool = False
+
+    model_config = ConfigDict(extra="ignore")
+
+
 class SyncPushRequest(BaseModel):
     """Batch of client-originated envelopes pushed to the server."""
 
     dataset_id: str
     device_id: str = Field(..., min_length=1)
+    client_profile_id: str | None = None
+    base_server_cursor: int | None = Field(None, ge=0)
     envelopes: list[SyncV2Envelope] = Field(
         default_factory=list,
         max_length=SYNC_V2_MAX_PUSH_ENVELOPES,
     )
     idempotency_key: str | None = None
     last_known_cursor: str | None = None
+    options: SyncPushOptions = Field(default_factory=SyncPushOptions)
 
 
 class SyncPushAcceptedEnvelope(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
@@ -1758,6 +1758,7 @@ __all__ = [
     "SyncPullResponse",
     "SyncPushAcceptedEnvelope",
     "SyncPushConflictEnvelope",
+    "SyncPushOptions",
     "SyncPushRejectedEnvelope",
     "SyncPushRequest",
     "SyncPushResponse",

--- a/tldw_Server_API/app/core/Sync/v2/blob_store.py
+++ b/tldw_Server_API/app/core/Sync/v2/blob_store.py
@@ -89,14 +89,6 @@ class LocalSyncBlobStore:
         except OSError as exc:
             _discard_temp_path(temp_path)
             raise SyncBlobStoreError("Sync blob upload commit failed") from exc
-        try:
-            shutil.rmtree(self.resolve_storage_key(f"_uploads/{upload_segment}"))
-        except OSError as exc:
-            logger.warning(
-                "Sync blob upload committed but cleanup failed for upload_id={}: {}",
-                upload_id,
-                exc,
-            )
         return final_key
 
     def read_blob(self, storage_key: str) -> bytes:

--- a/tldw_Server_API/app/core/Sync/v2/blob_store.py
+++ b/tldw_Server_API/app/core/Sync/v2/blob_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import shutil
+import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -61,7 +62,7 @@ class LocalSyncBlobStore:
         final_key = f"blobs/sha256/{digest[:2]}/{digest}.blob"
         final_path = self.resolve_storage_key(final_key)
         final_path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = final_path.with_suffix(final_path.suffix + ".tmp")
+        temp_path = _commit_temp_path(final_path, digest=digest, upload_segment=upload_segment)
         hasher = hashlib.sha256()
         try:
             with temp_path.open("wb") as output:
@@ -182,6 +183,18 @@ def _discard_temp_path(temp_path: Path) -> None:
         temp_path.unlink(missing_ok=True)
     except OSError as exc:
         logger.warning("Failed to remove temporary Sync blob path {}: {}", temp_path, exc)
+
+
+def _commit_temp_path(final_path: Path, *, digest: str, upload_segment: str) -> Path:
+    temp_file = tempfile.NamedTemporaryFile(
+        delete=False,
+        dir=final_path.parent,
+        prefix=f"{digest}.{upload_segment}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_file.name)
+    temp_file.close()
+    return temp_path
 
 
 __all__ = ["LocalSyncBlobStore", "STREAM_CHUNK_SIZE", "SyncBlobStoreError"]

--- a/tldw_Server_API/app/core/Sync/v2/factory.py
+++ b/tldw_Server_API/app/core/Sync/v2/factory.py
@@ -141,22 +141,24 @@ def _sync_v2_positive_int_env(name: str, *, default: int) -> int:
     value = os.getenv(name)
     if value is None or not value.strip():
         return default
-    try:
-        parsed = int(value)
-    except ValueError:
-        return default
-    return parsed if parsed > 0 else default
+    return _sync_v2_parse_positive_int_env(name, value)
 
 
 def _sync_v2_optional_positive_int_env(name: str) -> int | None:
     value = os.getenv(name)
     if value is None or not value.strip():
         return None
+    return _sync_v2_parse_positive_int_env(name, value)
+
+
+def _sync_v2_parse_positive_int_env(name: str, value: str) -> int:
     try:
-        parsed = int(value)
+        parsed = int(value.strip())
     except ValueError:
-        return None
-    return parsed if parsed > 0 else None
+        raise ValueError(f"{name} must be a positive integer") from None
+    if parsed <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return parsed
 
 
 def _workspace_access_checker(user_id: str, workspace_id: str, permission: str) -> bool:

--- a/tldw_Server_API/app/core/Sync/v2/factory.py
+++ b/tldw_Server_API/app/core/Sync/v2/factory.py
@@ -74,9 +74,7 @@ def sync_v2_service_for_user(user_id: str) -> SyncV2Service:
             "media.keyword_link": MediaMetadataMaterializer(domain="media.keyword_link"),
         },
         blob_store=_sync_v2_blob_store_for_user(user_id),
-        settings=SyncV2Settings(
-            server_trusted_encryption=server_trusted_encryption_status_from_env(),
-        ),
+        settings=_sync_v2_settings_from_env(),
         workspace_access_checker=_workspace_access_checker,
     )
 
@@ -113,9 +111,52 @@ def _chacha_notes_db_for_user(user_id: str) -> CharactersRAGDB:
 
 @lru_cache(maxsize=256)
 def _sync_v2_blob_store_for_user(user_id: str) -> LocalSyncBlobStore:
+    del user_id
+    configured_path = os.getenv("SYNC_V2_BLOB_STORE_PATH", "").strip()
+    if configured_path:
+        return LocalSyncBlobStore(configured_path)
     base_dir = DatabasePaths.resolve_user_db_base_dir()
-    safe_user_id = _resolve_user_id_for_storage(user_id)
-    return LocalSyncBlobStore(base_dir / safe_user_id / "sync_blobs")
+    return LocalSyncBlobStore(base_dir / "_sync_v2_blobs")
+
+
+def _sync_v2_settings_from_env() -> SyncV2Settings:
+    return SyncV2Settings(
+        supports_attachments=_sync_v2_bool_env("SYNC_V2_ENABLE_BLOB_TRANSFER", default=False),
+        max_blob_bytes=_sync_v2_optional_positive_int_env("SYNC_V2_MAX_BLOB_BYTES"),
+        max_chunk_bytes=_sync_v2_positive_int_env("SYNC_V2_MAX_CHUNK_BYTES", default=4_194_304),
+        max_active_blob_uploads=_sync_v2_positive_int_env("SYNC_V2_MAX_ACTIVE_BLOB_UPLOADS", default=8),
+        user_blob_quota_bytes=_sync_v2_optional_positive_int_env("SYNC_V2_USER_BLOB_QUOTA_BYTES"),
+        server_trusted_encryption=server_trusted_encryption_status_from_env(),
+    )
+
+
+def _sync_v2_bool_env(name: str, *, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _sync_v2_positive_int_env(name: str, *, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _sync_v2_optional_positive_int_env(name: str) -> int | None:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _workspace_access_checker(user_id: str, workspace_id: str, permission: str) -> bool:

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -1172,6 +1172,7 @@ class SyncV2Service:
             active_devices,
             offline_restore_window_seconds,
         )
+        workspace_ack_scope_blocked = self._retention_workspace_ack_scope_blocked(dataset)
         candidates: list[SyncRetentionCandidate] = []
 
         for envelope in envelopes:
@@ -1200,6 +1201,8 @@ class SyncV2Service:
                 blockers.append(window_blocker)
             if restore_window_blocked:
                 blockers.append("retention_restore_window_active")
+            if workspace_ack_scope_blocked:
+                blockers.append("retention_workspace_ack_scope_unknown")
             unacknowledged = self._retention_unacknowledged_devices(
                 dataset_id=dataset_id,
                 domain=envelope.domain,
@@ -1343,7 +1346,11 @@ class SyncV2Service:
         dataset_id: str,
         device_id: str,
         envelopes: Sequence[SyncEnvelopeCreate],
+        base_server_cursor: int | None = None,
+        stop_on_conflict: bool = False,
     ) -> SyncPushResult:
+        # The top-level cursor is a client dataset checkpoint; object conflict checks use envelope bases.
+        _ = base_server_cursor
         self._require_registered_device(user_id, device_id)
         try:
             dataset = self._require_dataset_access(user_id=user_id, dataset_id=dataset_id)
@@ -1363,8 +1370,19 @@ class SyncV2Service:
         accepted: list[SyncPushAccepted] = []
         rejected: list[SyncPushRejected] = []
         conflicts: list[SyncPushConflict] = []
+        stopped_after_conflict = False
 
         for index, envelope in enumerate(envelopes):
+            if stopped_after_conflict:
+                rejected.append(
+                    SyncPushRejected(
+                        client_envelope_id=envelope.client_envelope_id,
+                        error_code="stopped_after_conflict",
+                        message="Sync push stopped after a previous envelope conflicted.",
+                        retryable=True,
+                    )
+                )
+                continue
             if index >= self.settings.max_batch_size:
                 rejected.append(
                     SyncPushRejected(
@@ -1463,6 +1481,8 @@ class SyncV2Service:
                             message="Sync envelope ID was reused with different content",
                         )
                     )
+                if stop_on_conflict:
+                    stopped_after_conflict = True
                 continue
 
             try:
@@ -1496,6 +1516,8 @@ class SyncV2Service:
                             materialization,
                         )
                     )
+                    if stop_on_conflict:
+                        stopped_after_conflict = True
                     continue
             accepted.append(self._push_accepted_from_envelope(inserted))
 
@@ -1656,12 +1678,9 @@ class SyncV2Service:
             for domain, count in stats.approximate_counts.items():
                 total_counts[domain] = total_counts.get(domain, 0) + count
             domain_envelopes = {
-                domain: self.store.list_envelopes_after(
-                    dataset.dataset_id,
-                    0,
-                    limit=self.settings.restore_manifest_scan_limit,
-                    domains=[domain],
-                    status="accepted",
+                domain: self._list_restore_preview_domain_envelopes(
+                    dataset_id=dataset.dataset_id,
+                    domain=domain,
                 )
                 for domain in dataset_domains
             }
@@ -1838,11 +1857,15 @@ class SyncV2Service:
                 seen_refs.add(ref_key)
                 server_blob = None
                 if self.settings.supports_attachments:
+                    blob_owner_user_id = self._blob_owner_user_id(
+                        dataset=dataset,
+                        user_id=user_id,
+                    )
                     server_blob = self.store.get_blob_object(
                         dataset.dataset_id,
                         attachment_id=metadata.attachment_id,
                         payload_hash=metadata.payload_hash,
-                        owner_user_id=user_id,
+                        owner_user_id=blob_owner_user_id,
                     )
                 metadata_claims_server_blob = (
                     not self.settings.supports_attachments
@@ -2223,7 +2246,7 @@ class SyncV2Service:
             )
         except SyncBlobStoreError as exc:
             raise SyncStoreError(str(exc)) from exc
-        return self.store.complete_blob_upload(
+        blob = self.store.complete_blob_upload(
             SyncBlobObjectCreate(
                 blob_id=self.id_factory("blob"),
                 dataset_id=dataset_id,
@@ -2238,6 +2261,15 @@ class SyncV2Service:
                 metadata={},
             )
         )
+        try:
+            blob_store.discard_upload(upload_id)
+        except OSError as exc:
+            logger.warning(
+                "Sync blob upload completed but cleanup failed for upload_id={}: {}",
+                upload_id,
+                exc,
+            )
+        return blob
 
     def cancel_blob_upload(
         self,
@@ -2269,11 +2301,11 @@ class SyncV2Service:
         """Return resumable download metadata for an available blob or metadata-only ref."""
 
         blob_store = self._require_blob_transfer()
-        self._require_blob_dataset(user_id=user_id, dataset_id=dataset_id)
+        dataset = self._require_blob_dataset(user_id=user_id, dataset_id=dataset_id)
         blob = self.store.get_blob_object(
             dataset_id,
             attachment_id=attachment_id,
-            owner_user_id=user_id,
+            owner_user_id=self._blob_owner_user_id(dataset=dataset, user_id=user_id),
         )
         if blob is None:
             return self._metadata_only_blob_manifest(
@@ -3262,6 +3294,9 @@ class SyncV2Service:
             key=lambda device: device.device_id,
         )
 
+    def _retention_workspace_ack_scope_blocked(self, dataset: SyncDataset) -> bool:
+        return dataset.scope_type == "workspace"
+
     def _retention_latest_envelopes_by_object(
         self,
         envelopes: Sequence[SyncEnvelope],
@@ -3337,6 +3372,8 @@ class SyncV2Service:
                 blockers.append("retention_audit_mode")
             if restore_window_blocked:
                 blockers.append("retention_restore_window_active")
+            if self._retention_workspace_ack_scope_blocked(dataset):
+                blockers.append("retention_workspace_ack_scope_unknown")
             state = self.store.get_object_state(dataset.dataset_id, "attachment.ref", blob.attachment_id)
             if (
                 (state is not None and not state.deleted)
@@ -3663,6 +3700,36 @@ class SyncV2Service:
         visible = [envelope for envelope in raw if envelope.apply_status != "conflict"]
         return raw, visible
 
+    def _list_restore_preview_domain_envelopes(
+        self,
+        *,
+        dataset_id: str,
+        domain: SyncDomain,
+    ) -> list[SyncEnvelope]:
+        page_limit = self.settings.restore_manifest_scan_limit
+        if page_limit < 1:
+            raise SyncStoreError("Sync restore manifest scan limit must be greater than zero")
+        envelopes: list[SyncEnvelope] = []
+        since_sequence = 0
+        while True:
+            page = self.store.list_envelopes_after(
+                dataset_id,
+                since_sequence,
+                limit=page_limit,
+                domains=[domain],
+                status="accepted",
+            )
+            if not page:
+                break
+            envelopes.extend(page)
+            next_sequence = max(envelope.server_sequence for envelope in page)
+            if next_sequence <= since_sequence:
+                raise SyncStoreError("Sync restore manifest cursor did not advance")
+            since_sequence = next_sequence
+            if len(page) < page_limit:
+                break
+        return envelopes
+
     def _manifest_dataset(
         self,
         dataset: SyncDataset,
@@ -3752,15 +3819,20 @@ class SyncV2Service:
         """Return a verified blob-store handle and metadata for byte serving."""
 
         blob_store = self._require_blob_transfer()
-        self._require_blob_dataset(user_id=user_id, dataset_id=dataset_id)
+        dataset = self._require_blob_dataset(user_id=user_id, dataset_id=dataset_id)
         blob = self.store.get_blob_object(
             dataset_id,
             attachment_id=attachment_id,
-            owner_user_id=user_id,
+            owner_user_id=self._blob_owner_user_id(dataset=dataset, user_id=user_id),
         )
         if blob is None:
             raise SyncStoreError("Sync blob was not found or is not accessible")
         return blob_store, blob
+
+    def _blob_owner_user_id(self, *, dataset: SyncDataset, user_id: str) -> str | None:
+        if dataset.scope_type == "workspace":
+            return None
+        return user_id
 
     def _validate_blob_storage_metadata(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from loguru import logger
+
 from .adapters import (
     ATTACHMENT_REF_SERVER_AVAILABILITY,
     AdapterAccepted,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
@@ -42,6 +42,8 @@ def test_local_blob_store_commits_verified_chunks_atomically(tmp_path: Path):
     assert first_key.endswith("0.part")
     assert second_key.endswith("1.part")
     assert store.read_blob(final_key) == first + second
+    assert (tmp_path / "sync_blobs" / "_uploads" / "upload-1").exists()
+    store.discard_upload("upload-1")
     assert not (tmp_path / "sync_blobs" / "_uploads" / "upload-1").exists()
 
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
@@ -81,6 +81,48 @@ def test_local_blob_store_streams_commit_and_read_without_read_bytes(
     assert b"".join(store.iter_blob(final_key, chunk_size=3)) == first + second
 
 
+def test_local_blob_store_uses_unique_commit_temp_paths_for_same_payload_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    payload = b"same shared payload"
+    payload_hash = _sha256(payload)
+    for upload_id in ("upload-1", "upload-2"):
+        store.write_upload_chunk(
+            upload_id=upload_id,
+            chunk_index=0,
+            payload=payload,
+            expected_hash=payload_hash,
+        )
+
+    original_open = Path.open
+    commit_write_paths: list[Path] = []
+
+    def track_commit_write_path(self: Path, *args, **kwargs):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if "w" in mode and self.name.endswith(".tmp"):
+            commit_write_paths.append(self)
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", track_commit_write_path)
+
+    first_key = store.commit_upload(
+        upload_id="upload-1",
+        payload_hash=payload_hash,
+        chunk_indexes=[0],
+    )
+    second_key = store.commit_upload(
+        upload_id="upload-2",
+        payload_hash=payload_hash,
+        chunk_indexes=[0],
+    )
+
+    assert first_key == second_key
+    assert len(commit_write_paths) == 2
+    assert len(set(commit_write_paths)) == 2
+
+
 def test_local_blob_store_commit_cleanup_failure_is_nonfatal(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -21,6 +21,7 @@ from tldw_Server_API.app.core.Sync.v2.models import (
     SyncDeviceUpsert,
     SyncObjectState,
 )
+from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
 from tldw_Server_API.app.core.Sync.v2.security import (
     server_trusted_encryption_status_from_config,
 )
@@ -916,6 +917,58 @@ def test_push_and_pull_endpoint_expose_apply_outcomes_for_replayable_failures(
     assert "replayable" in failed["apply_error_message"]
 
 
+def test_pull_endpoint_accepts_m1_contract_limit_and_echo_aliases(
+    client: TestClient,
+) -> None:
+    client.post(
+        "/api/v1/sync/devices/register",
+        json={"device_id": "device-1", "display_name": "Laptop", "client_type": "chatbook"},
+    )
+    client.post(
+        "/api/v1/sync/datasets/enroll",
+        json={
+            "dataset_id": "dataset-1",
+            "domains": list(M1_SYNC_DOMAINS),
+            "encryption_policy": "server_trusted_v1",
+        },
+    )
+    pushed = client.post(
+        "/api/v1/sync/push",
+        json={
+            "dataset_id": "dataset-1",
+            "device_id": "device-1",
+            "base_server_cursor": 0,
+            "options": {"stop_on_conflict": False},
+            "envelopes": [
+                _note_envelope_json(client_envelope_id="env-note-1", payload_hash="sha256:note-1"),
+                _note_envelope_json(
+                    client_envelope_id="env-note-2",
+                    object_id="note-2",
+                    client_sequence=2,
+                    payload_hash="sha256:note-2",
+                ),
+            ],
+        },
+    )
+
+    pulled = client.get(
+        "/api/v1/sync/pull",
+        params={
+            "dataset_id": "dataset-1",
+            "device_id": "device-1",
+            "cursor": "0",
+            "domain": "notes.note",
+            "limit": "1",
+            "include_same_device_echoes": "true",
+        },
+    )
+
+    assert pushed.status_code == 200
+    assert pulled.status_code == 200
+    assert [item["client_envelope_id"] for item in pulled.json()["envelopes"]] == ["env-note-1"]
+    assert pulled.json()["has_more"] is True
+
+
 def test_push_endpoint_reports_dataset_mismatch_per_envelope_in_mixed_batch(
     client: TestClient,
 ) -> None:
@@ -1060,6 +1113,103 @@ def test_resumable_blob_upload_endpoints_accept_raw_chunks_and_complete(
     assert body["stored"] is True
     assert body["payload_hash"] == _sha256(payload)
     assert body["quota"]["used_blob_bytes"] == len(payload)
+
+
+def test_blob_chunk_endpoint_rejects_oversized_body_before_buffering(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path, supports_attachments=True)
+    client = _client_for_service(service)
+    service.register_device(
+        user_id="user-1",
+        device_id="device-1",
+        display_name="Laptop",
+        client_type="chatbook",
+    )
+    service.enroll_dataset(user_id="user-1", dataset_id="dataset-1", domains=["notes.note", "attachment.ref"])
+    payload = b"12345678"
+    create_response = client.post(
+        "/api/v1/sync/blob-uploads",
+        json={
+            "dataset_id": "dataset-1",
+            "device_id": "device-1",
+            "domain": "notes.note",
+            "object_id": "note-1",
+            "attachment_id": "attachment-1",
+            "content_type": "application/octet-stream",
+            "size_bytes": len(payload),
+            "payload_hash": _sha256(payload),
+            "chunk_size": len(payload),
+            "chunk_count": 1,
+        },
+    )
+    assert create_response.status_code == 200
+    upload_id = create_response.json()["upload_id"]
+
+    response = client.put(
+        f"/api/v1/sync/blob-uploads/{upload_id}/chunks/0",
+        params={
+            "dataset_id": "dataset-1",
+            "offset_bytes": 0,
+            "chunk_hash": _sha256(payload + b"x"),
+        },
+        content=payload + b"x",
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["error_code"] == "sync_blob_chunk_too_large"
+
+
+def test_blob_completion_preserves_staged_chunks_when_db_commit_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _build_service(tmp_path, supports_attachments=True)
+    service.register_device(
+        user_id="user-1",
+        device_id="device-1",
+        display_name="Laptop",
+        client_type="chatbook",
+    )
+    service.enroll_dataset(user_id="user-1", dataset_id="dataset-1", domains=["notes.note", "attachment.ref"])
+    payload = b"retry me"
+    session = service.create_blob_upload_session(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        device_id="device-1",
+        domain="notes.note",
+        entity_id="note-1",
+        attachment_id="attachment-1",
+        content_type="application/octet-stream",
+        size_bytes=len(payload),
+        payload_hash=_sha256(payload),
+        chunk_size=len(payload),
+        chunk_count=1,
+    )
+    service.upload_blob_chunk(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=session.upload_id,
+        chunk_index=0,
+        offset_bytes=0,
+        chunk_payload=payload,
+        chunk_hash=_sha256(payload),
+    )
+
+    def fail_complete_blob_upload(_blob):
+        raise SyncStoreError("database commit failed")
+
+    monkeypatch.setattr(service.store, "complete_blob_upload", fail_complete_blob_upload)
+
+    with pytest.raises(SyncStoreError):
+        service.complete_blob_upload(
+            user_id="user-1",
+            dataset_id="dataset-1",
+            upload_id=session.upload_id,
+        )
+
+    assert (tmp_path / "sync_blobs" / "_uploads" / session.upload_id / "0.part").exists()
 
 
 def test_blob_upload_endpoint_maps_validation_errors_to_safe_statuses(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_factory.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_factory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.Sync.v2.factory import _sync_v2_settings_from_env
 
 
@@ -25,3 +27,23 @@ def test_sync_v2_factory_enables_blob_transfer_from_env(monkeypatch) -> None:
     assert settings.max_chunk_bytes == 1024
     assert settings.max_active_blob_uploads == 3
     assert settings.user_blob_quota_bytes == 8192
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("SYNC_V2_MAX_BLOB_BYTES", "not-a-number"),
+        ("SYNC_V2_MAX_BLOB_BYTES", "0"),
+        ("SYNC_V2_MAX_CHUNK_BYTES", "not-a-number"),
+        ("SYNC_V2_MAX_CHUNK_BYTES", "0"),
+        ("SYNC_V2_MAX_ACTIVE_BLOB_UPLOADS", "not-a-number"),
+        ("SYNC_V2_MAX_ACTIVE_BLOB_UPLOADS", "0"),
+        ("SYNC_V2_USER_BLOB_QUOTA_BYTES", "not-a-number"),
+        ("SYNC_V2_USER_BLOB_QUOTA_BYTES", "0"),
+    ],
+)
+def test_sync_v2_factory_rejects_invalid_positive_integer_env(monkeypatch, name: str, value: str) -> None:
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(ValueError, match=name):
+        _sync_v2_settings_from_env()

--- a/tldw_Server_API/tests/Sync/test_sync_v2_factory.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_factory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sync.v2.factory import _sync_v2_settings_from_env
+
+
+def test_sync_v2_factory_keeps_blob_transfer_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("SYNC_V2_ENABLE_BLOB_TRANSFER", raising=False)
+
+    settings = _sync_v2_settings_from_env()
+
+    assert settings.supports_attachments is False
+
+
+def test_sync_v2_factory_enables_blob_transfer_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("SYNC_V2_ENABLE_BLOB_TRANSFER", "true")
+    monkeypatch.setenv("SYNC_V2_MAX_BLOB_BYTES", "4096")
+    monkeypatch.setenv("SYNC_V2_MAX_CHUNK_BYTES", "1024")
+    monkeypatch.setenv("SYNC_V2_MAX_ACTIVE_BLOB_UPLOADS", "3")
+    monkeypatch.setenv("SYNC_V2_USER_BLOB_QUOTA_BYTES", "8192")
+
+    settings = _sync_v2_settings_from_env()
+
+    assert settings.supports_attachments is True
+    assert settings.max_blob_bytes == 4096
+    assert settings.max_chunk_bytes == 1024
+    assert settings.max_active_blob_uploads == 3
+    assert settings.user_blob_quota_bytes == 8192

--- a/tldw_Server_API/tests/Sync/test_sync_v2_models.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_models.py
@@ -581,6 +581,23 @@ def test_sync_envelope_rejects_non_object_payload_as_validation_error():
         SyncV2Envelope.model_validate(_m1_envelope_payload(payload=[]))
 
 
+def test_push_request_accepts_locked_contract_cursor_and_options():
+    request = SyncPushRequest.model_validate(
+        {
+            "dataset_id": "dataset-1",
+            "device_id": "device-1",
+            "client_profile_id": "profile-1",
+            "base_server_cursor": 128,
+            "envelopes": [],
+            "options": {"stop_on_conflict": True},
+        }
+    )
+
+    assert request.client_profile_id == "profile-1"
+    assert request.base_server_cursor == 128
+    assert request.options.stop_on_conflict is True
+
+
 def test_whole_object_tombstone_requires_base_metadata():
     with pytest.raises(ValidationError):
         SyncV2Envelope.model_validate(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_models.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_models.py
@@ -598,6 +598,10 @@ def test_push_request_accepts_locked_contract_cursor_and_options():
     assert request.options.stop_on_conflict is True
 
 
+def test_sync_v2_models_exports_push_options_for_star_imports():
+    assert "SyncPushOptions" in api_sync_models.__all__
+
+
 def test_whole_object_tombstone_requires_base_metadata():
     with pytest.raises(ValidationError):
         SyncV2Envelope.model_validate(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_materializer.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_materializer.py
@@ -360,6 +360,47 @@ def test_materialization_conflict_is_not_returned_by_normal_pull(
     assert note["title"] == "Server winner"
 
 
+def test_push_stop_on_conflict_rejects_remaining_envelopes(
+    sync_service: SyncV2Service,
+) -> None:
+    _push_one(sync_service, _note_envelope())
+    current = sync_service.store.get_object_state("dataset-1", "notes.note", "note-1")
+    assert current is not None
+
+    result = sync_service.push(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        device_id="device-1",
+        stop_on_conflict=True,
+        envelopes=[
+            _note_envelope(
+                client_envelope_id="env-stale",
+                client_sequence=2,
+                base_server_cursor=current.latest_server_cursor,
+                base_object_revision=current.object_revision + 1,
+                base_object_hash=current.object_hash,
+                object_revision=2,
+                payload={"title": "Stale", "body": "Do not apply."},
+                payload_hash="sha256:stale",
+            ),
+            _note_envelope(
+                client_envelope_id="env-after-conflict",
+                object_id="note-2",
+                client_sequence=3,
+                object_revision=1,
+                payload={"title": "Skipped", "body": "Should not be applied."},
+                payload_hash="sha256:note-2",
+            ),
+        ],
+    )
+
+    assert [item.client_envelope_id for item in result.conflicts] == ["env-stale"]
+    assert [(item.client_envelope_id, item.error_code) for item in result.rejected] == [
+        ("env-after-conflict", "stopped_after_conflict")
+    ]
+    assert sync_service.store.get_object_state("dataset-1", "notes.note", "note-2") is None
+
+
 def test_pull_paginates_across_hidden_materialization_conflict(
     sync_service: SyncV2Service,
 ) -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -260,6 +261,44 @@ def test_restore_preview_empty_inventory_returns_safe_applies_ranges_counts_and_
         ("chat.conversation", 2, 2, 1),
         ("chat.message", 3, 3, 1),
     ]
+
+
+def test_restore_preview_paginates_past_scan_limit_without_truncating_domain(
+    sync_service: SyncV2Service,
+) -> None:
+    sync_service.settings = replace(sync_service.settings, restore_manifest_scan_limit=2)
+    _push(
+        sync_service,
+        _note_envelope(
+            object_id="note-1",
+            client_envelope_id="env-note-1",
+            client_sequence=1,
+            payload_hash="sha256:note-1",
+        ),
+        _note_envelope(
+            object_id="note-2",
+            client_envelope_id="env-note-2",
+            client_sequence=2,
+            payload_hash="sha256:note-2",
+        ),
+        _note_envelope(
+            object_id="note-3",
+            client_envelope_id="env-note-3",
+            client_sequence=3,
+            payload_hash="sha256:note-3",
+        ),
+    )
+
+    preview = sync_service.restore_preview(
+        user_id="user-1",
+        dataset_ids=["dataset-1"],
+        domains=["notes.note"],
+        local_inventory=[],
+    )
+
+    assert [item.object_id for item in preview.safe_applies] == ["note-1", "note-2", "note-3"]
+    assert preview.datasets[0].latest_cursors == {"notes.note": 3}
+    assert preview.envelope_ranges[0].envelope_count == 3
     assert preview.object_conflicts == []
     assert preview.tombstones == []
     assert preview.encryption["policy"] == "server_trusted_v1"

--- a/tldw_Server_API/tests/Sync/test_sync_v2_retention.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_retention.py
@@ -58,6 +58,7 @@ def sync_service(sync_store: SyncV2Store, tmp_path: Path) -> SyncV2Service:
         [
             StaticSyncAdapter(domain="notes.note", supported_adapter_versions={1}),
             StaticSyncAdapter(domain="attachment.ref", supported_adapter_versions={1}),
+            StaticSyncAdapter(domain="workspaces.source_ref", supported_adapter_versions={1}),
         ]
     )
     service = SyncV2Service(
@@ -273,6 +274,64 @@ def test_retention_dry_run_reports_eligible_candidate_after_all_devices_ack(
     assert dry_run.blocker_counts == {}
     assert dry_run.candidates[0].server_sequence == first.server_sequence
     assert dry_run.candidates[0].blockers == []
+
+
+def test_workspace_retention_blocks_until_ack_scope_is_explicit(
+    sync_service: SyncV2Service,
+) -> None:
+    sync_service.workspace_access_checker = lambda _user_id, workspace_id, permission: (
+        workspace_id == "workspace-1" and permission == "sync"
+    )
+    sync_service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        scope_type="workspace",
+        workspace_id="workspace-1",
+        domains=["workspaces.source_ref"],
+    )
+    first = sync_service.push(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        device_id="device-1",
+        envelopes=[
+            _note_envelope(
+                dataset_id="workspace-dataset",
+                domain="workspaces.source_ref",
+                client_envelope_id="workspace-note-v1",
+            )
+        ],
+    ).accepted[0]
+    sync_service.push(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        device_id="device-1",
+        envelopes=[
+            _note_envelope(
+                dataset_id="workspace-dataset",
+                domain="workspaces.source_ref",
+                client_envelope_id="workspace-note-v2",
+                client_sequence=2,
+                object_revision=2,
+                base_server_cursor=first.server_sequence,
+                base_object_revision=1,
+                base_object_hash="sha256:note-v1",
+                payload_hash="sha256:note-v2",
+            )
+        ],
+    )
+
+    dry_run = sync_service.retention_dry_run(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        audit_mode=False,
+        minimum_envelope_age_seconds=0,
+        minimum_tombstone_age_seconds=0,
+        offline_restore_window_seconds=0,
+    )
+
+    assert dry_run.candidates
+    assert "retention_workspace_ack_scope_unknown" in dry_run.candidates[0].blockers
+    assert dry_run.blocker_counts["retention_workspace_ack_scope_unknown"] >= 1
 
 
 def test_retention_dry_run_blocks_candidates_during_offline_restore_window(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_service.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_service.py
@@ -4513,6 +4513,67 @@ def test_blob_upload_session_chunk_and_complete_flow_commits_blob(
     assert quota.active_upload_count == 0
 
 
+def test_blob_upload_completion_returns_committed_blob_when_cleanup_fails(
+    sync_store: SyncV2Store,
+    registry: SyncAdapterRegistry,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    blob_store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    service = SyncV2Service(
+        store=sync_store,
+        adapters=registry,
+        clock=_clock,
+        id_factory=lambda prefix: f"{prefix}-generated",
+        blob_store=blob_store,
+        settings=SyncV2Settings(
+            supports_attachments=True,
+            max_blob_bytes=64,
+            max_chunk_bytes=16,
+            server_trusted_encryption=_ready_encryption(),
+        ),
+    )
+    _register_devices(service, "user-1", "device-1")
+    service.enroll_dataset(user_id="user-1", dataset_id="dataset-1", domains=["notes.note", "attachment.ref"])
+    payload = b"cleanup failure"
+    session = service.create_blob_upload_session(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        device_id="device-1",
+        domain="notes.note",
+        entity_id="note-1",
+        attachment_id="attachment-1",
+        content_type="application/octet-stream",
+        size_bytes=len(payload),
+        payload_hash=_sha256(payload),
+        chunk_size=len(payload),
+        chunk_count=1,
+    )
+    service.upload_blob_chunk(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=session.upload_id,
+        chunk_index=0,
+        offset_bytes=0,
+        chunk_payload=payload,
+        chunk_hash=_sha256(payload),
+    )
+
+    def fail_discard(_upload_id: str) -> None:
+        raise OSError("cleanup blocked")
+
+    monkeypatch.setattr(blob_store, "discard_upload", fail_discard)
+
+    blob = service.complete_blob_upload(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=session.upload_id,
+    )
+
+    assert blob.status == "available"
+    assert blob_store.read_blob(blob.storage_key) == payload
+
+
 def test_blob_upload_rejects_bad_hash_domain_and_quota(
     sync_store: SyncV2Store,
     registry: SyncAdapterRegistry,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_workspace_blobs.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_workspace_blobs.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2.adapters import StaticSyncAdapter, SyncAdapterRegistry
+from tldw_Server_API.app.core.Sync.v2.blob_store import LocalSyncBlobStore
+from tldw_Server_API.app.core.Sync.v2.security import server_trusted_encryption_status_from_config
+from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service, SyncV2Settings
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _ready_encryption():
+    return server_trusted_encryption_status_from_config(
+        mode="managed_storage",
+        server_trusted_enabled=True,
+        auth_mode="multi_user",
+    )
+
+
+def test_workspace_blob_download_is_dataset_scoped_not_uploader_scoped(tmp_path: Path) -> None:
+    service = SyncV2Service(
+        store=SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync_v2_workspace_blobs.db")),
+        adapters=SyncAdapterRegistry(
+            [
+                StaticSyncAdapter(domain="workspaces.source_ref", supported_adapter_versions={1}),
+            ]
+        ),
+        blob_store=LocalSyncBlobStore(tmp_path / "sync_blobs"),
+        settings=SyncV2Settings(
+            supports_attachments=True,
+            max_blob_bytes=1024,
+            max_chunk_bytes=128,
+            server_trusted_encryption=_ready_encryption(),
+        ),
+        workspace_access_checker=lambda _user_id, workspace_id, permission: (
+            workspace_id == "workspace-1" and permission == "sync"
+        ),
+    )
+    service.register_device(
+        user_id="user-1",
+        device_id="owner-device",
+        display_name="Owner",
+        client_type="chatbook",
+    )
+    service.register_device(
+        user_id="user-2",
+        device_id="member-device",
+        display_name="Member",
+        client_type="chatbook",
+    )
+    service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        scope_type="workspace",
+        workspace_id="workspace-1",
+        domains=["workspaces.source_ref"],
+    )
+    payload = b"workspace payload"
+    session = service.create_blob_upload_session(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        device_id="owner-device",
+        domain="workspaces.source_ref",
+        entity_id="source-1",
+        attachment_id="attachment-1",
+        content_type="application/octet-stream",
+        size_bytes=len(payload),
+        payload_hash=_sha256(payload),
+        chunk_size=len(payload),
+        chunk_count=1,
+    )
+    service.upload_blob_chunk(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        upload_id=session.upload_id,
+        chunk_index=0,
+        offset_bytes=0,
+        chunk_payload=payload,
+        chunk_hash=_sha256(payload),
+    )
+    service.complete_blob_upload(
+        user_id="user-1",
+        dataset_id="workspace-dataset",
+        upload_id=session.upload_id,
+    )
+
+    manifest = service.blob_download_manifest(
+        user_id="user-2",
+        dataset_id="workspace-dataset",
+        attachment_id="attachment-1",
+    )
+    downloaded = b"".join(
+        service.iter_blob_bytes(
+            user_id="user-2",
+            dataset_id="workspace-dataset",
+            attachment_id="attachment-1",
+        )
+    )
+
+    assert manifest.availability == "available"
+    assert manifest.payload_hash == _sha256(payload)
+    assert downloaded == payload


### PR DESCRIPTION
## Summary

- Addresses requested sync v2 review findings discovered after PR #2030 merged.
- Aligns the M1 push/pull API contract with the locked client-facing shape while preserving hidden compatibility aliases.
- Hardens restore preview pagination, blob upload/download behavior, workspace retention safety, and M2 blob transfer configuration.

## Why

These fixes close correctness and production-enablement gaps in the sync v2 follow-up work:

- restore previews must not silently truncate large per-domain histories;
- clients need the locked M1 request/response contract to interoperate cleanly;
- resumable blobs need safe streaming limits, retryable completion semantics, and production factory configuration;
- workspace-scoped blobs and retention must avoid owner-device assumptions.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sync` -> 424 passed, 6 warnings
- `git diff --check` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/sync.py tldw_Server_API/app/api/v1/schemas/sync_v2_models.py tldw_Server_API/app/core/Sync/v2/service.py tldw_Server_API/app/core/Sync/v2/blob_store.py tldw_Server_API/app/core/Sync/v2/factory.py -f json -o /tmp/bandit_sync_v2_review_fixes_pr2030.json` -> 0 findings

## Merge Gate

- [ ] Human requester must add the required `Change summary` before this AI-authored PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sync v2 review follow-ups: aligns the M1 push/pull API, prevents restore preview truncation, and hardens blob upload/download and workspace behavior for production use.

- **Bug Fixes**
  - Restore preview paginates per-domain past the scan limit to avoid silent truncation.
  - Pull endpoint accepts M1 aliases: `limit` and `include_same_device_echoes` (legacy `page_size`/`include_own_changes` kept as hidden aliases).
  - Blob chunk uploads use bounded streaming; oversize requests return 413 `sync_blob_chunk_too_large`. Blob completion is retry-safe (staged chunks persist if DB commit fails), and per-upload unique temp files avoid same-hash commit collisions.
  - Workspace correctness: blob downloads in workspace datasets are dataset-scoped (not uploader-scoped). Retention blocks until workspace ack scope is explicit.
  - Fail-fast on invalid Sync v2 numeric env values; export `SyncPushOptions` in the public schema.

- **New Features**
  - Honors M1 push fields: accepts `client_profile_id` and `base_server_cursor`; `options.stop_on_conflict` stops the batch after the first conflict.
  - Production config for M2 blob transfer via env vars; disabled by default. Added `SYNC_V2_ENABLE_BLOB_TRANSFER`, `SYNC_V2_BLOB_STORE_PATH`, `SYNC_V2_MAX_BLOB_BYTES`, `SYNC_V2_MAX_CHUNK_BYTES`, `SYNC_V2_MAX_ACTIVE_BLOB_UPLOADS`, `SYNC_V2_USER_BLOB_QUOTA_BYTES` (documented). Default blob store path is shared: `_sync_v2_blobs`.

<sup>Written for commit 0ba5878a8b426d5ffda821bca1ab4e0435bf2499. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2043?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

