### PR TITLE
Add native flashcards sidepanel capture

### DIFF
--- a/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -30,24 +30,25 @@ Why the 8 KB field limit did not increase:
 5. Use `Manage` when you want to inspect queue state on expanded cards or document rows while cleaning up a deck.
 6. Repeat daily. The scheduler adjusts next due dates from your ratings.
 
-## Extension Selected-Text Handoff
+## Extension Selected-Text Capture
 
-Use this path when you find a useful passage while browsing and want it to become editable flashcard drafts.
+Use this path when you find a useful passage while browsing and want to save one editable basic flashcard without leaving the sidepanel.
 
 Workflow:
 
 1. Select text on the source page.
 2. Open the extension sidepanel and choose `Flashcards`.
-3. Choose `Generate from page selection`.
-4. The Web UI opens Flashcards on `Create & Import` with the selected text prefilled in the generate workflow.
-5. Generate cards, edit the drafts, choose an existing deck or create a new one, then save.
+3. Choose `Capture page selection`.
+4. Select a deck, edit `Front` and `Back`, then choose `Save card`.
+5. Use `Open full Flashcards` for generation, imports, templates, review, or broader deck management.
 
 Important behavior:
 
-- The sidepanel Flashcards route is a bridge. Use `Open full Flashcards` for study/manage work, or `Generate from page selection` to turn the current page selection into drafts.
+- The sidepanel Flashcards route saves one basic card at a time and keeps the source page URL as provenance.
+- Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
-- Neither sidepanel path creates flashcards automatically. Cards are only saved after you review and save generated drafts in `Create & Import`.
-- If the sidepanel cannot open on the current site, use full Web UI `/flashcards` and paste text into `Create & Import` -> `Generate`.
+- Use the context-menu path or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of a single captured card.
+- If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery
 

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -30,24 +30,25 @@ Why the 8 KB field limit did not increase:
 5. Use `Manage` when you want to inspect queue state on expanded cards or document rows while cleaning up a deck.
 6. Repeat daily. The scheduler adjusts next due dates from your ratings.
 
-## Extension Selected-Text Handoff
+## Extension Selected-Text Capture
 
-Use this path when you find a useful passage while browsing and want it to become editable flashcard drafts.
+Use this path when you find a useful passage while browsing and want to save one editable basic flashcard without leaving the sidepanel.
 
 Workflow:
 
 1. Select text on the source page.
 2. Open the extension sidepanel and choose `Flashcards`.
-3. Choose `Generate from page selection`.
-4. The Web UI opens Flashcards on `Create & Import` with the selected text prefilled in the generate workflow.
-5. Generate cards, edit the drafts, choose an existing deck or create a new one, then save.
+3. Choose `Capture page selection`.
+4. Select a deck, edit `Front` and `Back`, then choose `Save card`.
+5. Use `Open full Flashcards` for generation, imports, templates, review, or broader deck management.
 
 Important behavior:
 
-- The sidepanel Flashcards route is a bridge. Use `Open full Flashcards` for study/manage work, or `Generate from page selection` to turn the current page selection into drafts.
+- The sidepanel Flashcards route saves one basic card at a time and keeps the source page URL as provenance.
+- Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
-- Neither sidepanel path creates flashcards automatically. Cards are only saved after you review and save generated drafts in `Create & Import`.
-- If the sidepanel cannot open on the current site, use full Web UI `/flashcards` and paste text into `Create & Import` -> `Generate`.
+- Use the context-menu path or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of a single captured card.
+- If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery
 

--- a/Docs/superpowers/plans/2026-05-26-flashcards-extension-native-capture-mvp-plan.md
+++ b/Docs/superpowers/plans/2026-05-26-flashcards-extension-native-capture-mvp-plan.md
@@ -1,0 +1,119 @@
+# Flashcards Extension Native Capture MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a native extension sidepanel flashcard capture MVP for selected page text.
+
+**Architecture:** Keep the sidepanel route as the only product surface changed. Reuse existing flashcard deck and create-card hooks, preserve the full Flashcards handoff, and keep LLM generation/templates/bulk drafting deferred.
+
+**Tech Stack:** React, TypeScript, Ant Design, WXT browser APIs, TanStack Query-backed flashcard hooks, Vitest and Testing Library.
+
+---
+
+### Task 1: Native Capture UI Contract
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-flashcards.tsx`
+
+- [x] **Step 1: Write failing tests**
+
+Add route tests that verify:
+- The sidepanel offers `Capture page selection` without opening the full options tab.
+- Capturing selected text opens an inline draft editor.
+- The draft editor shows deck selection, Front, Back, Save card, and full-workspace continuation controls.
+- Saving calls `useCreateFlashcardMutation().mutateAsync` with `deck_id`, edited front/back, `model_type: "basic"`, `is_cloze: false`, `reverse: false`, `source_ref_type: "manual"`, and the active page URL.
+
+- [x] **Step 2: Run focused sidepanel test and verify it fails**
+
+Run:
+
+```bash
+bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx
+```
+
+Expected: FAIL because the inline native capture editor and save behavior do not exist yet.
+
+- [x] **Step 3: Implement minimal sidepanel native capture**
+
+Use `useDecksQuery()` to load decks and `useCreateFlashcardMutation()` to save. Capture selected text through the existing injected helper, set draft state locally, and keep the existing full Flashcards opener. Use compact Ant Design `Select`, `Input`, and `Button` controls inside the sidepanel flow.
+
+- [x] **Step 4: Run focused test and verify it passes**
+
+Run:
+
+```bash
+bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx
+```
+
+Expected: PASS.
+
+### Task 2: Error And Empty States
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-flashcards.tsx`
+
+- [x] **Step 1: Write failing tests**
+
+Add coverage for:
+- No decks: save remains unavailable and the user can open full Flashcards to create a deck.
+- Save failure: draft stays visible and an inline error appears.
+- No selected text: user remains in place and sees the existing validation message.
+
+- [x] **Step 2: Run focused sidepanel test and verify it fails**
+
+Run:
+
+```bash
+bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx
+```
+
+Expected: FAIL for the new native capture recovery states.
+
+- [x] **Step 3: Implement minimal recovery behavior**
+
+Disable save until a deck and non-empty fields exist, preserve draft values on save failure, and show concise inline status/error copy.
+
+- [x] **Step 4: Run focused test and verify it passes**
+
+Run:
+
+```bash
+bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx
+```
+
+Expected: PASS.
+
+### Task 3: Close Checklist And Verify
+
+**Files:**
+- Modify: `Flashcards-UX-Fix-List.md`
+- Modify: `apps/extension/docs/features/flashcards.md`
+- Modify: `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+- Modify: `Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+- Modify: `backlog/tasks/task-516 - Flashcards-UX-F12-native-extension-capture-MVP.md`
+
+- [x] **Step 1: Update master checklist**
+
+Mark F12 native extension deck-picker/edit/save as completed for the MVP and keep deferred items explicit: generated drafts, templates, bulk editing, and in-extension review.
+
+- [x] **Step 2: Update user-facing docs**
+
+Update the extension flashcards feature doc and WebUI flashcards study guide copies so they describe `Capture page selection`, deck selection, editable Front/Back fields, one-card save, and the remaining full-workspace handoff for generation/import/review.
+
+- [x] **Step 3: Update Backlog task**
+
+Record touched files, verification, non-goals, and Bandit applicability.
+
+- [x] **Step 4: Run verification**
+
+Run:
+
+```bash
+bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx
+git diff --check
+NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false
+```
+
+Result: focused sidepanel and route-registry tests passed, `git diff --check` passed, and typecheck reported only the documented unrelated baseline `CharacterListContent.design-system.test.tsx` density diagnostic. No Python files were touched, so Bandit is not applicable to this slice.

