### PR TITLE
Add flashcards sidepanel capture queue

### DIFF
--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-capture-queue-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-capture-queue-implementation-plan.md
@@ -1,0 +1,118 @@
+# Flashcards Extension Capture Queue Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the next F12 extension slice: a sidepanel repeat-capture queue with editable drafts, delete, save-one, and save-all behavior while keeping generation/templates/import/review in full Flashcards.
+
+**Architecture:** Keep the work inside the existing `SidepanelFlashcards` route and tests. Replace the single `draft` state with a small local draft queue keyed by generated IDs, keep deck selection global for the sidepanel, and preserve failed drafts during save-all by removing only drafts that save successfully.
+
+**Tech Stack:** React, Ant Design, lucide-react icons, WXT `browser` APIs, existing Flashcards hooks, Vitest, React Testing Library.
+
+---
+
+### Task 1: Add Queue Behavior Tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx`
+
+- [x] **Step 1: Write failing multi-capture queue test**
+
+Add coverage proving two successful capture clicks append two editable draft cards instead of replacing the first draft. Mock `browserMocks.executeScript` with sequential selected-text values and assert both draft headings/fields are present.
+
+- [x] **Step 2: Write failing delete/edit test**
+
+Add coverage proving users can edit a draft, delete a different draft, and keep the edited draft in place.
+
+- [x] **Step 3: Write failing save-one test**
+
+Update the existing single-save expectation so saving one draft removes only that draft, leaves other unsaved drafts in the queue, and shows a success status.
+
+- [x] **Step 4: Write failing save-all partial failure test**
+
+Add coverage where the first save succeeds and the second save rejects. Assert the mutation ran for both valid drafts, the successful draft was removed, the failed draft remains editable, and the status uses partial-failure copy.
+
+- [x] **Step 5: Run focused tests and verify RED**
+
+Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+
+Expected: FAIL because the route still has a single `draft`, no delete controls, and no save-all action.
+
+### Task 2: Implement Sidepanel Queue
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-flashcards.tsx`
+
+- [x] **Step 1: Add draft queue model**
+
+Extend `CaptureDraft` with an `id`; store `drafts: CaptureDraft[]` instead of `draft: CaptureDraft | null`.
+
+- [x] **Step 2: Append successful captures**
+
+Change capture success to append a new draft while keeping existing drafts. Keep the existing behavior that a failed later capture shows an error, but do not discard existing queued drafts.
+
+- [x] **Step 3: Render queued drafts**
+
+Render each draft as an editable section with stable labels and per-draft Front/Back fields. Keep source context visible.
+
+- [x] **Step 4: Add delete and clear-saved mechanics**
+
+Add a visible delete action per draft. Remove successfully saved drafts from the queue after save-one/save-all; preserve failed drafts for retry.
+
+- [x] **Step 5: Add save-one and save-all actions**
+
+Use `useCreateFlashcardMutation().mutateAsync` for each valid draft. Save-one operates on a single draft. Save-all attempts all valid drafts, reports success/partial/failure, removes only successes, and keeps invalid or failed drafts.
+
+- [x] **Step 6: Preserve deck and availability states**
+
+Keep existing deck loading/error/unavailable/no-decks copy and disabled save behavior. Save-all should be disabled when there are no valid drafts, no selectable deck, or a save is pending.
+
+### Task 3: Update UX Source And Task Metadata
+
+**Files:**
+- Modify: `Flashcards-UX-Fix-List.md`
+- Modify via Backlog.md MCP: `backlog/tasks/task-517 - Add-flashcards-extension-repeat-capture-queue.md`
+
+- [x] **Step 1: Update master checklist wording**
+
+Change the deferred F12 item to show repeat-capture queue and bulk save as complete while leaving templates, generated drafts, and in-extension review deferred.
+
+- [x] **Step 2: Add implementation notes to TASK-517**
+
+Record touched files, plan path, and the narrowed non-goals: no native LLM generation, no template application, no in-extension review.
+
+### Task 4: Verification And Commit
+
+**Files:**
+- Verify: `apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx`
+- Verify: `apps/packages/ui/src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
+- Verify: touched docs/task files
+
+- [x] **Step 1: Run focused sidepanel tests**
+
+Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
+
+Expected: PASS.
+
+- [x] **Step 2: Run TypeScript check if practical**
+
+Run from `apps/packages/ui`: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
+
+Expected: PASS or only documented unrelated baseline failures.
+
+- [x] **Step 3: Run diff hygiene**
+
+Run from repo root: `git diff --check`
+
+Expected: PASS.
+
+- [x] **Step 4: Record Bandit applicability**
+
+No Python files should be touched. Record “Bandit not applicable: frontend/docs/task-only changes” in TASK-517.
+
+- [x] **Step 5: Finalize TASK-517**
+
+Mark acceptance criteria/DoD complete, add verification results, and add final summary.
+
+- [x] **Step 6: Commit**
+
+Commit message: `feat: add flashcards sidepanel capture queue`

--- a/Flashcards-UX-Fix-List.md
+++ b/Flashcards-UX-Fix-List.md
@@ -1,6 +1,6 @@
 # Flashcards UX Fix List
 
-Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split and F12 native sidepanel capture follow-ups.
+Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split and F12 native sidepanel capture queue follow-ups.
 
 Scope: `/flashcards` plus directly connected WebUI and extension flashcard workflows. This file is the master UX audit and fix-list source referenced by `Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md`.
 
@@ -47,7 +47,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 9. Recent sessions show user-facing deck/mode/count/timing labels where data is available.
 10. Deck dashboard rows expose direct Review, Cram, Edit, Scheduler, and Export actions.
 11. Generated-card save recovery distinguishes success, partial success, failure, fatal validation errors, and retry state.
-12. Extension sidepanel offers explicit full Flashcards and Capture page selection actions; selected page text becomes an editable sidepanel draft with deck picker, Front/Back fields, one-card save, and page URL provenance.
+12. Extension sidepanel offers explicit full Flashcards and Capture page selection actions; selected page text appends to an editable draft queue with deck picker, Front/Back fields, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
 13. Documentation describes the stabilized WebUI/extension capture and handoff behavior using current tab names.
 
 ## Phase Coverage
