### PR TITLE
test(flashcards): add phase 0 UX harness

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
@@ -413,6 +413,7 @@ export const FlashcardCreateDrawer: React.FC<
             <Button
               onClick={handleCreateAndAddAnother}
               loading={createMutation.isPending}
+              disabled={createMutation.isPending}
             >
               {t("option:flashcards.createAndAddAnother", {
                 defaultValue: "Create & Add Another"
@@ -422,6 +423,7 @@ export const FlashcardCreateDrawer: React.FC<
               type="primary"
               onClick={handleCreate}
               loading={createMutation.isPending}
+              disabled={createMutation.isPending}
             >
               {t("common:create", { defaultValue: "Create" })}
             </Button>

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { Form } from "antd"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -396,14 +396,32 @@ describe("FlashcardCreateDrawer deck reference section", () => {
     ).toBeInTheDocument()
   }, 15000)
 
-  it("shows create errors and keeps entered fields when creation fails", async () => {
+  it("shows create errors, disables while pending, and keeps entered fields after creation fails", async () => {
     const onClose = vi.fn()
     const onSuccess = vi.fn()
-    createFlashcardMutateAsync.mockRejectedValueOnce(
-      new Error("Create service unavailable")
-    )
+    let isCreatePending = false
+    let rejectCreate!: (error: Error) => void
+    const createError = new Error("Create service unavailable")
 
-    renderDrawer({ onClose, onSuccess })
+    createFlashcardMutateAsync.mockImplementationOnce(async () => {
+      isCreatePending = true
+      const pendingCreate = new Promise<never>((_resolve, reject) => {
+        rejectCreate = reject
+      })
+      try {
+        return await pendingCreate
+      } finally {
+        isCreatePending = false
+      }
+    })
+    vi.mocked(useCreateFlashcardMutation).mockImplementation(() => ({
+      mutateAsync: createFlashcardMutateAsync,
+      get isPending() {
+        return isCreatePending
+      }
+    } as any))
+
+    const { rerender } = renderDrawer({ onClose, onSuccess })
 
     await selectDeck("Biology")
     fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
@@ -418,9 +436,21 @@ describe("FlashcardCreateDrawer deck reference section", () => {
     await waitFor(() => {
       expect(createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
     })
+    rerender(<FlashcardCreateDrawer open onClose={onClose} onSuccess={onSuccess} />)
+    expect(screen.getByRole("button", { name: /Create$/ })).toBeDisabled()
+
+    const createPromise = createFlashcardMutateAsync.mock.results[0]?.value as
+      | Promise<unknown>
+      | undefined
+    await act(async () => {
+      rejectCreate(createError)
+      await createPromise?.catch(() => undefined)
+    })
+
     await waitFor(() => {
       expect(messageApi.error).toHaveBeenCalledWith("Create service unavailable")
     })
+    rerender(<FlashcardCreateDrawer open onClose={onClose} onSuccess={onSuccess} />)
 
     expect(onClose).not.toHaveBeenCalled()
     expect(onSuccess).not.toHaveBeenCalled()
@@ -430,7 +460,7 @@ describe("FlashcardCreateDrawer deck reference section", () => {
     expect((screen.getByPlaceholderText("Answer...") as HTMLTextAreaElement).value).toBe(
       "Retain this answer"
     )
-    expect(screen.getByRole("button", { name: "Create" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: /Create$/ })).toBeEnabled()
   })
 
   it("clears the reference search term when the selected deck changes", async () => {

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
@@ -77,16 +77,18 @@ vi.mock("react-i18next", () => ({
   })
 }))
 
+const messageApi = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  loading: vi.fn(),
+  open: vi.fn(),
+  destroy: vi.fn()
+}))
+
 vi.mock("@/hooks/useAntdMessage", () => ({
-  useAntdMessage: () => ({
-    success: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warning: vi.fn(),
-    loading: vi.fn(),
-    open: vi.fn(),
-    destroy: vi.fn()
-  })
+  useAntdMessage: () => messageApi
 }))
 
 vi.mock("../../hooks", () => ({
@@ -249,7 +251,10 @@ describe("FlashcardCreateDrawer deck reference section", () => {
   const selectDeck = async (deckName: string) => {
     const deckInputs = screen.getAllByLabelText("Deck")
     fireEvent.mouseDown(deckInputs[deckInputs.length - 1] as HTMLElement)
-    fireEvent.click(await screen.findByText(deckName))
+    const deckOptions = await screen.findAllByText(deckName, {
+      selector: ".ant-select-item-option-content"
+    })
+    fireEvent.click(deckOptions[deckOptions.length - 1] as HTMLElement)
   }
 
   const expandReferenceSection = async () => {
@@ -389,6 +394,43 @@ describe("FlashcardCreateDrawer deck reference section", () => {
         selector: ".ant-select-content-value"
       })
     ).toBeInTheDocument()
+  }, 15000)
+
+  it("shows create errors and keeps entered fields when creation fails", async () => {
+    const onClose = vi.fn()
+    const onSuccess = vi.fn()
+    createFlashcardMutateAsync.mockRejectedValueOnce(
+      new Error("Create service unavailable")
+    )
+
+    renderDrawer({ onClose, onSuccess })
+
+    await selectDeck("Biology")
+    fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
+      target: { value: "Retain this prompt" }
+    })
+    fireEvent.change(screen.getByPlaceholderText("Answer..."), {
+      target: { value: "Retain this answer" }
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(messageApi.error).toHaveBeenCalledWith("Create service unavailable")
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect((screen.getByPlaceholderText("Question or prompt...") as HTMLTextAreaElement).value).toBe(
+      "Retain this prompt"
+    )
+    expect((screen.getByPlaceholderText("Answer...") as HTMLTextAreaElement).value).toBe(
+      "Retain this answer"
+    )
+    expect(screen.getByRole("button", { name: "Create" })).toBeEnabled()
   })
 
   it("clears the reference search term when the selected deck changes", async () => {
@@ -405,7 +447,7 @@ describe("FlashcardCreateDrawer deck reference section", () => {
     await expandReferenceSection()
 
     expect((screen.getByPlaceholderText("Search this deck") as HTMLInputElement).value).toBe("")
-  })
+  }, 15000)
 
   it("clears the reference search term when the drawer closes and reopens", async () => {
     const { rerender } = render(

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -112,6 +112,10 @@ export class FlashcardsPage extends BasePage {
     return this.page.locator('[data-testid="flashcards-review-mode-toggle"]');
   }
 
+  get reviewModeCramOption(): Locator {
+    return this.reviewModeToggle.getByText('Cram', { exact: true });
+  }
+
   get reviewPromptSideToggle(): Locator {
     return this.page.locator('[data-testid="flashcards-review-prompt-side-toggle"]');
   }
@@ -132,8 +136,22 @@ export class FlashcardsPage extends BasePage {
     return this.page.locator('[data-testid="flashcards-review-show-answer"]');
   }
 
+  get reviewGoodButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-rate-3"]');
+  }
+
+  get reviewEasyButton(): Locator {
+    return this.page.locator('[data-testid="flashcards-review-rate-4"]');
+  }
+
   get reviewEmptyCard(): Locator {
     return this.page.locator('[data-testid="flashcards-review-empty-card"]');
+  }
+
+  get reviewCompletionState(): Locator {
+    return this.reviewEmptyCard.filter({
+      hasText: /cards reviewed this session|no cards are due|all caught up|cram complete/i,
+    });
   }
 
   get reviewAnalyticsSummary(): Locator {
@@ -187,15 +205,39 @@ export class FlashcardsPage extends BasePage {
   }
 
   get createDrawer(): Locator {
-    return this.page.locator('.ant-drawer-content').filter({ hasText: 'Create Flashcard' }).last();
+    return this.page.getByRole('dialog', { name: 'Create Flashcard' }).last();
   }
 
   get createDrawerDeckSelect(): Locator {
     return this.createDrawer.locator('.ant-select').first();
   }
 
+  get createFrontTextarea(): Locator {
+    return this.createDrawer.getByPlaceholder('Question or prompt...');
+  }
+
+  get createBackTextarea(): Locator {
+    return this.createDrawer.getByPlaceholder('Answer...');
+  }
+
+  get createSubmitButton(): Locator {
+    return this.createDrawer.getByRole('button', { name: 'Create', exact: true });
+  }
+
+  get createAndAddAnotherButton(): Locator {
+    return this.createDrawer.getByRole('button', { name: 'Create & Add Another', exact: true });
+  }
+
+  get createSuccessMessage(): Locator {
+    return this.page.locator('.ant-message-notice-success').filter({ hasText: /created/i });
+  }
+
+  get createErrorMessage(): Locator {
+    return this.page.locator('.ant-message-notice-error');
+  }
+
   get editDrawer(): Locator {
-    return this.page.locator('.ant-drawer-content').filter({ hasText: 'Edit Flashcard' }).last();
+    return this.page.getByRole('dialog', { name: 'Edit Flashcard' }).last();
   }
 
   get editDrawerAdditionalFieldsToggle(): Locator {

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -248,6 +248,70 @@ test.describe('Flashcards', () => {
 
       await assertNoCriticalErrors(diagnostics);
     });
+
+    test('should review a seeded card using only keyboard shortcuts', async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      skipIfServerUnavailable(serverInfo);
+
+      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const deck = await createFlashcardDeck(`E2E Keyboard Review ${runId}`);
+      const front = `Keyboard front ${runId}`;
+      const back = `Keyboard back ${runId}`;
+
+      await createFlashcardCard({
+        deckId: deck.id,
+        front,
+        back,
+      });
+
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.gotoPath(`/flashcards?tab=review&deck_id=${deck.id}`);
+      await flashcards.assertPageReady();
+
+      expect(await flashcards.isOnline()).toBe(true);
+      await expect(flashcards.reviewActiveCard).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.reviewActiveCard.getByText(front, { exact: true })).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(flashcards.reviewShowAnswerButton).toBeVisible({ timeout: 10_000 });
+
+      await authedPage.keyboard.press('Space');
+
+      await expect(flashcards.reviewGoodButton).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.reviewActiveCard.getByText(back, { exact: true })).toBeVisible({
+        timeout: 10_000,
+      });
+
+      const reviewResponsePromise = authedPage.waitForResponse((response) => {
+        return (
+          response.request().method() === 'POST' &&
+          /\/api\/v1\/flashcards\/review$/.test(response.url())
+        );
+      });
+
+      await authedPage.keyboard.press('3');
+
+      const reviewResponse = await reviewResponsePromise;
+      expect(reviewResponse.status()).toBeLessThan(400);
+
+      await expect
+        .poll(
+          async () => {
+            const completionVisible = await flashcards.reviewCompletionState
+              .isVisible()
+              .catch(() => false);
+            const activeCardVisible = await flashcards.reviewActiveCard.isVisible().catch(() => false);
+            return completionVisible || activeCardVisible;
+          },
+          { timeout: 20_000 }
+        )
+        .toBe(true);
+
+      await assertNoCriticalErrors(diagnostics);
+    });
   });
 
   // =========================================================================
@@ -369,6 +433,53 @@ test.describe('Flashcards', () => {
       } catch {
         // Search may debounce; acceptable if no immediate call
       }
+
+      await assertNoCriticalErrors(diagnostics);
+    });
+
+    test('creates a flashcard from the drawer and shows it in Manage', async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      skipIfServerUnavailable(serverInfo);
+
+      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const front = `Drawer-created front ${runId}`;
+      const back = `Drawer-created back ${runId}`;
+
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.gotoPath('/flashcards?tab=manage');
+      await flashcards.assertPageReady();
+
+      expect(await flashcards.isOnline()).toBe(true);
+      await flashcards.switchToTab('manage');
+      await expect(flashcards.manageTopBar).toBeVisible({ timeout: 10_000 });
+
+      await flashcards.fabCreateButton.click();
+      await expect(flashcards.createDrawer).toBeVisible({ timeout: 10_000 });
+      await flashcards.createFrontTextarea.fill(front);
+      await flashcards.createBackTextarea.fill(back);
+
+      const createResponsePromise = authedPage.waitForResponse((response) => {
+        return (
+          response.request().method() === 'POST' &&
+          /\/api\/v1\/flashcards$/.test(response.url())
+        );
+      });
+
+      await flashcards.createSubmitButton.click();
+
+      const createResponse = await createResponsePromise;
+      expect(createResponse.status()).toBeLessThan(400);
+      const createdCard = (await createResponse.json()) as SeededCard;
+      expect(createdCard.uuid).toBeTruthy();
+
+      await expect(flashcards.createDrawer).toBeHidden({ timeout: 10_000 });
+      await expect(flashcards.getManageFlashcardRow(createdCard.uuid)).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(flashcards.getManageFlashcardRow(createdCard.uuid)).toContainText(front);
 
       await assertNoCriticalErrors(diagnostics);
     });

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -297,18 +297,7 @@ test.describe('Flashcards', () => {
       const reviewResponse = await reviewResponsePromise;
       expect(reviewResponse.status()).toBeLessThan(400);
 
-      await expect
-        .poll(
-          async () => {
-            const completionVisible = await flashcards.reviewCompletionState
-              .isVisible()
-              .catch(() => false);
-            const activeCardVisible = await flashcards.reviewActiveCard.isVisible().catch(() => false);
-            return completionVisible || activeCardVisible;
-          },
-          { timeout: 20_000 }
-        )
-        .toBe(true);
+      await expect(flashcards.reviewCompletionState).toBeVisible({ timeout: 20_000 });
 
       await assertNoCriticalErrors(diagnostics);
     });

--- a/backlog/tasks/task-477 - Flashcards-UX-Phase-0-verification-harness.md
+++ b/backlog/tasks/task-477 - Flashcards-UX-Phase-0-verification-harness.md
@@ -1,0 +1,64 @@
+---
+id: TASK-477
+title: Flashcards UX Phase 0 verification harness
+status: Done
+labels:
+- flashcards
+- ux
+- e2e
+- tests
+modified_files:
+- apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+- apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+- apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Phase 0 of the flashcards UX remediation plan: add stable flashcards page-object selectors, prove or disprove the create-drawer submit issue with backend-backed e2e coverage, add failed-create component coverage, and add keyboard-only review e2e coverage without Phase 2 undo/re-rate scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Add stable page-object selectors needed for create drawer and keyboard review tests.
+- [x] Add backend-backed e2e coverage proving create-drawer submit works for an unscoped card.
+- [x] Add component coverage proving failed create keeps the drawer open and retains entered fields.
+- [x] Add keyboard-only review e2e coverage for Space to show answer and 3 to rate Good.
+- [x] Record broader-run blockers separately instead of silently folding them into Phase 0.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md#phase-0-verification-harness-and-create-drawer-proof
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added create-drawer page-object selectors for the accessible dialog, front/back textareas, create buttons, and message hooks.
+- Added review page-object selectors for Good/Easy rating controls and completion/empty states.
+- Added `should review a seeded card using only keyboard shortcuts`, which seeds a deck/card through the API, opens Review directly, presses Space, presses 3, and verifies the review POST succeeds.
+- Added `creates a flashcard from the drawer and shows it in Manage`, which opens the Manage drawer, submits a front/back card, verifies the create POST, and waits for the new row.
+- Added component regression coverage for create failure recovery: error message is shown, the drawer remains open, entered front/back text is retained, success/close callbacks are not fired, and the Create button is re-enabled.
+- No production component changes were retained. A temporary Drawer width probe was reverted because it introduced an AntD deprecation warning and did not resolve the drawer select behavior.
+- Broader `--grep "flashcard"` e2e run exposed follow-up blockers: review POST can hit backend 429 after repeated local runs, and the existing tag-suggestion drawer path still hits the create-drawer deck-select/off-viewport behavior. These are documented for the next phase rather than treated as resolved here.
+- Bandit was not run because the retained changes are frontend TypeScript tests/page objects and a Backlog task record, with no Python runtime code touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Phase 0 harness is implemented for create-submit, create-failure recovery, and keyboard-only review. Verification recorded: component drawer test suite passed 8/8; focused Playwright e2e for keyboard review, drawer create, and shortcuts passed 3/3; `git diff --check` passed. Broader grep was run and documented with unresolved blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-503 - Address-PR-2064-flashcards-Phase-0-review-comments.md
+++ b/backlog/tasks/task-503 - Address-PR-2064-flashcards-Phase-0-review-comments.md
@@ -1,0 +1,57 @@
+---
+id: TASK-503
+title: Address PR 2064 flashcards Phase 0 review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-25 22:20'
+labels:
+  - flashcards
+  - ux
+  - tests
+  - review-fix
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address review comments on PR #2064 for the Phase 0 flashcards UX harness: harden the keyboard review completion assertion and create-drawer failure pending/re-enable test coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Keyboard review e2e waits for the review completion state instead of accepting the still-active card as success.
+- [x] #2 Create-drawer failure coverage proves the submit button is disabled while create is pending and enabled again after rejection.
+- [x] #3 Create drawer submit buttons expose semantic disabled state while create mutation is pending.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review GitHub threads on PR #2064, verify each against the current branch, patch only still-valid test issues, run focused verification, update the Backlog task, commit, push, and resolve addressed threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified the two PR #2064 inline review comments against the current branch. Patched the keyboard e2e to wait specifically for review completion, updated the create-drawer failure regression to model pending and rejection separately, and added explicit disabled state to the create submit buttons so the pending state is semantically testable. Verification: focused Playwright keyboard shortcut grep passed; FlashcardCreateDrawer deck-reference Vitest passed; git diff --check passed. Bandit not run because only TypeScript/Playwright test files and a TSX component were touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed both PR #2064 review comments with scoped test hardening and create-drawer pending-state semantics. No backend or Python code changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: Added the Phase 0 flashcards UX verification harness, then addressed review feedback by hardening the keyboard review completion assertion and create-drawer pending/failure coverage.
- Why: The flashcards remediation plan needs stable, backend-backed checks for create and review flows before larger UX changes continue.
- Human-owned change summary: Still required before merge per repo policy. This PR body records the AI-authored implementation and validation details.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed) - not applicable; no docs, routes, or config changed

Local verification:

- `bunx vitest run src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx`
- `TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_E2E_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY TLDW_E2E_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY bunx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts --grep "keyboard shortcuts" --reporter=line`
- `git diff --check`
- Bandit not run because this PR only changes TypeScript/TSX and Playwright test files.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes - not run; this PR is scoped to Phase 0 flashcards harness coverage
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented) - not run; scoped focused flashcards checks were run
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` - no app-wide audit run; focused changed code does not add these deprecated props
- [x] No `Maximum update depth exceeded` warnings on audited routes - no such warnings observed in the focused flashcards checks
- [x] No unresolved `{{...}}` placeholders on audited routes - no copy changes or unresolved placeholders introduced
- [x] WebUI/extension parity validated for shared UI fixes - shared FlashcardCreateDrawer pending-state behavior is covered at the UI package layer
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path - no tab or CTA routing changes
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary` - footer order unchanged; only pending disabled state added
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors - not applicable; no help, copy, or import UX changes

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally - not applicable; no Watchlists changes
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports - not applicable; no Watchlists changes
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text) - not applicable; no Watchlists changes
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present) - not applicable; no Watchlists changes
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md` - not applicable; no Watchlists changes

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally - not applicable; no Watchlists changes
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap - not applicable; no Watchlists changes
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn) - not applicable; no Watchlists changes
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs - not applicable; no Watchlists changes
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md` - not applicable; no Watchlists changes

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert `ec451efb91` to remove the review-fix changes. If the whole Phase 0 harness needs rollback, revert the PR branch commits from this PR.

## Known Follow-Ups

- Broader flashcards grep still exposes existing follow-up blockers already tracked outside this review-fix slice: review 429 after repeated local runs and drawer deck-select/off-viewport behavior in the tag-suggestion path.