--- a/Flashcards-UX-Fix-List.md
+++ b/Flashcards-UX-Fix-List.md
@@ -1,6 +1,6 @@
 # Flashcards UX Fix List
 
-Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split follow-up.
+Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split and F12 native sidepanel capture follow-ups.
 
 Scope: `/flashcards` plus directly connected WebUI and extension flashcard workflows. This file is the master UX audit and fix-list source referenced by `Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md`.
 
@@ -34,7 +34,7 @@ Test setup assumptions from the original audit:
 
 ## Workflow Map
 
-Actual flow after Phase 0-5 remediation plus the F06 follow-up:
+Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 
 1. Entry point: user opens `/flashcards`.
 2. Empty first-run state lands on Study instead of a dense import utility screen.
@@ -47,8 +47,8 @@ Actual flow after Phase 0-5 remediation plus the F06 follow-up:
 9. Recent sessions show user-facing deck/mode/count/timing labels where data is available.
 10. Deck dashboard rows expose direct Review, Cram, Edit, Scheduler, and Export actions.
 11. Generated-card save recovery distinguishes success, partial success, failure, fatal validation errors, and retry state.
-12. Extension sidepanel offers explicit full Flashcards and Generate from page selection actions, preserving page URL/title as supported manual source references.
-13. Documentation describes the stabilized WebUI/extension handoff using current tab names.
+12. Extension sidepanel offers explicit full Flashcards and Capture page selection actions; selected page text becomes an editable sidepanel draft with deck picker, Front/Back fields, one-card save, and page URL provenance.
+13. Documentation describes the stabilized WebUI/extension capture and handoff behavior using current tab names.
 
 ## Phase Coverage
 
@@ -61,9 +61,10 @@ Actual flow after Phase 0-5 remediation plus the F06 follow-up:
 | Phase 3A: Recent sessions | TASK-509 | F09, F19 support | Completed. Recent sessions use deck/mode/count/timing labels and API exposes reviewed counts. |
 | Phase 3B: Deck dashboard | TASK-510, TASK-511 | F11 | Completed. Existing analytics data supports a deck-first dashboard with direct actions. Review fixes preserved session close behavior and dashboard switching. |
 | Phase 4: Import/generate recovery | TASK-512 | F01 support, F06 support | Completed for generated-card save recovery. The later F06 follow-up completes the task-first IA split. |
-| Phase 5: Extension capture and docs | TASK-513 | F12 support, F13 | Completed as an extension bridge and WebUI generate handoff. A fully native extension deck-picker/save flow remains deferred. |
+| Phase 5: Extension capture and docs | TASK-513 | F12 support, F13 | Completed as an extension bridge and WebUI generate handoff. |
 | Closeout source restoration | TASK-514 | Planning traceability | Completed. Restores this tracked source file on `dev`. |
 | F06 follow-up: Task-first Create & Import split | TASK-515 | F06 | Completed. Adds Create cards, Import file, and Export backup task workspaces while preserving existing route keys and panel handoffs. |
+| F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Generated drafts, templates, bulk editing, and in-extension review remain deferred. |
 
 ## Severity-Ranked Findings
 
@@ -80,7 +81,7 @@ Actual flow after Phase 0-5 remediation plus the F06 follow-up:
 | F09 | Medium | History comprehension | Recent sessions used labels like `Session #1`, `Deck 1`, or raw scope keys. | Progress/history was present but hard to trust. | Backend identifiers leaked into user-facing history. | Addressed in TASK-509. |
 | F10 | Medium | Progress semantics | Due/new/current queue labels could appear contradictory. | Users could misunderstand whether cards were available to study. | Scheduler labels were technically accurate but not explained in queue context. | Addressed in TASK-508. |
 | F11 | Medium | Expert workflow | Manage was card-first with no deck-first dashboard for quick study decisions. | Experienced users spent time filtering cards instead of selecting a deck action. | The model privileged card management over deck review. | Addressed in TASK-510/TASK-511. |
-| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed as a bridge/generate handoff in TASK-513; native in-extension deck picker/save remains deferred. |
+| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516. Sidepanel now supports native selected-text draft edit/save; richer generated drafts, templates, bulk editing, and in-extension review remain deferred. |
 | F13 | Medium | Docs mismatch | Extension and flashcards docs lagged current UI tab names and workflows. | Users could not rely on docs to understand current behavior. | Docs had not tracked UI evolution. | Addressed in TASK-513. |
 | F14 | Low | Empty-state hierarchy | Manage empty state showed expert filters before any cards existed. | New users saw advanced management chrome before first action. | Empty state inherited full management layout. | Addressed in TASK-506. |
 | F15 | Low | Scheduler discoverability | Scheduler was hidden until a deck existed. | New users could not learn scheduling exists until after setup. | Progressive disclosure hid a core concept too completely. | Addressed in TASK-506. |
