### PR TITLE
Add MCP profile structured resolution primitives

### DIFF
--- a/Docs/superpowers/plans/2026-05-27-mcp-unified-stage2c-structured-resolution-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-27-mcp-unified-stage2c-structured-resolution-implementation-plan.md
@@ -57,7 +57,7 @@ Out of scope:
 **Files:**
 - Create: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
 
-- [ ] **Step 1: Write failing profile-resolution tests**
+- [x] **Step 1: Write failing profile-resolution tests**
 
 Add tests covering:
 
@@ -94,7 +94,7 @@ async def test_resolve_profile_keeps_legacy_none_wrapper_behavior() -> None:
     assert await resolver.resolve_profile(None) is None
 ```
 
-- [ ] **Step 2: Run RED test**
+- [x] **Step 2: Run RED test**
 
 Run:
 
@@ -110,7 +110,7 @@ Expected: FAIL because `resolve_profile_result` and result models do not exist.
 - Create: `mcp_unified/profiles/resolution.py`
 - Modify: `mcp_unified/profiles/__init__.py`
 
-- [ ] **Step 1: Implement result models**
+- [x] **Step 1: Implement result models**
 
 Add Pydantic models:
 
@@ -140,11 +140,11 @@ class ProfileResolutionResult(BaseModel):
 
 Also add `EffectivePolicy` and `EffectivePolicyResult` with the same provenance/warning shape.
 
-- [ ] **Step 2: Export result primitives**
+- [x] **Step 2: Export result primitives**
 
 Export from `mcp_unified.profiles`.
 
-- [ ] **Step 3: Run focused import tests**
+- [x] **Step 3: Run focused import tests**
 
 Run:
 
@@ -160,7 +160,7 @@ Expected: PASS after exports are stable.
 - Modify: `mcp_unified/profiles/resolver.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
 
-- [ ] **Step 1: Implement `resolve_profile_result()`**
+- [x] **Step 1: Implement `resolve_profile_result()`**
 
 Add structured behavior:
 - no explicit/default id -> `profile_required`
@@ -171,11 +171,11 @@ Add structured behavior:
 
 Each result must include provenance with at least `requested_profile_id`, `resolved_profile_id`, `used_default_profile`, and `resolver`.
 
-- [ ] **Step 2: Preserve wrapper behavior**
+- [x] **Step 2: Preserve wrapper behavior**
 
 Keep `resolve_profile()` returning `MCPProfile | None` for existing primitive callers by delegating to `resolve_profile_result()` and returning the copied profile only when status is `resolved`.
 
-- [ ] **Step 3: Run focused tests**
+- [x] **Step 3: Run focused tests**
 
 Run:
 
@@ -193,7 +193,7 @@ Expected: PASS.
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
 
-- [ ] **Step 1: Write failing workspace-binding tests**
+- [x] **Step 1: Write failing workspace-binding tests**
 
 Add tests proving:
 - write-capable profiles without `path_scopes`, host binding, or assignment binding return `workspace_scope_required`
@@ -201,11 +201,11 @@ Add tests proving:
 - deny entries override allow entries
 - no allowed tools/capabilities defaults to deny for execution
 
-- [ ] **Step 2: Mark write-capable presets**
+- [x] **Step 2: Mark write-capable presets**
 
 Set `policy_document.resource_constraints["requires_workspace_binding"] = True` for bundled presets with mutating/write-scoped capabilities.
 
-- [ ] **Step 3: Implement effective-policy helper**
+- [x] **Step 3: Implement effective-policy helper**
 
 Add a package-local helper, for example:
 
