### PR TITLE
Add MCP Unified profile presets

### DIFF
--- a/Docs/superpowers/plans/2026-05-27-mcp-unified-profile-presets-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-mcp-unified-profile-presets-implementation-plan.md
@@ -1,0 +1,216 @@
+# MCP Unified Profile Presets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add package-local MCP profile preset primitives that model the initial front-end modes without changing current `tldw_server` MCP route behavior.
+
+**Architecture:** This slice keeps all new logic inside the standalone `mcp_unified` package. Built-in presets are immutable templates that can be listed, looked up, validated against the spec safety baseline, and duplicated into editable `MCPProfile` instances with preset provenance. No protocol dispatch, host adapter, SQLite store, FastAPI router, gateway entrypoint, or tool execution behavior changes in this slice.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, pytest, Ruff, Mypy, Bandit, Backlog.md.
+
+---
+
+## Source Spec
+
+- Spec: `Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md`
+- Previous package-boundary task: `TASK-518`
+- Backlog task: `TASK-519`
+
+## Scope Boundary
+
+In scope:
+
+- Add `mcp_unified.profiles.presets` with immutable preset definitions.
+- Include the spec's initial role/mode preset ids.
+- Add safety validation helpers that fail closed on unsafe default grants.
+- Add duplication helper to turn a preset into an editable `MCPProfile`.
+- Export preset primitives from `mcp_unified.profiles`.
+- Add package-boundary tests for preset import isolation, lookup, duplication, and safety validation.
+- Update task bookkeeping and verification evidence.
+
+Out of scope:
+
+- Profile persistence, SQLite stores, migrations, or assignments.
+- Policy enforcement inside `MCPProtocol`.
+- Host MCP Hub, AuthNZ, path scope, approval, credential, or route behavior changes.
+- Gateway entrypoints or stdio transports.
+- Tool catalog integration or execution filtering.
+
+## File Structure
+
+Create:
+
+- `mcp_unified/profiles/presets.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+
+Modify:
+
+- `mcp_unified/profiles/__init__.py`
+- `backlog/tasks/task-519 - Implement-MCP-Unified-Stage-2-profile-preset-primitives.md`
+
+## Task 1: Add Failing Preset Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+
+- [x] **Step 1: Write package-boundary preset tests**
+
+Add tests for:
+
+- `mcp_unified.profiles.presets` imports without `tldw_Server_API`.
+- `list_builtin_presets()` returns the spec's initial preset ids.
+- `get_builtin_preset("architect")` returns a stable preset with version.
+- `duplicate_builtin_preset("architect")` returns an `MCPProfile` with `preset_id`, `preset_version`, and provenance.
+- `validate_preset_safety()` catches unsafe grants such as process execution without approval provenance.
+
+- [x] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -v
+```
+
+Expected: FAIL because `mcp_unified.profiles.presets` does not exist.
+
+## Task 2: Implement Preset Primitives
+
+**Files:**
+- Create: `mcp_unified/profiles/presets.py`
+- Modify: `mcp_unified/profiles/__init__.py`
+
+- [x] **Step 1: Add immutable preset model**
+
+Create `ProfilePreset` as a frozen Pydantic model with:
+
+- `id`
+- `version`
+- `profile`
+
+The embedded profile should use `MCPProfile` and preserve extension metadata.
+
+- [x] **Step 2: Add bundled preset definitions**
+
+Add presets with these ids:
+
+- `orchestrator`
+- `product-owner`
+- `architect`
+- `merge-conflict-resolver`
+- `documentation-writer`
+- `project-researcher`
+- `deep-researcher`
+- `code-reviewer`
+- `devops-engineer`
+- `backend-engineer`
+- `frontend-engineer`
+- `qa-engineer`
+- `sdet`
+- `memory-keeper`
+
+Use conservative defaults:
+
+- no credential grants unless explicitly justified
+- no destructive filesystem capability by default
+- no process execution capability by default
+- external network grants only for `deep-researcher`, with provenance
+- write-oriented presets use approval policy and scoped capabilities instead of broad shell/process access
+
+- [x] **Step 3: Add public helpers**
+
+Implement:
+
+- `list_builtin_presets() -> tuple[ProfilePreset, ...]`
+- `get_builtin_preset(preset_id: str) -> ProfilePreset | None`
+- `duplicate_builtin_preset(preset_id: str, *, profile_id: str | None = None, name: str | None = None) -> MCPProfile`
+- `validate_preset_safety(preset: ProfilePreset) -> list[str]`
+
+- [x] **Step 4: Export from `profiles.__init__`**
+
+Export `ProfilePreset`, `duplicate_builtin_preset`, `get_builtin_preset`, `list_builtin_presets`, and `validate_preset_safety`.
+
+- [x] **Step 5: Run preset tests**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -v
+```
+
+Expected: PASS.
+
+## Task 3: Verify Package Boundary And Quality Gates
+
+**Files:**
+- Modify: `backlog/tasks/task-519 - Implement-MCP-Unified-Stage-2-profile-preset-primitives.md`
+
+- [x] **Step 1: Run focused MCP package tests**
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run package quality checks**
+
+Run:
+
+```bash
+python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+python -m mypy mcp_unified --config-file pyproject.toml
+python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_profile_presets.json
+git diff --check
+```
+
+Expected:
+
+- Ruff passes.
+- Mypy passes for `mcp_unified`.
+- Bandit reports 0 findings.
+- Diff whitespace check is clean.
+
+- [x] **Step 3: Update Backlog task**
+
+Record implementation summary, touched files, verification commands/results, and known skips/blockers.
+
+- [x] **Step 4: Commit**
+
+Run:
+
+```bash
+git add \
+  mcp_unified/profiles/__init__.py \
+  mcp_unified/profiles/presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  Docs/superpowers/plans/2026-05-27-mcp-unified-profile-presets-implementation-plan.md \
+  "backlog/tasks/task-519 - Implement-MCP-Unified-Stage-2-profile-preset-primitives.md"
+git commit -m "feat: add mcp unified profile presets"
+```
+
+## Final Verification Before PR
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -v
+python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+python -m mypy mcp_unified --config-file pyproject.toml
+python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_profile_presets.json
+git diff --check
+```
+
+Expected:
+
+- Preset tests pass.
+- Runtime package-boundary tests still pass.
+- Profile preset package stays free of `tldw_Server_API` imports.
+- Quality checks pass with 0 new security findings.

