### PR TITLE
fix: filter chat model selector to configured providers

### DIFF
--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
@@ -92,6 +92,8 @@ describe("TldwApiClient getModels normalization", () => {
               type: "chat",
               is_configured: false,
               provider_is_configured: false,
+              provider_enabled: false,
+              availability: "unavailable",
               catalog_only: true
             },
             {
@@ -117,6 +119,8 @@ describe("TldwApiClient getModels normalization", () => {
         provider: "openai",
         is_configured: false,
         provider_is_configured: false,
+        provider_enabled: false,
+        availability: "unavailable",
         catalog_only: true
       })
     )
@@ -126,7 +130,127 @@ describe("TldwApiClient getModels normalization", () => {
         provider: "custom",
         is_configured: undefined,
         provider_is_configured: undefined,
+        provider_enabled: undefined,
+        availability: undefined,
         catalog_only: undefined
+      })
+    )
+  })
+
+  it("enriches model availability from the provider listing when metadata omits it", async () => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string }) => {
+      if (request.path === "/api/v1/llm/models/metadata") {
+        return {
+          models: [
+            {
+              id: "openai/gpt-4o-mini",
+              provider: "openai",
+              type: "chat"
+            },
+            {
+              id: "anthropic/claude-sonnet-4",
+              provider: "anthropic",
+              type: "chat"
+            }
+          ]
+        }
+      }
+      if (request.path === "/api/v1/llm/providers") {
+        return {
+          providers: [
+            {
+              name: "openai",
+              is_configured: true,
+              enabled: true,
+              availability: "available"
+            },
+            {
+              name: "anthropic",
+              is_configured: false,
+              enabled: false,
+              availability: "unavailable"
+            }
+          ]
+        }
+      }
+      return {}
+    })
+
+    const client = new TldwApiClient()
+    const models = await client.getModels()
+
+    expect(models[0]).toEqual(
+      expect.objectContaining({
+        id: "openai/gpt-4o-mini",
+        is_configured: true,
+        provider_is_configured: true,
+        provider_enabled: true,
+        availability: "available"
+      })
+    )
+    expect(models[1]).toEqual(
+      expect.objectContaining({
+        id: "anthropic/claude-sonnet-4",
+        is_configured: false,
+        provider_is_configured: false,
+        provider_enabled: false,
+        availability: "unavailable"
+      })
+    )
+  })
+
+  it("enriches chat providers even when non-chat catalog entries already have availability metadata", async () => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string }) => {
+      if (request.path === "/api/v1/llm/models/metadata") {
+        return {
+          models: [
+            {
+              id: "openai/gpt-4o-mini",
+              provider: "openai",
+              type: "chat"
+            },
+            {
+              id: "anthropic/claude-sonnet-4",
+              provider: "anthropic",
+              type: "chat"
+            },
+            {
+              id: "image/stable_diffusion_cpp",
+              provider: "image",
+              type: "image",
+              is_configured: false
+            }
+          ]
+        }
+      }
+      if (request.path === "/api/v1/llm/providers") {
+        return {
+          providers: [
+            {
+              name: "openai",
+              is_configured: true
+            },
+            {
+              name: "anthropic",
+              is_configured: false
+            }
+          ]
+        }
+      }
+      return {}
+    })
+
+    const client = new TldwApiClient()
+    const models = await client.getModels()
+
+    expect(models.find((model) => model.id === "openai/gpt-4o-mini")).toEqual(
+      expect.objectContaining({
+        is_configured: true
+      })
+    )
+    expect(models.find((model) => model.id === "anthropic/claude-sonnet-4")).toEqual(
+      expect.objectContaining({
+        is_configured: false
       })
     )
   })

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
@@ -199,6 +199,98 @@ describe("TldwApiClient getModels normalization", () => {
     )
   })
 