@@ -221,7 +221,7 @@ def build_effective_policy_result(
 
 Do not call this from runtime execution in this slice.
 
-- [ ] **Step 4: Run focused tests**
+- [x] **Step 4: Run focused tests**
 
 Run:
 
@@ -236,7 +236,7 @@ Expected: PASS.
 **Files:**
 - Modify: implementation Backlog task file
 
-- [ ] **Step 1: Run focused regression tests**
+- [x] **Step 1: Run focused regression tests**
 
 Run:
 
@@ -251,7 +251,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 2: Run static and security checks**
+- [x] **Step 2: Run static and security checks**
 
 Run:
 
@@ -265,7 +265,7 @@ git diff --check
 
 Expected: Ruff passes, Mypy passes, runtime Bandit reports 0 findings, and diff whitespace is clean.
 
-- [ ] **Step 3: Update Backlog task and commit**
+- [x] **Step 3: Update Backlog task and commit**
 
 Record RED/GREEN evidence, verification, known skips, and final summary, then commit:
 

--- a/backlog/tasks/task-524 - Implement-MCP-Unified-Stage-2C-structured-profile-resolution-primitives.md
+++ b/backlog/tasks/task-524 - Implement-MCP-Unified-Stage-2C-structured-profile-resolution-primitives.md
@@ -4,7 +4,7 @@ title: Implement MCP Unified Stage 2C structured profile resolution primitives
 status: Done
 assignee: []
 created_date: '2026-05-28T00:57:00Z'
-updated_date: '2026-05-28 00:58'
+updated_date: '2026-05-28T00:58:00Z'
 labels:
   - mcp-unified
   - standalone

--- a/backlog/tasks/task-524 - Implement-MCP-Unified-Stage-2C-structured-profile-resolution-primitives.md
+++ b/backlog/tasks/task-524 - Implement-MCP-Unified-Stage-2C-structured-profile-resolution-primitives.md
@@ -1,0 +1,75 @@
+---
+id: TASK-524
+title: Implement MCP Unified Stage 2C structured profile resolution primitives
+status: Done
+assignee: []
+created_date: '2026-05-28T00:57:00Z'
+updated_date: '2026-05-28 00:58'
+labels:
+  - mcp-unified
+  - standalone
+  - stage2
+  - profiles
+dependencies: []
+references:
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-27-mcp-unified-stage2c-structured-resolution-implementation-plan.md
+modified_files:
+  - mcp_unified/profiles/resolution.py
+  - mcp_unified/profiles/resolver.py
+  - mcp_unified/profiles/presets.py
+  - mcp_unified/profiles/__init__.py
+  - tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+  - tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+  - >-
+    Docs/superpowers/plans/2026-05-27-mcp-unified-stage2c-structured-resolution-implementation-plan.md
+  - >-
+    backlog/tasks/task-524 -
+    Implement-MCP-Unified-Stage-2C-structured-profile-resolution-primitives.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add standalone structured profile-resolution and effective-policy result primitives for MCP Unified without wiring profile enforcement into runtime execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Profile resolution returns structured results for required, missing, disabled, store-unavailable, and resolved profiles while preserving the legacy resolve_profile wrapper behavior.
+- [x] #2 Effective-policy primitive enforces deny-over-allow, default-deny, and workspace-binding requirements for write-capable profiles without runtime execution wiring.
+- [x] #3 Bundled write-capable presets advertise assignment-time workspace-binding requirements.
+- [x] #4 Focused tests, Ruff, Mypy, Bandit touched runtime scope, and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Baseline before edits: profile registry/preset/runtime package tests passed: 20 passed, 3 warnings.
+- RED profile-resolution test run failed as expected: resolve_profile_result was missing on StoreBackedProfileResolver.
+- RED effective-policy/preset test run failed as expected: build_effective_policy_result was missing and bundled presets had no workspace-binding resource constraints.
+- GREEN focused regression: 33 passed, 3 warnings for structured resolution, registry resolver, presets, and runtime package boundary tests.
+- Ruff passed for mcp_unified and the new structured-resolution test.
+- Mypy passed for mcp_unified/profiles, storage protocol, and the structured-resolution test.
+- Bandit runtime touched scope reported 0 findings.
+- git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented MCP Unified Stage 2C structured profile resolution primitives in the standalone mcp_unified package. Added structured profile-resolution result models and StoreBackedProfileResolver.resolve_profile_result(), preserved resolve_profile() compatibility behavior, added effective-policy result primitives with workspace-scope-required, deny-over-allow, and default-deny outcomes, and marked write-capable bundled presets as assignment-time workspace-bound templates. No FastAPI route, MCP runtime execution, SQLite persistence, external server lifecycle, or gateway entrypoint wiring was changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-525 - Address-PR-2084-MCP-structured-resolution-review-comments.md
+++ b/backlog/tasks/task-525 - Address-PR-2084-MCP-structured-resolution-review-comments.md
@@ -1,0 +1,45 @@
+---
+id: TASK-525
+title: Address PR 2084 MCP structured resolution review comments
+status: Done
+labels:
+- mcp
+- review-fix
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix validated Qodo, CodeRabbit, and Gemini review feedback on PR #2084 after rebasing onto latest dev. Scope: structured profile resolution fallback semantics, workspace-binding validation, preset contract coverage, Backlog timestamp metadata, and targeted defensive handling where appropriate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased on latest origin/dev or confirmed current.
+- [x] #2 All valid Qodo, CodeRabbit, and Gemini review comments are addressed or documented as not applicable.
+- [x] #3 Focused tests and static checks covering touched MCP profile resolution code pass.
+- [x] #4 Bandit runs on the touched MCP profile scope with no new findings.
+- [x] #5 Review threads are resolved after fixes are pushed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebase check: git rebase origin/dev reported branch already up to date on origin/dev cbd71d19b29b7f2e08651cb49869fb733ee2fa58. Addressed review feedback by preserving explicit empty profile IDs instead of defaulting, validating assignment workspace-binding fields, asserting preset binding_stage == assignment, normalizing TASK-524 updated_date to RFC3339, and adding targeted defensive handling for None profile/policy/list/dict values. Verification: focused MCP profile tests 40 passed, Ruff passed, Mypy passed, Bandit reported 0 findings, and git diff --check passed. Pushed the review-fix commit and resolved all ten GitHub review threads.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed all validated PR #2084 Qodo, CodeRabbit, and Gemini review feedback for the MCP structured-resolution slice. The PR branch was already current with origin/dev, and focused verification passed locally.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/profiles/__init__.py
+++ b/mcp_unified/profiles/__init__.py
@@ -8,17 +8,31 @@ from .presets import (
     list_builtin_presets,
     validate_preset_safety,
 )
+from .resolution import (
+    EffectivePolicy,
+    EffectivePolicyResult,
+    EffectivePolicyStatus,
+    ProfileResolutionResult,
+    ProfileResolutionStatus,
+    build_effective_policy_result,
+)
 from .resolver import ProfileResolver, StoreBackedProfileResolver
 from .store import InMemoryProfileStore, ProfileStoreUnavailableError
 
 __all__ = [
+    "EffectivePolicy",
+    "EffectivePolicyResult",
+    "EffectivePolicyStatus",
     "InMemoryProfileStore",
     "MCPProfile",
     "ProfilePolicy",
     "ProfilePreset",
     "ProfileResolver",
+    "ProfileResolutionResult",
+    "ProfileResolutionStatus",
     "ProfileStoreUnavailableError",
     "StoreBackedProfileResolver",
+    "build_effective_policy_result",
     "duplicate_builtin_preset",
     "get_builtin_preset",
     "list_builtin_presets",

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -50,6 +50,7 @@ def _policy(
     allowed_tools: list[str] | None = None,
     tool_patterns: list[str] | None = None,
     module_patterns: list[str] | None = None,
+    resource_constraints: dict[str, Any] | None = None,
 ) -> ProfilePolicy:
     """Build a conservative package-local policy document for a preset."""
     return ProfilePolicy(
@@ -58,6 +59,7 @@ def _policy(
         tool_patterns=tool_patterns or [],
         module_patterns=module_patterns or [],
         risk_classes=risk_classes or [],
+        resource_constraints=resource_constraints or {},
     )
 
 
@@ -71,6 +73,7 @@ def _profile(
     approval_policy: dict[str, Any] | None = None,
     external_server_grants: list[dict[str, Any]] | None = None,
     credential_grants: list[dict[str, Any]] | None = None,
+    requires_workspace_binding: bool = False,
     provenance: dict[str, Any] | None = None,
     agent_metadata: dict[str, Any] | None = None,
 ) -> MCPProfile:
@@ -90,6 +93,12 @@ def _profile(
         policy_document=_policy(
             capabilities=capabilities,
             risk_classes=risk_classes,
+            resource_constraints={
+                "requires_workspace_binding": True,
+                "binding_stage": "assignment",
+            }
+            if requires_workspace_binding
+            else None,
         ),
         approval_policy=approval_policy or {},
         external_server_grants=external_server_grants or [],
@@ -113,6 +122,7 @@ def _preset(
     risk_classes: list[str] | None = None,
     approval_policy: dict[str, Any] | None = None,
     external_server_grants: list[dict[str, Any]] | None = None,
+    requires_workspace_binding: bool = False,
     provenance: dict[str, Any] | None = None,
     agent_metadata: dict[str, Any] | None = None,
 ) -> ProfilePreset:
@@ -128,6 +138,7 @@ def _preset(
             risk_classes=risk_classes,
             approval_policy=approval_policy,
             external_server_grants=external_server_grants,
+            requires_workspace_binding=requires_workspace_binding,
             provenance=provenance,
             agent_metadata=agent_metadata,
         ),
@@ -147,6 +158,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         capabilities=["workflow.plan", "task.coordinate", "workspace.read", "workspace.write_scoped"],
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="product-owner",
@@ -155,6 +167,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         capabilities=["issues.plan", "stories.write", "docs.read", "docs.write_scoped"],
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="architect",
@@ -172,6 +185,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             "required_for": ["repo.write_scoped", "git.destructive"],
             "reason": "Conflict resolution writes are repo-scoped and mutating.",
         },
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="documentation-writer",
@@ -180,6 +194,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         capabilities=["docs.read", "docs.write_scoped", "filesystem.read"],
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="project-researcher",
@@ -206,6 +221,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
                 "external_network": "External network is limited to research/citation tools.",
             },
         },
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="code-reviewer",
@@ -223,6 +239,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             "required_for": ["infra.mutate_scoped", "deployment.mutate"],
             "reason": "Infrastructure changes require explicit approval.",
         },
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="backend-engineer",
@@ -231,6 +248,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         capabilities=["source.write_scoped", "code_search", "tests.request", "backend.inspect"],
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="frontend-engineer",
@@ -239,6 +257,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         capabilities=["source.write_scoped", "browser.debug", "frontend.inspect", "tests.request"],
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="qa-engineer",
@@ -253,6 +272,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         capabilities=["tests.write_scoped", "tests.request", "code_search", "filesystem.read"],
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
+        requires_workspace_binding=True,
     ),
     _preset(
         preset_id="memory-keeper",
@@ -262,6 +282,7 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
         agent_metadata={"memory_provider": "graphiti"},
+        requires_workspace_binding=True,
     ),
 )
 

