### PR TITLE
Add WebUI launch modes to quick-launch scripts

### DIFF
--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -23,15 +23,15 @@ No-`make` shortcut scripts from the repository root:
 
 ```bash
 # macOS/Linux terminal
-./quick-launch.sh
+./quick-launch.sh all
 ```
 
 ```powershell
 # Windows PowerShell
-.\quick-launch.ps1
+.\quick-launch.ps1 all
 ```
 
-On macOS, you can also double-click `quick-launch.command` from Finder. These shortcuts create or update `.venv`, run the `local-single` setup wizard, and start the API at `http://127.0.0.1:8000`.
+On macOS, you can also double-click `quick-launch.command` from Finder. These shortcuts create or update `.venv`, run the `local-single` setup wizard when the API is started, and default to `all`: API at `http://127.0.0.1:8000` plus WebUI at `http://127.0.0.1:8080`. Use `api` for backend-only startup or `webui` when the API is already running.
 
 PowerShell / manual no-`make` equivalent:
 

--- a/Docs/superpowers/plans/2026-05-24-quick-launch-webui-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-24-quick-launch-webui-implementation-plan.md
@@ -1,0 +1,73 @@
+# Consolidated Quick-Launch WebUI Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the repo-root quick-launch scripts the canonical no-Docker API/WebUI launcher and reduce installer run scripts to compatibility wrappers.
+
+**Architecture:** Root launchers own setup and launch behavior: local-single API setup through the existing wizard, WebUI launch from `apps/tldw-frontend`, and `api`/`webui`/`all` modes. Installer run scripts only resolve their installed checkout and delegate to the root launcher with legacy `venv` defaults.
+
+**Tech Stack:** Bash, PowerShell, Windows batch compatibility wrappers, FastAPI/Uvicorn, Next.js WebUI via Bun, pytest contract tests, Bandit.
+
+---
+
+### Task 1: Canonical Launcher Contract Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Utils/test_quick_launch_scripts.py`
+- Delete: `Helper_Scripts/Installer_Scripts/Tests/test_run_tldw_launchers.py`
+
+- [x] Write tests requiring root `quick-launch.sh` and `quick-launch.ps1` to expose `api`, `webui`, and `all` modes with default `all`.
+- [x] Assert root launchers keep the local-single setup contract, launch FastAPI through `tldw_Server_API.app.main:app`, and launch the WebUI from `apps/tldw-frontend` with Bun.
+- [x] Assert installer run scripts delegate to root quick-launch scripts instead of duplicating launch logic.
+- [x] Run `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_quick_launch_scripts.py -v` and confirm the new tests fail before implementation.
+
+### Task 2: Root Bash Launcher
+
+**Files:**
+- Modify: `quick-launch.sh`
+- Modify: `quick-launch.command`
+
+- [x] Add mode parsing for `api`, `webui`, `all`, and help. Default to `all`.
+- [x] Preserve venv creation, editable install, and local-single wizard init for API/all modes.
+- [x] Add WebUI launch from `apps/tldw-frontend`, Bun checks, `TLDW_WEBUI_PORT`, and `NEXT_PUBLIC_API_URL`.
+- [x] For `all`, start API in the background, run WebUI in the foreground, and clean up the API process on exit.
+- [x] Keep `quick-launch.command` as a Finder-friendly wrapper around `quick-launch.sh`.
+
+### Task 3: Root PowerShell Launcher
+
+**Files:**
+- Modify: `quick-launch.ps1`
+
+- [x] Add a positional `Mode` parameter for `api`, `webui`, and `all`, defaulting to `all`.
+- [x] Preserve Windows venv creation, editable install, and local-single wizard init for API/all modes.
+- [x] Add WebUI launch from `apps/tldw-frontend`, Bun checks, `TLDW_WEBUI_PORT`, and `NEXT_PUBLIC_API_URL`.
+- [x] For `all`, start the API in a new PowerShell process and run WebUI in the current console.
+
+### Task 4: Installer Compatibility Wrappers
+
+**Files:**
+- Modify: `Helper_Scripts/Installer_Scripts/MacOS_Run_tldw.sh`
+- Modify: `Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh`
+- Modify: `Helper_Scripts/Installer_Scripts/Windows_Run_tldw.bat`
+- Modify: `Helper_Scripts/Installer_Scripts/MacOS_Install_Update.sh`
+- Modify: `Helper_Scripts/Installer_Scripts/Linux_Install_Update.sh`
+- Modify: `Helper_Scripts/Installer_Scripts/Windows_Install_Update.bat`
+
+- [x] Replace duplicated installer run logic with wrappers that resolve the installed checkout and delegate to root quick-launch scripts.
+- [x] Default installer wrappers to `TLDW_VENV_DIR=venv` and `TLDW_SKIP_INSTALL=1` so they reuse legacy installer environments.
+- [x] Keep installer completion output pointing to `all`, `api`, and `webui` modes.
+
+### Task 5: Documentation, Backlog, And Verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
+- Modify: `backlog/tasks/task-500 - Add-WebUI-support-to-OS-quick-launch-scripts.md`
+- Modify: `Docs/superpowers/plans/2026-05-24-quick-launch-webui-implementation-plan.md`
+
+- [x] Update local quick-launch docs so root scripts are described as API + WebUI launchers by default, with API-only and WebUI-only modes.
+- [x] Update Backlog task `TASK-500` with consolidated scope, touched files, and final verification.
+- [x] Run `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_quick_launch_scripts.py -v`.
+- [x] Run Bash syntax checks for touched shell scripts.
+- [x] Run Bandit on the touched Python test file.
+- [x] Run `git diff --check`.

--- a/Helper_Scripts/Installer_Scripts/Linux_Install_Update.sh
+++ b/Helper_Scripts/Installer_Scripts/Linux_Install_Update.sh
@@ -151,11 +151,7 @@ fi
 
 log "Installation/Update process completed"
 echo "Installation/Update completed successfully!"
-echo "To run TLDW, use the run_tldw.sh script"
-echo "Which is what I'm doing for you now..."
-# Run TLDW
-cd "tldw" || exit
-source venv/bin/activate
-python3 summarize.py -gui
-deactivate
-echo "TLDW has been ran. Goodbye!"
+echo "To launch tldw_server, use Linux_Run_tldw.sh:"
+echo "  bash Linux_Run_tldw.sh all    # API + WebUI"
+echo "  bash Linux_Run_tldw.sh api    # API only"
+echo "  bash Linux_Run_tldw.sh webui  # WebUI only"

--- a/Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh
+++ b/Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh
@@ -1,21 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Compatibility launcher for installs created by Linux_Install_Update.sh.
 
