### PR TITLE
Add flashcards sidepanel template application

### DIFF
--- a/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,7 +32,7 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find useful passages while browsing and want to save editable basic flashcards, generate a small draft batch without leaving the sidepanel, or send selected text directly to full Flashcards generation.
+Use this path when you find useful passages while browsing and want to save editable flashcards, generate a small draft batch without leaving the sidepanel, apply existing templates to drafts, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
@@ -40,17 +40,19 @@ Workflow:
 2. Open the extension sidepanel and choose `Flashcards`.
 3. Choose `Capture page selection` to add the selection to the sidepanel draft queue.
 4. Choose `Generate draft cards` to generate a small editable draft batch in the sidepanel from the selected text.
-5. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
-6. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
-7. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
+5. Choose `Apply template` on a queued draft when an existing template should fill or reshape the card fields before saving.
+6. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
+7. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
+8. Use `Open full Flashcards` for imports, review, or broader deck management.
 
 Important behavior:
 
 - The sidepanel Flashcards route saves queued captured and generated drafts and keeps the source page URL as provenance.
+- `Apply template` uses templates from full Flashcards and can be applied per draft before saving.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
 - Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want the fuller generation workflow instead of the sidepanel's compact generated draft batch.
-- Native sidepanel template application and in-sidepanel review remain deferred to the full Flashcards workspace.
+- In-sidepanel review remains deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,7 +32,7 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find useful passages while browsing and want to save editable basic flashcards, generate a small draft batch without leaving the sidepanel, or send selected text directly to full Flashcards generation.
+Use this path when you find useful passages while browsing and want to save editable flashcards, generate a small draft batch without leaving the sidepanel, apply existing templates to drafts, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
@@ -40,17 +40,19 @@ Workflow:
 2. Open the extension sidepanel and choose `Flashcards`.
 3. Choose `Capture page selection` to add the selection to the sidepanel draft queue.
 4. Choose `Generate draft cards` to generate a small editable draft batch in the sidepanel from the selected text.
-5. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
-6. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
-7. Use `Open full Flashcards` for imports, templates, review, or broader deck management.
+5. Choose `Apply template` on a queued draft when an existing template should fill or reshape the card fields before saving.
+6. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
+7. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
+8. Use `Open full Flashcards` for imports, review, or broader deck management.
 
 Important behavior:
 
 - The sidepanel Flashcards route saves queued captured and generated drafts and keeps the source page URL as provenance.
+- `Apply template` uses templates from full Flashcards and can be applied per draft before saving.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
 - Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want the fuller generation workflow instead of the sidepanel's compact generated draft batch.
-- Native sidepanel template application and in-sidepanel review remain deferred to the full Flashcards workspace.
+- In-sidepanel review remains deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-template-application-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-template-application-implementation-plan.md
@@ -100,6 +100,6 @@ Expected: PASS.
 Run: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
 Expected: No new sidepanel/template errors; known unrelated CharacterListContent density baseline may still fail.
 
-- [ ] **Step 4: Commit and open PR**
+- [x] **Step 4: Commit and open PR**
 
 Commit the slice and create a draft PR against `dev`.

--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-template-application-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-template-application-implementation-plan.md
@@ -1,0 +1,105 @@
+# Flashcards Extension Template Application Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native template application to the extension sidepanel draft queue without adding in-extension review.
+
+**Architecture:** Reuse the existing Flashcards template materialization modal and helper so the sidepanel does not duplicate placeholder parsing. Each sidepanel draft keeps its source provenance and queue identity while template application replaces front/back/model/notes/extra/tags for the selected draft.
+
+**Tech Stack:** React, Ant Design, TanStack Query flashcard hooks, existing Flashcards template utilities, Vitest and Testing Library.
+
+---
+
+### Task 1: Sidepanel Template Application Tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx`
+
+- [x] **Step 1: Establish baseline**
+
+Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+Expected: PASS before feature tests are added.
+
+- [x] **Step 2: Write failing tests**
+
+Add sidepanel route tests proving:
+- a captured draft exposes an `Apply template` action,
+- choosing a template with placeholders updates only that draft's front/back/model/notes/extra/tags,
+- save payload preserves source provenance and uses the template model fields,
+- generated drafts can also receive template output,
+- missing templates show the existing modal empty state without clearing the draft queue.
+
+- [x] **Step 3: Verify RED**
+
+Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+Expected: FAIL because the sidepanel does not yet render native template application controls.
+
+### Task 2: Sidepanel Template Application
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-flashcards.tsx`
+
+- [x] **Step 1: Reuse existing template modal**
+
+Import `FlashcardTemplateValueModal` and render it only when a draft is selected for template application.
+
+- [x] **Step 2: Apply materialized draft fields**
+
+When the modal returns a template draft, update the selected sidepanel draft's `front`, `back`, `modelType`, `tags`, `notes`, and `extra`, while preserving `id`, `sourceId`, and `sourceTitle`.
+
+- [x] **Step 3: Add per-draft action**
+
+Add a small `Apply template` button to each draft card, disabled while saving. Keep visual density consistent with the existing remove/save controls.
+
+- [x] **Step 4: Verify GREEN**
+
+Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+Expected: PASS.
+
+### Task 3: Docs And Source List
+
+**Files:**
+- Modify: `Flashcards-UX-Fix-List.md`
+- Modify: `apps/extension/docs/features/flashcards.md`
+- Modify: `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+- Modify: `Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+- Modify: `backlog/tasks/task-521 - Add-flashcards-extension-native-template-application.md`
+
+- [x] **Step 1: Update F12 status**
+
+Mark native sidepanel template application complete while leaving in-extension review deferred.
+
+- [x] **Step 2: Update docs**
+
+Describe that captured/generated sidepanel drafts can apply existing templates before save.
+
+- [x] **Step 3: Update task**
+
+Record acceptance criteria, implementation notes, final summary, touched files, and verification.
+
+### Task 4: Final Verification And PR
+
+**Files:**
+- No new production files beyond Task 2 and docs.
+
+- [x] **Step 1: Run focused tests**
+
+Run: `bunx vitest run src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx`
+Expected: PASS.
+
+- [x] **Step 2: Run broader sidepanel/generate handoff tests**
+
+Run: `bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
+Expected: PASS.
+
+- [x] **Step 3: Run static checks**
+
+Run: `git diff --check`
+Expected: PASS.
+
+Run: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
+Expected: No new sidepanel/template errors; known unrelated CharacterListContent density baseline may still fail.
+
+- [ ] **Step 4: Commit and open PR**
+
+Commit the slice and create a draft PR against `dev`.