--- a/mcp_unified/profiles/resolution.py
+++ b/mcp_unified/profiles/resolution.py
@@ -8,6 +8,15 @@ from pydantic import BaseModel, Field
 
 from .models import MCPProfile
 
+_WORKSPACE_BINDING_KEYS = (
+    "workspace_binding",
+    "workspace_id",
+    "workspace_root",
+    "path_scopes",
+    "scope",
+    "workspace",
+)
+
 ProfileResolutionStatus = Literal[
     "resolved",
     "profile_required",
@@ -72,7 +81,13 @@ def build_effective_policy_result(
     This helper only derives and validates policy metadata. It intentionally does
     not enforce runtime execution or call host-specific registries.
     """
+    if profile is None:
+        raise ValueError("profile cannot be None")
+
     policy_document = profile.policy_document
+    if policy_document is None:
+        raise ValueError("profile.policy_document cannot be None")
+
     provenance = {
         "profile_id": profile.id,
         "preset_id": profile.preset_id,
@@ -90,10 +105,10 @@ def build_effective_policy_result(
             provenance=provenance,
         )
 
-    allowed_tools = list(policy_document.allowed_tools)
-    denied_tools = list(policy_document.denied_tools)
-    capabilities = list(policy_document.capabilities)
-    denied_capabilities = list(policy_document.denied_capabilities)
+    allowed_tools = list(policy_document.allowed_tools or [])
+    denied_tools = list(policy_document.denied_tools or [])
+    capabilities = list(policy_document.capabilities or [])
+    denied_capabilities = list(policy_document.denied_capabilities or [])
 
     if tool_name is not None:
         if tool_name in denied_tools:
@@ -132,13 +147,15 @@ def build_effective_policy_result(
             denied_tools=denied_tools,
             capabilities=capabilities,
             denied_capabilities=denied_capabilities,
-            resource_constraints=policy_document.resource_constraints.copy(),
-            approval_policy=profile.approval_policy.copy(),
-            path_scopes=[scope.copy() for scope in profile.path_scopes],
+            resource_constraints=(policy_document.resource_constraints or {}).copy(),
+            approval_policy=(profile.approval_policy or {}).copy(),
+            path_scopes=[scope.copy() for scope in (profile.path_scopes or [])],
             external_server_grants=[
-                grant.copy() for grant in profile.external_server_grants
+                grant.copy() for grant in (profile.external_server_grants or [])
             ],
-            credential_grants=[grant.copy() for grant in profile.credential_grants],
+            credential_grants=[
+                grant.copy() for grant in (profile.credential_grants or [])
+            ],
         ),
         provenance=provenance,
     )
@@ -147,15 +164,18 @@ def build_effective_policy_result(
 def _requires_workspace_binding(profile: MCPProfile) -> bool:
     """Return whether a profile needs workspace binding before policy use."""
     policy_document = profile.policy_document
-    constraints = policy_document.resource_constraints
+    constraints = policy_document.resource_constraints or {}
     if constraints.get("requires_workspace_binding") is True:
         return True
 
-    capability_text = " ".join(policy_document.capabilities).lower()
-    if any(token in capability_text for token in ("write", "mutate", "delete")):
+    capabilities = policy_document.capabilities or []
+    if any(
+        any(token in str(capability).lower() for token in ("write", "mutate", "delete"))
+        for capability in capabilities
+    ):
         return True
 
-    risk_classes = set(policy_document.risk_classes)
+    risk_classes = set(policy_document.risk_classes or [])
     return bool(risk_classes & {"mutating", "destructive_filesystem"})
 
 
@@ -166,20 +186,32 @@ def _has_workspace_binding(
     assignment_binding: dict[str, Any] | None,
 ) -> bool:
     """Return whether profile, host, or assignment data binds workspace scope."""
-    if profile.path_scopes:
+    if _has_workspace_binding_value(profile.path_scopes or []):
         return True
-    if assignment_binding:
+    if _mapping_has_workspace_binding(assignment_binding):
         return True
-    if not host_caps:
-        return False
+    return _mapping_has_workspace_binding(host_caps)
 
-    binding_keys = (
-        "workspace_binding",
-        "workspace_id",
-        "workspace_root",
-        "path_scopes",
+
+def _mapping_has_workspace_binding(mapping: dict[str, Any] | None) -> bool:
+    """Return whether a mapping carries a recognized non-empty workspace binding."""
+    if not mapping:
+        return False
+    return any(
+        _has_workspace_binding_value(mapping.get(key))
+        for key in _WORKSPACE_BINDING_KEYS
     )
-    return any(bool(host_caps.get(key)) for key in binding_keys)
+
+
+def _has_workspace_binding_value(value: Any) -> bool:
+    """Return whether a value is meaningful workspace-binding data."""
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, dict):
+        return any(_has_workspace_binding_value(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_has_workspace_binding_value(item) for item in value)
+    return bool(value)
 
 
 def _tool_allowed(

--- a/mcp_unified/profiles/resolution.py
+++ b/mcp_unified/profiles/resolution.py
@@ -1,0 +1,198 @@
+"""Structured profile-resolution and policy result primitives."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from .models import MCPProfile
+
+ProfileResolutionStatus = Literal[
+    "resolved",
+    "profile_required",
+    "profile_not_found",
+    "profile_disabled",
+    "store_unavailable",
+]
+
+EffectivePolicyStatus = Literal[
+    "resolved",
+    "denied",
+    "approval_required",
+    "degraded",
+]
+
+
+class ProfileResolutionResult(BaseModel):
+    """Machine-readable result for resolving an MCP profile."""
+
+    status: ProfileResolutionStatus
+    reason_code: str
+    profile: MCPProfile | None = None
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    warnings: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class EffectivePolicy(BaseModel):
+    """Caller-owned effective policy document derived from a profile."""
+
+    profile_id: str
+    allowed_tools: list[str] = Field(default_factory=list)
+    denied_tools: list[str] = Field(default_factory=list)
+    capabilities: list[str] = Field(default_factory=list)
+    denied_capabilities: list[str] = Field(default_factory=list)
+    resource_constraints: dict[str, Any] = Field(default_factory=dict)
+    approval_policy: dict[str, Any] = Field(default_factory=dict)
+    path_scopes: list[dict[str, Any]] = Field(default_factory=list)
+    external_server_grants: list[dict[str, Any]] = Field(default_factory=list)
+    credential_grants: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class EffectivePolicyResult(BaseModel):
+    """Machine-readable result for deriving an MCP profile policy."""
+
+    status: EffectivePolicyStatus
+    reason_code: str
+    policy: EffectivePolicy | None = None
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    warnings: list[dict[str, Any]] = Field(default_factory=list)
+
+
+def build_effective_policy_result(
+    profile: MCPProfile,
+    *,
+    host_caps: dict[str, Any] | None = None,
+    assignment_binding: dict[str, Any] | None = None,
+    tool_name: str | None = None,
+    capability: str | None = None,
+) -> EffectivePolicyResult:
+    """Build a package-local effective policy result for a profile.
+
+    This helper only derives and validates policy metadata. It intentionally does
+    not enforce runtime execution or call host-specific registries.
+    """
+    policy_document = profile.policy_document
+    provenance = {
+        "profile_id": profile.id,
+        "preset_id": profile.preset_id,
+        "resolver": "build_effective_policy_result",
+    }
+
+    if _requires_workspace_binding(profile) and not _has_workspace_binding(
+        profile,
+        host_caps=host_caps,
+        assignment_binding=assignment_binding,
+    ):
+        return EffectivePolicyResult(
+            status="denied",
+            reason_code="workspace_scope_required",
+            provenance=provenance,
+        )
+
+    allowed_tools = list(policy_document.allowed_tools)
+    denied_tools = list(policy_document.denied_tools)
+    capabilities = list(policy_document.capabilities)
+    denied_capabilities = list(policy_document.denied_capabilities)
+
+    if tool_name is not None:
+        if tool_name in denied_tools:
+            return EffectivePolicyResult(
+                status="denied",
+                reason_code="tool_denied",
+                provenance={**provenance, "tool_name": tool_name},
+            )
+        if not _tool_allowed(tool_name, allowed_tools, capability):
+            return EffectivePolicyResult(
+                status="denied",
+                reason_code="tool_not_allowed",
+                provenance={**provenance, "tool_name": tool_name},
+            )
+
+    if capability is not None:
+        if capability in denied_capabilities:
+            return EffectivePolicyResult(
+                status="denied",
+                reason_code="capability_denied",
+                provenance={**provenance, "capability": capability},
+            )
+        if not _capability_allowed(capability, capabilities):
+            return EffectivePolicyResult(
+                status="denied",
+                reason_code="capability_not_allowed",
+                provenance={**provenance, "capability": capability},
+            )
+
+    return EffectivePolicyResult(
+        status="resolved",
+        reason_code="resolved",
+        policy=EffectivePolicy(
+            profile_id=profile.id,
+            allowed_tools=allowed_tools,
+            denied_tools=denied_tools,
+            capabilities=capabilities,
+            denied_capabilities=denied_capabilities,
+            resource_constraints=policy_document.resource_constraints.copy(),
+            approval_policy=profile.approval_policy.copy(),
+            path_scopes=[scope.copy() for scope in profile.path_scopes],
+            external_server_grants=[
+                grant.copy() for grant in profile.external_server_grants
+            ],
+            credential_grants=[grant.copy() for grant in profile.credential_grants],
+        ),
+        provenance=provenance,
+    )
+
+
+def _requires_workspace_binding(profile: MCPProfile) -> bool:
+    """Return whether a profile needs workspace binding before policy use."""
+    policy_document = profile.policy_document
+    constraints = policy_document.resource_constraints
+    if constraints.get("requires_workspace_binding") is True:
+        return True
+
+    capability_text = " ".join(policy_document.capabilities).lower()
+    if any(token in capability_text for token in ("write", "mutate", "delete")):
+        return True
+
+    risk_classes = set(policy_document.risk_classes)
+    return bool(risk_classes & {"mutating", "destructive_filesystem"})
+
+
+def _has_workspace_binding(
+    profile: MCPProfile,
+    *,
+    host_caps: dict[str, Any] | None,
+    assignment_binding: dict[str, Any] | None,
+) -> bool:
+    """Return whether profile, host, or assignment data binds workspace scope."""
+    if profile.path_scopes:
+        return True
+    if assignment_binding:
+        return True
+    if not host_caps:
+        return False
+
+    binding_keys = (
+        "workspace_binding",
+        "workspace_id",
+        "workspace_root",
+        "path_scopes",
+    )
+    return any(bool(host_caps.get(key)) for key in binding_keys)
+
+
+def _tool_allowed(
+    tool_name: str,
+    allowed_tools: list[str],
+    capability: str | None,
+) -> bool:
+    """Return whether a requested tool is allowed by explicit profile policy."""
+    if allowed_tools:
+        return tool_name in allowed_tools
+    return capability is not None
+
+
+def _capability_allowed(capability: str, capabilities: list[str]) -> bool:
+    """Return whether a requested capability is allowed by profile policy."""
+    return capability in capabilities

--- a/mcp_unified/profiles/resolver.py
+++ b/mcp_unified/profiles/resolver.py
@@ -8,6 +8,7 @@ from typing import Protocol
 from mcp_unified.interfaces.storage import ProfileStore
 
 from .models import MCPProfile
+from .resolution import ProfileResolutionResult
 from .store import ProfileStoreUnavailableError
 
 logger = logging.getLogger(__name__)
@@ -43,10 +44,31 @@ class StoreBackedProfileResolver:
         user_id: str | None = None,
     ) -> MCPProfile | None:
         """Return the enabled explicit or default profile, failing closed."""
+        result = await self.resolve_profile_result(profile_id, user_id=user_id)
+        return result.profile if result.status == "resolved" else None
+
+    async def resolve_profile_result(
+        self,
+        profile_id: str | None,
+        *,
+        user_id: str | None = None,
+    ) -> ProfileResolutionResult:
+        """Return a structured profile-resolution result."""
         del user_id
         resolved_id = profile_id or self.default_profile_id
+        used_default_profile = profile_id is None and self.default_profile_id is not None
+        provenance = {
+            "requested_profile_id": profile_id,
+            "resolved_profile_id": resolved_id,
+            "used_default_profile": used_default_profile,
+            "resolver": self.__class__.__name__,
+        }
         if resolved_id is None:
-            return None
+            return ProfileResolutionResult(
+                status="profile_required",
+                reason_code="profile_required",
+                provenance=provenance,
+            )
 
         try:
             profile = await self.profile_store.get_profile(resolved_id)
@@ -56,8 +78,35 @@ class StoreBackedProfileResolver:
                 resolved_id,
                 exc_info=True,
             )