@@ -65,6 +65,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | Closeout source restoration | TASK-514 | Planning traceability | Completed. Restores this tracked source file on `dev`. |
 | F06 follow-up: Task-first Create & Import split | TASK-515 | F06 | Completed. Adds Create cards, Import file, and Export backup task workspaces while preserving existing route keys and panel handoffs. |
 | F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Generated drafts, templates, bulk editing, and in-extension review remain deferred. |
+| F12 follow-up: Extension repeat-capture queue | TASK-517 | F12 | Completed. Converts native sidepanel capture from one draft to a repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery. Generated drafts, templates, and in-extension review remain deferred. |
 
 ## Severity-Ranked Findings
 
@@ -81,7 +82,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | F09 | Medium | History comprehension | Recent sessions used labels like `Session #1`, `Deck 1`, or raw scope keys. | Progress/history was present but hard to trust. | Backend identifiers leaked into user-facing history. | Addressed in TASK-509. |
 | F10 | Medium | Progress semantics | Due/new/current queue labels could appear contradictory. | Users could misunderstand whether cards were available to study. | Scheduler labels were technically accurate but not explained in queue context. | Addressed in TASK-508. |
 | F11 | Medium | Expert workflow | Manage was card-first with no deck-first dashboard for quick study decisions. | Experienced users spent time filtering cards instead of selecting a deck action. | The model privileged card management over deck review. | Addressed in TASK-510/TASK-511. |
-| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516. Sidepanel now supports native selected-text draft edit/save; richer generated drafts, templates, bulk editing, and in-extension review remain deferred. |
+| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517. Sidepanel now supports native selected-text repeat capture, draft edit/delete, save-one, save-all, partial failure recovery, and page provenance; richer generated drafts, templates, and in-extension review remain deferred. |
 | F13 | Medium | Docs mismatch | Extension and flashcards docs lagged current UI tab names and workflows. | Users could not rely on docs to understand current behavior. | Docs had not tracked UI evolution. | Addressed in TASK-513. |
 | F14 | Low | Empty-state hierarchy | Manage empty state showed expert filters before any cards existed. | New users saw advanced management chrome before first action. | Empty state inherited full management layout. | Addressed in TASK-506. |
 | F15 | Low | Scheduler discoverability | Scheduler was hidden until a deck existed. | New users could not learn scheduling exists until after setup. | Progressive disclosure hid a core concept too completely. | Addressed in TASK-506. |
@@ -101,7 +102,7 @@ Create & Import now separates setup into task-specific workspaces, so first-time
 
 The strongest power-user improvement is the deck dashboard. It gives experienced users deck-level counts and direct Review/Cram/Edit/Scheduler/Export actions, replacing a card-filter-first starting point for common study decisions. Review recovery and recent-session labels also make repeat review safer and easier to resume.
 
-Remaining weakness: extension capture now supports a one-card native save path, but richer expert capture controls remain deferred: generated drafts, templates, bulk editing, repeat capture queues, and in-extension review.
+Remaining weakness: extension capture now supports repeated native capture and bulk save, but richer expert capture controls remain deferred: generated drafts, templates, and in-extension review.
 
 ## Improvement Backlog
 
@@ -126,10 +127,11 @@ Remaining weakness: extension capture now supports a one-card native save path, 
 - Add first-time/review/create keyboard e2e coverage.
 - Add generated-card save recovery states with retry.
 - Split Create & Import into task-specific Create cards, Import file, and Export backup workspaces.
+- Add native extension repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery.
 
 ### Deferred Larger Product Improvements
 
-- Extend the native extension capture flow with generated drafts, templates, bulk editing, repeat capture queues, and in-extension review.
+- Extend the native extension capture flow with generated drafts, templates, and in-extension review.
 - Add broader import result normalization if future evidence shows unresolved partial/fatal import ambiguity outside generated-card save.
 - Run a full browser accessibility audit beyond the focused keyboard e2e coverage.
 
@@ -152,14 +154,14 @@ Remaining weakness: extension capture now supports a one-card native save path, 
 3. Review supports keyboard reveal/rate/undo/edit flows with visible equivalents.
 4. Completion supports repeat workflows.
 5. History uses meaningful session labels instead of raw ids.
-6. Extension selected-text capture creates an editable sidepanel draft, saves one basic card to the chosen deck with page provenance, and leaves full Flashcards available for generation/import/review.
+6. Extension selected-text capture appends editable sidepanel drafts, lets the user delete or save one/all drafts with partial failure recovery, preserves page provenance, and leaves full Flashcards available for generation/import/review.
 
 ## Open Questions And Non-Goals
 
 - Scheduler algorithm correctness and backend spaced-repetition math were not audited beyond visible UX effects.
 - Quiz surfaces were out of scope except for the direct Flashcards handoff.
 - Multi-user permission, workspace sharing, and collaboration states need separate testing.
-- Rich native extension generation, templates, bulk editing, repeat capture queues, and in-extension review remain future product improvements beyond the F12 MVP.
+- Rich native extension generation, templates, and in-extension review remain future product improvements beyond the F12 capture queue.
 
 ## Master Checklist
 
@@ -193,7 +195,8 @@ Remaining weakness: extension capture now supports a one-card native save path, 
 
 - [x] F12 Extension selected-text bridge added with page provenance into GeneratePanel saves.
 - [x] F12 Native extension deck-picker/edit/save MVP completed for one selected-text card.
-- [ ] F12 Rich native extension generated drafts/templates/bulk/review workflow remains deferred.
+- [x] F12 Native extension repeat-capture queue, draft delete, save-one, save-all, and partial failure recovery completed.
+- [ ] F12 Rich native extension generated drafts/templates/review workflow remains deferred.
 - [x] F13 WebUI and extension flashcards docs updated.
 - [x] F17 Quiz handoff made state-aware.
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -364,6 +364,24 @@ describe("sidepanel flashcards route", () => {
     expect(screen.getByDisplayValue("Second queued answer")).toBeInTheDocument()
   })
 
