### PR TITLE
Add flashcards extension generate handoff

### DIFF
--- a/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,22 +32,24 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find a useful passage while browsing and want to save one editable basic flashcard without leaving the sidepanel.
+Use this path when you find useful passages while browsing and want to save editable basic flashcards without leaving the sidepanel, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
 1. Select text on the source page.
 2. Open the extension sidepanel and choose `Flashcards`.
-3. Choose `Capture page selection`.
-4. Select a deck, edit `Front` and `Back`, then choose `Save card`.
-5. Use `Open full Flashcards` for generation, imports, templates, review, or broader deck management.
+3. Choose `Capture page selection` to add the selection to the sidepanel draft queue.
+4. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
+5. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
+6. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
 
 Important behavior:
 
-- The sidepanel Flashcards route saves one basic card at a time and keeps the source page URL as provenance.
+- The sidepanel Flashcards route saves queued basic-card drafts and keeps the source page URL as provenance.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
-- Use the context-menu path or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of a single captured card.
+- Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of native sidepanel basic-card drafts.
+- Native sidepanel generation templates and in-sidepanel review remain deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,22 +32,24 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find a useful passage while browsing and want to save one editable basic flashcard without leaving the sidepanel.
+Use this path when you find useful passages while browsing and want to save editable basic flashcards without leaving the sidepanel, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
 1. Select text on the source page.
 2. Open the extension sidepanel and choose `Flashcards`.
-3. Choose `Capture page selection`.
-4. Select a deck, edit `Front` and `Back`, then choose `Save card`.
-5. Use `Open full Flashcards` for generation, imports, templates, review, or broader deck management.
+3. Choose `Capture page selection` to add the selection to the sidepanel draft queue.
+4. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
+5. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
+6. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
 
 Important behavior:
 
-- The sidepanel Flashcards route saves one basic card at a time and keeps the source page URL as provenance.
+- The sidepanel Flashcards route saves queued basic-card drafts and keeps the source page URL as provenance.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
-- Use the context-menu path or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of a single captured card.
+- Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of native sidepanel basic-card drafts.
+- Native sidepanel generation templates and in-sidepanel review remain deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-generate-handoff-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-generate-handoff-implementation-plan.md
@@ -1,0 +1,32 @@
+# Flashcards Extension Generate Handoff Implementation Plan
+
+## Stage 1: Sidepanel Generate Handoff Tests
+**Goal**: Prove the extension can capture selected page text and open full Flashcards directly in the existing GeneratePanel.
+**Success Criteria**:
+- A sidepanel action labeled for generation is visible alongside manual capture.
+- Clicking it reads the active page selection with the existing injected helper.
+- The opened options URL targets `/flashcards` with `tab=importExport`, `generate=1`, selected text, page URL, and page title.
+- Capture validation failures stay inline and do not clear queued manual drafts.
+**Tests**:
+- `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+**Status**: Complete
+
+## Stage 2: Component Implementation
+**Goal**: Add a direct Generate-from-selection action without native sidepanel LLM generation.
+**Success Criteria**:
+- Handoff uses the existing `buildFlashcardsGenerateRoute` service.
+- Existing manual capture/save-one/save-all behavior remains unchanged.
+- In-flight save state still prevents sidepanel queue changes.
+**Tests**:
+- `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+**Status**: Complete
+
+## Stage 3: Source List And Task Closeout
+**Goal**: Keep the master fix list, user docs, and Backlog task aligned with the completed F12 handoff slice.
+**Success Criteria**:
+- `Flashcards-UX-Fix-List.md` distinguishes this generated-selection handoff from still-deferred native sidepanel generation/templates/review.
+- Extension flashcards docs describe queued capture, `Generate from selection`, and the deferred native generation/review boundary.
+- TASK-518 records verification and final summary.
+**Tests**:
+- `git diff --check`
+**Status**: Complete

--- a/Flashcards-UX-Fix-List.md
+++ b/Flashcards-UX-Fix-List.md
@@ -1,6 +1,6 @@
 # Flashcards UX Fix List
 
-Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split and F12 native sidepanel capture queue follow-ups.
+Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split, F12 native sidepanel capture queue, and F12 generate-from-selection handoff follow-ups.
 
 Scope: `/flashcards` plus directly connected WebUI and extension flashcard workflows. This file is the master UX audit and fix-list source referenced by `Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md`.
 
@@ -47,7 +47,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 9. Recent sessions show user-facing deck/mode/count/timing labels where data is available.
 10. Deck dashboard rows expose direct Review, Cram, Edit, Scheduler, and Export actions.
 11. Generated-card save recovery distinguishes success, partial success, failure, fatal validation errors, and retry state.
-12. Extension sidepanel offers explicit full Flashcards and Capture page selection actions; selected page text appends to an editable draft queue with deck picker, Front/Back fields, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
+12. Extension sidepanel offers explicit full Flashcards, Capture page selection, and Generate from selection actions; selected page text can either append to an editable sidepanel draft queue or open full Flashcards generation with source context. Native sidepanel drafts include deck picker, Front/Back fields, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
 13. Documentation describes the stabilized WebUI/extension capture and handoff behavior using current tab names.
 
 ## Phase Coverage
@@ -66,6 +66,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | F06 follow-up: Task-first Create & Import split | TASK-515 | F06 | Completed. Adds Create cards, Import file, and Export backup task workspaces while preserving existing route keys and panel handoffs. |
 | F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Generated drafts, templates, bulk editing, and in-extension review remain deferred. |
 | F12 follow-up: Extension repeat-capture queue | TASK-517 | F12 | Completed. Converts native sidepanel capture from one draft to a repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery. Generated drafts, templates, and in-extension review remain deferred. |
+| F12 follow-up: Extension generate-from-selection handoff | TASK-518 | F12 | Completed. Adds a sidepanel action that captures selected page text and opens full Flashcards generation with source URL/title context. Native sidepanel generated drafts, templates, and in-extension review remain deferred. |
 
 ## Severity-Ranked Findings
 
@@ -82,7 +83,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | F09 | Medium | History comprehension | Recent sessions used labels like `Session #1`, `Deck 1`, or raw scope keys. | Progress/history was present but hard to trust. | Backend identifiers leaked into user-facing history. | Addressed in TASK-509. |
 | F10 | Medium | Progress semantics | Due/new/current queue labels could appear contradictory. | Users could misunderstand whether cards were available to study. | Scheduler labels were technically accurate but not explained in queue context. | Addressed in TASK-508. |
 | F11 | Medium | Expert workflow | Manage was card-first with no deck-first dashboard for quick study decisions. | Experienced users spent time filtering cards instead of selecting a deck action. | The model privileged card management over deck review. | Addressed in TASK-510/TASK-511. |
-| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517. Sidepanel now supports native selected-text repeat capture, draft edit/delete, save-one, save-all, partial failure recovery, and page provenance; richer generated drafts, templates, and in-extension review remain deferred. |
+| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517/TASK-518. Sidepanel now supports native selected-text repeat capture, draft edit/delete, save-one, save-all, partial failure recovery, page provenance, and full-Flashcards generation handoff from selected text; native sidepanel generated drafts, templates, and in-extension review remain deferred. |
 | F13 | Medium | Docs mismatch | Extension and flashcards docs lagged current UI tab names and workflows. | Users could not rely on docs to understand current behavior. | Docs had not tracked UI evolution. | Addressed in TASK-513. |
 | F14 | Low | Empty-state hierarchy | Manage empty state showed expert filters before any cards existed. | New users saw advanced management chrome before first action. | Empty state inherited full management layout. | Addressed in TASK-506. |
 | F15 | Low | Scheduler discoverability | Scheduler was hidden until a deck existed. | New users could not learn scheduling exists until after setup. | Progressive disclosure hid a core concept too completely. | Addressed in TASK-506. |
@@ -102,7 +103,7 @@ Create & Import now separates setup into task-specific workspaces, so first-time
 
 The strongest power-user improvement is the deck dashboard. It gives experienced users deck-level counts and direct Review/Cram/Edit/Scheduler/Export actions, replacing a card-filter-first starting point for common study decisions. Review recovery and recent-session labels also make repeat review safer and easier to resume.
 