--- a/Flashcards-UX-Fix-List.md
+++ b/Flashcards-UX-Fix-List.md
@@ -1,6 +1,6 @@
 # Flashcards UX Fix List
 
-Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split, F12 native sidepanel capture queue, F12 generate-from-selection handoff, and F12 native generated-draft follow-ups.
+Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split, F12 native sidepanel capture queue, F12 generate-from-selection handoff, native generated-draft batches, and native sidepanel template application follow-ups.
 
 Scope: `/flashcards` plus directly connected WebUI and extension flashcard workflows. This file is the master UX audit and fix-list source referenced by `Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md`.
 
@@ -47,7 +47,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 9. Recent sessions show user-facing deck/mode/count/timing labels where data is available.
 10. Deck dashboard rows expose direct Review, Cram, Edit, Scheduler, and Export actions.
 11. Generated-card save recovery distinguishes success, partial success, failure, fatal validation errors, and retry state.
-12. Extension sidepanel offers explicit full Flashcards, Capture page selection, Generate draft cards, and Generate from selection actions; selected page text can append one captured draft, generate a small editable draft batch natively, or open full Flashcards generation with source context. Native sidepanel drafts include deck picker, Front/Back fields, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
+12. Extension sidepanel offers explicit full Flashcards, Capture page selection, Generate draft cards, and Generate from selection actions; selected page text can append one captured draft, generate a small editable draft batch natively, or open full Flashcards generation with source context. Native sidepanel drafts include deck picker, Front/Back fields, per-draft template application, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
 13. Documentation describes the stabilized WebUI/extension capture and handoff behavior using current tab names.
 
 ## Phase Coverage
@@ -64,10 +64,11 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | Phase 5: Extension capture and docs | TASK-513 | F12 support, F13 | Completed as an extension bridge and WebUI generate handoff. |
 | Closeout source restoration | TASK-514 | Planning traceability | Completed. Restores this tracked source file on `dev`. |
 | F06 follow-up: Task-first Create & Import split | TASK-515 | F06 | Completed. Adds Create cards, Import file, and Export backup task workspaces while preserving existing route keys and panel handoffs. |
-| F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Generated drafts, templates, bulk editing, and in-extension review remain deferred. |
-| F12 follow-up: Extension repeat-capture queue | TASK-517 | F12 | Completed. Converts native sidepanel capture from one draft to a repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery. Generated drafts, templates, and in-extension review remain deferred. |
-| F12 follow-up: Extension generate-from-selection handoff | TASK-518 | F12 | Completed. Adds a sidepanel action that captures selected page text and opens full Flashcards generation with source URL/title context. Native sidepanel generated drafts, templates, and in-extension review remain deferred. |
-| F12 follow-up: Native extension generated drafts | TASK-519 | F12 | Completed. Adds native sidepanel generated draft batches from selected page text, preserving edit/save queue behavior and source provenance. Native template application and in-extension review remain deferred. |
+| F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Later F12 follow-ups added repeat capture, generated drafts, and template application; in-extension review remains deferred. |
+| F12 follow-up: Extension repeat-capture queue | TASK-517 | F12 | Completed. Converts native sidepanel capture from one draft to a repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery. Later F12 follow-ups added generated drafts and template application; in-extension review remains deferred. |
+| F12 follow-up: Extension generate-from-selection handoff | TASK-518 | F12 | Completed. Adds a sidepanel action that captures selected page text and opens full Flashcards generation with source URL/title context. Later F12 follow-ups added native generated drafts and template application; in-extension review remains deferred. |
+| F12 follow-up: Native extension generated drafts | TASK-519 | F12 | Completed. Adds native sidepanel generated draft batches from selected page text, preserving edit/save queue behavior and source provenance. Later F12 follow-up added native template application; in-extension review remains deferred. |
+| F12 follow-up: Native extension template application | TASK-521 | F12 | Completed. Adds native sidepanel template application for captured and generated drafts while preserving selected draft scope, generated tags, model fields, and page provenance. In-extension review remains deferred. |
 
 ## Severity-Ranked Findings
 
@@ -84,7 +85,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | F09 | Medium | History comprehension | Recent sessions used labels like `Session #1`, `Deck 1`, or raw scope keys. | Progress/history was present but hard to trust. | Backend identifiers leaked into user-facing history. | Addressed in TASK-509. |
 | F10 | Medium | Progress semantics | Due/new/current queue labels could appear contradictory. | Users could misunderstand whether cards were available to study. | Scheduler labels were technically accurate but not explained in queue context. | Addressed in TASK-508. |
 | F11 | Medium | Expert workflow | Manage was card-first with no deck-first dashboard for quick study decisions. | Experienced users spent time filtering cards instead of selecting a deck action. | The model privileged card management over deck review. | Addressed in TASK-510/TASK-511. |
-| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517/TASK-518/TASK-519. Sidepanel now supports native selected-text repeat capture, native generated draft batches, draft edit/delete, save-one, save-all, partial failure recovery, page provenance, and full-Flashcards generation handoff from selected text; native template application and in-extension review remain deferred. |
+| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517/TASK-518/TASK-519/TASK-521. Sidepanel now supports native selected-text repeat capture, native generated draft batches, native template application, draft edit/delete, save-one, save-all, partial failure recovery, page provenance, and full-Flashcards generation handoff from selected text; in-extension review remains deferred. |
 | F13 | Medium | Docs mismatch | Extension and flashcards docs lagged current UI tab names and workflows. | Users could not rely on docs to understand current behavior. | Docs had not tracked UI evolution. | Addressed in TASK-513. |
 | F14 | Low | Empty-state hierarchy | Manage empty state showed expert filters before any cards existed. | New users saw advanced management chrome before first action. | Empty state inherited full management layout. | Addressed in TASK-506. |
 | F15 | Low | Scheduler discoverability | Scheduler was hidden until a deck existed. | New users could not learn scheduling exists until after setup. | Progressive disclosure hid a core concept too completely. | Addressed in TASK-506. |