+  it("ignores duplicate individual save clicks while the draft is saving", async () => {
+    flashcardMocks.createFlashcardMutateAsync.mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    const saveButton = screen.getByRole("button", { name: "Save card" })
+
+    fireEvent.click(saveButton)
+    fireEvent.click(saveButton)
+
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
   it("preserves failed drafts after save-all partial failure", async () => {
     browserMocks.executeScript
       .mockResolvedValueOnce([{ result: "Saved answer" }])
@@ -390,6 +408,56 @@ describe("sidepanel flashcards route", () => {
     ).toBeInTheDocument()
     expect(screen.queryByDisplayValue("Saved answer")).not.toBeInTheDocument()
     expect(screen.getByDisplayValue("Failed answer")).toBeInTheDocument()
+  })
+
+  it("ignores duplicate save-all clicks while the queue is saving", async () => {
+    browserMocks.executeScript
+      .mockResolvedValueOnce([{ result: "First queued answer" }])
+      .mockResolvedValueOnce([{ result: "Second queued answer" }])
+    flashcardMocks.createFlashcardMutateAsync.mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    const saveAllButton = screen.getByRole("button", {
+      name: "Save all cards"
+    })
+
+    fireEvent.click(saveAllButton)
+    fireEvent.click(saveAllButton)
+
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("locks draft editing and queue controls while a save is in progress", async () => {
+    flashcardMocks.createFlashcardMutateAsync.mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Save card" }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Front")).toBeDisabled()
+      expect(screen.getByLabelText("Back")).toBeDisabled()
+      expect(
+        screen.getByRole("button", { name: "Capture page selection" })
+      ).toBeDisabled()
+      expect(screen.getByTestId("sidepanel-flashcards-deck-select")).toHaveClass(
+        "ant-select-disabled"
+      )
+    })
   })
 
   it("keeps the draft in place when sidepanel save fails", async () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -57,13 +57,15 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (
       key: string,
-      fallbackOrOptions?: string | { defaultValue?: string; deckName?: string }
+      fallbackOrOptions?:
+        | string
+        | Record<string, string | number | undefined>
     ) => {
       if (typeof fallbackOrOptions === "string") return fallbackOrOptions
       if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
-        return (fallbackOrOptions.defaultValue || key).replace(
-          "{{deckName}}",
-          fallbackOrOptions.deckName || ""
+        const template = String(fallbackOrOptions.defaultValue || key)
+        return template.replace(/{{(\w+)}}/g, (_, token: string) =>
+          String(fallbackOrOptions[token] ?? "")
         )
       }
       return key
@@ -74,6 +76,27 @@ vi.mock("react-i18next", () => ({
 describe("sidepanel flashcards route", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    browserMocks.runtimeGetURL.mockReset()
+    browserMocks.tabsCreate.mockReset()
+    browserMocks.tabsQuery.mockReset()
+    browserMocks.executeScript.mockReset()
+    flashcardMocks.createFlashcardMutateAsync.mockReset()
+    browserMocks.runtimeGetURL.mockImplementation(
+      (path: string) => `chrome-extension://flashcards${path}`
+    )
+    browserMocks.tabsCreate.mockResolvedValue(undefined)
+    browserMocks.tabsQuery.mockResolvedValue([
+      {
+        id: 42,
+        title: "Selection Source",
+        url: "https://example.test/source"
+      }
+    ])
+    browserMocks.executeScript.mockResolvedValue([
+      {
+        result: "Key concept from the active page"
+      }
+    ])
     flashcardMocks.createFlashcardMutateAsync.mockResolvedValue({
       uuid: "card-1",
       deck_id: 7
@@ -210,6 +233,65 @@ describe("sidepanel flashcards route", () => {
     )
   })
 
+  it("appends repeated page selections into an editable draft queue", async () => {
+    browserMocks.executeScript
+      .mockResolvedValueOnce([{ result: "First captured concept" }])
+      .mockResolvedValueOnce([{ result: "Second captured concept" }])
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(screen.getByText("2 draft cards ready")).toBeInTheDocument()
+    expect(
+      screen.getAllByRole("heading", { name: "Draft flashcard" })
+    ).toHaveLength(2)
+    expect(screen.getAllByLabelText("Front")[0]).toHaveValue(
+      "Selection Source"
+    )
+    expect(screen.getAllByLabelText("Back")[0]).toHaveValue(
+      "First captured concept"
+    )
+    expect(screen.getAllByLabelText("Back")[1]).toHaveValue(
+      "Second captured concept"
+    )
+  })
+
+  it("edits one queued draft and removes another draft", async () => {
+    browserMocks.executeScript
+      .mockResolvedValueOnce([{ result: "Keep this answer" }])
+      .mockResolvedValueOnce([{ result: "Remove this answer" }])
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    fireEvent.change(screen.getAllByLabelText("Front")[0], {
+      target: { value: "Edited retained question" }
+    })
+    await user.click(screen.getByRole("button", { name: "Remove draft 2" }))
+
+    expect(
+      screen.getAllByRole("heading", { name: "Draft flashcard" })
+    ).toHaveLength(1)
+    expect(screen.getByLabelText("Front")).toHaveValue(
+      "Edited retained question"
+    )
+    expect(screen.getByLabelText("Back")).toHaveValue("Keep this answer")
+    expect(
+      screen.queryByDisplayValue("Remove this answer")
+    ).not.toBeInTheDocument()
+  })
+
   it("saves the edited sidepanel draft with deck and page provenance", async () => {
     const user = userEvent.setup()
     render(<SidepanelFlashcards />)
@@ -245,6 +327,69 @@ describe("sidepanel flashcards route", () => {
     expect(
       screen.getByRole("button", { name: "Open full Flashcards" })
     ).toBeInTheDocument()
+  })
+
+  it("saves one queued draft without discarding unsaved drafts", async () => {
+    browserMocks.executeScript
+      .mockResolvedValueOnce([{ result: "First queued answer" }])
+      .mockResolvedValueOnce([{ result: "Second queued answer" }])
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(screen.getAllByRole("button", { name: "Save card" })[0])
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledWith({
+      deck_id: 7,
+      front: "Selection Source",
+      back: "First queued answer",
+      model_type: "basic",
+      is_cloze: false,
+      reverse: false,
+      source_ref_type: "manual",
+      source_ref_id: "https://example.test/source"
+    })
+    expect(screen.getByText("Saved to Biology.")).toBeInTheDocument()
+    expect(
+      screen.queryByDisplayValue("First queued answer")
+    ).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue("Second queued answer")).toBeInTheDocument()
+  })
+
+  it("preserves failed drafts after save-all partial failure", async () => {
+    browserMocks.executeScript
+      .mockResolvedValueOnce([{ result: "Saved answer" }])
+      .mockResolvedValueOnce([{ result: "Failed answer" }])
+    flashcardMocks.createFlashcardMutateAsync
+      .mockResolvedValueOnce({ uuid: "card-1", deck_id: 7 })
+      .mockRejectedValueOnce(new Error("save failed"))
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(screen.getByRole("button", { name: "Save all cards" }))
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(2)
+    })
+    expect(
+      screen.getByText("Saved 1 card to Biology. 1 draft still needs attention.")
+    ).toBeInTheDocument()
+    expect(screen.queryByDisplayValue("Saved answer")).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue("Failed answer")).toBeInTheDocument()
   })
 
   it("keeps the draft in place when sidepanel save fails", async () => {
@@ -355,7 +500,7 @@ describe("sidepanel flashcards route", () => {
     expect(screen.getByRole("button", { name: "Save card" })).toBeDisabled()
   })
 
-  it("clears a previous draft when a later capture attempt fails", async () => {
+  it("keeps queued drafts when a later capture attempt fails", async () => {
     const user = userEvent.setup()
     render(<SidepanelFlashcards />)
 
@@ -375,8 +520,11 @@ describe("sidepanel flashcards route", () => {
       screen.getByText("Select text on the page first.")
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole("heading", { name: "Draft flashcard" })
-    ).not.toBeInTheDocument()
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText("Back")).toHaveValue(
+      "Key concept from the active page"
+    )
   })
 
   it("uses capture wording when no active page tab is available", async () => {

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -1,6 +1,12 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { ExternalLink, Layers, MessageSquareText, Save } from "lucide-react"
+import {
+  ExternalLink,
+  Layers,
+  MessageSquareText,
+  Save,
+  Trash2
+} from "lucide-react"
 import { Button, Input, Select, Typography } from "antd"
 import { browser } from "wxt/browser"
 import {
@@ -8,11 +14,13 @@ import {
   useDecksQuery,
   useFlashcardsEnabled
 } from "@/components/Flashcards/hooks"
+import type { FlashcardCreate } from "@/services/flashcards"
 
 const { Text, Title } = Typography
 const { TextArea } = Input
 
 type CaptureDraft = {
+  id: string
   front: string
   back: string
   sourceId: string
@@ -40,13 +48,17 @@ export const readSelectedTextFromPage = () => {
 
 export default function SidepanelFlashcards() {
   const { t } = useTranslation()
+  const draftIdRef = React.useRef(0)
   const [captureError, setCaptureError] = React.useState<string | null>(null)
   const [captureLoading, setCaptureLoading] = React.useState(false)
   const [saveStatus, setSaveStatus] = React.useState<{
     type: "success" | "error"
     message: string
   } | null>(null)
-  const [draft, setDraft] = React.useState<CaptureDraft | null>(null)
+  const [drafts, setDrafts] = React.useState<CaptureDraft[]>([])
+  const [savingDraftIds, setSavingDraftIds] = React.useState<Set<string>>(
+    () => new Set()
+  )
   const [selectedDeckId, setSelectedDeckId] = React.useState<number | null>(null)
   const flashcardsAvailability = useFlashcardsEnabled()
   const decksQuery = useDecksQuery()
@@ -112,7 +124,6 @@ export default function SidepanelFlashcards() {
   const handleCapturePageSelection = React.useCallback(async () => {
     setCaptureError(null)
     setSaveStatus(null)
-    setDraft(null)
     setCaptureLoading(true)
     const captureUnavailableMessage = t(
       "sidepanel:flashcards.selectionCaptureUnavailable",
@@ -154,7 +165,9 @@ export default function SidepanelFlashcards() {
         throw new Error(noSelectionMessage)
       }
 
-      setDraft({
+      draftIdRef.current += 1
+      const nextDraft: CaptureDraft = {
+        id: `capture-${draftIdRef.current}`,
         front:
           activeTab.title ||
           activeTab.url ||
@@ -162,7 +175,8 @@ export default function SidepanelFlashcards() {
         back: selectedText,
         sourceId: activeTab.url || String(tabId),
         sourceTitle: activeTab.title || activeTab.url || undefined
-      })
+      }
+      setDrafts((current) => [...current, nextDraft])
     } catch (error) {
       const message =
         error instanceof Error && error.message.trim() ? error.message : ""
@@ -179,16 +193,20 @@ export default function SidepanelFlashcards() {
     }
   }, [t])
 
-  const handleSaveDraft = React.useCallback(async () => {
-    if (!draft || selectedDeckId == null) return
+  const getDeckName = React.useCallback(
+    () => selectedDeck?.name || t("sidepanel:flashcards.defaultDeck", "deck"),
+    [selectedDeck?.name, t]
+  )
 
-    const front = draft.front.trim()
-    const back = draft.back.trim()
-    if (!front || !back) return
+  const buildSavePayload = React.useCallback(
+    (draft: CaptureDraft): FlashcardCreate | null => {
+      if (selectedDeckId == null) return null
 
-    setSaveStatus(null)
-    try {
-      await createFlashcardMutation.mutateAsync({
+      const front = draft.front.trim()
+      const back = draft.back.trim()
+      if (!front || !back) return null
+
+      return {
         deck_id: selectedDeckId,
         front,
         back,
@@ -197,31 +215,145 @@ export default function SidepanelFlashcards() {
         reverse: false,
         source_ref_type: "manual",
         source_ref_id: draft.sourceId
-      })
-      setSaveStatus({
-        type: "success",
-        message: t("sidepanel:flashcards.saveSuccess", {
-          defaultValue: "Saved to {{deckName}}.",
-          deckName:
-            selectedDeck?.name || t("sidepanel:flashcards.defaultDeck", "deck")
-        })
-      })
-      setDraft(null)
-    } catch {
-      setSaveStatus({
-        type: "error",
-        message: t(
-          "sidepanel:flashcards.saveFailed",
-          "Could not save flashcard. Check your connection and try again."
-        )
-      })
-    }
-  }, [createFlashcardMutation, draft, selectedDeck?.name, selectedDeckId, t])
+      }
+    },
+    [selectedDeckId]
+  )
 
-  const hasDraftContent = !!draft?.front.trim() && !!draft?.back.trim()
   const hasDeck = selectedDeckId != null && hasSelectableDecks
-  const canSaveDraft =
-    !!draft && hasDraftContent && hasDeck && !createFlashcardMutation.isPending
+
+  const handleUpdateDraft = React.useCallback(
+    (draftId: string, field: "front" | "back", value: string) => {
+      setDrafts((current) =>
+        current.map((draft) =>
+          draft.id === draftId ? { ...draft, [field]: value } : draft
+        )
+      )
+    },
+    []
+  )
+
+  const handleRemoveDraft = React.useCallback((draftId: string) => {
+    setSaveStatus(null)
+    setDrafts((current) => current.filter((draft) => draft.id !== draftId))
+  }, [])
+
+  const handleSaveDraft = React.useCallback(
+    async (draftId: string) => {
+      if (!hasDeck) return
+
+      const draft = drafts.find((candidate) => candidate.id === draftId)
+      if (!draft) return
+
+      const payload = buildSavePayload(draft)
+      if (!payload) return
+
+      setSaveStatus(null)
+      setSavingDraftIds(new Set([draftId]))
+      try {
+        await createFlashcardMutation.mutateAsync(payload)
+        setSaveStatus({
+          type: "success",
+          message: t("sidepanel:flashcards.saveSuccess", {
+            defaultValue: "Saved to {{deckName}}.",
+            deckName: getDeckName()
+          })
+        })
+        setDrafts((current) =>
+          current.filter((candidate) => candidate.id !== draftId)
+        )
+      } catch {
+        setSaveStatus({
+          type: "error",
+          message: t(
+            "sidepanel:flashcards.saveFailed",
+            "Could not save flashcard. Check your connection and try again."
+          )
+        })
+      } finally {
+        setSavingDraftIds(new Set())
+      }
+    },
+    [buildSavePayload, createFlashcardMutation, drafts, getDeckName, hasDeck, t]
+  )
+
+  const handleSaveAllDrafts = React.useCallback(async () => {
+    if (!hasDeck) return
+
+    const validDrafts = drafts.filter((draft) => buildSavePayload(draft))
+    if (!validDrafts.length) return
+
+    setSaveStatus(null)
+    setSavingDraftIds(new Set(validDrafts.map((draft) => draft.id)))
+    const savedDraftIds = new Set<string>()
+
+    try {
+      for (const draft of validDrafts) {
+        const payload = buildSavePayload(draft)
+        if (!payload) continue
+
+        try {
+          await createFlashcardMutation.mutateAsync(payload)
+          savedDraftIds.add(draft.id)
+        } catch {
+          // Keep saving the queue so users get a precise partial-success state.
+        }
+      }
+
+      if (savedDraftIds.size > 0) {
+        setDrafts((current) =>
+          current.filter((draft) => !savedDraftIds.has(draft.id))
+        )
+      }
+
+      const failedCount = validDrafts.length - savedDraftIds.size
+      const deckName = getDeckName()
+      if (failedCount === 0) {
+        setSaveStatus({
+          type: "success",
+          message: t("sidepanel:flashcards.saveAllSuccess", {
+            defaultValue: "Saved {{savedCount}} {{cardLabel}} to {{deckName}}.",
+            savedCount: savedDraftIds.size,
+            cardLabel: savedDraftIds.size === 1 ? "card" : "cards",
+            deckName
+          })
+        })
+      } else if (savedDraftIds.size > 0) {
+        setSaveStatus({
+          type: "error",
+          message: t("sidepanel:flashcards.saveAllPartial", {
+            defaultValue:
+              "Saved {{savedCount}} {{cardLabel}} to {{deckName}}. {{failedCount}} {{draftLabel}} still needs attention.",
+            savedCount: savedDraftIds.size,
+            cardLabel: savedDraftIds.size === 1 ? "card" : "cards",
+            deckName,
+            failedCount,
+            draftLabel: failedCount === 1 ? "draft" : "drafts"
+          })
+        })
+      } else {
+        setSaveStatus({
+          type: "error",
+          message: t(
+            "sidepanel:flashcards.saveAllFailed",
+            "Could not save any flashcards. Check your connection and try again."
+          )
+        })
+      }
+    } finally {
+      setSavingDraftIds(new Set())
+    }
+  }, [buildSavePayload, createFlashcardMutation, drafts, getDeckName, hasDeck, t])
+
+  const isSaving = createFlashcardMutation.isPending || savingDraftIds.size > 0
+  const canSaveDraft = React.useCallback(
+    (draft: CaptureDraft) => !!buildSavePayload(draft) && hasDeck && !isSaving,
+    [buildSavePayload, hasDeck, isSaving]
+  )
+  const validDraftCount = drafts.filter(
+    (draft) => buildSavePayload(draft)
+  ).length
+  const canSaveAllDrafts = validDraftCount > 0 && hasDeck && !isSaving
 
   return (
     <main className="flex min-h-full flex-col gap-4 p-4 text-left">
@@ -268,18 +400,28 @@ export default function SidepanelFlashcards() {
           "Create one editable card in the sidepanel. Use full Flashcards for generation, imports, and review."
         )}
       </Text>
-      {draft ? (
+      {drafts.length > 0 ? (
         <section
-          className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-3"
-          aria-label={t("sidepanel:flashcards.draftSection", "Draft flashcard")}
+          className="flex flex-col gap-3"
+          aria-label={t("sidepanel:flashcards.draftQueue", "Draft queue")}
         >
-          <div>
-            <Title level={5} className="!mb-1">
-              {t("sidepanel:flashcards.draftTitle", "Draft flashcard")}
-            </Title>
-            <Text type="secondary" className="text-xs">
-              {draft.sourceTitle || draft.sourceId}
+          <div className="flex items-center justify-between gap-2">
+            <Text strong>
+              {t("sidepanel:flashcards.draftQueueCount", {
+                defaultValue: "{{count}} draft {{cardLabel}} ready",
+                count: drafts.length,
+                cardLabel: drafts.length === 1 ? "card" : "cards"
+              })}
             </Text>
+            <Button
+              size="small"
+              icon={<Save className="size-4" aria-hidden="true" />}
+              loading={isSaving}
+              disabled={!canSaveAllDrafts}
+              onClick={handleSaveAllDrafts}
+            >
+              {t("sidepanel:flashcards.saveAllCards", "Save all cards")}
+            </Button>
           </div>
           <label className="flex flex-col gap-1 text-sm font-medium">
             {t("sidepanel:flashcards.deckLabel", "Deck")}
@@ -326,42 +468,69 @@ export default function SidepanelFlashcards() {
               )}
             </Text>
           ) : null}
-          <label className="flex flex-col gap-1 text-sm font-medium">
-            {t("sidepanel:flashcards.frontLabel", "Front")}
-            <TextArea
-              aria-label={t("sidepanel:flashcards.frontLabel", "Front")}
-              autoSize={{ minRows: 2, maxRows: 4 }}
-              value={draft.front}
-              onChange={(event) =>
-                setDraft((current) =>
-                  current ? { ...current, front: event.target.value } : current
-                )
-              }
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm font-medium">
-            {t("sidepanel:flashcards.backLabel", "Back")}
-            <TextArea
-              aria-label={t("sidepanel:flashcards.backLabel", "Back")}
-              autoSize={{ minRows: 4, maxRows: 8 }}
-              value={draft.back}
-              onChange={(event) =>
-                setDraft((current) =>
-                  current ? { ...current, back: event.target.value } : current
-                )
-              }
-            />
-          </label>
-          <Button
-            type="primary"
-            block
-            icon={<Save className="size-4" aria-hidden="true" />}
-            loading={createFlashcardMutation.isPending}
-            disabled={!canSaveDraft}
-            onClick={handleSaveDraft}
-          >
-            {t("sidepanel:flashcards.saveCard", "Save card")}
-          </Button>
+          {drafts.map((draft, index) => (
+            <section
+              key={draft.id}
+              className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-3"
+              aria-label={t("sidepanel:flashcards.draftSection", {
+                defaultValue: "Draft flashcard {{index}}",
+                index: index + 1
+              })}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <Title level={5} className="!mb-1">
+                    {t("sidepanel:flashcards.draftTitle", "Draft flashcard")}
+                  </Title>
+                  <Text type="secondary" className="text-xs">
+                    {draft.sourceTitle || draft.sourceId}
+                  </Text>
+                </div>
+                <Button
+                  size="small"
+                  icon={<Trash2 className="size-4" aria-hidden="true" />}
+                  aria-label={t("sidepanel:flashcards.removeDraft", {
+                    defaultValue: "Remove draft {{index}}",
+                    index: index + 1
+                  })}
+                  disabled={isSaving}
+                  onClick={() => handleRemoveDraft(draft.id)}
+                />
+              </div>
+              <label className="flex flex-col gap-1 text-sm font-medium">
+                {t("sidepanel:flashcards.frontLabel", "Front")}
+                <TextArea
+                  aria-label={t("sidepanel:flashcards.frontLabel", "Front")}
+                  autoSize={{ minRows: 2, maxRows: 4 }}
+                  value={draft.front}
+                  onChange={(event) =>
+                    handleUpdateDraft(draft.id, "front", event.target.value)
+                  }
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm font-medium">
+                {t("sidepanel:flashcards.backLabel", "Back")}
+                <TextArea
+                  aria-label={t("sidepanel:flashcards.backLabel", "Back")}
+                  autoSize={{ minRows: 4, maxRows: 8 }}
+                  value={draft.back}
+                  onChange={(event) =>
+                    handleUpdateDraft(draft.id, "back", event.target.value)
+                  }
+                />
+              </label>
+              <Button
+                type="primary"
+                block
+                icon={<Save className="size-4" aria-hidden="true" />}
+                loading={savingDraftIds.has(draft.id)}
+                disabled={!canSaveDraft(draft)}
+                onClick={() => void handleSaveDraft(draft.id)}
+              >
+                {t("sidepanel:flashcards.saveCard", "Save card")}
+              </Button>
+            </section>
+          ))}
         </section>
       ) : null}
       {saveStatus ? (

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -59,6 +59,7 @@ export default function SidepanelFlashcards() {
   const [savingDraftIds, setSavingDraftIds] = React.useState<Set<string>>(
     () => new Set()
   )
+  const savingDraftIdsRef = React.useRef<Set<string>>(new Set())
   const [selectedDeckId, setSelectedDeckId] = React.useState<number | null>(null)
   const flashcardsAvailability = useFlashcardsEnabled()
   const decksQuery = useDecksQuery()
@@ -198,6 +199,15 @@ export default function SidepanelFlashcards() {
     [selectedDeck?.name, t]
   )
 
+  const setActiveSavingDraftIds = React.useCallback(
+    (draftIds: Iterable<string>) => {
+      const nextDraftIds = new Set(draftIds)
+      savingDraftIdsRef.current = nextDraftIds
+      setSavingDraftIds(nextDraftIds)
+    },
+    []
+  )
+
   const buildSavePayload = React.useCallback(
     (draft: CaptureDraft): FlashcardCreate | null => {
       if (selectedDeckId == null) return null
@@ -240,7 +250,7 @@ export default function SidepanelFlashcards() {
 
   const handleSaveDraft = React.useCallback(
     async (draftId: string) => {
-      if (!hasDeck) return
+      if (!hasDeck || savingDraftIdsRef.current.size > 0) return
 
       const draft = drafts.find((candidate) => candidate.id === draftId)
       if (!draft) return
@@ -249,7 +259,7 @@ export default function SidepanelFlashcards() {
       if (!payload) return
 
       setSaveStatus(null)
-      setSavingDraftIds(new Set([draftId]))
+      setActiveSavingDraftIds([draftId])
       try {
         await createFlashcardMutation.mutateAsync(payload)
         setSaveStatus({
@@ -271,23 +281,32 @@ export default function SidepanelFlashcards() {
           )
         })
       } finally {
-        setSavingDraftIds(new Set())
+        setActiveSavingDraftIds([])
       }
     },
-    [buildSavePayload, createFlashcardMutation, drafts, getDeckName, hasDeck, t]
+    [
+      buildSavePayload,
+      createFlashcardMutation,
+      drafts,
+      getDeckName,
+      hasDeck,
+      setActiveSavingDraftIds,
+      t
+    ]
   )
 
   const handleSaveAllDrafts = React.useCallback(async () => {
-    if (!hasDeck) return
+    if (!hasDeck || savingDraftIdsRef.current.size > 0) return
 
-    const validDrafts = drafts.filter((draft) => buildSavePayload(draft))
-    if (!validDrafts.length) return
-
-    setSaveStatus(null)
-    setSavingDraftIds(new Set(validDrafts.map((draft) => draft.id)))
     const savedDraftIds = new Set<string>()
 
     try {
+      const validDrafts = drafts.filter((draft) => buildSavePayload(draft))
+      if (!validDrafts.length) return
+
+      setSaveStatus(null)
+      setActiveSavingDraftIds(validDrafts.map((draft) => draft.id))
+
       for (const draft of validDrafts) {
         const payload = buildSavePayload(draft)
         if (!payload) continue
@@ -340,10 +359,26 @@ export default function SidepanelFlashcards() {
           )
         })
       }
+    } catch {
+      setSaveStatus({
+        type: "error",
+        message: t(
+          "sidepanel:flashcards.saveAllUnexpectedFailed",
+          "Could not finish saving flashcards. Check your connection and try again."
+        )
+      })
     } finally {
-      setSavingDraftIds(new Set())
+      setActiveSavingDraftIds([])
     }
-  }, [buildSavePayload, createFlashcardMutation, drafts, getDeckName, hasDeck, t])
+  }, [
+    buildSavePayload,
+    createFlashcardMutation,
+    drafts,
+    getDeckName,
+    hasDeck,
+    setActiveSavingDraftIds,
+    t
+  ])
 
   const isSaving = createFlashcardMutation.isPending || savingDraftIds.size > 0
   const canSaveDraft = React.useCallback(
@@ -385,6 +420,7 @@ export default function SidepanelFlashcards() {
         <Button
           block
           loading={captureLoading}
+          disabled={isSaving}
           icon={<MessageSquareText className="size-4" aria-hidden="true" />}
           onClick={handleCapturePageSelection}
         >
@@ -418,7 +454,7 @@ export default function SidepanelFlashcards() {
               icon={<Save className="size-4" aria-hidden="true" />}
               loading={isSaving}
               disabled={!canSaveAllDrafts}
-              onClick={handleSaveAllDrafts}
+              onClick={() => void handleSaveAllDrafts()}
             >
               {t("sidepanel:flashcards.saveAllCards", "Save all cards")}
             </Button>
@@ -429,7 +465,7 @@ export default function SidepanelFlashcards() {
               data-testid="sidepanel-flashcards-deck-select"
               aria-label={t("sidepanel:flashcards.deckLabel", "Deck")}
               loading={decksLoading}
-              disabled={!hasSelectableDecks}
+              disabled={!hasSelectableDecks || isSaving}
               placeholder={t(
                 "sidepanel:flashcards.deckPlaceholder",
                 "Choose a deck"
@@ -502,6 +538,7 @@ export default function SidepanelFlashcards() {
                 <TextArea
                   aria-label={t("sidepanel:flashcards.frontLabel", "Front")}
                   autoSize={{ minRows: 2, maxRows: 4 }}
+                  disabled={isSaving}
                   value={draft.front}
                   onChange={(event) =>
                     handleUpdateDraft(draft.id, "front", event.target.value)
@@ -513,6 +550,7 @@ export default function SidepanelFlashcards() {
                 <TextArea
                   aria-label={t("sidepanel:flashcards.backLabel", "Back")}
                   autoSize={{ minRows: 4, maxRows: 8 }}
+                  disabled={isSaving}
                   value={draft.back}
                   onChange={(event) =>
                     handleUpdateDraft(draft.id, "back", event.target.value)

--- a/backlog/tasks/task-517 - Add-flashcards-extension-repeat-capture-queue.md
+++ b/backlog/tasks/task-517 - Add-flashcards-extension-repeat-capture-queue.md
@@ -48,12 +48,15 @@ Touched scope: `apps/packages/ui/src/routes/sidepanel-flashcards.tsx`, `apps/pac
 
 Implementation notes: converted sidepanel Flashcards from a single selected-text draft to a repeat-capture queue; added per-draft edit/delete, save-one, save-all, and partial failure preservation; kept full Flashcards as the handoff for LLM generation, templates, imports, and review.
 
+PR review follow-up after rebasing on `origin/dev@70a230aad`: added ref-backed duplicate-save guards for save-one/save-all, disabled draft editing, deck selection, and new captures while saves are in progress, and wrapped/caught the async save-all path.
+
 Non-goals: native sidepanel LLM generation, template application, and in-extension review.
 
 Verification:
 - RED: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` failed with 5 expected queue/save-all/preserve-on-capture-error failures after dependency setup.
-- PASS: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` passed 24 tests.
-- PARTIAL: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` has only the unrelated baseline `src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx(35,3): Type '"comfortable"' is not assignable to type 'GalleryCardDensity'.`
+- PASS: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` passed 21 tests after review fixes.
+- PASS: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` passed 27 tests after review fixes.
+- PARTIAL: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still has only the unrelated baseline `src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx(35,3): Type '"comfortable"' is not assignable to type 'GalleryCardDensity'.`
 - PASS: `git diff --check`.
 - Bandit not applicable: no Python files touched.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
@@ -63,7 +66,9 @@ Verification:
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added the F12 repeat-capture sidepanel queue. Users can capture multiple page selections, edit queued Front/Back drafts, remove individual drafts, save one card, or save all valid drafts. Successful saves are removed from the queue while failed drafts remain for retry, and the full Flashcards workspace remains the handoff for generation, templates, imports, and review.
 
-Focused sidepanel and route-registry tests pass. TypeScript touched scope is clean; the package-wide `tsc` command still reports the unrelated pre-existing `CharacterListContent.design-system.test.tsx` density baseline.
+PR review follow-up after rebasing on `origin/dev@70a230aad`: save-one and save-all now use a synchronous ref-backed in-flight guard so duplicate clicks cannot create duplicate cards before React disabled-state rendering catches up. Draft Front/Back fields, the deck selector, and the capture button are disabled during saves so users cannot make edits or change the apparent target/queue while an in-flight payload is being saved. The save-all button now wraps the async handler and `handleSaveAllDrafts` has an outer catch for unexpected failures.
+
+Focused sidepanel and route-registry tests pass. Package-wide TypeScript still reports the unrelated pre-existing `CharacterListContent.design-system.test.tsx` density baseline; no sidepanel TypeScript errors were reported. Bandit is not applicable because this slice touches TypeScript/docs only and no Python files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-517 - Add-flashcards-extension-repeat-capture-queue.md
+++ b/backlog/tasks/task-517 - Add-flashcards-extension-repeat-capture-queue.md
@@ -1,0 +1,77 @@
+---
+id: TASK-517
+title: Add flashcards extension repeat-capture queue
+status: Done
+labels:
+- flashcards
+- extension
+- ux
+priority: medium
+ordinal: 517
+documentation:
+- Flashcards-UX-Fix-List.md
+modified_files:
+- Docs/superpowers/plans/2026-05-27-flashcards-extension-capture-queue-implementation-plan.md
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- Flashcards-UX-Fix-List.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next F12 follow-up: a native sidepanel queue for repeated page-selection captures, editable drafts, and save-one/save-all actions while keeping LLM generation/templates/import/review in the full Flashcards workspace.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sidepanel Flashcards can hold multiple captured page-selection drafts at once without auto-opening the full workspace.
+- [x] #2 Each draft shows source context and supports editing Front/Back fields before save.
+- [x] #3 Users can delete individual drafts, save one draft, save all valid drafts, and clear saved drafts without losing unsaved failures.
+- [x] #4 Bulk save surfaces clear success, partial failure, and failure status, preserving failed drafts for retry.
+- [x] #5 Full Flashcards remains the explicit handoff for generation, templates, imports, and review; this slice does not add native sidepanel review or LLM generation.
+- [x] #6 Focused sidepanel tests cover multi-capture queue behavior, per-draft deletion/editing, save-one, save-all partial failure, and handoff copy.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-27-flashcards-extension-capture-queue-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Plan: `Docs/superpowers/plans/2026-05-27-flashcards-extension-capture-queue-implementation-plan.md`.
+
+Touched scope: `apps/packages/ui/src/routes/sidepanel-flashcards.tsx`, `apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx`, `Flashcards-UX-Fix-List.md`, and the implementation plan.
+
+Implementation notes: converted sidepanel Flashcards from a single selected-text draft to a repeat-capture queue; added per-draft edit/delete, save-one, save-all, and partial failure preservation; kept full Flashcards as the handoff for LLM generation, templates, imports, and review.
+
+Non-goals: native sidepanel LLM generation, template application, and in-extension review.
+
+Verification:
+- RED: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` failed with 5 expected queue/save-all/preserve-on-capture-error failures after dependency setup.
+- PASS: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` passed 24 tests.
+- PARTIAL: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` has only the unrelated baseline `src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx(35,3): Type '"comfortable"' is not assignable to type 'GalleryCardDensity'.`
+- PASS: `git diff --check`.
+- Bandit not applicable: no Python files touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the F12 repeat-capture sidepanel queue. Users can capture multiple page selections, edit queued Front/Back drafts, remove individual drafts, save one card, or save all valid drafts. Successful saves are removed from the queue while failed drafts remain for retry, and the full Flashcards workspace remains the handoff for generation, templates, imports, and review.
+
+Focused sidepanel and route-registry tests pass. TypeScript touched scope is clean; the package-wide `tsc` command still reports the unrelated pre-existing `CharacterListContent.design-system.test.tsx` density baseline.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Add a repeat-capture queue to the extension Flashcards sidepanel.
- Let users edit/delete queued drafts, save one draft, or save all valid drafts.
- Preserve failed drafts after partial save-all failures and keep full Flashcards as the handoff for generation, templates, imports, and review.
- Harden save recovery from PR review feedback: duplicate save-one/save-all clicks are ignored synchronously, draft/deck/capture controls lock during saves, and the async save-all path is wrapped with inline error handling.
- Update the flashcards UX fix list, implementation plan, and Backlog TASK-517.

## Validation

- [x] Tests: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` passed 27 tests.
- [x] Static check: `git diff --check` passed.
- [x] TypeScript run recorded: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still reports only the unrelated pre-existing `CharacterListContent.design-system.test.tsx` `GalleryCardDensity` baseline; no sidepanel errors were reported.
- [x] Docs/task tracking updated: `Flashcards-UX-Fix-List.md`, implementation plan, and TASK-517 reflect this slice and review follow-up.
- [x] Bandit/security scope assessed: no Python files touched, so Bandit is not applicable to this TypeScript/docs-only change.

## Risk

Low. The behavioral changes are scoped to the extension Flashcards sidepanel route and its tests. The full `/flashcards` workspace remains the handoff for generation, templates, imports, and review.

## Rollback

Revert the two PR commits on this branch to return the sidepanel to the previous single-draft capture behavior and restore the prior docs/task state.

## UX Audit / Watchlists

- [x] Flashcards F12 extension-capture follow-up addressed for repeat captures, draft edit/delete, save-one, save-all, and partial failure recovery.
- [x] No native sidepanel LLM generation, template application, or review flow added in this slice.
- [x] In-flight save recovery covered by disabling draft edits, deck selection, and new captures while a save is active.

## Merge Gate

Human-authored Change summary still required before marking this AI-authored PR ready for merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repeat-capture queue to the Flashcards extension sidepanel so users can capture multiple selections, edit/delete drafts, and save one or all. Failed saves stay in the queue for retry; full Flashcards remains the handoff for generation, templates, imports, and review (TASK-517).

- **New Features**
  - Convert single draft to a local queue with source context, queue count, and per-draft delete.
  - Repeated captures append; queued drafts persist even if a later capture fails.
  - Save one or save all valid drafts; remove only successes and show success/partial/failure status; ignore duplicate clicks with in-flight guards.
  - Disable deck picker, capture button, and draft fields while saving or when no valid deck/drafts; disable save-all when no valid drafts or deck.
  - Update tests and docs (UX fix list, implementation plan, task record).

<sup>Written for commit 13a086f1624cbc769080d421b7f088943c6e4286. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2075?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

