### PR TITLE
Migrate Character alerts to design system

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -704,61 +704,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/Characters/AvatarField.tsx:Alert#antd-alert-avatarfield-type-error-line-452-ymc4sw",
-    "path": "src/components/Option/Characters/AvatarField.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Characters/AvatarField.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Characters/AvatarField.tsx:Alert#antd-alert-avatarfield-type-info-line-398-diiopz",
-    "path": "src/components/Option/Characters/AvatarField.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Characters/AvatarField.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Characters/CharacterListContent.tsx:Alert",
-    "path": "src/components/Option/Characters/CharacterListContent.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Characters/CharacterListContent.tsx before the guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Characters/GenerateCharacterPanel.tsx:Alert#antd-alert-generatecharacterpanel-type-error-line-363-1dqa5ae",
-    "path": "src/components/Option/Characters/GenerateCharacterPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Characters/GenerateCharacterPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/Characters/GenerateCharacterPanel.tsx:Alert#antd-alert-generatecharacterpanel-type-info-line-322-1vn2xzn",
-    "path": "src/components/Option/Characters/GenerateCharacterPanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/Characters/GenerateCharacterPanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Option/ChatWorkflows/ChatWorkflowsPage.tsx:Alert#antd-alert-chatworkflowspage-type-error-unable-to-load-t-rynbj",
     "path": "src/components/Option/ChatWorkflows/ChatWorkflowsPage.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/Characters/AvatarField.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/AvatarField.tsx
@@ -454,6 +454,7 @@ export function AvatarField({
                   variant="error"
                   title={generationError}
                   dismissible
+                  dismissLabel={t("common:close", { defaultValue: "Close" })}
                   onDismiss={() => setGenerationError(null)}
                 />
               )}

