### PR TITLE
Fix custom OpenAI credential requirement

### DIFF
--- a/backlog/tasks/task-502 - Allow-custom-OpenAI-compatible-providers-without-default-credentials.md
+++ b/backlog/tasks/task-502 - Allow-custom-OpenAI-compatible-providers-without-default-credentials.md
@@ -1,0 +1,58 @@
+---
+id: TASK-502
+title: Allow custom OpenAI-compatible providers without default credentials
+status: Done
+labels:
+- bug
+- llm
+- custom-openai-api
+priority: High
+modified_files:
+- tldw_Server_API/app/core/LLM_Calls/provider_metadata.py
+- tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
+- tldw_Server_API/tests/Chat_NEW/unit/test_provider_keys_map.py
+- tldw_Server_API/tests/Config/test_config_providers_endpoints.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py
+- tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix custom-openai-api provider metadata so local/self-hosted OpenAI-compatible endpoints are not rejected before adapter invocation when no API key is configured.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regression coverage for custom OpenAI-compatible providers as keyless-by-default in provider metadata, config provider status, video confabulation checks, and chat completions credential gating.
+2. Change shared provider metadata so custom-openai-api, custom-openai-api-2, and numbered custom-openai-api-N providers do not require keys by default.
+3. Replace the video ingestion confabulation check's local custom-provider key rule with the shared provider_requires_api_key helper.
+4. Verify focused tests, adapter regression tests, py_compile, and Bandit on touched production files.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed custom OpenAI-compatible providers to be keyless by default in shared provider metadata, aligned video confabulation checks with the shared provider policy, and added regressions for metadata, config provider status, video confabulation, and chat completion credential gating. Verification: focused regression suite passed (6 passed), custom OpenAI adapter/provider map tests passed (7 passed), py_compile passed for touched production files, and Bandit reported 0 findings for touched production files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-502 - Allow-custom-OpenAI-compatible-providers-without-default-credentials.md
+++ b/backlog/tasks/task-502 - Allow-custom-OpenAI-compatible-providers-without-default-credentials.md
@@ -9,9 +9,11 @@ labels:
 priority: High
 modified_files:
 - tldw_Server_API/app/core/LLM_Calls/provider_metadata.py
+- tldw_Server_API/app/core/Evaluations/ms_g_eval.py
 - tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
 - tldw_Server_API/tests/Chat_NEW/unit/test_provider_keys_map.py
 - tldw_Server_API/tests/Config/test_config_providers_endpoints.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_ms_g_eval_validation.py
 - tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py
 - tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py
 ---
