### PR TITLE
Add MCP profile registry resolver primitives

### DIFF
--- a/Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md
@@ -27,6 +27,20 @@ Out of scope:
 - Built-in preset mutation or automatic preset-as-runtime-profile behavior.
 - External MCP registry lifecycle or gateway transport work.
 
+## Post-Review Continuation Gates
+
+This plan completes only the Stage 2B profile-document primitive slice. It must not be used as an execution-enforcement plan. Before continuing into runtime wiring, create a follow-up implementation plan for Stage 2C structured resolution with these gates:
+
+- Add `ProfileResolutionResult` and `EffectivePolicyResult` contracts with machine-readable reason codes and provenance. Execution code must branch on structured status/reason fields, not infer from `None`.
+- Preserve `tldw_server` no-profile compatibility separately from standalone gateway default-profile behavior.
+- Enforce deny-over-allow/default-deny precedence in tests before any runtime tool execution uses profiles.
+- Require effective workspace/path binding before any write-capable duplicated profile can execute mutating tools; missing binding denies with `workspace_scope_required`.
+- Keep `ProfileStore` as a profile-document primitive until dedicated assignment, approval policy, credential grant, external registry, and audit stores are planned.
+- Treat `mcp_unified` as internal/experimental until minimal-install, extras, and license/publishing metadata are verified.
+- Keep real upstream external stdio process spawning out of scope until registry storage, credential broker, audit sink, path/workspace policy, executable allowlist, environment allowlist, and process-policy adapters are present and tested.
+
+The next executable slice should be Stage 2C structured profile/effective-policy resolution, not FastAPI route wiring, SQLite persistence, external-server lifecycle, or gateway entrypoints.
+
 ## Files
 
 - Create: `mcp_unified/profiles/store.py`
@@ -271,4 +285,4 @@ git commit -m "feat: add mcp profile registry resolver primitives"
 
 Expected: Commit succeeds.
 
-Result: Commit `b9f1100a3` created with message `feat: add mcp profile registry resolver primitives`.
+Result: Commit `b9f1100a3` was created and then amended to `207aecef7` with message `feat: add mcp profile registry resolver primitives`.

