### PR TITLE
Add flashcards sidepanel generated drafts

### DIFF
--- a/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,24 +32,25 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find useful passages while browsing and want to save editable basic flashcards without leaving the sidepanel, or send selected text directly to full Flashcards generation.
+Use this path when you find useful passages while browsing and want to save editable basic flashcards, generate a small draft batch without leaving the sidepanel, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
 1. Select text on the source page.
 2. Open the extension sidepanel and choose `Flashcards`.
 3. Choose `Capture page selection` to add the selection to the sidepanel draft queue.
-4. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
-5. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
-6. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
+4. Choose `Generate draft cards` to generate a small editable draft batch in the sidepanel from the selected text.
+5. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
+6. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
+7. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
 
 Important behavior:
 
-- The sidepanel Flashcards route saves queued basic-card drafts and keeps the source page URL as provenance.
+- The sidepanel Flashcards route saves queued captured and generated drafts and keeps the source page URL as provenance.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
-- Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of native sidepanel basic-card drafts.
-- Native sidepanel generation templates and in-sidepanel review remain deferred to the full Flashcards workspace.
+- Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want the fuller generation workflow instead of the sidepanel's compact generated draft batch.
+- Native sidepanel template application and in-sidepanel review remain deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,24 +32,25 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find useful passages while browsing and want to save editable basic flashcards without leaving the sidepanel, or send selected text directly to full Flashcards generation.
+Use this path when you find useful passages while browsing and want to save editable basic flashcards, generate a small draft batch without leaving the sidepanel, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
 1. Select text on the source page.
 2. Open the extension sidepanel and choose `Flashcards`.
 3. Choose `Capture page selection` to add the selection to the sidepanel draft queue.
-4. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
-5. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
-6. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
+4. Choose `Generate draft cards` to generate a small editable draft batch in the sidepanel from the selected text.
+5. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
+6. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
+7. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
 
 Important behavior:
 
-- The sidepanel Flashcards route saves queued basic-card drafts and keeps the source page URL as provenance.
+- The sidepanel Flashcards route saves queued captured and generated drafts and keeps the source page URL as provenance.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
-- Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want generated drafts instead of native sidepanel basic-card drafts.
-- Native sidepanel generation templates and in-sidepanel review remain deferred to the full Flashcards workspace.
+- Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want the fuller generation workflow instead of the sidepanel's compact generated draft batch.
+- Native sidepanel template application and in-sidepanel review remain deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-implementation-plan.md
@@ -1,0 +1,43 @@
+# Flashcards Extension Native Generated Drafts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the extension sidepanel generate a small batch of editable draft flashcards from selected page text.
+
+**Architecture:** Reuse the existing sidepanel active-page selection reader, the existing `useGenerateFlashcardsMutation`, and the existing generated-card normalizer from the full Flashcards Generate panel. Generated drafts append into the current sidepanel draft queue so deck selection, editing, delete, save-one, save-all, source provenance, and partial save recovery stay on the established path.
+
+**Tech Stack:** React, Ant Design, WXT browser APIs, Vitest, Testing Library, existing Flashcards hooks/services.
+
+---
+
+## Stage 1: Native Generation Tests
+**Goal**: Prove selected page text can generate editable sidepanel drafts without opening the full workspace.
+**Success Criteria**:
+- `Generate draft cards` is visible alongside capture and full-workspace generation handoff.
+- Clicking it reads selected page text through the existing injected helper.
+- The flashcards generation mutation receives selected text, a compact default card count, and basic mixed-difficulty generation options.
+- Generated cards append to the existing editable sidepanel draft queue and keep source URL/title provenance.
+- Generation failures stay inline and do not clear queued manual drafts.
+**Tests**:
+- `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+**Status**: Complete
+
+## Stage 2: Sidepanel Implementation
+**Goal**: Add native sidepanel draft generation without adding native templates or in-extension review.
+**Success Criteria**:
+- `CaptureDraft` can represent manual and generated drafts with model type, tags, notes, and extra fields.
+- Generated draft saves preserve model type, cloze/reverse flags, tags, notes, extra, and page source id.
+- Capture, full-workspace generation handoff, save-one, save-all, and partial failure behavior remain unchanged.
+**Tests**:
+- `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+**Status**: Complete
+
+## Stage 3: Source List And Task Closeout
+**Goal**: Keep the master fix list, user docs, and TASK-519 aligned with the completed F12 sub-slice.
+**Success Criteria**:
+- `Flashcards-UX-Fix-List.md` marks native sidepanel generated drafts as completed while keeping templates and in-extension review deferred.
+- Extension flashcards docs describe `Generate draft cards` and distinguish compact native generation from the full Flashcards generation workflow.
+- TASK-519 records acceptance criteria, verification, known skips, and final summary.
+**Tests**:
+- `git diff --check`
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-review-fix-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-review-fix-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Review Comment Verification
+**Goal**: Verify PR #2079 review comments against the current sidepanel Flashcards branch after rebasing on `origin/dev`.
+**Success Criteria**: Unresolved GitHub review threads and PR checks are inspected; still-valid comments are listed in TASK-520.
+**Tests**: `gh pr view 2079`, GraphQL review-thread query, `gh pr checks 2079`.
+**Status**: Complete
+
+## Stage 2: Regression Tests
+**Goal**: Add coverage for duplicate generation activation, unexpected generation responses, and localized generated-card count copy.
+**Success Criteria**: New tests fail against the pre-fix implementation for the reviewed behavior.
+**Tests**: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`.
+**Status**: Complete
+
+## Stage 3: Sidepanel Review Fixes
+**Goal**: Make sidepanel generation re-entrant-safe, tolerate malformed generation responses, and avoid hardcoded English plural labels in translation interpolation.
+**Success Criteria**: Both generation entry points share a synchronous in-flight guard; native generation normalizes optional flashcard results; generated/save/queue status copy uses localized whole-message branches.
+**Tests**: Focused sidepanel Vitest suite.
+**Status**: Complete
+
+## Stage 4: Metadata, Verification, and PR Update
+**Goal**: Restore Backlog metadata and record verification before pushing review fixes.
+**Success Criteria**: TASK-519 has a creation timestamp; TASK-520 records the review fix summary and verification; review-fix changes are ready to push to PR #2079.
+**Tests**: `git diff --check`, focused Vitest, TypeScript check where practical, Bandit applicability review.
+**Status**: Complete

--- a/Flashcards-UX-Fix-List.md
+++ b/Flashcards-UX-Fix-List.md
@@ -1,6 +1,6 @@
 # Flashcards UX Fix List
 
-Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split, F12 native sidepanel capture queue, and F12 generate-from-selection handoff follow-ups.
+Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split, F12 native sidepanel capture queue, F12 generate-from-selection handoff, and F12 native generated-draft follow-ups.
 
 Scope: `/flashcards` plus directly connected WebUI and extension flashcard workflows. This file is the master UX audit and fix-list source referenced by `Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md`.
 
@@ -47,7 +47,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 9. Recent sessions show user-facing deck/mode/count/timing labels where data is available.
 10. Deck dashboard rows expose direct Review, Cram, Edit, Scheduler, and Export actions.
 11. Generated-card save recovery distinguishes success, partial success, failure, fatal validation errors, and retry state.
-12. Extension sidepanel offers explicit full Flashcards, Capture page selection, and Generate from selection actions; selected page text can either append to an editable sidepanel draft queue or open full Flashcards generation with source context. Native sidepanel drafts include deck picker, Front/Back fields, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
+12. Extension sidepanel offers explicit full Flashcards, Capture page selection, Generate draft cards, and Generate from selection actions; selected page text can append one captured draft, generate a small editable draft batch natively, or open full Flashcards generation with source context. Native sidepanel drafts include deck picker, Front/Back fields, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
 13. Documentation describes the stabilized WebUI/extension capture and handoff behavior using current tab names.
 
 ## Phase Coverage
@@ -67,6 +67,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Generated drafts, templates, bulk editing, and in-extension review remain deferred. |
 | F12 follow-up: Extension repeat-capture queue | TASK-517 | F12 | Completed. Converts native sidepanel capture from one draft to a repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery. Generated drafts, templates, and in-extension review remain deferred. |
 | F12 follow-up: Extension generate-from-selection handoff | TASK-518 | F12 | Completed. Adds a sidepanel action that captures selected page text and opens full Flashcards generation with source URL/title context. Native sidepanel generated drafts, templates, and in-extension review remain deferred. |
+| F12 follow-up: Native extension generated drafts | TASK-519 | F12 | Completed. Adds native sidepanel generated draft batches from selected page text, preserving edit/save queue behavior and source provenance. Native template application and in-extension review remain deferred. |
 
 ## Severity-Ranked Findings
 
@@ -83,7 +84,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | F09 | Medium | History comprehension | Recent sessions used labels like `Session #1`, `Deck 1`, or raw scope keys. | Progress/history was present but hard to trust. | Backend identifiers leaked into user-facing history. | Addressed in TASK-509. |
 | F10 | Medium | Progress semantics | Due/new/current queue labels could appear contradictory. | Users could misunderstand whether cards were available to study. | Scheduler labels were technically accurate but not explained in queue context. | Addressed in TASK-508. |
 | F11 | Medium | Expert workflow | Manage was card-first with no deck-first dashboard for quick study decisions. | Experienced users spent time filtering cards instead of selecting a deck action. | The model privileged card management over deck review. | Addressed in TASK-510/TASK-511. |
-| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517/TASK-518. Sidepanel now supports native selected-text repeat capture, draft edit/delete, save-one, save-all, partial failure recovery, page provenance, and full-Flashcards generation handoff from selected text; native sidepanel generated drafts, templates, and in-extension review remain deferred. |
+| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517/TASK-518/TASK-519. Sidepanel now supports native selected-text repeat capture, native generated draft batches, draft edit/delete, save-one, save-all, partial failure recovery, page provenance, and full-Flashcards generation handoff from selected text; native template application and in-extension review remain deferred. |
 | F13 | Medium | Docs mismatch | Extension and flashcards docs lagged current UI tab names and workflows. | Users could not rely on docs to understand current behavior. | Docs had not tracked UI evolution. | Addressed in TASK-513. |
 | F14 | Low | Empty-state hierarchy | Manage empty state showed expert filters before any cards existed. | New users saw advanced management chrome before first action. | Empty state inherited full management layout. | Addressed in TASK-506. |
 | F15 | Low | Scheduler discoverability | Scheduler was hidden until a deck existed. | New users could not learn scheduling exists until after setup. | Progressive disclosure hid a core concept too completely. | Addressed in TASK-506. |
@@ -103,7 +104,7 @@ Create & Import now separates setup into task-specific workspaces, so first-time
 
 The strongest power-user improvement is the deck dashboard. It gives experienced users deck-level counts and direct Review/Cram/Edit/Scheduler/Export actions, replacing a card-filter-first starting point for common study decisions. Review recovery and recent-session labels also make repeat review safer and easier to resume.
 
-Remaining weakness: extension capture now supports repeated native capture, bulk save, and full-workspace generation handoff, but richer native sidepanel expert controls remain deferred: generated drafts, templates, and in-extension review.
+Remaining weakness: extension capture now supports repeated native capture, native generated draft batches, bulk save, and full-workspace generation handoff, but richer native sidepanel expert controls remain deferred: template application and in-extension review.
 
 ## Improvement Backlog
 
@@ -130,10 +131,11 @@ Remaining weakness: extension capture now supports repeated native capture, bulk
 - Split Create & Import into task-specific Create cards, Import file, and Export backup workspaces.
 - Add native extension repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery.
 - Add extension Generate from selection handoff into the full Flashcards Generate workflow.
+- Add native extension generated draft batches from selected page text.
 
 ### Deferred Larger Product Improvements
 
-- Extend the native extension capture flow with in-sidepanel generated drafts, templates, and review.
+- Extend the native extension capture flow with template application and in-extension review.
 - Add broader import result normalization if future evidence shows unresolved partial/fatal import ambiguity outside generated-card save.
 - Run a full browser accessibility audit beyond the focused keyboard e2e coverage.
 
@@ -156,14 +158,14 @@ Remaining weakness: extension capture now supports repeated native capture, bulk
 3. Review supports keyboard reveal/rate/undo/edit flows with visible equivalents.
 4. Completion supports repeat workflows.
 5. History uses meaningful session labels instead of raw ids.
