### PR TITLE
Flashcards UX Phase 5 extension capture bridge

### DIFF
--- a/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -1,8 +1,8 @@
 # Flashcards Study Guide
 
-_Last updated: 2026-03-13_
+_Last updated: 2026-05-26_
 
-This guide explains the Flashcards flow in `Study`, `Manage`, `Transfer`, and `Scheduler`, including scheduling basics, queue states, cloze syntax, and import/export formats.
+This guide explains the Flashcards flow in `Study`, `Manage`, `Create & Import`, `Templates`, and `Scheduler`, including extension selected-text capture, scheduling basics, queue states, cloze syntax, and import/export formats.
 
 ## Card Images
 
@@ -23,12 +23,31 @@ Why the 8 KB field limit did not increase:
 
 ## Daily Study Workflow
 
-1. Add cards through `Manage` (manual create), `Transfer` import, `Transfer` generate, or `Transfer` image occlusion.
+1. Add cards through `Manage` manual creation, `Create & Import` import/generate/structured Q&A/image occlusion, or the extension selected-text handoff.
 2. Open `Scheduler` when you want to tune a deck's spaced-repetition policy.
 3. Open `Study` and review due cards.
 4. Reveal the answer, then rate recall (`Again`, `Hard`, `Good`, `Easy`).
 5. Use `Manage` when you want to inspect queue state on expanded cards or document rows while cleaning up a deck.
 6. Repeat daily. The scheduler adjusts next due dates from your ratings.
+
+## Extension Selected-Text Handoff
+
+Use this path when you find a useful passage while browsing and want it to become editable flashcard drafts.
+
+Workflow:
+
+1. Select text on the source page.
+2. Open the extension sidepanel and choose `Flashcards`.
+3. Choose `Generate from page selection`.
+4. The Web UI opens Flashcards on `Create & Import` with the selected text prefilled in the generate workflow.
+5. Generate cards, edit the drafts, choose an existing deck or create a new one, then save.
+
+Important behavior:
+
+- The sidepanel Flashcards route is a bridge. Use `Open full Flashcards` for study/manage work, or `Generate from page selection` to turn the current page selection into drafts.
+- The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
+- Neither sidepanel path creates flashcards automatically. Cards are only saved after you review and save generated drafts in `Create & Import`.
+- If the sidepanel cannot open on the current site, use full Web UI `/flashcards` and paste text into `Create & Import` -> `Generate`.
 
 ## Study Assistant Conflict Recovery
 
@@ -96,9 +115,9 @@ You can now set scheduler policy at deck-creation time instead of creating the d
 Flashcards creation flows:
 
 - `Manage` manual card creation
-- `Transfer` structured Q&A preview save
-- `Transfer` generated flashcards save
-- `Transfer` image occlusion save
+- `Create & Import` structured Q&A preview save
+- `Create & Import` generated flashcards save
+- `Create & Import` image occlusion save
 
 How it works:
 
@@ -194,7 +213,7 @@ Notes:
 
 - Without headers, default column order is `Deck, Front, Back, Tags, Notes`.
 - `Tags` can be comma-separated or space-separated.
-- If imports fail by row, use row-level errors in `Transfer` and jump to inline format help.
+- If imports fail by row, use row-level errors in `Create & Import` and jump to inline format help.
 
 ### JSON / JSONL
 
@@ -214,7 +233,7 @@ Accepted payload forms:
 
 ### Structured Q And A Preview
 
-Use `Transfer` → `Structured Q&A` when you already wrote your own questions and answers and only want the app to convert them into flashcards without LLM rewriting.
+Use `Create & Import` -> `Structured Q&A` when you already wrote your own questions and answers and only want the app to convert them into flashcards without LLM rewriting.
 
 Accepted label pairs:
 
@@ -231,7 +250,7 @@ Preview rules:
 
 ### Image Occlusion Authoring
 
-Use `Transfer` → `Image Occlusion` when you want to turn one labeled screenshot, diagram, or slide into several image-backed cards.
+Use `Create & Import` -> `Image Occlusion` when you want to turn one labeled screenshot, diagram, or slide into several image-backed cards.
 
 Workflow:
 
@@ -261,7 +280,7 @@ Current limits:
 
 ### APKG Export
 
-APKG export is available from `Transfer` and preserves scheduling metadata for Anki import.
+APKG export is available from `Create & Import` and preserves scheduling metadata for Anki import.
 
 Image-backed cards:
 

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -1,8 +1,8 @@
 # Flashcards Study Guide
 
-_Last updated: 2026-03-13_
+_Last updated: 2026-05-26_
 
-This guide explains the Flashcards flow in `Study`, `Manage`, `Transfer`, and `Scheduler`, including scheduling basics, queue states, cloze syntax, and import/export formats.
+This guide explains the Flashcards flow in `Study`, `Manage`, `Create & Import`, `Templates`, and `Scheduler`, including extension selected-text capture, scheduling basics, queue states, cloze syntax, and import/export formats.
 
 ## Card Images
 
@@ -23,12 +23,31 @@ Why the 8 KB field limit did not increase:
 
 ## Daily Study Workflow
 