--- a/backlog/tasks/task-519 - Implement-MCP-Unified-Stage-2-profile-preset-primitives.md
+++ b/backlog/tasks/task-519 - Implement-MCP-Unified-Stage-2-profile-preset-primitives.md
@@ -1,0 +1,73 @@
+---
+id: TASK-519
+title: Implement MCP Unified Stage 2 profile preset primitives
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-27 06:32'
+labels:
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage2
+  - profiles
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-27-mcp-unified-profile-presets-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Package-local profile preset primitives are available without importing tldw_Server_API.
+- [x] #2 Bundled role/mode presets cover the spec's initial mode list with stable ids and preset versions.
+- [x] #3 Preset policies satisfy the safety baseline: no broad process execution, destructive filesystem action, credentials, or external network by default unless explicitly granted with provenance.
+- [x] #4 Presets can be duplicated into editable MCPProfile instances with preset id/version provenance preserved.
+- [x] #5 Tests cover package import isolation, preset lookup, duplication, and safety validation.
+- [x] #6 Focused tests, Ruff/Mypy for mcp_unified, Bandit touched scope, and diff whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan: Docs/superpowers/plans/2026-05-27-mcp-unified-profile-presets-implementation-plan.md
+
+Implemented package-local MCP profile preset primitives:
+- Added mcp_unified.profiles.presets with immutable ProfilePreset templates, preset lookup/listing, duplication into editable MCPProfile objects, and safety validation helpers.
+- Added all initial spec role/mode ids: orchestrator, product-owner, architect, merge-conflict-resolver, documentation-writer, project-researcher, deep-researcher, code-reviewer, devops-engineer, backend-engineer, frontend-engineer, qa-engineer, sdet, memory-keeper.
+- Presets use conservative capabilities, no default credential grants, no broad process execution, and explicit external network provenance for deep-researcher.
+- Exported preset primitives from mcp_unified.profiles.
+- Added package-boundary tests for no tldw_Server_API imports, preset coverage, lookup, duplication/provenance, and safety rejection.
+
+Verification:
+- python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v -> 9 passed, 3 warnings
+- python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -> passed
+- python -m mypy mcp_unified --config-file pyproject.toml -> passed
+- python -m bandit -r mcp_unified -f json -o bandit_mcp_unified_profile_presets.json -> 0 findings
+- git diff --check -> clean
+
+Known skips/blockers: none for this slice.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added package-local built-in MCP profile preset primitives for the initial front-end role/mode set. Presets are conservative templates with stable ids/versioning, safety-baseline validation, and duplication into editable MCPProfile objects with preset provenance preserved. No tldw_server host MCP route, policy, approval, credential, or execution behavior changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-519 - Implement-MCP-Unified-Stage-2-profile-preset-primitives.md
+++ b/backlog/tasks/task-519 - Implement-MCP-Unified-Stage-2-profile-preset-primitives.md
@@ -54,12 +54,29 @@ Verification:
 - git diff --check -> clean
 
 Known skips/blockers: none for this slice.