--- a/Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md
@@ -1,0 +1,274 @@
+# MCP Unified Profile Registry Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add package-local profile store and resolver primitives for standalone MCP profile resolution without changing current `tldw_server` MCP route or execution behavior.
+
+**Architecture:** Keep this slice inside `mcp_unified.profiles` plus the package storage protocol. The store is an in-memory implementation for tests and future standalone bootstrap, while `StoreBackedProfileResolver` handles explicit profile id lookup, optional standalone default profile lookup, disabled-profile fail-closed behavior, and copy isolation. No SQLite, FastAPI route, MCP protocol dispatch, host adapter, approval, credential, or execution-policy wiring changes are included.
+
+**Tech Stack:** Python 3.11, Pydantic v2 models, pytest, Ruff, Mypy, Bandit.
+
+---
+
+## Scope
+
+In scope:
+- Package-local profile store primitives.
+- Store-backed profile resolver primitives.
+- Package exports and storage protocol alignment.
+- Focused tests under existing MCP Unified tests.
+- Backlog task update for TASK-521.
+
+Out of scope:
+- SQLite persistence and migrations.
+- User/profile assignment APIs.
+- FastAPI route changes.
+- Runtime `MCPProtocol` or `MCPServer` enforcement changes.
+- Built-in preset mutation or automatic preset-as-runtime-profile behavior.
+- External MCP registry lifecycle or gateway transport work.
+
+## Files
+
+- Create: `mcp_unified/profiles/store.py`
+  - In-memory `ProfileStore` implementation that stores `MCPProfile` documents by id and returns deep copies.
+- Modify: `mcp_unified/profiles/resolver.py`
+  - Add `StoreBackedProfileResolver` alongside the existing `ProfileResolver` protocol.
+- Modify: `mcp_unified/profiles/__init__.py`
+  - Export the new store and resolver primitives.
+- Modify: `mcp_unified/interfaces/storage.py`
+  - Update `ProfileStore` protocol to describe package profile-store behavior.
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py`
+  - Add package-boundary, store, resolver, fail-closed, and copy-isolation tests.
+- Modify: `backlog/tasks/task-521 - Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md`
+  - Record implementation notes, verification, final summary, and DoD.
+
+## Task 1: RED Tests For Store And Resolver Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests covering:
+
+```python
+def test_profile_registry_resolver_module_has_no_tldw_server_imports() -> None:
+    package_root = Path(profile_store.__file__).resolve().parent
+    ...
+
+
+@pytest.mark.asyncio
+async def test_in_memory_profile_store_returns_copy_isolated_profiles() -> None:
+    store = InMemoryProfileStore()
+    profile = MCPProfile(id="architect-workspace", name="Architect Workspace")
+    await store.upsert_profile(profile)
+
+    first = await store.get_profile("architect-workspace")
+    assert first is not None
+    first.name = "Mutated"
+
+    second = await store.get_profile("architect-workspace")
+    assert second is not None
+    assert second.name == "Architect Workspace"
+
+
+@pytest.mark.asyncio
+async def test_store_backed_resolver_resolves_explicit_enabled_profile() -> None:
+    store = InMemoryProfileStore()
+    await store.upsert_profile(MCPProfile(id="code-reviewer", name="Code Reviewer"))
+    resolver = StoreBackedProfileResolver(store)
+
+    profile = await resolver.resolve_profile("code-reviewer")
+
+    assert profile is not None
+    assert profile.id == "code-reviewer"
+
+
+@pytest.mark.asyncio
+async def test_store_backed_resolver_uses_default_only_without_explicit_id() -> None:
+    store = InMemoryProfileStore()
+    await store.upsert_profile(MCPProfile(id="default", name="Default"))
+    resolver = StoreBackedProfileResolver(store, default_profile_id="default")
+
+    assert (await resolver.resolve_profile(None)).id == "default"
+    assert await resolver.resolve_profile("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_store_backed_resolver_returns_none_for_disabled_profiles() -> None:
+    store = InMemoryProfileStore()
+    await store.upsert_profile(MCPProfile(id="disabled", name="Disabled", enabled=False))
+    resolver = StoreBackedProfileResolver(store, default_profile_id="disabled")
+
+    assert await resolver.resolve_profile("disabled") is None
+    assert await resolver.resolve_profile(None) is None
+```
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py -v
+```
+
+Expected: FAIL because `mcp_unified.profiles.store` and `StoreBackedProfileResolver` do not exist yet.
+
+## Task 2: Implement Package-Local Store And Resolver
+
+**Files:**
+- Create: `mcp_unified/profiles/store.py`
+- Modify: `mcp_unified/profiles/resolver.py`
+- Modify: `mcp_unified/interfaces/storage.py`
+- Modify: `mcp_unified/profiles/__init__.py`
+
+- [x] **Step 1: Add store implementation**
+
+Implement a minimal in-memory store:
+
+```python
+class InMemoryProfileStore:
+    """In-memory profile store for tests and standalone bootstrap."""
+
+    def __init__(self, profiles: Iterable[MCPProfile | Mapping[str, Any]] | None = None) -> None:
+        self._profiles: dict[str, MCPProfile] = {}
+        ...
+
+    async def get_profile(self, profile_id: str) -> MCPProfile | None:
+        ...
+
+    async def list_profiles(self) -> list[MCPProfile]:
+        ...
+
+    async def upsert_profile(self, profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
+        ...
+
+    async def delete_profile(self, profile_id: str) -> bool:
+        ...
+```
+
+Use `MCPProfile.model_validate()` for mappings and `model_copy(deep=True)` on writes and reads.
+
+- [x] **Step 2: Add store-backed resolver**
+
+Implement:
+
+```python
+class StoreBackedProfileResolver:
+    """Resolve profiles from a profile store with optional standalone default."""
+
+    def __init__(self, profile_store: ProfileStore, *, default_profile_id: str | None = None) -> None:
+        ...
+
+    async def resolve_profile(
+        self,
+        profile_id: str | None,
+        *,
+        user_id: str | None = None,
+    ) -> MCPProfile | None:
+        resolved_id = profile_id or self.default_profile_id
+        if resolved_id is None:
+            return None
+        profile = await self.profile_store.get_profile(resolved_id)
+        if profile is None or not profile.enabled:
+            return None
+        return profile.model_copy(deep=True)
+```
+
+The `user_id` parameter remains accepted for protocol compatibility but is not used in this package-local primitive.
+
+- [x] **Step 3: Update package exports and protocol**
+
+Export `InMemoryProfileStore` and `StoreBackedProfileResolver` from `mcp_unified.profiles`.
+
+Update `mcp_unified.interfaces.storage.ProfileStore` with package-local methods returning `MCPProfile` objects:
+
+```python
+async def get_profile(self, profile_id: str) -> MCPProfile | None: ...
+async def list_profiles(self) -> list[MCPProfile]: ...
+async def upsert_profile(self, profile: MCPProfile) -> MCPProfile: ...
+async def delete_profile(self, profile_id: str) -> bool: ...
+```
+
+- [x] **Step 4: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py -v
+```
+
+Expected: PASS.
+
+## Task 3: Regression, Quality Gates, And Task Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-521 - Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md`
+
+- [x] **Step 1: Run focused regression tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -v
+```
+
+Expected: PASS.
+
+Result: PASS, `20 passed, 3 warnings in 0.10s`.
+
+- [x] **Step 2: Run static checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m mypy mcp_unified --config-file pyproject.toml
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified -f json -o /tmp/bandit_mcp_unified_profile_registry.json
+jq '.metrics._totals, (.results | length)' /tmp/bandit_mcp_unified_profile_registry.json
+git diff --check
+```
+
+Expected: Ruff passes, Mypy passes, Bandit reports 0 findings, diff whitespace clean.
+
+Result:
+- Ruff PASS for `mcp_unified` and the new profile registry test.
+- Mypy PASS for `mcp_unified/profiles`, `mcp_unified/interfaces/storage.py`, and the new profile registry test.
+- Runtime Bandit PASS with 0 findings for `mcp_unified/profiles` and `mcp_unified/interfaces/storage.py`.
+- Full touched-scope Bandit produced only pytest `assert` B101 findings in the new test file.
+- `git diff --check` PASS.
+
+- [x] **Step 3: Update Backlog task**
+
+Record:
+- plan path
+- touched files
+- RED/GREEN verification
+- final quality gates
+- known skips or blockers
+
+Result: TASK-521 updated with implementation notes, final summary, completed acceptance criteria, and Definition of Done.
+
+- [x] **Step 4: Commit**
+
+Run:
+
+```bash
+git add \
+  mcp_unified/interfaces/storage.py \
+  mcp_unified/profiles/__init__.py \
+  mcp_unified/profiles/resolver.py \
+  mcp_unified/profiles/store.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py \
+  Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md \
+  "backlog/tasks/task-521 - Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md"
+git commit -m "feat: add mcp profile registry resolver primitives"
+```
+
+Expected: Commit succeeds.
+
+Result: Commit `b9f1100a3` created with message `feat: add mcp profile registry resolver primitives`.

--- a/Docs/superpowers/plans/2026-05-27-mcp-unified-stage2c-structured-resolution-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-mcp-unified-stage2c-structured-resolution-implementation-plan.md
@@ -1,0 +1,286 @@
+# MCP Unified Stage 2C Structured Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured profile and effective-policy resolution primitives for MCP Unified without wiring profiles into runtime tool execution.
+
+**Architecture:** Keep this slice inside the standalone `mcp_unified.profiles` package and package tests. `StoreBackedProfileResolver` gains a structured result path while preserving the existing `resolve_profile()` convenience behavior. A small effective-policy primitive records reason codes, provenance, deny-over-allow/default-deny behavior, and workspace-binding requirements for write-capable profiles, but does not modify FastAPI routes, `MCPProtocol`, `MCPServer`, SQLite persistence, external server lifecycle, or gateway entrypoints.
+
+**Tech Stack:** Python 3.11, Pydantic v2 models, pytest, Ruff, Mypy, Bandit.
+
+---
+
+## Source Design
+
+- Spec: `Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md`
+- Prior Stage 2B plan: `Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md`
+- Backlog task for plan hardening: `TASK-522`
+
+## Scope
+
+In scope:
+- Structured `ProfileResolutionResult` and `EffectivePolicyResult` package models.
+- Machine-readable reason codes for resolved, required, missing, disabled, store-unavailable, denied, and workspace-scope-required outcomes.
+- Store-backed resolver result method plus compatibility-preserving `resolve_profile()` behavior.
+- Effective-policy primitive that enforces deny-over-allow/default-deny and workspace-binding requirements for write-capable profiles.
+- Preset/resource-constraint tests that mark write-capable bundled presets as assignment-time workspace-bound templates.
+
+Out of scope:
+- FastAPI route changes.
+- Runtime `MCPProtocol` or `MCPServer` execution enforcement.
+- SQLite persistence or migrations.
+- Profile assignment APIs.
+- External MCP process spawning, stdio lifecycle, or gateway entrypoints.
+- Host MCP Hub policy rewiring.
+
+## Files
+
+- Create: `mcp_unified/profiles/resolution.py`
+  - Result models, reason-code literals, effective-policy helper, and write-capability workspace-binding checks.
+- Modify: `mcp_unified/profiles/resolver.py`
+  - Add `resolve_profile_result()` and keep `resolve_profile()` as a convenience wrapper.
+- Modify: `mcp_unified/profiles/presets.py`
+  - Mark write-capable bundled presets with `resource_constraints.requires_workspace_binding`.
+- Modify: `mcp_unified/profiles/__init__.py`
+  - Export structured result primitives.
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
+  - Package tests for result statuses, reason codes, provenance, default behavior, disabled/missing/store-unavailable states, and compatibility wrapper behavior.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+  - Assert write-capable presets advertise workspace-binding requirements.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+  - Keep package-boundary and shim-export assertions current if exports change.
+- Modify: `backlog/tasks/<new-task>.md`
+  - Track the implementation task, verification, and final summary.
+
+## Task 1: RED Tests For Structured Profile Resolution
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
+
+- [ ] **Step 1: Write failing profile-resolution tests**
+
+Add tests covering:
+
+```python
+@pytest.mark.asyncio
+async def test_profile_result_reports_required_when_no_explicit_or_default_profile() -> None:
+    resolver = StoreBackedProfileResolver(InMemoryProfileStore())
+
+    result = await resolver.resolve_profile_result(None)
+
+    assert result.status == "profile_required"
+    assert result.reason_code == "profile_required"
+    assert result.profile is None
+
+
+@pytest.mark.asyncio
+async def test_profile_result_reports_disabled_profile_with_provenance() -> None:
+    store = InMemoryProfileStore([
+        MCPProfile(id="disabled", name="Disabled", enabled=False),
+    ])
+    resolver = StoreBackedProfileResolver(store)
+
+    result = await resolver.resolve_profile_result("disabled")
+
+    assert result.status == "profile_disabled"
+    assert result.reason_code == "profile_disabled"
+    assert result.provenance["profile_id"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_resolve_profile_keeps_legacy_none_wrapper_behavior() -> None:
+    resolver = StoreBackedProfileResolver(InMemoryProfileStore())
+
+    assert await resolver.resolve_profile(None) is None
+```
+
+- [ ] **Step 2: Run RED test**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py -v
+```
+
+Expected: FAIL because `resolve_profile_result` and result models do not exist.
+
+## Task 2: Add Resolution Result Models
+
+**Files:**
+- Create: `mcp_unified/profiles/resolution.py`
+- Modify: `mcp_unified/profiles/__init__.py`
+
+- [ ] **Step 1: Implement result models**
+
+Add Pydantic models:
+
+```python
+ProfileResolutionStatus = Literal[
+    "resolved",
+    "profile_required",
+    "profile_not_found",
+    "profile_disabled",
+    "store_unavailable",
+]
+
+EffectivePolicyStatus = Literal[
+    "resolved",
+    "denied",
+    "approval_required",
+    "degraded",
+]
+
+class ProfileResolutionResult(BaseModel):
+    status: ProfileResolutionStatus
+    profile: MCPProfile | None = None
+    reason_code: str
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    warnings: list[dict[str, Any]] = Field(default_factory=list)
+```
+
+Also add `EffectivePolicy` and `EffectivePolicyResult` with the same provenance/warning shape.
+
+- [ ] **Step 2: Export result primitives**
+
+Export from `mcp_unified.profiles`.
+
+- [ ] **Step 3: Run focused import tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v
+```
+
+Expected: PASS after exports are stable.
+
+## Task 3: Add Store-Backed Structured Resolution
+
+**Files:**
+- Modify: `mcp_unified/profiles/resolver.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
+
+- [ ] **Step 1: Implement `resolve_profile_result()`**
+
+Add structured behavior:
+- no explicit/default id -> `profile_required`
+- missing profile -> `profile_not_found`
+- disabled profile -> `profile_disabled`
+- store unavailable -> `store_unavailable`
+- enabled profile -> `resolved`
+
+Each result must include provenance with at least `requested_profile_id`, `resolved_profile_id`, `used_default_profile`, and `resolver`.
+
+- [ ] **Step 2: Preserve wrapper behavior**
+
+Keep `resolve_profile()` returning `MCPProfile | None` for existing primitive callers by delegating to `resolve_profile_result()` and returning the copied profile only when status is `resolved`.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py -v
+```
+
+Expected: PASS.
+
+## Task 4: Add Effective Policy Workspace-Binding Primitive
+
+**Files:**
+- Modify: `mcp_unified/profiles/resolution.py`
+- Modify: `mcp_unified/profiles/presets.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
+
+- [ ] **Step 1: Write failing workspace-binding tests**
+
+Add tests proving:
+- write-capable profiles without `path_scopes`, host binding, or assignment binding return `workspace_scope_required`
+- read-only profiles can resolve effective policy without workspace binding
+- deny entries override allow entries
+- no allowed tools/capabilities defaults to deny for execution
+
+- [ ] **Step 2: Mark write-capable presets**
+
+Set `policy_document.resource_constraints["requires_workspace_binding"] = True` for bundled presets with mutating/write-scoped capabilities.
+
+- [ ] **Step 3: Implement effective-policy helper**
+
+Add a package-local helper, for example:
+
+```python
+def build_effective_policy_result(
+    profile: MCPProfile,
+    *,
+    host_caps: dict[str, Any] | None = None,
+    assignment_binding: dict[str, Any] | None = None,
+) -> EffectivePolicyResult:
+    ...
+```
+
+Do not call this from runtime execution in this slice.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -v
+```
+
+Expected: PASS.
+
+## Task 5: Regression And Quality Gates
+
+**Files:**
+- Modify: implementation Backlog task file
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run static and security checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m mypy mcp_unified/profiles mcp_unified/interfaces/storage.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/profiles mcp_unified/interfaces/storage.py -f json -o /tmp/bandit_mcp_unified_stage2c_resolution.json
+jq '.metrics._totals, (.results | length)' /tmp/bandit_mcp_unified_stage2c_resolution.json
+git diff --check
+```
+
+Expected: Ruff passes, Mypy passes, runtime Bandit reports 0 findings, and diff whitespace is clean.
+
+- [ ] **Step 3: Update Backlog task and commit**
+
+Record RED/GREEN evidence, verification, known skips, and final summary, then commit:
+
+```bash
+git add \
+  mcp_unified/profiles/resolution.py \
+  mcp_unified/profiles/resolver.py \
+  mcp_unified/profiles/presets.py \
+  mcp_unified/profiles/__init__.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  "backlog/tasks/<new-task>.md"
+git commit -m "feat: add mcp profile structured resolution primitives"
+```
+
+Expected: commit succeeds with no runtime execution wiring.

--- a/Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+++ b/Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
@@ -45,6 +45,8 @@ Acceptance criteria:
 - Existing `/api/v1/mcp/*` routes, JSON-RPC payloads, auth behavior, env vars, MCP Hub policy behavior, approvals, path scopes, and credential brokering remain compatible in `tldw_server`.
 - Existing clients that do not select a profile continue to resolve through the current default MCP Hub/AuthNZ/RBAC behavior in `tldw_server`; extraction must not unexpectedly deny or grant tools for no-profile legacy requests.
 - A minimal external FastAPI app can mount the package router with fake adapters and successfully call status, tools/list, and tools/call for a stub tool.
+- Runtime-neutral Stage 2 work is split into explicit sub-stages. Profile schema/store/resolver primitives are not treated as execution enforcement until structured profile/effective-policy resolution, reason codes, audit provenance, and host compatibility tests exist.
+- Profile and effective-policy resolution returns structured outcomes with machine-readable reason codes and provenance; execution code must not infer deny reasons from `None` alone.
 - The optional built-in SQLite storage provides separate `ProfileStore`, `ExternalRegistryStore`, and `AuditStore` interfaces for profiles/assignments/approval policies/credential grants, external server definitions, provenance, and audit events.
 - File/YAML data is limited to preset loading, seed/import/export, or read-only configuration, not concurrent policy persistence.
 - External-server stdio is supported in Phase A only as a managed upstream MCP server transport; the client-facing gateway stdio MCP server entrypoint belongs to Phase B.
@@ -115,12 +117,15 @@ The repository has conflicting license signals in local guidance and package met
 
 Until that decision is made, the package should be treated as an in-repo/internal package even if its technical boundary is clean.
 
+The project must not market, document, or tag `mcp_unified` as a standalone third-party package until the packaging gate is complete. Early in-repo users may depend on the boundary, but release notes and examples should describe it as internal/experimental until minimal-install, extras, and license metadata are proven.
+
 Packaging acceptance criteria:
 
 - `mcp_unified` can be installed without installing media ingestion, RAG, UI, STT/TTS, or other `tldw_server` optional dependency groups
 - extras are documented and tested independently
 - import-boundary tests run in a minimal environment
 - license metadata is explicit in the package metadata and docs
+- a CI or local smoke install verifies `mcp_unified` imports in a clean environment with only declared core dependencies
 
 ## Runtime Instance Model
 
@@ -223,11 +228,14 @@ tldw_Server_API/app/core/MCP_unified/adapters/
 
 Storage interfaces should be split by responsibility:
 
-- `ProfileStore`: profiles, assignments, approval policies, credential grants, schema migrations
+- `ProfileStore`: profile documents, profile schema version, profile lifecycle timestamps, and profile migrations
+- `ProfileAssignmentStore`: principal/workspace/default-profile assignments and assignment provenance
+- `ApprovalPolicyStore`: reusable approval policies and profile-to-approval-policy bindings
+- `CredentialGrantStore`: credential grant metadata and broker binding references, never secret values
 - `ExternalRegistryStore`: external server definitions, credential slot metadata, enabled/disabled state, registry migrations
 - `AuditStore`: append-only audit/provenance events and query helpers
 
-The bundled SQLite implementation can implement all three interfaces for the standalone gateway, but host integrations may provide each interface independently. `tldw_server` should adapt MCP Hub and AuthNZ repositories into these interfaces rather than routing all persistence through a generic profile store.
+The bundled SQLite implementation can implement all of these interfaces for the standalone gateway, but host integrations may provide each interface independently. `tldw_server` should adapt MCP Hub and AuthNZ repositories into these interfaces rather than routing all persistence through a generic profile store. If an early package slice provides only `ProfileStore`, it is a profile-document primitive, not the full standalone persistence contract.
 
 ## Protocol Compatibility
 
@@ -258,7 +266,8 @@ client request
   -> transport adapter (FastAPI HTTP/WS or stdio)
   -> auth/session adapter builds RequestContext
   -> runtime protocol validates JSON-RPC
-  -> profile resolver computes EffectivePolicy
+  -> profile resolver returns ProfileResolutionResult
+  -> effective-policy resolver computes EffectivePolicyResult
   -> RBAC/API-key ceilings are applied
   -> registry resolves local or external tool
   -> path, credential, approval, and risk hooks run
@@ -310,6 +319,14 @@ resource_constraints
 ```
 
 Profiles need schema and preset versioning from the start. Built-in presets can evolve, but duplicated user profiles must record the preset version they were created from. Migrations must be explicit and auditable; user-customized profiles should not be silently rewritten by preset updates.
+
+Write-capable profiles require an explicit workspace/path binding before they are executable. Capabilities such as `workspace.write_scoped`, `docs.write_scoped`, `source.write_scoped`, `repo.write_scoped`, `tests.write_scoped`, or any future mutating capability may appear in a preset template, but enabling that duplicated profile for execution requires one of:
+
+- a concrete `path_scopes` entry bound to a canonical workspace/root
+- a host-provided workspace binding in the effective policy provenance
+- a gateway-local assignment that supplies the workspace/root scope
+
+If a write-capable profile has no effective workspace/path binding, discovery may show the profile as incomplete, but execution must deny with a machine-readable `workspace_scope_required` reason. Preset safety tests should check that write-capable bundled presets either include this requirement in `resource_constraints` or are explicitly marked as templates requiring assignment-time binding.
 
 ## Preset Safety Baseline
 
@@ -380,6 +397,26 @@ Discovery may degrade more softly:
 - external discovery failure degrades only the affected server
 - catalog/profile resolution failures should not grant extra execution authority
 
+Resolution must be structured before it is wired into execution. The minimum package contract should include:
+
+```text
+ProfileResolutionResult
+  status: resolved | profile_required | profile_not_found | profile_disabled | store_unavailable
+  profile: MCPProfile | None
+  reason_code: str
+  provenance: dict
+  warnings: list[dict]
+
+EffectivePolicyResult
+  status: resolved | denied | approval_required | degraded
+  policy: EffectivePolicy | None
+  reason_code: str
+  provenance: dict
+  warnings: list[dict]
+```
+
+Allowed `ProfileResolutionResult.reason_code` values should include at least `profile_resolved`, `profile_required`, `profile_not_found`, `profile_disabled`, and `profile_store_unavailable`. Execution code must branch on these status and reason fields, not on whether a profile object is `None`. Discovery may translate the same result into softer visibility metadata, but execution remains fail-closed.
+
 Approval-required is a structured runtime outcome, not a generic permission error. It should include tool name, reason, target context, requested scope, expiry options when applicable, and safe argument summary or hash.
 
 ## Security Requirements
@@ -423,6 +460,8 @@ Phase A should manage registry plus lifecycle:
 - policy-gated execution
 
 It should not install or update third-party server packages in Phase A.
+
+Process-spawning upstream stdio is not the first external-server slice. Before the package starts external stdio processes, the implementation must already have registry storage, credential broker, audit sink, path/workspace policy, executable allowlist, environment allowlist, and process-policy adapters under test. Earlier external-server slices should be limited to non-spawning registry models, fake transports, health state, namespaced virtual-tool metadata, and policy-gated execution tests.
 
 There are two distinct stdio concerns:
 
@@ -541,9 +580,16 @@ Success means existing tests keep passing and behavior is unchanged.
 
 ### Stage 2: Runtime-Neutral Package
 
-Move request/response models, protocol dispatch, module registry, execution preparation, idempotency helpers, external server manager, transport contracts, profile schemas, and optional SQLite store implementations into `mcp_unified`.
+Stage 2 is not a single move. It should be broken into independently reviewable gates:
 
-Success means the package test suite runs without importing `tldw_Server_API`.
+- **Stage 2A: package boundary and neutral interfaces.** Create or maintain the `mcp_unified` package, host shim re-exports, import-boundary tests, and minimal dependency surface.
+- **Stage 2B: profile schema, presets, and profile-document store primitives.** Keep this limited to data contracts, copy isolation, preset safety, and profile lookup. No execution enforcement yet.
+- **Stage 2C: structured profile/effective-policy resolution.** Add result objects, reason codes, provenance, deny-over-allow precedence, workspace-binding requirements for write-capable profiles, and tests for standalone default-profile behavior versus `tldw_server` legacy no-profile behavior.
+- **Stage 2D: runtime protocol and execution shell.** Move request/response models, JSON-RPC protocol dispatch, module registry contracts, idempotency helpers, and execution preparation behind fake adapters. Prove two runtime instances do not share registry, profile, idempotency, session, or external-server state.
+- **Stage 2E: SQLite stores and migrations.** Add gateway-local SQLite implementations for the split stores: profiles, assignments, approval policies, credential grants, external registry, and audit. File/YAML remains seed/import/export only.
+- **Stage 2F: external registry and non-spawning federation shell.** Add external-server registry models, fake transport lifecycle, namespaced virtual-tool metadata, health state, and policy-gated execution tests. Defer real upstream stdio process spawning until registry, credential, audit, path, and process-policy adapters are all present.
+
+Success means each sub-stage has focused package tests that run without importing `tldw_Server_API`, and host compatibility tests prove existing `tldw_server` behavior remains unchanged before the next sub-stage begins.
 
 ### Stage 3: Host Adapters And Shims
 

--- a/backlog/tasks/task-521 - Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md
+++ b/backlog/tasks/task-521 - Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md
@@ -1,0 +1,65 @@
+---
+id: TASK-521
+title: Implement MCP Unified Stage 2 profile registry resolver primitives
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-27 07:19'
+labels:
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage2
+  - profiles
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next narrow MCP Unified Stage 2 slice after built-in profile presets: package-local profile store and resolver primitives that can load stored MCPProfile documents, apply an optional default profile for standalone gateway callers, and fail closed without changing host MCP route, approval, credential, or execution behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Package-local profile registry/resolver primitives are available without importing tldw_Server_API.
+- [x] #2 ProfileStore supports storing, listing, retrieving, and deleting MCPProfile documents in a package-local implementation suitable for tests and standalone bootstrap.
+- [x] #3 Store-backed resolver returns explicit profiles by id, uses an optional default profile only when no profile id is provided, returns no profile when unavailable or disabled, and does not treat built-in presets as mutable runtime profiles unless explicitly duplicated/stored.
+- [x] #4 Tests cover import isolation, explicit profile resolution, default standalone resolution, disabled/missing profile fail-closed behavior, and copy isolation.
+- [x] #5 Focused tests, Ruff/Mypy for mcp_unified, Bandit touched scope, and diff whitespace checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Plan: Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md
+- Added package-local InMemoryProfileStore plus ProfileStoreUnavailableError for explicit fail-closed availability handling.
+- Added StoreBackedProfileResolver for explicit/default profile lookup, disabled/missing fail-closed behavior, and copy-isolated returns.
+- Updated ProfileStore protocol to return MCPProfile values and support list/upsert/delete operations without host imports.
+- Added focused package-boundary, store copy-isolation, explicit/default resolution, disabled, missing, and unavailable-store tests.
+- Verification: profile registry/preset/runtime package tests passed: 20 passed, 3 warnings.
+- Verification: Ruff passed for mcp_unified and the new profile registry test.
+- Verification: Mypy passed for mcp_unified/profiles, mcp_unified/interfaces/storage.py, and the new test.
+- Verification: runtime Bandit scan passed with 0 findings for mcp_unified/profiles and mcp_unified/interfaces/storage.py. Full touched-scope Bandit produced only pytest assert B101 findings in the new test file.
+- Verification: git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented MCP Unified Stage 2 profile registry/resolver primitives in the standalone mcp_unified package. The slice adds an in-memory profile store, an explicit store-unavailable error signal, a store-backed resolver with optional default profile lookup and fail-closed disabled/missing/unavailable behavior, package exports, and a richer ProfileStore protocol. Focused tests cover package import isolation, copy isolation, list/delete behavior, explicit/default resolution, disabled profiles, and unavailable-store behavior. No FastAPI route, host MCP execution, approval, credential, or policy enforcement paths were changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-521 - Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md
+++ b/backlog/tasks/task-521 - Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md
@@ -3,7 +3,7 @@ id: TASK-521
 title: Implement MCP Unified Stage 2 profile registry resolver primitives
 status: Done
 assignee: []
-created_date: ''
+created_date: '2026-05-27T07:20:16Z'
 updated_date: '2026-05-27 07:19'
 labels:
   - mcp

--- a/backlog/tasks/task-522 - Harden-MCP-Unified-standalone-Stage-2-design-gates.md
+++ b/backlog/tasks/task-522 - Harden-MCP-Unified-standalone-Stage-2-design-gates.md
@@ -1,0 +1,59 @@
+---
+id: TASK-522
+title: Harden MCP Unified standalone Stage 2 design gates
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-27 15:48'
+labels:
+  - mcp
+  - mcp-unified
+  - standalone
+  - stage2
+  - design
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-27-mcp-unified-profile-registry-resolver-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the post-review design issues before continuing MCP Unified standalone extraction: split Stage 2 into explicit gates, add structured profile/effective-policy result semantics, require workspace binding for write-capable presets, clarify storage-contract split, add packaging/license release gate, and gate external stdio process work behind adapter/audit policy readiness.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Stage 2 is split into explicit sub-stages that distinguish profile primitives from enforcement/runtime/gateway work.
+- [x] #2 Spec defines structured profile/effective-policy resolution outcomes with machine-readable reason codes and provenance expectations before execution wiring.
+- [x] #3 Write-capable presets require workspace/path-scope binding before executable use.
+- [x] #4 Storage contract responsibilities are clarified before SQLite persistence work.
+- [x] #5 Packaging/license/minimal-install gate is explicit before standalone publication or third-party embedding claims.
+- [x] #6 External MCP stdio process lifecycle work is gated behind registry, credential, audit, path, and process-policy adapters.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the post-review design hardening before further MCP Unified standalone extraction. Updated the standalone design spec with explicit Stage 2 sub-stages, structured profile/effective-policy result contracts, workspace-binding requirements for write-capable profiles, split storage responsibilities, packaging/license/minimal-install release gate, and a non-spawning external federation gate before upstream stdio process lifecycle work. Updated the completed Stage 2B profile registry plan with continuation gates and corrected the amended commit hash. Added a Stage 2C structured resolution implementation plan as the next executable slice.
+
+Verification: git diff --check passed. Design self-review confirmed no runtime/code behavior changes, no FastAPI route changes, no MCPProtocol/MCPServer wiring, no SQLite persistence, no external stdio process work, and no gateway entrypoints. Bandit skipped because this task touched Markdown/Backlog design artifacts only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the MCP Unified standalone design and planning artifacts after review. The spec now prevents treating profile primitives as execution enforcement, requires structured reason/provenance results before runtime wiring, requires workspace/path binding for write-capable profiles, splits storage responsibilities beyond a generic ProfileStore, blocks standalone publication claims until packaging/license/minimal-install gates are proven, and defers real upstream stdio process spawning until policy, audit, credential, path, and process adapters are ready. Added the concrete Stage 2C structured resolution plan as the next code slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Design/plan changes reviewed for scope creep
+- [x] #3 Verification recorded
+- [x] #4 Final summary added
+<!-- DOD:END -->

--- a/backlog/tasks/task-523 - Address-PR-2082-MCP-profile-registry-review-comments.md
+++ b/backlog/tasks/task-523 - Address-PR-2082-MCP-profile-registry-review-comments.md
@@ -1,0 +1,61 @@
+---
+id: TASK-523
+title: Address PR 2082 MCP profile registry review comments
+status: Done
+assignee: []
+created_date: '2026-05-27T19:57:40Z'
+updated_date: '2026-05-27 19:57'
+labels:
+  - mcp-unified
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2082'
+modified_files:
+  - mcp_unified/profiles/resolver.py
+  - mcp_unified/profiles/store.py
+  - mcp_unified/interfaces/storage.py
+  - tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
+  - >-
+    backlog/tasks/task-521 -
+    Implement-MCP-Unified-Stage-2-profile-registry-resolver-primitives.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address unresolved CodeRabbit, Qodo, and Gemini review comments on PR #2082 after rebasing onto latest dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased onto latest origin/dev and pushed.
+- [x] #2 All valid unresolved review comments on PR #2082 are addressed or explicitly documented as skipped with rationale.
+- [x] #3 Focused MCP profile registry tests, lint/type checks, Bandit, and diff checks pass for the touched scope.
+- [x] #4 PR checks are inspected after the final push.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the valid PR #2082 review comments after rebasing onto origin/dev at fa8e549c8. Added observable logging for profile-store outages while preserving fail-closed behavior, narrowed the ProfileStore upsert protocol, removed redundant profile deep copies covered by the store copy-isolation contract, made the import-boundary test layout-tolerant, populated TASK-521 created_date metadata, and resolved the six fixed inline review threads. Local verification passed for focused tests, Ruff, Mypy, Bandit touched scope, and git diff --check. GitHub checks were inspected after push and were pending/skipping with no failures at inspection time.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
@@ -10,7 +9,11 @@ if TYPE_CHECKING:
 
 
 class ProfileStore(Protocol):
-    """Store for named MCP tool and permission profiles."""
+    """Store for named MCP tool and permission profiles.
+
+    Implementations return caller-owned ``MCPProfile`` instances so callers may
+    inspect or mutate returned models without changing persisted state.
+    """
 
     async def get_profile(self, profile_id: str) -> MCPProfile | None: ...
 
@@ -18,7 +21,7 @@ class ProfileStore(Protocol):
 
     async def upsert_profile(
         self,
-        profile: MCPProfile | Mapping[str, Any],
+        profile: MCPProfile,
     ) -> MCPProfile: ...
 
     async def delete_profile(self, profile_id: str) -> bool: ...

--- a/mcp_unified/interfaces/storage.py
+++ b/mcp_unified/interfaces/storage.py
@@ -2,13 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from mcp_unified.profiles.models import MCPProfile
 
 
 class ProfileStore(Protocol):
     """Store for named MCP tool and permission profiles."""
 
-    async def get_profile(self, profile_id: str) -> dict[str, Any] | None: ...
+    async def get_profile(self, profile_id: str) -> MCPProfile | None: ...
+
+    async def list_profiles(self) -> list[MCPProfile]: ...
+
+    async def upsert_profile(
+        self,
+        profile: MCPProfile | Mapping[str, Any],
+    ) -> MCPProfile: ...
+
+    async def delete_profile(self, profile_id: str) -> bool: ...
 
 
 class ExternalRegistryStore(Protocol):

--- a/mcp_unified/profiles/__init__.py
+++ b/mcp_unified/profiles/__init__.py
@@ -8,13 +8,17 @@ from .presets import (
     list_builtin_presets,
     validate_preset_safety,
 )
-from .resolver import ProfileResolver
+from .resolver import ProfileResolver, StoreBackedProfileResolver
+from .store import InMemoryProfileStore, ProfileStoreUnavailableError
 
 __all__ = [
+    "InMemoryProfileStore",
     "MCPProfile",
     "ProfilePolicy",
     "ProfilePreset",
     "ProfileResolver",
+    "ProfileStoreUnavailableError",
+    "StoreBackedProfileResolver",
     "duplicate_builtin_preset",
     "get_builtin_preset",
     "list_builtin_presets",

--- a/mcp_unified/profiles/resolver.py
+++ b/mcp_unified/profiles/resolver.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Protocol
 
 from mcp_unified.interfaces.storage import ProfileStore
 
 from .models import MCPProfile
 from .store import ProfileStoreUnavailableError
+
+logger = logging.getLogger(__name__)
 
 
 class ProfileResolver(Protocol):
@@ -48,8 +51,13 @@ class StoreBackedProfileResolver:
         try:
             profile = await self.profile_store.get_profile(resolved_id)
         except ProfileStoreUnavailableError:
+            logger.warning(
+                "Profile store unavailable while resolving MCP profile %r",
+                resolved_id,
+                exc_info=True,
+            )
             return None
 
         if profile is None or not profile.enabled:
             return None
-        return profile.model_copy(deep=True)
+        return profile

--- a/mcp_unified/profiles/resolver.py
+++ b/mcp_unified/profiles/resolver.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from mcp_unified.interfaces.storage import ProfileStore
+
 from .models import MCPProfile
+from .store import ProfileStoreUnavailableError
 
 
 class ProfileResolver(Protocol):
@@ -16,3 +19,37 @@ class ProfileResolver(Protocol):
         *,
         user_id: str | None = None,
     ) -> MCPProfile | None: ...
+
+
+class StoreBackedProfileResolver:
+    """Resolve profiles from a profile store with optional standalone default."""
+
+    def __init__(
+        self,
+        profile_store: ProfileStore,
+        *,
+        default_profile_id: str | None = None,
+    ) -> None:
+        self.profile_store = profile_store
+        self.default_profile_id = default_profile_id
+
+    async def resolve_profile(
+        self,
+        profile_id: str | None,
+        *,
+        user_id: str | None = None,
+    ) -> MCPProfile | None:
+        """Return the enabled explicit or default profile, failing closed."""
+        del user_id
+        resolved_id = profile_id or self.default_profile_id
+        if resolved_id is None:
+            return None
+
+        try:
+            profile = await self.profile_store.get_profile(resolved_id)
+        except ProfileStoreUnavailableError:
+            return None
+
+        if profile is None or not profile.enabled:
+            return None
+        return profile.model_copy(deep=True)

--- a/mcp_unified/profiles/store.py
+++ b/mcp_unified/profiles/store.py
@@ -56,4 +56,4 @@ class InMemoryProfileStore:
         """Validate and deep-copy a profile-like object for storage."""
         if isinstance(profile, MCPProfile):
             return profile.model_copy(deep=True)
-        return MCPProfile.model_validate(dict(profile)).model_copy(deep=True)
+        return MCPProfile.model_validate(profile)

--- a/mcp_unified/profiles/store.py
+++ b/mcp_unified/profiles/store.py
@@ -1,0 +1,59 @@
+"""Package-local profile store primitives for MCP Unified."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .models import MCPProfile
+
+
+class ProfileStoreUnavailableError(RuntimeError):
+    """Raised when a profile store cannot serve requests."""
+
+
+class InMemoryProfileStore:
+    """In-memory profile store for tests and standalone bootstrap."""
+
+    def __init__(
+        self,
+        profiles: Iterable[MCPProfile | Mapping[str, Any]] | None = None,
+    ) -> None:
+        self._profiles: dict[str, MCPProfile] = {}
+        for profile in profiles or ():
+            validated = self._validate_profile(profile)
+            self._profiles[validated.id] = validated
+
+    async def get_profile(self, profile_id: str) -> MCPProfile | None:
+        """Return a copy of a stored profile by id, or None when absent."""
+        profile = self._profiles.get(profile_id)
+        if profile is None:
+            return None
+        return profile.model_copy(deep=True)
+
+    async def list_profiles(self) -> list[MCPProfile]:
+        """Return copy-isolated profiles sorted by id for deterministic callers."""
+        return [
+            self._profiles[profile_id].model_copy(deep=True)
+            for profile_id in sorted(self._profiles)
+        ]
+
+    async def upsert_profile(
+        self,
+        profile: MCPProfile | Mapping[str, Any],
+    ) -> MCPProfile:
+        """Store a profile document and return a copy-isolated stored value."""
+        validated = self._validate_profile(profile)
+        self._profiles[validated.id] = validated
+        return validated.model_copy(deep=True)
+
+    async def delete_profile(self, profile_id: str) -> bool:
+        """Delete a profile by id and return whether it existed."""
+        return self._profiles.pop(profile_id, None) is not None
+
+    @staticmethod
+    def _validate_profile(profile: MCPProfile | Mapping[str, Any]) -> MCPProfile:
+        """Validate and deep-copy a profile-like object for storage."""
+        if isinstance(profile, MCPProfile):
+            return profile.model_copy(deep=True)
+        return MCPProfile.model_validate(dict(profile)).model_copy(deep=True)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
@@ -1,0 +1,156 @@
+"""Tests for package-local MCP profile store and resolver primitives."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import mcp_unified.profiles.resolver as profile_resolver
+import mcp_unified.profiles.store as profile_store
+import pytest
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.resolver import StoreBackedProfileResolver
+from mcp_unified.profiles.store import InMemoryProfileStore, ProfileStoreUnavailableError
+
+
+def _tldw_imports_for(path: Path) -> list[str]:
+    """Return imports from a Python file that cross into the host package."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "tldw_Server_API"
+                or alias.name.startswith("tldw_Server_API.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "tldw_Server_API" or node.module.startswith("tldw_Server_API."):
+                imports.append(node.module)
+    return imports
+
+
+def test_profile_store_and_resolver_modules_have_no_tldw_server_imports() -> None:
+    package_root = Path(profile_store.__file__).resolve().parent
+    assert Path(profile_resolver.__file__).resolve().parent == package_root
+
+    offenders: dict[str, list[str]] = {}
+    for path in package_root.rglob("*.py"):
+        imports = _tldw_imports_for(path)
+        if imports:
+            offenders[str(path)] = imports
+    assert offenders == {}
+
+
+@pytest.mark.asyncio
+async def test_in_memory_profile_store_returns_copy_isolated_profiles() -> None:
+    store = InMemoryProfileStore()
+    profile = MCPProfile(id="architect-workspace", name="Architect Workspace")
+
+    stored = await store.upsert_profile(profile)
+    stored.name = "Mutated Stored"
+
+    first = await store.get_profile("architect-workspace")
+    assert first is not None
+    assert first.name == "Architect Workspace"
+    first.name = "Mutated First"
+
+    second = await store.get_profile("architect-workspace")
+    assert second is not None
+    assert second.name == "Architect Workspace"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_profile_store_lists_and_deletes_profiles() -> None:
+    store = InMemoryProfileStore(
+        [
+            MCPProfile(id="code-reviewer", name="Code Reviewer"),
+            {
+                "id": "architect",
+                "name": "Architect",
+                "metadata": {"agent_metadata": {"ui_label": "Architect"}},
+            },
+        ]
+    )
+
+    listed = await store.list_profiles()
+    assert [profile.id for profile in listed] == ["architect", "code-reviewer"]
+
+    listed[0].name = "Mutated"
+    architect = await store.get_profile("architect")
+    assert architect is not None
+    assert architect.name == "Architect"
+
+    assert await store.delete_profile("architect") is True
+    assert await store.get_profile("architect") is None
+    assert await store.delete_profile("architect") is False
+
+
+@pytest.mark.asyncio
+async def test_store_backed_resolver_resolves_explicit_enabled_profile() -> None:
+    store = InMemoryProfileStore()
+    await store.upsert_profile(MCPProfile(id="code-reviewer", name="Code Reviewer"))
+    resolver = StoreBackedProfileResolver(store)
+
+    profile = await resolver.resolve_profile("code-reviewer")
+
+    assert profile is not None
+    assert profile.id == "code-reviewer"
+    profile.name = "Mutated"
+
+    original = await store.get_profile("code-reviewer")
+    assert original is not None
+    assert original.name == "Code Reviewer"
+
+
+@pytest.mark.asyncio
+async def test_store_backed_resolver_uses_default_only_without_explicit_id() -> None:
+    store = InMemoryProfileStore()
+    await store.upsert_profile(MCPProfile(id="default", name="Default"))
+    resolver = StoreBackedProfileResolver(store, default_profile_id="default")
+
+    default_profile = await resolver.resolve_profile(None)
+    assert default_profile is not None
+    assert default_profile.id == "default"
+    assert await resolver.resolve_profile("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_store_backed_resolver_returns_none_for_disabled_profiles() -> None:
+    store = InMemoryProfileStore()
+    await store.upsert_profile(MCPProfile(id="disabled", name="Disabled", enabled=False))
+    resolver = StoreBackedProfileResolver(store, default_profile_id="disabled")
+
+    assert await resolver.resolve_profile("disabled") is None
+    assert await resolver.resolve_profile(None) is None
+
+
+@pytest.mark.asyncio
+async def test_store_backed_resolver_fails_closed_when_store_unavailable() -> None:
+    class UnavailableStore:
+        async def get_profile(self, profile_id: str) -> MCPProfile | None:
+            raise ProfileStoreUnavailableError(
+                f"profile store unavailable: {profile_id}"
+            )
+
+        async def list_profiles(self) -> list[MCPProfile]:
+            raise ProfileStoreUnavailableError("profile store unavailable")
+
+        async def upsert_profile(
+            self,
+            profile: MCPProfile | Mapping[str, Any],
+        ) -> MCPProfile:
+            raise ProfileStoreUnavailableError("profile store unavailable")
+
+        async def delete_profile(self, profile_id: str) -> bool:
+            raise ProfileStoreUnavailableError(
+                f"profile store unavailable: {profile_id}"
+            )
+
+    resolver = StoreBackedProfileResolver(UnavailableStore(), default_profile_id="default")
+
+    assert await resolver.resolve_profile("explicit") is None
+    assert await resolver.resolve_profile(None) is None

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import ast
-from collections.abc import Mapping
+import logging
 from pathlib import Path
-from typing import Any
 
-import mcp_unified.profiles.resolver as profile_resolver
-import mcp_unified.profiles.store as profile_store
+import mcp_unified.profiles as profiles_pkg
 import pytest
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.resolver import StoreBackedProfileResolver
@@ -34,8 +32,7 @@ def _tldw_imports_for(path: Path) -> list[str]:
 
 
 def test_profile_store_and_resolver_modules_have_no_tldw_server_imports() -> None:
-    package_root = Path(profile_store.__file__).resolve().parent
-    assert Path(profile_resolver.__file__).resolve().parent == package_root
+    package_root = Path(profiles_pkg.__file__).resolve().parent
 
     offenders: dict[str, list[str]] = {}
     for path in package_root.rglob("*.py"):
@@ -129,7 +126,9 @@ async def test_store_backed_resolver_returns_none_for_disabled_profiles() -> Non
 
 
 @pytest.mark.asyncio
-async def test_store_backed_resolver_fails_closed_when_store_unavailable() -> None:
+async def test_store_backed_resolver_fails_closed_when_store_unavailable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     class UnavailableStore:
         async def get_profile(self, profile_id: str) -> MCPProfile | None:
             raise ProfileStoreUnavailableError(
@@ -141,7 +140,7 @@ async def test_store_backed_resolver_fails_closed_when_store_unavailable() -> No
 
         async def upsert_profile(
             self,
-            profile: MCPProfile | Mapping[str, Any],
+            profile: MCPProfile,
         ) -> MCPProfile:
             raise ProfileStoreUnavailableError("profile store unavailable")
 
@@ -151,6 +150,9 @@ async def test_store_backed_resolver_fails_closed_when_store_unavailable() -> No
             )
 
     resolver = StoreBackedProfileResolver(UnavailableStore(), default_profile_id="default")
+    caplog.set_level(logging.WARNING, logger="mcp_unified.profiles.resolver")
 
     assert await resolver.resolve_profile("explicit") is None
     assert await resolver.resolve_profile(None) is None
+    assert "MCP profile 'explicit'" in caplog.text
+    assert "MCP profile 'default'" in caplog.text


### PR DESCRIPTION
## Summary

- What changed: Added package-local MCP profile registry primitives: an in-memory profile store, explicit store-unavailable error, store-backed resolver, profile-store protocol updates, package exports, focused tests, and TASK-521 tracking.
- Design hardening follow-up: tightened the standalone MCP design gates after review by splitting Stage 2 into explicit sub-stages, adding structured profile/effective-policy result requirements, requiring workspace/path binding for write-capable profiles, clarifying split storage responsibilities, adding packaging/license/minimal-install release gates, and deferring real upstream stdio process spawning until policy/audit/credential/path/process adapters are ready. Added the concrete Stage 2C structured-resolution implementation plan and TASK-522.
- Why: This keeps the Stage 2 profile registry slice useful as a standalone primitive while preventing it from being mistaken for execution enforcement or gateway readiness.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run for code slice:

```bash
/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v
/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m mypy mcp_unified/profiles mcp_unified/interfaces/storage.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py
/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/profiles mcp_unified/interfaces/storage.py -f json -o /tmp/bandit_mcp_unified_profile_registry_runtime.json
git diff --check
```

Commands run for design-hardening follow-up:

```bash
git diff --check
backlog task TASK-522 --plain
```

Bandit note: runtime-code Bandit reported 0 findings for the code slice. The design-hardening follow-up touched Markdown/Backlog artifacts only, so Bandit was skipped there.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [x] No listed AntD deprecations in console output: N/A, no WebUI changes
- [x] No `Maximum update depth exceeded` warnings on audited routes: N/A, no WebUI changes
- [x] No unresolved `{{...}}` placeholders on audited routes: N/A, no WebUI changes
- [x] WebUI/extension parity validated for shared UI fixes: N/A, no WebUI changes
- [x] For Flashcards UI changes: N/A
- [x] For Flashcards drawer changes: N/A
- [x] For Flashcards help/copy/import UX changes: N/A

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: N/A, no Watchlists UI changes
- [x] If Watchlists UI behavior changed: N/A, no Watchlists UI changes
- [x] If Watchlists UI behavior changed: N/A, no Watchlists UI changes
- [x] If Watchlists UI behavior changed: N/A, no Watchlists UI changes
- [x] If Watchlists UI behavior changed: N/A, no Watchlists UI changes

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: N/A, no Watchlists UI changes
- [x] If Watchlists polling/notifications behavior changed: N/A
- [x] If Watchlists Activity polling changed: N/A
- [x] If Watchlists batch triage behavior changed: N/A
- [x] If Watchlists scale behavior changed: N/A

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR; the slice adds standalone profile registry primitives/tests and design/planning gates, with no current MCP route or execution behavior changes.

Human merge gate: before merge, the requester still needs to provide the required human-authored change summary explaining what changed and why these implementation choices were made.