+  it("matches provider availability across provider key aliases", async () => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string }) => {
+      if (request.path === "/api/v1/llm/models/metadata") {
+        return {
+          models: [
+            {
+              id: "local/llama",
+              provider: "llamacpp",
+              type: "chat"
+            },
+            {
+              id: "custom/model",
+              provider: "custom-openai-api",
+              type: "chat"
+            }
+          ]
+        }
+      }
+      if (request.path === "/api/v1/llm/providers") {
+        return {
+          providers: [
+            {
+              name: "llama.cpp",
+              is_configured: false,
+              enabled: false
+            },
+            {
+              name: "custom_openai_api",
+              is_configured: true,
+              enabled: true
+            }
+          ]
+        }
+      }
+      return {}
+    })
+
+    const client = new TldwApiClient()
+    const models = await client.getModels()
+
+    expect(models.find((model) => model.id === "local/llama")).toEqual(
+      expect.objectContaining({
+        is_configured: false,
+        provider_is_configured: false,
+        provider_enabled: false
+      })
+    )
+    expect(models.find((model) => model.id === "custom/model")).toEqual(
+      expect.objectContaining({
+        is_configured: true,
+        provider_is_configured: true,
+        provider_enabled: true
+      })
+    )
+  })
+
+  it("skips provider listing when model metadata already has availability status", async () => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string }) => {
+      if (request.path === "/api/v1/llm/models/metadata") {
+        return {
+          models: [
+            {
+              id: "openai/gpt-4o-mini",
+              provider: "openai",
+              type: "chat",
+              is_configured: true,
+              provider_enabled: true,
+              availability: "available"
+            }
+          ]
+        }
+      }
+      if (request.path === "/api/v1/llm/providers") {
+        throw new Error("provider listing should not be fetched")
+      }
+      return {}
+    })
+
+    const client = new TldwApiClient()
+    const models = await client.getModels()
+
+    expect(models[0]).toEqual(
+      expect.objectContaining({
+        id: "openai/gpt-4o-mini",
+        is_configured: true,
+        provider_enabled: true,
+        availability: "available"
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(1)
+  })
+
   it("enriches chat providers even when non-chat catalog entries already have availability metadata", async () => {
     mocks.bgRequest.mockImplementation(async (request: { path?: string }) => {
       if (request.path === "/api/v1/llm/models/metadata") {

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -46,6 +46,14 @@ import {
   type BrowserSurface
 } from "@/services/tldw/browser-networking"
 import {
+  buildProviderAvailabilityMap,
+  normalizeProviderAvailabilityKey,
+  shouldFetchProviderAvailability,
+  toNonEmptyProviderString,
+  toOptionalProviderBoolean,
+  type TldwProvidersResponse
+} from "@/services/tldw/model-provider-availability"
+import {
   buildContentPayload,
   mapApiDetailToUi,
   mapApiListToUi,
@@ -1959,49 +1967,13 @@ export class TldwApiClientBase {
       const trimmed = value.trim()
       return trimmed.length > 0 ? trimmed : null
     }
-    const toOptionalBoolean = (value: unknown): boolean | undefined =>
-      typeof value === "boolean" ? value : undefined
     const isLikelyModelId = (value: string): boolean => {
       if (/\s/.test(value)) return false
       return /[/:._-]/.test(value)
     }
-    const providerKey = (value: unknown): string | null =>
-      toNonEmptyString(value)?.toLowerCase() ?? null
-    const providerAvailability = new Map<
-      string,
-      {
-        is_configured?: boolean
-        provider_enabled?: boolean
-        availability?: string
-      }
-    >()
-    try {
-      const providersPayload = await this.getProviders()
-      const providers = Array.isArray(providersPayload)
-        ? providersPayload
-        : Array.isArray(providersPayload?.providers)
-          ? providersPayload.providers
-          : []
-      for (const provider of providers) {
-        const key = providerKey(
-          typeof provider === "string"
-            ? provider
-            : provider?.name ?? provider?.provider ?? provider?.id
-        )
-        if (!key) continue
-        providerAvailability.set(key, {
-          is_configured:
-            toOptionalBoolean(provider?.is_configured) ??
-            toOptionalBoolean(provider?.configured),
-          provider_enabled:
-            toOptionalBoolean(provider?.provider_enabled) ??
-            toOptionalBoolean(provider?.enabled),
-          availability: toNonEmptyString(provider?.availability) ?? undefined
-        })
-      }
-    } catch {
-      // Older servers may not expose provider listings; keep legacy behavior.
-    }
+    const providerAvailability = shouldFetchProviderAvailability(list)
+      ? await buildProviderAvailabilityMap(() => this.getProviders())
+      : new Map()
 
     return list.map((m: any) => {
       const rawModel =
@@ -2018,9 +1990,9 @@ export class TldwApiClientBase {
         rawName && !isLikelyModelId(rawName) && rawName !== canonicalModelId
           ? `${rawName} (${canonicalModelId})`
           : canonicalModelId
-      const provider = String(m.provider || "default")
+      const provider = toNonEmptyString(m.provider) || "default"
       const inheritedAvailability = providerAvailability.get(
-        provider.toLowerCase()
+        normalizeProviderAvailabilityKey(provider) || ""
       )
 
       return {
@@ -2057,19 +2029,23 @@ export class TldwApiClientBase {
         ),
         type: typeof m.type === "string" ? m.type : undefined,
         is_configured:
-          toOptionalBoolean(m.is_configured) ??
-          toOptionalBoolean(m.provider_configured) ??
+          toOptionalProviderBoolean(m.is_configured) ??
+          toOptionalProviderBoolean(m.provider_configured) ??
+          toOptionalProviderBoolean(m.configured) ??
           inheritedAvailability?.is_configured,
         provider_is_configured:
-          toOptionalBoolean(m.provider_is_configured) ??
+          toOptionalProviderBoolean(m.provider_is_configured) ??
+          toOptionalProviderBoolean(m.provider_configured) ??
+          toOptionalProviderBoolean(m.configured) ??
           inheritedAvailability?.is_configured,
         provider_enabled:
-          toOptionalBoolean(m.provider_enabled) ??
-          toOptionalBoolean(m.enabled) ??
+          toOptionalProviderBoolean(m.provider_enabled) ??
+          toOptionalProviderBoolean(m.enabled) ??
           inheritedAvailability?.provider_enabled,
         availability:
-          toNonEmptyString(m.availability) ?? inheritedAvailability?.availability,
-        catalog_only: toOptionalBoolean(m.catalog_only),
+          toNonEmptyProviderString(m.availability) ??
+          inheritedAvailability?.availability,
+        catalog_only: toOptionalProviderBoolean(m.catalog_only),
         modalities:
           m.modalities && typeof m.modalities === "object"
             ? {
@@ -2100,8 +2076,11 @@ export class TldwApiClientBase {
     })
   }
 
-  async getProviders(): Promise<any> {
-    return await bgRequest<any>({ path: '/api/v1/llm/providers', method: 'GET' })
+  async getProviders(): Promise<TldwProvidersResponse> {
+    return await bgRequest<TldwProvidersResponse>({
+      path: '/api/v1/llm/providers',
+      method: 'GET'
+    })
   }
 
   /**

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -550,6 +550,8 @@ export interface TldwModel {
   type?: string
   is_configured?: boolean
   provider_is_configured?: boolean
+  provider_enabled?: boolean
+  availability?: string
   catalog_only?: boolean
   modalities?: {
     input?: string[]
@@ -1957,9 +1959,48 @@ export class TldwApiClientBase {
       const trimmed = value.trim()
       return trimmed.length > 0 ? trimmed : null
     }
+    const toOptionalBoolean = (value: unknown): boolean | undefined =>
+      typeof value === "boolean" ? value : undefined
     const isLikelyModelId = (value: string): boolean => {
       if (/\s/.test(value)) return false
       return /[/:._-]/.test(value)
+    }
+    const providerKey = (value: unknown): string | null =>
+      toNonEmptyString(value)?.toLowerCase() ?? null
+    const providerAvailability = new Map<
+      string,
+      {
+        is_configured?: boolean
+        provider_enabled?: boolean
+        availability?: string
+      }
+    >()
+    try {
+      const providersPayload = await this.getProviders()
+      const providers = Array.isArray(providersPayload)
+        ? providersPayload
+        : Array.isArray(providersPayload?.providers)
+          ? providersPayload.providers
+          : []
+      for (const provider of providers) {
+        const key = providerKey(
+          typeof provider === "string"
+            ? provider
+            : provider?.name ?? provider?.provider ?? provider?.id
+        )
+        if (!key) continue
+        providerAvailability.set(key, {
+          is_configured:
+            toOptionalBoolean(provider?.is_configured) ??
+            toOptionalBoolean(provider?.configured),
+          provider_enabled:
+            toOptionalBoolean(provider?.provider_enabled) ??
+            toOptionalBoolean(provider?.enabled),
+          availability: toNonEmptyString(provider?.availability) ?? undefined
+        })
+      }
+    } catch {
+      // Older servers may not expose provider listings; keep legacy behavior.
     }
 
     return list.map((m: any) => {
@@ -1977,12 +2018,16 @@ export class TldwApiClientBase {
         rawName && !isLikelyModelId(rawName) && rawName !== canonicalModelId
           ? `${rawName} (${canonicalModelId})`
           : canonicalModelId
+      const provider = String(m.provider || "default")
+      const inheritedAvailability = providerAvailability.get(
+        provider.toLowerCase()
+      )
 
       return {
         ...m,
         id: canonicalModelId,
         name: displayName,
-        provider: String(m.provider || "default"),
+        provider,
         description: m.description,
         capabilities: Array.isArray(m.capabilities)
           ? m.capabilities
@@ -2011,9 +2056,20 @@ export class TldwApiClientBase {
           (m.capabilities && m.capabilities.json_mode) ?? m.json_output
         ),
         type: typeof m.type === "string" ? m.type : undefined,
-        is_configured: m.is_configured,
-        provider_is_configured: m.provider_is_configured,
-        catalog_only: m.catalog_only,
+        is_configured:
+          toOptionalBoolean(m.is_configured) ??
+          toOptionalBoolean(m.provider_configured) ??
+          inheritedAvailability?.is_configured,
+        provider_is_configured:
+          toOptionalBoolean(m.provider_is_configured) ??
+          inheritedAvailability?.is_configured,
+        provider_enabled:
+          toOptionalBoolean(m.provider_enabled) ??
+          toOptionalBoolean(m.enabled) ??
+          inheritedAvailability?.provider_enabled,
+        availability:
+          toNonEmptyString(m.availability) ?? inheritedAvailability?.availability,
+        catalog_only: toOptionalBoolean(m.catalog_only),
         modalities:
           m.modalities && typeof m.modalities === "object"
             ? {

--- a/apps/packages/ui/src/services/tldw/TldwModels.ts
+++ b/apps/packages/ui/src/services/tldw/TldwModels.ts
@@ -36,8 +36,24 @@ const AUDIO_MODEL_HINTS = [
 
 const NON_CHAT_MODEL_HINTS = ["rerank", "moderation", "safety"]
 
+const UNSELECTABLE_CHAT_MODEL_AVAILABILITY = new Set([
+  "disabled",
+  "failed",
+  "unavailable",
+  "not-configured"
+])
+
 const hasAnyHint = (value: string, hints: string[]): boolean =>
   hints.some((hint) => value.includes(hint))
+
+const normalizeAvailabilityStatus = (value: string | undefined): string | null => {
+  if (typeof value !== "string") return null
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, "-")
+  return normalized.length > 0 ? normalized : null
+}
 
 const isAbortLikeModelFetchError = (error: unknown): boolean => {
   const candidate = error as
@@ -424,13 +440,9 @@ export class TldwModelsService {
     if (model.isConfigured === false) return false
     if (model.providerIsConfigured === false) return false
     if (model.providerEnabled === false) return false
-    const availability = model.availability?.trim().toLowerCase()
-    if (
-      availability &&
-      ["disabled", "failed", "unavailable", "not-configured", "not_configured"].includes(
-        availability
-      )
-    ) {
+    if (model.catalogOnly === true) return false
+    const availability = normalizeAvailabilityStatus(model.availability)
+    if (availability && UNSELECTABLE_CHAT_MODEL_AVAILABILITY.has(availability)) {
       return false
     }
     return true

--- a/apps/packages/ui/src/services/tldw/TldwModels.ts
+++ b/apps/packages/ui/src/services/tldw/TldwModels.ts
@@ -66,6 +66,8 @@ export interface ModelInfo {
   description?: string
   isConfigured?: boolean
   providerIsConfigured?: boolean
+  providerEnabled?: boolean
+  availability?: string
   catalogOnly?: boolean
   modalities?: {
     input?: string[]
@@ -80,7 +82,7 @@ export class TldwModelsService {
   private readonly CACHE_DURATION = 15 * 60 * 1000 // 15 minutes
   private readonly FORCE_REFRESH_COOLDOWN = 30 * 1000
   private readonly CACHE_KEY = "tldwModelsCache"
-  private readonly CACHE_SCHEMA_VERSION = 6
+  private readonly CACHE_SCHEMA_VERSION = 7
   private storage = createSafeStorage({ area: "local" })
   private storageLoaded = false
   private storageInitPromise: Promise<void> | null = null
@@ -249,7 +251,7 @@ export class TldwModelsService {
     options?: { refreshOpenRouter?: boolean }
   ): Promise<ModelInfo[]> {
     const models = await this.getModels(forceRefresh, options)
-    return models.filter(m => m.type === 'chat')
+    return models.filter((model) => this.isSelectableChatModel(model))
   }
 
   async getCachedChatModels(): Promise<ModelInfo[]> {
@@ -262,7 +264,9 @@ export class TldwModelsService {
       this.lastForcedFetchTime = 0
     }
     this.cacheScopeKey = scopeKey
-    return (this.cachedModels || []).filter((model) => model.type === "chat")
+    return (this.cachedModels || []).filter((model) =>
+      this.isSelectableChatModel(model)
+    )
   }
 
   /**
@@ -392,6 +396,8 @@ export class TldwModelsService {
       inferProviderFromModel(tldwModel.id, "llm") ||
       inferProviderFromModel(tldwModel.name, "llm")
     const provider = tldwModel.provider || inferred || "unknown"
+    const toOptionalBoolean = (value: unknown): boolean | undefined =>
+      typeof value === "boolean" ? value : undefined
 
     return {
       id: tldwModel.id,
@@ -401,11 +407,33 @@ export class TldwModelsService {
       capabilities: caps.length ? Array.from(new Set(caps)) : undefined,
       contextLength: tldwModel.context_length,
       description: tldwModel.description,
-      isConfigured: tldwModel.is_configured,
-      providerIsConfigured: tldwModel.provider_is_configured,
-      catalogOnly: tldwModel.catalog_only,
+      isConfigured: toOptionalBoolean(tldwModel.is_configured),
+      providerIsConfigured: toOptionalBoolean(tldwModel.provider_is_configured),
+      providerEnabled: toOptionalBoolean(tldwModel.provider_enabled),
+      availability:
+        typeof tldwModel.availability === "string"
+          ? tldwModel.availability
+          : undefined,
+      catalogOnly: toOptionalBoolean(tldwModel.catalog_only),
       modalities: tldwModel.modalities
     }
+  }
+
+  private isSelectableChatModel(model: ModelInfo): boolean {
+    if (model.type !== "chat") return false
+    if (model.isConfigured === false) return false
+    if (model.providerIsConfigured === false) return false
+    if (model.providerEnabled === false) return false
+    const availability = model.availability?.trim().toLowerCase()
+    if (
+      availability &&
+      ["disabled", "failed", "unavailable", "not-configured", "not_configured"].includes(
+        availability
+      )
+    ) {
+      return false
+    }
+    return true
   }
 
   /**

--- a/apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
@@ -224,14 +224,46 @@ describe("TldwModelsService caching", () => {
     expect(chatIds).not.toContain("black-forest-labs/flux.1-schnell")
   })
 
-  it("carries provider configuration flags into chat model descriptors", async () => {
+  it("filters chat models from explicitly unconfigured providers", async () => {
     mocks.getModels.mockResolvedValue([
+      {
+        id: "openai/gpt-4o-mini",
+        name: "openai/gpt-4o-mini",
+        provider: "openai",
+        type: "chat",
+        is_configured: true
+      },
+      {
+        id: "anthropic/claude-sonnet-4",
+        name: "anthropic/claude-sonnet-4",
+        provider: "anthropic",
+        type: "chat",
+        is_configured: false
+      }
+    ])
+
+    const { TldwModelsService } = await importService()
+    const service = new TldwModelsService()
+
+    const chatModels = await service.getChatModels(true)
+
+    expect(chatModels.map((model) => model.id)).toEqual(["openai/gpt-4o-mini"])
+  })
+
+  it("filters chat models from explicitly unconfigured providers using provider-level metadata", async () => {
+    mocks.getModels.mockResolvedValue([
+      {
+        id: "openai/gpt-4o-mini",
+        name: "openai/gpt-4o-mini",
+        provider: "openai",
+        type: "chat",
+        provider_is_configured: true
+      },
       {
         id: "qwen/qwen-max",
         name: "qwen-max",
         provider: "qwen",
         type: "chat",
-        is_configured: false,
         provider_is_configured: false,
         catalog_only: true
       }
@@ -242,14 +274,113 @@ describe("TldwModelsService caching", () => {
 
     const chatModels = await service.getChatModels(true)
 
-    expect(chatModels[0]?.isConfigured).toBe(false)
-    expect(chatModels[0]?.providerIsConfigured).toBe(false)
-    expect(chatModels[0]?.catalogOnly).toBe(true)
+    expect(chatModels.map((model) => model.id)).toEqual(["openai/gpt-4o-mini"])
+  })
+
+  it("filters chat models from explicitly disabled providers", async () => {
+    mocks.getModels.mockResolvedValue([
+      {
+        id: "openai/gpt-4o-mini",
+        name: "openai/gpt-4o-mini",
+        provider: "openai",
+        type: "chat",
+        is_configured: true,
+        provider_enabled: true
+      },
+      {
+        id: "openrouter/meta-llama/llama-3.1-8b-instruct",
+        name: "openrouter/meta-llama/llama-3.1-8b-instruct",
+        provider: "openrouter",
+        type: "chat",
+        is_configured: true,
+        provider_enabled: false
+      }
+    ])
+
+    const { TldwModelsService } = await importService()
+    const service = new TldwModelsService()
+
+    const chatModels = await service.getChatModels(true)
+
+    expect(chatModels.map((model) => model.id)).toEqual(["openai/gpt-4o-mini"])
+  })
+
+  it("filters chat models from providers with failed availability", async () => {
+    mocks.getModels.mockResolvedValue([
+      {
+        id: "openai/gpt-4o-mini",
+        name: "openai/gpt-4o-mini",
+        provider: "openai",
+        type: "chat",
+        is_configured: true,
+        availability: "available"
+      },
+      {
+        id: "vllm/local-model",
+        name: "vllm/local-model",
+        provider: "vllm",
+        type: "chat",
+        is_configured: true,
+        availability: "failed"
+      }
+    ])
+
+    const { TldwModelsService } = await importService()
+    const service = new TldwModelsService()
+
+    const chatModels = await service.getChatModels(true)
+
+    expect(chatModels.map((model) => model.id)).toEqual(["openai/gpt-4o-mini"])
+  })
+
+  it("keeps legacy chat models when provider availability metadata is absent", async () => {
+    mocks.getModels.mockResolvedValue([
+      {
+        id: "legacy/model-a",
+        name: "legacy/model-a",
+        provider: "custom",
+        type: "chat"
+      }
+    ])
+
+    const { TldwModelsService } = await importService()
+    const service = new TldwModelsService()
+
+    const chatModels = await service.getChatModels(true)
+
+    expect(chatModels.map((model) => model.id)).toEqual(["legacy/model-a"])
+  })
+
+  it("carries provider configuration flags into model descriptors", async () => {
+    mocks.getModels.mockResolvedValue([
+      {
+        id: "qwen/qwen-max",
+        name: "qwen-max",
+        provider: "qwen",
+        type: "chat",
+        is_configured: false,
+        provider_is_configured: false,
+        provider_enabled: false,
+        availability: "unavailable",
+        catalog_only: true
+      }
+    ])
+
+    const { TldwModelsService } = await importService()
+    const service = new TldwModelsService()
+
+    const models = await service.getModels(true)
+
+    expect(models[0]?.isConfigured).toBe(false)
+    expect(models[0]?.providerIsConfigured).toBe(false)
+    expect(models[0]?.providerEnabled).toBe(false)
+    expect(models[0]?.availability).toBe("unavailable")
+    expect(models[0]?.catalogOnly).toBe(true)
   })
 
   it("returns cached chat models without fetching provider metadata again", async () => {
     mocks.storageGet.mockResolvedValue({
-      version: 6,
+      version: 7,
       timestamp: Date.now(),
       scope: "http://127.0.0.1:8000|single-user|key|none",
       models: [
@@ -258,6 +389,13 @@ describe("TldwModelsService caching", () => {
           name: "openai/gpt-4o-mini",
           provider: "openai",
           type: "chat"
+        },
+        {
+          id: "anthropic/claude-sonnet-4",
+          name: "anthropic/claude-sonnet-4",
+          provider: "anthropic",
+          type: "chat",
+          isConfigured: false
         },
         {
           id: "black-forest-labs/flux.1-schnell",

--- a/apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
@@ -322,6 +322,47 @@ describe("TldwModelsService caching", () => {
         type: "chat",
         is_configured: true,
         availability: "failed"
+      },
+      {
+        id: "custom/not-configured-model",
+        name: "custom/not-configured-model",
+        provider: "custom",
+        type: "chat",
+        is_configured: true,
+        availability: "not configured"
+      }
+    ])
+
+    const { TldwModelsService } = await importService()
+    const service = new TldwModelsService()
+
+    const chatModels = await service.getChatModels(true)
+
+    expect(chatModels.map((model) => model.id)).toEqual(["openai/gpt-4o-mini"])
+  })
+
+  it("filters catalog-only chat models even when provider metadata says configured", async () => {
+    mocks.getModels.mockResolvedValue([
+      {
+        id: "openai/gpt-4o-mini",
+        name: "openai/gpt-4o-mini",
+        provider: "openai",
+        type: "chat",
+        is_configured: true,
+        provider_is_configured: true,
+        provider_enabled: true,
+        availability: "available"
+      },
+      {
+        id: "anthropic/catalog-only",
+        name: "anthropic/catalog-only",
+        provider: "anthropic",
+        type: "chat",
+        is_configured: true,
+        provider_is_configured: true,
+        provider_enabled: true,
+        availability: "available",
+        catalog_only: true
       }
     ])
 

--- a/apps/packages/ui/src/services/tldw/domains/models-audio.ts
+++ b/apps/packages/ui/src/services/tldw/domains/models-audio.ts
@@ -1,6 +1,14 @@
 import { bgRequest } from "@/services/background-proxy"
 import { buildQuery } from "../client-utils"
 import { appendPathQuery } from "../path-utils"
+import {
+  buildProviderAvailabilityMap,
+  normalizeProviderAvailabilityKey,
+  shouldFetchProviderAvailability,
+  toNonEmptyProviderString,
+  toOptionalProviderBoolean,
+  type TldwProvidersResponse
+} from "../model-provider-availability"
 import type {
   LlamacppAsset,
   LlamacppAcquisitionJobListResponse,
@@ -49,7 +57,7 @@ import type {
  */
 export interface TldwApiClientCore {
   getModelsMetadata(options?: { refreshOpenRouter?: boolean }): Promise<any>
-  getProviders(): Promise<any>
+  getProviders(): Promise<TldwProvidersResponse>
   createImageArtifact(request: any): Promise<any>
   ensureConfigForRequest(requireAuth: boolean): Promise<any>
   request<T>(init: any, requireAuth?: boolean): Promise<T>
@@ -79,49 +87,13 @@ export const modelsAudioMethods = {
       const trimmed = value.trim()
       return trimmed.length > 0 ? trimmed : null
     }
-    const toOptionalBoolean = (value: unknown): boolean | undefined =>
-      typeof value === "boolean" ? value : undefined
     const isLikelyModelId = (value: string): boolean => {
       if (/\s/.test(value)) return false
       return /[/:._-]/.test(value)
     }
-    const providerKey = (value: unknown): string | null =>
-      toNonEmptyString(value)?.toLowerCase() ?? null
-    const providerAvailability = new Map<
-      string,
-      {
-        is_configured?: boolean
-        provider_enabled?: boolean
-        availability?: string
-      }
-    >()
-    try {
-      const providersPayload = await this.getProviders()
-      const providers = Array.isArray(providersPayload)
-        ? providersPayload
-        : Array.isArray(providersPayload?.providers)
-          ? providersPayload.providers
-          : []
-      for (const provider of providers) {
-        const key = providerKey(
-          typeof provider === "string"
-            ? provider
-            : provider?.name ?? provider?.provider ?? provider?.id
-        )
-        if (!key) continue
-        providerAvailability.set(key, {
-          is_configured:
-            toOptionalBoolean(provider?.is_configured) ??
-            toOptionalBoolean(provider?.configured),
-          provider_enabled:
-            toOptionalBoolean(provider?.provider_enabled) ??
-            toOptionalBoolean(provider?.enabled),
-          availability: toNonEmptyString(provider?.availability) ?? undefined
-        })
-      }
-    } catch {
-      // Older servers may not expose provider listings; keep legacy behavior.
-    }
+    const providerAvailability = shouldFetchProviderAvailability(list)
+      ? await buildProviderAvailabilityMap(() => this.getProviders())
+      : new Map()
 
     return list.map((m: any) => {
       const rawModel =
@@ -138,9 +110,9 @@ export const modelsAudioMethods = {
         rawName && !isLikelyModelId(rawName) && rawName !== canonicalModelId
           ? `${rawName} (${canonicalModelId})`
           : canonicalModelId
-      const provider = String(m.provider || "default")
+      const provider = toNonEmptyString(m.provider) || "default"
       const inheritedAvailability = providerAvailability.get(
-        provider.toLowerCase()
+        normalizeProviderAvailabilityKey(provider) || ""
       )
 
       return {
@@ -176,19 +148,23 @@ export const modelsAudioMethods = {
         ),
         type: typeof m.type === "string" ? m.type : undefined,
         is_configured:
-          toOptionalBoolean(m.is_configured) ??
-          toOptionalBoolean(m.provider_configured) ??
+          toOptionalProviderBoolean(m.is_configured) ??
+          toOptionalProviderBoolean(m.provider_configured) ??
+          toOptionalProviderBoolean(m.configured) ??
           inheritedAvailability?.is_configured,
         provider_is_configured:
-          toOptionalBoolean(m.provider_is_configured) ??
+          toOptionalProviderBoolean(m.provider_is_configured) ??
+          toOptionalProviderBoolean(m.provider_configured) ??
+          toOptionalProviderBoolean(m.configured) ??
           inheritedAvailability?.is_configured,
         provider_enabled:
-          toOptionalBoolean(m.provider_enabled) ??
-          toOptionalBoolean(m.enabled) ??
+          toOptionalProviderBoolean(m.provider_enabled) ??
+          toOptionalProviderBoolean(m.enabled) ??
           inheritedAvailability?.provider_enabled,
         availability:
-          toNonEmptyString(m.availability) ?? inheritedAvailability?.availability,
-        catalog_only: toOptionalBoolean(m.catalog_only),
+          toNonEmptyProviderString(m.availability) ??
+          inheritedAvailability?.availability,
+        catalog_only: toOptionalProviderBoolean(m.catalog_only),
         modalities:
           m.modalities && typeof m.modalities === "object"
             ? {
@@ -219,8 +195,11 @@ export const modelsAudioMethods = {
     })
   },
 
-  async getProviders(): Promise<any> {
-    return await bgRequest<any>({ path: '/api/v1/llm/providers', method: 'GET' })
+  async getProviders(): Promise<TldwProvidersResponse> {
+    return await bgRequest<TldwProvidersResponse>({
+      path: '/api/v1/llm/providers',
+      method: 'GET'
+    })
   },
 
   async getModelsMetadata(options?: {

--- a/apps/packages/ui/src/services/tldw/domains/models-audio.ts
+++ b/apps/packages/ui/src/services/tldw/domains/models-audio.ts
@@ -49,6 +49,7 @@ import type {
  */
 export interface TldwApiClientCore {
   getModelsMetadata(options?: { refreshOpenRouter?: boolean }): Promise<any>
+  getProviders(): Promise<any>
   createImageArtifact(request: any): Promise<any>
   ensureConfigForRequest(requireAuth: boolean): Promise<any>
   request<T>(init: any, requireAuth?: boolean): Promise<T>
@@ -84,6 +85,43 @@ export const modelsAudioMethods = {
       if (/\s/.test(value)) return false
       return /[/:._-]/.test(value)
     }
+    const providerKey = (value: unknown): string | null =>
+      toNonEmptyString(value)?.toLowerCase() ?? null
+    const providerAvailability = new Map<
+      string,
+      {
+        is_configured?: boolean
+        provider_enabled?: boolean
+        availability?: string
+      }
+    >()
+    try {
+      const providersPayload = await this.getProviders()
+      const providers = Array.isArray(providersPayload)
+        ? providersPayload
+        : Array.isArray(providersPayload?.providers)
+          ? providersPayload.providers
+          : []
+      for (const provider of providers) {
+        const key = providerKey(
+          typeof provider === "string"
+            ? provider
+            : provider?.name ?? provider?.provider ?? provider?.id
+        )
+        if (!key) continue
+        providerAvailability.set(key, {
+          is_configured:
+            toOptionalBoolean(provider?.is_configured) ??
+            toOptionalBoolean(provider?.configured),
+          provider_enabled:
+            toOptionalBoolean(provider?.provider_enabled) ??
+            toOptionalBoolean(provider?.enabled),
+          availability: toNonEmptyString(provider?.availability) ?? undefined
+        })
+      }
+    } catch {
+      // Older servers may not expose provider listings; keep legacy behavior.
+    }
 
     return list.map((m: any) => {
       const rawModel =
@@ -100,11 +138,15 @@ export const modelsAudioMethods = {
         rawName && !isLikelyModelId(rawName) && rawName !== canonicalModelId
           ? `${rawName} (${canonicalModelId})`
           : canonicalModelId
+      const provider = String(m.provider || "default")
+      const inheritedAvailability = providerAvailability.get(
+        provider.toLowerCase()
+      )
 
       return {
         id: canonicalModelId,
         name: displayName,
-        provider: String(m.provider || "default"),
+        provider,
         description: m.description,
         capabilities: Array.isArray(m.capabilities)
           ? m.capabilities
@@ -133,8 +175,19 @@ export const modelsAudioMethods = {
           (m.capabilities && m.capabilities.json_mode) ?? m.json_output
         ),
         type: typeof m.type === "string" ? m.type : undefined,
-        is_configured: toOptionalBoolean(m.is_configured),
-        provider_is_configured: toOptionalBoolean(m.provider_is_configured),
+        is_configured:
+          toOptionalBoolean(m.is_configured) ??
+          toOptionalBoolean(m.provider_configured) ??
+          inheritedAvailability?.is_configured,
+        provider_is_configured:
+          toOptionalBoolean(m.provider_is_configured) ??
+          inheritedAvailability?.is_configured,
+        provider_enabled:
+          toOptionalBoolean(m.provider_enabled) ??
+          toOptionalBoolean(m.enabled) ??
+          inheritedAvailability?.provider_enabled,
+        availability:
+          toNonEmptyString(m.availability) ?? inheritedAvailability?.availability,
         catalog_only: toOptionalBoolean(m.catalog_only),
         modalities:
           m.modalities && typeof m.modalities === "object"

--- a/apps/packages/ui/src/services/tldw/model-provider-availability.ts
+++ b/apps/packages/ui/src/services/tldw/model-provider-availability.ts
@@ -1,0 +1,167 @@
+export type ProviderAvailability = {
+  is_configured?: boolean
+  provider_enabled?: boolean
+  availability?: string
+}
+
+export type TldwProviderEntry =
+  | string
+  | {
+      name?: unknown
+      provider?: unknown
+      id?: unknown
+      is_configured?: unknown
+      configured?: unknown
+      provider_enabled?: unknown
+      enabled?: unknown
+      availability?: unknown
+      [key: string]: unknown
+    }
+
+export type TldwProvidersResponse =
+  | TldwProviderEntry[]
+  | {
+      providers?: TldwProviderEntry[]
+      [key: string]: unknown
+    }
+
+const PROVIDER_KEY_ALIASES: Record<string, string> = {
+  "custom-openai-api": "custom_openai_api",
+  custom_openai_api: "custom_openai_api",
+  customopenaiapi: "custom_openai_api",
+  customopenai: "custom_openai_api",
+  "custom-openai-api-2": "custom_openai_api2",
+  custom_openai_api_2: "custom_openai_api2",
+  custom_openai_api2: "custom_openai_api2",
+  customopenaiapi2: "custom_openai_api2",
+  customopenai2: "custom_openai_api2",
+  gemini: "google",
+  "llama.cpp": "llama",
+  "llama-cpp": "llama",
+  llama_cpp: "llama",
+  llamacpp: "llama",
+  oobabooga: "ooba",
+  tabbyapi: "tabby",
+  "z.ai": "zai",
+  z_ai: "zai"
+}
+
+export const toNonEmptyProviderString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export const toOptionalProviderBoolean = (
+  value: unknown
+): boolean | undefined => (typeof value === "boolean" ? value : undefined)
+
+export const normalizeProviderAvailabilityKey = (
+  value: unknown
+): string | null => {
+  const raw = toNonEmptyProviderString(value)?.toLowerCase()
+  if (!raw || raw === "unknown") return null
+
+  const noWhitespace = raw.replace(/\s+/g, "")
+  const compact = noWhitespace.replace(/[._-]+/g, "")
+  return (
+    PROVIDER_KEY_ALIASES[noWhitespace] ??
+    PROVIDER_KEY_ALIASES[compact] ??
+    noWhitespace
+  )
+}
+
+const asProviderRecord = (
+  provider: TldwProviderEntry
+): Exclude<TldwProviderEntry, string> | null =>
+  provider && typeof provider === "object" ? provider : null
+
+const normalizeProviders = (
+  payload: TldwProvidersResponse | null | undefined
+): TldwProviderEntry[] => {
+  if (Array.isArray(payload)) return payload
+  if (payload && Array.isArray(payload.providers)) return payload.providers
+  return []
+}
+
+const hasOptionalBoolean = (
+  record: Record<string, unknown>,
+  keys: string[]
+): boolean => keys.some((key) => typeof record[key] === "boolean")
+
+const hasNonEmptyString = (
+  record: Record<string, unknown>,
+  key: string
+): boolean => toNonEmptyProviderString(record[key]) != null
+
+const shouldEnrichModelRecord = (model: unknown): boolean => {
+  if (!model || typeof model !== "object") return false
+  const record = model as Record<string, unknown>
+  const type = toNonEmptyProviderString(record.type)?.toLowerCase()
+  if (type && type !== "chat") return false
+
+  const hasConfigured = hasOptionalBoolean(record, [
+    "is_configured",
+    "provider_is_configured",
+    "provider_configured",
+    "configured"
+  ])
+  const hasEnabled = hasOptionalBoolean(record, [
+    "provider_enabled",
+    "enabled"
+  ])
+  const hasAvailability = hasNonEmptyString(record, "availability")
+
+  return !hasConfigured || !hasEnabled || !hasAvailability
+}
+
+export const shouldFetchProviderAvailability = (models: unknown[]): boolean =>
+  models.some(shouldEnrichModelRecord)
+
+export const buildProviderAvailabilityMap = async (
+  fetchProviders: () => Promise<TldwProvidersResponse>
+): Promise<Map<string, ProviderAvailability>> => {
+  const providerAvailability = new Map<string, ProviderAvailability>()
+  let providersPayload: TldwProvidersResponse | null = null
+
+  try {
+    providersPayload = await fetchProviders()
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.warn("tldw_server: provider availability fetch failed", error)
+    }
+    return providerAvailability
+  }
+
+  const providers = normalizeProviders(providersPayload)
+  for (const provider of providers) {
+    try {
+      const record = asProviderRecord(provider)
+      const key = normalizeProviderAvailabilityKey(
+        typeof provider === "string"
+          ? provider
+          : record?.name ?? record?.provider ?? record?.id
+      )
+      if (!key) continue
+      providerAvailability.set(key, {
+        is_configured:
+          toOptionalProviderBoolean(record?.is_configured) ??
+          toOptionalProviderBoolean(record?.configured),
+        provider_enabled:
+          toOptionalProviderBoolean(record?.provider_enabled) ??
+          toOptionalProviderBoolean(record?.enabled),
+        availability:
+          toNonEmptyProviderString(record?.availability) ?? undefined
+      })
+    } catch (error) {
+      if (import.meta.env?.DEV) {
+        console.warn("tldw_server: provider availability enrichment failed", {
+          error,
+          provider
+        })
+      }
+    }
+  }
+
+  return providerAvailability
+}

--- a/backlog/tasks/task-477 - Filter-WebUI-and-extension-chat-models-to-configured-providers.md
+++ b/backlog/tasks/task-477 - Filter-WebUI-and-extension-chat-models-to-configured-providers.md
@@ -12,6 +12,7 @@ priority: medium
 modified_files:
 - apps/packages/ui/src/services/tldw/TldwApiClient.ts
 - apps/packages/ui/src/services/tldw/domains/models-audio.ts
+- apps/packages/ui/src/services/tldw/model-provider-availability.ts
 - apps/packages/ui/src/services/tldw/TldwModels.ts
 - apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
 - apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
@@ -28,7 +29,7 @@ Ensure shared WebUI/extension chat model selector data only includes models from
 - [x] #1 Shared chat model discovery excludes models from providers explicitly reported as unconfigured or disabled.
 - [x] #2 Configured provider models remain visible, including catalog/pricing models for a configured provider.
 - [x] #3 Older server responses without provider availability metadata remain backward compatible.
-- [x] #4 Focused frontend tests cover configured, unconfigured, disabled, and legacy metadata cases.
+- [x] #4 Focused frontend tests cover configured, unconfigured, disabled, alias, catalog-only, and legacy metadata cases.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,15 +44,15 @@ Ensure shared WebUI/extension chat model selector data only includes models from
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented shared WebUI/extension chat model filtering in the tldw model service. The API client now preserves provider availability metadata and best-effort enriches models from /api/v1/llm/providers when /api/v1/llm/models/metadata omits provider status. Chat model selectors now exclude models from providers explicitly marked is_configured=false, provider_is_configured=false, provider_enabled=false, or failed/disabled/unavailable/not-configured availability, while keeping legacy unknown metadata visible for backward compatibility. Bumped the persisted model cache schema to force stale unfiltered lists to refresh.
+Implemented shared WebUI/extension chat model filtering in the tldw model service. The API client now preserves provider availability metadata and best-effort enriches models from /api/v1/llm/providers when /api/v1/llm/models/metadata omits provider status. Provider enrichment is centralized in a typed helper with alias-aware provider keys, conditional provider-list fetching, and dev-mode logging for fetch/enrichment failures. Chat model selectors now exclude models from providers explicitly marked is_configured=false, provider_is_configured=false, provider_enabled=false, catalog_only=true, or failed/disabled/unavailable/not-configured availability, while keeping legacy unknown metadata visible for backward compatibility. Bumped the persisted model cache schema to force stale unfiltered lists to refresh.
 
-Verification: bunx vitest run src/services/__tests__/tldw-api-client.models-normalization.test.ts src/services/tldw/__tests__/TldwModels.test.ts --maxWorkers=1 --no-file-parallelism passed 23 tests in the clean PR worktree. git diff --check exited 0. bunx tsc --noEmit --pretty false hit the default Node heap limit, then NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false completed and failed on existing package-wide baseline type errors; /tmp/tldw_ui_tsc_model_selector_pr_final.log has no entries for touched files. Bandit skipped because only TypeScript/Backlog files were touched.
+Verification: review follow-up focused tests passed 26 tests with `bunx vitest run src/services/__tests__/tldw-api-client.models-normalization.test.ts src/services/tldw/__tests__/TldwModels.test.ts --maxWorkers=1 --no-file-parallelism`. `git diff --check` exited 0. GitHub CI reported `Lint & Type Check` success for the initial PR commit 87972e9f44. Local optional package-wide `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` completed and reported unrelated baseline type errors outside touched files; /tmp/tldw_ui_tsc_model_selector_review_fix.log has no entries for touched files. Bandit skipped because only TypeScript/Backlog files were touched.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Shared WebUI/extension chat model discovery is now provider-availability aware. Normal chat model selectors only receive models from providers that are explicitly configured/enabled/available, while legacy servers without status metadata remain compatible. Focused service regression tests cover metadata preservation, provider-list enrichment, image catalog edge cases, unconfigured providers, disabled providers, failed availability, cached unconfigured models, and legacy unknown status.
+Shared WebUI/extension chat model discovery is now provider-availability aware. Normal chat model selectors only receive models from providers that are explicitly configured/enabled/available and not catalog-only, while legacy servers without status metadata remain compatible. Focused service regression tests cover metadata preservation, provider-list enrichment, provider aliases, conditional provider fetching, image catalog edge cases, unconfigured providers, disabled providers, failed availability, separator variants, catalog-only models, cached unconfigured models, and legacy unknown status.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-477 - Filter-WebUI-and-extension-chat-models-to-configured-providers.md
+++ b/backlog/tasks/task-477 - Filter-WebUI-and-extension-chat-models-to-configured-providers.md
@@ -1,0 +1,65 @@
+---
+id: TASK-477
+title: Filter WebUI and extension chat models to configured providers
+status: Done
+labels:
+- webui
+- extension
+- chat
+- models
+- frontend
+priority: medium
+modified_files:
+- apps/packages/ui/src/services/tldw/TldwApiClient.ts
+- apps/packages/ui/src/services/tldw/domains/models-audio.ts
+- apps/packages/ui/src/services/tldw/TldwModels.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.models-normalization.test.ts
+- apps/packages/ui/src/services/tldw/__tests__/TldwModels.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure shared WebUI/extension chat model selector data only includes models from providers that are currently configured and enabled, so users do not see impractical catalog-only models in normal selectors.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Shared chat model discovery excludes models from providers explicitly reported as unconfigured or disabled.
+- [x] #2 Configured provider models remain visible, including catalog/pricing models for a configured provider.
+- [x] #3 Older server responses without provider availability metadata remain backward compatible.
+- [x] #4 Focused frontend tests cover configured, unconfigured, disabled, and legacy metadata cases.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing frontend service tests around TldwModelsService/TldwApiClient model availability metadata.
+2. Preserve provider/model availability metadata from /api/v1/llm/providers or /api/v1/llm/models/metadata in the shared model service.
+3. Filter getChatModels/fetchChatModels results to configured/enabled providers while keeping legacy unknown metadata visible.
+4. Run focused Vitest tests and record verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented shared WebUI/extension chat model filtering in the tldw model service. The API client now preserves provider availability metadata and best-effort enriches models from /api/v1/llm/providers when /api/v1/llm/models/metadata omits provider status. Chat model selectors now exclude models from providers explicitly marked is_configured=false, provider_is_configured=false, provider_enabled=false, or failed/disabled/unavailable/not-configured availability, while keeping legacy unknown metadata visible for backward compatibility. Bumped the persisted model cache schema to force stale unfiltered lists to refresh.
+
+Verification: bunx vitest run src/services/__tests__/tldw-api-client.models-normalization.test.ts src/services/tldw/__tests__/TldwModels.test.ts --maxWorkers=1 --no-file-parallelism passed 23 tests in the clean PR worktree. git diff --check exited 0. bunx tsc --noEmit --pretty false hit the default Node heap limit, then NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false completed and failed on existing package-wide baseline type errors; /tmp/tldw_ui_tsc_model_selector_pr_final.log has no entries for touched files. Bandit skipped because only TypeScript/Backlog files were touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Shared WebUI/extension chat model discovery is now provider-availability aware. Normal chat model selectors only receive models from providers that are explicitly configured/enabled/available, while legacy servers without status metadata remain compatible. Focused service regression tests cover metadata preservation, provider-list enrichment, image catalog edge cases, unconfigured providers, disabled providers, failed availability, cached unconfigured models, and legacy unknown status.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Enriches shared WebUI/extension model metadata with provider configuration, enabled, and availability status from `/api/v1/llm/providers` when model metadata omits it.
- Filters shared chat model selector lists to hide models from explicitly unconfigured, disabled, failed, unavailable, or not-configured providers while preserving legacy unknown-status responses.
- Bumps the model cache schema and adds focused service regression coverage for provider-list enrichment, non-chat catalog edge cases, unconfigured providers, disabled providers, failed availability, cached unconfigured entries, and legacy metadata.

Backlog: `TASK-477`

## Verification

- `bunx vitest run src/services/__tests__/tldw-api-client.models-normalization.test.ts src/services/tldw/__tests__/TldwModels.test.ts --maxWorkers=1 --no-file-parallelism` passed 23 tests.
- `git diff --check` passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on existing package-wide baseline type errors; no diagnostics reference the touched files.
- Bandit skipped because this change only touches TypeScript and Backlog markdown.

## Human Change Summary Required Before Merge

Per project policy, this AI-authored PR needs the human requester to add a `Change summary` explaining what changed and why these implementation choices were made before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters WebUI and extension chat model selectors to only show models from configured, enabled, and available providers, and hides catalog-only entries. Addresses `TASK-477` and keeps legacy servers without provider metadata compatible.

- **Bug Fixes**
  - Hide chat models from providers marked unconfigured, disabled, failed, or unavailable.
  - Exclude `catalog_only` chat models from selectors.
  - Enrich model metadata with provider status from `/api/v1/llm/providers` when missing, using alias-aware keys and only fetching when needed.
  - Preserve provider flags across `TldwApiClient` and audio model normalization.
  - Bump model cache schema to v7 and add focused tests for enrichment, filtering, caching, aliases, and legacy cases.

<sup>Written for commit a0e81524d428c9cbf081b26083578ad8b5bd9314. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2057?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