--- a/apps/packages/ui/src/components/Option/Characters/AvatarField.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/AvatarField.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Input, Radio, Upload, message, Button, Select, Alert, Spin } from "antd"
+import { Input, Radio, Upload, message, Button, Select, Spin } from "antd"
 import { ImageIcon, Link, X, Upload as UploadIcon, Sparkles, RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives/Alert"
 import {
   ALLOWED_IMAGE_MIME_TYPES,
   createImageDataUrl,
@@ -396,16 +397,16 @@ export function AvatarField({
             </div>
           ) : !hasConfiguredBackends ? (
             <Alert
-              type="info"
-              showIcon
+              variant="info"
               title={t("settings:manageCharacters.avatar.generate.noBackendsTitle", {
                 defaultValue: "No image backends configured"
               })}
-              description={t("settings:manageCharacters.avatar.generate.noBackendsDesc", {
+            >
+              {t("settings:manageCharacters.avatar.generate.noBackendsDesc", {
                 defaultValue:
                   "Configure stable-diffusion or SwarmUI in server settings to enable avatar generation."
               })}
-            />
+            </Alert>
           ) : (
             <>
               {/* Prompt input */}
@@ -450,11 +451,10 @@ export function AvatarField({
               {/* Error display */}
               {generationError && (
                 <Alert
-                  type="error"
-                  showIcon
+                  variant="error"
                   title={generationError}
-                  closable
-                  onClose={() => setGenerationError(null)}
+                  dismissible
+                  onDismiss={() => setGenerationError(null)}
                 />
               )}
 

--- a/apps/packages/ui/src/components/Option/Characters/CharacterListContent.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/CharacterListContent.tsx
@@ -396,40 +396,37 @@ export const CharacterListContent: React.FC<CharacterListContentProps> = (props)
           })}
       </div>
       {status === "error" && (
-        <div className="rounded-lg border border-danger/30 bg-danger/10 p-4">
-          <Alert
-            variant="error"
-            title={t("settings:manageCharacters.loadError.title", {
-              defaultValue: "Couldn't load characters"
-            })}
-            className="border-0 bg-transparent p-0"
-          >
-            <div className="flex items-center justify-between gap-2">
-              <div className="text-sm text-danger">
-                <p>
-                  {sanitizeServerErrorMessage(
-                    error,
-                    t("settings:manageCharacters.loadError.description", {
-                      defaultValue: "Check your connection and try again."
-                    })
-                  )}
-                </p>
-                <p className="mt-1 text-xs text-text-muted">
-                  {buildServerLogHint(
-                    error,
-                    t("settings:manageCharacters.loadError.logHint", {
-                      defaultValue:
-                        "If the issue persists, check server logs for more details."
-                    })
-                  )}
-                </p>
-              </div>
-              <Button size="small" onClick={() => refetch()}>
-                {t("common:retry", { defaultValue: "Retry" })}
-              </Button>
+        <Alert
+          variant="error"
+          title={t("settings:manageCharacters.loadError.title", {
+            defaultValue: "Couldn't load characters"
+          })}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-sm">
+              <p>
+                {sanitizeServerErrorMessage(
+                  error,
+                  t("settings:manageCharacters.loadError.description", {
+                    defaultValue: "Check your connection and try again."
+                  })
+                )}
+              </p>
+              <p className="mt-1 text-xs text-text-muted">
+                {buildServerLogHint(
+                  error,
+                  t("settings:manageCharacters.loadError.logHint", {
+                    defaultValue:
+                      "If the issue persists, check server logs for more details."
+                  })
+                )}
+              </p>
             </div>
-          </Alert>
-        </div>
+            <Button size="small" onClick={() => refetch()}>
+              {t("common:retry", { defaultValue: "Retry" })}
+            </Button>
+          </div>
+        </Alert>
       )}
       {status === "pending" && <Skeleton active paragraph={{ rows: 6 }} />}
       {status === "success" &&

--- a/apps/packages/ui/src/components/Option/Characters/CharacterListContent.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/CharacterListContent.tsx
@@ -6,7 +6,6 @@ import {
   Tag,
   Tooltip,
   Select,
-  Alert,
   Checkbox,
   Skeleton,
   Pagination,
@@ -50,6 +49,7 @@ import {
   sanitizeServerErrorMessage,
   buildServerLogHint
 } from "@/utils/server-error-message"
+import { Alert } from "@/components/ui/primitives/Alert"
 import type { TFunction } from "i18next"
 
 const LazyCharacterGalleryCard = React.lazy(() =>
@@ -398,39 +398,37 @@ export const CharacterListContent: React.FC<CharacterListContentProps> = (props)
       {status === "error" && (
         <div className="rounded-lg border border-danger/30 bg-danger/10 p-4">
           <Alert
-            type="error"
+            variant="error"
             title={t("settings:manageCharacters.loadError.title", {
               defaultValue: "Couldn't load characters"
             })}
-            description={
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-sm text-danger">
-                  <p>
-                    {sanitizeServerErrorMessage(
-                      error,
-                      t("settings:manageCharacters.loadError.description", {
-                        defaultValue: "Check your connection and try again."
-                      })
-                    )}
-                  </p>
-                  <p className="mt-1 text-xs text-text-muted">
-                    {buildServerLogHint(
-                      error,
-                      t("settings:manageCharacters.loadError.logHint", {
-                        defaultValue:
-                          "If the issue persists, check server logs for more details."
-                      })
-                    )}
-                  </p>
-                </div>
-                <Button size="small" onClick={() => refetch()}>
-                  {t("common:retry", { defaultValue: "Retry" })}
-                </Button>
-              </div>
-            }
-            showIcon
             className="border-0 bg-transparent p-0"
-          />
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-sm text-danger">
+                <p>
+                  {sanitizeServerErrorMessage(
+                    error,
+                    t("settings:manageCharacters.loadError.description", {
+                      defaultValue: "Check your connection and try again."
+                    })
+                  )}
+                </p>
+                <p className="mt-1 text-xs text-text-muted">
+                  {buildServerLogHint(
+                    error,
+                    t("settings:manageCharacters.loadError.logHint", {
+                      defaultValue:
+                        "If the issue persists, check server logs for more details."
+                    })
+                  )}
+                </p>
+              </div>
+              <Button size="small" onClick={() => refetch()}>
+                {t("common:retry", { defaultValue: "Retry" })}
+              </Button>
+            </div>
+          </Alert>
         </div>
       )}
       {status === "pending" && <Skeleton active paragraph={{ rows: 6 }} />}

--- a/apps/packages/ui/src/components/Option/Characters/GenerateCharacterPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/GenerateCharacterPanel.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from "react"
-import { Button, Input, Alert, Dropdown, Spin, Modal, Progress } from "antd"
+import { Button, Input, Dropdown, Spin, Modal, Progress } from "antd"
 import type { MenuProps } from "antd"
 import { Sparkles, ChevronDown, X, Check, RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
@@ -14,6 +14,7 @@ import { useStorage } from "@plasmohq/storage/hook"
 import { getProviderDisplayName } from "@/utils/provider-registry"
 import { resolveStartupSelectedModel } from "@/utils/model-startup-selection"
 import { ProviderIcons } from "@/components/Common/ProviderIcon"
+import { Alert } from "@/components/ui/primitives/Alert"
 import type { GeneratedCharacter } from "@/services/character-generation"
 
 type ChatModel = {
@@ -320,26 +321,24 @@ export const GenerateCharacterPanel: React.FC<GenerateCharacterPanelProps> = ({
   if (!hasModels) {
     return (
       <Alert
-        type="info"
-        showIcon
+        variant="info"
         title={t("settings:manageCharacters.generate.noModelsTitle", {
           defaultValue: "No AI generation model available"
         })}
-        description={
-          <span>
-            {t("settings:manageCharacters.generate.noModelsDesc", {
-              defaultValue:
-                "AI character generation needs a configured LLM model. Saved characters remain available for browsing, editing, and chat once a chat model is configured."
-            })}{" "}
-            <Link to="/settings/model" className="text-primary hover:underline">
-              {t("settings:manageCharacters.generate.goToSettings", {
-                defaultValue: "Go to model settings"
-              })}
-            </Link>
-          </span>
-        }
         className="mb-4"
-      />
+      >
+        <span>
+          {t("settings:manageCharacters.generate.noModelsDesc", {
+            defaultValue:
+              "AI character generation needs a configured LLM model. Saved characters remain available for browsing, editing, and chat once a chat model is configured."
+          })}{" "}
+          <Link to="/settings/model" className="text-primary hover:underline">
+            {t("settings:manageCharacters.generate.goToSettings", {
+              defaultValue: "Go to model settings"
+            })}
+          </Link>
+        </span>
+      </Alert>
     )
   }
 
@@ -361,24 +360,22 @@ export const GenerateCharacterPanel: React.FC<GenerateCharacterPanelProps> = ({
       {/* Error display with actionable guidance */}
       {parsedError && (
         <Alert
-          type="error"
-          showIcon
+          variant="error"
           title={parsedError.message}
-          description={
-            <div className="flex items-center justify-between gap-2 mt-1">
-              <span className="text-sm">{parsedError.action}</span>
-              <Button
-                size="small"
-                icon={<RefreshCw className="w-3 h-3" />}
-                onClick={handleRetry}>
-                {t("common:tryAgain", { defaultValue: "Try again" })}
-              </Button>
-            </div>
-          }
-          closable
-          onClose={onClearError}
+          dismissible
+          onDismiss={onClearError}
           className="mb-2"
-        />
+        >
+          <div className="flex items-center justify-between gap-2 mt-1">
+            <span className="text-sm">{parsedError.action}</span>
+            <Button
+              size="small"
+              icon={<RefreshCw className="w-3 h-3" />}
+              onClick={handleRetry}>
+              {t("common:tryAgain", { defaultValue: "Try again" })}
+            </Button>
+          </div>
+        </Alert>
       )}
 
       {/* Generation progress indicator */}

--- a/apps/packages/ui/src/components/Option/Characters/GenerateCharacterPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/GenerateCharacterPanel.tsx
@@ -363,6 +363,7 @@ export const GenerateCharacterPanel: React.FC<GenerateCharacterPanelProps> = ({
           variant="error"
           title={parsedError.message}
           dismissible
+          dismissLabel={t("common:close", { defaultValue: "Close" })}
           onDismiss={onClearError}
           className="mb-2"
         >

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/AvatarField.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/AvatarField.design-system.test.tsx
@@ -1,0 +1,88 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { AvatarField } from "../AvatarField"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    getImageBackends: vi.fn(),
+    createImageArtifact: vi.fn()
+  }
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [k: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        return fallbackOrOptions.defaultValue || key
+      }
+      return key
+    }
+  })
+}))
+
+const getImageBackendsMock = vi.mocked(tldwClient.getImageBackends)
+const createImageArtifactMock = vi.mocked(tldwClient.createImageArtifact)
+let consoleErrorMock: ReturnType<typeof vi.spyOn> | null = null
+
+describe("AvatarField design-system alerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    consoleErrorMock?.mockRestore()
+    consoleErrorMock = null
+  })
+
+  it("renders the no-backend state through the design-system Alert primitive", async () => {
+    getImageBackendsMock.mockResolvedValue([])
+
+    render(<AvatarField value={{ mode: "generate" }} onChange={vi.fn()} />)
+
+    const title = await screen.findByText("No image backends configured")
+    const alert = title.closest('[data-ds-component="Alert"]')
+
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveTextContent(
+      "Configure stable-diffusion or SwarmUI in server settings to enable avatar generation."
+    )
+  })
+
+  it("renders generation failures through the design-system Alert primitive and keeps dismiss behavior", async () => {
+    const user = userEvent.setup()
+    consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    getImageBackendsMock.mockResolvedValue([
+      {
+        id: "stable-diffusion",
+        name: "Stable Diffusion",
+        is_configured: true
+      }
+    ] as any)
+    createImageArtifactMock.mockRejectedValue(new Error("image_generation_failed"))
+
+    render(<AvatarField value={{ mode: "generate" }} onChange={vi.fn()} />)
+
+    await user.type(
+      await screen.findByPlaceholderText("Portrait of a wise mentor with kind eyes..."),
+      "portrait of a scholar"
+    )
+    await user.click(screen.getByRole("button", { name: "Generate Avatar" }))
+
+    const errorTitle = await screen.findByText("Generation failed. Try again.")
+    const alert = errorTitle.closest('[data-ds-component="Alert"]')
+
+    expect(alert).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }))
+
+    expect(screen.queryByText("Generation failed. Try again.")).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/AvatarField.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/AvatarField.design-system.test.tsx
@@ -81,7 +81,7 @@ describe("AvatarField design-system alerts", () => {
 
     expect(alert).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Dismiss" }))
+    await user.click(screen.getByRole("button", { name: "Close" }))
 
     expect(screen.queryByText("Generation failed. Try again.")).not.toBeInTheDocument()
   })

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx
@@ -1,0 +1,137 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import {
+  CharacterListContent,
+  type CharacterListContentProps
+} from "../CharacterListContent"
+
+const t = ((
+  key: string,
+  fallbackOrOptions?: string | { defaultValue?: string; [k: string]: unknown }
+) => {
+  if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+  if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+    return fallbackOrOptions.defaultValue || key
+  }
+  return key
+}) as CharacterListContentProps["t"]
+
+const createProps = (
+  overrides: Partial<CharacterListContentProps> = {}
+): CharacterListContentProps => ({
+  t,
+  status: "error",
+  error: new Error("server down"),
+  refetch: vi.fn(),
+  data: undefined,
+  totalCharacters: 0,
+  pagedGalleryData: [],
+  conversationCounts: undefined,
+  viewMode: "table",
+  characterListScope: "active",
+  setCharacterListScope: vi.fn(),
+  galleryDensity: "comfortable",
+  tableDensity: "comfortable",
+  currentPage: 1,
+  setCurrentPage: vi.fn(),
+  pageSize: 20,
+  setPageSize: vi.fn(),
+  sortColumn: null,
+  setSortColumn: vi.fn(),
+  sortOrder: null,
+  setSortOrder: vi.fn(),
+  hasFilters: false,
+  searchTerm: "",
+  filterTags: [],
+  setFilterTags: vi.fn(),
+  matchAllTags: false,
+  folderFilterId: undefined,
+  selectedFolderFilterLabel: undefined,
+  creatorFilter: undefined,
+  createdFromDate: "",
+  createdToDate: "",
+  updatedFromDate: "",
+  updatedToDate: "",
+  hasConversationsOnly: false,
+  favoritesOnly: false,
+  clearFilters: vi.fn(),
+  previewCharacter: null,
+  setPreviewCharacter: vi.fn(),
+  previewCharacterWorldBooks: [],
+  previewCharacterWorldBooksLoading: false,
+  crossNavigationContext: { launchedFromWorldBooks: false },
+  inlineEdit: null,
+  setInlineEdit: vi.fn(),
+  inlineUpdating: false,
+  inlineEditInputRef: React.createRef(),
+  startInlineEdit: vi.fn(),
+  saveInlineEdit: vi.fn(),
+  cancelInlineEdit: vi.fn(),
+  selectedCharacterIds: new Set(),
+  setSelectedCharacterIds: vi.fn(),
+  toggleCharacterSelection: vi.fn(),
+  selectAllOnPage: vi.fn(),
+  clearSelection: vi.fn(),
+  selectedCount: 0,
+  hasSelection: false,
+  allOnPageSelected: false,
+  someOnPageSelected: false,
+  handleBulkDelete: vi.fn(),
+  handleBulkExport: vi.fn(),
+  handleOpenCompareModal: vi.fn(),
+  bulkOperationLoading: false,
+  setBulkTagModalOpen: vi.fn(),
+  handleChat: vi.fn(),
+  handleChatInNewTab: vi.fn().mockResolvedValue(undefined),
+  preloadCharacterEditor: vi.fn().mockResolvedValue(undefined),
+  handleEdit: vi.fn(),
+  handleDuplicate: vi.fn(),
+  handleDelete: vi.fn().mockResolvedValue(undefined),
+  handleExport: vi.fn().mockResolvedValue(undefined),
+  handleViewConversations: vi.fn(),
+  handleRestoreFromTrash: vi.fn(),
+  handleToggleFavorite: vi.fn().mockResolvedValue(undefined),
+  handleSetDefaultCharacter: vi.fn().mockResolvedValue(undefined),
+  handleClearDefaultCharacter: vi.fn().mockResolvedValue(undefined),
+  isDefaultCharacterRecord: vi.fn().mockReturnValue(false),
+  isCharacterFavoriteRecord: vi.fn().mockReturnValue(false),
+  isPersonaCreatePending: vi.fn().mockReturnValue(false),
+  getCreatePersonaActionLabel: vi.fn().mockReturnValue("Create persona"),
+  openPersonaGardenForCharacter: vi.fn(),
+  createPersonaFromCharacter: vi.fn(),
+  openVersionHistory: vi.fn(),
+  openQuickChat: vi.fn(),
+  deleting: false,
+  exporting: null,
+  setConversationCharacter: vi.fn(),
+  setCharacterChats: vi.fn(),
+  setChatsError: vi.fn(),
+  setConversationsOpen: vi.fn(),
+  openCreateModal: vi.fn(),
+  setShowTemplates: vi.fn(),
+  markTemplateChooserSeen: vi.fn(),
+  isImportBusy: false,
+  triggerImportPicker: vi.fn(),
+  confirmDanger: vi.fn().mockResolvedValue(true),
+  ...overrides
+})
+
+describe("CharacterListContent design-system alerts", () => {
+  it("renders load errors through the design-system Alert primitive and keeps retry behavior", async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn()
+
+    render(<CharacterListContent {...createProps({ refetch })} />)
+
+    const title = screen.getByText("Couldn't load characters")
+    const alert = title.closest('[data-ds-component="Alert"]')
+
+    expect(alert).toBeInTheDocument()
+
+    await user.click(within(alert as HTMLElement).getByRole("button", { name: "Retry" }))
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/GenerateCharacterPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/GenerateCharacterPanel.test.tsx
@@ -102,8 +102,11 @@ describe("GenerateCharacterPanel", () => {
     expect(alert).toBeInTheDocument()
     expect(alert).toHaveTextContent("Check your internet connection and try again.")
 
+    await user.click(within(alert as HTMLElement).getByRole("button", { name: "Close" }))
+    expect(onClearError).toHaveBeenCalledTimes(1)
+
     await user.click(within(alert as HTMLElement).getByRole("button", { name: "Try again" }))
 
-    expect(onClearError).toHaveBeenCalledTimes(1)
+    expect(onClearError).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/GenerateCharacterPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/GenerateCharacterPanel.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { describe, expect, it, vi, beforeEach } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { useStorage } from "@plasmohq/storage/hook"
@@ -56,6 +57,10 @@ describe("GenerateCharacterPanel", () => {
 
     expect(
       screen.getByText("No AI generation model available")
+        .closest('[data-ds-component="Alert"]')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("No AI generation model available")
     ).toBeInTheDocument()
     expect(
       screen.getByText(
@@ -67,5 +72,38 @@ describe("GenerateCharacterPanel", () => {
       name: "Go to model settings"
     })
     expect(settingsLink).toHaveAttribute("href", "/settings/model")
+  })
+
+  it("renders generation errors through the design-system Alert primitive with retry behavior", async () => {
+    const user = userEvent.setup()
+    const onClearError = vi.fn()
+
+    useStorageMock.mockReturnValue(["gpt-4o", vi.fn(), { isLoading: false }] as any)
+    useQueryMock.mockReturnValue({
+      data: [{ model: "gpt-4o", provider: "openai" }],
+      isLoading: false
+    } as any)
+
+    render(
+      <MemoryRouter>
+        <GenerateCharacterPanel
+          isGenerating={false}
+          error="network connection error"
+          onGenerate={vi.fn()}
+          onCancel={vi.fn()}
+          onClearError={onClearError}
+        />
+      </MemoryRouter>
+    )
+
+    const errorTitle = screen.getByText("Network connection error.")
+    const alert = errorTitle.closest('[data-ds-component="Alert"]')
+
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveTextContent("Check your internet connection and try again.")
+
+    await user.click(within(alert as HTMLElement).getByRole("button", { name: "Try again" }))
+
+    expect(onClearError).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
@@ -3546,7 +3546,7 @@ describe("CharactersManager first-use onboarding", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Saved characters are still available. Configure a chat model, then return here to continue with No Model Character."
+        "Your character selection and draft are kept. Configure a chat model, then return here to continue with No Model Character."
       )
     ).toBeInTheDocument()
     expectDesignSystemAlertForText(
@@ -3615,7 +3615,7 @@ describe("CharactersManager first-use onboarding", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Saved characters are still available. Configure a chat model, then return here to continue with Intent Character."
+        "Your character selection and draft are kept. Configure a chat model, then return here to continue with Intent Character."
       )
     ).toBeInTheDocument()
     expectDesignSystemAlertForText(
@@ -3754,9 +3754,17 @@ describe("CharactersManager first-use onboarding", () => {
     )
     expect(
       await screen.findByText(
-        "Choose a chat model before chatting as Stale Model Character"
+        "Configure a chat model before chatting as Stale Model Character"
       )
     ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Your character selection and draft are kept. Configure a chat model, then return here to continue with Stale Model Character."
+      )
+    ).toBeInTheDocument()
+    expectDesignSystemAlertForText(
+      "Configure a chat model before chatting as Stale Model Character"
+    )
     expect(navigateMock).not.toHaveBeenCalled()
     expect(focusComposerMock).not.toHaveBeenCalled()
   }, 30000)

--- a/backlog/tasks/task-45.44.11.4 - Migrate-remaining-Character-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.11.4 - Migrate-remaining-Character-alerts-to-design-system-Alert.md
@@ -1,0 +1,71 @@
+---
+id: TASK-45.44.11.4
+title: Migrate remaining Character alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-24 17:00'
+labels:
+  - design-system
+  - webui
+  - extension
+  - product-state
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1668'
+  - apps/packages/ui/src/components/Option/Characters/AvatarField.tsx
+  - apps/packages/ui/src/components/Option/Characters/CharacterListContent.tsx
+  - apps/packages/ui/src/components/Option/Characters/GenerateCharacterPanel.tsx
+  - apps/packages/ui/scripts/design-system-product-state-baseline.json
+parent_task_id: TASK-45.44.11
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Migrate the remaining Character/Persona product-state AntD Alert usages to the canonical design-system Alert primitive and remove the corresponding baseline rows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Product-state baseline no longer contains Option/Characters Alert rows and the design-system guard passes.
+- [x] #2 AvatarField no-backend and generation-error states render via the design-system Alert primitive.
+- [x] #3 CharacterListContent load-error state renders via the design-system Alert primitive without losing retry behavior.
+- [x] #4 GenerateCharacterPanel no-model and generation-error states render via the design-system Alert primitive without losing settings/retry behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Starting from origin/dev in .worktrees/design-system-next-state-slice on branch codex/design-system-next-state-slice.
+
+RED: focused Character alert tests failed because titles had no data-ds-component="Alert" ancestor while components still used AntD Alert.
+
+GREEN: migrated AvatarField, CharacterListContent, and GenerateCharacterPanel to @/components/ui/primitives/Alert while preserving retry/settings/dismiss callbacks.
+
+Removed the five Option/Characters Alert exceptions from design-system-product-state-baseline.json.
+
+Verification:
+- bunx vitest run src/components/Option/Characters/__tests__/GenerateCharacterPanel.test.tsx src/components/Option/Characters/__tests__/AvatarField.design-system.test.tsx src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx => 3 files / 5 tests passed. Bun emitted its existing localStorage warning.
+- node scripts/verify-design-system-product-state.mjs => exit 0; baseline exceptions now 228 with no Character/Persona product area rows.
+- git diff --check => exit 0.
+
+Bandit: skipped because this slice only changes TypeScript/TSX frontend and Backlog.md task metadata; no Python code touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the remaining Character/Persona AntD Alert product states in AvatarField, CharacterListContent, and GenerateCharacterPanel to the canonical design-system Alert primitive. Added focused regression coverage for no-backend, load-error, no-model, and generation-error states, then removed the five fixed Option/Characters rows from the product-state baseline.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-45.44.11.4 - Migrate-remaining-Character-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.11.4 - Migrate-remaining-Character-alerts-to-design-system-Alert.md
@@ -3,8 +3,8 @@ id: TASK-45.44.11.4
 title: Migrate remaining Character alerts to design-system Alert
 status: Done
 assignee: []
-created_date: ''
-updated_date: '2026-05-24 17:00'
+created_date: '2026-05-24'
+updated_date: '2026-05-26 00:47'
 labels:
   - design-system
   - webui
@@ -46,9 +46,16 @@ GREEN: migrated AvatarField, CharacterListContent, and GenerateCharacterPanel to
 
 Removed the five Option/Characters Alert exceptions from design-system-product-state-baseline.json.
 
+PR review follow-up:
+- Localized dismiss labels for dismissible Character Alerts with common:close.
+- Added GenerateCharacterPanel dismiss-click coverage before retry coverage.
+- Let CharacterListContent use the design-system Alert error variant styling directly.
+- Populated created_date in task front matter.
+
 Verification:
+- bun run test:characters-harness => 3 files / 104 tests passed. Bun emitted its existing localStorage warning and an AntD popup/shadow-root warning in an unrelated preview path.
 - bunx vitest run src/components/Option/Characters/__tests__/GenerateCharacterPanel.test.tsx src/components/Option/Characters/__tests__/AvatarField.design-system.test.tsx src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx => 3 files / 5 tests passed. Bun emitted its existing localStorage warning.
-- node scripts/verify-design-system-product-state.mjs => exit 0; baseline exceptions now 228 with no Character/Persona product area rows.
+- node scripts/verify-design-system-product-state.mjs => exit 0; baseline remains 228 with no Character/Persona product-area rows.
 - git diff --check => exit 0.
 
 Bandit: skipped because this slice only changes TypeScript/TSX frontend and Backlog.md task metadata; no Python code touched.
@@ -57,7 +64,7 @@ Bandit: skipped because this slice only changes TypeScript/TSX frontend and Back
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Migrated the remaining Character/Persona AntD Alert product states in AvatarField, CharacterListContent, and GenerateCharacterPanel to the canonical design-system Alert primitive. Added focused regression coverage for no-backend, load-error, no-model, and generation-error states, then removed the five fixed Option/Characters rows from the product-state baseline.
+Migrated the remaining Character/Persona AntD Alert product states in AvatarField, CharacterListContent, and GenerateCharacterPanel to the canonical design-system Alert primitive. Addressed PR review follow-ups by localizing dismiss labels, relying on Alert variant styling directly for CharacterListContent load-error UI, adding dismiss-action regression coverage, updating Character harness copy assertions to current readiness text, and completing task metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Migrates the remaining Character/Persona AntD Alert product states in AvatarField, CharacterListContent, and GenerateCharacterPanel to the canonical design-system Alert primitive.
- Adds focused regression tests for no-backend, load-error, no-model, and generation-error states.
- Removes the five fixed Option/Characters rows from the product-state baseline and closes TASK-45.44.11.4.

## Verification
- bunx vitest run src/components/Option/Characters/__tests__/GenerateCharacterPanel.test.tsx src/components/Option/Characters/__tests__/AvatarField.design-system.test.tsx src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx
- node scripts/verify-design-system-product-state.mjs
- git diff --check

## Change summary
Human-written change summary required before merge per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated remaining Character/Persona alerts from `antd` to the design-system `Alert` to unify product-state UI and remove legacy exceptions. Preserves dismiss, retry, and settings-link behaviors; adds focused tests for no-backend, load-error, no-model, and generation-error states, and closes TASK-45.44.11.4.

- **Refactors**
  - Replaced `antd` `Alert` with `@/components/ui/primitives/Alert` in `AvatarField`, `CharacterListContent`, and `GenerateCharacterPanel`.
  - Removed five Option/Characters Alert exceptions from `apps/packages/ui/scripts/design-system-product-state-baseline.json`; design-system guard now passes.
  - Localized dismiss labels and used `Alert` variant styling/content slots; added dismiss/retry coverage and refreshed first‑use onboarding copy in tests.

<sup>Written for commit f73cb4018b2e006409d8506079d97619f6a58bce. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2054?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