-            return None
+            return ProfileResolutionResult(
+                status="store_unavailable",
+                reason_code="store_unavailable",
+                provenance={
+                    **provenance,
+                    "profile_id": resolved_id,
+                },
+            )
 
-        if profile is None or not profile.enabled:
-            return None
-        return profile
+        provenance = {
+            **provenance,
+            "profile_id": resolved_id,
+        }
+
+        if profile is None:
+            return ProfileResolutionResult(
+                status="profile_not_found",
+                reason_code="profile_not_found",
+                provenance=provenance,
+            )
+        if not profile.enabled:
+            return ProfileResolutionResult(
+                status="profile_disabled",
+                reason_code="profile_disabled",
+                provenance=provenance,
+            )
+        return ProfileResolutionResult(
+            status="resolved",
+            reason_code="resolved",
+            profile=profile,
+            provenance=provenance,
+        )

--- a/mcp_unified/profiles/resolver.py
+++ b/mcp_unified/profiles/resolver.py
@@ -55,7 +55,7 @@ class StoreBackedProfileResolver:
     ) -> ProfileResolutionResult:
         """Return a structured profile-resolution result."""
         del user_id
-        resolved_id = profile_id or self.default_profile_id
+        resolved_id = self.default_profile_id if profile_id is None else profile_id
         used_default_profile = profile_id is None and self.default_profile_id is not None
         provenance = {
             "requested_profile_id": profile_id,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -91,8 +91,15 @@ def test_write_capable_presets_advertise_workspace_binding_requirement() -> None
         )
         is True
     }
