### PR TITLE
Docs: cover v44 migration regression tests

### DIFF
--- a/backlog/tasks/task-500 - Fix-ChaChaNotes-v44-to-v45-migration-when-persona-tables-are-missing.md
+++ b/backlog/tasks/task-500 - Fix-ChaChaNotes-v44-to-v45-migration-when-persona-tables-are-missing.md
@@ -39,6 +39,7 @@ Investigate and fix a user-reported ChaChaNotes DB migration failure from schema
 - Review follow-up verification passed: focused persona visual/persistence tests (`16 passed, 5 warnings`), `py_compile`, `git diff --check`, Bandit production scan (`0 findings`), and Bandit touched-scope scan with pytest asserts skipped (`0 findings`). Production command: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_chachanotes_v44_v45_migration_review_prod.json`; touched-scope command: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py -s B101 -f json -o /tmp/bandit_chachanotes_v44_v45_migration_review_skip_b101.json`; skipped check: `B101` for pytest asserts; result: zero findings in both JSON summaries.
 - Addressed CodeRabbit follow-up by expanding Bandit details inline, wrapping migrated DB assertions in `try/finally`, and extending the v44 drift regression to assert repaired profile/memory columns and indexes.
 - CodeRabbit follow-up verification passed: focused persona visual/persistence tests (`16 passed, 5 warnings`), `py_compile`, `git diff --check`, Bandit production scan command `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_chachanotes_v44_v45_migration_coderabbit_prod.json` (`0 findings`), and Bandit touched-scope command `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py -s B101 -f json -o /tmp/bandit_chachanotes_v44_v45_migration_coderabbit_skip_b101.json` (`0 findings`; skipped check: `B101` for pytest asserts).
+- Addressed the CodeRabbit docstring coverage warning for touched test functions with concise regression-test docstrings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -48,6 +49,7 @@ Investigate and fix a user-reported ChaChaNotes DB migration failure from schema
 - Added regression coverage for the user-reported failure mode and verified the focused migration/persona persistence suites, syntax, whitespace, and Bandit checks.
 - Addressed PR review feedback by routing migration drift setup through DB_Management instead of direct SQLite setup in the regression test.
 - Addressed CodeRabbit follow-up by recording non-ephemeral Bandit command/result details, guaranteeing DB cleanup in migration tests, and asserting repaired persona profile/memory schema artifacts.
+- Added docstrings for the touched migration regression tests to satisfy reviewer coverage guidance.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py
@@ -37,6 +37,7 @@ def test_user_persona_visuals_dir_is_created_under_user_base(
 
 
 def test_migration_v44_to_latest_creates_persona_visual_tables(db_path: Path) -> None:
+    """Verify v44 migration recreates persona visual tables and indexes."""
     seeded = CharactersRAGDB(db_path, "persona-visuals-seed")
     seeded.close_connection()
 
@@ -74,6 +75,7 @@ def test_migration_v44_to_latest_creates_persona_visual_tables(db_path: Path) ->
 
 
 def test_migration_v44_to_latest_repairs_missing_persona_tables(db_path: Path) -> None:
+    """Verify drifted v44 databases repair missing persona schema artifacts."""
     seeded = CharactersRAGDB(db_path, "persona-visuals-missing-persona-seed")
     seeded.close_connection()
 


### PR DESCRIPTION
## Summary
- add concise docstrings to the touched v44 migration regression tests
- record the docstring-coverage follow-up in TASK-500

## Validation
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py -q --tb=short` (16 passed, 5 warnings)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_visuals_db.py`
- [x] `git diff --check`

## Risk / Rollback
Risk: low. This only adds docstrings and task notes.
Rollback: revert commit `2a02748e` if needed.

## Change summary
The original PR merged before the final non-blocking CodeRabbit docstring-coverage cleanup landed. This follow-up carries only that cleanup so the regression tests and task record reflect the review guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add concise docstrings to the v44-to-latest migration regression tests for persona visuals to satisfy review coverage and improve test clarity. Update TASK-500 to record the change and confirm coverage of the missing persona tables failure mode.

<sup>Written for commit 2a02748ea2d32511b3d6eca082065b8d43f33ed6. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2049?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