-6. Extension selected-text capture appends editable sidepanel drafts, lets the user delete or save one/all drafts with partial failure recovery, preserves page provenance, and can send selected text directly to full Flashcards generation with source context.
+6. Extension selected-text capture appends editable sidepanel drafts, can generate a small native draft batch, lets the user delete or save one/all drafts with partial failure recovery, preserves page provenance, and can send selected text directly to full Flashcards generation with source context.
 
 ## Open Questions And Non-Goals
 
 - Scheduler algorithm correctness and backend spaced-repetition math were not audited beyond visible UX effects.
 - Quiz surfaces were out of scope except for the direct Flashcards handoff.
 - Multi-user permission, workspace sharing, and collaboration states need separate testing.
-- Rich native extension generation, templates, and in-extension review remain future product improvements beyond the F12 capture queue and full-workspace generation handoff.
+- Native extension template application and in-extension review remain future product improvements beyond the F12 capture queue, native generated drafts, and full-workspace generation handoff.
 
 ## Master Checklist
 
@@ -199,7 +201,8 @@ Remaining weakness: extension capture now supports repeated native capture, bulk
 - [x] F12 Native extension deck-picker/edit/save MVP completed for one selected-text card.
 - [x] F12 Native extension repeat-capture queue, draft delete, save-one, save-all, and partial failure recovery completed.
 - [x] F12 Extension Generate from selection handoff opens full Flashcards generation with selected text and page provenance.
-- [ ] F12 Rich native sidepanel generated drafts/templates/review workflow remains deferred.
+- [x] F12 Native sidepanel generated draft batches completed for selected page text.
+- [ ] F12 Native sidepanel template application and in-extension review remain deferred.
 - [x] F13 WebUI and extension flashcards docs updated.
 - [x] F17 Quiz handoff made state-aware.
 

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -6,7 +6,7 @@ title: Flashcards (Experimental)
 
 The Flashcards page lets you create, review, and manage spaced-repetition cards backed by your tldw_server. It also supports CSV/TSV import and export, plus optional .apkg export where supported by the server.
 
-Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace, selected-text card creation, and selected-text generation handoff.
+Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace, selected-text card creation, native generated drafts, and selected-text generation handoff.
 
 ## Prerequisites
 
@@ -26,11 +26,12 @@ Access it from the Web UI header by clicking the Layers icon, or navigate to `/f
 1. Select text on a web page.
 2. Open the extension sidepanel and choose `Flashcards`.
 3. Click `Capture page selection` to add the selection to the sidepanel draft queue.
-4. Choose a deck, edit each draft's `Front` and `Back` fields, then click `Save card` or `Save all`.
-5. Click `Generate from selection` when you want the selected text to open in full Flashcards generation with the page URL/title attached.
-6. Use `Open full Flashcards` when you need imports, templates, review, or broader deck management.
+4. Click `Generate draft cards` to create a small batch of editable draft cards in the sidepanel from the selected text.
+5. Choose a deck, edit each draft's `Front` and `Back` fields, then click `Save card` or `Save all`.
+6. Click `Generate from selection` when you want the selected text to open in full Flashcards generation with the page URL/title attached.
+7. Use `Open full Flashcards` when you need imports, templates, review, or broader deck management.
 
-The sidepanel saves basic cards from queued drafts and keeps the page URL as source provenance. Generated drafts still open in the full Flashcards workspace; the sidepanel does not yet provide native generation templates or in-sidepanel review. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want generated drafts in the full Flashcards workspace.
+The sidepanel saves basic captured cards and generated draft cards from the same queue, keeping the page URL as source provenance. Native generation uses compact defaults; the sidepanel does not yet provide template application or in-sidepanel review. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want the fuller generation workflow in the full Flashcards workspace.
 
 ## Tips
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -8,6 +8,7 @@ import SidepanelFlashcards, {
 
 const flashcardMocks = vi.hoisted(() => ({
   createFlashcardMutateAsync: vi.fn(),
+  generateFlashcardsMutateAsync: vi.fn(),
   useFlashcardsEnabled: vi.fn(),
   useDecksQuery: vi.fn()
 }))
@@ -32,6 +33,10 @@ const browserMocks = vi.hoisted(() => ({
 vi.mock("@/components/Flashcards/hooks", () => ({
   useCreateFlashcardMutation: () => ({
     mutateAsync: flashcardMocks.createFlashcardMutateAsync,
+    isPending: false
+  }),
+  useGenerateFlashcardsMutation: () => ({
+    mutateAsync: flashcardMocks.generateFlashcardsMutateAsync,
     isPending: false
   }),
   useFlashcardsEnabled: () => flashcardMocks.useFlashcardsEnabled(),
@@ -81,6 +86,7 @@ describe("sidepanel flashcards route", () => {
     browserMocks.tabsQuery.mockReset()
     browserMocks.executeScript.mockReset()
     flashcardMocks.createFlashcardMutateAsync.mockReset()
+    flashcardMocks.generateFlashcardsMutateAsync.mockReset()
     browserMocks.runtimeGetURL.mockImplementation(
       (path: string) => `chrome-extension://flashcards${path}`
     )