@@ -104,7 +105,7 @@ Create & Import now separates setup into task-specific workspaces, so first-time
 
 The strongest power-user improvement is the deck dashboard. It gives experienced users deck-level counts and direct Review/Cram/Edit/Scheduler/Export actions, replacing a card-filter-first starting point for common study decisions. Review recovery and recent-session labels also make repeat review safer and easier to resume.
 
-Remaining weakness: extension capture now supports repeated native capture, native generated draft batches, bulk save, and full-workspace generation handoff, but richer native sidepanel expert controls remain deferred: template application and in-extension review.
+Remaining weakness: extension capture now supports repeated native capture, native generated draft batches, template application, bulk save, and full-workspace generation handoff, but in-extension review remains deferred.
 
 ## Improvement Backlog
 
@@ -132,10 +133,11 @@ Remaining weakness: extension capture now supports repeated native capture, nati
 - Add native extension repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery.
 - Add extension Generate from selection handoff into the full Flashcards Generate workflow.
 - Add native extension generated draft batches from selected page text.
+- Add native sidepanel template application for captured and generated drafts.
 
 ### Deferred Larger Product Improvements
 
-- Extend the native extension capture flow with template application and in-extension review.
+- Extend the native extension capture flow with in-extension review.
 - Add broader import result normalization if future evidence shows unresolved partial/fatal import ambiguity outside generated-card save.
 - Run a full browser accessibility audit beyond the focused keyboard e2e coverage.
 
@@ -158,14 +160,14 @@ Remaining weakness: extension capture now supports repeated native capture, nati
 3. Review supports keyboard reveal/rate/undo/edit flows with visible equivalents.
 4. Completion supports repeat workflows.
 5. History uses meaningful session labels instead of raw ids.
-6. Extension selected-text capture appends editable sidepanel drafts, can generate a small native draft batch, lets the user delete or save one/all drafts with partial failure recovery, preserves page provenance, and can send selected text directly to full Flashcards generation with source context.
+6. Extension selected-text capture appends editable sidepanel drafts, can generate a small native draft batch, lets the user apply existing templates, delete drafts, or save one/all drafts with partial failure recovery, preserves page provenance, and can send selected text directly to full Flashcards generation with source context.
 
 ## Open Questions And Non-Goals
 
 - Scheduler algorithm correctness and backend spaced-repetition math were not audited beyond visible UX effects.
 - Quiz surfaces were out of scope except for the direct Flashcards handoff.
 - Multi-user permission, workspace sharing, and collaboration states need separate testing.
-- Native extension template application and in-extension review remain future product improvements beyond the F12 capture queue, native generated drafts, and full-workspace generation handoff.
+- Native extension in-extension review remains a future product improvement beyond the F12 capture queue, native generated drafts, template application, and full-workspace generation handoff.
 
 ## Master Checklist
 
@@ -202,7 +204,8 @@ Remaining weakness: extension capture now supports repeated native capture, nati
 - [x] F12 Native extension repeat-capture queue, draft delete, save-one, save-all, and partial failure recovery completed.
 - [x] F12 Extension Generate from selection handoff opens full Flashcards generation with selected text and page provenance.
 - [x] F12 Native sidepanel generated draft batches completed for selected page text.
-- [ ] F12 Native sidepanel template application and in-extension review remain deferred.
+- [x] F12 Native sidepanel template application completed for captured and generated drafts.
+- [ ] F12 In-extension review remains deferred.
 - [x] F13 WebUI and extension flashcards docs updated.
 - [x] F17 Quiz handoff made state-aware.
 

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -6,7 +6,7 @@ title: Flashcards (Experimental)
 
 The Flashcards page lets you create, review, and manage spaced-repetition cards backed by your tldw_server. It also supports CSV/TSV import and export, plus optional .apkg export where supported by the server.
 
-Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace, selected-text card creation, native generated drafts, and selected-text generation handoff.
+Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace, selected-text card creation, native generated drafts, native template application, and selected-text generation handoff.
 
 ## Prerequisites
 