-Remaining weakness: extension capture now supports repeated native capture and bulk save, but richer expert capture controls remain deferred: generated drafts, templates, and in-extension review.
+Remaining weakness: extension capture now supports repeated native capture, bulk save, and full-workspace generation handoff, but richer native sidepanel expert controls remain deferred: generated drafts, templates, and in-extension review.
 
 ## Improvement Backlog
 
@@ -128,10 +129,11 @@ Remaining weakness: extension capture now supports repeated native capture and b
 - Add generated-card save recovery states with retry.
 - Split Create & Import into task-specific Create cards, Import file, and Export backup workspaces.
 - Add native extension repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery.
+- Add extension Generate from selection handoff into the full Flashcards Generate workflow.
 
 ### Deferred Larger Product Improvements
 
-- Extend the native extension capture flow with generated drafts, templates, and in-extension review.
+- Extend the native extension capture flow with in-sidepanel generated drafts, templates, and review.
 - Add broader import result normalization if future evidence shows unresolved partial/fatal import ambiguity outside generated-card save.
 - Run a full browser accessibility audit beyond the focused keyboard e2e coverage.
 
@@ -154,14 +156,14 @@ Remaining weakness: extension capture now supports repeated native capture and b
 3. Review supports keyboard reveal/rate/undo/edit flows with visible equivalents.
 4. Completion supports repeat workflows.
 5. History uses meaningful session labels instead of raw ids.
-6. Extension selected-text capture appends editable sidepanel drafts, lets the user delete or save one/all drafts with partial failure recovery, preserves page provenance, and leaves full Flashcards available for generation/import/review.
+6. Extension selected-text capture appends editable sidepanel drafts, lets the user delete or save one/all drafts with partial failure recovery, preserves page provenance, and can send selected text directly to full Flashcards generation with source context.
 
 ## Open Questions And Non-Goals
 
 - Scheduler algorithm correctness and backend spaced-repetition math were not audited beyond visible UX effects.
 - Quiz surfaces were out of scope except for the direct Flashcards handoff.
 - Multi-user permission, workspace sharing, and collaboration states need separate testing.
-- Rich native extension generation, templates, and in-extension review remain future product improvements beyond the F12 capture queue.
+- Rich native extension generation, templates, and in-extension review remain future product improvements beyond the F12 capture queue and full-workspace generation handoff.
 
 ## Master Checklist
 
@@ -196,7 +198,8 @@ Remaining weakness: extension capture now supports repeated native capture and b
 - [x] F12 Extension selected-text bridge added with page provenance into GeneratePanel saves.
 - [x] F12 Native extension deck-picker/edit/save MVP completed for one selected-text card.
 - [x] F12 Native extension repeat-capture queue, draft delete, save-one, save-all, and partial failure recovery completed.
-- [ ] F12 Rich native extension generated drafts/templates/review workflow remains deferred.
+- [x] F12 Extension Generate from selection handoff opens full Flashcards generation with selected text and page provenance.
+- [ ] F12 Rich native sidepanel generated drafts/templates/review workflow remains deferred.
 - [x] F13 WebUI and extension flashcards docs updated.
 - [x] F17 Quiz handoff made state-aware.
 

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -6,7 +6,7 @@ title: Flashcards (Experimental)
 
 The Flashcards page lets you create, review, and manage spaced-repetition cards backed by your tldw_server. It also supports CSV/TSV import and export, plus optional .apkg export where supported by the server.
 
-Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace and selected-text card creation.
+Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace, selected-text card creation, and selected-text generation handoff.
 
 ## Prerequisites
 
