### PR TITLE
fix(flashcards): clarify first-run entry

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
@@ -44,10 +44,10 @@ const parseInitialFlashcardsTab = (locationLike: { search?: string; hash?: strin
  * FlashcardsManager contains all the tabs and core flashcard logic.
  * Connection state is handled by FlashcardsWorkspace.
  *
- * Structure: Study | Manage | Import / Export
+ * Structure: Study | Manage | Create & Import
  * - Study: Spaced repetition review and cram loops
  * - Manage: Browse, filter, create, edit, bulk operations
- * - Import / Export: CSV/APKG import and export workflows
+ * - Create & Import: manual setup, generation, CSV/APKG import, and export workflows
  * - Scheduler: Deck-level scheduler policy editing and queue visibility
  */
 export const FlashcardsManager: React.FC = () => {
@@ -73,17 +73,8 @@ export const FlashcardsManager: React.FC = () => {
   const { data: initialDecks } = useDecksQuery({
     includeWorkspaceItems: currentStudyIntent?.forceShowWorkspaceItems ?? false
   })
-  const showSchedulerTab = !(initialDecks !== undefined && initialDecks.length === 0)
-  const hasCheckedInitialTab = React.useRef(false)
-  React.useEffect(() => {
-    if (!hasCheckedInitialTab.current && initialDecks !== undefined && !currentTab) {
-      hasCheckedInitialTab.current = true
-      if (initialDecks.length === 0) {
-        setActiveTab("importExport")
-      }
-    }
-  }, [initialDecks, currentTab])
-  // Reset activeTab if Scheduler tab is hidden (e.g., arrived via ?tab=scheduler with zero decks)
+  const schedulerDisabled = initialDecks !== undefined && initialDecks.length === 0
+  // Reset activeTab if Scheduler tab is unavailable for editing (e.g., arrived via ?tab=scheduler with zero decks)
   React.useEffect(() => {
     if (activeTab === "scheduler" && initialDecks !== undefined && initialDecks.length === 0) {
       setActiveTab("review")
@@ -133,10 +124,10 @@ export const FlashcardsManager: React.FC = () => {
   }, [currentGenerateIntent, currentStudyIntent?.deckId, currentStudyPackIntent, currentTab])
 
   React.useEffect(() => {
-    if (!showSchedulerTab && activeTab === "scheduler") {
-      setActiveTab("importExport")
+    if (schedulerDisabled && activeTab === "scheduler") {
+      setActiveTab("review")
     }
-  }, [activeTab, showSchedulerTab])
+  }, [activeTab, schedulerDisabled])
 
   const handleReviewCard = React.useCallback(
     (card: Flashcard) => {
@@ -162,6 +153,18 @@ export const FlashcardsManager: React.FC = () => {
       forceShowWorkspaceItems: currentStudyIntent?.forceShowWorkspaceItems ?? false
     })
   }, [currentStudyIntent?.attemptId, currentStudyIntent?.deckId, currentStudyIntent?.forceShowWorkspaceItems, currentStudyIntent?.quizId, reviewDeckId])
+  const canOpenQuizCta = currentStudyIntent?.quizId !== undefined
+  const schedulerTabLabel = schedulerDisabled ? (
+    <Tooltip
+      title={t("option:flashcards.schedulerNeedsDeck", {
+        defaultValue: "Create or import a deck to configure scheduling."
+      })}
+    >
+      <span>{t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" })}</span>
+    </Tooltip>
+  ) : (
+    t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" })
+  )
 
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
@@ -189,15 +192,31 @@ export const FlashcardsManager: React.FC = () => {
         onChange={handleTabChange}
         tabBarExtraContent={(
           <Space size={4}>
-            <Button
-              size="small"
-              data-testid="flashcards-to-quiz-cta"
-              onClick={() => navigate(quizCtaRoute)}
+            <Tooltip
+              title={
+                canOpenQuizCta
+                  ? undefined
+                  : t("option:flashcards.quizCtaNeedsContext", {
+                      defaultValue: "Open a Quiz-linked flashcard session before testing with Quiz."
+                    })
+              }
             >
-              {t("option:flashcards.testWithQuiz", {
-                defaultValue: "Test with Quiz"
-              })}
-            </Button>
+              <span>
+                <Button
+                  size="small"
+                  data-testid="flashcards-to-quiz-cta"
+                  disabled={!canOpenQuizCta}
+                  onClick={() => {
+                    if (!canOpenQuizCta) return
+                    navigate(quizCtaRoute)
+                  }}
+                >
+                  {t("option:flashcards.testWithQuiz", {
+                    defaultValue: "Test with Quiz"
+                  })}
+                </Button>
+              </span>
+            </Tooltip>
             <Tooltip
               title={t("option:flashcards.keyboardShortcutsHelp", {
                 defaultValue: "Press ? to show shortcuts"
@@ -250,18 +269,7 @@ export const FlashcardsManager: React.FC = () => {
           },
           {
             key: "importExport",
-            label: (
-              <span className="inline-flex items-center gap-1.5">
-                {t("option:flashcards.tabImportExport", { defaultValue: "Import / Export" })}
-                <Tooltip title={t("option:flashcards.llmBadgeTooltip", {
-                  defaultValue: "Some features in this tab require an LLM provider"
-                })}>
-                  <span className="rounded bg-surface2 px-1 py-px text-[10px] font-medium text-text-muted">
-                    LLM
-                  </span>
-                </Tooltip>
-              </span>
-            ),
+            label: t("option:flashcards.tabCreateImport", { defaultValue: "Create & Import" }),
             children: (
               <ImportExportTab
                 generateIntent={currentGenerateIntent}
@@ -274,24 +282,18 @@ export const FlashcardsManager: React.FC = () => {
             label: t("option:flashcards.tabTemplates", { defaultValue: "Templates" }),
             children: <TemplatesTab />
           },
-          // Hide Scheduler tab when there are zero decks
-          ...(showSchedulerTab
-            ? [
-                {
-                  key: "scheduler",
-                  label: t("option:flashcards.tabScheduler", {
-                    defaultValue: "Scheduler"
-                  }),
-                  children: (
-                    <SchedulerTab
-                      isActive={activeTab === "scheduler"}
-                      onDirtyChange={setSchedulerDirty}
-                      discardSignal={schedulerDiscardSignal}
-                    />
-                  )
-                }
-              ]
-            : [])
+          {
+            key: "scheduler",
+            label: schedulerTabLabel,
+            disabled: schedulerDisabled,
+            children: schedulerDisabled ? null : (
+              <SchedulerTab
+                isActive={activeTab === "scheduler"}
+                onDirtyChange={setSchedulerDirty}
+                discardSignal={schedulerDiscardSignal}
+              />
+            )
+          }
         ]}
       />
 

--- a/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
@@ -123,12 +123,6 @@ export const FlashcardsManager: React.FC = () => {
     }
   }, [currentGenerateIntent, currentStudyIntent?.deckId, currentStudyPackIntent, currentTab])
 
-  React.useEffect(() => {
-    if (schedulerDisabled && activeTab === "scheduler") {
-      setActiveTab("review")
-    }
-  }, [activeTab, schedulerDisabled])
-
   const handleReviewCard = React.useCallback(
     (card: Flashcard) => {
       setReviewDeckId(card.deck_id ?? undefined)
@@ -154,13 +148,20 @@ export const FlashcardsManager: React.FC = () => {
     })
   }, [currentStudyIntent?.attemptId, currentStudyIntent?.deckId, currentStudyIntent?.forceShowWorkspaceItems, currentStudyIntent?.quizId, reviewDeckId])
   const canOpenQuizCta = currentStudyIntent?.quizId !== undefined
+  const effectiveActiveTab =
+    schedulerDisabled && activeTab === "scheduler" ? "review" : activeTab
   const schedulerTabLabel = schedulerDisabled ? (
     <Tooltip
       title={t("option:flashcards.schedulerNeedsDeck", {
         defaultValue: "Create or import a deck to configure scheduling."
       })}
     >
-      <span>{t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" })}</span>
+      <span
+        aria-disabled="true"
+        className="cursor-not-allowed text-text-muted"
+      >
+        {t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" })}
+      </span>
     </Tooltip>
   ) : (
     t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" })
@@ -168,6 +169,8 @@ export const FlashcardsManager: React.FC = () => {
 
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
+      if (nextTab === "scheduler" && schedulerDisabled) return
+
       if (activeTab === "scheduler" && nextTab !== "scheduler" && schedulerDirty) {
         const shouldDiscard = window.confirm(
           t("option:flashcards.schedulerDiscardChangesPrompt", {
@@ -181,14 +184,14 @@ export const FlashcardsManager: React.FC = () => {
 
       setActiveTab(nextTab)
     },
-    [activeTab, schedulerDirty, t]
+    [activeTab, schedulerDirty, schedulerDisabled, t]
   )
 
   return (
     <div className="mx-auto max-w-6xl p-4">
       <Tabs
         data-testid="flashcards-tabs"
-        activeKey={activeTab}
+        activeKey={effectiveActiveTab}
         onChange={handleTabChange}
         tabBarExtraContent={(
           <Space size={4}>
@@ -246,7 +249,7 @@ export const FlashcardsManager: React.FC = () => {
                 onReviewDeckChange={setReviewDeckId}
                 reviewOverrideCard={reviewOverrideCard}
                 onClearOverride={() => setReviewOverrideCard(null)}
-                isActive={activeTab === "review"}
+                isActive={effectiveActiveTab === "review"}
                 forceShowWorkspaceItems={currentStudyIntent?.forceShowWorkspaceItems ?? false}
               />
             )
@@ -259,7 +262,7 @@ export const FlashcardsManager: React.FC = () => {
                 onNavigateToImport={() => setActiveTab("importExport")}
                 onReviewCard={handleReviewCard}
                 openCreateSignal={openCreateSignal}
-                isActive={activeTab === "cards"}
+                isActive={effectiveActiveTab === "cards"}
                 initialDeckId={currentTab === "cards" ? currentStudyIntent?.deckId : undefined}
                 initialShowWorkspaceDecks={
                   currentTab === "cards" ? (currentStudyIntent?.forceShowWorkspaceItems ?? false) : false
@@ -285,10 +288,9 @@ export const FlashcardsManager: React.FC = () => {
           {
             key: "scheduler",
             label: schedulerTabLabel,
-            disabled: schedulerDisabled,
             children: schedulerDisabled ? null : (
               <SchedulerTab
-                isActive={activeTab === "scheduler"}
+                isActive={effectiveActiveTab === "scheduler"}
                 onDirtyChange={setSchedulerDirty}
                 discardSignal={schedulerDiscardSignal}
               />
@@ -301,13 +303,13 @@ export const FlashcardsManager: React.FC = () => {
         open={shortcutsModalOpen}
         onClose={() => setShortcutsModalOpen(false)}
         activeTab={
-          activeTab === "importExport"
+          effectiveActiveTab === "importExport"
             ? "import"
-            : activeTab === "scheduler"
+            : effectiveActiveTab === "scheduler"
               ? "scheduler"
-              : activeTab === "templates"
+              : effectiveActiveTab === "templates"
                 ? "templates"
-              : (activeTab as "review" | "cards")
+                : (effectiveActiveTab as "review" | "cards")
         }
       />
     </div>

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -205,10 +205,16 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
     expect(screen.queryByTestId("mock-transfer-tab")).not.toBeInTheDocument()
     expect(screen.getByText("Templates")).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: /scheduler/i })).toHaveAttribute(
+    const schedulerTab = screen.getByRole("tab", { name: /scheduler/i })
+    const schedulerLabel = screen.getByText("Scheduler")
+    expect(schedulerTab).not.toHaveAttribute("aria-disabled", "true")
+    expect(schedulerLabel).toHaveAttribute(
       "aria-disabled",
       "true"
     )
+    fireEvent.click(schedulerTab)
+    expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
+    expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
   })
 
   it("routes template deep-links to the Templates tab", () => {
@@ -228,7 +234,11 @@ describe("FlashcardsManager consistency standards", () => {
 
     expect(screen.getByText("Templates")).toBeInTheDocument()
     expect(screen.getByTestId("mock-templates-tab")).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: /scheduler/i })).toHaveAttribute(
+    expect(screen.getByRole("tab", { name: /scheduler/i })).not.toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+    expect(screen.getByText("Scheduler")).toHaveAttribute(
       "aria-disabled",
       "true"
     )
@@ -258,10 +268,15 @@ describe("FlashcardsManager consistency standards", () => {
 
     expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: /scheduler/i })).toHaveAttribute(
+    const schedulerTab = screen.getByRole("tab", { name: /scheduler/i })
+    expect(schedulerTab).not.toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByText("Scheduler")).toHaveAttribute(
       "aria-disabled",
       "true"
     )
+    fireEvent.click(schedulerTab)
+    expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
+    expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
   })
 
   it("routes secondary create CTA to the Manage tab create entry point", () => {

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -185,26 +185,30 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByTestId("mock-manage-show-workspace")).toHaveTextContent("true")
   })
 
-  it("uses Study/Manage/Transfer/Scheduler tab labels", () => {
+  it("uses Study/Manage/Create & Import/Scheduler tab labels", () => {
     window.history.replaceState({}, "", "/flashcards")
     render(<FlashcardsManager />)
 
     expect(screen.getByText("Study")).toBeInTheDocument()
     expect(screen.getByText("Manage")).toBeInTheDocument()
-    expect(screen.getByText("Import / Export")).toBeInTheDocument()
+    expect(screen.getByText("Create & Import")).toBeInTheDocument()
     expect(screen.getByText("Templates")).toBeInTheDocument()
     expect(screen.getByText("Scheduler")).toBeInTheDocument()
   })
 
-  it("defaults to Import / Export and hides Scheduler when no decks are available", () => {
+  it("defaults to Study and keeps Scheduler discoverable when no decks are available", () => {
     mocks.decks = []
     window.history.replaceState({}, "", "/flashcards")
 
     render(<FlashcardsManager />)
 
-    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
+    expect(screen.queryByTestId("mock-transfer-tab")).not.toBeInTheDocument()
     expect(screen.getByText("Templates")).toBeInTheDocument()
-    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /scheduler/i })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
   })
 
   it("routes template deep-links to the Templates tab", () => {
@@ -224,7 +228,10 @@ describe("FlashcardsManager consistency standards", () => {
 
     expect(screen.getByText("Templates")).toBeInTheDocument()
     expect(screen.getByTestId("mock-templates-tab")).toBeInTheDocument()
-    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /scheduler/i })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
   })
 
   it("requests workspace decks when study links include workspace items", () => {
@@ -243,14 +250,18 @@ describe("FlashcardsManager consistency standards", () => {
     )
   })
 
-  it("clamps scheduler deep-links to Import / Export when Scheduler is hidden", () => {
+  it("clamps scheduler deep-links to Study when Scheduler is disabled", () => {
     mocks.decks = []
     window.history.replaceState({}, "", "/flashcards?tab=scheduler&deck_id=9")
 
     render(<FlashcardsManager />)
 
-    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /scheduler/i })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
   })
 
   it("routes secondary create CTA to the Manage tab create entry point", () => {
@@ -262,7 +273,7 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByTestId("mock-open-create-signal")).toHaveTextContent("1")
   })
 
-  it("keeps quiz CTA usable when handoff IDs are invalid", () => {
+  it("disables quiz CTA when handoff IDs are invalid", () => {
     window.history.replaceState(
       {},
       "",
@@ -270,9 +281,18 @@ describe("FlashcardsManager consistency standards", () => {
     )
     render(<FlashcardsManager />)
 
-    fireEvent.click(screen.getByTestId("flashcards-to-quiz-cta"))
+    const quizButton = screen.getByTestId("flashcards-to-quiz-cta")
+    expect(quizButton).toBeDisabled()
+    fireEvent.click(quizButton)
 
-    expect(mocks.navigate).toHaveBeenCalledWith("/quiz?tab=take&source=flashcards")
+    expect(mocks.navigate).not.toHaveBeenCalled()
+  })
+
+  it("disables quiz CTA without a valid quiz handoff context", () => {
+    window.history.replaceState({}, "", "/flashcards")
+    render(<FlashcardsManager />)
+
+    expect(screen.getByTestId("flashcards-to-quiz-cta")).toBeDisabled()
   })
 
   it("prompts before leaving the Scheduler tab when its draft is dirty", () => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
@@ -60,6 +60,7 @@ import {
   estimateJsonItemCount,
   getImportErrorGuidance,
   normalizeHeaderToken,
+  normalizeImportLimits,
   normalizeImportErrors,
   normalizeImportedItems,
   normalizeStructuredDrafts,
@@ -112,6 +113,10 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
     "columns"
   ])
   const structuredSchedulerDraft = useDeckSchedulerDraft()
+  const importLimits = React.useMemo(
+    () => normalizeImportLimits(limitsQuery.data),
+    [limitsQuery.data]
+  )
   const structuredSelectedDeck = React.useMemo(
     () =>
       typeof structuredTargetDeckId === "number"
@@ -1079,13 +1084,14 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
           </Text>
         </div>
       )}
-      {limitsQuery.data && (
+      {importLimits && (
         <Text type="secondary" className="text-xs">
-          {t("option:flashcards.importLimits", {
+          {t("option:flashcards.importLimitsValue", {
             defaultValue:
-              "Limits: max {{maxCards}} cards, {{maxSize}} bytes per import",
-            maxCards: limitsQuery.data.max_cards_per_import,
-            maxSize: limitsQuery.data.max_content_size_bytes
+              "Limits: max {{maxLines}} lines, {{maxLineBytes}} bytes per line, {{maxFieldBytes}} bytes per field",
+            maxLines: importLimits.maxLines.toLocaleString(),
+            maxLineBytes: importLimits.maxLineLengthBytes.toLocaleString(),
+            maxFieldBytes: importLimits.maxFieldLengthBytes.toLocaleString()
           })}
         </Text>
       )}

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/shared.ts
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/shared.ts
@@ -58,6 +58,12 @@ export interface TransferActionSummary extends TransferActionSummaryInput {
   at: string
 }
 
+export interface NormalizedImportLimits {
+  maxLines: number
+  maxLineLengthBytes: number
+  maxFieldLengthBytes: number
+}
+
 export interface TransferActionReporterProps {
   onTransferAction?: (summary: TransferActionSummaryInput) => void
 }
@@ -76,6 +82,27 @@ export const IMPORT_HELP_ANCHORS = {
   cloze: "flashcards-import-help-cloze",
   json: "flashcards-import-help-json"
 } as const
+
+const positiveNumberOrNull = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null
+
+export const normalizeImportLimits = (value: unknown): NormalizedImportLimits | null => {
+  if (!value || typeof value !== "object") return null
+  const record = value as Record<string, unknown>
+  const maxLines = positiveNumberOrNull(record.max_lines)
+  const maxLineLengthBytes = positiveNumberOrNull(record.max_line_length)
+  const maxFieldLengthBytes = positiveNumberOrNull(record.max_field_length)
+
+  if (maxLines === null || maxLineLengthBytes === null || maxFieldLengthBytes === null) {
+    return null
+  }
+
+  return {
+    maxLines,
+    maxLineLengthBytes,
+    maxFieldLengthBytes
+  }
+}
 
 export const detectJsonImportFormat = (rawContent: string): "json" | "jsonl" | "unknown" => {
   const trimmed = rawContent.trim()

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
@@ -13,6 +13,7 @@ import { GeneratePanel } from "./ImportExport/GeneratePanel"
 import { ImportPanel } from "./ImportExport/ImportPanel"
 import { StudyPackPanel } from "./ImportExport/StudyPackPanel"
 import {
+  normalizeImportLimits,
   type TransferActionSummary,
   type TransferActionSummaryInput
 } from "./ImportExport/shared"
@@ -37,11 +38,16 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
     React.useState<TransferActionSummary | null>(null)
   const [studyPackDrawerOpen, setStudyPackDrawerOpen] = React.useState(false)
   const importLimitsText = React.useMemo(() => {
-    if (!limitsQuery.data) return null
-    const cardsLimit = limitsQuery.data.max_cards_per_import.toLocaleString()
-    const bytesLimit = limitsQuery.data.max_content_size_bytes.toLocaleString()
-    return `${cardsLimit} cards / ${bytesLimit} bytes`
-  }, [limitsQuery.data])
+    const importLimits = normalizeImportLimits(limitsQuery.data)
+    if (!importLimits) return null
+    return t("option:flashcards.transferSummaryLimitsValue", {
+      defaultValue:
+        "{{lines}} lines / {{lineBytes}} bytes per line / {{fieldBytes}} bytes per field",
+      lines: importLimits.maxLines.toLocaleString(),
+      lineBytes: importLimits.maxLineLengthBytes.toLocaleString(),
+      fieldBytes: importLimits.maxFieldLengthBytes.toLocaleString()
+    })
+  }, [limitsQuery.data, t])
 
   React.useEffect(() => {
     if (studyPackIntent) {

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
@@ -36,6 +36,12 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
   const [lastTransferAction, setLastTransferAction] =
     React.useState<TransferActionSummary | null>(null)
   const [studyPackDrawerOpen, setStudyPackDrawerOpen] = React.useState(false)
+  const importLimitsText = React.useMemo(() => {
+    if (!limitsQuery.data) return null
+    const cardsLimit = limitsQuery.data.max_cards_per_import.toLocaleString()
+    const bytesLimit = limitsQuery.data.max_content_size_bytes.toLocaleString()
+    return `${cardsLimit} cards / ${bytesLimit} bytes`
+  }, [limitsQuery.data])
 
   React.useEffect(() => {
     if (studyPackIntent) {
@@ -115,12 +121,8 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
               })}
             </Text>
             <Text type="secondary">
-              {limitsQuery.data
-                ? t("option:flashcards.transferSummaryLimitsValue", {
-                    defaultValue: "{{cards}} cards · {{bytes}} bytes",
-                    cards: limitsQuery.data.max_cards_per_import,
-                    bytes: limitsQuery.data.max_content_size_bytes
-                  })
+              {importLimitsText
+                ? importLimitsText
                 : t("option:flashcards.transferSummaryLimitsUnknown", {
                     defaultValue: "Limits unavailable"
                   })}

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -561,6 +561,14 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   const allOnPageSelected = pageCount > 0 && selectedOnPageCount === pageCount
   const someOnPageSelected = selectedOnPageCount > 0 && selectedOnPageCount < pageCount
   const selectAllAcrossDisabled = isDocumentMode && documentQuery.isTruncated
+  const isNoCardFirstRun =
+    viewMode === "cards" &&
+    !isDocumentMode &&
+    manageQuery.data !== undefined &&
+    !manageQuery.isFetching &&
+    !hasActiveFilters &&
+    totalCount === 0 &&
+    pageItems.length === 0
 
   const updateMutation = useUpdateFlashcardMutation()
   const bulkUpdateMutation = useUpdateFlashcardsBulkMutation()
@@ -1558,7 +1566,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               ]}
             />
             {/* Keyboard shortcut hint */}
-            {viewMode === "cards" && (
+            {viewMode === "cards" && !isNoCardFirstRun && (
               <div
                 className="hidden md:flex items-center gap-1.5"
                 data-testid="flashcards-manage-shortcut-chips"
@@ -1631,7 +1639,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
         )}
 
         {/* Simplified Filter UI */}
-        {viewMode === "cards" && (
+        {viewMode === "cards" && !isNoCardFirstRun && (
         <div className="mb-3 space-y-3">
           {/* Primary filters: Search + Deck (always visible) */}
           <div className="flex items-center gap-2 flex-wrap">
@@ -1897,7 +1905,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
         )}
 
         {/* Selection Summary Bar - simplified to two modes */}
-        {viewMode === "cards" && (
+        {viewMode === "cards" && !isNoCardFirstRun && (
         <div
           className="mb-2 flex items-center gap-3"
           data-testid="flashcards-manage-selection-summary"
@@ -2026,14 +2034,29 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                         </Button>
                       ) : (
                         <>
-                          <Button type="primary" onClick={() => setCreateOpen(true)}>
+                          <Button
+                            type="primary"
+                            onClick={() => setCreateOpen(true)}
+                            data-testid="flashcards-manage-empty-create-cta"
+                          >
                             {t("option:flashcards.noCardsCreateCta", {
                               defaultValue: "Create card"
                             })}
                           </Button>
-                          <Button onClick={onNavigateToImport}>
+                          <Button
+                            onClick={onNavigateToImport}
+                            data-testid="flashcards-manage-empty-import-cta"
+                          >
                             {t("option:flashcards.noCardsImportCta", {
                               defaultValue: "Import flashcards"
+                            })}
+                          </Button>
+                          <Button
+                            onClick={onNavigateToImport}
+                            data-testid="flashcards-manage-empty-generate-cta"
+                          >
+                            {t("option:flashcards.noCardsGenerateCta", {
+                              defaultValue: "Generate from text"
                             })}
                           </Button>
                         </>

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx
@@ -73,6 +73,26 @@ describe("ImportExportTab decomposition", () => {
   it("renders concrete import limits instead of unresolved interpolation placeholders", () => {
     mocks.useImportLimitsQuery.mockReturnValue({
       data: {
+        max_lines: 2500,
+        max_line_length: 32768,
+        max_field_length: 1048576
+      }
+    })
+
+    render(<ImportExportTab />)
+
+    const limits = screen.getByTestId("flashcards-transfer-summary-limits")
+    expect(limits).not.toHaveTextContent("{{lines}}")
+    expect(limits).not.toHaveTextContent("{{lineBytes}}")
+    expect(limits).not.toHaveTextContent("{{fieldBytes}}")
+    expect(limits).toHaveTextContent(`${(2500).toLocaleString()} lines`)
+    expect(limits).toHaveTextContent(`${(32768).toLocaleString()} bytes per line`)
+    expect(limits).toHaveTextContent(`${(1048576).toLocaleString()} bytes per field`)
+  })
+
+  it("shows the unavailable fallback for malformed import limits", () => {
+    mocks.useImportLimitsQuery.mockReturnValue({
+      data: {
         max_cards_per_import: 2500,
         max_content_size_bytes: 1048576
       }
@@ -81,9 +101,6 @@ describe("ImportExportTab decomposition", () => {
     render(<ImportExportTab />)
 
     const limits = screen.getByTestId("flashcards-transfer-summary-limits")
-    expect(limits).not.toHaveTextContent("{{cards}}")
-    expect(limits).not.toHaveTextContent("{{bytes}}")
-    expect(limits).toHaveTextContent("2,500 cards")
-    expect(limits).toHaveTextContent("1,048,576 bytes")
+    expect(limits).toHaveTextContent("Limits unavailable")
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx
@@ -1,9 +1,66 @@
-import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
 
+import { ImportExportTab } from "../ImportExportTab"
 import { ExportPanel } from "../ImportExport/ExportPanel"
 import { GeneratePanel } from "../ImportExport/GeneratePanel"
 import { ImportPanel } from "../ImportExport/ImportPanel"
 import { StudyPackPanel } from "../ImportExport/StudyPackPanel"
+
+const mocks = vi.hoisted(() => ({
+  useImportLimitsQuery: vi.fn()
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) {
+        return defaultValueOrOptions.defaultValue.replace(
+          /\{\{(\w+)\}\}/g,
+          (_match, token: string) =>
+            String((defaultValueOrOptions as Record<string, unknown>)[token] ?? `{{${token}}}`)
+        )
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock("../../hooks", () => ({
+  useImportLimitsQuery: (...args: unknown[]) => mocks.useImportLimitsQuery(...args)
+}))
+
+vi.mock("../ImportExport/ImportPanel", () => ({
+  ImportPanel: () => <div data-testid="mock-import-panel" />
+}))
+
+vi.mock("../ImportExport/ExportPanel", () => ({
+  ExportPanel: () => <div data-testid="mock-export-panel" />
+}))
+
+vi.mock("../ImportExport/GeneratePanel", () => ({
+  GeneratePanel: () => <div data-testid="mock-generate-panel" />
+}))
+
+vi.mock("../ImportExport/StudyPackPanel", () => ({
+  StudyPackPanel: () => <div data-testid="mock-study-pack-panel" />
+}))
+
+vi.mock("../ImageOcclusionTransferPanel", () => ({
+  ImageOcclusionTransferPanel: () => <div data-testid="mock-image-occlusion-panel" />
+}))
+
+vi.mock("../../components/StudyPackCreateDrawer", () => ({
+  StudyPackCreateDrawer: () => null
+}))
 
 describe("ImportExportTab decomposition", () => {
   it("exposes focused panel modules for study packs, import, export, and generation", () => {
@@ -11,5 +68,22 @@ describe("ImportExportTab decomposition", () => {
     expect(ImportPanel).toBeTypeOf("function")
     expect(ExportPanel).toBeTypeOf("function")
     expect(GeneratePanel).toBeTypeOf("function")
+  })
+
+  it("renders concrete import limits instead of unresolved interpolation placeholders", () => {
+    mocks.useImportLimitsQuery.mockReturnValue({
+      data: {
+        max_cards_per_import: 2500,
+        max_content_size_bytes: 1048576
+      }
+    })
+
+    render(<ImportExportTab />)
+
+    const limits = screen.getByTestId("flashcards-transfer-summary-limits")
+    expect(limits).not.toHaveTextContent("{{cards}}")
+    expect(limits).not.toHaveTextContent("{{bytes}}")
+    expect(limits).toHaveTextContent("2,500 cards")
+    expect(limits).toHaveTextContent("1,048,576 bytes")
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -877,8 +877,9 @@ describe("ImportExportTab import result details", () => {
   it("renders transfer summary cards for formats, limits, and last action", () => {
     vi.mocked(useImportLimitsQuery).mockReturnValue({
       data: {
-        max_cards_per_import: 500,
-        max_content_size_bytes: 1048576
+        max_lines: 500,
+        max_line_length: 32768,
+        max_field_length: 1048576
       }
     } as any)
 
@@ -888,9 +889,10 @@ describe("ImportExportTab import result details", () => {
     expect(screen.getByTestId("flashcards-transfer-summary-formats")).toHaveTextContent(
       "Import: CSV, TSV, JSON, JSONL, Structured Q&A, APKG · Author: Generate, Image Occlusion · Export: TSV, CSV, JSON, APKG"
     )
-    expect(screen.getByTestId("flashcards-transfer-summary-limits")).toHaveTextContent(
-      "500 cards · 1048576 bytes"
-    )
+    const limits = screen.getByTestId("flashcards-transfer-summary-limits")
+    expect(limits).toHaveTextContent(`${(500).toLocaleString()} lines`)
+    expect(limits).toHaveTextContent(`${(32768).toLocaleString()} bytes per line`)
+    expect(limits).toHaveTextContent(`${(1048576).toLocaleString()} bytes per field`)
     expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
       "No transfer actions yet in this session."
     )

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
@@ -137,6 +137,25 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   })
 }
 
+if (typeof window !== "undefined" && !window.localStorage) {
+  const storage = new Map<string, string>()
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+      clear: () => {
+        storage.clear()
+      }
+    }
+  })
+}
+
 const sampleCard: Flashcard = {
   uuid: "card-meta-1",
   deck_id: 1,
@@ -258,6 +277,34 @@ describe("ManageTab scheduling metadata visibility", () => {
     expect(screen.getByTestId("flashcards-manage-shortcut-chips")).toBeInTheDocument()
     expect(screen.getByText("Sort: Due date")).toBeInTheDocument()
   }, 15000)
+
+  it("prioritizes first-run actions and hides expert card filters when no cards exist", () => {
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [],
+        count: 0,
+        total: 0
+      },
+      isFetching: false
+    } as any)
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive
+      />
+    )
+
+    expect(screen.getByText("No flashcards yet")).toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-shortcut-chips")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-search")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-deck-select")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-selection-summary")).not.toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-empty-create-cta")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-empty-import-cta")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-empty-generate-cta")).toBeInTheDocument()
+  })
 
   it("uses the markdown renderer for compact flashcard snippets", () => {
     const markdownFront = "**Important** concept"

--- a/apps/packages/ui/src/public/_locales/en/option.json
+++ b/apps/packages/ui/src/public/_locales/en/option.json
@@ -1775,6 +1775,9 @@
   "flashcards_transferSummaryFormatsValue": {
     "message": "Import: CSV, TSV, JSON, JSONL, APKG · Export: TSV, CSV, APKG"
   },
+  "flashcards_transferSummaryLimitsValue": {
+    "message": "{{lines}} lines / {{lineBytes}} bytes per line / {{fieldBytes}} bytes per field"
+  },
   "flashcards_pasteContent": {
     "message": "Paste content here..."
   },
@@ -1801,6 +1804,9 @@
   },
   "flashcards_importLimits": {
     "message": "Import Limits"
+  },
+  "flashcards_importLimitsValue": {
+    "message": "Limits: max {{maxLines}} lines, {{maxLineBytes}} bytes per line, {{maxFieldBytes}} bytes per field"
   },
   "flashcards_csv": {
     "message": "CSV/TSV"

--- a/apps/packages/ui/src/services/flashcards.ts
+++ b/apps/packages/ui/src/services/flashcards.ts
@@ -912,8 +912,18 @@ export async function regenerateStudyPackJob(
 export const regenerateStudyPack = regenerateStudyPackJob
 
 // Import
-export async function getFlashcardsImportLimits(): Promise<any> {
-  return await bgRequest<any, AllowedPath, "GET">({
+export interface FlashcardsImportLimitsResponse {
+  max_lines: number
+  max_line_length: number
+  max_field_length: number
+  overrides?: {
+    query_params?: string[]
+    note?: string
+  }
+}
+
+export async function getFlashcardsImportLimits(): Promise<FlashcardsImportLimitsResponse> {
+  return await bgRequest<FlashcardsImportLimitsResponse, AllowedPath, "GET">({
     path: "/api/v1/config/flashcards-import-limits",
     method: "GET"
   })

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -87,7 +87,7 @@ export class FlashcardsPage extends BasePage {
   }
 
   get transferTab(): Locator {
-    return this.page.getByRole('tab', { name: /import\s*\/\s*export/i });
+    return this.page.getByRole('tab', { name: /create\s*&\s*import|import\s*\/\s*export/i });
   }
 
   // -- Locators: Tab bar extra content ---------------------------------------

--- a/backlog/tasks/task-506 - Flashcards-UX-Phase-1-first-run-defaults-and-top-level-labels.md
+++ b/backlog/tasks/task-506 - Flashcards-UX-Phase-1-first-run-defaults-and-top-level-labels.md
@@ -1,0 +1,59 @@
+---
+id: TASK-506
+title: Flashcards UX Phase 1 first-run defaults and top-level labels
+status: Done
+assignee: []
+created_date: '2026-05-25 22:37'
+updated_date: '2026-05-25 22:39'
+labels:
+  - flashcards
+  - ux
+  - webui
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Phase 1 of the flashcards UX remediation plan: default empty /flashcards accounts to Study, fix transfer limit placeholder copy, clarify Create & Import top-level labeling, make scheduling/quiz handoffs state-aware, and reduce Manage no-card chrome.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Empty accounts land on Study instead of Import / Export.
+- [x] #2 Generate and study-pack intents continue to land on Create & Import.
+- [x] #3 Transfer limits never render literal {{cards}} or {{bytes}} placeholders.
+- [x] #4 Scheduler remains discoverable when no decks exist.
+- [x] #5 Quiz CTA is disabled/contextual when no valid quiz handoff exists.
+- [x] #6 Manage no-card state prioritizes create/import/generate actions and suppresses expert chrome until cards or filters exist.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Phase 1: first-run trust and top-level labels for the flashcards UX remediation plan.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Removed empty-deck auto-navigation from Study to Import / Export. Renamed the transfer tab label to Create & Import while preserving the importExport tab key. Kept Scheduler visible but disabled with explanatory tooltip when no decks exist, and clamped scheduler deep links back to Study. Gated Test with Quiz behind a valid Quiz-linked flashcard handoff. Formatted transfer limits directly and hid Manage expert chrome for the loaded no-card first-run state. Added focused component coverage and updated the Playwright page object for the Create & Import tab label.
+
+Post-merge rebase verification on 2026-05-25 after PR #2064 landed: rebased codex/flashcards-ux-phase1-first-run onto origin/dev at 073c1c4d0c; resolved the branch-local Backlog ID collision by replacing duplicate TASK-503 with TASK-506; reran focused Vitest 26/26 and focused Playwright route smoke 2/2; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Phase 1 first-run trust and top-level labels are implemented on top of merged Phase 0. Fresh post-rebase verification: focused Vitest passed 26/26 across FlashcardsManager, ImportExportTab, and ManageTab; focused Playwright route smoke passed 2/2 against the running backend; git diff --check passed. Bandit skipped because this phase only touched frontend TypeScript/TSX, Playwright page-object, and Backlog task files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-507 - Address-PR-2065-flashcards-Phase-1-review-comments.md
+++ b/backlog/tasks/task-507 - Address-PR-2065-flashcards-Phase-1-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-507
+title: Address PR 2065 flashcards Phase 1 review comments
+status: Done
+assignee: []
+created_date: '2026-05-25 22:45'
+updated_date: '2026-05-25 23:20'
+labels:
+  - flashcards
+  - ux
+  - tests
+  - review-fix
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address review comments on PR #2065 for flashcards Phase 1: remove redundant scheduler clamp logic, restore localized transfer-limit copy, and keep disabled Scheduler explanation discoverable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Redundant scheduler disabled useEffect is removed without losing scheduler deep-link clamping.
+- [x] #2 Transfer limit copy uses the translation key with formatted interpolation values instead of hardcoded English unit labels.
+- [x] #3 Scheduler remains unavailable with no decks while its explanatory tooltip remains discoverable.
+- [x] #4 Import-limit rendering and tests use the backend max_lines/max_line_length/max_field_length contract and do not crash on malformed limit payloads.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Verify each PR #2065 review thread against current code, patch only confirmed issues, run focused component and route verification, update Backlog, commit, push, reply, and resolve addressed threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified the three PR #2065 Gemini threads against current code. Removed the duplicate scheduler-disabled useEffect while preserving direct scheduler-link clamping through the existing effect plus an effective active tab. Switched import limits to option:flashcards.transferSummaryLimitsValue with formatted cards/bytes interpolation and added the English locale entry. Replaced the AntD-disabled Scheduler tab with a guarded tab-change path and disabled-looking aria-disabled label so the explanatory tooltip remains event-reachable while Scheduler content remains unavailable with no decks. Verification: focused FlashcardsManager/ImportExportTab/ManageTab Vitest passed 26/26; focused Flashcards Playwright route smoke passed 2/2; git diff --check passed. Bandit skipped because this review pass only touched frontend TypeScript/TSX, locale JSON, Playwright-adjacent test coverage, and Backlog task files.
+
+Additional Qodo pass: verified the import-limits schema mismatch against useImportLimitsQuery, getFlashcardsImportLimits, and the backend /api/v1/config/flashcards-import-limits endpoint. The endpoint returns max_lines/max_line_length/max_field_length, so the frontend now normalizes that backend shape for summaries and import-panel copy, treats malformed/legacy-shaped limits as unavailable instead of throwing, and keeps structured-import max-field validation independent because it only needs max_field_length. Updated ImportExportTab.import-results and decomposition tests to use the backend shape and avoid hard-coded locale separators by deriving expectations from toLocaleString() in the test runtime. Expanded verification: targeted ImportExport/FlashcardsManager/ManageTab Vitest passed 49/49; focused Playwright route smoke passed 2/2; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #2065 Gemini, CodeRabbit, and Qodo comments with scoped Phase 1 fixes: removed duplicate scheduler clamp logic, restored localized import-limit copy, made the Scheduler explanation discoverable without enabling Scheduler, and aligned import-limit rendering/tests to the backend schema. No backend or Python files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- What changed: Implemented Phase 1 of the flashcards UX remediation plan for first-run defaults and top-level labels.
- Why: Empty or low-context users should land in Study without being forced into transfer workflows, while import/generation remains discoverable under clearer Create & Import language.
- Human-owned change summary: Still required before merge per repo policy. This PR body records the AI-authored implementation and validation details.

## What Changed

- Keeps empty `/flashcards` accounts on Study instead of auto-routing to transfer.
- Renames the transfer surface label to `Create & Import` while preserving the existing `importExport` tab key.
- Keeps Scheduler visible but disabled when no decks exist, with explanatory tooltip copy.
- Disables `Test with Quiz` when there is no valid quiz-linked handoff.
- Reduces Manage first-run chrome by prioritizing create/import/generate actions when there are no cards.
- Adds focused component coverage and updates the Flashcards Playwright page object for the new tab label.
- Replaces the branch-local duplicate `TASK-503` with unique `TASK-506` after Phase 0 merged.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed) - not applicable; no docs, routes, or config changed

Local verification after rebasing onto merged Phase 0:

- `bunx vitest run src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx`
- `TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_E2E_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY TLDW_E2E_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY bunx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts --grep "render the Flashcards page|switch between tabs" --reporter=line`
- `git diff --check`
- Bandit not run because this PR only changes frontend TypeScript/TSX, Playwright page-object, and Backlog task files.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes - not run; focused Flashcards route smoke was run for this slice
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented) - not run; focused Flashcards route smoke was run
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` - no new deprecated props added in changed Flashcards code
- [x] No `Maximum update depth exceeded` warnings on audited routes - no such warnings observed in focused checks
- [x] No unresolved `{{...}}` placeholders on audited routes - transfer limit placeholders are now formatted directly
- [x] WebUI/extension parity validated for shared UI fixes - shared UI package tests cover the changed Flashcards manager behavior
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path - label intentionally changes user-facing transfer copy to `Create & Import`; the internal key remains `importExport`
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary` - no drawer footer changes in this slice
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors - not applicable; no help-link or guide-anchor changes

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert the Phase 1 commit `88ef55ec3f` to restore the previous first-run tab behavior and tab labels.

## Known Follow-Ups

- This PR does not address deeper authoring/import UX, deck-management IA, review-session progress model, or spaced-repetition controls. Those remain later phases in the flashcards UX remediation plan.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves first-run Flashcards UX: empty accounts now land on Study; the transfer tab is “Create & Import”; Scheduler stays visible but disabled with a tooltip; the Quiz CTA is gated by valid context; Manage prioritizes create/import/generate when no cards. Aligns with TASK-506 acceptance criteria and addresses review feedback in TASK-507.

- **New Features**
  - Default empty `/flashcards` to Study; keep generate/study-pack intents on Create & Import.
  - Rename tab to “Create & Import” (key remains `importExport`).
  - Keep Scheduler visible but disabled with a tooltip when no decks; deep-links clamp to Study and disabled clicks are ignored.
  - Disable “Test with Quiz” unless a valid quiz handoff exists.
  - In Manage with no cards, hide expert filters and show Create, Import, and Generate CTAs.

- **Bug Fixes**
  - Import limits now use backend `max_lines`/`max_line_length`/`max_field_length`, rendered with localized numbers; never show `{{...}}`; fallback shown on malformed payloads.
  - Removed redundant scheduler clamp logic while keeping the disabled tooltip discoverable.
  - Updated tests and locale strings; Playwright page object recognizes “Create & Import”.

<sup>Written for commit 2353e245edd841dfe5c491d3766761afef2884d8. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2065?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