@@ -27,11 +27,12 @@ Access it from the Web UI header by clicking the Layers icon, or navigate to `/f
 2. Open the extension sidepanel and choose `Flashcards`.
 3. Click `Capture page selection` to add the selection to the sidepanel draft queue.
 4. Click `Generate draft cards` to create a small batch of editable draft cards in the sidepanel from the selected text.
-5. Choose a deck, edit each draft's `Front` and `Back` fields, then click `Save card` or `Save all`.
-6. Click `Generate from selection` when you want the selected text to open in full Flashcards generation with the page URL/title attached.
-7. Use `Open full Flashcards` when you need imports, templates, review, or broader deck management.
+5. Use `Apply template` on a queued draft when an existing template should reshape its fields before saving.
+6. Choose a deck, edit each draft's `Front` and `Back` fields, then click `Save card` or `Save all`.
+7. Click `Generate from selection` when you want the selected text to open in full Flashcards generation with the page URL/title attached.
+8. Use `Open full Flashcards` when you need imports, review, or broader deck management.
 
-The sidepanel saves basic captured cards and generated draft cards from the same queue, keeping the page URL as source provenance. Native generation uses compact defaults; the sidepanel does not yet provide template application or in-sidepanel review. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want the fuller generation workflow in the full Flashcards workspace.
+The sidepanel saves captured cards and generated draft cards from the same queue, keeping the page URL as source provenance. Native generation uses compact defaults, and `Apply template` reuses the templates already managed in full Flashcards. The sidepanel does not yet provide in-sidepanel review. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want the fuller generation workflow in the full Flashcards workspace.
 
 ## Tips
 

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
@@ -18,7 +18,7 @@ interface FlashcardTemplateValueModalProps {
   onApply: (
     draft: Pick<FlashcardCreate, "deck_id" | "tags" | "model_type" | "front" | "back" | "notes" | "extra">
   ) => void
-  draftDefaults?: Pick<FlashcardCreate, "deck_id" | "tags">
+  draftDefaults?: Partial<Pick<FlashcardCreate, "deck_id" | "tags" | "front" | "back" | "notes" | "extra">>
 }
 
 type TemplateValueModalFormValues = {

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts
@@ -86,6 +86,47 @@ describe("flashcard-template-resolution", () => {
     ).toThrow("Missing required placeholder value: definition")
   })
 
+  it("falls back to draft defaults when a template omits optional fields", () => {
+    const sparseTemplate: FlashcardTemplate = {
+      ...template,
+      id: 20,
+      back_template: null,
+      notes_template: null,
+      extra_template: null,
+      placeholder_definitions: [
+        {
+          key: "term",
+          label: "Term",
+          help_text: null,
+          default_value: null,
+          required: true,
+          targets: ["front_template"]
+        }
+      ]
+    }
+
+    expect(
+      materializeFlashcardTemplateDraft(
+        sparseTemplate,
+        {
+          term: "ATP"
+        },
+        {
+          back: "Existing generated back",
+          notes: "Existing generated notes",
+          extra: "Existing generated extra"
+        }
+      )
+    ).toEqual(
+      expect.objectContaining({
+        front: "What does ATP mean?",
+        back: "Existing generated back",
+        notes: "Existing generated notes",
+        extra: "Existing generated extra"
+      })
+    )
+  })
+
   it("preserves cloze syntax when materializing cloze templates", () => {
     const clozeTemplate: FlashcardTemplate = {
       ...template,

--- a/apps/packages/ui/src/components/Flashcards/utils/flashcard-template-resolution.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/flashcard-template-resolution.ts
@@ -3,7 +3,9 @@ import type { FlashcardCreate, FlashcardTemplate } from "@/services/flashcards"
 const PLACEHOLDER_TOKEN_RE = /\{\{\s*([^\s{}]+)\s*\}\}/g
 const CLOZE_TOKEN_SEPARATOR = "::"
 
-type FlashcardTemplateDraftDefaults = Pick<FlashcardCreate, "deck_id" | "tags">
+type FlashcardTemplateDraftDefaults = Partial<
+  Pick<FlashcardCreate, "deck_id" | "tags" | "front" | "back" | "notes" | "extra">
+>
 
 const normalizePlaceholderValue = (value: string | null | undefined): string => value?.trim() ?? ""
 const isClozeToken = (token: string): boolean => token.includes(CLOZE_TOKEN_SEPARATOR)
@@ -57,9 +59,9 @@ export function materializeFlashcardTemplateDraft(
     deck_id: defaults?.deck_id ?? undefined,
     tags: defaults?.tags ? [...defaults.tags] : undefined,
     model_type: template.model_type,
-    front: resolveTemplateText(template.front_template) ?? "",
-    back: resolveTemplateText(template.back_template) ?? "",
-    notes: resolveTemplateText(template.notes_template),
-    extra: resolveTemplateText(template.extra_template)
+    front: resolveTemplateText(template.front_template) ?? defaults?.front ?? "",
+    back: resolveTemplateText(template.back_template) ?? defaults?.back ?? "",
+    notes: resolveTemplateText(template.notes_template) ?? defaults?.notes ?? null,
+    extra: resolveTemplateText(template.extra_template) ?? defaults?.extra ?? null
   }
 }

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -254,7 +254,7 @@ describe("sidepanel flashcards route", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Create one editable card, generate a small draft batch, or use full Flashcards for templates, imports, and review."
+        "Create one editable card, generate a small draft batch, apply templates to queued drafts, or use full Flashcards for imports, review, and management."
       )
     ).toBeInTheDocument()
     expect(
@@ -384,6 +384,17 @@ describe("sidepanel flashcards route", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Apply" }))
   }
 
+  it("describes native template application in the sidepanel hint", () => {
+    render(<SidepanelFlashcards />)
+
+    expect(
+      screen.getByText(/apply templates to queued drafts/)
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/for templates, imports, and review/)
+    ).not.toBeInTheDocument()
+  })
+
   it("applies an existing template to a captured sidepanel draft before saving", async () => {
     const user = userEvent.setup()
     render(<SidepanelFlashcards />)
@@ -471,6 +482,50 @@ describe("sidepanel flashcards route", () => {
       tags: ["biology", "energy"],
       notes: "From selected page",
       extra: "Review after reading.",
+      model_type: "basic_reverse",
+      is_cloze: false,
+      reverse: true,
+      source_ref_type: "manual",
+      source_ref_id: "https://example.test/source"
+    })
+  })
+
+  it("preserves generated notes and extra when a template omits those fields", async () => {
+    currentTemplates = [
+      {
+        ...currentTemplates[0],
+        id: 22,
+        name: "Sparse source vocabulary",
+        notes_template: null,
+        extra_template: null,
+        placeholder_definitions: currentTemplates[0].placeholder_definitions.filter(
+          (definition) => definition.key !== "source"
+        )
+      }
+    ]
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate draft cards" })
+    )
+    const modal = await openTemplateModal("Apply template to draft 1")
+    await fillAndApplyTemplate(modal, {
+      term: "ATP",
+      definition: "The cell's energy currency"
+    })
+    await user.click(screen.getAllByRole("button", { name: "Save card" })[0])
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledWith({
+      deck_id: 7,
+      front: "What does ATP mean?",
+      back: "The cell's energy currency",
+      tags: ["biology", "energy"],
+      notes: "Generated from selected source text",
+      extra: "Review with the source page open",
       model_type: "basic_reverse",
       is_cloze: false,
       reverse: true,

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -1,16 +1,40 @@
 import React from "react"
 import userEvent from "@testing-library/user-event"
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import SidepanelFlashcards, {
   readSelectedTextFromPage
 } from "../sidepanel-flashcards"
 
+type TemplateFixture = {
+  id: number
+  name: string
+  model_type: "basic" | "basic_reverse" | "cloze"
+  front_template: string
+  back_template?: string | null
+  notes_template?: string | null
+  extra_template?: string | null
+  placeholder_definitions: Array<{
+    key: string
+    label: string
+    help_text?: string | null
+    default_value?: string | null
+    required?: boolean
+    targets: string[]
+  }>
+  created_at?: string | null
+  last_modified?: string | null
+  deleted: boolean
+  client_id: string
+  version: number
+}
+
 const flashcardMocks = vi.hoisted(() => ({
   createFlashcardMutateAsync: vi.fn(),
   generateFlashcardsMutateAsync: vi.fn(),
   useFlashcardsEnabled: vi.fn(),
-  useDecksQuery: vi.fn()
+  useDecksQuery: vi.fn(),
+  useFlashcardTemplatesQuery: vi.fn()
 }))
 
 const browserMocks = vi.hoisted(() => ({
@@ -60,7 +84,9 @@ vi.mock("@/components/Flashcards/hooks", () => ({
     isPending: false
   }),
   useFlashcardsEnabled: () => flashcardMocks.useFlashcardsEnabled(),
-  useDecksQuery: (...args: unknown[]) => flashcardMocks.useDecksQuery(...args)
+  useDecksQuery: (...args: unknown[]) => flashcardMocks.useDecksQuery(...args),
+  useFlashcardTemplatesQuery: (...args: unknown[]) =>
+    flashcardMocks.useFlashcardTemplatesQuery(...args)
 }))
 
 vi.mock("wxt/browser", () => ({
@@ -85,6 +111,8 @@ vi.mock("react-i18next", () => ({
 }))
 
 describe("sidepanel flashcards route", () => {
+  let currentTemplates: TemplateFixture[]
+
   beforeEach(() => {
     vi.clearAllMocks()
     translationMocks.t.mockClear()
@@ -94,6 +122,49 @@ describe("sidepanel flashcards route", () => {
     browserMocks.executeScript.mockReset()
     flashcardMocks.createFlashcardMutateAsync.mockReset()
     flashcardMocks.generateFlashcardsMutateAsync.mockReset()
+    flashcardMocks.useFlashcardTemplatesQuery.mockReset()
+    currentTemplates = [
+      {
+        id: 21,
+        name: "Source vocabulary",
+        model_type: "basic_reverse",
+        front_template: "What does {{term}} mean?",
+        back_template: "{{definition}}",
+        notes_template: "From {{source}}",
+        extra_template: "Review after reading.",
+        placeholder_definitions: [
+          {
+            key: "term",
+            label: "Term",
+            help_text: null,
+            default_value: null,
+            required: true,
+            targets: ["front_template"]
+          },
+          {
+            key: "definition",
+            label: "Definition",
+            help_text: null,
+            default_value: null,
+            required: true,
+            targets: ["back_template"]
+          },
+          {
+            key: "source",
+            label: "Source",
+            help_text: null,
+            default_value: "selected page",
+            required: false,
+            targets: ["notes_template"]
+          }
+        ],
+        created_at: "2026-05-27T00:00:00Z",
+        last_modified: "2026-05-27T00:00:00Z",
+        deleted: false,
+        client_id: "test-client",
+        version: 1
+      }
+    ]
     browserMocks.runtimeGetURL.mockImplementation(
       (path: string) => `chrome-extension://flashcards${path}`
     )