+    assignment_bound = {
+        preset.id
+        for preset in bundled
+        if preset.profile.policy_document.resource_constraints.get("binding_stage")
+        == "assignment"
+    }
 
     assert workspace_bound == WORKSPACE_BOUND_PRESET_IDS
+    assert assignment_bound == WORKSPACE_BOUND_PRESET_IDS
 
 
 def test_get_builtin_preset_returns_stable_profile_template() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -26,6 +26,19 @@ EXPECTED_PRESET_IDS = {
     "memory-keeper",
 }
 
+WORKSPACE_BOUND_PRESET_IDS = {
+    "orchestrator",
+    "product-owner",
+    "merge-conflict-resolver",
+    "documentation-writer",
+    "deep-researcher",
+    "devops-engineer",
+    "backend-engineer",
+    "frontend-engineer",
+    "sdet",
+    "memory-keeper",
+}
+
 
 def _tldw_imports_for(path: Path) -> list[str]:
     """Return imports from a Python file that cross into the host package."""
@@ -66,6 +79,20 @@ def test_builtin_presets_cover_initial_mode_ids_and_pass_safety_baseline() -> No
         if presets.validate_preset_safety(preset)
     }
     assert safety_violations == {}
+
+
+def test_write_capable_presets_advertise_workspace_binding_requirement() -> None:
+    bundled = presets.list_builtin_presets()
+    workspace_bound = {
+        preset.id
+        for preset in bundled
+        if preset.profile.policy_document.resource_constraints.get(
+            "requires_workspace_binding"
+        )
+        is True
+    }
+
+    assert workspace_bound == WORKSPACE_BOUND_PRESET_IDS
 
 
 def test_get_builtin_preset_returns_stable_profile_template() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import mcp_unified.profiles.resolution as profile_resolution
 import pytest
 from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