@@ -38,21 +40,21 @@ Fix custom-openai-api provider metadata so local/self-hosted OpenAI-compatible e
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Review follow-up: G-Eval validation also used its own provider key list, so custom OpenAI-compatible providers still failed no-key confabulation checks after video ingestion reached run_geval. G-Eval now uses provider_requires_api_key, provider metadata initializes all custom OpenAI-compatible provider names from the shared iterator, and video ingestion lazily imports the provider policy inside the optional confabulation branch.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Changed custom OpenAI-compatible providers to be keyless by default in shared provider metadata, aligned video confabulation checks with the shared provider policy, and added regressions for metadata, config provider status, video confabulation, and chat completion credential gating. Verification: focused regression suite passed (6 passed), custom OpenAI adapter/provider map tests passed (7 passed), py_compile passed for touched production files, and Bandit reported 0 findings for touched production files.
+Changed custom OpenAI-compatible providers to be keyless by default in shared provider metadata, aligned video confabulation and G-Eval validation with the shared provider policy, and added regressions for metadata, config provider status, video confabulation, G-Eval validation, and chat completion credential gating. Verification: focused regression suite passed (21 passed), custom OpenAI adapter/provider map tests passed (7 passed), py_compile passed for touched production files, and Bandit reported 0 findings for touched production files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
 - [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/core/Evaluations/ms_g_eval.py
+++ b/tldw_Server_API/app/core/Evaluations/ms_g_eval.py
@@ -498,25 +498,9 @@ def validate_inputs(document: str, summary: str, api_name: str | None, api_key: 
         raise ValueError(f"Unsupported API: {api_name}")
 
     # Check if API key is required for the given API
-    commercial_apis = {
-        "openai",
-        "anthropic",
-        "cohere",
-        "groq",
-        "openrouter",
-        "deepseek",
-        "huggingface",
-        "mistral",
-        "google",
-        "qwen",
-        "custom-openai-api",
-        "custom-openai-api-2",
-        "aphrodite",
-    }
-    if (
-        api_provider_key in commercial_apis
-        or custom_openai_provider_number(api_provider_key) is not None
-    ) and not api_key:
+    from tldw_Server_API.app.core.LLM_Calls.provider_metadata import provider_requires_api_key
+
+    if provider_requires_api_key(api_provider_key) and not api_key:
         raise ValueError(f"API key is required for {api_name}. Please provide a valid API key.")
 
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
@@ -62,6 +62,7 @@ from tldw_Server_API.app.core.custom_openai_providers import (
     custom_openai_section_name,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import resolve_safe_local_path
+from tldw_Server_API.app.core.LLM_Calls.provider_metadata import provider_requires_api_key
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_Server_API.app.core.Security.egress import evaluate_url_policy
@@ -132,22 +133,6 @@ _PROVIDER_ENV_MAP: dict[str, str] = {
     "local-llm": "LOCAL_LLM_API_KEY",
     "ollama": "OLLAMA_API_KEY",
     "aphrodite": "APHRODITE_API_KEY",
-}
-
-_PROVIDERS_REQUIRING_KEYS = {
-    "openai",
-    "anthropic",
-    "cohere",
-    "groq",
-    "openrouter",
-    "deepseek",
-    "huggingface",
-    "mistral",
-    "google",
-    "qwen",
-    "custom-openai-api",
-    "custom-openai-api-2",
-    "aphrodite",
 }
 
 media_config = loaded_config_data.get('media_processing', {}) if loaded_config_data else {}
@@ -1204,10 +1189,7 @@ def process_videos(
         else:
             resolved_api_key = _resolve_eval_api_key(api_name)
             api_provider_key = api_name.lower().strip()
-            provider_requires_key = (
-                api_provider_key in _PROVIDERS_REQUIRING_KEYS
-                or custom_openai_provider_number(api_provider_key) is not None
-            )
+            provider_requires_key = provider_requires_api_key(api_provider_key)
             if provider_requires_key and not resolved_api_key:
                 warning_msg = f"Confabulation check skipped: missing API key for provider '{api_name}'."
                 logging.warning(warning_msg)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
@@ -62,7 +62,6 @@ from tldw_Server_API.app.core.custom_openai_providers import (
     custom_openai_section_name,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import resolve_safe_local_path
-from tldw_Server_API.app.core.LLM_Calls.provider_metadata import provider_requires_api_key
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_Server_API.app.core.Security.egress import evaluate_url_policy
@@ -1189,7 +1188,12 @@ def process_videos(
         else:
             resolved_api_key = _resolve_eval_api_key(api_name)
             api_provider_key = api_name.lower().strip()
-            provider_requires_key = provider_requires_api_key(api_provider_key)
+            try:
+                from tldw_Server_API.app.core.LLM_Calls.provider_metadata import provider_requires_api_key
+
+                provider_requires_key = provider_requires_api_key(api_provider_key)
+            except _VIDEO_NONCRITICAL_EXCEPTIONS:
+                provider_requires_key = True
             if provider_requires_key and not resolved_api_key:
                 warning_msg = f"Confabulation check skipped: missing API key for provider '{api_name}'."
                 logging.warning(warning_msg)

--- a/tldw_Server_API/app/core/LLM_Calls/provider_metadata.py
+++ b/tldw_Server_API/app/core/LLM_Calls/provider_metadata.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from tldw_Server_API.app.core.custom_openai_providers import iter_custom_openai_provider_names
-from tldw_Server_API.app.core.LLM_Calls.adapter_registry import get_registry
 
 PROVIDER_REQUIRES_KEY: dict[str, bool] = {
     "openai": True,
@@ -31,11 +30,9 @@ PROVIDER_REQUIRES_KEY: dict[str, bool] = {
     "ollama": False,
     "aphrodite": False,
     "mlx": False,
-    "custom-openai-api": False,
-    "custom-openai-api-2": False,
 }
 PROVIDER_REQUIRES_KEY.update(
-    {provider_name: False for provider_name in iter_custom_openai_provider_names(start=3)}
+    {provider_name: False for provider_name in iter_custom_openai_provider_names()}
 )
 
 DEFAULT_BYOK_ALLOWED_FIELDS: set[str] = {"org_id", "project_id"}
@@ -46,13 +43,11 @@ BYOK_CREDENTIAL_FIELDS: dict[str, dict[str, set[str]]] = {
     "novita": {"allowed": {"org_id", "project_id"}, "required": set()},
     "poe": {"allowed": {"org_id", "project_id"}, "required": set()},
     "together": {"allowed": {"org_id", "project_id"}, "required": set()},
-    "custom-openai-api": {"allowed": {"org_id", "project_id"}, "required": set()},
-    "custom-openai-api-2": {"allowed": {"org_id", "project_id"}, "required": set()},
 }
 BYOK_CREDENTIAL_FIELDS.update(
     {
         provider_name: {"allowed": {"org_id", "project_id"}, "required": set()}
-        for provider_name in iter_custom_openai_provider_names(start=3)
+        for provider_name in iter_custom_openai_provider_names()
     }
 )
 
@@ -246,4 +241,6 @@ PROVIDER_CAPABILITIES.update(
 
 
 def list_registered_providers() -> list[str]:
+    from tldw_Server_API.app.core.LLM_Calls.adapter_registry import get_registry
+
     return get_registry().list_providers()

--- a/tldw_Server_API/app/core/LLM_Calls/provider_metadata.py
+++ b/tldw_Server_API/app/core/LLM_Calls/provider_metadata.py
@@ -31,11 +31,11 @@ PROVIDER_REQUIRES_KEY: dict[str, bool] = {
     "ollama": False,
     "aphrodite": False,
     "mlx": False,
-    "custom-openai-api": True,
-    "custom-openai-api-2": True,
+    "custom-openai-api": False,
+    "custom-openai-api-2": False,
 }
 PROVIDER_REQUIRES_KEY.update(
-    {provider_name: True for provider_name in iter_custom_openai_provider_names(start=3)}
+    {provider_name: False for provider_name in iter_custom_openai_provider_names(start=3)}
 )
 
 DEFAULT_BYOK_ALLOWED_FIELDS: set[str] = {"org_id", "project_id"}

--- a/tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py
+++ b/tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py
@@ -657,6 +657,8 @@ def test_keyless_provider_proceeds_without_key(  # Added default_chat_request_da
     valid_auth_token,
     mock_media_db,
     mock_chat_db,
+    monkeypatch,
+    bypass_api_limits,
 ):
     mock_load_template.return_value = None  # Default passthrough
     mock_apply_template.side_effect = lambda template_str, data: data.get(
@@ -666,20 +668,33 @@ def test_keyless_provider_proceeds_without_key(  # Added default_chat_request_da
     app.dependency_overrides[get_media_db_for_user] = lambda: mock_media_db
     app.dependency_overrides[get_chacha_db_for_user] = lambda: mock_chat_db
 
+    monkeypatch.delenv("CUSTOM_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CUSTOM_OPENAI_API_KEY_99", raising=False)
+    monkeypatch.delenv("CUSTOM_OPENAI_API_KEY_1", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.AuthNZ.byok_runtime.resolve_server_default_key",
+        lambda _provider: None,
+    )
+
     with (
+        bypass_api_limits(app),
         patch.dict("tldw_Server_API.app.api.v1.endpoints.chat.API_KEYS", {}, clear=True),
+        patch.dict("tldw_Server_API.app.api.v1.schemas.chat_request_schemas.API_KEYS", {}, clear=True),
+        patch("tldw_Server_API.app.api.v1.schemas.chat_request_schemas.get_api_keys", return_value={}),
         patch("tldw_Server_API.app.api.v1.endpoints.chat.perform_chat_api_call") as mock_chat_api_call,
     ):
-        mock_chat_api_call.return_value = {"id": "res_ollama"}
-        request_data_ollama = default_chat_request_data.model_copy(update={"api_provider": "ollama"})
+        mock_chat_api_call.return_value = {"id": "res_custom_openai"}
+        request_data_keyless = default_chat_request_data.model_copy(update={"api_provider": "custom-openai-api"})
 
         response = client.post_with_csrf(
-            "/api/v1/chat/completions", json=request_data_ollama.model_dump(), headers={"Authorization": valid_auth_token}
+            "/api/v1/chat/completions",
+            json=request_data_keyless.model_dump(),
+            headers={"Authorization": valid_auth_token},
         )
         assert response.status_code == status.HTTP_200_OK
         mock_chat_api_call.assert_called_once()
         api_key = mock_chat_api_call.call_args[1].get("api_key")
-        assert api_key is None, f"Expected None for keyless provider, got: {api_key!r}"
+        assert api_key is None, f"Expected None for custom-openai-api, got: {api_key!r}"
     # Clean up only the overrides we added (not the auth override from fixture)
     app.dependency_overrides.pop(get_media_db_for_user, None)
     app.dependency_overrides.pop(get_chacha_db_for_user, None)

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_provider_keys_map.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_provider_keys_map.py
@@ -16,12 +16,23 @@ def test_provider_requires_key_map_basic():
         "novita",
         "poe",
         "together",
-        "custom-openai-api-99",
     ]:
         assert provider_requires_api_key(prov) is True
 
-    # Local providers typically do not require keys
-    for prov in ["llama.cpp", "kobold", "ooba", "tabbyapi", "vllm", "local-llm", "ollama", "aphrodite"]:
+    # Local and user-configured OpenAI-compatible providers typically do not require keys.
+    for prov in [
+        "llama.cpp",
+        "kobold",
+        "ooba",
+        "tabbyapi",
+        "vllm",
+        "local-llm",
+        "ollama",
+        "aphrodite",
+        "custom-openai-api",
+        "custom-openai-api-2",
+        "custom-openai-api-99",
+    ]:
         assert provider_requires_api_key(prov) is False
 
     # Unknown providers default to requiring keys

--- a/tldw_Server_API/tests/Config/test_config_providers_endpoints.py
+++ b/tldw_Server_API/tests/Config/test_config_providers_endpoints.py
@@ -255,6 +255,24 @@ class TestListConfiguredProviders:
         assert ollama.key_hint is None
 
     @pytest.mark.asyncio
+    async def test_custom_openai_providers_do_not_require_keys_by_default(self, monkeypatch):
+        monkeypatch.delenv("CUSTOM_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CUSTOM_OPENAI2_API_KEY", raising=False)
+        monkeypatch.delenv("CUSTOM_OPENAI_API_KEY_99", raising=False)
+
+        with patch(
+            "tldw_Server_API.app.api.v1.schemas.chat_request_schemas.get_api_keys",
+            return_value={},
+        ):
+            response = await list_configured_providers()
+
+        for provider_name in ("custom-openai-api", "custom-openai-api-2", "custom-openai-api-99"):
+            provider = next(p for p in response.providers if p.name == provider_name)
+            assert provider.configured is True
+            assert provider.requires_api_key is False
+            assert provider.key_hint is None
+
+    @pytest.mark.asyncio
     async def test_no_cloud_providers_configured(self, monkeypatch):
         # Remove all env vars
         for env_var in [

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_ms_g_eval_validation.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_ms_g_eval_validation.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tldw_Server_API.app.core.Evaluations import ms_g_eval
 from tldw_Server_API.app.core.Evaluations.ms_g_eval import validate_inputs
 
 
@@ -7,12 +8,12 @@ from tldw_Server_API.app.core.Evaluations.ms_g_eval import validate_inputs
 @pytest.mark.parametrize(
     ("api_name", "api_key"),
     [
-        ("custom-openai-api", "key"),
-        ("custom-openai-api-2", "key"),
-        ("custom-openai-api-99", "key"),
+        ("custom-openai-api", None),
+        ("custom-openai-api-2", None),
+        ("custom-openai-api-99", None),
+        ("aphrodite", None),
         ("google", "key"),
         ("qwen", "key"),
-        ("aphrodite", "key"),
         ("llama.cpp", None),
     ],
 )
@@ -24,11 +25,28 @@ def test_validate_inputs_accepts_supported_providers(api_name, api_key):
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "api_name",
-    ["google", "qwen", "custom-openai-api", "custom-openai-api-2", "custom-openai-api-99", "aphrodite"],
+    ["google", "qwen", "openai"],
 )
 def test_validate_inputs_enforces_keys_for_commercial_apis(api_name):
     with pytest.raises(ValueError, match="API key is required"):
         validate_inputs("document", "summary", api_name, api_key=None)
+
+
+@pytest.mark.unit
+def test_run_geval_accepts_custom_openai_provider_without_key(monkeypatch):
+    monkeypatch.setattr(ms_g_eval, "geval_summarization", lambda *args, **kwargs: 4)
+
+    result = ms_g_eval.run_geval(
+        "document",
+        "summary",
+        api_key=None,
+        api_name="custom-openai-api",
+        save=False,
+    )
+
+    assert not result["assessment"].startswith("Validation error")
+    assert result["metrics"]["coherence"] == 4
+    assert result["average_score"] == 4.0
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py
@@ -175,7 +175,8 @@ def test_confabulation_requires_keys_for_commercial_providers(mock_single, mock_
 @patch("tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib._resolve_eval_api_key", return_value=None)
 @patch("tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib.run_geval")
 @patch("tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib.process_single_video")
-def test_confabulation_allows_keyless_provider(mock_single, mock_geval, _mock_resolve_key, tmp_path):
+@pytest.mark.parametrize("api_name", ["llama.cpp", "custom-openai-api", "custom-openai-api-99"])
+def test_confabulation_allows_keyless_provider(mock_single, mock_geval, _mock_resolve_key, api_name, tmp_path):
     transcript_text = "local transcript"
     summary_text = "summary via local model"
 
@@ -213,7 +214,7 @@ def test_confabulation_allows_keyless_provider(mock_single, mock_geval, _mock_re
         use_multi_level_chunking=False,
         chunk_language=None,
         summarize_recursively=False,
-        api_name="llama.cpp",
+        api_name=api_name,
         use_cookies=False,
         cookies=None,
         timestamp_option=False,
@@ -227,7 +228,7 @@ def test_confabulation_allows_keyless_provider(mock_single, mock_geval, _mock_re
     mock_geval.assert_called_once()
     args, kwargs = mock_geval.call_args
     assert args[:3] == (transcript_text, summary_text, None)
-    assert args[3] == "llama.cpp"
+    assert args[3] == api_name
     assert kwargs.get("user_identifier") == "42"
     assert result["processed_count"] == 1
     assert result["confabulation_results"].startswith("Confabulation checks completed")


### PR DESCRIPTION
Summary
- Treat custom OpenAI-compatible providers as keyless by default in shared provider metadata, including numbered custom providers.
- Align video ingestion confabulation checks with the shared provider credential policy.
- Add regressions for provider metadata, provider status reporting, video confabulation checks, and chat completions credential gating.

Verification
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat_NEW/unit/test_provider_keys_map.py tldw_Server_API/tests/Config/test_config_providers_endpoints.py::TestListConfiguredProviders::test_custom_openai_providers_do_not_require_keys_by_default tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py::test_confabulation_allows_keyless_provider tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py::test_keyless_provider_proceeds_without_key
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py tldw_Server_API/tests/Chat_NEW/unit/test_provider_keys_map.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/LLM_Calls/provider_metadata.py tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/LLM_Calls/provider_metadata.py tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py -f json -o /tmp/bandit_custom_openai_optional_key.json

Notes
- TASK-502 tracks this PR slice.
- Per repo policy, a human-authored Change summary should be added before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make custom OpenAI‑compatible providers keyless by default and align credential checks across chat, video ingestion, and G‑Eval to stop rejecting self‑hosted endpoints. Addresses TASK-502.

- **Bug Fixes**
  - Marked `custom-openai-api`, `custom-openai-api-2`, and all numbered variants as not requiring API keys in shared provider metadata.
  - Replaced hardcoded lists with shared `provider_requires_api_key` in video confabulation (with a safe lazy import) and G‑Eval validation.
  - Added tests for provider metadata/configuration, chat with keyless custom providers, video confabulation, and G‑Eval without keys.

<sup>Written for commit a21346f5d11a7b94ca9db9b04763b0bbf4d0918d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2063?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

