### PR TITLE
Add flashcards sidepanel review loop

### DIFF
--- a/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,7 +32,7 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find useful passages while browsing and want to save editable flashcards, generate a small draft batch without leaving the sidepanel, apply existing templates to drafts, or send selected text directly to full Flashcards generation.
+Use this path when you find useful passages while browsing and want to save editable flashcards, generate a small draft batch without leaving the sidepanel, apply existing templates to drafts, review due cards quickly, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
@@ -43,16 +43,17 @@ Workflow:
 5. Choose `Apply template` on a queued draft when an existing template should fill or reshape the card fields before saving.
 6. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
 7. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
-8. Use `Open full Flashcards` for imports, review, or broader deck management.
+8. Choose `Review due card` to review the next due card for the selected deck, reveal the answer, and submit `Again`, `Hard`, `Good`, or `Easy`.
+9. Use `Open full Flashcards` for imports, richer review tools, or broader deck management.
 
 Important behavior:
 
 - The sidepanel Flashcards route saves queued captured and generated drafts and keeps the source page URL as provenance.
 - `Apply template` uses templates from full Flashcards and can be applied per draft before saving.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
+- `Review due card` is a compact sidepanel review loop. Use full Flashcards for cram, assistant support, analytics, undo/re-rate, and broader deck management.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
 - Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want the fuller generation workflow instead of the sidepanel's compact generated draft batch.
-- In-sidepanel review remains deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -32,7 +32,7 @@ Why the 8 KB field limit did not increase:
 
 ## Extension Selected-Text Capture
 
-Use this path when you find useful passages while browsing and want to save editable flashcards, generate a small draft batch without leaving the sidepanel, apply existing templates to drafts, or send selected text directly to full Flashcards generation.
+Use this path when you find useful passages while browsing and want to save editable flashcards, generate a small draft batch without leaving the sidepanel, apply existing templates to drafts, review due cards quickly, or send selected text directly to full Flashcards generation.
 
 Workflow:
 
@@ -43,16 +43,17 @@ Workflow:
 5. Choose `Apply template` on a queued draft when an existing template should fill or reshape the card fields before saving.
 6. Select a deck, edit each draft's `Front` and `Back`, then choose `Save card` or `Save all`.
 7. Choose `Generate from selection` to open full Flashcards generation with the selected text and source page context.
-8. Use `Open full Flashcards` for imports, review, or broader deck management.
+8. Choose `Review due card` to review the next due card for the selected deck, reveal the answer, and submit `Again`, `Hard`, `Good`, or `Easy`.
+9. Use `Open full Flashcards` for imports, richer review tools, or broader deck management.
 
 Important behavior:
 
 - The sidepanel Flashcards route saves queued captured and generated drafts and keeps the source page URL as provenance.
 - `Apply template` uses templates from full Flashcards and can be applied per draft before saving.
 - Create the deck in full Flashcards first if the sidepanel shows no deck options.
+- `Review due card` is a compact sidepanel review loop. Use full Flashcards for cram, assistant support, analytics, undo/re-rate, and broader deck management.
 - The browser context menu path still works: choose `tldw` -> `Save` -> `Save to Notes`, review the selection in the sidepanel dialog, then choose `Generate flashcards`.
 - Use `Generate from selection`, the context-menu path, or full Web UI `/flashcards` -> `Create & Import` -> `Generate` when you want the fuller generation workflow instead of the sidepanel's compact generated draft batch.
-- In-sidepanel review remains deferred to the full Flashcards workspace.
 - If the sidepanel cannot capture on the current site, use full Web UI `/flashcards` and paste text into `Create & Import`.
 
 ## Study Assistant Conflict Recovery

--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-review-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-review-implementation-plan.md
@@ -86,11 +86,11 @@
 
 - [x] **Step 1: Focused tests**
   Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
-  Result: PASS, 39 tests.
+  Result: PASS, 44 tests after PR review fixes.
 
 - [x] **Step 2: Related regression tests**
   Run: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.review-next.test.tsx src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