-1. Add cards through `Manage` (manual create), `Transfer` import, `Transfer` generate, or `Transfer` image occlusion.
+1. Add cards through `Manage` manual creation, `Create & Import` import/generate/structured Q&A/image occlusion, or the extension selected-text handoff.
 2. Open `Scheduler` when you want to tune a deck's spaced-repetition policy.
 3. Open `Study` and review due cards.
 4. Reveal the answer, then rate recall (`Again`, `Hard`, `Good`, `Easy`).
 5. Use `Manage` when you want to inspect queue state on expanded cards or document rows while cleaning up a deck.
 6. Repeat daily. The scheduler adjusts next due dates from your ratings.
+
+## Extension Selected-Text Handoff
+
+Use this path when you find a useful passage while browsing and want it to become editable flashcard drafts.
+
+Workflow:
+
+1. Select text on the source page.
+2. Open the extension sidepanel and choose `Flashcards`.
+3. Choose `Generate from page selection`.
+4. The Web UI opens Flashcards on `Create & Import` with the selected text prefilled in the generate workflow.
+5. Generate cards, edit the drafts, choose an existing deck or create a new one, then save.
+
+Important behavior:
+
+- The sidepanel Flashcards route is a bridge. Use `Open full Flashcards` for study/manage work, or `Generate from page selection` to turn the current page selection into drafts.
+- The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
+- Neither sidepanel path creates flashcards automatically. Cards are only saved after you review and save generated drafts in `Create & Import`.
+- If the sidepanel cannot open on the current site, use full Web UI `/flashcards` and paste text into `Create & Import` -> `Generate`.
 
 ## Study Assistant Conflict Recovery
 
@@ -96,9 +115,9 @@ You can now set scheduler policy at deck-creation time instead of creating the d
 Flashcards creation flows:
 
 - `Manage` manual card creation
-- `Transfer` structured Q&A preview save
-- `Transfer` generated flashcards save
-- `Transfer` image occlusion save
+- `Create & Import` structured Q&A preview save
+- `Create & Import` generated flashcards save
+- `Create & Import` image occlusion save
 
 How it works:
 
@@ -194,7 +213,7 @@ Notes:
 
 - Without headers, default column order is `Deck, Front, Back, Tags, Notes`.
 - `Tags` can be comma-separated or space-separated.
-- If imports fail by row, use row-level errors in `Transfer` and jump to inline format help.
+- If imports fail by row, use row-level errors in `Create & Import` and jump to inline format help.
 
 ### JSON / JSONL
 
@@ -214,7 +233,7 @@ Accepted payload forms:
 
 ### Structured Q And A Preview
 
-Use `Transfer` → `Structured Q&A` when you already wrote your own questions and answers and only want the app to convert them into flashcards without LLM rewriting.
+Use `Create & Import` -> `Structured Q&A` when you already wrote your own questions and answers and only want the app to convert them into flashcards without LLM rewriting.
 
 Accepted label pairs:
 
@@ -231,7 +250,7 @@ Preview rules:
 
 ### Image Occlusion Authoring
 
-Use `Transfer` → `Image Occlusion` when you want to turn one labeled screenshot, diagram, or slide into several image-backed cards.
+Use `Create & Import` -> `Image Occlusion` when you want to turn one labeled screenshot, diagram, or slide into several image-backed cards.
 
 Workflow:
 
@@ -261,7 +280,7 @@ Current limits:
 
 ### APKG Export
 
-APKG export is available from `Transfer` and preserves scheduling metadata for Anki import.
+APKG export is available from `Create & Import` and preserves scheduling metadata for Anki import.
 
 Image-backed cards:
 

--- a/Docs/superpowers/plans/2026-05-26-flashcards-ux-phase5-extension-capture-plan.md
+++ b/Docs/superpowers/plans/2026-05-26-flashcards-ux-phase5-extension-capture-plan.md
@@ -1,0 +1,17 @@
+## Stage 1: Extension Flashcards Bridge
+**Goal**: Replace the auto-redirect-only sidepanel flashcards route with a small focused bridge that exposes full Flashcards and the existing selected-text capture path.
+**Success Criteria**: Users can open full Flashcards directly, see how to make cards from selected text, and jump to the sidepanel chat route where the existing note quick-save `Generate flashcards` action lives.
+**Tests**: Focused route/component tests for the sidepanel flashcards bridge and route registration.
+**Status**: Complete
+
+## Stage 2: Direct Documentation Refresh
+**Goal**: Update the extension flashcards feature doc and WebUI/extension study guide to match the current Flashcards tab names and extension handoff.
+**Success Criteria**: Docs describe `Study`, `Manage`, `Create & Import`, `Templates`, and `Scheduler`; direct extension capture docs point to selected text -> Save to Notes -> Generate flashcards.
+**Tests**: Documentation review plus `git diff --check`.
+**Status**: Complete
+
+## Stage 3: Verification And Task Finalization
+**Goal**: Run focused verification, record results in `TASK-513`, and leave the branch ready for review.
+**Success Criteria**: Focused tests pass or known unrelated failures are documented; task acceptance criteria and final summary are updated.
+**Tests**: `bunx vitest run ...`, `git diff --check`; design-system guard if the implementation introduces product-state surfaces.
+**Status**: Complete

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -4,30 +4,37 @@ title: Flashcards (Experimental)
 
 # Flashcards (Experimental)
 