@@ -152,6 +223,15 @@ describe("sidepanel flashcards route", () => {
       isLoading: false,
       isError: false
     })
+    flashcardMocks.useFlashcardTemplatesQuery.mockImplementation(() => ({
+      data: {
+        items: currentTemplates,
+        count: currentTemplates.length,
+        total: currentTemplates.length
+      },
+      isLoading: false,
+      error: null
+    }))
   })
 
   afterEach(() => {
@@ -265,6 +345,156 @@ describe("sidepanel flashcards route", () => {
       "Biology"
     )
     expect(screen.getByLabelText("Front")).toHaveValue("Selection Source")
+    expect(screen.getByLabelText("Back")).toHaveValue(
+      "Key concept from the active page"
+    )
+  })
+
+  const openTemplateModal = async (buttonName: string | RegExp) => {
+    await userEvent.setup().click(
+      screen.getByRole("button", { name: buttonName })
+    )
+
+    return await waitFor(() => {
+      const dialog = screen.getAllByRole("dialog").find((candidate) =>
+        within(candidate).queryByLabelText("Template")
+      )
+      expect(dialog).toBeDefined()
+      return dialog as HTMLElement
+    })
+  }
+
+  const fillAndApplyTemplate = async (
+    dialog: HTMLElement,
+    values: {
+      term: string
+      definition: string
+    }
+  ) => {
+    fireEvent.change(within(dialog).getByLabelText("Term"), {
+      target: { value: values.term }
+    })
+    fireEvent.change(within(dialog).getByLabelText("Definition"), {
+      target: { value: values.definition }
+    })
+
+    await waitFor(() => {
+      expect(within(dialog).getByRole("button", { name: "Apply" })).not.toBeDisabled()
+    })
+    fireEvent.click(within(dialog).getByRole("button", { name: "Apply" }))
+  }
+
+  it("applies an existing template to a captured sidepanel draft before saving", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    const modal = await openTemplateModal("Apply template to draft 1")
+    await fillAndApplyTemplate(modal, {
+      term: "ATP",
+      definition: "The cell's energy currency"
+    })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Front")).toHaveValue("What does ATP mean?")
+    })
+    expect(screen.getByLabelText("Back")).toHaveValue("The cell's energy currency")
+    await user.click(screen.getByRole("button", { name: "Save card" }))
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledWith({
+      deck_id: 7,
+      front: "What does ATP mean?",
+      back: "The cell's energy currency",
+      notes: "From selected page",
+      extra: "Review after reading.",
+      model_type: "basic_reverse",
+      is_cloze: false,
+      reverse: true,
+      source_ref_type: "manual",
+      source_ref_id: "https://example.test/source"
+    })
+  })
+
+  it("applies a template only to the selected queued draft", async () => {
+    browserMocks.executeScript
+      .mockResolvedValueOnce([{ result: "First captured concept" }])
+      .mockResolvedValueOnce([{ result: "Second captured concept" }])
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    const modal = await openTemplateModal("Apply template to draft 2")
+    await fillAndApplyTemplate(modal, {
+      term: "Respiration",
+      definition: "ATP production from nutrients"
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Back")[1]).toHaveValue(
+        "ATP production from nutrients"
+      )
+    })
+    expect(screen.getAllByLabelText("Back")[0]).toHaveValue("First captured concept")
+  })
+
+  it("applies templates to generated drafts without losing generated tags", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate draft cards" })
+    )
+    const modal = await openTemplateModal("Apply template to draft 1")
+    await fillAndApplyTemplate(modal, {
+      term: "ATP",
+      definition: "The cell's energy currency"
+    })
+    await user.click(screen.getAllByRole("button", { name: "Save card" })[0])
+
+    await waitFor(() => {
+      expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.createFlashcardMutateAsync).toHaveBeenCalledWith({
+      deck_id: 7,
+      front: "What does ATP mean?",
+      back: "The cell's energy currency",
+      tags: ["biology", "energy"],
+      notes: "From selected page",
+      extra: "Review after reading.",
+      model_type: "basic_reverse",
+      is_cloze: false,
+      reverse: true,
+      source_ref_type: "manual",
+      source_ref_id: "https://example.test/source"
+    })
+  })
+
+  it("keeps queued drafts visible when no templates exist", async () => {
+    currentTemplates = []
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Capture page selection" })
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Apply template to draft 1" })
+    )
+
+    expect(await screen.findByText("No templates yet")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Draft flashcard" })
+    ).toBeInTheDocument()
     expect(screen.getByLabelText("Back")).toHaveValue(
       "Key concept from the active page"
     )

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import {
   ExternalLink,
+  LayoutTemplate,
   Layers,
   MessageSquareText,
   Save,
@@ -17,8 +18,10 @@ import {
   useFlashcardsEnabled,
   useGenerateFlashcardsMutation
 } from "@/components/Flashcards/hooks"
+import { FlashcardTemplateValueModal } from "@/components/Flashcards/components/FlashcardTemplateValueModal"
 import type { GeneratedCardDraft } from "@/components/Flashcards/tabs/ImportExport/shared"
 import { normalizeGeneratedCards } from "@/components/Flashcards/tabs/ImportExport/shared"
+import { normalizeFlashcardTemplateFields } from "@/components/Flashcards/utils/template-helpers"
 import type { FlashcardCreate } from "@/services/flashcards"
 import { buildFlashcardsGenerateRoute } from "@/services/tldw/flashcards-generate-handoff"
 
@@ -78,6 +81,9 @@ export default function SidepanelFlashcards() {
   } | null>(null)
   const generationInFlightRef = React.useRef(false)
   const [drafts, setDrafts] = React.useState<CaptureDraft[]>([])
+  const [templateDraftId, setTemplateDraftId] = React.useState<string | null>(
+    null
+  )
   const [savingDraftIds, setSavingDraftIds] = React.useState<Set<string>>(
     () => new Set()
   )
@@ -495,6 +501,45 @@ export default function SidepanelFlashcards() {
     setDrafts((current) => current.filter((draft) => draft.id !== draftId))
   }, [])
 
+  const handleOpenTemplateDraft = React.useCallback((draftId: string) => {
+    setCaptureError(null)
+    setSaveStatus(null)
+    setTemplateDraftId(draftId)
+  }, [])
+
+  const handleCloseTemplateDraft = React.useCallback(() => {
+    setTemplateDraftId(null)
+  }, [])
+
+  const handleApplyTemplateDraft = React.useCallback(
+    (
+      templateDraft: Pick<
+        FlashcardCreate,
+        "deck_id" | "tags" | "model_type" | "front" | "back" | "notes" | "extra"
+      >
+    ) => {
+      setSaveStatus(null)
+      setDrafts((current) =>
+        current.map((draft) => {
+          if (draft.id !== templateDraftId) return draft
+
+          const normalized = normalizeFlashcardTemplateFields(templateDraft)
+          return {
+            ...draft,
+            front: normalized.front ?? "",
+            back: normalized.back ?? "",
+            modelType: normalized.model_type,
+            tags: normalized.tags ?? draft.tags,
+            notes: normalized.notes ?? null,
+            extra: normalized.extra ?? null
+          }
+        })
+      )
+      setTemplateDraftId(null)
+    },
+    [templateDraftId]
+  )
+
   const handleSaveDraft = React.useCallback(
     async (draftId: string) => {
       if (!hasDeck || savingDraftIdsRef.current.size > 0) return
@@ -618,6 +663,8 @@ export default function SidepanelFlashcards() {
 
   const isSaving = createFlashcardMutation.isPending || savingDraftIds.size > 0
   const isGenerating = generateHandoffLoading || draftGenerateLoading
+  const templateTargetDraft =
+    drafts.find((draft) => draft.id === templateDraftId) ?? null
   const canSaveDraft = React.useCallback(
     (draft: CaptureDraft) => !!buildSavePayload(draft) && hasDeck && !isSaving,
     [buildSavePayload, hasDeck, isSaving]
@@ -779,16 +826,30 @@ export default function SidepanelFlashcards() {
                     {draft.sourceTitle || draft.sourceId}
                   </Text>
                 </div>
-                <Button
-                  size="small"
-                  icon={<Trash2 className="size-4" aria-hidden="true" />}
-                  aria-label={t("sidepanel:flashcards.removeDraft", {
-                    defaultValue: "Remove draft {{index}}",
-                    index: index + 1
-                  })}
-                  disabled={isSaving}
-                  onClick={() => handleRemoveDraft(draft.id)}
-                />
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    size="small"
+                    icon={<LayoutTemplate className="size-4" aria-hidden="true" />}
+                    aria-label={t("sidepanel:flashcards.applyTemplateToDraft", {
+                      defaultValue: "Apply template to draft {{index}}",
+                      index: index + 1
+                    })}
+                    disabled={isSaving}
+                    onClick={() => handleOpenTemplateDraft(draft.id)}
+                  >
+                    {t("sidepanel:flashcards.applyTemplate", "Apply template")}
+                  </Button>
+                  <Button
+                    size="small"
+                    icon={<Trash2 className="size-4" aria-hidden="true" />}
+                    aria-label={t("sidepanel:flashcards.removeDraft", {
+                      defaultValue: "Remove draft {{index}}",
+                      index: index + 1
+                    })}
+                    disabled={isSaving}
+                    onClick={() => handleRemoveDraft(draft.id)}
+                  />
+                </div>
               </div>
               <label className="flex flex-col gap-1 text-sm font-medium">
                 {t("sidepanel:flashcards.frontLabel", "Front")}
@@ -841,6 +902,13 @@ export default function SidepanelFlashcards() {
         <Text type="danger" className="text-xs" role="status">
           {captureError}
         </Text>
+      ) : null}
+      {templateTargetDraft ? (
+        <FlashcardTemplateValueModal
+          open
+          onClose={handleCloseTemplateDraft}
+          onApply={handleApplyTemplateDraft}
+        />
       ) : null}
     </main>
   )

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -526,12 +526,12 @@ export default function SidepanelFlashcards() {
           const normalized = normalizeFlashcardTemplateFields(templateDraft)
           return {
             ...draft,
-            front: normalized.front ?? "",
-            back: normalized.back ?? "",
+            front: normalized.front ?? draft.front,
+            back: normalized.back ?? draft.back,
             modelType: normalized.model_type,
             tags: normalized.tags ?? draft.tags,
-            notes: normalized.notes ?? null,
-            extra: normalized.extra ?? null
+            notes: normalized.notes ?? draft.notes ?? null,
+            extra: normalized.extra ?? draft.extra ?? null
           }
         })
       )
@@ -741,7 +741,7 @@ export default function SidepanelFlashcards() {
       <Text type="secondary" className="text-xs">
         {t(
           "sidepanel:flashcards.selectionHint",
-          "Create one editable card, generate a small draft batch, or use full Flashcards for templates, imports, and review."
+          "Create one editable card, generate a small draft batch, apply templates to queued drafts, or use full Flashcards for imports, review, and management."
         )}
       </Text>
       {drafts.length > 0 ? (
@@ -836,9 +836,7 @@ export default function SidepanelFlashcards() {
                     })}
                     disabled={isSaving}
                     onClick={() => handleOpenTemplateDraft(draft.id)}
-                  >
-                    {t("sidepanel:flashcards.applyTemplate", "Apply template")}
-                  </Button>
+                  />
                   <Button
                     size="small"
                     icon={<Trash2 className="size-4" aria-hidden="true" />}
@@ -908,6 +906,14 @@ export default function SidepanelFlashcards() {
           open
           onClose={handleCloseTemplateDraft}
           onApply={handleApplyTemplateDraft}
+          draftDefaults={{
+            deck_id: selectedDeckId ?? undefined,
+            front: templateTargetDraft.front,
+            back: templateTargetDraft.back,
+            tags: templateTargetDraft.tags,
+            notes: templateTargetDraft.notes ?? null,
+            extra: templateTargetDraft.extra ?? null
+          }}
         />
       ) : null}
     </main>

--- a/backlog/tasks/task-521 - Add-flashcards-extension-native-template-application.md
+++ b/backlog/tasks/task-521 - Add-flashcards-extension-native-template-application.md
@@ -15,6 +15,9 @@ references:
 modified_files:
 - apps/packages/ui/src/routes/sidepanel-flashcards.tsx
 - apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- apps/packages/ui/src/components/Flashcards/components/FlashcardTemplateValueModal.tsx
+- apps/packages/ui/src/components/Flashcards/utils/flashcard-template-resolution.ts
+- apps/packages/ui/src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts
 - Flashcards-UX-Fix-List.md
 - apps/extension/docs/features/flashcards.md
 - Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -46,20 +49,20 @@ Docs/superpowers/plans/2026-05-27-flashcards-extension-template-application-impl
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented sidepanel template application by reusing FlashcardTemplateValueModal and normalizeFlashcardTemplateFields. Captured and generated queued drafts now expose an Apply template action; applying a template updates only the selected draft's front/back/model/notes/extra/tags while preserving draft id, page source title, and source URL provenance. Generated draft tags are retained when a template does not provide tags. In-extension review remains deferred and documented.
+Review-fix pass after rebasing on latest dev: preserved hidden generated draft notes/extra when templates omit optional fields, passed selected draft defaults into FlashcardTemplateValueModal, kept front/back fallbacks null-safe, changed the sidepanel Apply template action to icon-only with its existing aria-label, and updated the sidepanel hint copy so it no longer sends users to full Flashcards for templates.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed native sidepanel template application for the F12 Flashcards extension flow. Captured and generated draft cards now expose Apply template, reuse the existing template value modal/materialization behavior, update only the selected draft, preserve generated tags and page source provenance, and save templated model/notes/extra fields through the existing sidepanel save payload. Updated the master fix list and extension/user docs to mark template application complete while leaving in-extension review deferred.
+Completed native sidepanel template application for the F12 Flashcards extension flow and addressed PR review feedback after rebasing on latest dev. Captured and generated draft cards expose Apply template, reuse the existing template value modal/materialization behavior, update only the selected draft, preserve generated tags, hidden notes/extra, and page source provenance, and save templated model/notes/extra fields through the existing sidepanel save payload. The Apply template action is now icon-only for narrow sidepanel density, and the sidepanel hint copy now describes native template application while leaving in-extension review deferred.
 
 Draft PR: https://github.com/rmusser01/tldw_server/pull/2081
 
 Verification:
-- bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx: 33 tests passed.
-- bunx vitest run src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx: 38 tests passed.
-- bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts: 43 tests passed.
+- bunx vitest run src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx: 40 tests passed.
+- bunx vitest run src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx: 41 tests passed.
+- bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts: 45 tests passed.
 - git diff --check: passed.
 - NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false: still fails only on the known unrelated CharacterListContent.design-system.test.tsx GalleryCardDensity baseline.
 - Bandit not applicable: no Python files touched.

--- a/backlog/tasks/task-521 - Add-flashcards-extension-native-template-application.md
+++ b/backlog/tasks/task-521 - Add-flashcards-extension-native-template-application.md
@@ -1,0 +1,73 @@
+---
+id: TASK-521
+title: Add flashcards extension native template application
+status: Done
+assignee:
+- Codex
+labels:
+- flashcards
+- extension
+- ux
+priority: medium
+references:
+- Flashcards-UX-Fix-List.md
+modified_files:
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- Flashcards-UX-Fix-List.md
+- apps/extension/docs/features/flashcards.md
+- Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next narrow F12 follow-up: let extension sidepanel users apply existing Flashcards templates to captured or generated drafts before saving, while keeping in-extension review deferred.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sidepanel draft cards expose a native Apply template action.
+- [x] #2 Applying a template uses existing Flashcards template placeholder/materialization behavior.
+- [x] #3 Template application updates only the selected draft and preserves page source provenance.
+- [x] #4 Saving templated drafts preserves model type, cloze/reverse flags, tags, notes, extra fields, selected deck, and source URL provenance.
+- [x] #5 Captured drafts and generated draft batches both support template application.
+- [x] #6 In-extension review remains deferred and documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-27-flashcards-extension-template-application-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented sidepanel template application by reusing FlashcardTemplateValueModal and normalizeFlashcardTemplateFields. Captured and generated queued drafts now expose an Apply template action; applying a template updates only the selected draft's front/back/model/notes/extra/tags while preserving draft id, page source title, and source URL provenance. Generated draft tags are retained when a template does not provide tags. In-extension review remains deferred and documented.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed native sidepanel template application for the F12 Flashcards extension flow. Captured and generated draft cards now expose Apply template, reuse the existing template value modal/materialization behavior, update only the selected draft, preserve generated tags and page source provenance, and save templated model/notes/extra fields through the existing sidepanel save payload. Updated the master fix list and extension/user docs to mark template application complete while leaving in-extension review deferred.
+
+Verification:
+- bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx: 33 tests passed.
+- bunx vitest run src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx: 38 tests passed.
+- bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts: 43 tests passed.
+- git diff --check: passed.
+- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false: still fails only on the known unrelated CharacterListContent.design-system.test.tsx GalleryCardDensity baseline.
+- Bandit not applicable: no Python files touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-521 - Add-flashcards-extension-native-template-application.md
+++ b/backlog/tasks/task-521 - Add-flashcards-extension-native-template-application.md
@@ -11,6 +11,7 @@ labels:
 priority: medium
 references:
 - Flashcards-UX-Fix-List.md
+- https://github.com/rmusser01/tldw_server/pull/2081
 modified_files:
 - apps/packages/ui/src/routes/sidepanel-flashcards.tsx
 - apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -52,6 +53,8 @@ Implemented sidepanel template application by reusing FlashcardTemplateValueModa
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Completed native sidepanel template application for the F12 Flashcards extension flow. Captured and generated draft cards now expose Apply template, reuse the existing template value modal/materialization behavior, update only the selected draft, preserve generated tags and page source provenance, and save templated model/notes/extra fields through the existing sidepanel save payload. Updated the master fix list and extension/user docs to mark template application complete while leaving in-extension review deferred.
+
+Draft PR: https://github.com/rmusser01/tldw_server/pull/2081
 
 Verification:
 - bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx: 33 tests passed.


### PR DESCRIPTION
## Change summary

Adds native template application to the extension sidepanel flashcard draft queue. Captured and generated drafts now expose an `Apply template` action that opens the existing Flashcards template value modal, materializes placeholder values through the shared template helper, and writes the selected draft's front/back/model/notes/extra/tags before save.

This keeps the slice narrow: sidepanel drafts gain the missing template workflow without adding in-extension review. Reusing the existing modal/materializer avoids a second placeholder parser and keeps template behavior consistent with the full WebUI create workflow, while the draft update preserves source URL/title provenance and generated tags.

## Verification

- `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` - 33 tests passed.
- `bunx vitest run src/components/Flashcards/components/__tests__/FlashcardTemplateValueModal.test.tsx src/components/Flashcards/utils/__tests__/flashcard-template-resolution.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx` - 38 tests passed.
- `bunx vitest run src/services/__tests__/flashcards-generate-handoff.test.ts src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` - 43 tests passed.
- `git diff --check` - passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` - still fails only on the known unrelated `CharacterListContent.design-system.test.tsx` `GalleryCardDensity` baseline.
- Bandit not applicable: no Python files touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native template application to the Flashcards extension sidepanel. Apply templates to captured or generated drafts before saving; provenance, generated tags, and generated notes/extra are preserved. Satisfies F12 follow-up TASK-521.

- New Features
  - Reuses `FlashcardTemplateValueModal` and `normalizeFlashcardTemplateFields`; updates only the selected draft’s front/back/model/notes/extra/tags.
  - Falls back to draft defaults when templates omit back/notes/extra, preserving generated notes/extra.
  - Per-draft Apply Template icon action; shows an empty state when no templates exist.
  - Saves with templated model fields while keeping page URL/title provenance; docs updated across extension and study guides.

<sup>Written for commit f475c9fc9074cc41123e0c4f36c30908b8e744b0. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2081?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