@@ -100,6 +106,24 @@ describe("sidepanel flashcards route", () => {
     flashcardMocks.createFlashcardMutateAsync.mockResolvedValue({
       uuid: "card-1",
       deck_id: 7
+    })
+    flashcardMocks.generateFlashcardsMutateAsync.mockResolvedValue({
+      flashcards: [
+        {
+          front: "What does ATP do?",
+          back: "ATP stores and transfers cellular energy.",
+          tags: ["biology", "energy"],
+          model_type: "basic",
+          notes: "Generated from selected source text",
+          extra: "Review with the source page open"
+        },
+        {
+          front: "What is {{c1::mitochondrial respiration}}?",
+          back: "A process that produces ATP from nutrients.",
+          tags: ["biology"],
+          model_type: "cloze"
+        }
+      ]
     })
     flashcardMocks.useFlashcardsEnabled.mockReturnValue({
       isOnline: true,
@@ -143,7 +167,7 @@ describe("sidepanel flashcards route", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Create one editable card in the sidepanel. Use full Flashcards for generation, imports, and review."
+        "Create one editable card, generate a small draft batch, or use full Flashcards for templates, imports, and review."
       )
     ).toBeInTheDocument()
     expect(
@@ -151,6 +175,9 @@ describe("sidepanel flashcards route", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: "Generate from selection" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Generate draft cards" })
     ).toBeInTheDocument()
     expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
   })
@@ -263,6 +290,73 @@ describe("sidepanel flashcards route", () => {
     expect(
       screen.queryByRole("heading", { name: "Draft flashcard" })
     ).not.toBeInTheDocument()
+  })
+
+  it("generates selected page text into editable sidepanel drafts", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate draft cards" })
+    )
+
+    await waitFor(() => {
+      expect(flashcardMocks.generateFlashcardsMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.generateFlashcardsMutateAsync).toHaveBeenCalledWith({
+      text: "Key concept from the active page",
+      numCards: 3,
+      cardType: "basic",
+      difficulty: "mixed"
+    })
+    expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
+    expect(screen.getByText("Generated 2 draft cards.")).toBeInTheDocument()
+    expect(screen.getByText("2 draft cards ready")).toBeInTheDocument()
+    expect(screen.getAllByLabelText("Front")[0]).toHaveValue(
+      "What does ATP do?"
+    )
+    expect(screen.getAllByLabelText("Back")[0]).toHaveValue(
+      "ATP stores and transfers cellular energy."
+    )
+    expect(screen.getAllByLabelText("Front")[1]).toHaveValue(
+      "What is {{c1::mitochondrial respiration}}?"
+    )
+
+    await user.click(screen.getAllByRole("button", { name: "Save card" })[0])
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledWith({
+      deck_id: 7,
+      front: "What does ATP do?",
+      back: "ATP stores and transfers cellular energy.",
+      tags: ["biology", "energy"],
+      notes: "Generated from selected source text",
+      extra: "Review with the source page open",
+      model_type: "basic",
+      is_cloze: false,
+      reverse: false,
+      source_ref_type: "manual",
+      source_ref_id: "https://example.test/source"
+    })
+
+    await user.click(screen.getByRole("button", { name: "Save card" }))
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(2)
+    })
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenLastCalledWith({
+      deck_id: 7,
+      front: "What is {{c1::mitochondrial respiration}}?",
+      back: "A process that produces ATP from nutrients.",
+      tags: ["biology"],
+      model_type: "cloze",
+      is_cloze: true,
+      reverse: false,
+      source_ref_type: "manual",
+      source_ref_id: "https://example.test/source"
+    })
   })
 
   it("appends repeated page selections into an editable draft queue", async () => {
@@ -645,6 +739,37 @@ describe("sidepanel flashcards route", () => {
 
     expect(
       screen.getByText("Select text on the page first.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText("Back")).toHaveValue(
+      "Key concept from the active page"
+    )
+  })
+
+  it("keeps queued drafts when native generation fails", async () => {
+    flashcardMocks.generateFlashcardsMutateAsync.mockRejectedValueOnce(
+      new Error("Generation failed")
+    )
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    expect(
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate draft cards" })
+    )
+
+    expect(
+      await screen.findByText(
+        "Could not generate draft cards. Generation failed"
+      )
     ).toBeInTheDocument()
     expect(
       screen.getByRole("heading", { name: "Draft flashcard" })

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import userEvent from "@testing-library/user-event"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import SidepanelFlashcards, {
   readSelectedTextFromPage
@@ -28,6 +28,26 @@ const browserMocks = vi.hoisted(() => ({
       result: "Key concept from the active page"
     }
   ])
+}))
+
+const translationMocks = vi.hoisted(() => ({
+  t: vi.fn(
+    (
+      key: string,
+      fallbackOrOptions?:
+        | string
+        | Record<string, string | number | undefined>
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        const template = String(fallbackOrOptions.defaultValue || key)
+        return template.replace(/{{(\w+)}}/g, (_, token: string) =>
+          String(fallbackOrOptions[token] ?? "")
+        )
+      }
+      return key
+    }
+  )
 }))
 
 vi.mock("@/components/Flashcards/hooks", () => ({
@@ -60,27 +80,14 @@ vi.mock("wxt/browser", () => ({
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (
-      key: string,
-      fallbackOrOptions?:
-        | string
-        | Record<string, string | number | undefined>
-    ) => {
-      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
-      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
-        const template = String(fallbackOrOptions.defaultValue || key)
-        return template.replace(/{{(\w+)}}/g, (_, token: string) =>
-          String(fallbackOrOptions[token] ?? "")
-        )
-      }
-      return key
-    }
+    t: translationMocks.t
   })
 }))
 
 describe("sidepanel flashcards route", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    translationMocks.t.mockClear()
     browserMocks.runtimeGetURL.mockReset()
     browserMocks.tabsCreate.mockReset()
     browserMocks.tabsQuery.mockReset()
@@ -357,6 +364,91 @@ describe("sidepanel flashcards route", () => {
       source_ref_type: "manual",
       source_ref_id: "https://example.test/source"
     })
+  })
+
+  it("ignores duplicate native generation clicks before disabled state rerenders", async () => {
+    flashcardMocks.generateFlashcardsMutateAsync.mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    render(<SidepanelFlashcards />)
+    const generateDraftCardsButton = screen.getByRole("button", {
+      name: "Generate draft cards"
+    })
+
+    await act(async () => {
+      fireEvent.click(generateDraftCardsButton)
+      fireEvent.click(generateDraftCardsButton)
+    })
+
+    await waitFor(() => {
+      expect(flashcardMocks.generateFlashcardsMutateAsync).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("blocks the full-workspace generation handoff while native generation is in flight", async () => {
+    flashcardMocks.generateFlashcardsMutateAsync.mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    render(<SidepanelFlashcards />)
+    const generateDraftCardsButton = screen.getByRole("button", {
+      name: "Generate draft cards"
+    })
+    const generateFromSelectionButton = screen.getByRole("button", {
+      name: "Generate from selection"
+    })
+
+    await act(async () => {
+      fireEvent.click(generateDraftCardsButton)
+      fireEvent.click(generateFromSelectionButton)
+    })
+
+    await waitFor(() => {
+      expect(flashcardMocks.generateFlashcardsMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
+  })
+
+  it("shows empty-generation guidance when the generation response has no flashcards", async () => {
+    flashcardMocks.generateFlashcardsMutateAsync.mockResolvedValueOnce(undefined)
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate draft cards" })
+    )
+
+    expect(
+      await screen.findByText(
+        "No draft cards were generated. Try selecting a longer passage."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Could not generate draft cards/)
+    ).not.toBeInTheDocument()
+  })
+
+  it("uses localized whole-message copy for generated draft counts", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate draft cards" })
+    )
+
+    expect(await screen.findByText("Generated 2 draft cards.")).toBeInTheDocument()
+    const generatedStatusCalls = translationMocks.t.mock.calls.filter(
+      ([key]) => String(key).startsWith("sidepanel:flashcards.generateDraftsSuccess")
+    )
+    expect(generatedStatusCalls).toContainEqual([
+      "sidepanel:flashcards.generateDraftsSuccess_other",
+      expect.objectContaining({
+        count: 2,
+        defaultValue: "Generated {{count}} draft cards."
+      })
+    ])
+    for (const [, options] of generatedStatusCalls) {
+      expect(options).not.toHaveProperty("cardLabel")
+    }
   })
 
   it("appends repeated page selections into an editable draft queue", async () => {

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -6,20 +6,25 @@ import {
   MessageSquareText,
   Save,
   Sparkles,
-  Trash2
+  Trash2,
+  WandSparkles
 } from "lucide-react"
 import { Button, Input, Select, Typography } from "antd"
 import { browser } from "wxt/browser"
 import {
   useCreateFlashcardMutation,
   useDecksQuery,
-  useFlashcardsEnabled
+  useFlashcardsEnabled,
+  useGenerateFlashcardsMutation
 } from "@/components/Flashcards/hooks"
+import type { GeneratedCardDraft } from "@/components/Flashcards/tabs/ImportExport/shared"
+import { normalizeGeneratedCards } from "@/components/Flashcards/tabs/ImportExport/shared"
 import type { FlashcardCreate } from "@/services/flashcards"
 import { buildFlashcardsGenerateRoute } from "@/services/tldw/flashcards-generate-handoff"
 
 const { Text, Title } = Typography
 const { TextArea } = Input
+const SIDE_PANEL_GENERATE_CARD_COUNT = 3
 
 type CaptureDraft = {
   id: string
@@ -27,6 +32,10 @@ type CaptureDraft = {
   back: string
   sourceId: string
   sourceTitle?: string
+  tags?: string[]
+  modelType?: "basic" | "basic_reverse" | "cloze"
+  notes?: string | null
+  extra?: string | null
 }
 
 type CapturedPageSelection = {
@@ -60,7 +69,9 @@ export default function SidepanelFlashcards() {
   const draftIdRef = React.useRef(0)
   const [captureError, setCaptureError] = React.useState<string | null>(null)
   const [captureLoading, setCaptureLoading] = React.useState(false)
-  const [generateLoading, setGenerateLoading] = React.useState(false)
+  const [generateHandoffLoading, setGenerateHandoffLoading] =
+    React.useState(false)
+  const [draftGenerateLoading, setDraftGenerateLoading] = React.useState(false)
   const [saveStatus, setSaveStatus] = React.useState<{
     type: "success" | "error"
     message: string
@@ -74,6 +85,7 @@ export default function SidepanelFlashcards() {
   const flashcardsAvailability = useFlashcardsEnabled()
   const decksQuery = useDecksQuery()
   const createFlashcardMutation = useCreateFlashcardMutation()
+  const generateFlashcardsMutation = useGenerateFlashcardsMutation()
   const decks = React.useMemo(() => decksQuery.data ?? [], [decksQuery.data])
   const selectedDeck = decks.find((deck) => deck.id === selectedDeckId) ?? null
   const flashcardsUnavailable =
@@ -228,7 +240,7 @@ export default function SidepanelFlashcards() {
   const handleGenerateFromSelection = React.useCallback(async () => {
     setCaptureError(null)
     setSaveStatus(null)
-    setGenerateLoading(true)
+    setGenerateHandoffLoading(true)
     try {
       const captured = await readActivePageSelection()
       await openOptionsHashRoute(
@@ -242,9 +254,101 @@ export default function SidepanelFlashcards() {
     } catch (error) {
       setCaptureError(formatCaptureErrorMessage(error))
     } finally {
-      setGenerateLoading(false)
+      setGenerateHandoffLoading(false)
     }
   }, [formatCaptureErrorMessage, openOptionsHashRoute, readActivePageSelection])
+
+  const buildGeneratedDrafts = React.useCallback(
+    (
+      cards: GeneratedCardDraft[],
+      captured: CapturedPageSelection
+    ): CaptureDraft[] =>
+      cards.map((card) => {
+        draftIdRef.current += 1
+        return {
+          id: `generated-${draftIdRef.current}`,
+          front: card.front,
+          back: card.back,
+          sourceId: captured.sourceId,
+          sourceTitle: captured.sourceTitle,
+          tags: card.tags,
+          modelType: card.model_type,
+          notes: card.notes,
+          extra: card.extra
+        }
+      }),
+    []
+  )
+
+  const formatGenerateDraftErrorMessage = React.useCallback(
+    (error: unknown) => {
+      const message =
+        error instanceof Error && error.message.trim() ? error.message : ""
+      const validationMessages = [
+        captureMessages.unavailable,
+        captureMessages.activeTabUnavailable,
+        captureMessages.noSelection
+      ]
+      if (validationMessages.includes(message)) return message
+      return t("sidepanel:flashcards.generateDraftsFailed", {
+        defaultValue: "Could not generate draft cards. {{message}}",
+        message:
+          message ||
+          t(
+            "sidepanel:flashcards.generateDraftsFailedFallback",
+            "Check provider settings and try again."
+          )
+      })
+    },
+    [captureMessages, t]
+  )
+
+  const handleGenerateDraftCards = React.useCallback(async () => {
+    setCaptureError(null)
+    setSaveStatus(null)
+    setDraftGenerateLoading(true)
+    try {
+      const captured = await readActivePageSelection()
+      const result = await generateFlashcardsMutation.mutateAsync({
+        text: captured.selectedText,
+        numCards: SIDE_PANEL_GENERATE_CARD_COUNT,
+        cardType: "basic",
+        difficulty: "mixed"
+      })
+      const generatedDrafts = buildGeneratedDrafts(
+        normalizeGeneratedCards(result.flashcards),
+        captured
+      )
+      if (generatedDrafts.length === 0) {
+        setCaptureError(
+          t(
+            "sidepanel:flashcards.generateDraftsEmpty",
+            "No draft cards were generated. Try selecting a longer passage."
+          )
+        )
+        return
+      }
+      setDrafts((current) => [...current, ...generatedDrafts])
+      setSaveStatus({
+        type: "success",
+        message: t("sidepanel:flashcards.generateDraftsSuccess", {
+          defaultValue: "Generated {{count}} draft {{cardLabel}}.",
+          count: generatedDrafts.length,
+          cardLabel: generatedDrafts.length === 1 ? "card" : "cards"
+        })
+      })
+    } catch (error) {
+      setCaptureError(formatGenerateDraftErrorMessage(error))
+    } finally {
+      setDraftGenerateLoading(false)
+    }
+  }, [
+    buildGeneratedDrafts,
+    formatGenerateDraftErrorMessage,
+    generateFlashcardsMutation,
+    readActivePageSelection,
+    t
+  ])
 
   const getDeckName = React.useCallback(
     () => selectedDeck?.name || t("sidepanel:flashcards.defaultDeck", "deck"),
@@ -269,12 +373,15 @@ export default function SidepanelFlashcards() {
       if (!front || !back) return null
 
       return {
+        ...(draft.tags?.length ? { tags: draft.tags } : {}),
+        ...(draft.notes ? { notes: draft.notes } : {}),
+        ...(draft.extra ? { extra: draft.extra } : {}),
         deck_id: selectedDeckId,
         front,
         back,
-        model_type: "basic",
-        is_cloze: false,
-        reverse: false,
+        model_type: draft.modelType ?? "basic",
+        is_cloze: draft.modelType === "cloze",
+        reverse: draft.modelType === "basic_reverse",
         source_ref_type: "manual",
         source_ref_id: draft.sourceId
       }
@@ -433,6 +540,7 @@ export default function SidepanelFlashcards() {
   ])
 
   const isSaving = createFlashcardMutation.isPending || savingDraftIds.size > 0
+  const isGenerating = generateHandoffLoading || draftGenerateLoading
   const canSaveDraft = React.useCallback(
     (draft: CaptureDraft) => !!buildSavePayload(draft) && hasDeck && !isSaving,
     [buildSavePayload, hasDeck, isSaving]
@@ -472,7 +580,7 @@ export default function SidepanelFlashcards() {
         <Button
           block
           loading={captureLoading}
-          disabled={isSaving || generateLoading}
+          disabled={isSaving || isGenerating}
           icon={<MessageSquareText className="size-4" aria-hidden="true" />}
           onClick={handleCapturePageSelection}
         >
@@ -483,8 +591,20 @@ export default function SidepanelFlashcards() {
         </Button>
         <Button
           block
-          loading={generateLoading}
-          disabled={isSaving || captureLoading}
+          loading={draftGenerateLoading}
+          disabled={isSaving || captureLoading || generateHandoffLoading}
+          icon={<WandSparkles className="size-4" aria-hidden="true" />}
+          onClick={() => void handleGenerateDraftCards()}
+        >
+          {t(
+            "sidepanel:flashcards.generateDraftCards",
+            "Generate draft cards"
+          )}
+        </Button>
+        <Button
+          block
+          loading={generateHandoffLoading}
+          disabled={isSaving || captureLoading || draftGenerateLoading}
           icon={<Sparkles className="size-4" aria-hidden="true" />}
           onClick={() => void handleGenerateFromSelection()}
         >
@@ -497,7 +617,7 @@ export default function SidepanelFlashcards() {
       <Text type="secondary" className="text-xs">
         {t(
           "sidepanel:flashcards.selectionHint",
-          "Create one editable card in the sidepanel. Use full Flashcards for generation, imports, and review."
+          "Create one editable card, generate a small draft batch, or use full Flashcards for templates, imports, and review."
         )}
       </Text>
       {drafts.length > 0 ? (

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -76,6 +76,7 @@ export default function SidepanelFlashcards() {
     type: "success" | "error"
     message: string
   } | null>(null)
+  const generationInFlightRef = React.useRef(false)
   const [drafts, setDrafts] = React.useState<CaptureDraft[]>([])
   const [savingDraftIds, setSavingDraftIds] = React.useState<Set<string>>(
     () => new Set()
@@ -238,6 +239,8 @@ export default function SidepanelFlashcards() {
   }, [formatCaptureErrorMessage, readActivePageSelection])
 
   const handleGenerateFromSelection = React.useCallback(async () => {
+    if (generationInFlightRef.current) return
+    generationInFlightRef.current = true
     setCaptureError(null)
     setSaveStatus(null)
     setGenerateHandoffLoading(true)
@@ -254,6 +257,7 @@ export default function SidepanelFlashcards() {
     } catch (error) {
       setCaptureError(formatCaptureErrorMessage(error))
     } finally {
+      generationInFlightRef.current = false
       setGenerateHandoffLoading(false)
     }
   }, [formatCaptureErrorMessage, openOptionsHashRoute, readActivePageSelection])
@@ -303,7 +307,93 @@ export default function SidepanelFlashcards() {
     [captureMessages, t]
   )
 
+  const formatGeneratedDraftsSuccess = React.useCallback(
+    (count: number) =>
+      count === 1
+        ? t("sidepanel:flashcards.generateDraftsSuccess_one", {
+            defaultValue: "Generated 1 draft card.",
+            count
+          })
+        : t("sidepanel:flashcards.generateDraftsSuccess_other", {
+            defaultValue: "Generated {{count}} draft cards.",
+            count
+          }),
+    [t]
+  )
+
+  const formatDraftQueueCount = React.useCallback(
+    (count: number) =>
+      count === 1
+        ? t("sidepanel:flashcards.draftQueueCount_one", {
+            defaultValue: "1 draft card ready",
+            count
+          })
+        : t("sidepanel:flashcards.draftQueueCount_other", {
+            defaultValue: "{{count}} draft cards ready",
+            count
+          }),
+    [t]
+  )
+
+  const formatSaveAllSuccess = React.useCallback(
+    (savedCount: number, deckName: string) =>
+      savedCount === 1
+        ? t("sidepanel:flashcards.saveAllSuccess_one", {
+            defaultValue: "Saved 1 card to {{deckName}}.",
+            savedCount,
+            deckName
+          })
+        : t("sidepanel:flashcards.saveAllSuccess_other", {
+            defaultValue: "Saved {{savedCount}} cards to {{deckName}}.",
+            savedCount,
+            deckName
+          }),
+    [t]
+  )
+
+  const formatSaveAllPartial = React.useCallback(
+    (savedCount: number, failedCount: number, deckName: string) => {
+      if (savedCount === 1 && failedCount === 1) {
+        return t("sidepanel:flashcards.saveAllPartial_one_one", {
+          defaultValue:
+            "Saved 1 card to {{deckName}}. 1 draft still needs attention.",
+          savedCount,
+          failedCount,
+          deckName
+        })
+      }
+      if (savedCount === 1) {
+        return t("sidepanel:flashcards.saveAllPartial_one_other", {
+          defaultValue:
+            "Saved 1 card to {{deckName}}. {{failedCount}} drafts still need attention.",
+          savedCount,
+          failedCount,
+          deckName
+        })
+      }
+      if (failedCount === 1) {
+        return t("sidepanel:flashcards.saveAllPartial_other_one", {
+          defaultValue:
+            "Saved {{savedCount}} cards to {{deckName}}. 1 draft still needs attention.",
+          savedCount,
+          failedCount,
+          deckName
+        })
+      }
+      return t("sidepanel:flashcards.saveAllPartial_other_other", {
+        defaultValue:
+          "Saved {{savedCount}} cards to {{deckName}}. {{failedCount}} drafts still need attention.",
+        savedCount,
+        failedCount,
+        deckName
+      })
+    },
+    [t]
+  )
+
   const handleGenerateDraftCards = React.useCallback(async () => {
+    if (generationInFlightRef.current) return
+    generationInFlightRef.current = true
     setCaptureError(null)
     setSaveStatus(null)
     setDraftGenerateLoading(true)
@@ -316,7 +406,7 @@ export default function SidepanelFlashcards() {
         difficulty: "mixed"
       })
       const generatedDrafts = buildGeneratedDrafts(
-        normalizeGeneratedCards(result.flashcards),
+        normalizeGeneratedCards(result?.flashcards),
         captured
       )
       if (generatedDrafts.length === 0) {
@@ -331,20 +421,18 @@ export default function SidepanelFlashcards() {
       setDrafts((current) => [...current, ...generatedDrafts])
       setSaveStatus({
         type: "success",
-        message: t("sidepanel:flashcards.generateDraftsSuccess", {
-          defaultValue: "Generated {{count}} draft {{cardLabel}}.",
-          count: generatedDrafts.length,
-          cardLabel: generatedDrafts.length === 1 ? "card" : "cards"
-        })
+        message: formatGeneratedDraftsSuccess(generatedDrafts.length)
       })
     } catch (error) {
       setCaptureError(formatGenerateDraftErrorMessage(error))
     } finally {
+      generationInFlightRef.current = false
       setDraftGenerateLoading(false)
     }
   }, [
     buildGeneratedDrafts,
     formatGenerateDraftErrorMessage,
+    formatGeneratedDraftsSuccess,
     generateFlashcardsMutation,
     readActivePageSelection,
     t
@@ -489,25 +577,12 @@ export default function SidepanelFlashcards() {
       if (failedCount === 0) {
         setSaveStatus({
           type: "success",
-          message: t("sidepanel:flashcards.saveAllSuccess", {
-            defaultValue: "Saved {{savedCount}} {{cardLabel}} to {{deckName}}.",
-            savedCount: savedDraftIds.size,
-            cardLabel: savedDraftIds.size === 1 ? "card" : "cards",
-            deckName
-          })
+          message: formatSaveAllSuccess(savedDraftIds.size, deckName)
         })
       } else if (savedDraftIds.size > 0) {
         setSaveStatus({
           type: "error",
-          message: t("sidepanel:flashcards.saveAllPartial", {
-            defaultValue:
-              "Saved {{savedCount}} {{cardLabel}} to {{deckName}}. {{failedCount}} {{draftLabel}} still needs attention.",
-            savedCount: savedDraftIds.size,
-            cardLabel: savedDraftIds.size === 1 ? "card" : "cards",
-            deckName,
-            failedCount,
-            draftLabel: failedCount === 1 ? "draft" : "drafts"
-          })
+          message: formatSaveAllPartial(savedDraftIds.size, failedCount, deckName)
         })
       } else {
         setSaveStatus({
@@ -533,6 +608,8 @@ export default function SidepanelFlashcards() {
     buildSavePayload,
     createFlashcardMutation,
     drafts,
+    formatSaveAllPartial,
+    formatSaveAllSuccess,
     getDeckName,
     hasDeck,
     setActiveSavingDraftIds,
@@ -627,11 +704,7 @@ export default function SidepanelFlashcards() {
         >
           <div className="flex items-center justify-between gap-2">
             <Text strong>
-              {t("sidepanel:flashcards.draftQueueCount", {
-                defaultValue: "{{count}} draft {{cardLabel}} ready",
-                count: drafts.length,
-                cardLabel: drafts.length === 1 ? "card" : "cards"
-              })}
+              {formatDraftQueueCount(drafts.length)}
             </Text>
             <Button
               size="small"

--- a/backlog/tasks/task-519 - Add-flashcards-extension-native-generated-draft-queue.md
+++ b/backlog/tasks/task-519 - Add-flashcards-extension-native-generated-draft-queue.md
@@ -1,0 +1,82 @@
+---
+id: TASK-519
+title: Add flashcards extension native generated draft queue
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-27 05:30
+labels:
+- flashcards
+- extension
+- ux
+dependencies: []
+documentation:
+- Flashcards-UX-Fix-List.md
+priority: medium
+modified_files:
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- apps/extension/docs/features/flashcards.md
+- Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Flashcards-UX-Fix-List.md
+- Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next narrow F12 follow-up: let the extension sidepanel generate a small set of editable draft cards from selected page text using the existing flashcards generation mutation, while keeping native template application and in-extension review deferred.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sidepanel Flashcards exposes Generate draft cards next to native capture and full-workspace generation handoff.
+- [x] #2 Generate draft cards captures active-page selected text through the existing browser scripting path.
+- [x] #3 Native generation uses the existing flashcards generation mutation with compact defaults and appends normalized generated cards to the sidepanel draft queue.
+- [x] #4 Generated draft saves preserve model type, cloze/reverse flags, tags, notes, extra fields, selected deck, and page source provenance.
+- [x] #5 Generation failures remain inline and do not clear queued manual drafts.
+- [x] #6 Native sidepanel template application and in-extension review remain deferred.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-implementation-plan.md.
+
+Touched scope: sidepanel Flashcards route/tests, extension/WebUI flashcards docs, master UX fix list, and the implementation plan.
+
+Implementation notes: added Generate draft cards beside existing capture and full-workspace generation handoff actions. The new action shares the active-page selection reader, calls useGenerateFlashcardsMutation with compact defaults, normalizes results with normalizeGeneratedCards, and appends generated drafts to the existing editable queue. Generated draft save payloads preserve model type, cloze/reverse flags, tags, notes, extra fields, selected deck, and source URL provenance. Template application and in-extension review remain deferred.
+
+Verification:
+- RED: bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx failed with the expected missing Generate draft cards action after dependency setup.
+- PASS: bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx passed 25 tests.
+- PASS: bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts passed 35 tests.
+- PASS: git diff --check.
+- PARTIAL: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false still reports only the unrelated CharacterListContent design-system density baseline.
+- Bandit not applicable: no Python files touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added native sidepanel generated draft batches for selected page text. The sidepanel now offers a compact Generate draft cards action that reads the active page selection, uses the existing flashcards generation mutation, normalizes generated cards through the existing shared helper, and appends editable drafts into the existing sidepanel queue. Generated drafts preserve model type, tags, notes, extra fields, source URL provenance, and reuse save-one/save-all recovery.
+
+Focused sidepanel, route-registry, and generate-handoff tests pass. Package-wide TypeScript still reports the unrelated pre-existing CharacterListContent density baseline; no flashcards/sidepanel TypeScript errors were reported. Bandit is not applicable because this slice touches TypeScript/docs only and no Python files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-519 - Add-flashcards-extension-native-generated-draft-queue.md
+++ b/backlog/tasks/task-519 - Add-flashcards-extension-native-generated-draft-queue.md
@@ -3,7 +3,7 @@ id: TASK-519
 title: Add flashcards extension native generated draft queue
 status: Done
 assignee: []
-created_date: ''
+created_date: 2026-05-27 05:30
 updated_date: 2026-05-27 05:30
 labels:
 - flashcards

--- a/backlog/tasks/task-520 - Address-PR-2079-flashcards-generated-drafts-review-comments.md
+++ b/backlog/tasks/task-520 - Address-PR-2079-flashcards-generated-drafts-review-comments.md
@@ -1,0 +1,74 @@
+---
+id: TASK-520
+title: Address PR 2079 flashcards generated drafts review comments
+status: Done
+assignee:
+- Codex
+labels:
+- flashcards
+- extension
+- review-fix
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/2079
+modified_files:
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- backlog/tasks/task-519 - Add-flashcards-extension-native-generated-draft-queue.md
+- Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-review-fix-plan.md
+- backlog/tasks/task-520 - Address-PR-2079-flashcards-generated-drafts-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the actionable PR #2079 review feedback for the flashcards extension native generated-draft queue after rebasing on the latest `dev`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased on current `origin/dev` without conflicts.
+- [x] #2 Sidepanel generation actions are protected by a synchronous shared in-flight guard.
+- [x] #3 Native generated-draft handling tolerates missing or malformed mutation results without surfacing a TypeError to users.
+- [x] #4 Generated-draft count status copy no longer interpolates hardcoded English singular/plural label fragments.
+- [x] #5 TASK-519 `created_date` metadata is populated for audit traceability.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-27-flashcards-extension-native-generated-drafts-review-fix-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Review verification:
+- `git rebase origin/dev` reported the branch was up to date.
+- GitHub review threads showed unresolved Gemini comments for optional mutation result handling and generated-count localization, plus a CodeRabbit comment for TASK-519 `created_date` metadata.
+- CodeRabbit also posted an outside-diff recommendation to add a synchronous generation in-flight guard.
+
+TDD record:
+- RED: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` failed 4 new assertions covering duplicate native generation, competing full-workspace handoff during native generation, missing flashcards response handling, and localized generated-count copy.
+- GREEN: the same focused sidepanel suite passed 29 tests after implementation.
+
+Implementation notes: added a shared `generationInFlightRef` around both generation handlers; changed native generation normalization to use `result?.flashcards`; moved generated/queue/save-all count messages to localized whole-message branches instead of English `cardLabel`/`draftLabel` interpolation; populated TASK-519 `created_date`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #2079 review comments after rebasing on `origin/dev`. Added regression coverage for rapid duplicate generation activation, native/full-workspace generation contention, missing generation results, and localized generated-count status copy. Updated the sidepanel route with a shared generation in-flight ref, optional generation result normalization, and localized whole-message branches for generated/queue/save-all count copy. Populated TASK-519 `created_date` metadata.
+
+Verification: focused sidepanel RED run failed 4 new review-fix assertions before implementation; focused sidepanel GREEN run passed 29 tests; broader flashcards sidepanel/generate-handoff suite passed 39 tests; `git diff --check` passed. TypeScript check still reports the unrelated baseline `CharacterListContent.design-system.test.tsx(35,3)` density type mismatch. Bandit is not applicable because no Python files changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add a compact sidepanel `Generate draft cards` action for selected page text.
- Reuse the existing flashcards generation mutation and normalizer, then append generated cards into the existing editable sidepanel draft queue.
- Preserve generated metadata on save, including model type, cloze/reverse flags, tags, notes, extra fields, selected deck, and source URL provenance.
- Update the UX fix list, docs, implementation plan, and TASK-519 while keeping native template application and in-extension review deferred.

## Test Plan
- [x] `bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
- [x] `git diff --check`
- [ ] `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` - still reports the unrelated pre-existing `CharacterListContent.design-system.test.tsx` density baseline.
- [x] Bandit not applicable: TypeScript/docs-only slice; no Python files touched.

## Change summary
TODO: human-authored change summary required before marking this PR ready for review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native generated draft cards to the extension sidepanel with compact defaults, safer activation, and clearer messages. Users can generate a small editable batch from selected text without leaving the page.

- New Features
  - Added “Generate draft cards” beside Capture and Generate from selection; drafts append to the sidepanel queue with edit/delete, save-one/save-all.
  - Saved cards preserve model type, cloze/reverse, tags, notes, extra fields, selected deck, and source URL. Reuses the existing generation mutation and normalizer. Satisfies TASK-519.

- Bug Fixes
  - Added a shared in-flight guard to prevent duplicate native generation and to block the full-workspace handoff while generation is running.
  - Tolerates empty/malformed generation responses and shows helpful empty-state guidance.
  - Switched generated/queue/save-all count copy to localized whole-message variants (no hardcoded plural fragments).
  - Expanded tests for duplicate clicks, contention, empty responses, and i18n; updated docs and the UX fix list. Addresses TASK-520.

<sup>Written for commit 744c14ead8b1ce86e46d6373f80dd1a14d2aa952. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2079?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