-The Flashcards page lets you create, review, and manage spaced‑repetition cards backed by your tldw_server. It also supports CSV/TSV import and export (and optional .apkg export where supported by the server).
+The Flashcards page lets you create, review, and manage spaced-repetition cards backed by your tldw_server. It also supports CSV/TSV import and export, plus optional .apkg export where supported by the server.
 
-Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`.
+Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact bridge with actions for the full Flashcards workspace and selected-text generation.
 
 ## Prerequisites
 
-- The extension must be connected to a running tldw_server instance (Options → Settings → tldw Server).
+- The extension must be connected to a running tldw_server instance (Options -> Settings -> tldw Server).
 - You need to be signed in or configured with an API key if your server requires authentication.
 
 ## Tabs
 
-- Review: Fetches the next due card (optionally by deck), reveals the answer, and lets you submit an Anki‑style 0–5 rating. The server schedules the next review via `/api/v1/flashcards/review`.
-- Create: Choose a deck (or create one), set Model Type (`basic`, `basic_reverse`, `cloze`), toggles (Reverse/Cloze), add tags and content, then create via `/api/v1/flashcards`.
-- Manage: Search/filter by deck/tag/due status, paginate, edit cards (PATCH), or delete them (DELETE with expected version).
- - Manage: Search/filter by deck/tag/due status, paginate, select multiple, bulk move/delete/export (CSV/TSV), edit cards (PATCH), or delete them (DELETE with expected version).
-- Import/Export:
-  - Import: Paste TSV/CSV lines with columns `Deck, Front, Back, Tags, Notes`. Choose delimiter and header presence. Uses `/api/v1/flashcards/import`. Limits can be inspected via `/api/v1/config/flashcards-import-limits`.
-  - Export: Filter by deck/tag/query, choose CSV/TSV (and optional .apkg), set options like delimiter, header, and extended columns, then download.
-  - Optional import column mapping lets you re-order your columns to match the server’s expected `Deck, Front, Back, Tags, Notes` shape.
+- Study: Fetches the next due card, optionally by deck, reveals the answer, and lets you submit `Again`, `Hard`, `Good`, or `Easy`. The server schedules the next review via `/api/v1/flashcards/review`.
+- Manage: Search/filter by deck/tag/due status, paginate, select cards, bulk move/delete/export, edit cards, or delete them with expected-version protection.
+- Create & Import: Manually create cards, import delimited/JSON/APKG content, generate draft flashcards from text, run structured Q&A preview, author image occlusion cards, and export decks.
+- Templates: Manage reusable flashcard templates and field presets.
+- Scheduler: Edit deck-level scheduler policy, presets, queue visibility, and conflict recovery.
+
+## Extension Selected-Text Flow
+
+1. Select text on a web page.
+2. Open the extension sidepanel and choose `Flashcards`.
+3. Click `Generate from page selection`.
+4. The full Web UI opens `/flashcards?tab=importExport` with the selected text prefilled in the generation workflow.
+5. Generate, review/edit the drafts, choose a deck or create one, then save the cards.
+
+You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog. The sidepanel Flashcards route does not save cards by itself; the save happens after you review and save generated drafts in the full Flashcards workspace.
 
 ## Tips
 
-- Due cards: Use the Review tab’s “Next due” to step through scheduled cards.
+- Due cards: Use the Study tab’s next-card flow to step through scheduled cards.
 - Cloze cards: Toggle “Is Cloze” and select `cloze` model when creating/editing.
-- Tags: Use the tags input in Create/Edit; tags are stored as a JSON array.
+- Tags: Use the tags input in Create & Import or Manage edit flows; tags are stored as a JSON array.
 
 > Note: Flashcards features are marked Experimental in the server API and may change.

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -26,7 +26,7 @@ Access it from the Web UI header by clicking the Layers icon, or navigate to `/f
 1. Select text on a web page.
 2. Open the extension sidepanel and choose `Flashcards`.
 3. Click `Generate from page selection`.
-4. The full Web UI opens `/flashcards?tab=importExport` with the selected text prefilled in the generation workflow.
+4. The full Web UI opens Flashcards on the `Create & Import` tab with the selected text prefilled in the generation workflow.
 5. Generate, review/edit the drafts, choose a deck or create one, then save the cards.
 
 You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog. The sidepanel Flashcards route does not save cards by itself; the save happens after you review and save generated drafts in the full Flashcards workspace.

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx
@@ -74,16 +74,22 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
   const sourceContext = React.useMemo<GenerateSourceContext | null>(() => {
     if (!initialIntent) return null
     if (
+      initialIntent.sourceType !== "manual" &&
       initialIntent.sourceType !== "media" &&
       initialIntent.sourceType !== "note" &&
       initialIntent.sourceType !== "message"
     ) {
       return null
     }
+    const sourceId = initialIntent.sourceId?.trim() || null
+    const sourceTitle = initialIntent.sourceTitle?.trim() || null
+    if (initialIntent.sourceType === "manual" && !sourceId && !sourceTitle) {
+      return null
+    }
     return {
       sourceType: initialIntent.sourceType,
-      sourceId: initialIntent.sourceId?.trim() || null,
-      sourceTitle: initialIntent.sourceTitle?.trim() || null
+      sourceId: sourceId || (initialIntent.sourceType === "manual" ? sourceTitle : null),
+      sourceTitle
     }
   }, [initialIntent])
 