@@ -100,7 +101,7 @@ Create & Import now separates setup into task-specific workspaces, so first-time
 
 The strongest power-user improvement is the deck dashboard. It gives experienced users deck-level counts and direct Review/Cram/Edit/Scheduler/Export actions, replacing a card-filter-first starting point for common study decisions. Review recovery and recent-session labels also make repeat review safer and easier to resume.
 
-Remaining weakness: extension capture is still a bridge to full Flashcards generation, not a full in-extension save flow with deck picker and direct draft editing. That deeper workflow is intentionally deferred.
+Remaining weakness: extension capture now supports a one-card native save path, but richer expert capture controls remain deferred: generated drafts, templates, bulk editing, repeat capture queues, and in-extension review.
 
 ## Improvement Backlog
 
@@ -128,7 +129,7 @@ Remaining weakness: extension capture is still a bridge to full Flashcards gener
 
 ### Deferred Larger Product Improvements
 
-- Build a fully native extension capture flow with deck picker, generated drafts, edit, save, and open-in-WebUI continuation.
+- Extend the native extension capture flow with generated drafts, templates, bulk editing, repeat capture queues, and in-extension review.
 - Add broader import result normalization if future evidence shows unresolved partial/fatal import ambiguity outside generated-card save.
 - Run a full browser accessibility audit beyond the focused keyboard e2e coverage.
 
@@ -151,14 +152,14 @@ Remaining weakness: extension capture is still a bridge to full Flashcards gener
 3. Review supports keyboard reveal/rate/undo/edit flows with visible equivalents.
 4. Completion supports repeat workflows.
 5. History uses meaningful session labels instead of raw ids.
-6. Extension selected-text capture opens the Create & Import generate flow with page provenance preserved.
+6. Extension selected-text capture creates an editable sidepanel draft, saves one basic card to the chosen deck with page provenance, and leaves full Flashcards available for generation/import/review.
 
 ## Open Questions And Non-Goals
 
 - Scheduler algorithm correctness and backend spaced-repetition math were not audited beyond visible UX effects.
 - Quiz surfaces were out of scope except for the direct Flashcards handoff.
 - Multi-user permission, workspace sharing, and collaboration states need separate testing.
-- Native extension flashcard save/edit remains a future product improvement, not a Phase 5 deliverable.
+- Rich native extension generation, templates, bulk editing, repeat capture queues, and in-extension review remain future product improvements beyond the F12 MVP.
 
 ## Master Checklist
 
@@ -191,7 +192,8 @@ Remaining weakness: extension capture is still a bridge to full Flashcards gener
 ### Connected Workflows
 
 - [x] F12 Extension selected-text bridge added with page provenance into GeneratePanel saves.
-- [ ] F12 Native extension deck-picker/edit/save workflow remains deferred.
+- [x] F12 Native extension deck-picker/edit/save MVP completed for one selected-text card.
+- [ ] F12 Rich native extension generated drafts/templates/bulk/review workflow remains deferred.
 - [x] F13 WebUI and extension flashcards docs updated.
 - [x] F17 Quiz handoff made state-aware.
 

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -6,7 +6,7 @@ title: Flashcards (Experimental)
 
 The Flashcards page lets you create, review, and manage spaced-repetition cards backed by your tldw_server. It also supports CSV/TSV import and export, plus optional .apkg export where supported by the server.
 
-Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact bridge with actions for the full Flashcards workspace and selected-text generation.
+Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace and selected-text card creation.
 
 ## Prerequisites
 