-# TLDW Run Script
+set -euo pipefail
 
-install_dir="$(dirname "$0")/tldw"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install_dir="${TLDW_INSTALL_DIR:-$script_dir/tldw}"
+launcher="$install_dir/quick-launch.sh"
 
-if [ ! -d "$install_dir" ]; then
-    echo "TLDW installation not found. Please run the install_update_tldw.sh script first."
+if [ ! -f "$launcher" ]; then
+    echo "tldw_server launcher not found at: $launcher" >&2
+    echo "Run Linux_Install_Update.sh first, or set TLDW_INSTALL_DIR to a checkout that contains quick-launch.sh." >&2
     exit 1
 fi
 
-cd "$install_dir" || exit
+export TLDW_VENV_DIR="${TLDW_VENV_DIR:-venv}"
+export TLDW_SKIP_INSTALL="${TLDW_SKIP_INSTALL:-1}"
 
-# Activate virtual environment
-source venv/bin/activate
-
-# Run TLDW
-python3 summarize.py -gui
-
-# Deactivate virtual environment when done
-deactivate
+cd "$install_dir"
+exec bash "$launcher" "$@"

--- a/Helper_Scripts/Installer_Scripts/MacOS_Install_Update.sh
+++ b/Helper_Scripts/Installer_Scripts/MacOS_Install_Update.sh
@@ -160,12 +160,7 @@ fi
 
 log "Installation/Update process completed"
 echo "Installation/Update completed successfully!"
-echo "To run TLDW, use the run_tldw.sh script"
-echo "To run TLDW, use the run_tldw.sh script"
-echo "Which is what I'm doing for you now..."
-# Run TLDW
-cd "$install_dir" || exit
-source venv/bin/activate
-python3 summarize.py -gui
-deactivate
-echo "TLDW has been ran. Goodbye!"
+echo "To launch tldw_server, use MacOS_Run_tldw.sh:"
+echo "  bash MacOS_Run_tldw.sh all    # API + WebUI"
+echo "  bash MacOS_Run_tldw.sh api    # API only"
+echo "  bash MacOS_Run_tldw.sh webui  # WebUI only"

--- a/Helper_Scripts/Installer_Scripts/MacOS_Run_tldw.sh
+++ b/Helper_Scripts/Installer_Scripts/MacOS_Run_tldw.sh
@@ -1,21 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Compatibility launcher for installs created by MacOS_Install_Update.sh.
 
-# TLDW Run Script for macOS
+set -euo pipefail
 
-install_dir="$(dirname "$0")/tldw"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install_dir="${TLDW_INSTALL_DIR:-$script_dir/tldw}"
+launcher="$install_dir/quick-launch.sh"
 
-if [ ! -d "$install_dir" ]; then
-    echo "TLDW installation not found. Please run the install_update_tldw.sh script first."
+if [ ! -f "$launcher" ]; then
+    echo "tldw_server launcher not found at: $launcher" >&2
+    echo "Run MacOS_Install_Update.sh first, or set TLDW_INSTALL_DIR to a checkout that contains quick-launch.sh." >&2
     exit 1
 fi
 
-cd "$install_dir" || exit
+export TLDW_VENV_DIR="${TLDW_VENV_DIR:-venv}"
+export TLDW_SKIP_INSTALL="${TLDW_SKIP_INSTALL:-1}"
 
-# Activate virtual environment
-source venv/bin/activate
-
-# Run TLDW
-python3 summarize.py -gui
-
-# Deactivate virtual environment when done
-deactivate
+cd "$install_dir"
+exec bash "$launcher" "$@"