-  Result: PASS, 49 tests.
+  Result: PASS, 54 tests after PR review fixes.
 
 - [x] **Step 3: Typecheck**
   Run: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`

--- a/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-review-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-flashcards-extension-native-review-implementation-plan.md
@@ -1,0 +1,107 @@
+# Flashcards Extension Native Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a compact native flashcard review loop to the extension sidepanel so users can review due cards without leaving the sidepanel.
+
+**Architecture:** Reuse the existing sidepanel deck selection state and the shared Flashcards review query/mutation hooks. Keep the sidepanel review flow intentionally small: select deck, fetch next due card, reveal back, submit Again/Hard/Good/Easy, refetch next card, and report inline progress or errors.
+
+**Tech Stack:** React, Ant Design, lucide-react, TanStack Query hooks from `apps/packages/ui/src/components/Flashcards/hooks`, Vitest + Testing Library.
+
+---
+
+### Task 1: Sidepanel Review Contract Tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx`
+
+- [x] **Step 1: Extend test hook mocks**
+  Add `useReviewQuery`, `useReviewFlashcardMutation`, and review mutation/refetch mocks to the existing Flashcards hook mock.
+
+- [x] **Step 2: Write failing native review test**
+  Add a test that renders a due card, clicks `Review due card`, reveals the answer, submits `Good`, verifies `{ cardUuid, rating: 3, answerTimeMs }`, confirms no full Flashcards tab opens, and sees inline reviewed progress.
+
+- [x] **Step 3: Write caught-up empty-state test**
+  Add a test where the review query returns `null`, then verify the sidepanel says no due cards are available and still offers the full Flashcards workspace for richer review.
+
+- [x] **Step 4: Write failure-retention test**
+  Add a test where the rating mutation rejects, then verify the current card remains visible and an inline error is shown.
+
+- [x] **Step 5: Run RED**
+  Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+  Expected: FAIL because the sidepanel has no native review action yet.
+
+### Task 2: Compact Native Review UI
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-flashcards.tsx`
+
+- [x] **Step 1: Import review hook contracts**
+  Import `useReviewQuery` and `useReviewFlashcardMutation` from the existing Flashcards hooks barrel.
+
+- [x] **Step 2: Add review state**
+  Add state for review panel visibility, revealed-answer state, reviewed count, and answer-start timing.
+
+- [x] **Step 3: Add top-level review action**
+  Add a `Review due card` button alongside the existing open/capture/generate actions. Opening the panel clears stale capture/save status.
+
+- [x] **Step 4: Render deck-aware review panel**
+  Reuse the same deck availability states as saving: unavailable, loading, load error, no decks, and selected deck.
+
+- [x] **Step 5: Render one-card review**
+  Show front first, reveal answer on demand, then render rating buttons for Again/Hard/Good/Easy using the established rating values `0`, `2`, `3`, and `5`.
+
+- [x] **Step 6: Submit and advance**
+  On rating submit, call `mutateAsync({ cardUuid, rating, answerTimeMs })`, increment sidepanel reviewed count, reset reveal state, and refetch the next review card.
+
+- [x] **Step 7: Preserve recovery**
+  On mutation failure, keep the current card and answer visible and show an inline error.
+
+- [x] **Step 8: Run GREEN**
+  Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+  Expected: PASS.
+
+### Task 3: UX Source And Docs Updates
+
+**Files:**
+- Modify: `Flashcards-UX-Fix-List.md`
+- Modify: `apps/extension/docs/features/flashcards.md`
+- Modify: `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+- Modify: `Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+- Modify: `backlog/tasks/task-522 - Add-native-sidepanel-flashcard-review-loop.md`
+
+- [x] **Step 1: Update master fix list**
+  Mark F12 in-extension review complete with the limited native due-card sidepanel scope.
+
+- [x] **Step 2: Update extension docs**
+  Replace copy that says review is unavailable in-sidepanel with the new compact due-card review workflow, while keeping richer study tools in full Flashcards.
+
+- [x] **Step 3: Update Backlog task**
+  Record implementation notes, touched files, verification commands, and completion summary.
+
+### Task 4: Final Verification And PR
+
+**Files:**
+- All changed files above.
+
+- [x] **Step 1: Focused tests**
+  Run: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx`
+  Result: PASS, 39 tests.
+
+- [x] **Step 2: Related regression tests**
+  Run: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.review-next.test.tsx src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts`
+  Result: PASS, 49 tests.
+
+- [x] **Step 3: Typecheck**
+  Run: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
+  Result: Known unrelated baseline failure remains in `src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx(35,3)` where `"comfortable"` is not assignable to `GalleryCardDensity`.
+
+- [x] **Step 4: Diff hygiene**
+  Run: `git diff --check`
+  Expected: PASS.
+
+- [x] **Step 5: Security check**
+  Bandit is not applicable unless Python files are touched. Record the non-Python scope in the Backlog task.
+
+- [ ] **Step 6: Commit and PR**
+  Commit the task and open a draft PR with a human-written change summary explaining why this is intentionally a compact sidepanel review loop rather than a full Study redesign.

--- a/Flashcards-UX-Fix-List.md
+++ b/Flashcards-UX-Fix-List.md
@@ -1,6 +1,6 @@
 # Flashcards UX Fix List
 
-Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split, F12 native sidepanel capture queue, F12 generate-from-selection handoff, native generated-draft batches, and native sidepanel template application follow-ups.
+Status: closeout update after Phase 0 through Phase 5 remediation plus F06 task-first split, F12 native sidepanel capture queue, F12 generate-from-selection handoff, native generated-draft batches, native sidepanel template application, and native sidepanel review follow-ups.
 
 Scope: `/flashcards` plus directly connected WebUI and extension flashcard workflows. This file is the master UX audit and fix-list source referenced by `Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md`.
 
@@ -47,7 +47,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 9. Recent sessions show user-facing deck/mode/count/timing labels where data is available.
 10. Deck dashboard rows expose direct Review, Cram, Edit, Scheduler, and Export actions.
 11. Generated-card save recovery distinguishes success, partial success, failure, fatal validation errors, and retry state.
-12. Extension sidepanel offers explicit full Flashcards, Capture page selection, Generate draft cards, and Generate from selection actions; selected page text can append one captured draft, generate a small editable draft batch natively, or open full Flashcards generation with source context. Native sidepanel drafts include deck picker, Front/Back fields, per-draft template application, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance.
+12. Extension sidepanel offers explicit full Flashcards, Review due card, Capture page selection, Generate draft cards, and Generate from selection actions; selected page text can append one captured draft, generate a small editable draft batch natively, or open full Flashcards generation with source context. Native sidepanel drafts include deck picker, Front/Back fields, per-draft template application, per-draft delete, save-one, save-all, partial failure recovery, and page URL provenance. The sidepanel review loop fetches the next due card for the selected deck, supports reveal-first review, submits Again/Hard/Good/Easy ratings, advances/refetches, and keeps the current card visible on rating failure.
 13. Documentation describes the stabilized WebUI/extension capture and handoff behavior using current tab names.
 
 ## Phase Coverage
@@ -64,11 +64,12 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | Phase 5: Extension capture and docs | TASK-513 | F12 support, F13 | Completed as an extension bridge and WebUI generate handoff. |
 | Closeout source restoration | TASK-514 | Planning traceability | Completed. Restores this tracked source file on `dev`. |
 | F06 follow-up: Task-first Create & Import split | TASK-515 | F06 | Completed. Adds Create cards, Import file, and Export backup task workspaces while preserving existing route keys and panel handoffs. |
-| F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Later F12 follow-ups added repeat capture, generated drafts, and template application; in-extension review remains deferred. |
-| F12 follow-up: Extension repeat-capture queue | TASK-517 | F12 | Completed. Converts native sidepanel capture from one draft to a repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery. Later F12 follow-ups added generated drafts and template application; in-extension review remains deferred. |
-| F12 follow-up: Extension generate-from-selection handoff | TASK-518 | F12 | Completed. Adds a sidepanel action that captures selected page text and opens full Flashcards generation with source URL/title context. Later F12 follow-ups added native generated drafts and template application; in-extension review remains deferred. |
-| F12 follow-up: Native extension generated drafts | TASK-519 | F12 | Completed. Adds native sidepanel generated draft batches from selected page text, preserving edit/save queue behavior and source provenance. Later F12 follow-up added native template application; in-extension review remains deferred. |
-| F12 follow-up: Native extension template application | TASK-521 | F12 | Completed. Adds native sidepanel template application for captured and generated drafts while preserving selected draft scope, generated tags, model fields, and page provenance. In-extension review remains deferred. |
+| F12 follow-up: Native extension capture MVP | TASK-516 | F12 | Completed. Adds native sidepanel deck picker, editable Front/Back draft, one-card save, and page provenance. Later F12 follow-ups added repeat capture, generated drafts, template application, and compact native review. |
+| F12 follow-up: Extension repeat-capture queue | TASK-517 | F12 | Completed. Converts native sidepanel capture from one draft to a repeat-capture queue with edit/delete, save-one, save-all, and partial failure recovery. Later F12 follow-ups added generated drafts, template application, and compact native review. |
+| F12 follow-up: Extension generate-from-selection handoff | TASK-518 | F12 | Completed. Adds a sidepanel action that captures selected page text and opens full Flashcards generation with source URL/title context. Later F12 follow-ups added native generated drafts, template application, and compact native review. |
+| F12 follow-up: Native extension generated drafts | TASK-519 | F12 | Completed. Adds native sidepanel generated draft batches from selected page text, preserving edit/save queue behavior and source provenance. Later F12 follow-ups added native template application and compact native review. |
+| F12 follow-up: Native extension template application | TASK-521 | F12 | Completed. Adds native sidepanel template application for captured and generated drafts while preserving selected draft scope, generated tags, model fields, and page provenance. Later F12 follow-up added compact native review. |
+| F12 follow-up: Native extension review loop | TASK-522 | F12 | Completed. Adds compact sidepanel due-card review with selected deck, reveal answer, Again/Hard/Good/Easy ratings, progress status, caught-up guidance, and failure recovery that keeps the current card visible. |
 
 ## Severity-Ranked Findings
 
@@ -85,7 +86,7 @@ Actual flow after Phase 0-5 remediation plus the F06 and F12 follow-ups:
 | F09 | Medium | History comprehension | Recent sessions used labels like `Session #1`, `Deck 1`, or raw scope keys. | Progress/history was present but hard to trust. | Backend identifiers leaked into user-facing history. | Addressed in TASK-509. |
 | F10 | Medium | Progress semantics | Due/new/current queue labels could appear contradictory. | Users could misunderstand whether cards were available to study. | Scheduler labels were technically accurate but not explained in queue context. | Addressed in TASK-508. |
 | F11 | Medium | Expert workflow | Manage was card-first with no deck-first dashboard for quick study decisions. | Experienced users spent time filtering cards instead of selecting a deck action. | The model privileged card management over deck review. | Addressed in TASK-510/TASK-511. |
-| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517/TASK-518/TASK-519/TASK-521. Sidepanel now supports native selected-text repeat capture, native generated draft batches, native template application, draft edit/delete, save-one, save-all, partial failure recovery, page provenance, and full-Flashcards generation handoff from selected text; in-extension review remains deferred. |
+| F12 | Medium | Extension workflow | Extension sidepanel behaved mainly as a link-out path. | Capturing web content into cards was slower and could lose context. | Extension was treated as navigation, not capture workflow. | Addressed in TASK-513/TASK-516/TASK-517/TASK-518/TASK-519/TASK-521/TASK-522. Sidepanel now supports native selected-text repeat capture, native generated draft batches, native template application, draft edit/delete, save-one, save-all, partial failure recovery, page provenance, full-Flashcards generation handoff from selected text, and compact native due-card review. |
 | F13 | Medium | Docs mismatch | Extension and flashcards docs lagged current UI tab names and workflows. | Users could not rely on docs to understand current behavior. | Docs had not tracked UI evolution. | Addressed in TASK-513. |
 | F14 | Low | Empty-state hierarchy | Manage empty state showed expert filters before any cards existed. | New users saw advanced management chrome before first action. | Empty state inherited full management layout. | Addressed in TASK-506. |
 | F15 | Low | Scheduler discoverability | Scheduler was hidden until a deck existed. | New users could not learn scheduling exists until after setup. | Progressive disclosure hid a core concept too completely. | Addressed in TASK-506. |
@@ -105,7 +106,7 @@ Create & Import now separates setup into task-specific workspaces, so first-time
 
 The strongest power-user improvement is the deck dashboard. It gives experienced users deck-level counts and direct Review/Cram/Edit/Scheduler/Export actions, replacing a card-filter-first starting point for common study decisions. Review recovery and recent-session labels also make repeat review safer and easier to resume.
 