@@ -25,11 +25,11 @@ Access it from the Web UI header by clicking the Layers icon, or navigate to `/f
 
 1. Select text on a web page.
 2. Open the extension sidepanel and choose `Flashcards`.
-3. Click `Generate from page selection`.
-4. The full Web UI opens Flashcards on the `Create & Import` tab with the selected text prefilled in the generation workflow.
-5. Generate, review/edit the drafts, choose a deck or create one, then save the cards.
+3. Click `Capture page selection`.
+4. Choose a deck, edit the `Front` and `Back` fields, then click `Save card`.
+5. Use `Open full Flashcards` when you need generation, imports, templates, review, or broader deck management.
 
-You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog. The sidepanel Flashcards route does not save cards by itself; the save happens after you review and save generated drafts in the full Flashcards workspace.
+The sidepanel saves one basic card at a time and keeps the page URL as source provenance. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want generated drafts in the full Flashcards workspace.
 
 ## Tips
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -8,6 +8,7 @@ import SidepanelFlashcards, {
 
 const flashcardMocks = vi.hoisted(() => ({
   createFlashcardMutateAsync: vi.fn(),
+  useFlashcardsEnabled: vi.fn(),
   useDecksQuery: vi.fn()
 }))
 
@@ -33,6 +34,7 @@ vi.mock("@/components/Flashcards/hooks", () => ({
     mutateAsync: flashcardMocks.createFlashcardMutateAsync,
     isPending: false
   }),
+  useFlashcardsEnabled: () => flashcardMocks.useFlashcardsEnabled(),
   useDecksQuery: (...args: unknown[]) => flashcardMocks.useDecksQuery(...args)
 }))
 
@@ -75,6 +77,12 @@ describe("sidepanel flashcards route", () => {
     flashcardMocks.createFlashcardMutateAsync.mockResolvedValue({
       uuid: "card-1",
       deck_id: 7
+    })
+    flashcardMocks.useFlashcardsEnabled.mockReturnValue({
+      isOnline: true,
+      capsLoading: false,
+      flashcardsUnsupported: false,
+      flashcardsEnabled: true
     })
     flashcardMocks.useDecksQuery.mockReturnValue({
       data: [
@@ -232,6 +240,9 @@ describe("sidepanel flashcards route", () => {
     })
     expect(screen.getByText("Saved to Biology.")).toBeInTheDocument()
     expect(
+      screen.queryByRole("heading", { name: "Draft flashcard" })
+    ).not.toBeInTheDocument()
+    expect(
       screen.getByRole("button", { name: "Open full Flashcards" })
     ).toBeInTheDocument()
   })
@@ -273,6 +284,113 @@ describe("sidepanel flashcards route", () => {
       screen.getByText("Create a deck in full Flashcards before saving here.")
     ).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Save card" })).toBeDisabled()
+  })
+
+  it("does not show true-empty deck guidance while decks are still loading", async () => {
+    flashcardMocks.useDecksQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false
+    })
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(
+      screen.queryByText("Create a deck in full Flashcards before saving here.")
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save card" })).toBeDisabled()
+  })
+
+  it("differentiates deck load errors from true empty deck state", async () => {
+    flashcardMocks.useDecksQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true
+    })
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(
+      screen.getByText("Could not load decks. Check your connection and try again.")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("Create a deck in full Flashcards before saving here.")
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save card" })).toBeDisabled()
+  })
+
+  it("explains when flashcards are unavailable instead of saying there are no decks", async () => {
+    flashcardMocks.useFlashcardsEnabled.mockReturnValue({
+      isOnline: false,
+      capsLoading: false,
+      flashcardsUnsupported: false,
+      flashcardsEnabled: false
+    })
+    flashcardMocks.useDecksQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false
+    })
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(
+      screen.getByText("Flashcards are unavailable. Check the server connection and try again.")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("Create a deck in full Flashcards before saving here.")
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save card" })).toBeDisabled()
+  })
+
+  it("clears a previous draft when a later capture attempt fails", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    expect(
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
+
+    browserMocks.executeScript.mockResolvedValueOnce([{ result: "" }])
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(
+      screen.getByText("Select text on the page first.")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("heading", { name: "Draft flashcard" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("uses capture wording when no active page tab is available", async () => {
+    browserMocks.tabsQuery.mockResolvedValueOnce([])
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(
+      screen.getByText("Open a page tab before capturing page selection.")
+    ).toBeInTheDocument()
   })
 
   it("keeps the user in place when no page text is selected", async () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -1,10 +1,15 @@
 import React from "react"
 import userEvent from "@testing-library/user-event"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import SidepanelFlashcards, {
   readSelectedTextFromPage
 } from "../sidepanel-flashcards"
+
+const flashcardMocks = vi.hoisted(() => ({
+  createFlashcardMutateAsync: vi.fn(),
+  useDecksQuery: vi.fn()
+}))
 
 const browserMocks = vi.hoisted(() => ({
   runtimeGetURL: vi.fn((path: string) => `chrome-extension://flashcards${path}`),
@@ -21,6 +26,14 @@ const browserMocks = vi.hoisted(() => ({
       result: "Key concept from the active page"
     }
   ])
+}))
+
+vi.mock("@/components/Flashcards/hooks", () => ({
+  useCreateFlashcardMutation: () => ({
+    mutateAsync: flashcardMocks.createFlashcardMutateAsync,
+    isPending: false
+  }),
+  useDecksQuery: (...args: unknown[]) => flashcardMocks.useDecksQuery(...args)
 }))
 
 vi.mock("wxt/browser", () => ({
@@ -42,11 +55,14 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (
       key: string,
-      fallbackOrOptions?: string | { defaultValue?: string }
+      fallbackOrOptions?: string | { defaultValue?: string; deckName?: string }
     ) => {
       if (typeof fallbackOrOptions === "string") return fallbackOrOptions
       if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
-        return fallbackOrOptions.defaultValue || key
+        return (fallbackOrOptions.defaultValue || key).replace(
+          "{{deckName}}",
+          fallbackOrOptions.deckName || ""
+        )
       }
       return key
     }
@@ -56,6 +72,24 @@ vi.mock("react-i18next", () => ({
 describe("sidepanel flashcards route", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    flashcardMocks.createFlashcardMutateAsync.mockResolvedValue({
+      uuid: "card-1",
+      deck_id: 7
+    })
+    flashcardMocks.useDecksQuery.mockReturnValue({
+      data: [
+        {
+          id: 7,
+          name: "Biology",
+          description: null,
+          deleted: false,
+          client_id: "test",
+          version: 1
+        }
+      ],
+      isLoading: false,
+      isError: false
+    })
   })
 
   afterEach(() => {
@@ -70,7 +104,7 @@ describe("sidepanel flashcards route", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Study, manage, and create cards in the full Flashcards workspace."
+        "Capture selected page text into a deck, or open the full Flashcards workspace."
       )
     ).toBeInTheDocument()
     expect(
@@ -78,11 +112,11 @@ describe("sidepanel flashcards route", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Turn the current page selection into editable flashcard drafts."
+        "Create one editable card in the sidepanel. Use full Flashcards for generation, imports, and review."
       )
     ).toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "Generate from page selection" })
+      screen.getByRole("button", { name: "Capture page selection" })
     ).toBeInTheDocument()
     expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
   })
@@ -139,12 +173,12 @@ describe("sidepanel flashcards route", () => {
     }
   })
 