--- a/Helper_Scripts/Installer_Scripts/Windows_Install_Update.bat
+++ b/Helper_Scripts/Installer_Scripts/Windows_Install_Update.bat
@@ -45,7 +45,10 @@ if exist "%install_dir%" (
 call :cleanup
 call :log "Installation/Update process completed"
 echo Installation/Update completed successfully!
-echo To run TLDW, use the run_tldw.bat script.
+echo To launch tldw_server, use Windows_Run_tldw.bat:
+echo   Windows_Run_tldw.bat all    ^(API + WebUI^)
+echo   Windows_Run_tldw.bat api    ^(API only^)
+echo   Windows_Run_tldw.bat webui  ^(WebUI only^)
 pause
 exit /b 0
 

--- a/Helper_Scripts/Installer_Scripts/Windows_Run_tldw.bat
+++ b/Helper_Scripts/Installer_Scripts/Windows_Run_tldw.bat
@@ -1,25 +1,20 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal
 
-:: TLDW Run Script
+:: Compatibility launcher for installs created by Windows_Install_Update.bat.
 
 set "install_dir=%~dp0tldw"
+if not "%TLDW_INSTALL_DIR%"=="" set "install_dir=%TLDW_INSTALL_DIR%"
+set "launcher=%install_dir%\quick-launch.ps1"
 
-if not exist "%install_dir%" (
-    echo TLDW installation not found. Please run the install_update_tldw.bat script first.
-    pause
+if not exist "%launcher%" (
+    echo tldw_server launcher not found at: %launcher%
+    echo Run Windows_Install_Update.bat first, or set TLDW_INSTALL_DIR to a checkout that contains quick-launch.ps1.
     exit /b 1
 )
 
-cd "%install_dir%"
+if "%TLDW_VENV_DIR%"=="" set "TLDW_VENV_DIR=venv"
+if "%TLDW_SKIP_INSTALL%"=="" set "TLDW_SKIP_INSTALL=1"
 
-:: Activate virtual environment
-call .\venv\Scripts\activate.bat
-
-:: Run TLDW
-python summarize.py -gui
-
-:: Deactivate virtual environment when done
-call .\venv\Scripts\deactivate.bat
-
-exit /b 0
+powershell -ExecutionPolicy Bypass -File "%launcher%" %*
+exit /b %errorlevel%

--- a/README.md
+++ b/README.md
@@ -319,10 +319,11 @@ Use these paths when `make` is not available.
 
 Local single-user:
 - Shortcut scripts from the repository root:
-  - macOS/Linux terminal: `./quick-launch.sh`
-  - macOS Finder: double-click `quick-launch.command`
-  - Windows PowerShell: `.\quick-launch.ps1`
-- These scripts create or update `.venv`, run the `local-single` setup wizard, and start the API at `http://127.0.0.1:8000`.
+  - macOS/Linux terminal: `./quick-launch.sh [api|webui|all]`
+  - macOS Finder: double-click `quick-launch.command` for the default `all` mode.
+  - Windows PowerShell: `.\quick-launch.ps1 [api|webui|all]`
+- These scripts create or update `.venv`, run the `local-single` setup wizard when the API is started, and default to `all`: API at `http://127.0.0.1:8000` plus WebUI at `http://127.0.0.1:8080`.
+- Use `api` for backend-only startup or `webui` when the API is already running.
 - For manual control, follow [Manual Setup](#manual-setup) below, then start with `python -m uvicorn tldw_Server_API.app.main:app --reload`.
 
 Docker single-user + WebUI:
@@ -469,6 +470,16 @@ See [MCP System Admin Guide](Docs/MCP/Unified/System_Admin_Guide.md) for details
 | Develop the WebUI or browser extension | [Extension & Web UI Development Guide](apps/DEVELOPMENT.md) |
 
 ### Local Profile: Add the WebUI
+
+The repo-root quick-launch scripts start the local API and WebUI together by default:
+
+```bash
+./quick-launch.sh all
+```
+
+```powershell
+.\quick-launch.ps1 all
+```
 
 If you already completed the [Local Single-User Profile](Docs/Getting_Started/Profile_Local_Single_User.md) and your API is running at `http://127.0.0.1:8000`, this is the shortest add-on path:
 

--- a/backlog/tasks/task-500 - Add-WebUI-support-to-OS-quick-launch-scripts.md
+++ b/backlog/tasks/task-500 - Add-WebUI-support-to-OS-quick-launch-scripts.md
@@ -1,0 +1,77 @@
+---
+id: TASK-500
+title: Add WebUI support to OS quick-launch scripts
+status: Done
+assignee: []
+created_date: '2026-05-24T05:55:00Z'
+updated_date: 2026-05-24 05:55
+labels:
+- quickstart
+- webui
+- installer
+dependencies: []
+priority: medium
+modified_files:
+- quick-launch.sh
+- quick-launch.command
+- quick-launch.ps1
+- Helper_Scripts/Installer_Scripts/MacOS_Run_tldw.sh
+- Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh
+- Helper_Scripts/Installer_Scripts/Windows_Run_tldw.bat
+- Helper_Scripts/Installer_Scripts/MacOS_Install_Update.sh
+- Helper_Scripts/Installer_Scripts/Linux_Install_Update.sh
+- Helper_Scripts/Installer_Scripts/Windows_Install_Update.bat
+- tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
+- README.md
+- Docs/Getting_Started/Profile_Local_Single_User.md
+- Docs/superpowers/plans/2026-05-24-quick-launch-webui-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Consolidate WebUI-capable quick launch behavior around the repo-root quick-launch scripts. Root macOS/Linux shell and Windows PowerShell launchers should support api, webui, and all modes, while installer run scripts become compatibility wrappers that delegate to the root launchers for installed checkouts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Repo-root quick-launch.sh and quick-launch.ps1 support api, webui, and all modes with all as the default.
+- [x] #2 Root quick-launch scripts keep local-single setup for API startup and launch the Next.js WebUI from apps/tldw-frontend via Bun.
+- [x] #3 Installer macOS/Linux/Windows run scripts delegate to the root launchers instead of duplicating API/WebUI launch logic.
+- [x] #4 README and local single-user docs describe the consolidated quick-launch modes and default API + WebUI behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-24-quick-launch-webui-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Red-green coverage recorded in `tldw_Server_API/tests/Utils/test_quick_launch_scripts.py`: the new consolidation assertions first failed against API-only root launchers and duplicated installer run scripts, then passed after consolidation.
+- Verification passed: focused launcher and onboarding docs suites reported 34 passed; Bash syntax checks passed for touched shell launchers and installer scripts; root and wrapper help output returned successfully; Bandit reported no findings for the touched Python test file; `git diff --check` passed.
+- Follow-up PR review fixes: populated the task creation timestamp, corrected user-facing `macOS` casing, validated PowerShell `TLDW_API_START_DELAY`, used the current PowerShell edition for the child API process, and avoided `0.0.0.0` as the default browser-facing WebUI API URL.
+- Follow-up pre-merge fixes: added the missing quick-launch test helper docstring and expanded the PR description to match the repository template sections.
+- Qodo review coverage: added explicit regression assertions for documented launcher tests, direct Uvicorn PID capture in shell all-mode cleanup, and removal of the brittle legacy Windows exit-count assertion.
+- PowerShell parser execution was skipped because neither `pwsh` nor `powershell` is installed on this host.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Consolidated quick-launch behavior around the repo-root launchers. quick-launch.sh and quick-launch.ps1 now support api, webui, and all modes, default to all, preserve local-single API setup, launch the Next.js WebUI from apps/tldw-frontend on port 8080, and set NEXT_PUBLIC_API_URL by default. The installer macOS/Linux/Windows run scripts are now compatibility wrappers that delegate to the root launchers with legacy venv defaults. Documentation now describes the default API + WebUI behavior and mode-specific startup commands. Verification passed with 34 focused launcher/onboarding tests, Bash syntax checks, launcher help checks, Bandit with no findings, and diff whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/quick-launch.ps1
+++ b/quick-launch.ps1
@@ -2,8 +2,12 @@
 
 [CmdletBinding()]
 param(
+    [Parameter(Position = 0)]
+    [ValidateSet("api", "webui", "all", "help")]
+    [string]$Mode = "all",
     [string]$HostAddress,
     [int]$Port,
+    [int]$WebUIPort,
     [switch]$SkipInstall,
     [switch]$ForceInstall
 )
@@ -32,6 +36,14 @@ function Resolve-QuickLaunchPort {
         return $PortParameter
     }
 
+    if ($env:TLDW_API_PORT) {
+        if ($env:TLDW_API_PORT -match '^\d+$') {
+            return [int]$env:TLDW_API_PORT
+        }
+
+        Write-Warning "[quick-launch] Ignoring invalid TLDW_API_PORT='$($env:TLDW_API_PORT)'; checking TLDW_PORT."
+    }
+
     if ($env:TLDW_PORT) {
         if ($env:TLDW_PORT -match '^\d+$') {
             return [int]$env:TLDW_PORT
@@ -43,19 +55,208 @@ function Resolve-QuickLaunchPort {
     return 8000
 }
 
+function Resolve-QuickLaunchWebUIPort {
+    param(
+        [bool]$HasPortParameter,
+        [int]$PortParameter
+    )
+
+    if ($HasPortParameter) {
+        return $PortParameter
+    }
+
+    if ($env:TLDW_WEBUI_PORT) {
+        if ($env:TLDW_WEBUI_PORT -match '^\d+$') {
+            return [int]$env:TLDW_WEBUI_PORT
+        }
+
+        Write-Warning "[quick-launch] Ignoring invalid TLDW_WEBUI_PORT='$($env:TLDW_WEBUI_PORT)'; using 8080."
+    }
+
+    return 8080
+}
+
+function Resolve-QuickLaunchApiUrl {
+    if ($env:NEXT_PUBLIC_API_URL) {
+        return $env:NEXT_PUBLIC_API_URL
+    }
+
+    $ApiUrlHost = $HostAddress
+    if ($ApiUrlHost -eq "0.0.0.0") {
+        $ApiUrlHost = "127.0.0.1"
+        Write-Host "[quick-launch] API is bound to 0.0.0.0; using 127.0.0.1 for local browser requests."
+        Write-Host "[quick-launch] Set NEXT_PUBLIC_API_URL to your LAN URL for non-local browser clients."
+    }
+
+    return "http://$ApiUrlHost`:$Port"
+}
+
+function Resolve-QuickLaunchApiStartDelay {
+    if ($env:TLDW_API_START_DELAY) {
+        if ($env:TLDW_API_START_DELAY -match '^\d+$') {
+            return [int]$env:TLDW_API_START_DELAY
+        }
+
+        Write-Warning "[quick-launch] Ignoring invalid TLDW_API_START_DELAY='$($env:TLDW_API_START_DELAY)'; using 2."
+    }
+
+    return 2
+}
+
+function Show-Usage {
+    Write-Host "Usage: .\quick-launch.ps1 [api|webui|all] [-HostAddress 127.0.0.1] [-Port 8000] [-WebUIPort 8080]"
+    Write-Host ""
+    Write-Host "Modes:"
+    Write-Host "  api     Start the FastAPI backend only on http://$HostAddress`:$Port"
+    Write-Host "  webui   Start the Next.js WebUI only on http://127.0.0.1:$WebUIPort"
+    Write-Host "  all     Start the backend and WebUI (default)"
+    Write-Host ""
+    Write-Host "Environment:"
+    Write-Host "  TLDW_PYTHON          Python executable for venv creation"
+    Write-Host "  TLDW_VENV_DIR        Virtualenv directory (default: .venv)"
+    Write-Host "  TLDW_ENV_FILE        Env file path"
+    Write-Host "  TLDW_HOST            Backend host (default: 127.0.0.1)"
+    Write-Host "  TLDW_API_PORT        Backend port (default: TLDW_PORT or 8000)"
+    Write-Host "  TLDW_PORT            Legacy backend port override"
+    Write-Host "  TLDW_WEBUI_PORT      WebUI port (default: 8080)"
+    Write-Host "  NEXT_PUBLIC_API_URL  Override WebUI API URL"
+}
+
+function Test-Bun {
+    if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+        throw "[quick-launch] Bun is required to launch the WebUI but was not found in PATH. Install Bun from https://bun.sh/docs/installation, then rerun this launcher."
+    }
+}
+
+function Test-WebUIDirectory {
+    if (-not (Test-Path $WebUIDir)) {
+        throw "[quick-launch] WebUI directory not found: $WebUIDir. Update your checkout before launching the WebUI."
+    }
+}
+
+function Initialize-ApiEnvironment {
+    Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"))
+
+    $VenvCreated = $false
+    if (-not (Test-Path $VenvPython)) {
+        Write-Host "[quick-launch] Creating virtualenv at $VenvDir"
+        Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-m", "venv", $VenvDir))
+        $VenvCreated = $true
+    }
+
+    if (
+        -not $SkipInstall `
+        -and $env:TLDW_SKIP_INSTALL -ne "1" `
+        -and ($ForceInstall -or $env:TLDW_FORCE_INSTALL -eq "1" -or $VenvCreated -or -not (Test-Path $InstallMarker))
+    ) {
+        Write-Host "[quick-launch] Installing/updating local Python dependencies..."
+        Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
+        Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "-e", ".")
+        New-Item -Path $InstallMarker -ItemType File -Force | Out-Null
+    } elseif ($SkipInstall -or $env:TLDW_SKIP_INSTALL -eq "1") {
+        Write-Host "[quick-launch] Skipping dependency install"
+    } else {
+        Write-Host "[quick-launch] Dependency setup already completed; set TLDW_FORCE_INSTALL=1 or pass -ForceInstall to reinstall/update."
+    }
+
+    Write-Host "[quick-launch] Configuring local single-user profile..."
+    Invoke-CheckedNative -FilePath $VenvPython -Arguments @(
+        "-m",
+        "tldw_Server_API.cli.wizard.cli",
+        "init",
+        "--profile",
+        "local-single",
+        "--env-file",
+        $EnvFile,
+        "--default",
+        "--yes"
+    )
+}
+
+function run_api {
+    Write-Host "=== tldw_server quick launch: API ==="
+    Write-Host ""
+    Initialize-ApiEnvironment
+
+    Write-Host ""
+    Write-Host "[quick-launch] Starting API at http://$HostAddress`:$Port"
+    Write-Host "[quick-launch] Docs:   http://$HostAddress`:$Port/docs"
+    Write-Host "[quick-launch] Health: http://$HostAddress`:$Port/health"
+    Write-Host ""
+
+    $env:TLDW_ENV_FILE = $EnvFile
+    Invoke-CheckedNative -FilePath $VenvPython -Arguments @(
+        "-m",
+        "uvicorn",
+        "tldw_Server_API.app.main:app",
+        "--host",
+        $HostAddress,
+        "--port",
+        "$Port"
+    )
+}
+
+function run_webui {
+    Test-Bun
+    Test-WebUIDirectory
+
+    $env:NEXT_PUBLIC_API_URL = Resolve-QuickLaunchApiUrl
+
+    Write-Host ""
+    Write-Host "[quick-launch] Starting WebUI at http://127.0.0.1:$WebUIPort"
+    Write-Host "[quick-launch] Using API URL: $($env:NEXT_PUBLIC_API_URL)"
+    Write-Host ""
+
+    Set-Location $WebUIDir
+    Invoke-CheckedNative -FilePath "bun" -Arguments @("run", "dev", "--", "-p", "$WebUIPort")
+}
+
+function run_all {
+    Initialize-ApiEnvironment
+
+    Write-Host "=== tldw_server quick launch: API + WebUI ==="
+    Write-Host "[quick-launch] Starting API in a new PowerShell window at http://$HostAddress`:$Port"
+    Write-Host "[quick-launch] Starting WebUI in this window at http://127.0.0.1:$WebUIPort"
+
+    $apiArgs = @(
+        "-NoExit",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        $PSCommandPath,
+        "api",
+        "-HostAddress",
+        $HostAddress,
+        "-Port",
+        "$Port",
+        "-WebUIPort",
+        "$WebUIPort",
+        "-SkipInstall"
+    )
+    $PsExe = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh" } else { "powershell" }
+    Start-Process -FilePath $PsExe -ArgumentList $apiArgs | Out-Null
+    $ApiStartDelay = Resolve-QuickLaunchApiStartDelay
+    Start-Sleep -Seconds $ApiStartDelay
+    run_webui
+}
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 
 if (-not $HostAddress) {
     $HostAddress = if ($env:TLDW_HOST) { $env:TLDW_HOST } else { "127.0.0.1" }
 }
+
 $HasPortParameter = $PSBoundParameters.ContainsKey("Port")
 $Port = Resolve-QuickLaunchPort -HasPortParameter $HasPortParameter -PortParameter $Port
+$HasWebUIPortParameter = $PSBoundParameters.ContainsKey("WebUIPort")
+$WebUIPort = Resolve-QuickLaunchWebUIPort -HasPortParameter $HasWebUIPortParameter -PortParameter $WebUIPort
 
 $VenvDir = if ($env:TLDW_VENV_DIR) { $env:TLDW_VENV_DIR } else { ".venv" }
 $VenvPython = Join-Path $VenvDir "Scripts/python.exe"
 $InstallMarker = Join-Path $VenvDir ".initialized"
 $EnvFile = if ($env:TLDW_ENV_FILE) { $env:TLDW_ENV_FILE } else { "tldw_Server_API/Config_Files/.env" }
+$WebUIDir = Join-Path $ScriptDir "apps/tldw-frontend"
 
 if ($env:TLDW_PYTHON) {
     $PythonExe = $env:TLDW_PYTHON
@@ -68,59 +269,18 @@ if ($env:TLDW_PYTHON) {
     $PythonArgs = @()
 }
 
-Write-Host "=== tldw_server quick launch ==="
-Write-Host ""
-
-Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"))
-
-$VenvCreated = $false
-if (-not (Test-Path $VenvPython)) {
-    Write-Host "[quick-launch] Creating virtualenv at $VenvDir"
-    Invoke-CheckedNative -FilePath $PythonExe -Arguments ($PythonArgs + @("-m", "venv", $VenvDir))
-    $VenvCreated = $true
+switch ($Mode) {
+    "api" {
+        run_api
+    }
+    "webui" {
+        Write-Host "=== tldw_server quick launch: WebUI ==="
+        run_webui
+    }
+    "all" {
+        run_all
+    }
+    "help" {
+        Show-Usage
+    }
 }
-
-if (
-    -not $SkipInstall `
-    -and $env:TLDW_SKIP_INSTALL -ne "1" `
-    -and ($ForceInstall -or $env:TLDW_FORCE_INSTALL -eq "1" -or $VenvCreated -or -not (Test-Path $InstallMarker))
-) {
-    Write-Host "[quick-launch] Installing/updating local Python dependencies..."
-    Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
-    Invoke-CheckedNative -FilePath $VenvPython -Arguments @("-m", "pip", "install", "-e", ".")
-    New-Item -Path $InstallMarker -ItemType File -Force | Out-Null
-} elseif ($SkipInstall -or $env:TLDW_SKIP_INSTALL -eq "1") {
-    Write-Host "[quick-launch] Skipping dependency install"
-} else {
-    Write-Host "[quick-launch] Dependency setup already completed; set TLDW_FORCE_INSTALL=1 or pass -ForceInstall to reinstall/update."
-}
-
-Write-Host "[quick-launch] Configuring local single-user profile..."
-Invoke-CheckedNative -FilePath $VenvPython -Arguments @(
-    "-m",
-    "tldw_Server_API.cli.wizard.cli",
-    "init",
-    "--profile",
-    "local-single",
-    "--env-file",
-    $EnvFile,
-    "--default",
-    "--yes"
-)
-
-Write-Host ""
-Write-Host "[quick-launch] Starting API at http://$HostAddress`:$Port"
-Write-Host "[quick-launch] Docs:   http://$HostAddress`:$Port/docs"
-Write-Host "[quick-launch] Health: http://$HostAddress`:$Port/health"
-Write-Host ""
-
-$env:TLDW_ENV_FILE = $EnvFile
-Invoke-CheckedNative -FilePath $VenvPython -Arguments @(
-    "-m",
-    "uvicorn",
-    "tldw_Server_API.app.main:app",
-    "--host",
-    $HostAddress,
-    "--port",
-    "$Port"
-)

--- a/quick-launch.sh
+++ b/quick-launch.sh
@@ -6,12 +6,38 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+mode="${1:-all}"
 PYTHON_CMD="${TLDW_PYTHON:-python3}"
 VENV_DIR="${TLDW_VENV_DIR:-.venv}"
 INSTALL_MARKER="$VENV_DIR/.initialized"
 ENV_FILE="${TLDW_ENV_FILE:-tldw_Server_API/Config_Files/.env}"
 HOST="${TLDW_HOST:-127.0.0.1}"
-PORT="${TLDW_PORT:-8000}"
+PORT="${TLDW_API_PORT:-${TLDW_PORT:-8000}}"
+WEBUI_PORT="${TLDW_WEBUI_PORT:-8080}"
+WEBUI_DIR="apps/tldw-frontend"
+VENV_PYTHON=""
+api_pid=""
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [api|webui|all]
+
+Modes:
+  api     Start the FastAPI backend only on http://$HOST:$PORT
+  webui   Start the Next.js WebUI only on http://127.0.0.1:$WEBUI_PORT
+  all     Start the backend, then run the WebUI (default)
+
+Environment:
+  TLDW_PYTHON         Python executable for venv creation (default: python3)
+  TLDW_VENV_DIR       Virtualenv directory (default: .venv)
+  TLDW_ENV_FILE       Env file path (default: tldw_Server_API/Config_Files/.env)
+  TLDW_HOST           Backend host (default: 127.0.0.1)
+  TLDW_API_PORT       Backend port (default: TLDW_PORT or 8000)
+  TLDW_PORT           Legacy backend port override
+  TLDW_WEBUI_PORT     WebUI port (default: 8080)
+  NEXT_PUBLIC_API_URL Override WebUI API URL
+USAGE
+}
 
 resolve_venv_python() {
     if [ -x "$VENV_DIR/bin/python" ]; then
@@ -32,57 +58,159 @@ resolve_venv_python() {
     return 1
 }
 
-echo "=== tldw_server quick launch ==="
-echo ""
-
-if ! command -v "$PYTHON_CMD" >/dev/null 2>&1; then
-    echo "[quick-launch] $PYTHON_CMD not found. Install Python 3.10+ or set TLDW_PYTHON." >&2
-    exit 1
-fi
-
-"$PYTHON_CMD" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' || {
-    echo "[quick-launch] Python 3.10+ is required." >&2
-    exit 1
-}
-
-VENV_CREATED=0
-if ! VENV_PYTHON="$(resolve_venv_python)"; then
-    echo "[quick-launch] Creating virtualenv at $VENV_DIR"
-    "$PYTHON_CMD" -m venv "$VENV_DIR"
-    VENV_CREATED=1
-    if ! VENV_PYTHON="$(resolve_venv_python)"; then
-        echo "[quick-launch] Could not find Python in $VENV_DIR after creating the virtualenv." >&2
+ensure_python() {
+    if ! command -v "$PYTHON_CMD" >/dev/null 2>&1; then
+        echo "[quick-launch] $PYTHON_CMD not found. Install Python 3.10+ or set TLDW_PYTHON." >&2
         exit 1
     fi
-fi
 
-if [ "${TLDW_SKIP_INSTALL:-0}" != "1" ]; then
-    if [ "${TLDW_FORCE_INSTALL:-0}" = "1" ] || [ "$VENV_CREATED" = "1" ] || [ ! -f "$INSTALL_MARKER" ]; then
-        echo "[quick-launch] Installing/updating local Python dependencies..."
-        "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel
-        "$VENV_PYTHON" -m pip install -e .
-        touch "$INSTALL_MARKER"
-    else
-        echo "[quick-launch] Dependency setup already completed; set TLDW_FORCE_INSTALL=1 to reinstall/update."
+    "$PYTHON_CMD" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' || {
+        echo "[quick-launch] Python 3.10+ is required." >&2
+        exit 1
+    }
+}
+
+ensure_api_environment() {
+    ensure_python
+
+    local venv_created=0
+    if ! VENV_PYTHON="$(resolve_venv_python)"; then
+        echo "[quick-launch] Creating virtualenv at $VENV_DIR"
+        "$PYTHON_CMD" -m venv "$VENV_DIR"
+        venv_created=1
+        if ! VENV_PYTHON="$(resolve_venv_python)"; then
+            echo "[quick-launch] Could not find Python in $VENV_DIR after creating the virtualenv." >&2
+            exit 1
+        fi
     fi
-else
-    echo "[quick-launch] Skipping dependency install because TLDW_SKIP_INSTALL=1"
-fi
 
-echo "[quick-launch] Configuring local single-user profile..."
-"$VENV_PYTHON" -m tldw_Server_API.cli.wizard.cli init \
-    --profile local-single \
-    --env-file "$ENV_FILE" \
-    --default \
-    --yes
+    if [ "${TLDW_SKIP_INSTALL:-0}" != "1" ]; then
+        if [ "${TLDW_FORCE_INSTALL:-0}" = "1" ] || [ "$venv_created" = "1" ] || [ ! -f "$INSTALL_MARKER" ]; then
+            echo "[quick-launch] Installing/updating local Python dependencies..."
+            "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel
+            "$VENV_PYTHON" -m pip install -e .
+            touch "$INSTALL_MARKER"
+        else
+            echo "[quick-launch] Dependency setup already completed; set TLDW_FORCE_INSTALL=1 to reinstall/update."
+        fi
+    else
+        echo "[quick-launch] Skipping dependency install because TLDW_SKIP_INSTALL=1"
+    fi
 
-echo ""
-echo "[quick-launch] Starting API at http://$HOST:$PORT"
-echo "[quick-launch] Docs:   http://$HOST:$PORT/docs"
-echo "[quick-launch] Health: http://$HOST:$PORT/health"
-echo ""
+    echo "[quick-launch] Configuring local single-user profile..."
+    "$VENV_PYTHON" -m tldw_Server_API.cli.wizard.cli init \
+        --profile local-single \
+        --env-file "$ENV_FILE" \
+        --default \
+        --yes
+}
 
-TLDW_ENV_FILE="$ENV_FILE" exec "$VENV_PYTHON" -m uvicorn \
-    tldw_Server_API.app.main:app \
-    --host "$HOST" \
-    --port "$PORT"
+ensure_bun() {
+    if ! command -v bun >/dev/null 2>&1; then
+        echo "[quick-launch] Bun is required to launch the WebUI but was not found in PATH." >&2
+        echo "[quick-launch] Install Bun from https://bun.sh/docs/installation, then rerun this launcher." >&2
+        exit 1
+    fi
+}
+
+ensure_webui_dir() {
+    if [ ! -d "$WEBUI_DIR" ]; then
+        echo "[quick-launch] WebUI directory not found: $SCRIPT_DIR/$WEBUI_DIR" >&2
+        echo "[quick-launch] Update your checkout before launching the WebUI." >&2
+        exit 1
+    fi
+}
+
+run_api() {
+    echo "=== tldw_server quick launch: API ==="
+    echo ""
+    ensure_api_environment
+
+    echo ""
+    echo "[quick-launch] Starting API at http://$HOST:$PORT"
+    echo "[quick-launch] Docs:   http://$HOST:$PORT/docs"
+    echo "[quick-launch] Health: http://$HOST:$PORT/health"
+    echo ""
+
+    TLDW_ENV_FILE="$ENV_FILE" exec "$VENV_PYTHON" -m uvicorn \
+        tldw_Server_API.app.main:app \
+        --host "$HOST" \
+        --port "$PORT"
+}
+
+start_api_background() {
+    echo "=== tldw_server quick launch: API + WebUI ==="
+    echo ""
+    ensure_api_environment
+
+    echo ""
+    echo "[quick-launch] Starting API at http://$HOST:$PORT"
+    echo "[quick-launch] Docs:   http://$HOST:$PORT/docs"
+    echo "[quick-launch] Health: http://$HOST:$PORT/health"
+    TLDW_ENV_FILE="$ENV_FILE" "$VENV_PYTHON" -m uvicorn \
+        tldw_Server_API.app.main:app \
+        --host "$HOST" \
+        --port "$PORT" &
+    api_pid="$!"
+    sleep "${TLDW_API_START_DELAY:-2}"
+}
+
+run_webui() {
+    ensure_bun
+    ensure_webui_dir
+    api_url_host="$HOST"
+    if [ "$api_url_host" = "0.0.0.0" ]; then
+        api_url_host="127.0.0.1"
+    fi
+
+    if [ -z "${NEXT_PUBLIC_API_URL:-}" ]; then
+        export NEXT_PUBLIC_API_URL="http://$api_url_host:$PORT"
+        if [ "$HOST" = "0.0.0.0" ]; then
+            echo "[quick-launch] API is bound to 0.0.0.0; using 127.0.0.1 for local browser requests."
+            echo "[quick-launch] Set NEXT_PUBLIC_API_URL to your LAN URL for non-local browser clients."
+        fi
+    fi
+
+    echo ""
+    echo "[quick-launch] Starting WebUI at http://127.0.0.1:$WEBUI_PORT"
+    echo "[quick-launch] Using API URL: $NEXT_PUBLIC_API_URL"
+    echo ""
+
+    cd "$WEBUI_DIR"
+    bun run dev -- -p "$WEBUI_PORT"
+}
+
+cleanup() {
+    if [ -n "$api_pid" ] && kill -0 "$api_pid" >/dev/null 2>&1; then
+        echo "[quick-launch] Stopping API..."
+        kill "$api_pid" >/dev/null 2>&1 || true
+        wait "$api_pid" 2>/dev/null || true
+    fi
+}
+
+run_all() {
+    trap cleanup EXIT INT TERM
+    start_api_background
+    run_webui
+}
+
+case "$mode" in
+    api)
+        run_api
+        ;;
+    webui)
+        echo "=== tldw_server quick launch: WebUI ==="
+        run_webui
+        ;;
+    all)
+        run_all
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        echo "[quick-launch] Unknown launch mode: $mode" >&2
+        usage >&2
+        exit 2
+        ;;
+esac