-Remaining weakness: extension capture now supports repeated native capture, native generated draft batches, template application, bulk save, and full-workspace generation handoff, but in-extension review remains deferred.
+Remaining weakness: extension review is intentionally compact. Full Flashcards remains the path for richer review controls such as cram, assistant support, analytics, and broader deck management.
 
 ## Improvement Backlog
 
@@ -134,10 +135,11 @@ Remaining weakness: extension capture now supports repeated native capture, nati
 - Add extension Generate from selection handoff into the full Flashcards Generate workflow.
 - Add native extension generated draft batches from selected page text.
 - Add native sidepanel template application for captured and generated drafts.
+- Add compact native sidepanel review for due cards.
 
 ### Deferred Larger Product Improvements
 
-- Extend the native extension capture flow with in-extension review.
+- Consider richer sidepanel review controls only if future evidence shows users need more than the compact due-card loop in the extension.
 - Add broader import result normalization if future evidence shows unresolved partial/fatal import ambiguity outside generated-card save.
 - Run a full browser accessibility audit beyond the focused keyboard e2e coverage.
 
@@ -160,14 +162,14 @@ Remaining weakness: extension capture now supports repeated native capture, nati
 3. Review supports keyboard reveal/rate/undo/edit flows with visible equivalents.
 4. Completion supports repeat workflows.
 5. History uses meaningful session labels instead of raw ids.
-6. Extension selected-text capture appends editable sidepanel drafts, can generate a small native draft batch, lets the user apply existing templates, delete drafts, or save one/all drafts with partial failure recovery, preserves page provenance, and can send selected text directly to full Flashcards generation with source context.
+6. Extension selected-text capture appends editable sidepanel drafts, can generate a small native draft batch, lets the user apply existing templates, delete drafts, or save one/all drafts with partial failure recovery, preserves page provenance, can send selected text directly to full Flashcards generation with source context, and supports compact due-card review without leaving the sidepanel.
 
 ## Open Questions And Non-Goals
 
 - Scheduler algorithm correctness and backend spaced-repetition math were not audited beyond visible UX effects.
 - Quiz surfaces were out of scope except for the direct Flashcards handoff.
 - Multi-user permission, workspace sharing, and collaboration states need separate testing.
-- Native extension in-extension review remains a future product improvement beyond the F12 capture queue, native generated drafts, template application, and full-workspace generation handoff.
+- Richer extension review capabilities such as cram, undo/re-rate, assistant actions, and analytics were intentionally left in full Flashcards for this slice.
 
 ## Master Checklist
 
@@ -205,7 +207,7 @@ Remaining weakness: extension capture now supports repeated native capture, nati
 - [x] F12 Extension Generate from selection handoff opens full Flashcards generation with selected text and page provenance.
 - [x] F12 Native sidepanel generated draft batches completed for selected page text.
 - [x] F12 Native sidepanel template application completed for captured and generated drafts.
-- [ ] F12 In-extension review remains deferred.
+- [x] F12 Compact in-extension due-card review completed for the sidepanel.
 - [x] F13 WebUI and extension flashcards docs updated.
 - [x] F17 Quiz handoff made state-aware.
 

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -6,7 +6,7 @@ title: Flashcards (Experimental)
 
 The Flashcards page lets you create, review, and manage spaced-repetition cards backed by your tldw_server. It also supports CSV/TSV import and export, plus optional .apkg export where supported by the server.
 
-Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact flashcards tool with actions for the full Flashcards workspace, selected-text card creation, native generated drafts, native template application, compact due-card review, and selected-text generation handoff.
+Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact flashcards tool with actions for the full Flashcards workspace, selected-text card creation, natively generated drafts, native template application, compact due-card review, and selected-text generation handoff.
 
 ## Prerequisites
 

--- a/apps/extension/docs/features/flashcards.md
+++ b/apps/extension/docs/features/flashcards.md
@@ -6,7 +6,7 @@ title: Flashcards (Experimental)
 
 The Flashcards page lets you create, review, and manage spaced-repetition cards backed by your tldw_server. It also supports CSV/TSV import and export, plus optional .apkg export where supported by the server.
 
-Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact capture tool with actions for the full Flashcards workspace, selected-text card creation, native generated drafts, native template application, and selected-text generation handoff.
+Access it from the Web UI header by clicking the Layers icon, or navigate to `/flashcards`. In the extension sidepanel, the Flashcards entry opens a compact flashcards tool with actions for the full Flashcards workspace, selected-text card creation, native generated drafts, native template application, compact due-card review, and selected-text generation handoff.
 
 ## Prerequisites
 
