### PR TITLE
Add MCP Unified package boundary

### DIFF
--- a/Docs/superpowers/plans/2026-05-27-mcp-unified-stage2-package-boundary-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-mcp-unified-stage2-package-boundary-implementation-plan.md
@@ -1,0 +1,416 @@
+# MCP Unified Stage 2 Package Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Create the first runtime-neutral `mcp_unified` package boundary while preserving all existing `tldw_Server_API.app.core.MCP_unified` imports.
+
+**Architecture:** This slice creates a top-level package containing host-neutral interface contracts and profile schema primitives. The existing in-repo MCP Unified interface modules become compatibility shims that re-export those package contracts; no protocol dispatch, server routes, domain modules, or gateway entrypoints move in this PR.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, pytest, existing Backlog.md task tracking, Bandit.
+
+---
+
+## Source Spec
+
+- Spec: `Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md`
+- Stage 1 inventory: `Docs/MCP/mcp_unified_module_ownership_inventory.md`
+- Backlog task: `TASK-518`
+
+## Scope Boundary
+
+In scope:
+
+- Create `mcp_unified/` as a top-level package included by setuptools discovery.
+- Move/copy the neutral runtime, policy, and storage protocols into `mcp_unified.interfaces`.
+- Add profile model and resolver/store primitives that encode the profile fields from the spec without enforcing policy yet.
+- Convert `tldw_Server_API.app.core.MCP_unified.interfaces.*` into compatibility shims that re-export the new package contracts.
+- Add boundary tests proving the new package imports without `tldw_Server_API` and existing host imports still resolve to the same contracts.
+
+Out of scope:
+
+- Moving `protocol.py`, `server.py`, `modules/base.py`, or any domain module into the package.
+- Creating a standalone gateway, FastAPI router, CLI, stdio server, SQLite store, or external server manager in the new package.
+- Changing `/api/v1/mcp/*` behavior or route contracts.
+- Changing MCP Hub, AuthNZ, credential, approval, or path-scope behavior.
+
+## File Structure
+
+Create:
+
+- `mcp_unified/__init__.py`
+- `mcp_unified/interfaces/__init__.py`
+- `mcp_unified/interfaces/policy.py`
+- `mcp_unified/interfaces/runtime.py`
+- `mcp_unified/interfaces/storage.py`
+- `mcp_unified/profiles/__init__.py`
+- `mcp_unified/profiles/models.py`
+- `mcp_unified/profiles/resolver.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+Modify:
+
+- `pyproject.toml`
+- `tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py`
+- `tldw_Server_API/app/core/MCP_unified/interfaces/policy.py`
+- `tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py`
+- `tldw_Server_API/app/core/MCP_unified/interfaces/storage.py`
+- `backlog/tasks/task-518 - Implement-MCP-Unified-Stage-2-runtime-neutral-package-boundary.md`
+
+## Task 1: Add Failing Package Boundary Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write boundary tests**
+
+Add tests that fail until the `mcp_unified` package and shims exist:
+
+```python
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path("mcp_unified")
+
+
+def _tldw_imports_for(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "tldw_Server_API"
+                or alias.name.startswith("tldw_Server_API.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "tldw_Server_API" or node.module.startswith("tldw_Server_API."):
+                imports.append(node.module)
+    return imports
+
+
+def test_runtime_package_boundary_has_no_tldw_server_imports() -> None:
+    assert PACKAGE_ROOT.exists()
+    offenders: dict[str, list[str]] = {}
+    for path in PACKAGE_ROOT.rglob("*.py"):
+        imports = _tldw_imports_for(path)
+        if imports:
+            offenders[str(path)] = imports
+    assert offenders == {}
+
+
+def test_host_interface_shims_reexport_package_contracts() -> None:
+    package_runtime = importlib.import_module("mcp_unified.interfaces.runtime")
+    host_runtime = importlib.import_module(
+        "tldw_Server_API.app.core.MCP_unified.interfaces.runtime"
+    )
+    assert host_runtime.MCPRuntimeDependencies is package_runtime.MCPRuntimeDependencies
+    assert host_runtime.ModuleRegistry is package_runtime.ModuleRegistry
+
+
+def test_profile_defaults_are_safe_and_preserve_extension_metadata() -> None:
+    from mcp_unified.profiles.models import MCPProfile
+
+    profile = MCPProfile(
+        id="architect",
+        name="Architect",
+        metadata={"agent_metadata": {"system_prompt": "review architecture"}},
+    )
+
+    assert profile.enabled is True
+    assert profile.policy_document.allowed_tools == []
+    assert profile.policy_document.capabilities == []
+    assert profile.credential_grants == []
+    assert profile.external_server_grants == []
+    assert profile.metadata["agent_metadata"]["system_prompt"] == "review architecture"
+```
+
+- [x] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v
+```
+
+Expected: FAIL because `mcp_unified` does not exist.
+
+## Task 2: Create Runtime-Neutral Package Contracts
+
+**Files:**
+- Create: `mcp_unified/__init__.py`
+- Create: `mcp_unified/interfaces/__init__.py`
+- Create: `mcp_unified/interfaces/policy.py`
+- Create: `mcp_unified/interfaces/runtime.py`
+- Create: `mcp_unified/interfaces/storage.py`
+- Create: `mcp_unified/profiles/__init__.py`
+- Create: `mcp_unified/profiles/models.py`
+- Create: `mcp_unified/profiles/resolver.py`
+
+- [x] **Step 1: Create `mcp_unified/__init__.py`**
+
+Expose only stable, neutral package metadata:
+
+```python
+"""Standalone MCP Unified runtime package boundary."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"
+```
+
+- [x] **Step 2: Copy neutral interface contracts**
+
+Create `mcp_unified/interfaces/policy.py`, `runtime.py`, and `storage.py` from the current Stage 1 interface contents. Keep these files free of `tldw_Server_API` imports.
+
+- [x] **Step 3: Export interface contracts**
+
+Create `mcp_unified/interfaces/__init__.py` that exports:
+
+```python
+from .policy import (
+    ApprovalEvaluator,
+    EffectivePolicyResolver,
+    ExternalAccessEvaluator,
+    PathScopeEnforcer,
+)
+from .runtime import (
+    ApiKeyScopeNormalizer,
+    CircuitBreakerFactory,
+    DatabasePathResolver,
+    MCPRuntimeDependencies,
+    MetricsCollector,
+    ModuleRegistry,
+    RateLimiter,
+    RbacPolicy,
+    RedisClientFactory,
+    TelemetryProvider,
+)
+from .storage import AuditStore, ExternalRegistryStore, ProfileStore
+```
+
+- [x] **Step 4: Add profile models**
+
+Create `mcp_unified/profiles/models.py` with Pydantic models for the profile fields in the spec. Use safe defaults:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ProfilePolicy(BaseModel):
+    allowed_tools: list[str] = Field(default_factory=list)
+    denied_tools: list[str] = Field(default_factory=list)
+    capabilities: list[str] = Field(default_factory=list)
+    denied_capabilities: list[str] = Field(default_factory=list)
+    tool_patterns: list[str] = Field(default_factory=list)
+    module_patterns: list[str] = Field(default_factory=list)
+    risk_classes: list[str] = Field(default_factory=list)
+    resource_constraints: dict[str, Any] = Field(default_factory=dict)
+
+
+class MCPProfile(BaseModel):
+    id: str
+    name: str
+    description: str = ""
+    schema_version: int = 1
+    preset_id: str | None = None
+    preset_version: str | None = None
+    enabled: bool = True
+    policy_document: ProfilePolicy = Field(default_factory=ProfilePolicy)
+    approval_policy: dict[str, Any] = Field(default_factory=dict)
+    path_scopes: list[dict[str, Any]] = Field(default_factory=list)
+    external_server_grants: list[dict[str, Any]] = Field(default_factory=list)
+    credential_grants: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+```
+
+- [x] **Step 5: Add resolver/store protocols**
+
+Create `mcp_unified/profiles/resolver.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Protocol
+
+from .models import MCPProfile
+
+
+class ProfileResolver(Protocol):
+    async def resolve_profile(self, profile_id: str | None, *, user_id: str | None = None) -> MCPProfile | None: ...
+```
+
+- [x] **Step 6: Export profile primitives**
+
+Create `mcp_unified/profiles/__init__.py` that exports `MCPProfile`, `ProfilePolicy`, and `ProfileResolver`.
+
+- [x] **Step 7: Run package boundary test**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_runtime_package_boundary_has_no_tldw_server_imports -v
+```
+
+Expected: PASS.
+
+## Task 3: Convert Host Interfaces To Compatibility Shims
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/interfaces/policy.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/interfaces/runtime.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/interfaces/storage.py`
+- Modify: `pyproject.toml`
+
+- [x] **Step 1: Replace host interface definitions with package re-exports**
+
+Each host interface module should import and re-export the matching `mcp_unified.interfaces` contracts. Example for `runtime.py`:
+
+```python
+"""Compatibility re-exports for MCP Unified runtime interfaces."""
+
+from mcp_unified.interfaces.runtime import (
+    ApiKeyScopeNormalizer,
+    CircuitBreakerFactory,
+    DatabasePathResolver,
+    MCPRuntimeDependencies,
+    MetricsCollector,
+    ModuleRegistry,
+    RateLimiter,
+    RbacPolicy,
+    RedisClientFactory,
+    TelemetryProvider,
+)
+
+__all__ = [...]
+```
+
+- [x] **Step 2: Update setuptools package discovery**
+
+In `pyproject.toml`, update `[tool.setuptools.packages.find] include` to include the new package:
+
+```toml
+include = ["tldw_Server_API", "tldw_Server_API.*", "mcp_unified", "mcp_unified.*"]
+```
+
+- [x] **Step 3: Run shim identity test**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_host_interface_shims_reexport_package_contracts -v
+```
+
+Expected: PASS.
+
+- [x] **Step 4: Run Stage 1 extraction contracts**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -v
+```
+
+Expected: PASS.
+
+## Task 4: Verify, Record, And Commit The Stage 2 Slice
+
+**Files:**
+- Modify: `backlog/tasks/task-518 - Implement-MCP-Unified-Stage-2-runtime-neutral-package-boundary.md`
+
+- [x] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run Bandit on touched package and interface code**
+
+Run:
+
+```bash
+python -m bandit -r \
+  mcp_unified \
+  tldw_Server_API/app/core/MCP_unified/interfaces \
+  -f json -o /tmp/bandit_mcp_unified_stage2_package_boundary.json
+```
+
+Expected: 0 findings.
+
+- [x] **Step 3: Update Backlog task**
+
+Record:
+
+- implementation plan path
+- modified files
+- test commands and results
+- Bandit result
+- any known skips or blockers
+
+- [x] **Step 4: Commit**
+
+Run:
+
+```bash
+git add \
+  pyproject.toml \
+  mcp_unified \
+  tldw_Server_API/app/core/MCP_unified/interfaces \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  Docs/superpowers/plans/2026-05-27-mcp-unified-stage2-package-boundary-implementation-plan.md \
+  "backlog/tasks/task-518 - Implement-MCP-Unified-Stage-2-runtime-neutral-package-boundary.md"
+git commit -m "feat: add mcp unified package boundary"
+```
+
+## Final Verification Before PR
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  -v
+```
+
+Run:
+
+```bash
+python -m bandit -r \
+  mcp_unified \
+  tldw_Server_API/app/core/MCP_unified/interfaces \
+  -f json -o /tmp/bandit_mcp_unified_stage2_package_boundary.json
+```
+
+Expected:
+
+- Package boundary tests pass.
+- Stage 1 extraction contracts still pass.
+- Basic MCP functionality still passes.
+- Bandit reports 0 findings.
+- `TASK-518` contains final verification notes.

--- a/backlog/tasks/task-518 - Implement-MCP-Unified-Stage-2-runtime-neutral-package-boundary.md
+++ b/backlog/tasks/task-518 - Implement-MCP-Unified-Stage-2-runtime-neutral-package-boundary.md
@@ -4,7 +4,7 @@ title: Implement MCP Unified Stage 2 runtime-neutral package boundary
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-05-27 04:59'
+updated_date: '2026-05-27 05:21'
 labels:
   - mcp
   - mcp-unified
@@ -50,12 +50,30 @@ Verification:
 - git diff --check -> clean
 
 Known skips/blockers: none for this slice.
+
+Review-fix pass after PR #2077 feedback:
+- Rebased on latest origin/dev; branch was already current.
+- Made package-boundary test resolve mcp_unified from the imported package path instead of cwd.
+- Preserved profile and policy extension fields with Pydantic extra=allow.
+- Coerced explicit null list/dict profile fields to safe empty defaults.
+- Enforced aware profile timestamps and added naive timestamp rejection coverage.
+- Included MCP_unified tests in pytest discovery and mcp_unified in Ruff/Mypy target config.
+- Kept RbacPolicy sync-or-async because current protocol consumers support both and legacy in-memory RBAC is synchronous while AuthNZ RBAC is asynchronous.
+
+Review-fix verification:
+- python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py -v -> 31 passed, 5 warnings
+- python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -> passed
+- python -m mypy mcp_unified --config-file pyproject.toml -> passed
+- python -m bandit -r mcp_unified tldw_Server_API/app/core/MCP_unified/interfaces -f json -o bandit_mcp_unified_stage2_package_boundary.json -> 0 findings
+- git diff --check -> clean
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Created the first runtime-neutral mcp_unified package boundary with host-neutral interface contracts and profile primitives. Converted the in-repo MCP Unified interface modules into compatibility re-export shims so existing imports keep working while the new package contracts become the canonical definitions. Updated package discovery and added focused boundary coverage for package isolation, shim identity, and safe profile defaults.
+
+Review-fix follow-up addressed PR feedback for cwd-independent boundary tests, extension-preserving profile models, null-safe profile defaults, aware timestamp validation, pytest discovery, and mcp_unified Ruff/Mypy coverage. The RBAC protocol remains sync-or-async by design because existing host implementations use both shapes and protocol consumers already normalize them.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-518 - Implement-MCP-Unified-Stage-2-runtime-neutral-package-boundary.md
+++ b/backlog/tasks/task-518 - Implement-MCP-Unified-Stage-2-runtime-neutral-package-boundary.md
@@ -1,0 +1,69 @@
+---
+id: TASK-518
+title: Implement MCP Unified Stage 2 runtime-neutral package boundary
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-27 04:59'
+labels:
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage2
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-27-mcp-unified-stage2-package-boundary-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Top-level mcp_unified package is included by package discovery.
+- [x] #2 Runtime-neutral interface contracts are available under mcp_unified.interfaces without tldw_Server_API imports.
+- [x] #3 Existing tldw_Server_API.app.core.MCP_unified.interfaces imports remain compatibility shims to the same package contracts.
+- [x] #4 Profile schema and resolver primitives are available under mcp_unified.profiles with safe defaults.
+- [x] #5 Focused MCP boundary, extraction, and basic functionality tests pass.
+- [x] #6 Bandit reports no findings for touched package/interface code.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-27-mcp-unified-stage2-package-boundary-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Stage 2 package-boundary slice from Docs/superpowers/plans/2026-05-27-mcp-unified-stage2-package-boundary-implementation-plan.md.
+
+Verification:
+- python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py -v -> 30 passed, 5 warnings
+- python -m bandit -r mcp_unified tldw_Server_API/app/core/MCP_unified/interfaces -f json -o bandit_mcp_unified_stage2_package_boundary.json -> 0 findings
+- git diff --check -> clean
+
+Known skips/blockers: none for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the first runtime-neutral mcp_unified package boundary with host-neutral interface contracts and profile primitives. Converted the in-repo MCP Unified interface modules into compatibility re-export shims so existing imports keep working while the new package contracts become the canonical definitions. Updated package discovery and added focused boundary coverage for package isolation, shim identity, and safe profile defaults.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/__init__.py
+++ b/mcp_unified/__init__.py
@@ -1,0 +1,5 @@
+"""Standalone MCP Unified runtime package boundary."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/mcp_unified/interfaces/__init__.py
+++ b/mcp_unified/interfaces/__init__.py
@@ -1,6 +1,12 @@
-"""Compatibility re-exports for MCP Unified runtime interfaces."""
+"""Host-neutral MCP Unified interface contracts."""
 
-from mcp_unified.interfaces.runtime import (
+from .policy import (
+    ApprovalEvaluator,
+    EffectivePolicyResolver,
+    ExternalAccessEvaluator,
+    PathScopeEnforcer,
+)
+from .runtime import (
     ApiKeyScopeNormalizer,
     CircuitBreakerFactory,
     DatabasePathResolver,
@@ -12,14 +18,22 @@ from mcp_unified.interfaces.runtime import (
     RedisClientFactory,
     TelemetryProvider,
 )
+from .storage import AuditStore, ExternalRegistryStore, ProfileStore
 
 __all__ = [
     "ApiKeyScopeNormalizer",
+    "ApprovalEvaluator",
+    "AuditStore",
     "CircuitBreakerFactory",
     "DatabasePathResolver",
+    "EffectivePolicyResolver",
+    "ExternalAccessEvaluator",
+    "ExternalRegistryStore",
     "MCPRuntimeDependencies",
     "MetricsCollector",
     "ModuleRegistry",
+    "PathScopeEnforcer",
+    "ProfileStore",
     "RateLimiter",
     "RbacPolicy",
     "RedisClientFactory",

--- a/mcp_unified/interfaces/policy.py
+++ b/mcp_unified/interfaces/policy.py
@@ -1,0 +1,60 @@
+"""Policy dependency protocols for MCP governance integrations."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class EffectivePolicyResolver(Protocol):
+    """Resolve policy documents that apply to an MCP request context."""
+
+    async def resolve_for_context(
+        self,
+        *,
+        user_id: str | None,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any] | None: ...
+
+
+class ApprovalEvaluator(Protocol):
+    """Evaluate whether a tool call is allowed, denied, or needs approval."""
+
+    async def evaluate_tool_call(
+        self,
+        *,
+        effective_policy: dict[str, Any],
+        tool_name: str,
+        tool_args: Any,
+        context: Any,
+        tool_def: dict[str, Any] | None,
+        is_write: bool | None,
+        within_effective_policy: bool,
+        force_approval: bool = False,
+        approval_reason: str | None = None,
+        scope_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+
+
+class PathScopeEnforcer(Protocol):
+    """Enforce filesystem and resource path scopes for MCP tool calls."""
+
+    async def evaluate_tool_call(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        context: Any,
+        tool_name: str,
+        tool_args: Any,
+        tool_def: dict[str, Any] | None,
+    ) -> dict[str, Any]: ...
+
+
+class ExternalAccessEvaluator(Protocol):
+    """Evaluate external server/source access against effective policy."""
+
+    async def resolve_for_sources(
+        self,
+        *,
+        sources: list[dict[str, Any]],
+        effective_policy: dict[str, Any],
+    ) -> dict[str, Any]: ...

--- a/mcp_unified/interfaces/runtime.py
+++ b/mcp_unified/interfaces/runtime.py
@@ -1,0 +1,171 @@
+"""Runtime dependency protocols for the MCP Unified package boundary.
+
+These protocols describe the services MCP Unified needs without importing a
+host application. Embedders can satisfy them with local implementations, while
+`tldw_server` re-exports the same contracts through its compatibility shims.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .policy import (
+    ApprovalEvaluator,
+    EffectivePolicyResolver,
+    ExternalAccessEvaluator,
+    PathScopeEnforcer,
+)
+
+
+class ModuleRegistry(Protocol):
+    """Registry operations needed by protocol and server request routing."""
+
+    async def start_health_monitoring(self) -> Any: ...
+
+    async def register_module(
+        self,
+        module_id: str,
+        module_type: type[Any],
+        config: Any,
+    ) -> None: ...
+
+    async def get_module(self, module_id: str) -> Any | None: ...
+
+    async def get_all_modules(self) -> dict[str, Any]: ...
+
+    async def find_module_for_tool(self, tool_name: str) -> Any | None: ...
+
+    def get_module_id_for_tool(self, tool_name: str) -> str | None: ...
+
+    async def find_module_for_resource(self, uri: str) -> Any | None: ...
+
+    def get_module_id_for_resource(self, uri: str) -> str | None: ...
+
+    async def find_module_for_prompt(self, name: str) -> Any | None: ...
+
+    def get_module_id_for_prompt(self, name: str) -> str | None: ...
+
+    async def check_all_health(self) -> dict[str, Any]: ...
+
+    async def get_module_status(self, module_id: str) -> dict[str, Any] | None: ...
+
+    async def list_registrations(self) -> list[dict[str, Any]]: ...
+
+    async def shutdown_all(self) -> None: ...
+
+
+class RbacPolicy(Protocol):
+    """RBAC permission checker used for MCP resource and tool access."""
+
+    def check_permission(
+        self,
+        user_id: str | None,
+        resource: Any,
+        action: Any,
+        resource_id: str | None = None,
+    ) -> bool | Awaitable[bool]: ...
+
+
+class RateLimiter(Protocol):
+    """Rate-limit gate for MCP protocol operations."""
+
+    async def check_rate_limit(self, key: str, *, category: str = "default") -> None: ...
+
+
+class MetricsCollector(Protocol):
+    """Metrics sink used by MCP protocol and server lifecycle paths."""
+
+    async def start_collection(self) -> None: ...
+
+    async def stop_collection(self) -> None: ...
+
+    def record_request(
+        self,
+        method: str,
+        duration: float,
+        status: str = "success",
+        labels: dict[str, str] | None = None,
+    ) -> None: ...
+
+    def record_module_operation(
+        self,
+        module: str,
+        operation: str,
+        duration: float,
+        success: bool,
+    ) -> None: ...
+
+    def update_connection_count(self, connection_type: str, count: int) -> None: ...
+
+    def record_connection_error(self, connection_type: str, error: str) -> None: ...
+
+    def record_ws_session_closure(self, reason: str) -> None: ...
+
+    def record_ws_rejection(self, reason: str, ip_bucket: str = "unknown") -> None: ...
+
+    def record_rate_limit_hit(self, key_type: str = "user") -> None: ...
+
+    def record_idempotency_hit(self, module: str, tool: str) -> None: ...
+
+    def record_idempotency_miss(self, module: str, tool: str) -> None: ...
+
+    def record_governance_check(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def record_tool_invalid_params(self, module: str, tool: str) -> None: ...
+
+    def record_tool_validator_missing(self, module: str, tool: str) -> None: ...
+
+
+class TelemetryProvider(Protocol):
+    """Tracing provider that yields span-like context managers."""
+
+    def trace_context(
+        self,
+        operation_name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> Any: ...
+
+
+class DatabasePathResolver(Protocol):
+    """Resolver for per-user database paths visible to MCP modules."""
+
+    def resolve_user_db_paths(self, user_id: str | int | None) -> dict[str, str]: ...
+
+
+class ApiKeyScopeNormalizer(Protocol):
+    """Normalizer for API-key scope payloads from a host auth layer."""
+
+    def normalize(self, raw_scopes: Any) -> set[str]: ...
+
+
+class RedisClientFactory(Protocol):
+    """Factory for creating Redis-compatible async clients."""
+
+    def __call__(self, **kwargs: Any) -> Awaitable[Any]: ...
+
+
+class CircuitBreakerFactory(Protocol):
+    """Factory for creating module circuit breakers from neutral configs."""
+
+    def __call__(self, *, name: str, config: Any) -> Any: ...
+
+
+@dataclass(slots=True)
+class MCPRuntimeDependencies:
+    """Concrete dependency bundle passed into MCP runtime components."""
+
+    module_registry: ModuleRegistry
+    rbac_policy: RbacPolicy
+    rate_limiter: RateLimiter
+    metrics_collector: MetricsCollector
+    telemetry_provider: TelemetryProvider
+    database_path_resolver: DatabasePathResolver
+    api_key_scope_normalizer: ApiKeyScopeNormalizer
+    effective_policy_resolver: EffectivePolicyResolver
+    approval_evaluator: ApprovalEvaluator
+    path_scope_enforcer: PathScopeEnforcer
+    external_access_evaluator: ExternalAccessEvaluator
+    redis_client_factory: RedisClientFactory
+    circuit_breaker_factory: CircuitBreakerFactory

--- a/mcp_unified/interfaces/runtime.py
+++ b/mcp_unified/interfaces/runtime.py
@@ -57,7 +57,11 @@ class ModuleRegistry(Protocol):
 
 
 class RbacPolicy(Protocol):
-    """RBAC permission checker used for MCP resource and tool access."""
+    """RBAC permission checker used for MCP resource and tool access.
+
+    Hosts may provide synchronous in-memory checks or asynchronous database-backed
+    checks; protocol consumers normalize either result shape.
+    """
 
     def check_permission(
         self,

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -1,0 +1,23 @@
+"""Storage protocols for standalone MCP profile and registry stores."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class ProfileStore(Protocol):
+    """Store for named MCP tool and permission profiles."""
+
+    async def get_profile(self, profile_id: str) -> dict[str, Any] | None: ...
+
+
+class ExternalRegistryStore(Protocol):
+    """Store for external MCP server registry entries."""
+
+    async def list_servers(self) -> list[dict[str, Any]]: ...
+
+
+class AuditStore(Protocol):
+    """Append-only audit sink for MCP policy and tool events."""
+
+    async def append_event(self, event: dict[str, Any]) -> None: ...

--- a/mcp_unified/profiles/__init__.py
+++ b/mcp_unified/profiles/__init__.py
@@ -1,0 +1,6 @@
+"""Profile schema and resolver primitives for MCP Unified."""
+
+from .models import MCPProfile, ProfilePolicy
+from .resolver import ProfileResolver
+
+__all__ = ["MCPProfile", "ProfilePolicy", "ProfileResolver"]

--- a/mcp_unified/profiles/models.py
+++ b/mcp_unified/profiles/models.py
@@ -1,0 +1,47 @@
+"""Profile models for MCP tool and permission presets."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _utc_now() -> datetime:
+    """Return an aware UTC timestamp for profile metadata defaults."""
+    return datetime.now(timezone.utc)
+
+
+class ProfilePolicy(BaseModel):
+    """Enforceable tool and capability policy for an MCP profile."""
+
+    allowed_tools: list[str] = Field(default_factory=list)
+    denied_tools: list[str] = Field(default_factory=list)
+    capabilities: list[str] = Field(default_factory=list)
+    denied_capabilities: list[str] = Field(default_factory=list)
+    tool_patterns: list[str] = Field(default_factory=list)
+    module_patterns: list[str] = Field(default_factory=list)
+    risk_classes: list[str] = Field(default_factory=list)
+    resource_constraints: dict[str, Any] = Field(default_factory=dict)
+
+
+class MCPProfile(BaseModel):
+    """User-selectable MCP profile that defines an enforceable action boundary."""
+
+    id: str
+    name: str
+    description: str = ""
+    schema_version: int = 1
+    preset_id: str | None = None
+    preset_version: str | None = None
+    enabled: bool = True
+    policy_document: ProfilePolicy = Field(default_factory=ProfilePolicy)
+    approval_policy: dict[str, Any] = Field(default_factory=dict)
+    path_scopes: list[dict[str, Any]] = Field(default_factory=list)
+    external_server_grants: list[dict[str, Any]] = Field(default_factory=list)
+    credential_grants: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)

--- a/mcp_unified/profiles/models.py
+++ b/mcp_unified/profiles/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
 
 
 def _utc_now() -> datetime:
@@ -16,6 +16,8 @@ def _utc_now() -> datetime:
 class ProfilePolicy(BaseModel):
     """Enforceable tool and capability policy for an MCP profile."""
 
+    model_config = ConfigDict(extra="allow")
+
     allowed_tools: list[str] = Field(default_factory=list)
     denied_tools: list[str] = Field(default_factory=list)
     capabilities: list[str] = Field(default_factory=list)
@@ -25,9 +27,32 @@ class ProfilePolicy(BaseModel):
     risk_classes: list[str] = Field(default_factory=list)
     resource_constraints: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator(
+        "allowed_tools",
+        "denied_tools",
+        "capabilities",
+        "denied_capabilities",
+        "tool_patterns",
+        "module_patterns",
+        "risk_classes",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_none_to_list(cls, value: Any) -> Any:
+        """Treat explicit null list fields as omitted safe defaults."""
+        return [] if value is None else value
+
+    @field_validator("resource_constraints", mode="before")
+    @classmethod
+    def _coerce_none_to_dict(cls, value: Any) -> Any:
+        """Treat explicit null mapping fields as omitted safe defaults."""
+        return {} if value is None else value
+
 
 class MCPProfile(BaseModel):
     """User-selectable MCP profile that defines an enforceable action boundary."""
+
+    model_config = ConfigDict(extra="allow")
 
     id: str
     name: str
@@ -43,5 +68,33 @@ class MCPProfile(BaseModel):
     credential_grants: list[dict[str, Any]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
     provenance: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=_utc_now)
-    updated_at: datetime = Field(default_factory=_utc_now)
+    created_at: AwareDatetime = Field(default_factory=_utc_now)
+    updated_at: AwareDatetime = Field(default_factory=_utc_now)
+
+    @field_validator("policy_document", mode="before")
+    @classmethod
+    def _coerce_none_to_policy(cls, value: Any) -> Any:
+        """Treat an explicit null policy as the empty safe policy."""
+        return {} if value is None else value
+
+    @field_validator(
+        "path_scopes",
+        "external_server_grants",
+        "credential_grants",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_none_to_list(cls, value: Any) -> Any:
+        """Treat explicit null list fields as omitted safe defaults."""
+        return [] if value is None else value
+
+    @field_validator(
+        "approval_policy",
+        "metadata",
+        "provenance",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_none_to_dict(cls, value: Any) -> Any:
+        """Treat explicit null mapping fields as omitted safe defaults."""
+        return {} if value is None else value

--- a/mcp_unified/profiles/resolver.py
+++ b/mcp_unified/profiles/resolver.py
@@ -1,0 +1,18 @@
+"""Profile resolution contracts for MCP Unified hosts and gateways."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .models import MCPProfile
+
+
+class ProfileResolver(Protocol):
+    """Resolve an effective MCP profile for a request principal."""
+
+    async def resolve_profile(
+        self,
+        profile_id: str | None,
+        *,
+        user_id: str | None = None,
+    ) -> MCPProfile | None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -630,7 +630,7 @@ markers = [
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-testpaths = ["tldw_Server_API/tests"]
+testpaths = ["tldw_Server_API/tests", "tldw_Server_API/app/core/MCP_unified/tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
@@ -690,7 +690,7 @@ extend-exclude = '''
 [tool.ruff]
 line-length = 120
 target-version = "py39"
-src = ["tldw_Server_API"]
+src = ["tldw_Server_API", "mcp_unified"]
 extend-include = ["*.ipynb"]
 exclude = [
   "migrations",
@@ -1823,7 +1823,7 @@ warn_no_return = true
 follow_imports = "silent"
 show_error_codes = true
 strict_equality = true
-files = ["tldw_Server_API"]
+files = ["tldw_Server_API", "mcp_unified"]
 exclude = [
     "tests",
     "migrations",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -514,7 +514,7 @@ include-package-data = false
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["tldw_Server_API", "tldw_Server_API.*"]
+include = ["tldw_Server_API", "tldw_Server_API.*", "mcp_unified", "mcp_unified.*"]
 namespaces = false
 exclude = [
   "tests*",

--- a/tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py
+++ b/tldw_Server_API/app/core/MCP_unified/interfaces/__init__.py
@@ -1,24 +1,24 @@
-from __future__ import annotations
+"""Compatibility re-exports for MCP Unified interface contracts."""
 
-from .policy import (
-    ApprovalEvaluator,
-    EffectivePolicyResolver,
-    ExternalAccessEvaluator,
-    PathScopeEnforcer,
-)
-from .runtime import (
+from mcp_unified.interfaces import (
     ApiKeyScopeNormalizer,
+    ApprovalEvaluator,
+    AuditStore,
     CircuitBreakerFactory,
     DatabasePathResolver,
+    EffectivePolicyResolver,
+    ExternalAccessEvaluator,
+    ExternalRegistryStore,
     MCPRuntimeDependencies,
     MetricsCollector,
     ModuleRegistry,
+    PathScopeEnforcer,
+    ProfileStore,
     RateLimiter,
     RbacPolicy,
     RedisClientFactory,
     TelemetryProvider,
 )
-from .storage import AuditStore, ExternalRegistryStore, ProfileStore
 
 __all__ = [
     "ApiKeyScopeNormalizer",

--- a/tldw_Server_API/app/core/MCP_unified/interfaces/policy.py
+++ b/tldw_Server_API/app/core/MCP_unified/interfaces/policy.py
@@ -1,60 +1,15 @@
-"""Policy dependency protocols for MCP Hub governance integration."""
+"""Compatibility re-exports for MCP Unified policy interfaces."""
 
-from __future__ import annotations
+from mcp_unified.interfaces.policy import (
+    ApprovalEvaluator,
+    EffectivePolicyResolver,
+    ExternalAccessEvaluator,
+    PathScopeEnforcer,
+)
 
-from typing import Any, Protocol
-
-
-class EffectivePolicyResolver(Protocol):
-    """Resolve policy documents that apply to an MCP request context."""
-
-    async def resolve_for_context(
-        self,
-        *,
-        user_id: str | None,
-        metadata: dict[str, Any],
-    ) -> dict[str, Any] | None: ...
-
-
-class ApprovalEvaluator(Protocol):
-    """Evaluate whether a tool call is allowed, denied, or needs approval."""
-
-    async def evaluate_tool_call(
-        self,
-        *,
-        effective_policy: dict[str, Any],
-        tool_name: str,
-        tool_args: Any,
-        context: Any,
-        tool_def: dict[str, Any] | None,
-        is_write: bool | None,
-        within_effective_policy: bool,
-        force_approval: bool = False,
-        approval_reason: str | None = None,
-        scope_payload: dict[str, Any] | None = None,
-    ) -> dict[str, Any]: ...
-
-
-class PathScopeEnforcer(Protocol):
-    """Enforce filesystem and resource path scopes for MCP tool calls."""
-
-    async def evaluate_tool_call(
-        self,
-        *,
-        effective_policy: dict[str, Any] | None,
-        context: Any,
-        tool_name: str,
-        tool_args: Any,
-        tool_def: dict[str, Any] | None,
-    ) -> dict[str, Any]: ...
-
-
-class ExternalAccessEvaluator(Protocol):
-    """Evaluate external server/source access against effective policy."""
-
-    async def resolve_for_sources(
-        self,
-        *,
-        sources: list[dict[str, Any]],
-        effective_policy: dict[str, Any],
-    ) -> dict[str, Any]: ...
+__all__ = [
+    "ApprovalEvaluator",
+    "EffectivePolicyResolver",
+    "ExternalAccessEvaluator",
+    "PathScopeEnforcer",
+]

--- a/tldw_Server_API/app/core/MCP_unified/interfaces/storage.py
+++ b/tldw_Server_API/app/core/MCP_unified/interfaces/storage.py
@@ -1,23 +1,5 @@
-"""Storage protocols reserved for standalone MCP profile and registry stores."""
+"""Compatibility re-exports for MCP Unified storage interfaces."""
 
-from __future__ import annotations
+from mcp_unified.interfaces.storage import AuditStore, ExternalRegistryStore, ProfileStore
 
-from typing import Any, Protocol
-
-
-class ProfileStore(Protocol):
-    """Store for named MCP tool and permission profiles."""
-
-    async def get_profile(self, profile_id: str) -> dict[str, Any] | None: ...
-
-
-class ExternalRegistryStore(Protocol):
-    """Store for external MCP server registry entries."""
-
-    async def list_servers(self) -> list[dict[str, Any]]: ...
-
-
-class AuditStore(Protocol):
-    """Append-only audit sink for MCP policy and tool events."""
-
-    async def append_event(self, event: dict[str, Any]) -> None: ...
+__all__ = ["AuditStore", "ExternalRegistryStore", "ProfileStore"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import ast
 import importlib
+from datetime import datetime
 from pathlib import Path
 
+import mcp_unified
+import pytest
+from pydantic import ValidationError
 
-PACKAGE_ROOT = Path("mcp_unified")
+PACKAGE_ROOT = Path(mcp_unified.__file__).resolve().parent
 
 
 def _tldw_imports_for(path: Path) -> list[str]:
@@ -60,12 +64,38 @@ def test_profile_defaults_are_safe_and_preserve_extension_metadata() -> None:
     profile = MCPProfile(
         id="architect",
         name="Architect",
+        approval_policy=None,
+        path_scopes=None,
+        external_server_grants=None,
+        credential_grants=None,
+        policy_document={
+            "allowed_tools": None,
+            "capabilities": None,
+            "resource_constraints": None,
+            "policy_extension": {"level": "experimental"},
+        },
         metadata={"agent_metadata": {"system_prompt": "review architecture"}},
+        profile_extension={"owner": "frontend"},
     )
 
     assert profile.enabled is True
     assert profile.policy_document.allowed_tools == []
     assert profile.policy_document.capabilities == []
+    assert profile.policy_document.resource_constraints == {}
     assert profile.credential_grants == []
     assert profile.external_server_grants == []
     assert profile.metadata["agent_metadata"]["system_prompt"] == "review architecture"
+    dumped = profile.model_dump()
+    assert dumped["profile_extension"] == {"owner": "frontend"}
+    assert dumped["policy_document"]["policy_extension"] == {"level": "experimental"}
+
+
+def test_profile_rejects_naive_timestamps() -> None:
+    from mcp_unified.profiles.models import MCPProfile
+
+    with pytest.raises(ValidationError):
+        MCPProfile(
+            id="architect",
+            name="Architect",
+            created_at=datetime(2026, 5, 27, 5, 0, 0),
+        )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path("mcp_unified")
+
+
+def _tldw_imports_for(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "tldw_Server_API"
+                or alias.name.startswith("tldw_Server_API.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "tldw_Server_API" or node.module.startswith("tldw_Server_API."):
+                imports.append(node.module)
+    return imports
+
+
+def test_runtime_package_boundary_has_no_tldw_server_imports() -> None:
+    assert PACKAGE_ROOT.exists()
+    offenders: dict[str, list[str]] = {}
+    for path in PACKAGE_ROOT.rglob("*.py"):
+        imports = _tldw_imports_for(path)
+        if imports:
+            offenders[str(path)] = imports
+    assert offenders == {}
+
+
+def test_host_interface_shims_reexport_package_contracts() -> None:
+    package_policy = importlib.import_module("mcp_unified.interfaces.policy")
+    package_runtime = importlib.import_module("mcp_unified.interfaces.runtime")
+    package_storage = importlib.import_module("mcp_unified.interfaces.storage")
+    host_policy = importlib.import_module(
+        "tldw_Server_API.app.core.MCP_unified.interfaces.policy"
+    )
+    host_runtime = importlib.import_module(
+        "tldw_Server_API.app.core.MCP_unified.interfaces.runtime"
+    )
+    host_storage = importlib.import_module(
+        "tldw_Server_API.app.core.MCP_unified.interfaces.storage"
+    )
+    assert host_policy.ApprovalEvaluator is package_policy.ApprovalEvaluator
+    assert host_runtime.MCPRuntimeDependencies is package_runtime.MCPRuntimeDependencies
+    assert host_runtime.ModuleRegistry is package_runtime.ModuleRegistry
+    assert host_storage.ProfileStore is package_storage.ProfileStore
+
+
+def test_profile_defaults_are_safe_and_preserve_extension_metadata() -> None:
+    from mcp_unified.profiles.models import MCPProfile
+
+    profile = MCPProfile(
+        id="architect",
+        name="Architect",
+        metadata={"agent_metadata": {"system_prompt": "review architecture"}},
+    )
+
+    assert profile.enabled is True
+    assert profile.policy_document.allowed_tools == []
+    assert profile.policy_document.capabilities == []
+    assert profile.credential_grants == []
+    assert profile.external_server_grants == []
+    assert profile.metadata["agent_metadata"]["system_prompt"] == "review architecture"


### PR DESCRIPTION
## Summary
- Adds a top-level `mcp_unified` package containing host-neutral interface contracts and profile primitives.
- Converts existing `tldw_Server_API.app.core.MCP_unified.interfaces` modules into compatibility re-export shims.
- Adds focused package-boundary tests for package isolation, shim identity, and safe profile defaults.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py -v`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified tldw_Server_API/app/core/MCP_unified/interfaces -f json -o /tmp/bandit_mcp_unified_stage2_package_boundary.json`
- [x] `git diff --check`

## Change summary
Pending human-owned summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Backlog: TASK-518

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creates a runtime-neutral `mcp_unified` package and converts host interfaces to compatibility re-exports so existing `tldw_Server_API` imports keep working. Adds safe, extensible profile models and boundary tests; enables standalone embedding and completes TASK-518.

- **New Features**
  - Added `mcp_unified` with host-neutral interfaces: `interfaces.runtime`, `interfaces.policy`, `interfaces.storage`.
  - Added profile primitives: `MCPProfile`, `ProfilePolicy`, `ProfileResolver`; preserve extension fields, coerce None to safe defaults, and enforce aware timestamps.
  - Converted `tldw_Server_API.app.core.MCP_unified.interfaces.*` to re-export shims of the new contracts.
  - Added boundary tests for package isolation, shim identity, safe defaults, and naive timestamp rejection; tests locate the package via import (cwd-independent).
  - Updated `pyproject.toml` to include `mcp_unified` in package discovery, pytest testpaths, and Ruff/Mypy targets.
  - Verified with focused pytest and Bandit (0 findings).

<sup>Written for commit 20d615c9097a4c2f8b8febe7c700625f8b39085b. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2077?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

