### PR TITLE
Flashcards UX Phase 4 generated save recovery

### DIFF
--- a/Docs/superpowers/plans/2026-05-26-flashcards-ux-phase4-import-recovery-plan.md
+++ b/Docs/superpowers/plans/2026-05-26-flashcards-ux-phase4-import-recovery-plan.md
@@ -1,0 +1,30 @@
+# Flashcards UX Phase 4 Import Recovery Plan
+
+## Stage 4A: Generated Save Recovery State
+**Goal**: Make generated-card save outcomes persist in the Create & Import screen so users can recover from partial or failed saves without relying on transient toast copy.
+**Success Criteria**:
+- Generated-card save success, partial success, and full failure produce an inline status in the Generate panel.
+- Partial success clearly says successful drafts were saved and only failed drafts remain editable.
+- Full failure clearly says all drafts are still available and can be retried.
+- A visible retry action reuses the existing save path for remaining drafts.
+- Focused regression tests cover partial and failed generated-card save recovery.
+**Tests**:
+- `bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx`
+- `bun run verify:design-system-state`
+- `git diff --check`
+**Status**: Complete
+
+## Stage 4B: Transfer Summary Consistency Check
+**Goal**: Ensure the top-level transfer summary reflects generated save recovery without adding more primary CTAs to the already dense Create & Import surface.
+**Success Criteria**:
+- Last action remains synchronized with generated save success, warning, and error outcomes.
+- Transfer summary stays free of top-level primary CTAs.
+- Snapshot or focused assertions cover the summary state.
+**Tests**:
+- Covered by `ImportExportTab.import-results.test.tsx`.
+**Status**: Complete
+
+## Non-Goals
+- Do not split Create & Import into new route-level tabs in this slice.
+- Do not change backend import/generate APIs unless a current client contract is proven insufficient.
+- Do not add extension capture or documentation updates in this slice.

--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -66,39 +66,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx:Alert#antd-alert-generatepanel-type-error-line-522-1gz2kd2",
-    "path": "src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx:Alert#antd-alert-generatepanel-type-info-line-349-dzq1nd",
-    "path": "src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx:Alert#antd-alert-generatepanel-type-info-line-470-3elzvw",
-    "path": "src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx:Alert#antd-alert-importpanel-type-warning-line-1099-o87fjq",
     "path": "src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { Link } from "react-router-dom"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { Alert, Button, Card, Form, Input, Select, Space, Tooltip, Typography } from "antd"
+import { Button, Card, Form, Input, Select, Space, Tooltip, Typography } from "antd"
 import { useTranslation } from "react-i18next"
 
+import { Alert, type AlertVariant } from "@/components/ui/primitives"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { getLlmProviders } from "@/services/prompt-studio"
 import type { DeckReviewPromptSide } from "@/services/flashcards"
@@ -28,6 +29,13 @@ import {
 } from "./shared"
 
 const { Text } = Typography