@@ -60,6 +62,25 @@ async def test_profile_result_reports_missing_profile_with_default_provenance() 
     assert resolved_default.provenance["requested_profile_id"] is None
     assert resolved_default.provenance["resolved_profile_id"] == "default"
     assert resolved_default.provenance["used_default_profile"] is True
+
+
+@pytest.mark.asyncio
+async def test_profile_result_preserves_explicit_empty_profile_id() -> None:
+    store = InMemoryProfileStore(
+        [
+            MCPProfile(id="default", name="Default"),
+        ]
+    )
+    resolver = StoreBackedProfileResolver(store, default_profile_id="default")
+
+    result = await resolver.resolve_profile_result("")
+
+    assert result.status == "profile_not_found"
+    assert result.reason_code == "profile_not_found"
+    assert result.profile is None
+    assert result.provenance["requested_profile_id"] == ""
+    assert result.provenance["resolved_profile_id"] == ""
+    assert result.provenance["used_default_profile"] is False
 
 
 @pytest.mark.asyncio
@@ -155,6 +176,66 @@ def test_effective_policy_allows_write_profile_with_assignment_binding() -> None
     assert result.policy.profile_id == "backend-engineer"
 
 
+def test_effective_policy_rejects_unrelated_assignment_binding() -> None:
+    profile = MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            capabilities=["source.write_scoped"],
+            risk_classes=["mutating"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        assignment_binding={"unrelated": "workspace-1"},
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "workspace_scope_required"
+    assert result.policy is None
+
+
+def test_effective_policy_rejects_empty_assignment_binding_value() -> None:
+    profile = MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            capabilities=["source.write_scoped"],
+            risk_classes=["mutating"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        assignment_binding={"workspace_id": ""},
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "workspace_scope_required"
+    assert result.policy is None
+
+
+def test_effective_policy_allows_write_profile_with_assignment_path_scopes() -> None:
+    profile = MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            capabilities=["source.write_scoped"],
+            risk_classes=["mutating"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        assignment_binding={"path_scopes": [{"root": "/workspace"}]},
+    )
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+
+
 def test_effective_policy_denied_tool_overrides_allowed_tool() -> None:
     profile = MCPProfile(
         id="strict-reviewer",
@@ -192,6 +273,59 @@ def test_effective_policy_requires_tool_or_capability_allow_for_tool_execution()
     assert result.status == "denied"
     assert result.reason_code == "tool_not_allowed"
     assert result.policy is None
+
+
+def test_effective_policy_rejects_missing_profile() -> None:
+    with pytest.raises(ValueError, match="profile cannot be None"):
+        profile_resolution.build_effective_policy_result(cast(Any, None))
+
+
+def test_effective_policy_rejects_missing_policy_document() -> None:
+    profile = MCPProfile.model_construct(
+        id="dynamic",
+        name="Dynamic",
+        preset_id=None,
+        policy_document=None,
+    )
+
+    with pytest.raises(ValueError, match="profile.policy_document cannot be None"):
+        profile_resolution.build_effective_policy_result(profile)
+
+
+def test_effective_policy_treats_dynamic_null_collections_as_safe_defaults() -> None:
+    policy_document = ProfilePolicy.model_construct(
+        allowed_tools=None,
+        denied_tools=None,
+        capabilities=None,
+        denied_capabilities=None,
+        risk_classes=None,
+        resource_constraints=None,
+    )
+    profile = MCPProfile.model_construct(
+        id="dynamic",
+        name="Dynamic",
+        preset_id=None,
+        policy_document=policy_document,
+        approval_policy=None,
+        path_scopes=None,
+        external_server_grants=None,
+        credential_grants=None,
+    )
+
+    result = profile_resolution.build_effective_policy_result(profile)
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+    assert result.policy.allowed_tools == []
+    assert result.policy.denied_tools == []
+    assert result.policy.capabilities == []
+    assert result.policy.denied_capabilities == []
+    assert result.policy.resource_constraints == {}
+    assert result.policy.approval_policy == {}
+    assert result.policy.path_scopes == []
+    assert result.policy.external_server_grants == []
+    assert result.policy.credential_grants == []
 
 
 def test_effective_policy_allows_tool_execution_with_allowed_capability_mapping() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py
@@ -1,0 +1,230 @@
+"""Tests for structured MCP profile resolution primitives."""
+
+from __future__ import annotations
+
+import mcp_unified.profiles.resolution as profile_resolution
+import pytest
+from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+from mcp_unified.profiles.resolver import StoreBackedProfileResolver
+from mcp_unified.profiles.store import InMemoryProfileStore, ProfileStoreUnavailableError
+
+
+@pytest.mark.asyncio
+async def test_profile_result_reports_required_when_no_explicit_or_default_profile() -> None:
+    resolver = StoreBackedProfileResolver(InMemoryProfileStore())
+
+    result = await resolver.resolve_profile_result(None)
+
+    assert result.status == "profile_required"
+    assert result.reason_code == "profile_required"
+    assert result.profile is None
+
+
+@pytest.mark.asyncio
+async def test_profile_result_reports_disabled_profile_with_provenance() -> None:
+    store = InMemoryProfileStore(
+        [
+            MCPProfile(id="disabled", name="Disabled", enabled=False),
+        ]
+    )
+    resolver = StoreBackedProfileResolver(store)
+
+    result = await resolver.resolve_profile_result("disabled")
+
+    assert result.status == "profile_disabled"
+    assert result.reason_code == "profile_disabled"
+    assert result.profile is None
+    assert result.provenance["profile_id"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_profile_result_reports_missing_profile_with_default_provenance() -> None:
+    store = InMemoryProfileStore(
+        [
+            MCPProfile(id="default", name="Default"),
+        ]
+    )
+    resolver = StoreBackedProfileResolver(store, default_profile_id="default")
+
+    missing = await resolver.resolve_profile_result("missing")
+    resolved_default = await resolver.resolve_profile_result(None)
+
+    assert missing.status == "profile_not_found"
+    assert missing.reason_code == "profile_not_found"
+    assert missing.provenance["requested_profile_id"] == "missing"
+    assert missing.provenance["resolved_profile_id"] == "missing"
+    assert missing.provenance["used_default_profile"] is False
+    assert resolved_default.status == "resolved"
+    assert resolved_default.profile is not None
+    assert resolved_default.profile.id == "default"
+    assert resolved_default.provenance["requested_profile_id"] is None
+    assert resolved_default.provenance["resolved_profile_id"] == "default"
+    assert resolved_default.provenance["used_default_profile"] is True
+
+
+@pytest.mark.asyncio
+async def test_profile_result_reports_store_unavailable_with_reason_code() -> None:
+    class UnavailableStore:
+        async def get_profile(self, profile_id: str) -> MCPProfile | None:
+            raise ProfileStoreUnavailableError(
+                f"profile store unavailable: {profile_id}"
+            )
+
+        async def list_profiles(self) -> list[MCPProfile]:
+            raise ProfileStoreUnavailableError("profile store unavailable")
+
+        async def upsert_profile(self, profile: MCPProfile) -> MCPProfile:
+            raise ProfileStoreUnavailableError("profile store unavailable")
+
+        async def delete_profile(self, profile_id: str) -> bool:
+            raise ProfileStoreUnavailableError(
+                f"profile store unavailable: {profile_id}"
+            )
+
+    resolver = StoreBackedProfileResolver(UnavailableStore(), default_profile_id="default")
+
+    result = await resolver.resolve_profile_result(None)
+
+    assert result.status == "store_unavailable"
+    assert result.reason_code == "store_unavailable"
+    assert result.profile is None
+    assert result.provenance["profile_id"] == "default"
+    assert result.provenance["used_default_profile"] is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_profile_keeps_legacy_none_wrapper_behavior() -> None:
+    resolver = StoreBackedProfileResolver(InMemoryProfileStore())
+
+    assert await resolver.resolve_profile(None) is None
+
+
+def test_effective_policy_requires_workspace_scope_for_write_capable_profiles() -> None:
+    profile = MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            capabilities=["source.write_scoped"],
+            risk_classes=["mutating"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(profile)
+
+    assert result.status == "denied"
+    assert result.reason_code == "workspace_scope_required"
+    assert result.policy is None
+    assert result.provenance["profile_id"] == "backend-engineer"
+
+
+def test_effective_policy_allows_read_only_profile_without_workspace_binding() -> None:
+    profile = MCPProfile(
+        id="code-reviewer",
+        name="Code Reviewer",
+        policy_document=ProfilePolicy(
+            capabilities=["code_search", "filesystem.read"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(profile)
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+    assert result.policy.capabilities == ["code_search", "filesystem.read"]
+
+
+def test_effective_policy_allows_write_profile_with_assignment_binding() -> None:
+    profile = MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            capabilities=["source.write_scoped"],
+            risk_classes=["mutating"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        assignment_binding={"workspace_id": "workspace-1"},
+    )
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+    assert result.policy.profile_id == "backend-engineer"
+
+
+def test_effective_policy_denied_tool_overrides_allowed_tool() -> None:
+    profile = MCPProfile(
+        id="strict-reviewer",
+        name="Strict Reviewer",
+        policy_document=ProfilePolicy(
+            allowed_tools=["filesystem.read"],
+            denied_tools=["filesystem.read"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.read",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "tool_denied"
+    assert result.policy is None
+
+
+def test_effective_policy_requires_tool_or_capability_allow_for_tool_execution() -> None:
+    profile = MCPProfile(
+        id="capability-only",
+        name="Capability Only",
+        policy_document=ProfilePolicy(
+            capabilities=["filesystem.read"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.read",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "tool_not_allowed"
+    assert result.policy is None
+
+
+def test_effective_policy_allows_tool_execution_with_allowed_capability_mapping() -> None:
+    profile = MCPProfile(
+        id="capability-mapped",
+        name="Capability Mapped",
+        policy_document=ProfilePolicy(
+            capabilities=["filesystem.read"],
+        ),
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.read",
+        capability="filesystem.read",
+    )
+
+    assert result.status == "resolved"
+    assert result.reason_code == "resolved"
+    assert result.policy is not None
+
+
+def test_effective_policy_defaults_to_deny_for_unlisted_tool_execution() -> None:
+    profile = MCPProfile(
+        id="empty",
+        name="Empty",
+    )
+
+    result = profile_resolution.build_effective_policy_result(
+        profile,
+        tool_name="filesystem.read",
+    )
+
+    assert result.status == "denied"
+    assert result.reason_code == "tool_not_allowed"
+    assert result.policy is None


### PR DESCRIPTION
## Summary
- Add standalone structured profile-resolution result models and `StoreBackedProfileResolver.resolve_profile_result()` while preserving `resolve_profile()` compatibility.
- Add package-local effective-policy result primitives for workspace-binding, deny-over-allow, and default-deny decisions without runtime execution wiring.
- Mark write-capable bundled presets as assignment-time workspace-bound templates and record TASK-524/plan evidence.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_registry_resolver.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check mcp_unified tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m mypy mcp_unified/profiles mcp_unified/interfaces/storage.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_structured_resolution.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/profiles mcp_unified/interfaces/storage.py -f json -o /tmp/bandit_mcp_unified_stage2c_resolution.json`
- [x] `jq ' .metrics._totals, (.results | length)' /tmp/bandit_mcp_unified_stage2c_resolution.json`\n- [x] `git diff --check`\n\n## Merge Gate Note\nThe AI-generated PR change-summary gate still needs a human-authored `Change summary` before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured profile resolution and effective-policy primitives to `mcp_unified` with clear statuses, workspace-binding checks, and safer defaults. Aligns with TASK-524 and addresses review feedback in TASK-525.

- **New Features**
  - Added `ProfileResolutionResult`/`ProfileResolutionStatus` with provenance and warnings; statuses: resolved, profile_required, profile_not_found, profile_disabled, store_unavailable.
  - Added `EffectivePolicy`/`EffectivePolicyResult` and `build_effective_policy_result()` with deny-over-allow, default-deny, and workspace-binding validation (no runtime wiring).
  - Implemented `StoreBackedProfileResolver.resolve_profile_result()`; `resolve_profile()` now returns a profile only when status is resolved. Bundled write-capable presets now set `resource_constraints.requires_workspace_binding = True` with `binding_stage = "assignment"`.

- **Bug Fixes**
  - Preserved explicit empty profile IDs (no default fallback) and expanded provenance (`requested_profile_id`, `resolved_profile_id`, `used_default_profile`, `resolver`).
  - Validated workspace binding across recognized keys and asserted preset binding stage.
  - Added defensive handling for None profile/policy/collections in effective-policy derivation.

<sup>Written for commit c5d7505bf1d526ff1cc0b91b4dfc21de8b7f9e0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2084?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