-  it("captures the active page selection into the Flashcards generate workflow", async () => {
+  it("captures the active page selection into an editable sidepanel draft", async () => {
     const user = userEvent.setup()
     render(<SidepanelFlashcards />)
 
     await user.click(
-      screen.getByRole("button", { name: "Generate from page selection" })
+      screen.getByRole("button", { name: "Capture page selection" })
     )
 
     expect(browserMocks.tabsQuery).toHaveBeenCalledWith({
@@ -155,17 +189,90 @@ describe("sidepanel flashcards route", () => {
       target: { tabId: 42 },
       func: expect.any(Function)
     })
-    const openedUrl = browserMocks.tabsCreate.mock.calls.at(-1)?.[0]?.url
-    expect(openedUrl).toBeDefined()
-    const url = new URL(openedUrl as string)
-    expect(url.pathname).toBe("/options.html")
-    expect(url.hash).toContain("/flashcards?")
-    const hashSearch = url.hash.slice(url.hash.indexOf("?") + 1)
-    const params = new URLSearchParams(hashSearch)
-    expect(params.get("generate")).toBe("1")
-    expect(params.get("generate_text")).toBe("Key concept from the active page")
-    expect(params.get("generate_source_id")).toBe("https://example.test/source")
-    expect(params.get("generate_source_title")).toBe("Selection Source")
+    expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("sidepanel-flashcards-deck-select")).toHaveTextContent(
+      "Biology"
+    )
+    expect(screen.getByLabelText("Front")).toHaveValue("Selection Source")
+    expect(screen.getByLabelText("Back")).toHaveValue(
+      "Key concept from the active page"
+    )
+  })
+
+  it("saves the edited sidepanel draft with deck and page provenance", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    fireEvent.change(screen.getByLabelText("Front"), {
+      target: { value: "Edited question" }
+    })
+    fireEvent.change(screen.getByLabelText("Back"), {
+      target: { value: "Edited answer" }
+    })
+    await user.click(screen.getByRole("button", { name: "Save card" }))
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledWith({
+      deck_id: 7,
+      front: "Edited question",
+      back: "Edited answer",
+      model_type: "basic",
+      is_cloze: false,
+      reverse: false,
+      source_ref_type: "manual",
+      source_ref_id: "https://example.test/source"
+    })
+    expect(screen.getByText("Saved to Biology.")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Open full Flashcards" })
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the draft in place when sidepanel save fails", async () => {
+    flashcardMocks.createFlashcardMutateAsync.mockRejectedValueOnce(
+      new Error("save failed")
+    )
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(screen.getByRole("button", { name: "Save card" }))
+
+    expect(
+      await screen.findByText("Could not save flashcard. Check your connection and try again.")
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText("Back")).toHaveValue(
+      "Key concept from the active page"
+    )
+  })
+
+  it("requires a deck before saving a sidepanel draft", async () => {
+    flashcardMocks.useDecksQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false
+    })
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(
+      screen.getByText("Create a deck in full Flashcards before saving here.")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save card" })).toBeDisabled()
   })
 
   it("keeps the user in place when no page text is selected", async () => {
@@ -174,7 +281,7 @@ describe("sidepanel flashcards route", () => {
     render(<SidepanelFlashcards />)
 
     await user.click(
-      screen.getByRole("button", { name: "Generate from page selection" })
+      screen.getByRole("button", { name: "Capture page selection" })
     )
 
     expect(

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -1,11 +1,22 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { ExternalLink, Layers, MessageSquareText } from "lucide-react"
-import { Button, Typography } from "antd"
+import { ExternalLink, Layers, MessageSquareText, Save } from "lucide-react"
+import { Button, Input, Select, Typography } from "antd"
 import { browser } from "wxt/browser"
-import { buildFlashcardsGenerateRoute } from "@/services/tldw/flashcards-generate-handoff"
+import {
+  useCreateFlashcardMutation,
+  useDecksQuery
+} from "@/components/Flashcards/hooks"
 
 const { Text, Title } = Typography
+const { TextArea } = Input
+
+type CaptureDraft = {
+  front: string
+  back: string
+  sourceId: string
+  sourceTitle?: string
+}
 
 export const readSelectedTextFromPage = () => {
   const activeElement = document.activeElement
@@ -30,6 +41,26 @@ export default function SidepanelFlashcards() {
   const { t } = useTranslation()
   const [captureError, setCaptureError] = React.useState<string | null>(null)
   const [captureLoading, setCaptureLoading] = React.useState(false)
+  const [saveStatus, setSaveStatus] = React.useState<{
+    type: "success" | "error"
+    message: string
+  } | null>(null)
+  const [draft, setDraft] = React.useState<CaptureDraft | null>(null)
+  const [selectedDeckId, setSelectedDeckId] = React.useState<number | null>(null)
+  const decksQuery = useDecksQuery()
+  const createFlashcardMutation = useCreateFlashcardMutation()
+  const decks = React.useMemo(() => decksQuery.data ?? [], [decksQuery.data])
+  const selectedDeck = decks.find((deck) => deck.id === selectedDeckId) ?? null
+
+  React.useEffect(() => {
+    if (
+      selectedDeckId != null &&
+      decks.some((deck) => deck.id === selectedDeckId)
+    ) {
+      return
+    }
+    setSelectedDeckId(decks[0]?.id ?? null)
+  }, [decks, selectedDeckId])
 
   const openOptionsHashRoute = React.useCallback(async (route: string) => {
     setCaptureError(null)
@@ -61,8 +92,9 @@ export default function SidepanelFlashcards() {
     void openOptionsHashRoute("/flashcards")
   }, [openOptionsHashRoute])
 
-  const handleGenerateFromPageSelection = React.useCallback(async () => {
+  const handleCapturePageSelection = React.useCallback(async () => {
     setCaptureError(null)
+    setSaveStatus(null)
     setCaptureLoading(true)
     const captureUnavailableMessage = t(
       "sidepanel:flashcards.selectionCaptureUnavailable",
@@ -104,14 +136,15 @@ export default function SidepanelFlashcards() {
         throw new Error(noSelectionMessage)
       }
 
-      await openOptionsHashRoute(
-        buildFlashcardsGenerateRoute({
-          text: selectedText,
-          sourceType: "manual",
-          sourceId: activeTab.url || String(tabId),
-          sourceTitle: activeTab.title || activeTab.url || undefined
-        })
-      )
+      setDraft({
+        front:
+          activeTab.title ||
+          activeTab.url ||
+          t("sidepanel:flashcards.defaultFront", "Page selection"),
+        back: selectedText,
+        sourceId: activeTab.url || String(tabId),
+        sourceTitle: activeTab.title || activeTab.url || undefined
+      })
     } catch (error) {
       const message =
         error instanceof Error && error.message.trim() ? error.message : ""
@@ -126,23 +159,70 @@ export default function SidepanelFlashcards() {
     } finally {
       setCaptureLoading(false)
     }
-  }, [openOptionsHashRoute, t])
+  }, [t])
+
+  const handleSaveDraft = React.useCallback(async () => {
+    if (!draft || selectedDeckId == null) return
+
+    const front = draft.front.trim()
+    const back = draft.back.trim()
+    if (!front || !back) return
+
+    setSaveStatus(null)
+    try {
+      await createFlashcardMutation.mutateAsync({
+        deck_id: selectedDeckId,
+        front,
+        back,
+        model_type: "basic",
+        is_cloze: false,
+        reverse: false,
+        source_ref_type: "manual",
+        source_ref_id: draft.sourceId
+      })
+      setSaveStatus({
+        type: "success",
+        message: t("sidepanel:flashcards.saveSuccess", {
+          defaultValue: "Saved to {{deckName}}.",
+          deckName:
+            selectedDeck?.name || t("sidepanel:flashcards.defaultDeck", "deck")
+        })
+      })
+    } catch {
+      setSaveStatus({
+        type: "error",
+        message: t(
+          "sidepanel:flashcards.saveFailed",
+          "Could not save flashcard. Check your connection and try again."
+        )
+      })
+    }
+  }, [createFlashcardMutation, draft, selectedDeck?.name, selectedDeckId, t])
+
+  const hasDraftContent = !!draft?.front.trim() && !!draft?.back.trim()
+  const hasDeck = selectedDeckId != null
+  const canSaveDraft =
+    !!draft && hasDraftContent && hasDeck && !createFlashcardMutation.isPending
 
   return (
-    <main className="flex min-h-full flex-col items-center justify-center gap-4 p-6 text-center">
-      <div className="rounded-full border border-border bg-surface2 p-3">
-        <Layers className="size-8 text-text-muted" aria-hidden="true" />
+    <main className="flex min-h-full flex-col gap-4 p-4 text-left">
+      <div className="flex items-start gap-3">
+        <div className="rounded-full border border-border bg-surface2 p-3">
+          <Layers className="size-6 text-text-muted" aria-hidden="true" />
+        </div>
+        <div className="min-w-0">
+          <Title level={4} className="!mb-1">
+            {t("sidepanel:flashcards.title", "Flashcards")}
+          </Title>
+          <Text type="secondary">
+            {t(
+              "sidepanel:flashcards.workspaceDescription",
+              "Capture selected page text into a deck, or open the full Flashcards workspace."
+            )}
+          </Text>
+        </div>
       </div>
-      <Title level={4} className="!mb-0">
-        {t("sidepanel:flashcards.title", "Flashcards")}
-      </Title>
-      <Text type="secondary">
-        {t(
-          "sidepanel:flashcards.workspaceDescription",
-          "Study, manage, and create cards in the full Flashcards workspace."
-        )}
-      </Text>
-      <div className="flex w-full max-w-xs flex-col gap-2">
+      <div className="flex w-full flex-col gap-2">
         <Button
           type="primary"
           block
@@ -155,22 +235,109 @@ export default function SidepanelFlashcards() {
           block
           loading={captureLoading}
           icon={<MessageSquareText className="size-4" aria-hidden="true" />}
-          onClick={handleGenerateFromPageSelection}
+          onClick={handleCapturePageSelection}
         >
           {t(
-            "sidepanel:flashcards.generateFromPageSelection",
-            "Generate from page selection"
+            "sidepanel:flashcards.capturePageSelection",
+            "Capture page selection"
           )}
         </Button>
       </div>
-      <Text type="secondary" className="max-w-xs text-xs">
+      <Text type="secondary" className="text-xs">
         {t(
           "sidepanel:flashcards.selectionHint",
-          "Turn the current page selection into editable flashcard drafts."
+          "Create one editable card in the sidepanel. Use full Flashcards for generation, imports, and review."
         )}
       </Text>
+      {draft ? (
+        <section
+          className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-3"
+          aria-label={t("sidepanel:flashcards.draftSection", "Draft flashcard")}
+        >
+          <div>
+            <Title level={5} className="!mb-1">
+              {t("sidepanel:flashcards.draftTitle", "Draft flashcard")}
+            </Title>
+            <Text type="secondary" className="text-xs">
+              {draft.sourceTitle || draft.sourceId}
+            </Text>
+          </div>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            {t("sidepanel:flashcards.deckLabel", "Deck")}
+            <Select
+              data-testid="sidepanel-flashcards-deck-select"
+              aria-label={t("sidepanel:flashcards.deckLabel", "Deck")}
+              loading={decksQuery.isLoading}
+              disabled={decks.length === 0}
+              placeholder={t(
+                "sidepanel:flashcards.deckPlaceholder",
+                "Choose a deck"
+              )}
+              value={selectedDeckId ?? undefined}
+              options={decks.map((deck) => ({
+                label: deck.name,
+                value: deck.id
+              }))}
+              onChange={(value) => setSelectedDeckId(value)}
+            />
+          </label>
+          {decks.length === 0 ? (
+            <Text type="warning" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.noDecks",
+                "Create a deck in full Flashcards before saving here."
+              )}
+            </Text>
+          ) : null}
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            {t("sidepanel:flashcards.frontLabel", "Front")}
+            <TextArea
+              aria-label={t("sidepanel:flashcards.frontLabel", "Front")}
+              autoSize={{ minRows: 2, maxRows: 4 }}
+              value={draft.front}
+              onChange={(event) =>
+                setDraft((current) =>
+                  current ? { ...current, front: event.target.value } : current
+                )
+              }
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            {t("sidepanel:flashcards.backLabel", "Back")}
+            <TextArea
+              aria-label={t("sidepanel:flashcards.backLabel", "Back")}
+              autoSize={{ minRows: 4, maxRows: 8 }}
+              value={draft.back}
+              onChange={(event) =>
+                setDraft((current) =>
+                  current ? { ...current, back: event.target.value } : current
+                )
+              }
+            />
+          </label>
+          <Button
+            type="primary"
+            block
+            icon={<Save className="size-4" aria-hidden="true" />}
+            loading={createFlashcardMutation.isPending}
+            disabled={!canSaveDraft}
+            onClick={handleSaveDraft}
+          >
+            {t("sidepanel:flashcards.saveCard", "Save card")}
+          </Button>
+          {saveStatus ? (
+            <Text
+              type={saveStatus.type === "error" ? "danger" : "success"}
+              className="text-xs"
+              role="status"
+            >
+              {saveStatus.message}
+            </Text>
+          ) : null}
+        </section>
+      ) : null}
       {captureError ? (
-        <Text type="danger" className="max-w-xs text-xs" role="status">
+        <Text type="danger" className="text-xs" role="status">
           {captureError}
         </Text>
       ) : null}

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -5,7 +5,8 @@ import { Button, Input, Select, Typography } from "antd"
 import { browser } from "wxt/browser"
 import {
   useCreateFlashcardMutation,
-  useDecksQuery
+  useDecksQuery,
+  useFlashcardsEnabled
 } from "@/components/Flashcards/hooks"
 
 const { Text, Title } = Typography
@@ -47,10 +48,26 @@ export default function SidepanelFlashcards() {
   } | null>(null)
   const [draft, setDraft] = React.useState<CaptureDraft | null>(null)
   const [selectedDeckId, setSelectedDeckId] = React.useState<number | null>(null)
+  const flashcardsAvailability = useFlashcardsEnabled()
   const decksQuery = useDecksQuery()
   const createFlashcardMutation = useCreateFlashcardMutation()
   const decks = React.useMemo(() => decksQuery.data ?? [], [decksQuery.data])
   const selectedDeck = decks.find((deck) => deck.id === selectedDeckId) ?? null
+  const flashcardsUnavailable =
+    !flashcardsAvailability.isOnline ||
+    flashcardsAvailability.flashcardsUnsupported
+  const decksLoading = decksQuery.isLoading || flashcardsAvailability.capsLoading
+  const decksLoadFailed = decksQuery.isError
+  const hasSelectableDecks =
+    !flashcardsUnavailable &&
+    !decksLoading &&
+    !decksLoadFailed &&
+    decks.length > 0
+  const showNoDecksMessage =
+    !flashcardsUnavailable &&
+    !decksLoading &&
+    !decksLoadFailed &&
+    decks.length === 0
 
   React.useEffect(() => {
     if (
@@ -95,6 +112,7 @@ export default function SidepanelFlashcards() {
   const handleCapturePageSelection = React.useCallback(async () => {
     setCaptureError(null)
     setSaveStatus(null)
+    setDraft(null)
     setCaptureLoading(true)
     const captureUnavailableMessage = t(
       "sidepanel:flashcards.selectionCaptureUnavailable",
@@ -102,7 +120,7 @@ export default function SidepanelFlashcards() {
     )
     const activeTabUnavailableMessage = t(
       "sidepanel:flashcards.activeTabUnavailable",
-      "Open a page tab before generating flashcards."
+      "Open a page tab before capturing page selection."
     )
     const noSelectionMessage = t(
       "sidepanel:flashcards.noPageSelection",
@@ -188,6 +206,7 @@ export default function SidepanelFlashcards() {
             selectedDeck?.name || t("sidepanel:flashcards.defaultDeck", "deck")
         })
       })
+      setDraft(null)
     } catch {
       setSaveStatus({
         type: "error",
@@ -200,7 +219,7 @@ export default function SidepanelFlashcards() {
   }, [createFlashcardMutation, draft, selectedDeck?.name, selectedDeckId, t])
 
   const hasDraftContent = !!draft?.front.trim() && !!draft?.back.trim()
-  const hasDeck = selectedDeckId != null
+  const hasDeck = selectedDeckId != null && hasSelectableDecks
   const canSaveDraft =
     !!draft && hasDraftContent && hasDeck && !createFlashcardMutation.isPending
 
@@ -267,8 +286,8 @@ export default function SidepanelFlashcards() {
             <Select
               data-testid="sidepanel-flashcards-deck-select"
               aria-label={t("sidepanel:flashcards.deckLabel", "Deck")}
-              loading={decksQuery.isLoading}
-              disabled={decks.length === 0}
+              loading={decksLoading}
+              disabled={!hasSelectableDecks}
               placeholder={t(
                 "sidepanel:flashcards.deckPlaceholder",
                 "Choose a deck"
@@ -281,7 +300,25 @@ export default function SidepanelFlashcards() {
               onChange={(value) => setSelectedDeckId(value)}
             />
           </label>
-          {decks.length === 0 ? (
+          {flashcardsUnavailable ? (
+            <Text type="danger" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.unavailable",
+                "Flashcards are unavailable. Check the server connection and try again."
+              )}
+            </Text>
+          ) : decksLoadFailed ? (
+            <Text type="danger" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.decksLoadFailed",
+                "Could not load decks. Check your connection and try again."
+              )}
+            </Text>
+          ) : decksLoading ? (
+            <Text type="secondary" className="text-xs" role="status">
+              {t("sidepanel:flashcards.decksLoading", "Loading decks...")}
+            </Text>
+          ) : showNoDecksMessage ? (
             <Text type="warning" className="text-xs" role="status">
               {t(
                 "sidepanel:flashcards.noDecks",
@@ -325,16 +362,16 @@ export default function SidepanelFlashcards() {
           >
             {t("sidepanel:flashcards.saveCard", "Save card")}
           </Button>
-          {saveStatus ? (
-            <Text
-              type={saveStatus.type === "error" ? "danger" : "success"}
-              className="text-xs"
-              role="status"
-            >
-              {saveStatus.message}
-            </Text>
-          ) : null}
         </section>
+      ) : null}
+      {saveStatus ? (
+        <Text
+          type={saveStatus.type === "error" ? "danger" : "success"}
+          className="text-xs"
+          role="status"
+        >
+          {saveStatus.message}
+        </Text>
       ) : null}
       {captureError ? (
         <Text type="danger" className="text-xs" role="status">

--- a/backlog/tasks/task-516 - Flashcards-UX-F12-native-extension-capture-MVP.md
+++ b/backlog/tasks/task-516 - Flashcards-UX-F12-native-extension-capture-MVP.md
@@ -1,0 +1,65 @@
+---
+id: TASK-516
+title: Flashcards UX F12 native extension capture MVP
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-27 01:45
+labels:
+- ux
+- flashcards
+- extension
+- webui
+dependencies: []
+priority: medium
+modified_files:
+- Docs/superpowers/plans/2026-05-26-flashcards-extension-native-capture-mvp-plan.md
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- Flashcards-UX-Fix-List.md
+- apps/extension/docs/features/flashcards.md
+- Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next F12 flashcards UX slice: add a native extension sidepanel capture MVP that lets users capture selected page text, choose a deck, edit front/back draft fields, save a basic flashcard with page provenance, and continue to the full Flashcards workspace. Keep this scoped to sidepanel capture; defer LLM generation, templates, bulk drafts, and full in-extension review.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sidepanel Flashcards captures selected page text into an inline draft without opening the options tab.
+- [x] #2 Draft editor supports deck selection, Front/Back edits, and saving one basic card with manual page URL provenance.
+- [x] #3 No-deck, no-selection, and save-failure states keep the user in place with inline recovery copy.
+- [x] #4 Docs and Flashcards UX master checklist describe the completed F12 MVP and deferred richer extension workflows.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-26-flashcards-extension-native-capture-mvp-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented native sidepanel selected-text capture with deck picker, editable Front/Back draft fields, one-card save, manual page URL provenance, no-deck guard, no-selection validation, save-failure recovery, and full Flashcards continuation. Updated tests, master UX checklist, extension feature docs, and WebUI study guide copies. Non-goals remain generated drafts, templates, bulk editing, repeat capture queues, and in-extension review.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Native F12 sidepanel capture MVP completed. The Flashcards sidepanel now supports Capture page selection -> editable draft -> deck picker -> Save card with manual page URL provenance, while keeping Open full Flashcards for generation/import/review. Docs and the master Flashcards UX fix list now describe the completed MVP and deferred richer extension workflows. Verification: focused sidepanel/registry Vitest passed; git diff --check passed; UI typecheck reached one unrelated baseline CharacterListContent density diagnostic; no Python files touched, so Bandit is not applicable.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-516 - Flashcards-UX-F12-native-extension-capture-MVP.md
+++ b/backlog/tasks/task-516 - Flashcards-UX-F12-native-extension-capture-MVP.md
@@ -4,22 +4,14 @@ title: Flashcards UX F12 native extension capture MVP
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-05-27 01:45
+updated_date: '2026-05-27 02:28'
 labels:
-- ux
-- flashcards
-- extension
-- webui
+  - ux
+  - flashcards
+  - extension
+  - webui
 dependencies: []
 priority: medium
-modified_files:
-- Docs/superpowers/plans/2026-05-26-flashcards-extension-native-capture-mvp-plan.md
-- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
-- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
-- Flashcards-UX-Fix-List.md
-- apps/extension/docs/features/flashcards.md
-- Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
-- Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
 ---
 
 ## Description
@@ -46,12 +38,14 @@ Docs/superpowers/plans/2026-05-26-flashcards-extension-native-capture-mvp-plan.m
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented native sidepanel selected-text capture with deck picker, editable Front/Back draft fields, one-card save, manual page URL provenance, no-deck guard, no-selection validation, save-failure recovery, and full Flashcards continuation. Updated tests, master UX checklist, extension feature docs, and WebUI study guide copies. Non-goals remain generated drafts, templates, bulk editing, repeat capture queues, and in-extension review.
+
+PR #2073 review-fix pass: addressed Gemini/Qodo/CodeRabbit findings by clearing stale drafts on new capture attempts, clearing drafts after successful save while keeping success status visible outside the draft section, differentiating deck loading/error/unavailable states from true empty decks, and replacing stale active-tab generate wording with capture wording. Added regression coverage for each behavior.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Native F12 sidepanel capture MVP completed. The Flashcards sidepanel now supports Capture page selection -> editable draft -> deck picker -> Save card with manual page URL provenance, while keeping Open full Flashcards for generation/import/review. Docs and the master Flashcards UX fix list now describe the completed MVP and deferred richer extension workflows. Verification: focused sidepanel/registry Vitest passed; git diff --check passed; UI typecheck reached one unrelated baseline CharacterListContent density diagnostic; no Python files touched, so Bandit is not applicable.
+Native F12 sidepanel capture MVP completed, with PR #2073 review fixes applied. The sidepanel now prevents stale draft saves after failed recapture, prevents duplicate save submissions after success, preserves success feedback after clearing the draft, distinguishes deck load/unavailable states from true empty deck state, and uses capture-specific recovery copy. Verification: focused sidepanel/registry Vitest passed 20 tests; git diff --check passed; UI typecheck still reports only unrelated baseline CharacterListContent density diagnostic; no Python files touched, so Bandit is not applicable.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Adds a native Flashcards sidepanel capture MVP: selected page text becomes an editable draft with deck picker, Front/Back fields, save, and page URL provenance.
- Keeps Open full Flashcards as the path for generation, imports, templates, review, and broader deck management.
- Updates the Flashcards UX master list, extension feature docs, WebUI study guide copies, implementation plan, and Backlog TASK-516.

## Test Plan
- [x] bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts
- [x] git diff --check
- [x] NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false *(reports unrelated baseline `src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx(35,3): Type "comfortable" is not assignable to type `GalleryCardDensity`)*

## Change summary
Draft PR: human-authored change summary required before merge per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Flashcards sidepanel capture so selected page text becomes an inline editable draft with a deck picker and Save, storing the page URL as provenance. Keeps “Open full Flashcards” for generation, imports, templates, review, and deck management; updates docs and tests. Addresses TASK-516 (F12).

- New Features
  - Added “Capture page selection” in the sidepanel: inline draft editor with deck select, editable Front/Back, and “Save card” (no options tab).
  - Saves one basic card via `useCreateFlashcardMutation` with `deck_id`, edited `front`/`back`, `model_type: "basic"`, `is_cloze: false`, `reverse: false`, `source_ref_type: "manual"`, and the active page URL.
  - Decks load via `useDecksQuery` and availability via `useFlashcardsEnabled`; default-selects a deck when available; shows success with deck name; Save disabled until a deck and both fields are set.

- Bug Fixes
  - Clear stale drafts on new capture attempts; keep draft on save failure; clear draft after success while keeping a success message.
  - Differentiate “flashcards unavailable,” decks loading, and deck load error from true “no decks” state with inline messages.
  - Updated copy for capture flow, including no active tab and no selection messages; expanded tests and user docs to match.

<sup>Written for commit ad005c14c584a56053b023e86009f7ff3b201b93. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2073?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