+
+type GeneratedSaveStatus = {
+  variant: AlertVariant
+  title: string
+  detail: string
+  retryable: boolean
+}
 
 /**
  * Generate panel for LLM-assisted card generation from free text.
@@ -95,6 +103,7 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
   const [reviewPromptSide, setReviewPromptSide] = React.useState<DeckReviewPromptSide>("front")
   const [generatedCards, setGeneratedCards] = React.useState<GeneratedCardDraft[]>([])
   const [generationError, setGenerationError] = React.useState<string | null>(null)
+  const [saveStatus, setSaveStatus] = React.useState<GeneratedSaveStatus | null>(null)
   const [isSaving, setIsSaving] = React.useState(false)
   const generatedDeckSchedulerDraft = useDeckSchedulerDraft()
   const selectedDeck = React.useMemo(
@@ -126,22 +135,29 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
     setTargetDeckId(NEW_DECK_OPTION_VALUE)
   }, [decks, targetDeckId])
 
+  const clearRetryableSaveStatus = React.useCallback(() => {
+    setSaveStatus((current) => (current?.retryable ? null : current))
+  }, [])
+
   const updateGeneratedCard = React.useCallback(
     (id: string, patch: Partial<GeneratedCardDraft>) => {
+      clearRetryableSaveStatus()
       setGeneratedCards((prev) =>
         prev.map((card) => (card.id === id ? { ...card, ...patch } : card))
       )
     },
-    []
+    [clearRetryableSaveStatus]
   )
 
   const removeGeneratedCard = React.useCallback((id: string) => {
+    clearRetryableSaveStatus()
     setGeneratedCards((prev) => prev.filter((card) => card.id !== id))
-  }, [])
+  }, [clearRetryableSaveStatus])
 
   const handleGenerate = React.useCallback(async () => {
     try {
       setGenerationError(null)
+      setSaveStatus(null)
       const result = await generateMutation.mutateAsync({
         text: sourceText,
         numCards,
@@ -247,6 +263,7 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
   const handleSaveGeneratedCards = React.useCallback(async () => {
     if (generatedCards.length === 0) return
     setIsSaving(true)
+    setSaveStatus(null)
     try {
       const deckId = await resolveTargetDeckId()
       let created = 0
@@ -287,6 +304,14 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
           count: created
         })
         message.success(successCopy)
+        setSaveStatus({
+          variant: "success",
+          title: successCopy,
+          detail: t("option:flashcards.generateSaveSuccessDetail", {
+            defaultValue: "All generated drafts were saved to the selected deck."
+          }),
+          retryable: false
+        })
         onTransferAction?.({
           area: "generate",
           status: "success",
@@ -303,6 +328,15 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
           failed
         })
         message.warning(warningCopy)
+        setSaveStatus({
+          variant: "warning",
+          title: warningCopy,
+          detail: t("option:flashcards.generateSavePartialDetail", {
+            defaultValue:
+              "Only failed drafts remain below. Review them, then retry saving."
+          }),
+          retryable: true
+        })
         onTransferAction?.({
           area: "generate",
           status: "warning",
@@ -318,6 +352,37 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
         defaultValue: "Failed to save generated cards."
       })
       message.error(errorCopy)
+      setSaveStatus({
+        variant: "error",
+        title: errorCopy,
+        detail: t("option:flashcards.generateSaveFailedDetail", {
+          defaultValue:
+            "All generated drafts are still available. Check the deck and draft content, then retry saving."
+        }),
+        retryable: true
+      })
+      onTransferAction?.({
+        area: "generate",
+        status: "error",
+        message: errorCopy
+      })
+    } catch (e: unknown) {
+      const errorCopy =
+        e instanceof Error && e.message
+          ? e.message
+          : t("option:flashcards.generateSaveFailed", {
+              defaultValue: "Failed to save generated cards."
+            })
+      message.error(errorCopy)
+      setSaveStatus({
+        variant: "error",
+        title: errorCopy,
+        detail: t("option:flashcards.generateSaveFatalDetail", {
+          defaultValue:
+            "Generated drafts are still available. Check the deck settings and draft content, then retry saving."
+        }),
+        retryable: generatedCards.length > 0
+      })
       onTransferAction?.({
         area: "generate",
         status: "error",
@@ -337,6 +402,8 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
     t
   ])
 
+  const saveInProgress = isSaving || createMutation.isPending || createDeckMutation.isPending
+
   return (
     <div className="flex flex-col gap-3">
       <Text type="secondary">
@@ -347,13 +414,13 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
       </Text>
       {sourceContext && (
         <Alert
-          type="info"
-          showIcon
+          variant="info"
           data-testid="flashcards-generate-source-context"
           title={t("option:flashcards.generateSourceContextTitle", {
             defaultValue: "Source context attached"
           })}
-          description={t("option:flashcards.generateSourceContextDescription", {
+        >
+          {t("option:flashcards.generateSourceContextDescription", {
             defaultValue:
               "Cards saved from this draft will be linked to {{sourceType}} {{sourceId}}.",
             sourceType: sourceContext.sourceType,
@@ -364,7 +431,7 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
                 defaultValue: "unknown source"
               })
           })}
-        />
+        </Alert>
       )}
       <Input.TextArea
         rows={6}
@@ -468,15 +535,15 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
         ) : null}
         {!hasLlmProviders && (
           <Alert
-            type="info"
-            showIcon
+            variant="info"
             className="mb-3 md:col-span-2"
             data-testid="flashcards-generate-no-llm-banner"
-            message={t("option:flashcards.generateNoLlmBanner", {
+          >
+            {t("option:flashcards.generateNoLlmBanner", {
               defaultValue:
                 "Flashcard generation requires an LLM provider. Configure one in Settings \u2192 LLM Providers."
             })}
-          />
+          </Alert>
         )}
         <Form.Item
           label={t("option:flashcards.generateProvider", {
@@ -520,23 +587,21 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
       </Form.Item>
       {generationError && (
         <Alert
-          type="error"
-          showIcon
+          variant="error"
           title={generationError}
-          description={
-            <span className="text-xs">
-              {t("option:flashcards.generateProviderKeyHint", {
-                defaultValue: "If this is a provider or API key issue, "
+        >
+          <span className="text-xs">
+            {t("option:flashcards.generateProviderKeyHint", {
+              defaultValue: "If this is a provider or API key issue, "
+            })}
+            <Link to="/settings/provider-keys" className="text-primary hover:text-primaryStrong underline">
+              {t("option:flashcards.generateProviderKeyLink", {
+                defaultValue: "configure provider keys in Settings"
               })}
-              <Link to="/settings/provider-keys" className="text-primary hover:text-primaryStrong underline">
-                {t("option:flashcards.generateProviderKeyLink", {
-                  defaultValue: "configure provider keys in Settings"
-                })}
-              </Link>
-              .
-            </span>
-          }
-        />
+            </Link>
+            .
+          </span>
+        </Alert>
       )}
       <Tooltip
         title={
@@ -559,6 +624,29 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
           </Button>
         </span>
       </Tooltip>
+
+      {saveStatus && (
+        <Alert
+          variant={saveStatus.variant}
+          title={saveStatus.title}
+          action={
+            saveStatus.retryable
+              ? {
+                  label: t("option:flashcards.generateSaveRetry", {
+                    defaultValue: "Retry saving remaining drafts"
+                  }),
+                  onClick: handleSaveGeneratedCards,
+                  loading: saveInProgress,
+                  disabled: generatedCards.length === 0 || saveInProgress,
+                  "data-testid": "flashcards-generate-save-retry"
+                }
+              : undefined
+          }
+          data-testid="flashcards-generate-save-status"
+        >
+          {saveStatus.detail}
+        </Alert>
+      )}
 
       {generatedCards.length > 0 && (
         <div className="space-y-2">
@@ -621,7 +709,7 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
           <Button
             type="primary"
             onClick={handleSaveGeneratedCards}
-            loading={isSaving || createMutation.isPending || createDeckMutation.isPending}
+            loading={saveInProgress}
             data-testid="flashcards-generate-save-button"
           >
             {t("option:flashcards.generateSaveButton", {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -1039,6 +1039,68 @@ describe("ImportExportTab import result details", () => {
     })
   })
 
+  it("shows an inline retryable recovery state after partial generated-card saves", async () => {
+    const generateMutateAsync = vi.fn().mockResolvedValue({
+      flashcards: [
+        { front: "Card A", back: "Back A", tags: ["a"], model_type: "basic" },
+        { front: "Card B", back: "Back B", tags: ["b"], model_type: "basic" },
+        { front: "Card C", back: "Back C", tags: ["c"], model_type: "basic" }
+      ],
+      count: 3
+    })
+    const createCardMutateAsync = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("save failed"))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+
+    vi.mocked(useGenerateFlashcardsMutation).mockReturnValue({
+      mutateAsync: generateMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
+      mutateAsync: createCardMutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+
+    fireEvent.change(screen.getByTestId("flashcards-generate-text"), {
+      target: { value: "Interleaved retry case" }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-button"))
+
+    await waitFor(() => {
+      expect(generateMutateAsync).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(screen.getByTestId("flashcards-generate-save-button"))
+
+    await waitFor(() => {
+      expect(createCardMutateAsync).toHaveBeenCalledTimes(3)
+    })
+    const status = screen.getByTestId("flashcards-generate-save-status")
+    expect(status).toHaveTextContent("Saved 2 cards; 1 failed.")
+    expect(status).toHaveTextContent(
+      "Only failed drafts remain below. Review them, then retry saving."
+    )
+    expect(status).toHaveAttribute("data-ds-component", "Alert")
+    expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
+      "Generate Flashcards · Saved 2 cards; 1 failed."
+    )
+    expect(screen.getByDisplayValue("Card B")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId("flashcards-generate-save-retry"))
+
+    await waitFor(() => {
+      expect(createCardMutateAsync).toHaveBeenCalledTimes(4)
+    })
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue("Card B")).not.toBeInTheDocument()
+    })
+  })
+
   it("keeps generated drafts when all generated-card saves fail", async () => {
     const generateMutateAsync = vi.fn().mockResolvedValue({
       flashcards: [
@@ -1081,6 +1143,153 @@ describe("ImportExportTab import result details", () => {
 
     expect(screen.getByDisplayValue("Fail A")).toBeInTheDocument()
     expect(screen.getByDisplayValue("Fail B")).toBeInTheDocument()
+  })
+
+  it("shows an inline retryable recovery state when all generated-card saves fail", async () => {
+    const generateMutateAsync = vi.fn().mockResolvedValue({
+      flashcards: [
+        { front: "Fail A", back: "Back A", tags: ["a"], model_type: "basic" },
+        { front: "Fail B", back: "Back B", tags: ["b"], model_type: "basic" }
+      ],
+      count: 2
+    })
+    const createCardMutateAsync = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("save failed"))
+      .mockRejectedValueOnce(new Error("save failed"))
+
+    vi.mocked(useGenerateFlashcardsMutation).mockReturnValue({
+      mutateAsync: generateMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
+      mutateAsync: createCardMutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+
+    fireEvent.change(screen.getByTestId("flashcards-generate-text"), {
+      target: { value: "All fail retry case" }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-button"))
+
+    await waitFor(() => {
+      expect(generateMutateAsync).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(screen.getByTestId("flashcards-generate-save-button"))
+
+    await waitFor(() => {
+      expect(createCardMutateAsync).toHaveBeenCalledTimes(2)
+    })
+    const status = screen.getByTestId("flashcards-generate-save-status")
+    expect(status).toHaveTextContent("Failed to save generated cards.")
+    expect(status).toHaveTextContent(
+      "All generated drafts are still available. Check the deck and draft content, then retry saving."
+    )
+    expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
+      "Generate Flashcards · Failed to save generated cards."
+    )
+    expect(screen.getByTestId("flashcards-generate-save-retry")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Fail A")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Fail B")).toBeInTheDocument()
+  })
+
+  it("shows inline recovery when generated-card deck resolution fails", async () => {
+    const generateMutateAsync = vi.fn().mockResolvedValue({
+      flashcards: [
+        { front: "Needs deck", back: "Back", tags: ["deck"], model_type: "basic" }
+      ],
+      count: 1
+    })
+    const createCardMutateAsync = vi.fn()
+
+    vi.mocked(useGenerateFlashcardsMutation).mockReturnValue({
+      mutateAsync: generateMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
+      mutateAsync: createCardMutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+
+    fireEvent.change(screen.getByTestId("flashcards-generate-text"), {
+      target: { value: "Deck validation case" }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-button"))
+
+    await waitFor(() => {
+      expect(generateMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    fireEvent.change(screen.getByTestId("flashcards-generate-new-deck-name"), {
+      target: { value: " " }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-save-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flashcards-generate-save-status")).toHaveTextContent(
+        "Enter a deck name."
+      )
+    })
+    expect(messageSpies.error).toHaveBeenCalledWith("Enter a deck name.")
+    expect(createCardMutateAsync).not.toHaveBeenCalled()
+    expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
+      "Generate Flashcards · Enter a deck name."
+    )
+    expect(screen.getByDisplayValue("Needs deck")).toBeInTheDocument()
+  })
+
+  it("clears retryable generated-card save status when the remaining draft is removed", async () => {
+    const generateMutateAsync = vi.fn().mockResolvedValue({
+      flashcards: [
+        { front: "Saved draft", back: "Back A", tags: ["a"], model_type: "basic" },
+        { front: "Remaining draft", back: "Back B", tags: ["b"], model_type: "basic" }
+      ],
+      count: 2
+    })
+    const createCardMutateAsync = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("save failed"))
+
+    vi.mocked(useGenerateFlashcardsMutation).mockReturnValue({
+      mutateAsync: generateMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
+      mutateAsync: createCardMutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+
+    fireEvent.change(screen.getByTestId("flashcards-generate-text"), {
+      target: { value: "Remove retry case" }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-button"))
+
+    await waitFor(() => {
+      expect(generateMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-save-button"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flashcards-generate-save-status")).toHaveTextContent(
+        "Saved 1 cards; 1 failed."
+      )
+    })
+    expect(screen.getByDisplayValue("Remaining draft")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }))
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue("Remaining draft")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("flashcards-generate-save-status")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("flashcards-generate-save-retry")).not.toBeInTheDocument()
+    })
   })
 
   it("attaches source attribution when launched from deep-link intent", async () => {

--- a/backlog/tasks/task-512 - Flashcards-UX-Phase-4-import-recovery-states.md
+++ b/backlog/tasks/task-512 - Flashcards-UX-Phase-4-import-recovery-states.md
@@ -1,0 +1,63 @@
+---
+id: TASK-512
+title: Flashcards UX Phase 4 import recovery states
+status: Done
+labels:
+- ux
+- flashcards
+- phase-4
+- frontend
+modified_files:
+- Docs/superpowers/plans/2026-05-26-flashcards-ux-phase4-import-recovery-plan.md
+- backlog/tasks/task-512 - Flashcards-UX-Phase-4-import-recovery-states.md
+- apps/packages/ui/scripts/design-system-product-state-baseline.json
+- apps/packages/ui/src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next scoped flashcards UX remediation slice after Phase 3B: improve Create & Import result recovery states so import/generate/save flows clearly distinguish full success, partial success, and failure, with retry/recovery affordances and focused regression coverage. Scope is /flashcards Create & Import workflows only; defer extension capture, docs, and broad tab restructuring unless directly needed for recovery copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Generated-card save success, partial success, and full failure render a persistent inline status in GeneratePanel.
+- [x] #2 Partial save status explains that saved drafts were removed and failed drafts remain editable.
+- [x] #3 Full save failure status explains that all drafts remain available and can be retried.
+- [x] #4 A visible retry action reuses the existing save path for remaining generated drafts.
+- [x] #5 Focused regression tests cover partial and full generated-card save recovery plus transfer summary consistency.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-26-flashcards-ux-phase4-import-recovery-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added a persistent GeneratePanel save status for generated-card save outcomes, including success, partial success, and full failure.
+- Partial generated saves now keep the existing failed-draft-only behavior while explaining that saved drafts were removed and failed drafts remain editable below.
+- Full generated-save failures now keep all drafts visible and show an inline retry action.
+- Migrated the existing GeneratePanel AntD Alert instances to the shared design-system Alert and removed the stale product-state baseline exceptions for that file.
+- Addressed PR review feedback by catching fatal deck-resolution/save-path errors, surfacing them inline and in the transfer summary, clearing retryable status when remaining drafts are manually edited/removed, and explicitly disabling retry while a save is in progress.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Phase 4 generated-save recovery is implemented. GeneratePanel now shows durable design-system status messaging for saved, partially saved, and failed generated-card saves, with retry for recoverable partial/full failures. The top-level transfer summary stays synchronized with the generated save result, existing generated save behavior still removes saved drafts while preserving failed drafts for editing, and review follow-ups now cover fatal save-path errors plus stale retry states after draft removal/editing. Verification: the new tests failed red first on the missing review fixes, then ImportExportTab import-results passed 26/26. The broader ImportExportTab suite, design-system product-state guard, and git diff --check were rerun after the review fixes. Bandit skipped because this slice only touched frontend TypeScript/TSX tests, JSON baseline, docs, and Backlog files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds a persistent generated-card save status in the flashcards Generate panel for success, partial success, and full failure.
- Keeps failed generated drafts editable after partial saves and adds a retry action for remaining drafts.
- Migrates GeneratePanel state messaging to the shared design-system Alert and removes stale baseline exceptions.

## Test Plan
- [x] `bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab*.test.tsx`
- [x] `bun run verify:design-system-state`
- [x] `git diff --check`

## Change Summary
Draft PR is AI-authored. Before marking ready to merge, the human requester must replace this section with a human-written change summary explaining what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent inline save recovery to the Flashcards Generate panel with success, partial, failure, and deck-resolution error states, plus one-click retry. The transfer summary mirrors the outcome, and Alerts now use the design-system. Addresses TASK-512.

- **New Features**
  - Persistent save status for success, partial, failure, and deck errors with clear detail.
  - Failed drafts stay editable; successful drafts are removed; one-click retry saves remaining, disables while saving, and clears if remaining drafts change.
  - Transfer summary mirrors the latest generate save outcome.

- **Refactors**
  - Replaced `antd` Alert with design-system `Alert` in `GeneratePanel.tsx` and removed related baseline exceptions.
  - Added focused tests for partial/full recovery, deck errors, retry-state clearing, and summary sync.

<sup>Written for commit 1fe2204e7512c04245f8e408cf5e99ec958f5378. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2069?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