@@ -25,11 +25,12 @@ Access it from the Web UI header by clicking the Layers icon, or navigate to `/f
 
 1. Select text on a web page.
 2. Open the extension sidepanel and choose `Flashcards`.
-3. Click `Capture page selection`.
-4. Choose a deck, edit the `Front` and `Back` fields, then click `Save card`.
-5. Use `Open full Flashcards` when you need generation, imports, templates, review, or broader deck management.
+3. Click `Capture page selection` to add the selection to the sidepanel draft queue.
+4. Choose a deck, edit each draft's `Front` and `Back` fields, then click `Save card` or `Save all`.
+5. Click `Generate from selection` when you want the selected text to open in full Flashcards generation with the page URL/title attached.
+6. Use `Open full Flashcards` when you need imports, templates, review, or broader deck management.
 
-The sidepanel saves one basic card at a time and keeps the page URL as source provenance. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want generated drafts in the full Flashcards workspace.
+The sidepanel saves basic cards from queued drafts and keeps the page URL as source provenance. Generated drafts still open in the full Flashcards workspace; the sidepanel does not yet provide native generation templates or in-sidepanel review. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want generated drafts in the full Flashcards workspace.
 
 ## Tips
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -149,6 +149,9 @@ describe("sidepanel flashcards route", () => {
     expect(
       screen.getByRole("button", { name: "Capture page selection" })
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Generate from selection" })
+    ).toBeInTheDocument()
     expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
   })
 
@@ -231,6 +234,35 @@ describe("sidepanel flashcards route", () => {
     expect(screen.getByLabelText("Back")).toHaveValue(
       "Key concept from the active page"
     )
+  })
+
+  it("opens full Flashcards generation with selected page text and source context", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate from selection" })
+    )
+
+    const generatePath = browserMocks.runtimeGetURL.mock.calls
+      .map(([path]) => path)
+      .find((path) => path.includes("generate=1"))
+    expect(generatePath).toBeTruthy()
+    expect(generatePath).toContain("/options.html#/flashcards?")
+
+    const query = generatePath?.slice(generatePath.indexOf("?") + 1) ?? ""
+    const params = new URLSearchParams(query)
+    expect(params.get("tab")).toBe("importExport")
+    expect(params.get("generate")).toBe("1")
+    expect(params.get("generate_text")).toBe("Key concept from the active page")
+    expect(params.get("generate_source_id")).toBe("https://example.test/source")
+    expect(params.get("generate_source_title")).toBe("Selection Source")
+    expect(browserMocks.tabsCreate).toHaveBeenCalledWith({
+      url: `chrome-extension://flashcards${generatePath}`
+    })
+    expect(
+      screen.queryByRole("heading", { name: "Draft flashcard" })
+    ).not.toBeInTheDocument()
   })
 
   it("appends repeated page selections into an editable draft queue", async () => {
@@ -582,6 +614,33 @@ describe("sidepanel flashcards route", () => {
     browserMocks.executeScript.mockResolvedValueOnce([{ result: "" }])
     await user.click(
       screen.getByRole("button", { name: "Capture page selection" })
+    )
+
+    expect(
+      screen.getByText("Select text on the page first.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText("Back")).toHaveValue(
+      "Key concept from the active page"
+    )
+  })
+
+  it("keeps queued drafts when generate-from-selection capture fails", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    expect(
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
+
+    browserMocks.executeScript.mockResolvedValueOnce([{ result: "" }])
+    await user.click(
+      screen.getByRole("button", { name: "Generate from selection" })
     )
 
     expect(

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -5,6 +5,7 @@ import {
   Layers,
   MessageSquareText,
   Save,
+  Sparkles,
   Trash2
 } from "lucide-react"
 import { Button, Input, Select, Typography } from "antd"
@@ -15,6 +16,7 @@ import {
   useFlashcardsEnabled
 } from "@/components/Flashcards/hooks"
 import type { FlashcardCreate } from "@/services/flashcards"
+import { buildFlashcardsGenerateRoute } from "@/services/tldw/flashcards-generate-handoff"
 
 const { Text, Title } = Typography
 const { TextArea } = Input
@@ -25,6 +27,13 @@ type CaptureDraft = {
   back: string
   sourceId: string
   sourceTitle?: string
+}
+
+type CapturedPageSelection = {
+  selectedText: string
+  sourceId: string
+  sourceTitle?: string
+  draftFront: string
 }
 
 export const readSelectedTextFromPage = () => {
@@ -51,6 +60,7 @@ export default function SidepanelFlashcards() {
   const draftIdRef = React.useRef(0)
   const [captureError, setCaptureError] = React.useState<string | null>(null)
   const [captureLoading, setCaptureLoading] = React.useState(false)
+  const [generateLoading, setGenerateLoading] = React.useState(false)
   const [saveStatus, setSaveStatus] = React.useState<{
     type: "success" | "error"
     message: string
@@ -122,77 +132,119 @@ export default function SidepanelFlashcards() {
     void openOptionsHashRoute("/flashcards")
   }, [openOptionsHashRoute])
 
+  const captureMessages = React.useMemo(() => ({
+    unavailable: t(
+      "sidepanel:flashcards.selectionCaptureUnavailable",
+      "Page selection capture is unavailable in this browser."
+    ),
+    activeTabUnavailable: t(
+      "sidepanel:flashcards.activeTabUnavailable",
+      "Open a page tab before capturing page selection."
+    ),
+    noSelection: t(
+      "sidepanel:flashcards.noPageSelection",
+      "Select text on the page first."
+    ),
+    failed: t(
+      "sidepanel:flashcards.selectionCaptureFailed",
+      "Could not read the current page selection. Use the Save to Notes context menu or paste text into Create & Import."
+    )
+  }), [t])
+
+  const formatCaptureErrorMessage = React.useCallback(
+    (error: unknown) => {
+      const message =
+        error instanceof Error && error.message.trim() ? error.message : ""
+      const validationMessages = [
+        captureMessages.unavailable,
+        captureMessages.activeTabUnavailable,
+        captureMessages.noSelection
+      ]
+      return validationMessages.includes(message) ? message : captureMessages.failed
+    },
+    [captureMessages]
+  )
+
+  const readActivePageSelection = React.useCallback(async (): Promise<CapturedPageSelection> => {
+    if (!browser.tabs?.query || !browser.scripting?.executeScript) {
+      throw new Error(captureMessages.unavailable)
+    }
+
+    const activeTabs = await browser.tabs.query({
+      active: true,
+      currentWindow: true
+    })
+    const activeTab = activeTabs[0]
+    const tabId = activeTab?.id
+    if (typeof tabId !== "number") {
+      throw new Error(captureMessages.activeTabUnavailable)
+    }
+
+    const results = await browser.scripting.executeScript({
+      target: { tabId },
+      func: readSelectedTextFromPage
+    })
+    const selectedText = String(results?.[0]?.result ?? "").trim()
+    if (!selectedText) {
+      throw new Error(captureMessages.noSelection)
+    }
+
+    const sourceId = activeTab.url || String(tabId)
+    const sourceTitle = activeTab.title || activeTab.url || undefined
+    return {
+      selectedText,
+      sourceId,
+      sourceTitle,
+      draftFront:
+        activeTab.title ||
+        activeTab.url ||
+        t("sidepanel:flashcards.defaultFront", "Page selection")
+    }
+  }, [captureMessages, t])
+
   const handleCapturePageSelection = React.useCallback(async () => {
     setCaptureError(null)
     setSaveStatus(null)
     setCaptureLoading(true)
-    const captureUnavailableMessage = t(
-      "sidepanel:flashcards.selectionCaptureUnavailable",
-      "Page selection capture is unavailable in this browser."
-    )
-    const activeTabUnavailableMessage = t(
-      "sidepanel:flashcards.activeTabUnavailable",
-      "Open a page tab before capturing page selection."
-    )
-    const noSelectionMessage = t(
-      "sidepanel:flashcards.noPageSelection",
-      "Select text on the page first."
-    )
-    const captureFailedMessage = t(
-      "sidepanel:flashcards.selectionCaptureFailed",
-      "Could not read the current page selection. Use the Save to Notes context menu or paste text into Create & Import."
-    )
     try {
-      if (!browser.tabs?.query || !browser.scripting?.executeScript) {
-        throw new Error(captureUnavailableMessage)
-      }
-
-      const activeTabs = await browser.tabs.query({
-        active: true,
-        currentWindow: true
-      })
-      const activeTab = activeTabs[0]
-      const tabId = activeTab?.id
-      if (typeof tabId !== "number") {
-        throw new Error(activeTabUnavailableMessage)
-      }
-
-      const results = await browser.scripting.executeScript({
-        target: { tabId },
-        func: readSelectedTextFromPage
-      })
-      const selectedText = String(results?.[0]?.result ?? "").trim()
-      if (!selectedText) {
-        throw new Error(noSelectionMessage)
-      }
+      const captured = await readActivePageSelection()
 
       draftIdRef.current += 1
       const nextDraft: CaptureDraft = {
         id: `capture-${draftIdRef.current}`,
-        front:
-          activeTab.title ||
-          activeTab.url ||
-          t("sidepanel:flashcards.defaultFront", "Page selection"),
-        back: selectedText,
-        sourceId: activeTab.url || String(tabId),
-        sourceTitle: activeTab.title || activeTab.url || undefined
+        front: captured.draftFront,
+        back: captured.selectedText,
+        sourceId: captured.sourceId,
+        sourceTitle: captured.sourceTitle
       }
       setDrafts((current) => [...current, nextDraft])
     } catch (error) {
-      const message =
-        error instanceof Error && error.message.trim() ? error.message : ""
-      const validationMessages = [
-        captureUnavailableMessage,
-        activeTabUnavailableMessage,
-        noSelectionMessage
-      ]
-      setCaptureError(
-        validationMessages.includes(message) ? message : captureFailedMessage
-      )
+      setCaptureError(formatCaptureErrorMessage(error))
     } finally {
       setCaptureLoading(false)
     }
-  }, [t])
+  }, [formatCaptureErrorMessage, readActivePageSelection])
+
+  const handleGenerateFromSelection = React.useCallback(async () => {
+    setCaptureError(null)
+    setSaveStatus(null)
+    setGenerateLoading(true)
+    try {
+      const captured = await readActivePageSelection()
+      await openOptionsHashRoute(
+        buildFlashcardsGenerateRoute({
+          text: captured.selectedText,
+          sourceType: "manual",
+          sourceId: captured.sourceId,
+          sourceTitle: captured.sourceTitle
+        })
+      )
+    } catch (error) {
+      setCaptureError(formatCaptureErrorMessage(error))
+    } finally {
+      setGenerateLoading(false)
+    }
+  }, [formatCaptureErrorMessage, openOptionsHashRoute, readActivePageSelection])
 
   const getDeckName = React.useCallback(
     () => selectedDeck?.name || t("sidepanel:flashcards.defaultDeck", "deck"),
@@ -420,13 +472,25 @@ export default function SidepanelFlashcards() {
         <Button
           block
           loading={captureLoading}
-          disabled={isSaving}
+          disabled={isSaving || generateLoading}
           icon={<MessageSquareText className="size-4" aria-hidden="true" />}
           onClick={handleCapturePageSelection}
         >
           {t(
             "sidepanel:flashcards.capturePageSelection",
             "Capture page selection"
+          )}
+        </Button>
+        <Button
+          block
+          loading={generateLoading}
+          disabled={isSaving || captureLoading}
+          icon={<Sparkles className="size-4" aria-hidden="true" />}
+          onClick={() => void handleGenerateFromSelection()}
+        >
+          {t(
+            "sidepanel:flashcards.generateFromSelection",
+            "Generate from selection"
           )}
         </Button>
       </div>

--- a/backlog/tasks/task-518 - Add-flashcards-extension-generate-from-selection-handoff.md
+++ b/backlog/tasks/task-518 - Add-flashcards-extension-generate-from-selection-handoff.md
@@ -1,0 +1,84 @@
+---
+id: TASK-518
+title: Add flashcards extension generate-from-selection handoff
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-27 05:01
+labels:
+- flashcards
+- extension
+- ux
+dependencies: []
+documentation:
+- Flashcards-UX-Fix-List.md
+priority: medium
+modified_files:
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- apps/extension/docs/features/flashcards.md
+- Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Flashcards-UX-Fix-List.md
+- Docs/superpowers/plans/2026-05-27-flashcards-extension-generate-handoff-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next narrow F12 follow-up: let the extension sidepanel capture selected page text and open full Flashcards directly in the existing GeneratePanel with source context, while keeping native sidepanel LLM generation/templates/review deferred.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sidepanel Flashcards exposes Generate from selection next to native capture.
+- [x] #2 Generate from selection captures active-page selected text through the existing browser scripting path.
+- [x] #3 The generated handoff opens full Flashcards with tab=importExport, generate=1, selected text, source URL, and source title.
+- [x] #4 Capture validation failures remain inline and do not clear queued manual drafts.
+- [x] #5 Native sidepanel LLM generation, templates, and in-extension review remain deferred.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-27-flashcards-extension-generate-handoff-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-27-flashcards-extension-generate-handoff-implementation-plan.md.
+
+Touched scope: sidepanel Flashcards route/tests, extension/WebUI flashcards docs, master UX fix list, and the implementation plan.
+
+Implementation notes: added Generate from selection beside existing sidepanel capture, sharing the same active-page selection reader and validation messages. The action opens full Flashcards with buildFlashcardsGenerateRoute so generated drafts stay in the existing full workspace while selected text, source URL, and title are prefilled. Manual queued capture/save-one/save-all behavior remains unchanged.
+
+Non-goals: native sidepanel LLM generation, native generation templates, and in-extension review.
+
+Verification:
+- RED: bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx initially failed because Generate from selection was missing.
+- PASS: bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx passed 23 tests.
+- PASS: bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts passed 29 tests.
+- PASS: bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts passed 33 tests.
+- PARTIAL: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still reports only the unrelated CharacterListContent design-system density baseline.
+- PASS: git diff --check.
+- Bandit not applicable: no Python files touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the F12 extension generate-from-selection handoff. Users can select text on a page and open full Flashcards generation directly from the sidepanel with selected text, source URL, and source title prefilled. Existing native sidepanel queued basic-card capture remains intact, and richer native sidepanel generated drafts/templates/review remain deferred to the full Flashcards workspace.
+
+Focused sidepanel, route-registry, and generate-handoff tests pass. Package-wide TypeScript still reports the unrelated pre-existing CharacterListContent density baseline; no flashcards/sidepanel TypeScript errors were reported. Bandit is not applicable because this slice touches TypeScript/docs only and no Python files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add a sidepanel `Generate from selection` action that reuses the existing full Flashcards generate-route handoff.
- Share the active-page selection reader between native capture and generation handoff so selected text, source URL, and page title are preserved.
- Update the flashcards UX fix list, implementation plan, Backlog task, and extension/user docs to distinguish full-workspace generation handoff from deferred native sidepanel generation/templates/review.

## Test Plan
- [x] `bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
- [x] `git diff --check`
- [ ] `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` - still reports the unrelated pre-existing `CharacterListContent.design-system.test.tsx` density baseline.
- [x] Bandit not applicable: TypeScript/docs-only slice; no Python files touched.

## Change summary
TODO: human-authored change summary required before marking this PR ready for review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Generate from selection action to the extension sidepanel that opens full Flashcards generation with the selected text, source URL, and page title. Keeps the native capture queue unchanged and updates tests and docs; completes TASK-518.

- **New Features**
  - Added “Generate from selection” next to “Capture page selection” in the sidepanel; launches `/flashcards` with `tab=importExport` and `generate=1` via `buildFlashcardsGenerateRoute`.
  - Shared the active-page selection reader and validation across capture and handoff; errors stay inline and do not clear queued drafts.
  - Preserves existing save-one/save-all flow; native generation templates and in-panel review remain deferred to the full workspace.
  - Added route tests for the new action and updated user and extension docs and the UX fix list.

<sup>Written for commit 57edcc1497d9870c208ea705b267937f2156ee6c. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2078?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