@@ -30,9 +30,10 @@ Access it from the Web UI header by clicking the Layers icon, or navigate to `/f
 5. Use `Apply template` on a queued draft when an existing template should reshape its fields before saving.
 6. Choose a deck, edit each draft's `Front` and `Back` fields, then click `Save card` or `Save all`.
 7. Click `Generate from selection` when you want the selected text to open in full Flashcards generation with the page URL/title attached.
-8. Use `Open full Flashcards` when you need imports, review, or broader deck management.
+8. Click `Review due card` to review the next due card for the selected deck, reveal the answer, and submit `Again`, `Hard`, `Good`, or `Easy`.
+9. Use `Open full Flashcards` when you need imports, richer review tools, or broader deck management.
 
-The sidepanel saves captured cards and generated draft cards from the same queue, keeping the page URL as source provenance. Native generation uses compact defaults, and `Apply template` reuses the templates already managed in full Flashcards. The sidepanel does not yet provide in-sidepanel review. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want the fuller generation workflow in the full Flashcards workspace.
+The sidepanel saves captured cards and generated draft cards from the same queue, keeping the page URL as source provenance. Native generation uses compact defaults, and `Apply template` reuses the templates already managed in full Flashcards. `Review due card` is a compact due-card loop; use full Flashcards for imports, cram, assistant support, analytics, and broader deck management. You can also use the browser context menu path: `tldw` -> `Save` -> `Save to Notes`, then choose `Generate flashcards` from the sidepanel review dialog when you want the fuller generation workflow in the full Flashcards workspace.
 
 ## Tips
 

--- a/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
@@ -60,6 +60,7 @@ export interface DueCounts {
 
 export interface UseFlashcardQueriesOptions {
   enabled?: boolean
+  refetchOnWindowFocus?: boolean
   includeWorkspaceItems?: boolean
   workspaceId?: string | null
 }
@@ -186,7 +187,8 @@ export function useReviewQuery(deckId: number | null | undefined, options?: UseF
       const response = await getNextReviewCard(deckId ?? undefined, visibilityParams)
       return response.card ?? null
     },
-    enabled: options?.enabled ?? flashcardsEnabled
+    enabled: options?.enabled ?? flashcardsEnabled,
+    refetchOnWindowFocus: options?.refetchOnWindowFocus
   })
 }
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -29,9 +29,36 @@ type TemplateFixture = {
   version: number
 }
 
+type ReviewCardFixture = {
+  uuid: string
+  deck_id?: number | null
+  front: string
+  back: string
+  notes?: string | null
+  extra?: string | null
+  is_cloze: boolean
+  tags?: string[] | null
+  ef: number
+  interval_days: number
+  repetitions: number
+  lapses: number
+  due_at?: string | null
+  created_at?: string | null
+  last_reviewed_at?: string | null
+  queue_state: "new" | "learning" | "review" | "relearning" | "suspended"
+  last_modified?: string | null
+  deleted: boolean
+  client_id: string
+  version: number
+  model_type: "basic" | "basic_reverse" | "cloze"
+  reverse: boolean
+}
+
 const flashcardMocks = vi.hoisted(() => ({
   createFlashcardMutateAsync: vi.fn(),
   generateFlashcardsMutateAsync: vi.fn(),
+  reviewFlashcardMutateAsync: vi.fn(),
+  useReviewQuery: vi.fn(),
   useFlashcardsEnabled: vi.fn(),
   useDecksQuery: vi.fn(),
   useFlashcardTemplatesQuery: vi.fn()
@@ -83,8 +110,13 @@ vi.mock("@/components/Flashcards/hooks", () => ({
     mutateAsync: flashcardMocks.generateFlashcardsMutateAsync,
     isPending: false
   }),
+  useReviewFlashcardMutation: () => ({
+    mutateAsync: flashcardMocks.reviewFlashcardMutateAsync,
+    isPending: false
+  }),
   useFlashcardsEnabled: () => flashcardMocks.useFlashcardsEnabled(),
   useDecksQuery: (...args: unknown[]) => flashcardMocks.useDecksQuery(...args),
+  useReviewQuery: (...args: unknown[]) => flashcardMocks.useReviewQuery(...args),
   useFlashcardTemplatesQuery: (...args: unknown[]) =>
     flashcardMocks.useFlashcardTemplatesQuery(...args)
 }))
@@ -112,6 +144,8 @@ vi.mock("react-i18next", () => ({
 
 describe("sidepanel flashcards route", () => {
   let currentTemplates: TemplateFixture[]
+  let currentReviewCard: ReviewCardFixture | null
+  let reviewRefetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -122,7 +156,34 @@ describe("sidepanel flashcards route", () => {
     browserMocks.executeScript.mockReset()
     flashcardMocks.createFlashcardMutateAsync.mockReset()
     flashcardMocks.generateFlashcardsMutateAsync.mockReset()
+    flashcardMocks.reviewFlashcardMutateAsync.mockReset()
+    flashcardMocks.useReviewQuery.mockReset()
     flashcardMocks.useFlashcardTemplatesQuery.mockReset()
+    currentReviewCard = {
+      uuid: "review-card-1",
+      deck_id: 7,
+      front: "What does ATP do?",
+      back: "ATP stores and transfers cellular energy.",
+      notes: null,
+      extra: null,
+      is_cloze: false,
+      tags: ["biology"],
+      ef: 2.5,
+      interval_days: 0,
+      repetitions: 0,
+      lapses: 0,
+      due_at: "2026-05-27T00:00:00Z",
+      created_at: "2026-05-27T00:00:00Z",
+      last_reviewed_at: null,
+      queue_state: "new",
+      last_modified: "2026-05-27T00:00:00Z",
+      deleted: false,
+      client_id: "test-client",
+      version: 1,
+      model_type: "basic",
+      reverse: false
+    }
+    reviewRefetchMock = vi.fn(async () => ({ data: currentReviewCard }))
     currentTemplates = [
       {
         id: 21,
@@ -203,6 +264,25 @@ describe("sidepanel flashcards route", () => {
         }
       ]
     })
+    flashcardMocks.reviewFlashcardMutateAsync.mockResolvedValue({
+      uuid: "review-card-1",
+      ef: 2.5,
+      interval_days: 1,
+      repetitions: 1,
+      lapses: 0,
+      due_at: "2026-05-28T00:00:00Z",
+      last_reviewed_at: "2026-05-27T01:00:00Z",
+      last_modified: "2026-05-27T01:00:00Z",
+      version: 2,
+      scheduler_type: "sm2_plus",
+      queue_state: "review",
+      next_intervals: {
+        again: "< 1 min",
+        hard: "< 10 min",
+        good: "1 day",
+        easy: "4 days"
+      }
+    })
     flashcardMocks.useFlashcardsEnabled.mockReturnValue({
       isOnline: true,
       capsLoading: false,
@@ -223,6 +303,13 @@ describe("sidepanel flashcards route", () => {
       isLoading: false,
       isError: false
     })
+    flashcardMocks.useReviewQuery.mockImplementation(() => ({
+      data: currentReviewCard,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: reviewRefetchMock
+    }))
     flashcardMocks.useFlashcardTemplatesQuery.mockImplementation(() => ({
       data: {
         items: currentTemplates,
@@ -254,7 +341,7 @@ describe("sidepanel flashcards route", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Create one editable card, generate a small draft batch, apply templates to queued drafts, or use full Flashcards for imports, review, and management."
+        "Create one editable card, generate a small draft batch, apply templates to queued drafts, review due cards here, or use full Flashcards for imports and management."
       )
     ).toBeInTheDocument()
     expect(
@@ -283,6 +370,92 @@ describe("sidepanel flashcards route", () => {
     expect(browserMocks.tabsCreate).toHaveBeenCalledWith({
       url: "chrome-extension://flashcards/options.html#/flashcards"
     })
+  })
+
+  it("reviews a due card inside the sidepanel without opening full Flashcards", async () => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(screen.getByRole("button", { name: "Review due card" }))
+
+    expect(screen.getByRole("heading", { name: "Review due card" })).toBeInTheDocument()
+    expect(screen.getByTestId("sidepanel-flashcards-review-deck-select")).toHaveTextContent(
+      "Biology"
+    )
+    expect(screen.getByText("What does ATP do?")).toBeInTheDocument()
+    expect(
+      screen.queryByText("ATP stores and transfers cellular energy.")
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Reveal answer" }))
+
+    expect(
+      screen.getByText("ATP stores and transfers cellular energy.")
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Good" }))
+
+    await waitFor(() => {
+      expect(flashcardMocks.reviewFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.reviewFlashcardMutateAsync).toHaveBeenCalledWith({
+      cardUuid: "review-card-1",
+      rating: 3,
+      answerTimeMs: expect.any(Number)
+    })
+    expect(reviewRefetchMock).toHaveBeenCalledTimes(1)
+    expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
+    expect(screen.getByText("Reviewed 1 card in this sidepanel session.")).toBeInTheDocument()
+  })
+
+  it("shows caught-up guidance when no sidepanel review card is due", async () => {
+    currentReviewCard = null
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(screen.getByRole("button", { name: "Review due card" }))
+
+    expect(screen.getByText("No due cards right now.")).toBeInTheDocument()
+    expect(
+      screen.getByText("Use full Flashcards for imports, management, and richer review controls.")
+    ).toBeInTheDocument()
+    expect(flashcardMocks.reviewFlashcardMutateAsync).not.toHaveBeenCalled()
+  })
+
+  it("keeps the review card visible when sidepanel rating submit fails", async () => {
+    flashcardMocks.reviewFlashcardMutateAsync.mockRejectedValueOnce(
+      new Error("review failed")
+    )
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(screen.getByRole("button", { name: "Review due card" }))
+    await user.click(screen.getByRole("button", { name: "Reveal answer" }))
+    await user.click(screen.getByRole("button", { name: "Good" }))
+
+    expect(
+      await screen.findByText(
+        "Could not submit review. Check your connection and try again."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText("What does ATP do?")).toBeInTheDocument()
+    expect(
+      screen.getByText("ATP stores and transfers cellular energy.")
+    ).toBeInTheDocument()
+  })
+
+  it("ignores duplicate sidepanel review ratings before disabled state rerenders", async () => {
+    flashcardMocks.reviewFlashcardMutateAsync.mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    render(<SidepanelFlashcards />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Review due card" }))
+    fireEvent.click(screen.getByRole("button", { name: "Reveal answer" }))
+    const goodButton = screen.getByRole("button", { name: "Good" })
+    fireEvent.click(goodButton)
+    fireEvent.click(goodButton)
+
+    expect(flashcardMocks.reviewFlashcardMutateAsync).toHaveBeenCalledTimes(1)
   })
 
   it("shows an inline error when tab and fallback window opening fail", async () => {
@@ -390,6 +563,7 @@ describe("sidepanel flashcards route", () => {
     expect(
       screen.getByText(/apply templates to queued drafts/)
     ).toBeInTheDocument()
+    expect(screen.getByText(/review due cards here/)).toBeInTheDocument()
     expect(
       screen.queryByText(/for templates, imports, and review/)
     ).not.toBeInTheDocument()

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
@@ -145,6 +145,7 @@ vi.mock("react-i18next", () => ({
 describe("sidepanel flashcards route", () => {
   let currentTemplates: TemplateFixture[]
   let currentReviewCard: ReviewCardFixture | null
+  let reviewQueryError: boolean
   let reviewRefetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
@@ -159,6 +160,7 @@ describe("sidepanel flashcards route", () => {
     flashcardMocks.reviewFlashcardMutateAsync.mockReset()
     flashcardMocks.useReviewQuery.mockReset()
     flashcardMocks.useFlashcardTemplatesQuery.mockReset()
+    reviewQueryError = false
     currentReviewCard = {
       uuid: "review-card-1",
       deck_id: 7,
@@ -307,7 +309,7 @@ describe("sidepanel flashcards route", () => {
       data: currentReviewCard,
       isLoading: false,
       isFetching: false,
-      isError: false,
+      isError: reviewQueryError,
       refetch: reviewRefetchMock
     }))
     flashcardMocks.useFlashcardTemplatesQuery.mockImplementation(() => ({
@@ -379,6 +381,13 @@ describe("sidepanel flashcards route", () => {
     await user.click(screen.getByRole("button", { name: "Review due card" }))
 
     expect(screen.getByRole("heading", { name: "Review due card" })).toBeInTheDocument()
+    expect(flashcardMocks.useReviewQuery).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        enabled: true,
+        refetchOnWindowFocus: false
+      })
+    )
     expect(screen.getByTestId("sidepanel-flashcards-review-deck-select")).toHaveTextContent(
       "Biology"
     )
@@ -402,9 +411,35 @@ describe("sidepanel flashcards route", () => {
       rating: 3,
       answerTimeMs: expect.any(Number)
     })
-    expect(reviewRefetchMock).toHaveBeenCalledTimes(1)
+    expect(reviewRefetchMock).not.toHaveBeenCalled()
     expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
     expect(screen.getByText("Reviewed 1 card in this sidepanel session.")).toBeInTheDocument()
+    expect(screen.getByText("Review saved. Loading next card...")).toBeInTheDocument()
+  })
+
+  it.each([
+    { label: "Again", rating: 0 },
+    { label: "Hard", rating: 2 },
+    { label: "Good", rating: 3 },
+    { label: "Easy", rating: 5 }
+  ])("submits $label with the correct rating value", async ({ label, rating }) => {
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(screen.getByRole("button", { name: "Review due card" }))
+    await user.click(screen.getByRole("button", { name: "Reveal answer" }))
+    await user.click(screen.getByRole("button", { name: label }))
+
+    await waitFor(() => {
+      expect(flashcardMocks.reviewFlashcardMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(flashcardMocks.reviewFlashcardMutateAsync).toHaveBeenCalledWith({
+      cardUuid: "review-card-1",
+      rating,
+      answerTimeMs: expect.any(Number)
+    })
+    expect(reviewRefetchMock).not.toHaveBeenCalled()
+    expect(browserMocks.tabsCreate).not.toHaveBeenCalled()
   })
 
   it("shows caught-up guidance when no sidepanel review card is due", async () => {
@@ -422,6 +457,9 @@ describe("sidepanel flashcards route", () => {
   })
 
   it("keeps the review card visible when sidepanel rating submit fails", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
     flashcardMocks.reviewFlashcardMutateAsync.mockRejectedValueOnce(
       new Error("review failed")
     )
@@ -441,6 +479,53 @@ describe("sidepanel flashcards route", () => {
     expect(
       screen.getByText("ATP stores and transfers cellular energy.")
     ).toBeInTheDocument()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to submit sidepanel flashcard review:",
+      expect.objectContaining({
+        cardUuid: "review-card-1",
+        rating: 3,
+        error: expect.any(Error)
+      })
+    )
+  })
+
+  it("keeps a saved review from being rated again when next-card loading fails", async () => {
+    flashcardMocks.reviewFlashcardMutateAsync.mockImplementation(async () => {
+      reviewQueryError = true
+      return {
+        uuid: "review-card-1",
+        ef: 2.5,
+        interval_days: 1,
+        repetitions: 1,
+        lapses: 0,
+        version: 2,
+        scheduler_type: "sm2_plus",
+        queue_state: "review",
+        next_intervals: {
+          again: "< 1 min",
+          hard: "< 10 min",
+          good: "1 day",
+          easy: "4 days"
+        }
+      }
+    })
+    const user = userEvent.setup()
+    render(<SidepanelFlashcards />)
+
+    await user.click(screen.getByRole("button", { name: "Review due card" }))
+    await user.click(screen.getByRole("button", { name: "Reveal answer" }))
+    await user.click(screen.getByRole("button", { name: "Good" }))
+
+    expect(
+      await screen.findByText(
+        "Review saved, but could not load the next card. Try again."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Retry loading next card" })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Good" })).not.toBeInTheDocument()
+    expect(flashcardMocks.reviewFlashcardMutateAsync).toHaveBeenCalledTimes(1)
   })
 
   it("ignores duplicate sidepanel review ratings before disabled state rerenders", async () => {

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import {
+  BookOpenCheck,
   ExternalLink,
   LayoutTemplate,
   Layers,
@@ -16,7 +17,9 @@ import {
   useCreateFlashcardMutation,
   useDecksQuery,
   useFlashcardsEnabled,
-  useGenerateFlashcardsMutation
+  useGenerateFlashcardsMutation,
+  useReviewFlashcardMutation,
+  useReviewQuery
 } from "@/components/Flashcards/hooks"
 import { FlashcardTemplateValueModal } from "@/components/Flashcards/components/FlashcardTemplateValueModal"
 import type { GeneratedCardDraft } from "@/components/Flashcards/tabs/ImportExport/shared"
@@ -81,6 +84,12 @@ export default function SidepanelFlashcards() {
   } | null>(null)
   const generationInFlightRef = React.useRef(false)
   const [drafts, setDrafts] = React.useState<CaptureDraft[]>([])
+  const [reviewOpen, setReviewOpen] = React.useState(false)
+  const [reviewAnswerRevealed, setReviewAnswerRevealed] =
+    React.useState(false)
+  const [sidepanelReviewedCount, setSidepanelReviewedCount] = React.useState(0)
+  const reviewAnswerStartRef = React.useRef<number | null>(null)
+  const reviewSubmitInFlightRef = React.useRef(false)
   const [templateDraftId, setTemplateDraftId] = React.useState<string | null>(
     null
   )
@@ -93,6 +102,7 @@ export default function SidepanelFlashcards() {
   const decksQuery = useDecksQuery()
   const createFlashcardMutation = useCreateFlashcardMutation()
   const generateFlashcardsMutation = useGenerateFlashcardsMutation()
+  const reviewFlashcardMutation = useReviewFlashcardMutation()
   const decks = React.useMemo(() => decksQuery.data ?? [], [decksQuery.data])
   const selectedDeck = decks.find((deck) => deck.id === selectedDeckId) ?? null
   const flashcardsUnavailable =
@@ -110,6 +120,34 @@ export default function SidepanelFlashcards() {
     !decksLoading &&
     !decksLoadFailed &&
     decks.length === 0
+  const hasDeck = selectedDeckId != null && hasSelectableDecks
+  const reviewQuery = useReviewQuery(selectedDeckId, {
+    enabled: reviewOpen && hasDeck
+  })
+  const reviewCard = reviewQuery.data ?? null
+  const isReviewLoading = reviewQuery.isLoading || reviewQuery.isFetching
+
+  const sidepanelRatingOptions = React.useMemo(
+    () => [
+      {
+        value: 0,
+        label: t("option:flashcards.ratingAgain", { defaultValue: "Again" })
+      },
+      {
+        value: 2,
+        label: t("option:flashcards.ratingHard", { defaultValue: "Hard" })
+      },
+      {
+        value: 3,
+        label: t("option:flashcards.ratingGood", { defaultValue: "Good" })
+      },
+      {
+        value: 5,
+        label: t("option:flashcards.ratingEasy", { defaultValue: "Easy" })
+      }
+    ],
+    [t]
+  )
 
   React.useEffect(() => {
     if (
@@ -120,6 +158,11 @@ export default function SidepanelFlashcards() {
     }
     setSelectedDeckId(decks[0]?.id ?? null)
   }, [decks, selectedDeckId])
+
+  React.useEffect(() => {
+    setReviewAnswerRevealed(false)
+    reviewAnswerStartRef.current = null
+  }, [reviewCard?.uuid, selectedDeckId])
 
   const openOptionsHashRoute = React.useCallback(async (route: string) => {
     setCaptureError(null)
@@ -397,6 +440,21 @@ export default function SidepanelFlashcards() {
     [t]
   )
 
+  const formatSidepanelReviewProgress = React.useCallback(
+    (reviewedCount: number) =>
+      reviewedCount === 1
+        ? t("sidepanel:flashcards.sidepanelReviewProgress_one", {
+            defaultValue: "Reviewed 1 card in this sidepanel session.",
+            reviewedCount
+          })
+        : t("sidepanel:flashcards.sidepanelReviewProgress_other", {
+            defaultValue:
+              "Reviewed {{reviewedCount}} cards in this sidepanel session.",
+            reviewedCount
+          }),
+    [t]
+  )
+
   const handleGenerateDraftCards = React.useCallback(async () => {
     if (generationInFlightRef.current) return
     generationInFlightRef.current = true
@@ -483,8 +541,6 @@ export default function SidepanelFlashcards() {
     [selectedDeckId]
   )
 
-  const hasDeck = selectedDeckId != null && hasSelectableDecks
-
   const handleUpdateDraft = React.useCallback(
     (draftId: string, field: "front" | "back", value: string) => {
       setDrafts((current) =>
@@ -506,6 +562,77 @@ export default function SidepanelFlashcards() {
     setSaveStatus(null)
     setTemplateDraftId(draftId)
   }, [])
+
+  const handleToggleReview = React.useCallback(() => {
+    setCaptureError(null)
+    setSaveStatus(null)
+    setReviewAnswerRevealed(false)
+    reviewAnswerStartRef.current = null
+    if (!reviewOpen) {
+      setSidepanelReviewedCount(0)
+    }
+    setReviewOpen((current) => !current)
+  }, [reviewOpen])
+
+  const handleRevealReviewAnswer = React.useCallback(() => {
+    setCaptureError(null)
+    setSaveStatus(null)
+    setReviewAnswerRevealed(true)
+    reviewAnswerStartRef.current = Date.now()
+  }, [])
+
+  const handleSubmitSidepanelReview = React.useCallback(
+    async (rating: number) => {
+      if (
+        !reviewCard ||
+        reviewFlashcardMutation.isPending ||
+        reviewSubmitInFlightRef.current
+      ) {
+        return
+      }
+      reviewSubmitInFlightRef.current = true
+
+      const answerTimeMs =
+        reviewAnswerStartRef.current == null
+          ? undefined
+          : Math.max(0, Date.now() - reviewAnswerStartRef.current)
+
+      try {
+        await reviewFlashcardMutation.mutateAsync({
+          cardUuid: reviewCard.uuid,
+          rating,
+          answerTimeMs
+        })
+        const nextReviewedCount = sidepanelReviewedCount + 1
+        setSidepanelReviewedCount(nextReviewedCount)
+        setSaveStatus({
+          type: "success",
+          message: formatSidepanelReviewProgress(nextReviewedCount)
+        })
+        setReviewAnswerRevealed(false)
+        reviewAnswerStartRef.current = null
+        await reviewQuery.refetch()
+      } catch {
+        setSaveStatus({
+          type: "error",
+          message: t(
+            "sidepanel:flashcards.sidepanelReviewSubmitFailed",
+            "Could not submit review. Check your connection and try again."
+          )
+        })
+      } finally {
+        reviewSubmitInFlightRef.current = false
+      }
+    },
+    [
+      formatSidepanelReviewProgress,
+      reviewCard,
+      reviewFlashcardMutation,
+      reviewQuery,
+      sidepanelReviewedCount,
+      t
+    ]
+  )
 
   const handleCloseTemplateDraft = React.useCallback(() => {
     setTemplateDraftId(null)
@@ -703,6 +830,16 @@ export default function SidepanelFlashcards() {
         </Button>
         <Button
           block
+          disabled={isSaving || isGenerating}
+          icon={<BookOpenCheck className="size-4" aria-hidden="true" />}
+          onClick={handleToggleReview}
+        >
+          {reviewOpen
+            ? t("sidepanel:flashcards.closeSidepanelReview", "Close review")
+            : t("sidepanel:flashcards.reviewDueCard", "Review due card")}
+        </Button>
+        <Button
+          block
           loading={captureLoading}
           disabled={isSaving || isGenerating}
           icon={<MessageSquareText className="size-4" aria-hidden="true" />}
@@ -741,9 +878,159 @@ export default function SidepanelFlashcards() {
       <Text type="secondary" className="text-xs">
         {t(
           "sidepanel:flashcards.selectionHint",
-          "Create one editable card, generate a small draft batch, apply templates to queued drafts, or use full Flashcards for imports, review, and management."
+          "Create one editable card, generate a small draft batch, apply templates to queued drafts, review due cards here, or use full Flashcards for imports and management."
         )}
       </Text>
+      {reviewOpen ? (
+        <section
+          className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-3"
+          aria-label={t(
+            "sidepanel:flashcards.sidepanelReviewSection",
+            "Sidepanel flashcard review"
+          )}
+        >
+          <div>
+            <Title level={5} className="!mb-1">
+              {t("sidepanel:flashcards.reviewDueCard", "Review due card")}
+            </Title>
+            <Text type="secondary" className="text-xs">
+              {t(
+                "sidepanel:flashcards.sidepanelReviewDescription",
+                "Review the next due card from the selected deck."
+              )}
+            </Text>
+          </div>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            {t("sidepanel:flashcards.deckLabel", "Deck")}
+            <Select
+              data-testid="sidepanel-flashcards-review-deck-select"
+              aria-label={t("sidepanel:flashcards.reviewDeckLabel", "Review deck")}
+              loading={decksLoading}
+              disabled={
+                !hasSelectableDecks || reviewFlashcardMutation.isPending
+              }
+              placeholder={t(
+                "sidepanel:flashcards.deckPlaceholder",
+                "Choose a deck"
+              )}
+              value={selectedDeckId ?? undefined}
+              options={decks.map((deck) => ({
+                label: deck.name,
+                value: deck.id
+              }))}
+              onChange={(value) => setSelectedDeckId(value)}
+            />
+          </label>
+          {flashcardsUnavailable ? (
+            <Text type="danger" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.unavailable",
+                "Flashcards are unavailable. Check the server connection and try again."
+              )}
+            </Text>
+          ) : decksLoadFailed ? (
+            <Text type="danger" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.decksLoadFailed",
+                "Could not load decks. Check your connection and try again."
+              )}
+            </Text>
+          ) : decksLoading ? (
+            <Text type="secondary" className="text-xs" role="status">
+              {t("sidepanel:flashcards.decksLoading", "Loading decks...")}
+            </Text>
+          ) : showNoDecksMessage ? (
+            <Text type="warning" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.noDecks",
+                "Create a deck in full Flashcards before saving here."
+              )}
+            </Text>
+          ) : reviewQuery.isError ? (
+            <Text type="danger" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.sidepanelReviewLoadFailed",
+                "Could not load the next review card. Check your connection and try again."
+              )}
+            </Text>
+          ) : hasDeck && isReviewLoading ? (
+            <Text type="secondary" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.sidepanelReviewLoading",
+                "Loading review card..."
+              )}
+            </Text>
+          ) : hasDeck && reviewCard ? (
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1">
+                <Text type="secondary" className="text-xs">
+                  {t("sidepanel:flashcards.frontLabel", "Front")}
+                </Text>
+                <div className="whitespace-pre-wrap rounded-md border border-border bg-surface2 p-3 text-sm">
+                  {reviewCard.front}
+                </div>
+              </div>
+              {reviewAnswerRevealed ? (
+                <>
+                  <div className="flex flex-col gap-1">
+                    <Text type="secondary" className="text-xs">
+                      {t("sidepanel:flashcards.backLabel", "Back")}
+                    </Text>
+                    <div className="whitespace-pre-wrap rounded-md border border-border bg-surface2 p-3 text-sm">
+                      {reviewCard.back}
+                    </div>
+                  </div>
+                  <div
+                    className="grid grid-cols-2 gap-2"
+                    role="group"
+                    aria-label={t(
+                      "sidepanel:flashcards.ratingOptions",
+                      "Rating options"
+                    )}
+                  >
+                    {sidepanelRatingOptions.map((option) => (
+                      <Button
+                        key={option.value}
+                        loading={reviewFlashcardMutation.isPending}
+                        disabled={reviewFlashcardMutation.isPending}
+                        onClick={() =>
+                          void handleSubmitSidepanelReview(option.value)
+                        }
+                      >
+                        {option.label}
+                      </Button>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <Button
+                  type="primary"
+                  block
+                  disabled={reviewFlashcardMutation.isPending}
+                  onClick={handleRevealReviewAnswer}
+                >
+                  {t("sidepanel:flashcards.revealAnswer", "Reveal answer")}
+                </Button>
+              )}
+            </div>
+          ) : hasDeck ? (
+            <div className="flex flex-col gap-1" role="status">
+              <Text>
+                {t(
+                  "sidepanel:flashcards.sidepanelReviewCaughtUp",
+                  "No due cards right now."
+                )}
+              </Text>
+              <Text type="secondary" className="text-xs">
+                {t(
+                  "sidepanel:flashcards.sidepanelReviewFullWorkspaceHint",
+                  "Use full Flashcards for imports, management, and richer review controls."
+                )}
+              </Text>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
       {drafts.length > 0 ? (
         <section
           className="flex flex-col gap-3"

--- a/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-flashcards.tsx
@@ -88,6 +88,9 @@ export default function SidepanelFlashcards() {
   const [reviewAnswerRevealed, setReviewAnswerRevealed] =
     React.useState(false)
   const [sidepanelReviewedCount, setSidepanelReviewedCount] = React.useState(0)
+  const [submittedReviewUuid, setSubmittedReviewUuid] = React.useState<
+    string | null
+  >(null)
   const reviewAnswerStartRef = React.useRef<number | null>(null)
   const reviewSubmitInFlightRef = React.useRef(false)
   const [templateDraftId, setTemplateDraftId] = React.useState<string | null>(
@@ -122,10 +125,20 @@ export default function SidepanelFlashcards() {
     decks.length === 0
   const hasDeck = selectedDeckId != null && hasSelectableDecks
   const reviewQuery = useReviewQuery(selectedDeckId, {
-    enabled: reviewOpen && hasDeck
+    enabled: reviewOpen && hasDeck,
+    refetchOnWindowFocus: false
   })
   const reviewCard = reviewQuery.data ?? null
-  const isReviewLoading = reviewQuery.isLoading || reviewQuery.isFetching
+  const isReviewLoading = reviewQuery.isLoading
+  const isReviewFetching = reviewQuery.isFetching
+  const isReviewSubmitting = reviewFlashcardMutation.isPending
+  const submitReviewFlashcard = reviewFlashcardMutation.mutateAsync
+  const refetchReviewCard = reviewQuery.refetch
+  const reviewCardUuid = reviewCard?.uuid ?? null
+  const isReviewAdvancePending =
+    submittedReviewUuid != null && reviewCardUuid === submittedReviewUuid
+  const isReviewAdvanceFailed =
+    submittedReviewUuid != null && reviewQuery.isError
 
   const sidepanelRatingOptions = React.useMemo(
     () => [
@@ -163,6 +176,22 @@ export default function SidepanelFlashcards() {
     setReviewAnswerRevealed(false)
     reviewAnswerStartRef.current = null
   }, [reviewCard?.uuid, selectedDeckId])
+
+  React.useEffect(() => {
+    if (submittedReviewUuid == null) return
+    if (reviewCardUuid != null && reviewCardUuid !== submittedReviewUuid) {
+      setSubmittedReviewUuid(null)
+      return
+    }
+    if (!reviewCardUuid && !isReviewFetching && !reviewQuery.isError) {
+      setSubmittedReviewUuid(null)
+    }
+  }, [
+    isReviewFetching,
+    reviewCardUuid,
+    reviewQuery.isError,
+    submittedReviewUuid
+  ])
 
   const openOptionsHashRoute = React.useCallback(async (route: string) => {
     setCaptureError(null)
@@ -567,6 +596,7 @@ export default function SidepanelFlashcards() {
     setCaptureError(null)
     setSaveStatus(null)
     setReviewAnswerRevealed(false)
+    setSubmittedReviewUuid(null)
     reviewAnswerStartRef.current = null
     if (!reviewOpen) {
       setSidepanelReviewedCount(0)
@@ -584,8 +614,9 @@ export default function SidepanelFlashcards() {
   const handleSubmitSidepanelReview = React.useCallback(
     async (rating: number) => {
       if (
-        !reviewCard ||
-        reviewFlashcardMutation.isPending ||
+        !reviewCardUuid ||
+        isReviewSubmitting ||
+        submittedReviewUuid === reviewCardUuid ||
         reviewSubmitInFlightRef.current
       ) {
         return
@@ -598,21 +629,17 @@ export default function SidepanelFlashcards() {
           : Math.max(0, Date.now() - reviewAnswerStartRef.current)
 
       try {
-        await reviewFlashcardMutation.mutateAsync({
-          cardUuid: reviewCard.uuid,
+        await submitReviewFlashcard({
+          cardUuid: reviewCardUuid,
           rating,
           answerTimeMs
         })
-        const nextReviewedCount = sidepanelReviewedCount + 1
-        setSidepanelReviewedCount(nextReviewedCount)
-        setSaveStatus({
-          type: "success",
-          message: formatSidepanelReviewProgress(nextReviewedCount)
+      } catch (error) {
+        console.error("Failed to submit sidepanel flashcard review:", {
+          cardUuid: reviewCardUuid,
+          rating,
+          error
         })
-        setReviewAnswerRevealed(false)
-        reviewAnswerStartRef.current = null
-        await reviewQuery.refetch()
-      } catch {
         setSaveStatus({
           type: "error",
           message: t(
@@ -620,19 +647,58 @@ export default function SidepanelFlashcards() {
             "Could not submit review. Check your connection and try again."
           )
         })
+        return
       } finally {
         reviewSubmitInFlightRef.current = false
       }
+
+      const nextReviewedCount = sidepanelReviewedCount + 1
+      setSidepanelReviewedCount(nextReviewedCount)
+      setSubmittedReviewUuid(reviewCardUuid)
+      setSaveStatus({
+        type: "success",
+        message: formatSidepanelReviewProgress(nextReviewedCount)
+      })
+      setReviewAnswerRevealed(false)
+      reviewAnswerStartRef.current = null
     },
     [
       formatSidepanelReviewProgress,
-      reviewCard,
-      reviewFlashcardMutation,
-      reviewQuery,
+      isReviewSubmitting,
+      reviewCardUuid,
       sidepanelReviewedCount,
+      submitReviewFlashcard,
+      submittedReviewUuid,
       t
     ]
   )
+
+  const handleRetryLoadReviewCard = React.useCallback(async () => {
+    setCaptureError(null)
+    setSaveStatus(null)
+    try {
+      const result = await refetchReviewCard()
+      if (result.error) {
+        throw result.error
+      }
+      const nextCard = result.data ?? null
+      if (!nextCard || nextCard.uuid !== submittedReviewUuid) {
+        setSubmittedReviewUuid(null)
+      }
+    } catch (error) {
+      console.error("Failed to retry sidepanel flashcard review load:", {
+        cardUuid: submittedReviewUuid,
+        error
+      })
+      setSaveStatus({
+        type: "error",
+        message: t(
+          "sidepanel:flashcards.sidepanelReviewAdvanceFailed",
+          "Review saved, but could not load the next card. Try again."
+        )
+      })
+    }
+  }, [refetchReviewCard, submittedReviewUuid, t])
 
   const handleCloseTemplateDraft = React.useCallback(() => {
     setTemplateDraftId(null)
@@ -907,7 +973,7 @@ export default function SidepanelFlashcards() {
               aria-label={t("sidepanel:flashcards.reviewDeckLabel", "Review deck")}
               loading={decksLoading}
               disabled={
-                !hasSelectableDecks || reviewFlashcardMutation.isPending
+                !hasSelectableDecks || isReviewSubmitting
               }
               placeholder={t(
                 "sidepanel:flashcards.deckPlaceholder",
@@ -944,6 +1010,28 @@ export default function SidepanelFlashcards() {
               {t(
                 "sidepanel:flashcards.noDecks",
                 "Create a deck in full Flashcards before saving here."
+              )}
+            </Text>
+          ) : isReviewAdvanceFailed ? (
+            <div className="flex flex-col gap-2" role="status">
+              <Text type="warning">
+                {t(
+                  "sidepanel:flashcards.sidepanelReviewAdvanceFailed",
+                  "Review saved, but could not load the next card. Try again."
+                )}
+              </Text>
+              <Button onClick={() => void handleRetryLoadReviewCard()}>
+                {t(
+                  "sidepanel:flashcards.retryLoadNextReviewCard",
+                  "Retry loading next card"
+                )}
+              </Button>
+            </div>
+          ) : isReviewAdvancePending ? (
+            <Text type="secondary" className="text-xs" role="status">
+              {t(
+                "sidepanel:flashcards.sidepanelReviewAdvanceLoading",
+                "Review saved. Loading next card..."
               )}
             </Text>
           ) : reviewQuery.isError ? (
@@ -991,8 +1079,8 @@ export default function SidepanelFlashcards() {
                     {sidepanelRatingOptions.map((option) => (
                       <Button
                         key={option.value}
-                        loading={reviewFlashcardMutation.isPending}
-                        disabled={reviewFlashcardMutation.isPending}
+                        loading={isReviewSubmitting}
+                        disabled={isReviewSubmitting}
                         onClick={() =>
                           void handleSubmitSidepanelReview(option.value)
                         }
@@ -1006,7 +1094,7 @@ export default function SidepanelFlashcards() {
                 <Button
                   type="primary"
                   block
-                  disabled={reviewFlashcardMutation.isPending}
+                  disabled={isReviewSubmitting}
                   onClick={handleRevealReviewAnswer}
                 >
                   {t("sidepanel:flashcards.revealAnswer", "Reveal answer")}

--- a/backlog/tasks/task-522 - Add-native-sidepanel-flashcard-review-loop.md
+++ b/backlog/tasks/task-522 - Add-native-sidepanel-flashcard-review-loop.md
@@ -15,6 +15,7 @@ documentation:
 modified_files:
 - apps/packages/ui/src/routes/sidepanel-flashcards.tsx
 - apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
 - Flashcards-UX-Fix-List.md
 - apps/extension/docs/features/flashcards.md
 - Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -24,6 +25,7 @@ modified_files:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
+Add a compact native flashcard review loop to the extension sidepanel so users can review due cards without opening the full Flashcards workspace.
 
 <!-- SECTION:DESCRIPTION:END -->
 
@@ -52,13 +54,20 @@ Implementation added a compact sidepanel review panel instead of duplicating ful
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented a compact native sidepanel review loop for F12. The sidepanel now exposes Review due card, reuses the existing next-review query and review mutation, lets users select a deck, reveal a due card, submit Again/Hard/Good/Easy ratings, refetch the next due card, and see inline session progress. Rating failures keep the current card and answer visible with recovery copy, and rapid duplicate rating clicks are guarded synchronously. Updated the master UX fix list plus extension/user docs to remove the deferred in-sidepanel review claim and keep richer review controls scoped to full Flashcards.
+Implemented a compact native sidepanel review loop for F12. The sidepanel now exposes Review due card, reuses the existing next-review query and review mutation, lets users select a deck, reveal a due card, submit Again/Hard/Good/Easy ratings, and see inline session progress. Rating failures keep the current card and answer visible with recovery copy, rapid duplicate rating clicks are guarded synchronously, successful ratings hide the already-rated card while invalidation-driven next-card loading advances, and next-card loading failures show distinct retry UI without allowing duplicate re-rating. Updated the master UX fix list plus extension/user docs to remove the deferred in-sidepanel review claim and keep richer review controls scoped to full Flashcards.
+
+PR review fixes:
+- Added `refetchOnWindowFocus` support for review queries and disabled it in the sidepanel review panel.
+- Switched sidepanel review loading display to initial `isLoading` only so background refetches do not blank the active card.
+- Removed the normal explicit post-submit `reviewQuery.refetch()` path to avoid redundant next-card fetches; retry still uses `refetch` after an advance failure.
+- Logged review submission and retry-load errors with safe card/rating context.
+- Added all-four rating mapping tests, next-card-load failure tests, and backlog/doc copy fixes requested on PR #2083.
 
 Verification:
 - RED: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` failed on the missing Review due card action after dependency install.
 - RED duplicate guard: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx -t "ignores duplicate sidepanel review ratings"` failed with two mutation calls before the synchronous guard.
-- GREEN focused: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` passed 39 tests.
-- Related regression: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.review-next.test.tsx src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` passed 49 tests.
+- GREEN focused after review fixes: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` passed 44 tests.
+- Related regression after review fixes: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.review-next.test.tsx src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` passed 54 tests.
 - Typecheck: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on unrelated baseline `CharacterListContent.design-system.test.tsx(35,3)` (`"comfortable"` not assignable to `GalleryCardDensity`).
 - Diff hygiene: `git diff --check` passed.
 - Bandit: not applicable; no Python files touched.

--- a/backlog/tasks/task-522 - Add-native-sidepanel-flashcard-review-loop.md
+++ b/backlog/tasks/task-522 - Add-native-sidepanel-flashcard-review-loop.md
@@ -1,0 +1,75 @@
+---
+id: TASK-522
+title: Add native sidepanel flashcard review loop
+status: Done
+labels:
+- flashcards
+- extension
+- ux
+priority: medium
+references:
+- Flashcards-UX-Fix-List.md
+- Docs/superpowers/plans/2026-05-25-flashcards-ux-fixes-implementation-plan.md
+documentation:
+- Docs/superpowers/plans/2026-05-27-flashcards-extension-native-review-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/routes/sidepanel-flashcards.tsx
+- apps/packages/ui/src/routes/__tests__/sidepanel-flashcards.test.tsx
+- Flashcards-UX-Fix-List.md
+- apps/extension/docs/features/flashcards.md
+- Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+- Docs/Published/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sidepanel exposes a compact review action for due flashcards without requiring full Flashcards navigation.
+- [x] #2 Review action reuses existing next-review query and review mutation contracts.
+- [x] #3 Users can select a deck, reveal the answer, and submit Again/Hard/Good/Easy ratings.
+- [x] #4 Successful rating advances/refetches the next due card and shows session progress/saved state.
+- [x] #5 Failed rating submission keeps the current card visible with inline recovery copy.
+- [x] #6 Full Flashcards remains the path for imports, management, analytics, and richer review controls.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-05-27-flashcards-extension-native-review-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation added a compact sidepanel review panel instead of duplicating full Flashcards Study. Full Flashcards remains the richer path for cram, assistant support, analytics, undo/re-rate, imports, and deck management.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a compact native sidepanel review loop for F12. The sidepanel now exposes Review due card, reuses the existing next-review query and review mutation, lets users select a deck, reveal a due card, submit Again/Hard/Good/Easy ratings, refetch the next due card, and see inline session progress. Rating failures keep the current card and answer visible with recovery copy, and rapid duplicate rating clicks are guarded synchronously. Updated the master UX fix list plus extension/user docs to remove the deferred in-sidepanel review claim and keep richer review controls scoped to full Flashcards.
+
+Verification:
+- RED: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` failed on the missing Review due card action after dependency install.
+- RED duplicate guard: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx -t "ignores duplicate sidepanel review ratings"` failed with two mutation calls before the synchronous guard.
+- GREEN focused: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` passed 39 tests.
+- Related regression: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.review-next.test.tsx src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` passed 49 tests.
+- Typecheck: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on unrelated baseline `CharacterListContent.design-system.test.tsx(35,3)` (`"comfortable"` not assignable to `GalleryCardDensity`).
+- Diff hygiene: `git diff --check` passed.
+- Bandit: not applicable; no Python files touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Added a compact native `Review due card` flow to the extension sidepanel using the existing next-review query and review mutation contracts.
- Kept the extension scope narrow: deck selection, reveal-first review, Again/Hard/Good/Easy rating, progress status, caught-up state, rating failure recovery, and rapid duplicate-rating protection.
- Updated the flashcards UX master fix list, extension docs, user guides, implementation plan, and Backlog task to close the F12 in-extension review follow-up while keeping richer review tools in full Flashcards.

## Verification
- RED: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` failed on the missing `Review due card` action after dependency install.
- RED: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx -t "ignores duplicate sidepanel review ratings"` failed with duplicate mutation calls before the guard.
- PASS: `bunx vitest run src/routes/__tests__/sidepanel-flashcards.test.tsx` (39 tests).
- PASS: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.review-next.test.tsx src/routes/__tests__/sidepanel-flashcards.test.tsx src/routes/__tests__/route-registry.sidepanel-flashcards.test.ts` (49 tests).
- PASS: `git diff --check`.
- Typecheck note: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still fails on unrelated baseline `src/components/Option/Characters/__tests__/CharacterListContent.design-system.test.tsx(35,3)` where `"comfortable"` is not assignable to `GalleryCardDensity`.
- Bandit: not applicable; no Python files touched.

## Notes
- Draft PR: requester should provide/confirm the merge-gate Change summary before marking ready for review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact due-card review loop to the extension sidepanel so users can study without leaving the page. Reuses the existing next-review query and review mutation, and keeps richer tools in full Flashcards; addresses TASK-522.

- **New Features**
  - Added a deck-aware "Review due card" panel with reveal-first flow and rating buttons (Again/Hard/Good/Easy → 0/2/3/5).
  - Shows inline session progress after each rating and does not open a new tab.
  - Handles caught-up state with guidance to use full Flashcards for cram, analytics, and management.
  - Improves resilience: keeps the current card on rating failure, ignores duplicate rating clicks, adds retry when loading the next card fails, and prevents re-rating an already-saved review.
  - Reused `useReviewQuery` and `useReviewFlashcardMutation`; added `refetchOnWindowFocus` to `useReviewQuery` and disabled it in the sidepanel to avoid flicker; removed explicit post-submit refetch; expanded tests and updated extension/user docs and the UX fix list.

<sup>Written for commit 2d583e7d98e50059da8273f31119e4dc80549493. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2083?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