+
+PR review follow-up:
+- Rebased branch on latest origin/dev after PR #2079 merged.
+- Made duplicated built-in preset ids unique by default and refreshed duplicate created_at/updated_at timestamps.
+- Hardened preset safety checks so process_execution approval requires explicit process_execution coverage or a globally required approval policy.
+- Made approval required_for normalization defensive for null and unexpected values.
+- Added docstrings requested by review comments and narrowed the preset import-boundary scan to the profile package.
+- Added regression tests for duplicate id uniqueness, duplicate timestamp refresh, explicit process_execution approval, and null required_for handling.
+
+Review follow-up verification:
+- python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v -> 13 passed, 3 warnings
+- python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -> passed
+- python -m mypy mcp_unified --config-file pyproject.toml -> passed
+- python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_profile_presets.json -> 0 findings
+- git diff --check -> clean
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added package-local built-in MCP profile preset primitives for the initial front-end role/mode set. Presets are conservative templates with stable ids/versioning, safety-baseline validation, and duplication into editable MCPProfile objects with preset provenance preserved. No tldw_server host MCP route, policy, approval, credential, or execution behavior changed.
+
+PR review follow-up tightened duplicate profile creation and preset safety validation. Duplicates now get unique default ids plus fresh timestamps, process execution approval must be explicit unless approval is globally required, malformed required_for policies fail closed, and the package-boundary test now scans only the profile package seam under review.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/profiles/__init__.py
+++ b/mcp_unified/profiles/__init__.py
@@ -1,6 +1,22 @@
 """Profile schema and resolver primitives for MCP Unified."""
 
 from .models import MCPProfile, ProfilePolicy
+from .presets import (
+    ProfilePreset,
+    duplicate_builtin_preset,
+    get_builtin_preset,
+    list_builtin_presets,
+    validate_preset_safety,
+)
 from .resolver import ProfileResolver
 
-__all__ = ["MCPProfile", "ProfilePolicy", "ProfileResolver"]
+__all__ = [
+    "MCPProfile",
+    "ProfilePolicy",
+    "ProfilePreset",
+    "ProfileResolver",
+    "duplicate_builtin_preset",
+    "get_builtin_preset",
+    "list_builtin_presets",
+    "validate_preset_safety",
+]

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
+from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict
 
@@ -49,6 +51,7 @@ def _policy(
     tool_patterns: list[str] | None = None,
     module_patterns: list[str] | None = None,
 ) -> ProfilePolicy:
+    """Build a conservative package-local policy document for a preset."""
     return ProfilePolicy(
         allowed_tools=allowed_tools or [],
         capabilities=capabilities,
@@ -71,6 +74,7 @@ def _profile(
     provenance: dict[str, Any] | None = None,
     agent_metadata: dict[str, Any] | None = None,
 ) -> MCPProfile:
+    """Build an MCP profile template with preset provenance metadata."""
     metadata = {
         "agent_metadata": {
             "ui_label": name,
@@ -112,6 +116,7 @@ def _preset(
     provenance: dict[str, Any] | None = None,
     agent_metadata: dict[str, Any] | None = None,
 ) -> ProfilePreset:
+    """Build an immutable preset wrapper for a bundled MCP profile template."""
     return ProfilePreset(
         id=preset_id,
         version=PRESET_VERSION,
@@ -288,11 +293,14 @@ def duplicate_builtin_preset(
         raise ValueError(f"Unknown MCP profile preset: {preset_id}")
 
     profile = preset.profile.model_copy(deep=True)
-    profile.id = profile_id or f"{preset.id}-copy"
+    now = datetime.now(timezone.utc)
+    profile.id = profile_id or f"{preset.id}-{uuid4().hex[:8]}"
     if name is not None:
         profile.name = name
     profile.preset_id = preset.id
     profile.preset_version = preset.version
+    profile.created_at = now
+    profile.updated_at = now
     profile.provenance = {
         **profile.provenance,
         "source": "builtin_preset",
@@ -341,16 +349,29 @@ def validate_preset_safety(preset: ProfilePreset) -> list[str]:
 
 
 def _approval_required_for(profile: MCPProfile, risk_class: str) -> bool:
+    """Return whether a profile requires approval for the given risk class."""
     approval_policy = profile.approval_policy
-    required_for = approval_policy.get("required_for", [])
     if approval_policy.get("required") is True:
         return True
-    if isinstance(required_for, str):
-        required_for = [required_for]
+
+    raw_required_for = approval_policy.get("required_for", [])
+    if raw_required_for is None:
+        required_for: list[str] = []
+    elif isinstance(raw_required_for, str):
+        required_for = [raw_required_for]
+    elif isinstance(raw_required_for, (list, tuple, set)):
+        required_for = [item for item in raw_required_for if isinstance(item, str)]
+    else:
+        required_for = []
+
+    if risk_class == "process_execution":
+        return "process_execution" in required_for
+
     return risk_class in required_for or "mutating" in required_for or "write" in required_for
 
 
 def _has_high_risk_provenance(profile: MCPProfile, risk_class: str) -> bool:
+    """Return whether high-risk capability provenance is recorded."""
     high_risk = profile.provenance.get("high_risk")
     if isinstance(high_risk, dict) and high_risk.get(risk_class):
         return True

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -1,0 +1,357 @@
+"""Built-in MCP profile presets for front-end modes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from .models import MCPProfile, ProfilePolicy
+
+PRESET_VERSION = "2026.05.27"
+
+_PROCESS_CAPABILITIES = {
+    "command.run",
+    "process.execute",
+    "shell.execute",
+}
+_DESTRUCTIVE_FILESYSTEM_CAPABILITIES = {
+    "filesystem.delete",
+    "filesystem.destructive",
+    "filesystem.write_unscoped",
+}
+_EXTERNAL_NETWORK_CAPABILITIES = {
+    "external.network",
+}
+_HIGH_RISK_RISK_CLASSES = {
+    "credential_use",
+    "destructive_filesystem",
+    "external_network",
+    "process_execution",
+}
+
+
+class ProfilePreset(BaseModel):
+    """Immutable template for a built-in MCP profile preset."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    version: str
+    profile: MCPProfile
+
+
+def _policy(
+    *,
+    capabilities: list[str],
+    risk_classes: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    tool_patterns: list[str] | None = None,
+    module_patterns: list[str] | None = None,
+) -> ProfilePolicy:
+    return ProfilePolicy(
+        allowed_tools=allowed_tools or [],
+        capabilities=capabilities,
+        tool_patterns=tool_patterns or [],
+        module_patterns=module_patterns or [],
+        risk_classes=risk_classes or [],
+    )
+
+
+def _profile(
+    *,
+    preset_id: str,
+    name: str,
+    description: str,
+    capabilities: list[str],
+    risk_classes: list[str] | None = None,
+    approval_policy: dict[str, Any] | None = None,
+    external_server_grants: list[dict[str, Any]] | None = None,
+    credential_grants: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    agent_metadata: dict[str, Any] | None = None,
+) -> MCPProfile:
+    metadata = {
+        "agent_metadata": {
+            "ui_label": name,
+            **(agent_metadata or {}),
+        }
+    }
+    return MCPProfile(
+        id=preset_id,
+        name=name,
+        description=description,
+        preset_id=preset_id,
+        preset_version=PRESET_VERSION,
+        policy_document=_policy(
+            capabilities=capabilities,
+            risk_classes=risk_classes,
+        ),
+        approval_policy=approval_policy or {},
+        external_server_grants=external_server_grants or [],
+        credential_grants=credential_grants or [],
+        metadata=metadata,
+        provenance={
+            "source": "builtin_preset",
+            "preset_id": preset_id,
+            "preset_version": PRESET_VERSION,
+            **(provenance or {}),
+        },
+    )
+
+
+def _preset(
+    *,
+    preset_id: str,
+    name: str,
+    description: str,
+    capabilities: list[str],
+    risk_classes: list[str] | None = None,
+    approval_policy: dict[str, Any] | None = None,
+    external_server_grants: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    agent_metadata: dict[str, Any] | None = None,
+) -> ProfilePreset:
+    return ProfilePreset(
+        id=preset_id,
+        version=PRESET_VERSION,
+        profile=_profile(
+            preset_id=preset_id,
+            name=name,
+            description=description,
+            capabilities=capabilities,
+            risk_classes=risk_classes,
+            approval_policy=approval_policy,
+            external_server_grants=external_server_grants,
+            provenance=provenance,
+            agent_metadata=agent_metadata,
+        ),
+    )
+
+
+_WRITE_APPROVAL_POLICY: dict[str, Any] = {
+    "required_for": ["write", "mutating"],
+    "reason": "Preset includes scoped write-oriented capabilities.",
+}
+
+_BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
+    _preset(
+        preset_id="orchestrator",
+        name="Orchestrator",
+        description="Coordinates workflows with broad read access and approval-gated scoped writes.",
+        capabilities=["workflow.plan", "task.coordinate", "workspace.read", "workspace.write_scoped"],
+        risk_classes=["mutating"],
+        approval_policy=_WRITE_APPROVAL_POLICY,
+    ),
+    _preset(
+        preset_id="product-owner",
+        name="Product Owner",
+        description="Plans user stories, requirements, and documentation without process execution.",
+        capabilities=["issues.plan", "stories.write", "docs.read", "docs.write_scoped"],
+        risk_classes=["mutating"],
+        approval_policy=_WRITE_APPROVAL_POLICY,
+    ),
+    _preset(
+        preset_id="architect",
+        name="Architect",
+        description="Reviews architecture with code search, documentation, and read-only filesystem access.",
+        capabilities=["code_search", "docs.read", "filesystem.read"],
+    ),
+    _preset(
+        preset_id="merge-conflict-resolver",
+        name="Merge Conflict Resolver",
+        description="Inspects git state and writes repo-scoped conflict resolutions with approval gates.",
+        capabilities=["git.status", "git.diff", "filesystem.read", "repo.write_scoped"],
+        risk_classes=["mutating"],
+        approval_policy={
+            "required_for": ["repo.write_scoped", "git.destructive"],
+            "reason": "Conflict resolution writes are repo-scoped and mutating.",
+        },
+    ),
+    _preset(
+        preset_id="documentation-writer",
+        name="Documentation Writer",
+        description="Reads and writes documentation within scoped workspace paths.",
+        capabilities=["docs.read", "docs.write_scoped", "filesystem.read"],
+        risk_classes=["mutating"],
+        approval_policy=_WRITE_APPROVAL_POLICY,
+    ),
+    _preset(
+        preset_id="project-researcher",
+        name="Project Researcher",
+        description="Searches and reads the codebase without write or execution capabilities.",
+        capabilities=["code_search", "filesystem.read", "docs.read"],
+    ),
+    _preset(
+        preset_id="deep-researcher",
+        name="Deep Researcher",
+        description="Uses research and citation tools with explicit external network permission.",
+        capabilities=["research.web", "citations.write", "external.network"],
+        risk_classes=["external_network"],
+        external_server_grants=[
+            {
+                "server_id": "research",
+                "grant": "network_research",
+                "provenance": "Deep research requires explicitly granted external network access.",
+            }
+        ],
+        provenance={
+            "external_network": "Deep research preset intentionally grants web research capability.",
+            "high_risk": {
+                "external_network": "External network is limited to research/citation tools.",
+            },
+        },
+    ),
+    _preset(
+        preset_id="code-reviewer",
+        name="Code Reviewer",
+        description="Reviews diffs, code, and test results without write access.",
+        capabilities=["code_search", "diff.read", "tests.read", "filesystem.read"],
+    ),
+    _preset(
+        preset_id="devops-engineer",
+        name="DevOps Engineer",
+        description="Inspects deployment, logs, and infrastructure state with approval for mutating actions.",
+        capabilities=["deploy.inspect", "logs.read", "infra.read", "infra.mutate_scoped"],
+        risk_classes=["mutating"],
+        approval_policy={
+            "required_for": ["infra.mutate_scoped", "deployment.mutate"],
+            "reason": "Infrastructure changes require explicit approval.",
+        },
+    ),
+    _preset(
+        preset_id="backend-engineer",
+        name="Backend Engineer",
+        description="Reads and writes backend source with scoped test/build commands behind approval.",
+        capabilities=["source.write_scoped", "code_search", "tests.request", "backend.inspect"],
+        risk_classes=["mutating"],
+        approval_policy=_WRITE_APPROVAL_POLICY,
+    ),
+    _preset(
+        preset_id="frontend-engineer",
+        name="Frontend Engineer",
+        description="Works on scoped frontend source and browser/debug flows without broad process execution.",
+        capabilities=["source.write_scoped", "browser.debug", "frontend.inspect", "tests.request"],
+        risk_classes=["mutating"],
+        approval_policy=_WRITE_APPROVAL_POLICY,
+    ),
+    _preset(
+        preset_id="qa-engineer",
+        name="QA Engineer",
+        description="Debugs running applications with browser, logs, screenshots, and read-only app state.",
+        capabilities=["browser.debug", "logs.read", "screenshots.capture", "app_state.read"],
+    ),
+    _preset(
+        preset_id="sdet",
+        name="Software Development Engineer in Test",
+        description="Authors and runs automated tests through scoped write and approval-gated runner requests.",
+        capabilities=["tests.write_scoped", "tests.request", "code_search", "filesystem.read"],
+        risk_classes=["mutating"],
+        approval_policy=_WRITE_APPROVAL_POLICY,
+    ),
+    _preset(
+        preset_id="memory-keeper",
+        name="Memory Keeper",
+        description="Maintains graph and memory tools without shell or process access.",
+        capabilities=["memory.graph.read", "memory.graph.write_scoped", "notes.read"],
+        risk_classes=["mutating"],
+        approval_policy=_WRITE_APPROVAL_POLICY,
+        agent_metadata={"memory_provider": "graphiti"},
+    ),
+)
+
+_BUILTIN_BY_ID = {preset.id: preset for preset in _BUILTIN_PRESETS}
+
+
+def list_builtin_presets() -> tuple[ProfilePreset, ...]:
+    """Return copies of the bundled profile presets."""
+    return tuple(preset.model_copy(deep=True) for preset in _BUILTIN_PRESETS)
+
+
+def get_builtin_preset(preset_id: str) -> ProfilePreset | None:
+    """Return a copy of a bundled preset by id, or None when unknown."""
+    preset = _BUILTIN_BY_ID.get(preset_id)
+    if preset is None:
+        return None
+    return preset.model_copy(deep=True)
+
+
+def duplicate_builtin_preset(
+    preset_id: str,
+    *,
+    profile_id: str | None = None,
+    name: str | None = None,
+) -> MCPProfile:
+    """Copy a bundled preset into an editable user profile."""
+    preset = get_builtin_preset(preset_id)
+    if preset is None:
+        raise ValueError(f"Unknown MCP profile preset: {preset_id}")
+
+    profile = preset.profile.model_copy(deep=True)
+    profile.id = profile_id or f"{preset.id}-copy"
+    if name is not None:
+        profile.name = name
+    profile.preset_id = preset.id
+    profile.preset_version = preset.version
+    profile.provenance = {
+        **profile.provenance,
+        "source": "builtin_preset",
+        "preset_id": preset.id,
+        "preset_version": preset.version,
+        "duplicated": True,
+    }
+    return profile
+
+
+def validate_preset_safety(preset: ProfilePreset) -> list[str]:
+    """Return safety-baseline violation codes for a preset template."""
+    profile = preset.profile
+    policy = profile.policy_document
+    capabilities = set(policy.capabilities)
+    risk_classes = set(policy.risk_classes)
+    violations: list[str] = []
+
+    if capabilities & _PROCESS_CAPABILITIES or "process_execution" in risk_classes:
+        if not _approval_required_for(profile, "process_execution"):
+            violations.append("process_execution_requires_approval")
+        if not _has_high_risk_provenance(profile, "process_execution"):
+            violations.append("high_risk_capability_requires_provenance")
+
+    if capabilities & _DESTRUCTIVE_FILESYSTEM_CAPABILITIES or "destructive_filesystem" in risk_classes:
+        if not _approval_required_for(profile, "destructive_filesystem"):
+            violations.append("destructive_filesystem_requires_approval")
+        if not _has_high_risk_provenance(profile, "destructive_filesystem"):
+            violations.append("high_risk_capability_requires_provenance")
+
+    if profile.credential_grants or "credential_use" in risk_classes:
+        if not _has_high_risk_provenance(profile, "credential_use"):
+            violations.append("credential_grant_requires_provenance")
+
+    if capabilities & _EXTERNAL_NETWORK_CAPABILITIES or "external_network" in risk_classes:
+        if not profile.external_server_grants:
+            violations.append("external_network_requires_explicit_grant")
+        if not _has_high_risk_provenance(profile, "external_network"):
+            violations.append("high_risk_capability_requires_provenance")
+
+    unknown_high_risk = risk_classes - _HIGH_RISK_RISK_CLASSES - {"mutating"}
+    if unknown_high_risk:
+        violations.append("unknown_high_risk_requires_review")
+
+    return sorted(set(violations))
+
+
+def _approval_required_for(profile: MCPProfile, risk_class: str) -> bool:
+    approval_policy = profile.approval_policy
+    required_for = approval_policy.get("required_for", [])
+    if approval_policy.get("required") is True:
+        return True
+    if isinstance(required_for, str):
+        required_for = [required_for]
+    return risk_class in required_for or "mutating" in required_for or "write" in required_for
+
+
+def _has_high_risk_provenance(profile: MCPProfile, risk_class: str) -> bool:
+    high_risk = profile.provenance.get("high_risk")
+    if isinstance(high_risk, dict) and high_risk.get(risk_class):
+        return True
+    return bool(profile.provenance.get(risk_class))

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -1,6 +1,9 @@
+"""Tests for package-local MCP profile preset primitives."""
+
 from __future__ import annotations
 
 import ast
+from datetime import datetime, timezone
 from pathlib import Path
 
 import mcp_unified.profiles.presets as presets
@@ -25,6 +28,7 @@ EXPECTED_PRESET_IDS = {
 
 
 def _tldw_imports_for(path: Path) -> list[str]:
+    """Return imports from a Python file that cross into the host package."""
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     imports: list[str] = []
     for node in ast.walk(tree):
@@ -42,7 +46,7 @@ def _tldw_imports_for(path: Path) -> list[str]:
 
 
 def test_profile_presets_module_has_no_tldw_server_imports() -> None:
-    package_root = Path(presets.__file__).resolve().parents[1]
+    package_root = Path(presets.__file__).resolve().parent
     offenders: dict[str, list[str]] = {}
     for path in package_root.rglob("*.py"):
         imports = _tldw_imports_for(path)
@@ -98,6 +102,28 @@ def test_duplicate_builtin_preset_returns_editable_profile_with_provenance() -> 
     assert "custom.search" not in original.profile.policy_document.allowed_tools
 
 
+def test_duplicate_builtin_preset_default_ids_are_unique() -> None:
+    first = presets.duplicate_builtin_preset("architect")
+    second = presets.duplicate_builtin_preset("architect")
+
+    assert first.id != second.id
+    assert first.id.startswith("architect-")
+    assert second.id.startswith("architect-")
+
+
+def test_duplicate_builtin_preset_refreshes_timestamps() -> None:
+    template = presets.get_builtin_preset("architect")
+    assert template is not None
+
+    before_duplicate = datetime.now(timezone.utc)
+    profile = presets.duplicate_builtin_preset("architect")
+
+    assert profile.created_at >= before_duplicate
+    assert profile.updated_at >= before_duplicate
+    assert profile.created_at != template.profile.created_at
+    assert profile.updated_at != template.profile.updated_at
+
+
 def test_safety_validation_rejects_unsafe_unapproved_process_capability() -> None:
     unsafe_profile = MCPProfile(
         id="unsafe",
@@ -117,3 +143,60 @@ def test_safety_validation_rejects_unsafe_unapproved_process_capability() -> Non
 
     assert "process_execution_requires_approval" in violations
     assert "high_risk_capability_requires_provenance" in violations
+
+
+def test_safety_validation_requires_explicit_process_execution_approval() -> None:
+    unsafe_profile = MCPProfile(
+        id="unsafe-process",
+        name="Unsafe Process",
+        policy_document={
+            "capabilities": ["process.execute"],
+            "risk_classes": ["process_execution"],
+        },
+        approval_policy={
+            "required_for": ["mutating", "write"],
+        },
+        provenance={
+            "high_risk": {
+                "process_execution": "Process execution is intentionally present.",
+            },
+        },
+    )
+    unsafe_preset = presets.ProfilePreset(
+        id="unsafe-process",
+        version="test",
+        profile=unsafe_profile,
+    )
+
+    violations = presets.validate_preset_safety(unsafe_preset)
+
+    assert "process_execution_requires_approval" in violations
+    assert "high_risk_capability_requires_provenance" not in violations
+
+
+def test_safety_validation_handles_null_required_for_policy() -> None:
+    unsafe_profile = MCPProfile(
+        id="unsafe-null-required-for",
+        name="Unsafe Null Required For",
+        policy_document={
+            "capabilities": ["process.execute"],
+            "risk_classes": ["process_execution"],
+        },
+        approval_policy={
+            "required_for": None,
+        },
+        provenance={
+            "high_risk": {
+                "process_execution": "Process execution is intentionally present.",
+            },
+        },
+    )
+    unsafe_preset = presets.ProfilePreset(
+        id="unsafe-null-required-for",
+        version="test",
+        profile=unsafe_profile,
+    )
+
+    violations = presets.validate_preset_safety(unsafe_preset)
+
+    assert "process_execution_requires_approval" in violations

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import mcp_unified.profiles.presets as presets
+from mcp_unified.profiles.models import MCPProfile
+
+EXPECTED_PRESET_IDS = {
+    "orchestrator",
+    "product-owner",
+    "architect",
+    "merge-conflict-resolver",
+    "documentation-writer",
+    "project-researcher",
+    "deep-researcher",
+    "code-reviewer",
+    "devops-engineer",
+    "backend-engineer",
+    "frontend-engineer",
+    "qa-engineer",
+    "sdet",
+    "memory-keeper",
+}
+
+
+def _tldw_imports_for(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "tldw_Server_API"
+                or alias.name.startswith("tldw_Server_API.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "tldw_Server_API" or node.module.startswith("tldw_Server_API."):
+                imports.append(node.module)
+    return imports
+
+
+def test_profile_presets_module_has_no_tldw_server_imports() -> None:
+    package_root = Path(presets.__file__).resolve().parents[1]
+    offenders: dict[str, list[str]] = {}
+    for path in package_root.rglob("*.py"):
+        imports = _tldw_imports_for(path)
+        if imports:
+            offenders[str(path)] = imports
+    assert offenders == {}
+
+
+def test_builtin_presets_cover_initial_mode_ids_and_pass_safety_baseline() -> None:
+    bundled = presets.list_builtin_presets()
+    assert {preset.id for preset in bundled} == EXPECTED_PRESET_IDS
+    assert all(preset.version == "2026.05.27" for preset in bundled)
+
+    safety_violations = {
+        preset.id: presets.validate_preset_safety(preset)
+        for preset in bundled
+        if presets.validate_preset_safety(preset)
+    }
+    assert safety_violations == {}
+
+
+def test_get_builtin_preset_returns_stable_profile_template() -> None:
+    preset = presets.get_builtin_preset("architect")
+
+    assert preset is not None
+    assert preset.id == "architect"
+    assert preset.profile.id == "architect"
+    assert preset.profile.preset_id == "architect"
+    assert preset.profile.preset_version == preset.version
+    assert preset.profile.metadata["agent_metadata"]["ui_label"] == "Architect"
+    assert "code_search" in preset.profile.policy_document.capabilities
+    assert preset.profile.credential_grants == []
+
+
+def test_duplicate_builtin_preset_returns_editable_profile_with_provenance() -> None:
+    profile = presets.duplicate_builtin_preset(
+        "architect",
+        profile_id="workspace-architect",
+        name="Workspace Architect",
+    )
+
+    assert isinstance(profile, MCPProfile)
+    assert profile.id == "workspace-architect"
+    assert profile.name == "Workspace Architect"
+    assert profile.preset_id == "architect"
+    assert profile.preset_version == "2026.05.27"
+    assert profile.provenance["source"] == "builtin_preset"
+    assert profile.provenance["preset_id"] == "architect"
+
+    profile.policy_document.allowed_tools.append("custom.search")
+    original = presets.get_builtin_preset("architect")
+    assert original is not None
+    assert "custom.search" not in original.profile.policy_document.allowed_tools
+
+
+def test_safety_validation_rejects_unsafe_unapproved_process_capability() -> None:
+    unsafe_profile = MCPProfile(
+        id="unsafe",
+        name="Unsafe",
+        policy_document={
+            "capabilities": ["process.execute"],
+            "risk_classes": ["process_execution"],
+        },
+    )
+    unsafe_preset = presets.ProfilePreset(
+        id="unsafe",
+        version="test",
+        profile=unsafe_profile,
+    )
+
+    violations = presets.validate_preset_safety(unsafe_preset)
+
+    assert "process_execution_requires_approval" in violations
+    assert "high_risk_capability_requires_provenance" in violations


### PR DESCRIPTION
## Summary

- What changed: Added package-local built-in MCP profile presets for the initial front-end role/mode set, including preset lookup/listing, safety-baseline validation, and duplication into editable `MCPProfile` objects with preset provenance.
- Why: This is the next narrow Stage 2 step toward a standalone MCP package boundary and front-end role/profile modes without changing host MCP route, policy, approval, credential, or execution behavior.

## Validation

- [x] Tests added/updated for behavior changes.
- [x] Relevant unit/integration tests pass locally:
  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v`
  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m mypy mcp_unified --config-file pyproject.toml`
  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_profile_presets.json`
  - `git diff --check`
- [x] Docs updated: implementation plan and Backlog task record updated for this slice.

## UX Audit Checklist (v2 Stage 5)

- [x] Not applicable: this PR changes package-local MCP profile preset primitives and tests only; no WebUI or extension rendered routes changed.
- [x] `npm run e2e:smoke:stage5` not run; not applicable because no UI route or visual behavior changed.
- [x] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` not run; not applicable because no UI route or visual behavior changed.
- [x] No AntD component usage changed.
- [x] No audited route state, placeholders, or WebUI/extension parity surfaces changed.
- [x] No Flashcards UI, drawer, help, copy, or import UX changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: no Watchlists polling, notifications, activity, batch triage, or scale behavior changed.

## Risk & Rollback

- Risk level: Low.
- Risk notes: Changes are scoped to package-local preset templates, exports, safety validation, tests, and task documentation. Existing host MCP routes, policy enforcement, approvals, credentials, and tool execution behavior are unchanged.
- Rollback plan: Revert the PR commits for this branch, or remove `mcp_unified.profiles.presets`, its profile exports, the focused tests, and the Backlog/plan records if the preset primitive surface needs to be withdrawn.

## Change summary

- [ ] Human-owned Change summary pending before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Backlog: TASK-519