@@ -425,8 +431,8 @@ export const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporter
               "Cards saved from this draft will be linked to {{sourceType}} {{sourceId}}.",
             sourceType: sourceContext.sourceType,
             sourceId:
-              sourceContext.sourceId ||
               sourceContext.sourceTitle ||
+              sourceContext.sourceId ||
               t("option:flashcards.unknownSource", {
                 defaultValue: "unknown source"
               })

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/shared.ts
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/shared.ts
@@ -31,10 +31,7 @@ export interface StructuredImportDraft extends StructuredQaImportPreviewDraft {
 
 export type SupportedDelimiter = "\t" | "," | ";" | "|"
 export type ImportMode = "delimited" | "json" | "apkg" | "structured"
-export type GenerateSourceType = Exclude<
-  NonNullable<FlashcardsGenerateIntent["sourceType"]>,
-  "manual"
->
+export type GenerateSourceType = NonNullable<FlashcardsGenerateIntent["sourceType"]>
 
 export interface GenerateSourceContext {
   sourceType: GenerateSourceType

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -1349,6 +1349,60 @@ describe("ImportExportTab import result details", () => {
     )
   })
 
+  it("preserves manual source attribution for selected-page generate handoffs", async () => {
+    const generateMutateAsync = vi.fn().mockResolvedValue({
+      flashcards: [
+        {
+          front: "Captured front",
+          back: "Captured back",
+          tags: ["page"],
+          model_type: "basic"
+        }
+      ],
+      count: 1
+    })
+    const createCardMutateAsync = vi.fn().mockResolvedValue({})
+    vi.mocked(useGenerateFlashcardsMutation).mockReturnValue({
+      mutateAsync: generateMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
+      mutateAsync: createCardMutateAsync,
+      isPending: false
+    } as any)
+
+    render(
+      <ImportExportTab
+        generateIntent={{
+          text: "Highlighted page passage",
+          sourceType: "manual",
+          sourceId: "https://example.test/source",
+          sourceTitle: "Captured Page"
+        }}
+      />
+    )
+
+    expect(screen.getByTestId("flashcards-generate-source-context")).toHaveTextContent(
+      "Captured Page"
+    )
+
+    fireEvent.click(screen.getByTestId("flashcards-generate-button"))
+    await waitFor(() => {
+      expect(generateMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-save-button"))
+
+    await waitFor(() => {
+      expect(createCardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(createCardMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source_ref_type: "manual",
+        source_ref_id: "https://example.test/source"
+      })
+    )
+  })
+
   it("offers undo rollback for the latest import batch", async () => {
     const mutateAsync = vi.fn().mockResolvedValue({
       imported: 2,

--- a/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
@@ -73,6 +73,7 @@ describe("sidepanel flashcards route registration", () => {
   it("sidepanel-flashcards.tsx opens options page at /flashcards", () => {
     expect(flashcardsComponentPath).toBeDefined()
     const source = readFileSync(flashcardsComponentPath!, "utf8")
-    expect(source).toContain("/options.html#/flashcards")
+    expect(source).toContain("options.html#")
+    expect(source).toContain('openOptionsHashRoute("/flashcards")')
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -1,0 +1,139 @@
+import React from "react"
+import userEvent from "@testing-library/user-event"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import SidepanelFlashcards from "../sidepanel-flashcards"
+
+const browserMocks = vi.hoisted(() => ({
+  runtimeGetURL: vi.fn((path: string) => `chrome-extension://flashcards${path}`),
+  tabsCreate: vi.fn(async () => undefined),
+  tabsQuery: vi.fn(async () => [
+    {
+      id: 42,
+      title: "Selection Source",
+      url: "https://example.test/source"
+    }
+  ]),
+  executeScript: vi.fn(async () => [
+    {
+      result: "Key concept from the active page"
+    }
+  ])
+}))
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    runtime: {
+      getURL: browserMocks.runtimeGetURL
+    },
+    tabs: {
+      create: browserMocks.tabsCreate,
+      query: browserMocks.tabsQuery
+    },
+    scripting: {
+      executeScript: browserMocks.executeScript
+    }
+  }
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        return fallbackOrOptions.defaultValue || key
+      }
+      return key
+    }
+  })
+}))
+
+describe("sidepanel flashcards route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows explicit full-workspace and selected-text capture actions without auto-opening a tab", () => {
+    render(<SidepanelFlashcards />)
+
+    expect(
+      screen.getByRole("heading", { name: "Flashcards" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Study, manage, and create cards in the full Flashcards workspace."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Open full Flashcards" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Turn the current page selection into editable flashcard drafts."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Generate from page selection" })
+    ).toBeInTheDocument()
+    expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
+  })
+
+  it("opens the full Flashcards workspace when the user chooses that action", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Open full Flashcards" })
+    )
+
+    expect(browserMocks.runtimeGetURL).toHaveBeenCalledWith(
+      "/options.html#/flashcards"
+    )
+    expect(browserMocks.tabsCreate).toHaveBeenCalledWith({
+      url: "chrome-extension://flashcards/options.html#/flashcards"
+    })
+  })
+
+  it("captures the active page selection into the Flashcards generate workflow", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate from page selection" })
+    )
+
+    expect(browserMocks.tabsQuery).toHaveBeenCalledWith({
+      active: true,
+      currentWindow: true
+    })
+    expect(browserMocks.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 42 },
+      func: expect.any(Function)
+    })
+    const openedUrl = browserMocks.tabsCreate.mock.calls.at(-1)?.[0]?.url
+    expect(openedUrl).toContain("/options.html#/flashcards?")
+    const search = openedUrl?.split("?")[1] || ""
+    const params = new URLSearchParams(search)
+    expect(params.get("generate")).toBe("1")
+    expect(params.get("generate_text")).toBe("Key concept from the active page")
+    expect(params.get("generate_source_title")).toBe("Selection Source")
+  })
+
+  it("keeps the user in place when no page text is selected", async () => {
+    browserMocks.executeScript.mockResolvedValueOnce([{ result: "" }])
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate from page selection" })
+    )
+
+    expect(
+      screen.getByText("Select text on the page first.")
+    ).toBeInTheDocument()
+    expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -1,8 +1,10 @@
 import React from "react"
 import userEvent from "@testing-library/user-event"
 import { render, screen } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import SidepanelFlashcards from "../sidepanel-flashcards"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import SidepanelFlashcards, {
+  readSelectedTextFromPage
+} from "../sidepanel-flashcards"
 
 const browserMocks = vi.hoisted(() => ({
   runtimeGetURL: vi.fn((path: string) => `chrome-extension://flashcards${path}`),
@@ -56,6 +58,10 @@ describe("sidepanel flashcards route", () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("shows explicit full-workspace and selected-text capture actions without auto-opening a tab", () => {
     render(<SidepanelFlashcards />)
 
@@ -97,6 +103,42 @@ describe("sidepanel flashcards route", () => {
     })
   })
 
+  it("shows an inline error when tab and fallback window opening fail", async () => {
+    browserMocks.tabsCreate.mockRejectedValueOnce(new Error("tab open failed"))
+    vi.spyOn(window, "open").mockReturnValue(null)
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Open full Flashcards" })
+    )
+
+    expect(window.open).toHaveBeenCalledWith(
+      "chrome-extension://flashcards/options.html#/flashcards",
+      "_blank"
+    )
+    expect(
+      await screen.findByText(
+        "Could not open Flashcards. Check popup permissions and try again."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("reads selected text from focused form controls in the injected page helper", () => {
+    const input = document.createElement("input")
+    input.value = "Before selected phrase after"
+    document.body.append(input)
+
+    try {
+      input.focus()
+      input.setSelectionRange(7, 22)
+
+      expect(readSelectedTextFromPage()).toBe("selected phrase")
+    } finally {
+      input.remove()
+    }
+  })
+
   it("captures the active page selection into the Flashcards generate workflow", async () => {
     const user = userEvent.setup()
     render(<SidepanelFlashcards />)
@@ -114,11 +156,15 @@ describe("sidepanel flashcards route", () => {
       func: expect.any(Function)
     })
     const openedUrl = browserMocks.tabsCreate.mock.calls.at(-1)?.[0]?.url
-    expect(openedUrl).toContain("/options.html#/flashcards?")
-    const search = openedUrl?.split("?")[1] || ""
-    const params = new URLSearchParams(search)
+    expect(openedUrl).toBeDefined()
+    const url = new URL(openedUrl as string)
+    expect(url.pathname).toBe("/options.html")
+    expect(url.hash).toContain("/flashcards?")
+    const hashSearch = url.hash.slice(url.hash.indexOf("?") + 1)
+    const params = new URLSearchParams(hashSearch)
     expect(params.get("generate")).toBe("1")
     expect(params.get("generate_text")).toBe("Key concept from the active page")
+    expect(params.get("generate_source_id")).toBe("https://example.test/source")
     expect(params.get("generate_source_title")).toBe("Selection Source")
   })
 

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -1,17 +1,20 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { Layers } from "lucide-react"
+import { ExternalLink, Layers, MessageSquareText } from "lucide-react"
 import { Button, Typography } from "antd"
 import { browser } from "wxt/browser"
+import { buildFlashcardsGenerateRoute } from "@/services/tldw/flashcards-generate-handoff"
 
 const { Text, Title } = Typography
 
 export default function SidepanelFlashcards() {
   const { t } = useTranslation()
-  const hasAutoOpenedRef = React.useRef(false)
+  const [captureError, setCaptureError] = React.useState<string | null>(null)
+  const [captureLoading, setCaptureLoading] = React.useState(false)
 
-  const openFlashcards = React.useCallback(() => {
-    const url = browser.runtime.getURL("/options.html#/flashcards")
+  const openOptionsHashRoute = React.useCallback((route: string) => {
+    const normalizedRoute = route.startsWith("/") ? route : `/${route}`
+    const url = browser.runtime.getURL(`/options.html#${normalizedRoute}`)
     if (browser.tabs?.create) {
       browser.tabs.create({ url }).catch(() => {
         window.open(url, "_blank")
@@ -21,27 +24,122 @@ export default function SidepanelFlashcards() {
     window.open(url, "_blank")
   }, [])
 
-  React.useEffect(() => {
-    if (hasAutoOpenedRef.current) return
-    hasAutoOpenedRef.current = true
-    openFlashcards()
-  }, [openFlashcards])
+  const openFlashcards = React.useCallback(() => {
+    openOptionsHashRoute("/flashcards")
+  }, [openOptionsHashRoute])
+
+  const handleGenerateFromPageSelection = React.useCallback(async () => {
+    setCaptureError(null)
+    setCaptureLoading(true)
+    const captureUnavailableMessage = t(
+      "sidepanel:flashcards.selectionCaptureUnavailable",
+      "Page selection capture is unavailable in this browser."
+    )
+    const activeTabUnavailableMessage = t(
+      "sidepanel:flashcards.activeTabUnavailable",
+      "Open a page tab before generating flashcards."
+    )
+    const noSelectionMessage = t(
+      "sidepanel:flashcards.noPageSelection",
+      "Select text on the page first."
+    )
+    const captureFailedMessage = t(
+      "sidepanel:flashcards.selectionCaptureFailed",
+      "Could not read the current page selection. Use the Save to Notes context menu or paste text into Create & Import."
+    )
+    try {
+      if (!browser.tabs?.query || !browser.scripting?.executeScript) {
+        throw new Error(captureUnavailableMessage)
+      }
+
+      const activeTabs = await browser.tabs.query({
+        active: true,
+        currentWindow: true
+      })
+      const activeTab = activeTabs[0]
+      const tabId = activeTab?.id
+      if (typeof tabId !== "number") {
+        throw new Error(activeTabUnavailableMessage)
+      }
+
+      const results = await browser.scripting.executeScript({
+        target: { tabId },
+        func: () => window.getSelection()?.toString() ?? ""
+      })
+      const selectedText = String(results?.[0]?.result ?? "").trim()
+      if (!selectedText) {
+        throw new Error(noSelectionMessage)
+      }
+
+      openOptionsHashRoute(
+        buildFlashcardsGenerateRoute({
+          text: selectedText,
+          sourceId: activeTab.url || String(tabId),
+          sourceTitle: activeTab.title || activeTab.url || undefined
+        })
+      )
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message.trim() ? error.message : ""
+      const validationMessages = [
+        captureUnavailableMessage,
+        activeTabUnavailableMessage,
+        noSelectionMessage
+      ]
+      setCaptureError(
+        validationMessages.includes(message) ? message : captureFailedMessage
+      )
+    } finally {
+      setCaptureLoading(false)
+    }
+  }, [openOptionsHashRoute, t])
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-6 text-center">
-      <Layers className="size-10 text-text-muted" aria-hidden="true" />
-      <Title level={5}>
+    <main className="flex min-h-full flex-col items-center justify-center gap-4 p-6 text-center">
+      <div className="rounded-full border border-border bg-surface2 p-3">
+        <Layers className="size-8 text-text-muted" aria-hidden="true" />
+      </div>
+      <Title level={4} className="!mb-0">
         {t("sidepanel:flashcards.title", "Flashcards")}
       </Title>
       <Text type="secondary">
         {t(
-          "sidepanel:flashcards.openedInTab",
-          "Flashcards opens in a full tab for the best study experience."
+          "sidepanel:flashcards.workspaceDescription",
+          "Study, manage, and create cards in the full Flashcards workspace."
         )}
       </Text>
-      <Button type="primary" onClick={openFlashcards}>
-        {t("sidepanel:flashcards.openAgain", "Open Flashcards")}
-      </Button>
-    </div>
+      <div className="flex w-full max-w-xs flex-col gap-2">
+        <Button
+          type="primary"
+          block
+          icon={<ExternalLink className="size-4" aria-hidden="true" />}
+          onClick={openFlashcards}
+        >
+          {t("sidepanel:flashcards.openFull", "Open full Flashcards")}
+        </Button>
+        <Button
+          block
+          loading={captureLoading}
+          icon={<MessageSquareText className="size-4" aria-hidden="true" />}
+          onClick={handleGenerateFromPageSelection}
+        >
+          {t(
+            "sidepanel:flashcards.generateFromPageSelection",
+            "Generate from page selection"
+          )}
+        </Button>
+      </div>
+      <Text type="secondary" className="max-w-xs text-xs">
+        {t(
+          "sidepanel:flashcards.selectionHint",
+          "Turn the current page selection into editable flashcard drafts."
+        )}
+      </Text>
+      {captureError ? (
+        <Text type="danger" className="max-w-xs text-xs" role="status">
+          {captureError}
+        </Text>
+      ) : null}
+    </main>
   )
 }

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -7,25 +7,58 @@ import { buildFlashcardsGenerateRoute } from "@/services/tldw/flashcards-generat
 
 const { Text, Title } = Typography
 
+export const readSelectedTextFromPage = () => {
+  const activeElement = document.activeElement
+  if (
+    activeElement instanceof HTMLInputElement ||
+    activeElement instanceof HTMLTextAreaElement
+  ) {
+    const { selectionStart, selectionEnd, value } = activeElement
+    if (
+      typeof selectionStart === "number" &&
+      typeof selectionEnd === "number" &&
+      selectionEnd > selectionStart
+    ) {
+      return value.slice(selectionStart, selectionEnd)
+    }
+  }
+
+  return window.getSelection()?.toString() ?? ""
+}
+
 export default function SidepanelFlashcards() {
   const { t } = useTranslation()
   const [captureError, setCaptureError] = React.useState<string | null>(null)
   const [captureLoading, setCaptureLoading] = React.useState(false)
 
-  const openOptionsHashRoute = React.useCallback((route: string) => {
+  const openOptionsHashRoute = React.useCallback(async (route: string) => {
+    setCaptureError(null)
     const normalizedRoute = route.startsWith("/") ? route : `/${route}`
     const url = browser.runtime.getURL(`/options.html#${normalizedRoute}`)
-    if (browser.tabs?.create) {
-      browser.tabs.create({ url }).catch(() => {
-        window.open(url, "_blank")
-      })
-      return
+    const openFailedMessage = t(
+      "sidepanel:flashcards.openFailed",
+      "Could not open Flashcards. Check popup permissions and try again."
+    )
+    const openFallbackWindow = () => {
+      const openedWindow = window.open(url, "_blank")
+      if (openedWindow) return true
+      setCaptureError(openFailedMessage)
+      return false
     }
-    window.open(url, "_blank")
-  }, [])
+
+    if (browser.tabs?.create) {
+      try {
+        await browser.tabs.create({ url })
+        return true
+      } catch {
+        return openFallbackWindow()
+      }
+    }
+    return openFallbackWindow()
+  }, [t])
 
   const openFlashcards = React.useCallback(() => {
-    openOptionsHashRoute("/flashcards")
+    void openOptionsHashRoute("/flashcards")
   }, [openOptionsHashRoute])
 
   const handleGenerateFromPageSelection = React.useCallback(async () => {
@@ -64,16 +97,17 @@ export default function SidepanelFlashcards() {
 
       const results = await browser.scripting.executeScript({
         target: { tabId },
-        func: () => window.getSelection()?.toString() ?? ""
+        func: readSelectedTextFromPage
       })
       const selectedText = String(results?.[0]?.result ?? "").trim()
       if (!selectedText) {
         throw new Error(noSelectionMessage)
       }
 
-      openOptionsHashRoute(
+      await openOptionsHashRoute(
         buildFlashcardsGenerateRoute({
           text: selectedText,
+          sourceType: "manual",
           sourceId: activeTab.url || String(tabId),
           sourceTitle: activeTab.title || activeTab.url || undefined
         })

--- a/apps/packages/ui/src/services/__tests__/flashcards-generate-handoff.test.ts
+++ b/apps/packages/ui/src/services/__tests__/flashcards-generate-handoff.test.ts
@@ -42,6 +42,28 @@ describe("flashcards generate handoff helpers", () => {
     })
   })
 
+  it("keeps manual source details for selected-page extension captures", () => {
+    const route = buildFlashcardsGenerateRoute({
+      text: "Highlighted page text",
+      sourceType: "manual",
+      sourceId: "https://example.test/source",
+      sourceTitle: "Captured Page"
+    })
+
+    const intent = parseFlashcardsGenerateIntentFromSearch(
+      route.slice(route.indexOf("?"))
+    )
+
+    expect(intent).toEqual({
+      text: "Highlighted page text",
+      sourceType: "manual",
+      sourceId: "https://example.test/source",
+      sourceTitle: "Captured Page",
+      conversationId: undefined,
+      messageId: undefined
+    })
+  })
+
   it("parses generate intent from hash-based routes", () => {
     const intent = parseFlashcardsGenerateIntentFromLocation({
       search: "",

--- a/backlog/tasks/task-513 - Flashcards-UX-Phase-5-extension-capture-and-docs.md
+++ b/backlog/tasks/task-513 - Flashcards-UX-Phase-5-extension-capture-and-docs.md
@@ -1,0 +1,61 @@
+---
+id: TASK-513
+title: Flashcards UX Phase 5 extension capture and docs
+status: Done
+labels:
+- ux
+- flashcards
+- phase-5
+- extension
+- docs
+- frontend
+modified_files:
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
+- apps/extension/docs/features/flashcards.md
+- Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the scoped Phase 5 flashcards UX follow-up after the merged import recovery work: make the extension flashcards entry point better support the existing capture-to-card handoff and refresh directly connected flashcards documentation so it matches the current WebUI/extension workflow.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Sidepanel flashcards entry point exposes clear actions for opening full Flashcards and finding the existing selected-text capture-to-flashcards handoff.
+- [ ] #2 Extension/WebUI flashcards docs describe the current tab names and directly connected extension capture workflow.
+- [ ] #3 Focused route tests cover the sidepanel flashcards entry point behavior.
+- [ ] #4 Verification commands are recorded in the task before completion.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-26-flashcards-ux-phase5-extension-capture-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Phase 5 extension flashcards capture bridge. The sidepanel /flashcards route no longer auto-opens a tab on mount; it now offers an explicit full Flashcards action and a direct Generate from page selection action that captures the active tab selection with browser.scripting and opens the existing /flashcards Create & Import generate handoff. Updated the extension feature doc and WebUI/extension study guide, including the published mirror, to use current tab names and describe the selected-text capture workflow. Verification: bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts passed with 10 tests; git diff --check passed; bun run verify:design-system-state exited 0 with existing baseline exceptions; stale Flashcards doc term grep returned no matches. Bandit skipped because this task touched TypeScript/Markdown only, not Python.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-513 - Flashcards-UX-Phase-5-extension-capture-and-docs.md
+++ b/backlog/tasks/task-513 - Flashcards-UX-Phase-5-extension-capture-and-docs.md
@@ -13,6 +13,10 @@ modified_files:
 - apps/packages/ui/src/routes/sidepanel-flashcards.tsx
 - apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
 - apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
+- apps/packages/ui/src/services/__tests__/flashcards-generate-handoff.test.ts
+- apps/packages/ui/src/components/Flashcards/tabs/ImportExport/GeneratePanel.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/ImportExport/shared.ts
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
 - apps/extension/docs/features/flashcards.md
 - Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
 - Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -26,10 +30,10 @@ Implement the scoped Phase 5 flashcards UX follow-up after the merged import rec
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Sidepanel flashcards entry point exposes clear actions for opening full Flashcards and finding the existing selected-text capture-to-flashcards handoff.
-- [ ] #2 Extension/WebUI flashcards docs describe the current tab names and directly connected extension capture workflow.
-- [ ] #3 Focused route tests cover the sidepanel flashcards entry point behavior.
-- [ ] #4 Verification commands are recorded in the task before completion.
+- [x] #1 Sidepanel flashcards entry point exposes clear actions for opening full Flashcards and finding the existing selected-text capture-to-flashcards handoff.
+- [x] #2 Extension/WebUI flashcards docs describe the current tab names and directly connected extension capture workflow.
+- [x] #3 Focused route tests cover the sidepanel flashcards entry point behavior.
+- [x] #4 Verification commands are recorded in the task before completion.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -41,21 +45,21 @@ Docs/superpowers/plans/2026-05-26-flashcards-ux-phase5-extension-capture-plan.md
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- PR review-fix pass: rebased on `origin/dev`; preserved selected-page capture provenance as backend-supported `manual` source references; reported tab-open fallback failures inline; captured focused input/textarea selections before falling back to `window.getSelection()`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the Phase 5 extension flashcards capture bridge. The sidepanel /flashcards route no longer auto-opens a tab on mount; it now offers an explicit full Flashcards action and a direct Generate from page selection action that captures the active tab selection with browser.scripting and opens the existing /flashcards Create & Import generate handoff. Updated the extension feature doc and WebUI/extension study guide, including the published mirror, to use current tab names and describe the selected-text capture workflow. Verification: bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts passed with 10 tests; git diff --check passed; bun run verify:design-system-state exited 0 with existing baseline exceptions; stale Flashcards doc term grep returned no matches. Bandit skipped because this task touched TypeScript/Markdown only, not Python.
+Implemented the Phase 5 extension flashcards capture bridge and PR review fixes. The sidepanel /flashcards route no longer auto-opens a tab on mount; it now offers an explicit full Flashcards action, a direct Generate from page selection action, inline failure feedback if tab/window opening is blocked, and an injected selection reader that handles focused input/textarea selections before falling back to window selection. Selected-page captures now carry manual source attribution through the generate handoff and GeneratePanel save payload, preserving the active tab URL/title without inventing an unsupported backend source type. Updated the extension feature doc to use the visible Create & Import tab label and checked the Backlog AC/DoD items. Verification: rebased on origin/dev with no conflicts; bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts src/services/__tests__/flashcards-generate-handoff.test.ts src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx passed with 43 tests; git diff --check passed; bun run verify:design-system-state exited 0 with 225 existing allowed baseline exceptions; rg -n '/flashcards[?]tab=importExport.*selected text|selected text.*\\/flashcards[?]tab=importExport' apps/extension/docs Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md returned no matches. Bandit skipped because this task touched TypeScript/Markdown/Backlog task metadata only, not Python.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Replace the extension sidepanel `/flashcards` auto-open behavior with explicit actions for opening full Flashcards and generating drafts from the active page selection.
- Use the existing Flashcards generate handoff so captured selection text lands in `Create & Import` as editable drafts before save.
- Refresh the extension/WebUI flashcards docs and published guide mirror to match current tab names and selected-text capture paths.

## Change summary
This draft is AI-authored. Before marking ready, the human requester should confirm or replace this section per the AI-generated PR merge gate. The implementation keeps full study/manage workflows in the full Flashcards workspace, while using the extension sidepanel only for a focused capture bridge. It reuses the existing generate handoff instead of adding a parallel save path, so users still review/edit drafts before cards are persisted.

## Test Plan
- [x] `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
- [x] `git diff --check`
- [x] `bun run verify:design-system-state` (exits 0 with existing baseline exceptions)
- [x] stale Flashcards doc term grep returned no matches for old `Transfer`/`Review tab`/`ImportExport` labels
- [x] Bandit skipped: touched TypeScript and Markdown only

Backlog: TASK-513

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the extension sidepanel `/flashcards` auto-open with a focused capture bridge. It sends selected page text into `Create & Import`, preserves page source details, and adds clearer failure handling, addressing TASK-513.

- **New Features**
  - Sidepanel now shows explicit actions and no longer auto-opens a tab.
  - “Generate from page selection” reads focused input/textarea or page selection, opens the options hash route built by `buildFlashcardsGenerateRoute`, and carries `manual` source URL/title into drafts.
  - Route opening uses `openOptionsHashRoute("/flashcards")` with inline errors for no selection, unavailable capture, or blocked tab/window opening; added focused tests for the sidepanel, route registry, generate handoff, and manual source attribution in saves.
  - Docs updated to match current tabs (`Study`, `Manage`, `Create & Import`, `Templates`, `Scheduler`), explain the selected-text handoff, and clarify that cards save only after draft review.

<sup>Written for commit 9784f6adef0697bad712400d76928847caef009b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2070?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

