### PR TITLE
Fix notes image attachment save

### DIFF
--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability-followup.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability-followup.test.tsx
@@ -182,7 +182,7 @@ describe("NotesManagerPage stage 1 editor reliability follow-up", () => {
         }
       }
 
-      if (path.startsWith("/api/v1/notes/11?expected_version=") && method === "PUT") {
+      if (path === "/api/v1/notes/11" && method === "PUT") {
         return { id: 11, version: 2 }
       }
 

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
@@ -152,7 +152,7 @@ const updateCalls = () =>
   mockBgRequest.mock.calls.filter(([request]) => {
     const path = String(request?.path || "")
     const method = String(request?.method || "GET").toUpperCase()
-    return path.startsWith("/api/v1/notes/11?expected_version=") && method === "PUT"
+    return path === "/api/v1/notes/11" && method === "PUT"
   })
 
 describe("NotesManagerPage stage 1 editor reliability", () => {
@@ -189,7 +189,7 @@ describe("NotesManagerPage stage 1 editor reliability", () => {
         }
       }
 
-      if (path.startsWith("/api/v1/notes/11?expected_version=") && method === "PUT") {
+      if (path === "/api/v1/notes/11" && method === "PUT") {
         return { id: 11, version: 2 }
       }
 

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
@@ -155,6 +155,13 @@ const updateCalls = () =>
     return path === "/api/v1/notes/11" && method === "PUT"
   })
 
+const callsFor = (path: string, method: string) =>
+  mockBgRequest.mock.calls.filter(([request]) => {
+    const requestPath = String(request?.path || "")
+    const requestMethod = String(request?.method || "GET").toUpperCase()
+    return requestPath === path && requestMethod === method.toUpperCase()
+  })
+
 describe("NotesManagerPage stage 1 editor reliability", () => {
   beforeEach(() => {
     cleanup()
@@ -293,6 +300,84 @@ describe("NotesManagerPage stage 1 editor reliability", () => {
       expect(createCalls()).toHaveLength(0)
     })
     expect(screen.getByTestId("notes-editor-empty-state")).toBeInTheDocument()
+  })
+
+  it("encodes reserved note ids for save refresh requests", async () => {
+    const reservedId = "folder/note?image#1"
+    const rawPath = `/api/v1/notes/${reservedId}`
+    const encodedPath = `/api/v1/notes/${encodeURIComponent(reservedId)}`
+    let detailLoadCount = 0
+
+    mockBgRequest.mockImplementation(async (request: { path?: string; method?: string }) => {
+      const path = String(request.path || "")
+      const method = String(request.method || "GET").toUpperCase()
+
+      if (path.startsWith("/api/v1/notes/?")) {
+        return {
+          items: [],
+          pagination: { total_items: 0, total_pages: 1 }
+        }
+      }
+
+      if (path === "/api/v1/notes/" && method === "POST") {
+        return { id: reservedId }
+      }
+
+      if ((path === rawPath || path === encodedPath) && method === "GET") {
+        detailLoadCount += 1
+        return {
+          id: reservedId,
+          title: "Reserved route note",
+          content: detailLoadCount === 1 ? "Saved first pass" : "Updated reserved route note",
+          metadata: { keywords: [] },
+          ...(detailLoadCount === 1 ? {} : { version: detailLoadCount })
+        }
+      }
+
+      if (path === encodedPath && method === "PUT") {
+        return { id: reservedId }
+      }
+
+      return {}
+    })
+
+    renderPage()
+
+    const titleInput = screen.getByPlaceholderText("Title")
+    const contentInput = screen.getByPlaceholderText(
+      "Write your note here... (Markdown supported)"
+    )
+
+    fireEvent.change(titleInput, {
+      target: { value: "Reserved route note" }
+    })
+    fireEvent.change(contentInput, {
+      target: { value: "Saved first pass" }
+    })
+
+    fireEvent.focus(contentInput)
+    fireEvent.keyDown(contentInput, { key: "s", ctrlKey: true })
+
+    await waitFor(() => {
+      expect(createCalls()).toHaveLength(1)
+    })
+
+    fireEvent.change(contentInput, {
+      target: { value: "Updated reserved route note" }
+    })
+
+    fireEvent.focus(titleInput)
+    fireEvent.keyDown(titleInput, { key: "s", metaKey: true })
+
+    await waitFor(() => {
+      expect(callsFor(encodedPath, "PUT")).toHaveLength(1)
+    })
+
+    expect(callsFor(rawPath, "GET")).toHaveLength(0)
+    expect(callsFor(encodedPath, "GET").length).toBeGreaterThanOrEqual(3)
+    expect(callsFor(encodedPath, "PUT")[0]?.[0]?.headers).toMatchObject({
+      "expected-version": "2"
+    })
   })
 
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage34.keyword-partial-save-warning.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage34.keyword-partial-save-warning.test.tsx
@@ -145,7 +145,7 @@ const updateCalls = () =>
   mockBgRequest.mock.calls.filter(([request]) => {
     const path = String(request?.path || "")
     const method = String(request?.method || "GET").toUpperCase()
-    return path.startsWith("/api/v1/notes/11?expected_version=") && method === "PUT"
+    return path === "/api/v1/notes/11" && method === "PUT"
   })
 
 describe("NotesManagerPage stage 34 keyword partial save warnings", () => {
@@ -187,7 +187,7 @@ describe("NotesManagerPage stage 34 keyword partial save warnings", () => {
         }
       }
 
-      if (path.startsWith("/api/v1/notes/11?expected_version=") && method === "PUT") {
+      if (path === "/api/v1/notes/11" && method === "PUT") {
         return {
           id: 11,
           version: 2,

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage4.revision-attachments.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage4.revision-attachments.test.tsx
@@ -102,6 +102,14 @@ vi.mock('@/store/option', () => ({
     })
 }))
 
+vi.mock('@/store/tutorials', () => ({
+  useTutorialStore: {
+    getState: () => ({
+      startTutorial: vi.fn()
+    })
+  }
+}))
+
 vi.mock('@/services/settings/registry', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/services/settings/registry')>()
   return {
@@ -184,7 +192,7 @@ describe('NotesManagerPage stage 4 revision and attachments groundwork', () => {
         }
       }
 
-      if (path.startsWith('/api/v1/notes/22?expected_version=') && method === 'PUT') {
+      if (path === '/api/v1/notes/22' && method === 'PUT') {
         return {
           id: 22,
           version: 2,
@@ -267,6 +275,54 @@ describe('NotesManagerPage stage 4 revision and attachments groundwork', () => {
     })
     expect(uploadCalls.length).toBeGreaterThan(0)
     expect(uploadCalls[0][0]?.body).toBeInstanceOf(FormData)
+  })
+
+  it('saves inserted image attachment markdown with the backend version header', async () => {
+    renderPage()
+
+    fireEvent.change(screen.getByPlaceholderText('Title'), {
+      target: { value: 'Attachment save note' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('Write your note here... (Markdown supported)'), {
+      target: { value: 'Body' }
+    })
+    fireEvent.click(screen.getByTestId('notes-save-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notes-editor-revision-meta')).toHaveTextContent('Version 1')
+    })
+
+    const textarea = screen.getByPlaceholderText(
+      'Write your note here... (Markdown supported)'
+    ) as HTMLTextAreaElement
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+
+    const input = screen.getByTestId('notes-attachment-input')
+    const image = new File(['image-bytes'], 'diagram.png', { type: 'image/png' })
+    fireEvent.change(input, { target: { files: [image] } })
+
+    await waitFor(() => {
+      expect(textarea.value).toContain(
+        '![diagram.png](/api/v1/notes/22/attachments/diagram.png)'
+      )
+    })
+
+    fireEvent.click(screen.getByTestId('notes-save-button'))
+
+    await waitFor(() => {
+      const updateCall = mockBgRequest.mock.calls.find(([request]) => {
+        const path = String(request?.path || '')
+        const method = String(request?.method || 'GET').toUpperCase()
+        return path === '/api/v1/notes/22' && method === 'PUT'
+      })
+      expect(updateCall?.[0]?.headers).toMatchObject({
+        'Content-Type': 'application/json',
+        'expected-version': '1'
+      })
+      expect(updateCall?.[0]?.body?.content).toContain(
+        '![diagram.png](/api/v1/notes/22/attachments/diagram.png)'
+      )
+    })
   })
 
   it('does not intercept native undo shortcuts', () => {

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage41.offline-drafting-sync.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage41.offline-drafting-sync.test.tsx
@@ -136,6 +136,28 @@ vi.mock('@/components/Notes/NotesListPanel', () => ({
 
 const OFFLINE_QUEUE_KEY = 'tldw:notesOfflineDraftQueue:v1'
 
+const ensureLocalStorage = () => {
+  if (typeof window.localStorage !== 'undefined') return
+  const storage = new Map<string, string>()
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => Array.from(storage.keys())[index] ?? null,
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(key, String(value))
+      },
+      get length() {
+        return storage.size
+      }
+    }
+  })
+}
+
 const renderPage = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -161,12 +183,13 @@ const putUpdateCalls = () =>
   mockBgRequest.mock.calls.filter(([request]) => {
     const path = String(request?.path || '')
     const method = String(request?.method || 'GET').toUpperCase()
-    return path.startsWith('/api/v1/notes/11?expected_version=') && method === 'PUT'
+    return path === '/api/v1/notes/11' && method === 'PUT'
   })
 
 describe('NotesManagerPage stage 41 offline drafting and sync', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ensureLocalStorage()
     window.localStorage.clear()
     mockOnlineState.value = true
     mockRemoteVersion.value = 1
@@ -204,7 +227,7 @@ describe('NotesManagerPage stage 41 offline drafting and sync', () => {
         }
       }
 
-      if (path.startsWith('/api/v1/notes/11?expected_version=') && method === 'PUT') {
+      if (path === '/api/v1/notes/11' && method === 'PUT') {
         return {
           id: 11,
           version: mockRemoteVersion.value + 1,

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage9.stale-version-warning.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage9.stale-version-warning.test.tsx
@@ -184,7 +184,7 @@ const setupVersionDriftMock = () => {
         last_modified: "2026-02-18T11:10:00.000Z"
       }
     }
-    if (path.startsWith("/api/v1/notes/note-a?expected_version=") && method === "PUT") {
+    if (path === "/api/v1/notes/note-a" && method === "PUT") {
       return {
         id: "note-a",
         title: "Drift note",
@@ -236,7 +236,7 @@ describe("NotesManagerPage stage 9 stale-version warning", () => {
     const putCalled = mockBgRequest.mock.calls.some(([request]) => {
       const path = String(request?.path || "")
       const method = String(request?.method || "GET").toUpperCase()
-      return path.startsWith("/api/v1/notes/note-a?expected_version=") && method === "PUT"
+      return path === "/api/v1/notes/note-a" && method === "PUT"
     })
     expect(putCalled).toBe(false)
   })

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
@@ -85,6 +85,9 @@ export interface UseNotesEditorStateDeps {
   editorDisabled: boolean
 }
 
+const noteResourcePath = (id: string | number) =>
+  `/api/v1/notes/${encodeURIComponent(String(id))}`
+
 export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
   const {
     isOnline,
@@ -370,7 +373,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     clearAssistUndoState()
     setLoadingDetail(true)
     try {
-      const d = await bgRequest<any>({ path: `/api/v1/notes/${id}` as any, method: 'GET' as any })
+      const d = await bgRequest<any>({ path: noteResourcePath(id) as any, method: 'GET' as any })
       const loadedTitle = String(d?.title || `Note ${id}`)
       setSelectedId(id)
       setTitle(String(d?.title || ''))
@@ -546,7 +549,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     const target = noteId ?? selectedId
     if (target == null) return
     try {
-      const detail = await bgRequest<any>({ path: `/api/v1/notes/${target}` as any, method: 'GET' as any })
+      const detail = await bgRequest<any>({ path: noteResourcePath(target) as any, method: 'GET' as any })
       const version = toNoteVersion(detail)
       if (version != null) setSelectedVersion(version)
       setSelectedLastSavedAt(toNoteLastModified(detail))
@@ -765,7 +768,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
           if (expectedVersion == null) {
             try {
               const latest = await bgRequest<any>({
-                path: `/api/v1/notes/${selectedId}` as any,
+                path: noteResourcePath(selectedId) as any,
                 method: 'GET' as any
               })
               expectedVersion = toNoteVersion(latest)
@@ -785,7 +788,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
             return
           }
           const updated = await bgRequest<any>({
-            path: `/api/v1/notes/${encodeURIComponent(String(selectedId))}` as any,
+            path: noteResourcePath(selectedId) as any,
             method: 'PUT' as any,
             headers: {
               'Content-Type': 'application/json',
@@ -812,7 +815,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
           } else if (selectedId != null) {
             try {
               const latest = await bgRequest<any>({
-                path: `/api/v1/notes/${selectedId}` as any,
+                path: noteResourcePath(selectedId) as any,
                 method: 'GET' as any
               })
               setSelectedVersion(toNoteVersion(latest))
@@ -915,9 +918,9 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
           }
         }
 
-        const encodedId = encodeURIComponent(String(draft.noteId))
+        const draftNotePath = noteResourcePath(draft.noteId)
         const remote = await bgRequest<any>({
-          path: `/api/v1/notes/${encodedId}` as any,
+          path: draftNotePath as any,
           method: 'GET' as any
         })
         const remoteVersion = toNoteVersion(remote)
@@ -942,7 +945,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
         }
 
         const updated = await bgRequest<any>({
-          path: `/api/v1/notes/${encodedId}` as any,
+          path: draftNotePath as any,
           method: 'PUT' as any,
           headers: {
             'Content-Type': 'application/json',
@@ -1457,7 +1460,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     if (saving) return
     try {
       const detail = await bgRequest<any>({
-        path: `/api/v1/notes/${selectedId}` as any,
+        path: noteResourcePath(selectedId) as any,
         method: 'GET' as any
       })
       const remoteVersion = toNoteVersion(detail)
@@ -1842,7 +1845,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
         }
         try {
           const detail = await bgRequest<any>({
-            path: `/api/v1/notes/${encodeURIComponent(noteId)}` as any,
+            path: noteResourcePath(noteId) as any,
             method: 'GET' as any
           })
           return toNoteVersion(detail)

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
@@ -785,11 +785,12 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
             return
           }
           const updated = await bgRequest<any>({
-            path: `/api/v1/notes/${selectedId}?expected_version=${encodeURIComponent(
-              String(expectedVersion)
-            )}` as any,
+            path: `/api/v1/notes/${encodeURIComponent(String(selectedId))}` as any,
             method: 'PUT' as any,
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              'expected-version': String(expectedVersion)
+            },
             body: payload
           })
           const updatedKeywordWarning = toKeywordSyncWarning(updated)
@@ -941,11 +942,12 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
         }
 
         const updated = await bgRequest<any>({
-          path: `/api/v1/notes/${encodedId}?expected_version=${encodeURIComponent(
-            String(expectedVersion)
-          )}` as any,
+          path: `/api/v1/notes/${encodedId}` as any,
           method: 'PUT' as any,
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'expected-version': String(expectedVersion)
+          },
           body: payload
         })
 

--- a/backlog/tasks/task-474 - Fix-notes-image-attachment-save-path.md
+++ b/backlog/tasks/task-474 - Fix-notes-image-attachment-save-path.md
@@ -29,6 +29,7 @@ Investigate and fix user-reported failure saving a note after attaching an image
 - [x] #2 Frontend note update requests send the optimistic lock in the format accepted by the backend.
 - [x] #3 Targeted frontend tests pass.
 - [x] #4 Touched scope is checked with Bandit where applicable, or documented if no Python scope changed.
+- [x] #5 PR #2046 review comments about unencoded note-id refresh requests are addressed.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -37,12 +38,14 @@ Investigate and fix user-reported failure saving a note after attaching an image
 Root cause: NotesManagerPage sent expected_version as a query parameter on PUT /api/v1/notes/{id}, but the backend requires expected-version as a header. Image attachment upload succeeded and inserted markdown, but the next save hit the broken existing-note update path.
 
 Fix: send existing-note save and offline draft sync updates to /api/v1/notes/{id} with the expected-version header. No Python files were touched, so Bandit is not applicable for this task.
+
+Review follow-up: centralized note resource path construction with encodeURIComponent so load, reload, expected-version fallback, save refresh, freshness checks, offline sync, and attachment expected-version lookups all encode note ids consistently.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed notes image attachment save failure by aligning existing-note save requests with the backend optimistic-lock header contract. Added regression coverage for saving inserted image attachment markdown and updated related notes save/conflict/offline tests. Verification: bunx vitest run the six touched NotesManagerPage test files -- 6 files, 17 tests passed. Touched-file git diff --check passed. Repo-wide git diff --check still reports an unrelated pre-existing trailing whitespace issue in Docs/Design/Agents.md.
+Fixed notes image attachment save failure by aligning existing-note save requests with the backend optimistic-lock header contract. Added regression coverage for saving inserted image attachment markdown and reserved-character note ids, and updated related notes save/conflict/offline tests. PR #2046 review follow-up now encodes note ids consistently across the hook's note-resource GET and PUT paths. Verification: bunx vitest run the six touched NotesManagerPage test files -- 6 files, 18 tests passed. Touched-file git diff --check passed. Repo-wide git diff --check still reports an unrelated pre-existing trailing whitespace issue in Docs/Design/Agents.md.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-474 - Fix-notes-image-attachment-save-path.md
+++ b/backlog/tasks/task-474 - Fix-notes-image-attachment-save-path.md
@@ -1,0 +1,56 @@
+---
+id: TASK-474
+title: Fix notes image attachment save path
+status: Done
+labels:
+- bug
+- notes
+- frontend
+priority: high
+modified_files:
+- apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
+- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage4.revision-attachments.test.tsx
+- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
+- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability-followup.test.tsx
+- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage9.stale-version-warning.test.tsx
+- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage34.keyword-partial-save-warning.test.tsx
+- apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage41.offline-drafting-sync.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix user-reported failure saving a note after attaching an image. Suspected root cause: frontend notes save sends expected_version as a query parameter while the notes update endpoint requires the expected-version header.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A regression test covers saving note content after an image attachment is inserted.
+- [x] #2 Frontend note update requests send the optimistic lock in the format accepted by the backend.
+- [x] #3 Targeted frontend tests pass.
+- [x] #4 Touched scope is checked with Bandit where applicable, or documented if no Python scope changed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause: NotesManagerPage sent expected_version as a query parameter on PUT /api/v1/notes/{id}, but the backend requires expected-version as a header. Image attachment upload succeeded and inserted markdown, but the next save hit the broken existing-note update path.
+
+Fix: send existing-note save and offline draft sync updates to /api/v1/notes/{id} with the expected-version header. No Python files were touched, so Bandit is not applicable for this task.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed notes image attachment save failure by aligning existing-note save requests with the backend optimistic-lock header contract. Added regression coverage for saving inserted image attachment markdown and updated related notes save/conflict/offline tests. Verification: bunx vitest run the six touched NotesManagerPage test files -- 6 files, 17 tests passed. Touched-file git diff --check passed. Repo-wide git diff --check still reports an unrelated pre-existing trailing whitespace issue in Docs/Design/Agents.md.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## AI Draft Summary
- Fix existing-note saves in NotesManagerPage to send optimistic locking as the backend-required `expected-version` header.
- Add regression coverage for the reported flow: upload an image attachment, insert the image markdown, then save the note.
- Update adjacent notes save, conflict, keyword warning, and offline sync tests to model the header-based update path.

## Why
Image attachment upload succeeded and inserted markdown into the editor, but the next save used the existing-note update path. That path sent `expected_version` in the query string while `PUT /api/v1/notes/{id}` requires `expected-version` as a header, so saving after attaching an image could fail.

## Test Plan
- [x] `bunx vitest run ../packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx ../packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability-followup.test.tsx ../packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage4.revision-attachments.test.tsx ../packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage9.stale-version-warning.test.tsx ../packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage34.keyword-partial-save-warning.test.tsx ../packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage41.offline-drafting-sync.test.tsx --maxWorkers=1 --no-file-parallelism`
- [x] `git diff --check`

## Merge Note
Per the repo AI-generated PR merge gate, the human requester still needs to add or own the final `Change summary` before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes saving a note after inserting an image attachment by sending the `expected-version` header on updates. Also encodes note IDs for all note GET/PUT requests to handle reserved characters.

- **Bug Fixes**
  - Send `expected-version` header for existing-note saves and offline draft sync.
  - Encode note IDs in all note GET/PUT paths to avoid unencoded reserved characters.
  - Add regression tests for image markdown save and reserved-character IDs; update related tests to the header-based update path.

<sup>Written for commit 842754a14b5e1e04e243d31a41172479256e5146. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2046?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