--- a/tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
+++ b/tldw_Server_API/tests/Utils/test_quick_launch_scripts.py
@@ -1,5 +1,6 @@
 """Contract tests for no-Docker quick-launch scripts."""
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -15,10 +16,37 @@ def _require(condition: bool, message: str) -> None:
 
 
 def _read(path: str) -> str:
+    """Return a repository-relative script's text for contract assertions."""
     script_path = REPO_ROOT / path
     if not script_path.exists():
         pytest.fail(f"{path} should exist")
     return script_path.read_text(encoding="utf-8")
+
+
+def _shell_function_body(source: str, function_name: str) -> str:
+    """Return a shell function body from quick-launch.sh source text."""
+    marker = f"{function_name}() {{"
+    _require(marker in source, f"quick-launch.sh should define {function_name}")
+    body_with_suffix = source.split(marker, 1)[1]
+    _require("\n}\n" in body_with_suffix, f"quick-launch.sh should close {function_name}")
+    return body_with_suffix.split("\n}\n", 1)[0]
+
+
+def test_launcher_contract_tests_include_docstrings() -> None:
+    """Launcher contract tests should keep module and function docstrings."""
+    source = _read("tldw_Server_API/tests/Utils/test_quick_launch_scripts.py")
+    module = ast.parse(source)
+    missing = []
+
+    if ast.get_docstring(module) is None:
+        missing.append("<module>")
+
+    for node in ast.walk(module):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if ast.get_docstring(node) is None:
+                missing.append(f"{node.name}:{node.lineno}")
+
+    _require(not missing, f"launcher contract tests should document: {', '.join(missing)}")
 
 
 @pytest.mark.parametrize(
@@ -75,6 +103,166 @@ def test_shell_launcher_supports_git_bash_venv_layout() -> None:
     _require("resolve_venv_python" in text, "quick-launch.sh should resolve venv Python dynamically")
     _require("$VENV_DIR/Scripts/python" in text, "quick-launch.sh should support Windows venv layout")
     _require("$VENV_DIR/bin/python" in text, "quick-launch.sh should support POSIX venv layout")
+
+
+@pytest.mark.parametrize(
+    ("path", "mode_contract"),
+    [
+        ("quick-launch.sh", 'mode="${1:-all}"'),
+        ("quick-launch.ps1", '[ValidateSet("api", "webui", "all", "help")]'),
+    ],
+)
+def test_root_quick_launch_scripts_expose_api_webui_and_all_modes(
+    path: str, mode_contract: str
+) -> None:
+    """Root quick-launch scripts should be the canonical API/WebUI mode launchers."""
+    text = _read(path)
+
+    _require(mode_contract in text, f"{path} should default to all-mode launch")
+    for expected in ("api", "webui", "all", "run_api", "run_webui", "run_all"):
+        _require(expected in text.lower(), f"{path} should include {expected}")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "quick-launch.sh",
+        "quick-launch.ps1",
+    ],
+)
+def test_root_quick_launch_scripts_start_current_webui(path: str) -> None:
+    """Root quick-launch scripts should launch the current Next.js WebUI."""
+    text = _read(path)
+
+    for expected in (
+        "apps/tldw-frontend",
+        "bun",
+        "run",
+        "dev",
+        "TLDW_WEBUI_PORT",
+        "NEXT_PUBLIC_API_URL",
+        "8080",
+    ):
+        _require(expected in text, f"{path} should include {expected}")
+
+
+def test_root_quick_launch_scripts_avoid_zero_bind_host_in_webui_url() -> None:
+    """WebUI API defaults should not point browser clients at 0.0.0.0."""
+    shell_text = _read("quick-launch.sh")
+    powershell_text = _read("quick-launch.ps1")
+    zero_bind_host = ".".join(("0", "0", "0", "0"))
+
+    for expected in ("api_url_host", zero_bind_host, "127.0.0.1"):
+        _require(expected in shell_text, f"quick-launch.sh should include {expected}")
+
+    for expected in ("Resolve-QuickLaunchApiUrl", zero_bind_host, "127.0.0.1"):
+        _require(expected in powershell_text, f"quick-launch.ps1 should include {expected}")
+
+
+def test_shell_launcher_backgrounds_uvicorn_directly_for_cleanup() -> None:
+    """Shell all-mode cleanup should target the real Uvicorn process PID."""
+    text = _read("quick-launch.sh")
+    start_api_block = _shell_function_body(text, "start_api_background")
+
+    _require(
+        'TLDW_ENV_FILE="$ENV_FILE" "$VENV_PYTHON" -m uvicorn' in start_api_block,
+        "quick-launch.sh should start Uvicorn directly in all mode",
+    )
+    _require(
+        '--port "$PORT" &' in start_api_block,
+        "quick-launch.sh should background the Uvicorn command itself",
+    )
+    _require(
+        'api_pid="$!"' in start_api_block,
+        "quick-launch.sh should capture the backgrounded Uvicorn PID",
+    )
+    _require("(\n" not in start_api_block, "quick-launch.sh should not wrap Uvicorn in a subshell")
+
+
+def test_powershell_launcher_validates_api_start_delay() -> None:
+    """PowerShell launcher should ignore invalid TLDW_API_START_DELAY values."""
+    text = _read("quick-launch.ps1")
+
+    for expected in (
+        "Resolve-QuickLaunchApiStartDelay",
+        "TLDW_API_START_DELAY",
+        "-match '^\\d+$'",
+        "using 2",
+    ):
+        _require(expected in text, f"quick-launch.ps1 should include {expected}")
+
+
+def test_powershell_launcher_uses_current_host_for_child_api_window() -> None:
+    """PowerShell all mode should spawn the same edition as the parent process."""
+    text = _read("quick-launch.ps1")
+
+    for expected in (
+        "$PSVersionTable.PSEdition",
+        '"pwsh"',
+        "$PsExe",
+        'Start-Process -FilePath $PsExe',
+    ):
+        _require(expected in text, f"quick-launch.ps1 should include {expected}")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "Helper_Scripts/Installer_Scripts/MacOS_Run_tldw.sh",
+        "Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh",
+    ],
+)
+def test_unix_installer_run_scripts_delegate_to_root_quick_launch(path: str) -> None:
+    """Installer shortcuts should wrap the canonical root shell launcher."""
+    text = _read(path)
+
+    _require("quick-launch.sh" in text, f"{path} should delegate to quick-launch.sh")
+    _require("TLDW_VENV_DIR" in text, f"{path} should set legacy installer venv defaults")
+    _require("TLDW_SKIP_INSTALL" in text, f"{path} should avoid duplicate installer pip work")
+
+    for duplicated_fragment in (
+        "python3 -m uvicorn",
+        "bun run dev",
+        "apps/tldw-frontend",
+    ):
+        _require(
+            duplicated_fragment not in text,
+            f"{path} should not duplicate {duplicated_fragment}",
+        )
+
+
+def test_windows_installer_run_script_delegates_to_root_quick_launch() -> None:
+    """Windows installer shortcut should wrap the canonical PowerShell launcher."""
+    text = _read("Helper_Scripts/Installer_Scripts/Windows_Run_tldw.bat")
+
+    _require("quick-launch.ps1" in text, "Windows wrapper should delegate to quick-launch.ps1")
+    _require("TLDW_VENV_DIR" in text, "Windows wrapper should set legacy installer venv defaults")
+    _require("TLDW_SKIP_INSTALL" in text, "Windows wrapper should avoid duplicate installer pip work")
+
+    for duplicated_fragment in (
+        "python -m uvicorn",
+        "bun run dev",
+        "apps\\tldw-frontend",
+    ):
+        _require(
+            duplicated_fragment not in text,
+            f"Windows wrapper should not duplicate {duplicated_fragment}",
+        )
+
+
+def test_launcher_tests_do_not_use_brittle_exit_count_contract() -> None:
+    """Launcher coverage should avoid exact global exit-code string counts."""
+    legacy_test_path = REPO_ROOT / "Helper_Scripts/Installer_Scripts/Tests/test_run_tldw_launchers.py"
+    text = _read("tldw_Server_API/tests/Utils/test_quick_launch_scripts.py")
+    count_call = "source" ".count"
+    exit_propagation = "exit /b " "!errorlevel!"
+
+    _require(not legacy_test_path.exists(), "legacy launcher test module should not remain")
+    _require(count_call not in text, "launcher tests should not count global source strings")
+    _require(
+        exit_propagation not in text,
+        "launcher tests should not assert an exact exit propagation count",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- What changed: consolidated no-Docker quick launch behavior around the repo-root scripts, added `api`, `webui`, and `all` modes, and kept installer run scripts as compatibility wrappers.
- Why: there were two overlapping launcher families; making the root scripts canonical keeps setup and API/WebUI startup behavior in one place while preserving existing installer entrypoints.

## Change summary

- Makes the repo-root quick-launch scripts the canonical no-Docker API/WebUI launch path.
- Adds `api`, `webui`, and `all` modes to `quick-launch.sh` and `quick-launch.ps1`, with `all` as the default.
- Converts the installer `MacOS_Run_tldw.sh`, `Linux_Run_tldw.sh`, and `Windows_Run_tldw.bat` scripts into compatibility wrappers that delegate to the root launchers.
- Updates README and local single-user docs to describe the default API + WebUI behavior and mode-specific commands.
- Addresses Qodo review feedback by documenting launcher tests, ensuring shell all-mode cleanup targets the actual Uvicorn PID, avoiding `0.0.0.0` as the default browser-facing WebUI API URL, and removing brittle exit-count coverage.
- Addresses follow-up review feedback by populating the Backlog task creation timestamp, correcting `macOS` casing, validating `TLDW_API_START_DELAY`, and spawning the same PowerShell edition for API child processes.

## Validation

- [x] Tests added/updated for behavior changes.
- [x] Relevant unit/integration tests pass locally.
- [x] Docs updated for launch behavior/config changes.
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_quick_launch_scripts.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py -v` (34 passed)
- [x] `bash -n quick-launch.sh`
- [x] `bash -n quick-launch.command`
- [x] `bash -n Helper_Scripts/Installer_Scripts/MacOS_Run_tldw.sh`
- [x] `bash -n Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh`
- [x] `bash -n Helper_Scripts/Installer_Scripts/MacOS_Install_Update.sh`
- [x] `bash -n Helper_Scripts/Installer_Scripts/Linux_Install_Update.sh`
- [x] `./quick-launch.sh --help`
- [x] `TLDW_INSTALL_DIR="$PWD" bash Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh --help`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/Utils/test_quick_launch_scripts.py -f json -o /tmp/bandit_quick_launch_qodo_followup.json` (0 findings, 0 errors)
- [x] `git diff --check`

PowerShell parser execution was skipped because neither `pwsh` nor `powershell` is installed on this host.

## UX Audit Checklist (v2 Stage 5)

- [x] No rendered WebUI route/component behavior changed; UX smoke routes are not applicable to this launcher-only PR.
- [x] No AntD components changed, so no new `Drawer.width`, `Space.direction`, `Alert.message`, or `List` deprecation surface was introduced.
- [x] No audited routes changed, so maximum-update-depth, unresolved placeholder, and WebUI/extension parity checks are not applicable.
- [x] No Flashcards UI, drawer, help, copy, or import UX behavior changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] No Watchlists UI behavior changed.
- [x] Watchlists keyboard flow, labels/live-region copy, active-state signaling, and assistive-technology constraints are not affected by launcher script changes.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] No Watchlists UI polling, notification, Activity refresh, batch triage, or scale behavior changed.
- [x] Watchlists scale gates are not applicable to launcher script consolidation.

## Risk & Rollback

- Risk level: Low.
- Rollback plan: revert this PR to restore the prior root quick-launch scripts and installer run-script behavior. No database migrations or persisted data changes are involved.
